### PR TITLE
docs(observability): secret profiles coexist by envelope; datacenter sync is Vault+VSO (ADR-025)

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,8 +209,10 @@ make list                                            # list all defined clusters
 > cluster is "observability-ready" only when the gate is green. The charts read
 > the admin passwords from the Secret (Grafana `admin.existingSecret`, OpenSearch
 > `secretKeyRef`, Fluent Bit `${OPENSEARCH_PASSWORD}`); no plaintext password is
-> passed to helm. A later phase replaces the Secret-creation step with an
-> External-Secrets sync from the ok-shared Vault, with no chart change.
+> passed to helm. A later phase replaces the Secret-creation step with a Vault
+> sync from ok-shared — a `VaultStaticSecret` via the Vault Secrets Operator
+> (ADR-Platform-025) — with no chart change; edge/air-gapped clusters keep the
+> file-based profile.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -209,10 +209,11 @@ make list                                            # list all defined clusters
 > cluster is "observability-ready" only when the gate is green. The charts read
 > the admin passwords from the Secret (Grafana `admin.existingSecret`, OpenSearch
 > `secretKeyRef`, Fluent Bit `${OPENSEARCH_PASSWORD}`); no plaintext password is
-> passed to helm. A later phase replaces the Secret-creation step with a Vault
-> sync from ok-shared — a `VaultStaticSecret` via the Vault Secrets Operator
-> (ADR-Platform-025) — with no chart change; edge/air-gapped clusters keep the
-> file-based profile.
+> passed to helm. This file-based step is the offline-reconcilable profile;
+> datacenter-envelope clusters have the same Secret populated from Vault on
+> ok-shared by a `VaultStaticSecret` via the Vault Secrets Operator
+> (ADR-Platform-025) instead, with no chart change. The two profiles coexist by
+> envelope rather than in sequence (Secret Contract, ADR-Platform-011).
 
 ---
 

--- a/install-observability.sh
+++ b/install-observability.sh
@@ -12,10 +12,13 @@
 # Kubernetes Secret `ok-observability-credentials`. The charts consume that
 # Secret (Grafana admin.existingSecret, OpenSearch secretKeyRef, Fluent Bit
 # ${OPENSEARCH_PASSWORD}) — no plaintext password is ever passed to helm.
-# Phase 2 will replace the "create Secret" step with a Vault sync from ok-shared
-# — a VaultStaticSecret via the Vault Secrets Operator (ADR-Platform-025) — with
-# NO chart change. That is the datacenter-envelope profile; edge/air-gapped
-# clusters keep this file-based profile (Secret Contract, ADR-Platform-011).
+# This file-based step is the OFFLINE-RECONCILABLE profile (edge/air-gapped, and
+# any cluster with no Vault mount yet). Datacenter-envelope clusters instead have
+# the Secret populated from Vault on ok-shared by a VaultStaticSecret — see
+# ok-observability/implementations/vault-secrets-operator/ (ADR-Platform-025) —
+# with NO chart change; only who populates the Secret differs. The two profiles
+# coexist by envelope, they are not sequential phases (Secret Contract,
+# ADR-Platform-011). Skip this step where VSO owns the Secret.
 #
 # Required env (set by the Makefile target):
 #   CLUSTER                cluster name (kubeconfig at $KUBECONFIG_PATH)
@@ -109,9 +112,9 @@ kubectl label namespace "$NAMESPACE" \
   --overwrite
 
 # --- [2/6] credentials Secret (idempotent) --------------------------------
-# Charts read from this Secret; it must exist BEFORE the pods start. Later a
-# Vault sync (Vault Secrets Operator, ADR-Platform-025) will produce the SAME
-# Secret with no chart change.
+# Charts read from this Secret; it must exist BEFORE the pods start. On
+# datacenter clusters a Vault sync (Vault Secrets Operator, ADR-Platform-025)
+# produces the SAME Secret with the same keys instead of this step.
 #
 # Credential-handling invariant (ADR-Platform-024): secret values MUST NOT be
 # exposed via process arguments, shell tracing, stdout/stderr, logs, or temp

--- a/install-observability.sh
+++ b/install-observability.sh
@@ -12,8 +12,10 @@
 # Kubernetes Secret `ok-observability-credentials`. The charts consume that
 # Secret (Grafana admin.existingSecret, OpenSearch secretKeyRef, Fluent Bit
 # ${OPENSEARCH_PASSWORD}) — no plaintext password is ever passed to helm.
-# Phase 2 will replace the "create Secret" step with an External-Secrets sync
-# from the ok-shared Vault, with NO chart change.
+# Phase 2 will replace the "create Secret" step with a Vault sync from ok-shared
+# — a VaultStaticSecret via the Vault Secrets Operator (ADR-Platform-025) — with
+# NO chart change. That is the datacenter-envelope profile; edge/air-gapped
+# clusters keep this file-based profile (Secret Contract, ADR-Platform-011).
 #
 # Required env (set by the Makefile target):
 #   CLUSTER                cluster name (kubeconfig at $KUBECONFIG_PATH)
@@ -108,7 +110,8 @@ kubectl label namespace "$NAMESPACE" \
 
 # --- [2/6] credentials Secret (idempotent) --------------------------------
 # Charts read from this Secret; it must exist BEFORE the pods start. Later a
-# Vault sync (External Secrets) will produce the SAME Secret with no chart change.
+# Vault sync (Vault Secrets Operator, ADR-Platform-025) will produce the SAME
+# Secret with no chart change.
 #
 # Credential-handling invariant (ADR-Platform-024): secret values MUST NOT be
 # exposed via process arguments, shell tracing, stdout/stderr, logs, or temp


### PR DESCRIPTION
Corrects stale docs (README + install-observability.sh comments): the file-based step is the offline-reconcilable profile; datacenter-envelope clusters have the same Secret populated from Vault via a VaultStaticSecret (VSO, ADR-Platform-025), not External Secrets. The two profiles coexist by envelope, not sequential phases (Secret Contract, ADR-Platform-011). Docs-only, no functional change. Refs OK-110, ADR-Platform-025.