### PR TITLE
feat(observability): gate passthrough, consumed-revision evidence, empty-render guard

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,10 @@ OKB           := kubectl --kubeconfig ~/.kube/ok-infra.yaml
 # per cluster; override the path with OBSERVABILITY_VALUES=... if it lives elsewhere.
 OK_OBSERVABILITY_PATH ?= $(SCRIPT_DIR)/../ok-observability
 OBSERVABILITY_VALUES  ?= $(OK_OBSERVABILITY_PATH)/$(CLUSTER).provider-values.yaml
+# Optional pin: assert WHICH ok-observability revision a run may consume (branch,
+# tag or sha). Empty = consume whatever the checkout is on — transitional, and the
+# resolved sha is printed as gate evidence either way (ADR-024, OK-109).
+OK_OBSERVABILITY_REF  ?=
 
 # ── guard helper ──────────────────────────────────────────────────────────────
 require-cluster:
@@ -148,12 +152,15 @@ install-ingress: require-cluster kubeconfig ## ingress controller (Traefik) + In
 	done; \
 	echo "⚠️  No LoadBalancer IP after 60s — check MetalLB pool ok-pool on RKE2 host cluster"; exit 1
 
-install-observability: require-cluster kubeconfig ## Install ok-observability-standard profile + run the gated Contract Test (OK-79). Vars: OK_OBSERVABILITY_PATH, OBSERVABILITY_VALUES
+install-observability: require-cluster kubeconfig ## Install ok-observability-standard profile + run the gated Contract Test (OK-79). Vars: OK_OBSERVABILITY_PATH, OK_OBSERVABILITY_REF, OBSERVABILITY_VALUES, CONTRACT_TEST_TIMEOUT, CONTRACT_TEST_RECEIVER_CAPTURE_URL
 	@CLUSTER=$(CLUSTER) \
 	 KUBECONFIG_PATH=$(HOME)/.kube/$(CLUSTER).yaml \
 	 OK_OBSERVABILITY_PATH=$(OK_OBSERVABILITY_PATH) \
+	 OK_OBSERVABILITY_REF=$(OK_OBSERVABILITY_REF) \
 	 OBSERVABILITY_VALUES=$(OBSERVABILITY_VALUES) \
 	 OBSERVABILITY_HELM_VALUES=$(OBSERVABILITY_HELM_VALUES) \
+	 CONTRACT_TEST_TIMEOUT=$(CONTRACT_TEST_TIMEOUT) \
+	 CONTRACT_TEST_RECEIVER_CAPTURE_URL=$(CONTRACT_TEST_RECEIVER_CAPTURE_URL) \
 	 bash $(SCRIPT_DIR)/install-observability.sh
 
 bootstrap: require-cluster

--- a/install-observability.sh
+++ b/install-observability.sh
@@ -21,6 +21,13 @@
 #   OK_OBSERVABILITY_PATH  path to the ok-observability repo checkout
 #   OBSERVABILITY_VALUES   path to the provider-values file (see schema below)
 #
+# Optional env (forwarded to the gate; unset => the gate's own default):
+#   OK_OBSERVABILITY_REF              assert which ok-observability revision may
+#                                     be consumed (see "provenance" below)
+#   CONTRACT_TEST_TIMEOUT             per-check async timeout, seconds
+#   CONTRACT_TEST_RECEIVER_CAPTURE_URL  capture endpoint that upgrades the alert
+#                                     check from "fired" to "delivered"
+#
 # provider-values schema (git-ignored, per cluster):
 #   grafanaAdminPassword: "..."
 #   opensearchAdminPassword: "..."
@@ -49,7 +56,39 @@ fi
 
 export KUBECONFIG="$KUBECONFIG_PATH"
 
