### PR TITLE
fix(observability): DIRTY should mean tracked code changed, not untracked files

### DIFF
--- a/install-observability.sh
+++ b/install-observability.sh
@@ -71,7 +71,12 @@ export KUBECONFIG="$KUBECONFIG_PATH"
 # worse than refusing to run.
 _here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 sha_of()   { git -C "$1" rev-parse HEAD 2>/dev/null || echo "unknown"; }
-state_of() { [ -z "$(git -C "$1" status --porcelain 2>/dev/null)" ] && echo clean || echo DIRTY; }
+# --untracked-files=no on purpose: DIRTY must mean "tracked code was modified",
+# which is what threatens reproducibility. Counting untracked files made every
+# FRESH-cluster run report DIRTY, because `make new` renders an untracked
+# <cluster>/ directory — i.e. it fired exactly when the clean marker mattered
+# most (OK-109 Part 1 evidence, ok-cluster f67aa1a).
+state_of() { [ -z "$(git -C "$1" status --porcelain --untracked-files=no 2>/dev/null)" ] && echo clean || echo DIRTY; }
 OK_CLUSTER_SHA="$(sha_of "$_here")";               OK_CLUSTER_STATE="$(state_of "$_here")"
 OBSERVABILITY_SHA="$(sha_of "$OK_OBSERVABILITY_PATH")"; OBSERVABILITY_STATE="$(state_of "$OK_OBSERVABILITY_PATH")"
 


### PR DESCRIPTION
## The bug

The provenance check added in #3 used `git status --porcelain`, which **counts untracked files**. `make new` renders an untracked `<cluster>/` directory, so every **fresh-cluster** run reported:

```
consumed ok-cluster: <sha> (DIRTY)
⚠️  a consumed checkout is DIRTY — this run is not reproducible conformance evidence
```

The warning fired exactly when the clean marker matters most — a first run on a new cluster is the canonical case for conformance evidence.

It bit for real in **OK-109 Part 1**: `ok-cluster f67aa1a` went into the acceptance evidence marked `DIRTY` with **zero tracked modifications**, the sole untracked item being the `ok-obs-verify/` render directory the run itself had just created.

## The fix

`--untracked-files=no`, so `DIRTY` means **tracked code was modified** — the thing that actually threatens reproducibility. Untracked render output doesn't change the behaviour of the consumed revision.

One line, plus a comment explaining why, so nobody "fixes" it back.

## Verification

| repo state | old check | new check |
|---|---|---|
| only an untracked directory | `DIRTY` | **`clean`** |
| a modified tracked file | `DIRTY` | `DIRTY` |

`bash -n` clean.

## Note for readers of the existing evidence

The OK-109 Part 1 evidence (comment 12631) and ADR-024's Path to acceptance both record `ok-cluster f67aa1a (DIRTY)` with an explicit caveat that it was this false positive. That evidence stands — the caveat is documented in both places — but runs after this merges will report `clean` for the same situation.

I deliberately did not hand-edit the check mid-run: a local edit would have made ok-cluster *genuinely* dirty and desynced the recorded SHA from `main`, which is worse than a documented false positive.

Refs OK-109.
