### PR TITLE
feat(observability): pin the consumed ok-observability revision

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,10 +25,15 @@ OKB           := kubectl --kubeconfig ~/.kube/ok-infra.yaml
 # per cluster; override the path with OBSERVABILITY_VALUES=... if it lives elsewhere.
 OK_OBSERVABILITY_PATH ?= $(SCRIPT_DIR)/../ok-observability
 OBSERVABILITY_VALUES  ?= $(OK_OBSERVABILITY_PATH)/$(CLUSTER).provider-values.yaml
-# Optional pin: assert WHICH ok-observability revision a run may consume (branch,
-# tag or sha). Empty = consume whatever the checkout is on — transitional, and the
-# resolved sha is printed as gate evidence either way (ADR-024, OK-109).
-OK_OBSERVABILITY_REF  ?=
+# Pin: WHICH ok-observability revision a run may consume. The consumer declares
+# what it consumes, so the value lives here rather than in the capability repo — a
+# file inside ok-observability would be self-referential (a checkout always reports
+# its own revision, so it could never detect drift, and a re-runner needs the
+# revision *before* they have a checkout to read). One line, tag or sha; bumping it
+# is a visible diff. Override on the command line for a one-off. Empty/missing file
+# = unpinned, and the resolved sha is printed as gate evidence either way
+# (ADR-Platform-024 open item 1, OK-109).
+OK_OBSERVABILITY_REF  ?= $(shell cat $(SCRIPT_DIR)/ok-observability.ref 2>/dev/null)
 
 # ── guard helper ──────────────────────────────────────────────────────────────
 require-cluster:

--- a/ok-observability.ref
+++ b/ok-observability.ref
@@ -1,0 +1,1 @@
+6ed389ddb6f2da8a020ced3b1e8ac435b711b426


### PR DESCRIPTION
Supplies the durable value for `OK_OBSERVABILITY_REF`, completing the pin prerequisite of OK-109 AC1 / ADR-Platform-024 open item 1. Enforcement already landed in `30648be` — this PR is only the *source of the value*.

Placement per OK-109 comment 12550.

## Two files

- **`ok-observability.ref`** — one line, the consumed revision.
- **`Makefile`** — `OK_OBSERVABILITY_REF ?= $(shell cat $(SCRIPT_DIR)/ok-observability.ref 2>/dev/null)`

`?=` keeps a command-line override working for one-offs. The `2>/dev/null` stops a missing file from writing to stderr on *every* make invocation; a missing or empty file means unpinned, which is the pre-existing behaviour.

## Why the pin lives in ok-cluster, not ok-observability

The consumer declares what it consumes. A version file inside the capability repo would be self-referential: a checkout always reports its own revision, so it can never disagree with itself and could never detect drift. It also fails the test that motivated the pin — a re-runner needs to know which revision to check out **before** they have a checkout to read. ok-cluster@X now declares it consumes ok-observability@Y, and the two travel together in one history.

## Why a SHA and not a tag — please read

Arash asked for a tag by preference. I pinned `6ed389d` (current ok-observability `main`) instead, for two reasons:

1. **The only existing tag would pin a known bug.** `v0.12.0` → `c77486c`, which predates `349b280`, the two-level chart dependency fix. Pinning it would pin the silent empty-install failure: `helm template` renders nothing, Helm installs a release with no workloads, and the gate later times out looking like a flake.
2. **`v0.12.0` is a coordinated platform tag,** present in ok-cluster, openkubes *and* ok-observability. Cutting a new one for a single repo would be claiming a platform release, which is not this PR's call.

**Action for whoever owns releases:** move the pin to the next platform tag once one is cut that contains `349b280`. One-line diff.

## Verification

| Case | Result |
|---|---|
| make resolves the value from the file | `OK_OBSERVABILITY_REF=6ed389d…` |
| command-line override still wins | `OK_OBSERVABILITY_REF=override-me` |
| file missing | empty, no stderr noise, make unaffected |
| **pin mismatch** (pin `6ed389d`, checkout `610937b`) | refuses with both SHAs, `exit 2`, before any cluster contact |
| **pin matches** checkout | proceeds, prints `[pinned …]` in the provenance banner |

Note on the first run of the mismatch/match pair: my initial attempt "passed" for the wrong reason — a missing test fixture made the script exit 2 on a missing kubeconfig, not on the pin. Re-run with fixtures restored, and the table above is from that run.

Next: this unblocks the `ok-obs-verify` full-chain re-verify, which is simultaneously the acceptance evidence for OK-109 AC1, ADR-024 → Accepted, and ADR-025 criterion 7 (A8(i)).

Refs OK-109.