+# --- provenance: consumed revisions (ADR-Platform-024) --------------------
+# A readiness result is only reproducible if the revisions it consumed are
+# known, so both are resolved and printed as gate evidence. The sibling-checkout
+# mechanism is TRANSITIONAL until a real pin lands (OK-109): setting
+# OK_OBSERVABILITY_REF asserts which ok-observability revision this run may
+# consume and fails loudly on mismatch. It deliberately does NOT check the
+# sibling repo out — silently mutating someone's working tree mid-install is
+# worse than refusing to run.
+_here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+sha_of()   { git -C "$1" rev-parse HEAD 2>/dev/null || echo "unknown"; }
+state_of() { [ -z "$(git -C "$1" status --porcelain 2>/dev/null)" ] && echo clean || echo DIRTY; }
+OK_CLUSTER_SHA="$(sha_of "$_here")";               OK_CLUSTER_STATE="$(state_of "$_here")"
+OBSERVABILITY_SHA="$(sha_of "$OK_OBSERVABILITY_PATH")"; OBSERVABILITY_STATE="$(state_of "$OK_OBSERVABILITY_PATH")"
+
+if [ -n "${OK_OBSERVABILITY_REF:-}" ]; then
+  # -q --verify: without it, rev-parse echoes an unresolvable arg back on stdout
+  # and $want ends up non-empty garbage, misreporting "does not resolve" as a mismatch.
+  want="$(git -C "$OK_OBSERVABILITY_PATH" rev-parse -q --verify "${OK_OBSERVABILITY_REF}^{commit}" 2>/dev/null || true)"
+  [ -n "$want" ] || { echo "❌ OK_OBSERVABILITY_REF='${OK_OBSERVABILITY_REF}' does not resolve in $OK_OBSERVABILITY_PATH"; exit 2; }
+  if [ "$want" != "$OBSERVABILITY_SHA" ]; then
+    echo "❌ ok-observability pin mismatch"
+    echo "   requested OK_OBSERVABILITY_REF=${OK_OBSERVABILITY_REF} -> ${want}"
+    echo "   checkout  ${OK_OBSERVABILITY_PATH} is at ${OBSERVABILITY_SHA}"
+    echo "   Check out the requested revision yourself, then re-run."
+    exit 2
+  fi
+fi
+
 echo "━━━ install-observability: ${RELEASE} → ${CLUSTER} (ns ${NAMESPACE}) ━━━"
+echo "  consumed ok-cluster:       ${OK_CLUSTER_SHA} (${OK_CLUSTER_STATE})"
+echo "  consumed ok-observability: ${OBSERVABILITY_SHA} (${OBSERVABILITY_STATE})${OK_OBSERVABILITY_REF:+ [pinned ${OK_OBSERVABILITY_REF}]}"
+[ "$OK_CLUSTER_STATE" = clean ] && [ "$OBSERVABILITY_STATE" = clean ] || \
+  echo "  ⚠️  a consumed checkout is DIRTY — this run is not reproducible conformance evidence"
 
 # --- read passwords from provider-values ----------------------------------
 read_val() { python3 -c "import sys,yaml; print(yaml.safe_load(open('$OBSERVABILITY_VALUES')).get('$1',''))"; }
@@ -97,15 +136,41 @@ rm -rf "$_cred_dir"; trap - EXIT INT TERM; umask "$_old_umask"
 # helm repo (that repo refresh is the slow part of `update`). Fall back to
 # `update` only on first run when the lock/vendored charts don't exist yet.
 echo "  [3/6] helm dependency build (no repo refresh) + install"
-helm dependency build "$PROFILE" 2>/dev/null || helm dependency update --skip-refresh "$PROFILE"
+# The profile is a TWO-level umbrella (profile -> implementations/* -> upstream),
+# and `helm dependency build` resolves only ONE level: building just the profile
+# packages the wrappers with an empty charts/, which renders to NOTHING and would
+# install an empty release. The capability repo owns how its charts are built, so
+# use its `deps` target; fall back to the old single-level build for checkouts
+# that predate it.
+if make -C "$OK_OBSERVABILITY_PATH" -n deps >/dev/null 2>&1; then
+  make -C "$OK_OBSERVABILITY_PATH" deps
+else
+  echo "    (no 'make deps' in the capability repo — falling back to single-level build)"
+  helm dependency build "$PROFILE" 2>/dev/null || helm dependency update --skip-refresh "$PROFILE"
+fi
+
+helm_values=( -f "$PROFILE/values.yaml" -f "${OK_OBSERVABILITY_PATH}/alerting/alertmanager-values.yaml" )
+if [ -n "${OBSERVABILITY_HELM_VALUES:-}" ]; then
+  helm_values+=( -f "$OBSERVABILITY_HELM_VALUES" )
+fi
+
+# Guard: refuse to install a render that does not reference the credentials Secret.
+# An empty/partial render is otherwise a SILENT success — helm happily installs a
+# release containing nothing and the failure only surfaces later as a confusing
+# gate timeout.
+if [ "$(helm template "$RELEASE" "$PROFILE" --namespace "$NAMESPACE" "${helm_values[@]}" 2>/dev/null | grep -c "$SECRET_NAME")" -eq 0 ]; then
+  echo "❌ rendered profile contains no reference to Secret ${SECRET_NAME} — refusing to install."
+  echo "   Chart dependencies are probably unbuilt at the inner umbrella level."
+  echo "   Run: make -C ${OK_OBSERVABILITY_PATH} deps"
+  exit 1
+fi
+
 # NOTE: no --wait. The Prometheus/Alertmanager StatefulSets are created
 # asynchronously by the Operator, so --wait both blocks silently for minutes AND
 # doesn't actually cover them. Step 5 does a visible readiness wait instead.
 helm upgrade --install "$RELEASE" "$PROFILE" \
   --namespace "$NAMESPACE" \
-  -f "$PROFILE/values.yaml" \
-  -f "${OK_OBSERVABILITY_PATH}/alerting/alertmanager-values.yaml" \
-  ${OBSERVABILITY_HELM_VALUES:+-f "$OBSERVABILITY_HELM_VALUES"} \
+  "${helm_values[@]}" \
   --timeout "${HELM_TIMEOUT:-10m}"
 
 # --- [4/6] alerting rules + dashboards (bare manifests) -------------------
@@ -138,10 +203,21 @@ done
 echo "  [6/6] running Contract Test Gate (make new is complete only when this passes)"
 GATE="${OK_OBSERVABILITY_PATH}/tests/contract-test.sh"
 [ -x "$GATE" ] || { echo "❌ contract test not executable: $GATE"; exit 1; }
+# Forwarded as shell prefix assignments, NOT `env VAR=val` — prefix assignments
+# reach the child's environment without appearing in its argv (ADR-024 credential
+# invariant). CONTRACT_TEST_* are optional: the gate reads them as ${VAR:-default},
+# so forwarding an empty value is identical to not setting it.
 GRAFANA_PASSWORD="$GRAFANA_PASSWORD" \
 OPENSEARCH_PASSWORD="$OPENSEARCH_PASSWORD" \
 CONTRACT_TEST_NAMESPACE="$NAMESPACE" \
+CONTRACT_TEST_TIMEOUT="${CONTRACT_TEST_TIMEOUT:-}" \
+CONTRACT_TEST_RECEIVER_CAPTURE_URL="${CONTRACT_TEST_RECEIVER_CAPTURE_URL:-}" \
   "$GATE"
 
 echo ""
 echo "✅ install-observability complete on ${CLUSTER} — profile deployed and Contract Test Gate PASSED."
+echo "   evidence: ok-cluster ${OK_CLUSTER_SHA} (${OK_CLUSTER_STATE}) · ok-observability ${OBSERVABILITY_SHA} (${OBSERVABILITY_STATE})"
+if [ -z "${CONTRACT_TEST_RECEIVER_CAPTURE_URL:-}" ]; then
+  echo "   note: alert guarantee verified as FIRED only — set CONTRACT_TEST_RECEIVER_CAPTURE_URL"
+  echo "         to verify DELIVERY. This pass is the documented weaker form."
+fi


### PR DESCRIPTION
Three changes needed before OK-109's full-chain re-verify can produce honest evidence. Two were agreed on OK-109; the third is a bug found while validating.

## 1. Gate passthrough (agreed, OK-109)

The gate invocation forwarded only `GRAFANA_PASSWORD`, `OPENSEARCH_PASSWORD` and `CONTRACT_TEST_NAMESPACE`. Two consequences:

- `CONTRACT_TEST_RECEIVER_CAPTURE_URL` could never be set through the make path, so **guarantee 4 was always verified as "fired", never "delivered"**.
- `CONTRACT_TEST_TIMEOUT` could not be raised for a cold cluster — despite having already been tuned 120 → 240s once, because a fresh ServiceMonitor scrape measured ~120-135s on ok-robotics, right at the old edge.

Both are now forwarded, and the success output states plainly when the run was the weaker firing-only form — so a pass can't be quietly mistaken for delivery-verified.

Forwarded as **shell prefix assignments, not `env VAR=val`**: prefix assignments reach the child's environment without appearing in its `argv`, which preserves the ADR-Platform-024 credential invariant. (`env` would have put the passwords in `ps` output — the exact bug `463cfd8` just fixed.) The gate reads all of these as `${VAR:-default}`, so forwarding an empty value is identical to not setting it, which keeps the change to two lines.

## 2. Consumed-revision evidence + optional pin (ADR-024 open item 1)

ADR-024 makes it normative that a reproducible readiness result must identify the consumed `ok-observability` revision. Both consumed revisions are now resolved and printed as evidence, with a clean/`DIRTY` marker and an explicit warning that a dirty checkout is **not** reproducible conformance evidence:

```
━━━ install-observability: ok-observability-standard → ok-obs-verify (ns ok-observability) ━━━
  consumed ok-cluster:       61f7f09… (clean)
  consumed ok-observability: 7399da8… (clean) [pinned main]
```

`OK_OBSERVABILITY_REF` (new Makefile variable, empty by default) optionally asserts which revision a run may consume and fails loudly on mismatch. It **deliberately does not check the sibling repo out** — silently mutating someone's working tree mid-install is worse than refusing to run.

This satisfies the *recording* half of the invariant. The durable pin mechanism (Makefile variable vs. version file vs. `cluster-config.yaml`) remains open under OK-109.

## 3. Empty-render guard — a real bug

`profiles/ok-observability-standard` is a two-level umbrella (profile → `implementations/*` wrappers → upstream charts) and `helm dependency build` resolves only one level. From a fresh clone the profile renders to **nothing**, and `helm upgrade --install` accepts that silently, creating a release with no workloads. The failure only appears later as a confusing gate timeout.

Step 3 now calls the capability repo's `make deps` (it owns how its charts are built — see openkubes/ok-observability#1), falls back to the old single-level build for checkouts predating that target, and then **refuses to install a render containing no reference to the credentials Secret**.

Depends on openkubes/ok-observability#1 for the non-fallback path.

## Verification (no cluster required)

- `bash -n` clean.
- Pin **mismatch** → exit 2 with both SHAs, before any cluster contact.
- **Unresolvable** ref → exit 2 with a distinct message. This one caught a bug in my first attempt: bare `git rev-parse` echoes an unresolvable argument back on stdout, so the check reported "mismatch" instead of "does not resolve". Fixed with `-q --verify`.
- A branch, a tag and a full/short SHA all resolve correctly.
- Evidence lines print, and the DIRTY warning fires on a modified checkout.
- Guard counts **0** credential refs with dependencies wiped, **7** after `make deps`.
- Fallback path taken when the capability repo has no `deps` target.

Not verified here: anything past step 1 on a live cluster — that's OK-109's re-verify on the approved throwaway `ok-obs-verify` cluster, which is also what unblocks ADR-Platform-024 → Accepted.

Refs OK-109.
