### PR TITLE
feat(storage): reap orphaned Longhorn volumes left behind by CDI imports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # OpenKubes Cluster Templating — Makefile
 # Usage: make new CLUSTER=ok3 TYPE=ubuntu [HA=true] [WORKERS=3] [NODE_SELECTOR=ok-gpu|NODE=ok-gpu]
-.PHONY: new render install kubeconfig install-cni install-storage install-ingress install-observability register-cluster unregister-cluster bootstrap annotate-pvcs upgrade clean teardown teardown-all e2e e2e-verify list status help
+.PHONY: new render install kubeconfig install-cni install-storage install-ingress install-observability register-cluster unregister-cluster bootstrap annotate-pvcs upgrade clean teardown teardown-all reap-orphaned-volumes e2e e2e-verify list status help
 .DEFAULT_GOAL := help
 
 CLUSTER       ?=
@@ -352,6 +352,13 @@ teardown-all: ## Tear down ALL rendered clusters (every dir with a cluster-confi
 		$(MAKE) --no-print-directory teardown CLUSTER=$$c CONFIRM=yes; \
 	done
 
+## reap-orphaned-volumes: list (dry-run) or delete orphaned Longhorn volumes left
+## behind by CDI import artifacts that `make teardown` never sees (OK-118).
+## Vars: MIN_AGE_HOURS (default 24), EXCLUDE_NAMESPACES, CONFIRM=yes to delete.
+## See docs/longhorn-orphaned-volumes.md.
+reap-orphaned-volumes:
+	@./longhorn-orphan-reaper.sh
+
 e2e: ## Full clean rebuild of ok-mgmt only: teardown+rebuild mgmt → reuse/create workload cluster → Crossplane wiring → OpenWebUI claim → verify (scope limited to mgmt, see OK-102) [CONFIRM=yes to skip prompt]
 	@if [ "$(CONFIRM)" != "yes" ]; then \
 		echo "⚠️  This will TEAR DOWN and RECREATE $(MGMT_CLUSTER)."; \
@@ -509,6 +516,7 @@ help:
 	@echo "  make clean         CLUSTER=ok1"
 	@echo "  make teardown      CLUSTER=ok-ai"
 	@echo "  make teardown-all                      # tear down ALL rendered clusters"
+	@echo "  make reap-orphaned-volumes [MIN_AGE_HOURS=24] [EXCLUDE_NAMESPACES=ok-x] [CONFIRM=yes] # clean orphaned Longhorn volumes (OK-118)"
 	@echo "  make e2e           [OLLAMA_URL=http://<ip>:11434] [CONFIRM=yes]  # asks for confirmation; rebuilds mgmt only; reuse/create WORKLOAD_CLUSTER; verify (OK-102)"
 	@echo "  make e2e-verify                        # verification matrix only"
 	@echo "  make list"

--- a/docs/longhorn-orphaned-volumes.md
+++ b/docs/longhorn-orphaned-volumes.md
@@ -1,0 +1,88 @@
+# Longhorn orphaned volumes — `longhorn-orphan-reaper.sh`
+
+> **Symptom:** a fresh cluster's VM disk PVC stays `Pending` indefinitely; the
+> CDI importer pod hangs `ContainerCreating`; `kubectl describe pvc` shows
+> `FailedAttachVolume ... volume ... is not ready for workloads`, or Longhorn
+> reports `robustness: faulted` with condition
+> `ReplicaSchedulingFailure: disks are unavailable;insufficient storage;precheck new replica failed` —
+> **even though `df -h` on the node shows plenty of free disk space.**
+>
+> Root cause discovered and fixed live: [OK-118](https://kubernauts.atlassian.net/browse/OK-118).
+
+## Why this happens
+
+`ok-storage-block` (the default Longhorn StorageClass, see the `ok-storage`
+repo / [ADR-Platform-009](../../openkubes/architecture/decisions/ADR-Platform-009-storage-contract.md))
+uses `reclaimPolicy: Retain` **by design** — it protects VM disks from
+accidental data loss if a PVC is deleted. `make teardown` already cleans up
+Retain-policy PVs and their Longhorn volumes, but only for PVCs still present
+in the torn-down cluster's namespace *at teardown time*.
+
+KubeVirt's CDI (Containerized Data Importer) creates its own transient
+`prime-*` / `prime-*-scratch` PVCs while importing a VM disk image. CDI
+deletes these itself once the import completes — **before `make teardown`
+ever runs** — so `make teardown`'s cleanup loop (which reads
+`kubectl get pvc -n $CLUSTER`) never sees them. The underlying Longhorn
+`Volume` object is left behind: the k8s PVC is gone
+(`status.kubernetesStatus.lastPVCRefAt` gets set), but the Volume itself
+survives forever.
+
+## Why it's silent until it isn't
+
+Longhorn's scheduler tracks committed replica size (`storageScheduled`) per
+disk, separately from actual on-disk usage. Every orphaned volume still
+counts against that budget. Once `storageScheduled` exceeds
+`storageMaximum - storageReserved` (a per-disk threshold, default reserves
+~30%), Longhorn refuses to schedule **any new replica** on that disk — even
+though the physical disk is nearly empty. This surfaces as a completely
+unrelated-looking failure on whatever cluster happens to be provisioned next.
+
+On 2026-07-27, **61 orphaned volumes** were found accumulated across the
+fleet — some over 3 weeks old, several in namespaces that no longer exist at
+all (`ok1-talos`, `ok2-rmf`, `ok3-openclaw`) — accounting for ~900GB of
+phantom scheduling budget. That was enough to fully block new replica
+placement on `ok-infra` and stall an unrelated cluster's control-plane disk
+for 75+ minutes before the cause was traced back here.
+
+## Diagnose
+
+```bash
+kubectl --kubeconfig ~/.kube/ok-infra.yaml -n longhorn-system get volumes.longhorn.io -o json | jq -r '
+  .items[]
+  | select(.status.state=="detached")
+  | select(.status.kubernetesStatus.lastPVCRefAt != "" and .status.kubernetesStatus.lastPVCRefAt != null)
+  | .metadata.name'
+```
+
+Any hit here is a candidate orphan — cross-check its `status.kubernetesStatus.namespace`
+against `kubectl get ns` and `kubectl get pvc -n <ns>` to confirm the PVC is
+really gone, not just mid-flight.
+
+## Clean up — `longhorn-orphan-reaper.sh`
+
+```bash
+# Dry-run: list orphans older than 24h (default), nothing is deleted
+./longhorn-orphan-reaper.sh
+
+# Actually delete
+CONFIRM=yes ./longhorn-orphan-reaper.sh
+
+# Tighter/looser age gate, protect a specific in-flight cluster's namespace
+MIN_AGE_HOURS=1 EXCLUDE_NAMESPACES=ok-obs-verify ./longhorn-orphan-reaper.sh
+```
+
+The `MIN_AGE_HOURS` gate (default 24h) exists because a volume can briefly
+show the exact same "detached + `lastPVCRefAt` set" signature while a cluster
+is actively being provisioned right now (CDI's prime/scratch PVCs cycle
+through create → use → delete within minutes) — without the age gate, this
+script could delete a volume that belongs to a build in progress.
+
+## Structural fix — not done here
+
+A dedicated `ok-storage-block-ephemeral` StorageClass (`reclaimPolicy: Delete`)
+for throwaway/verify clusters was considered but deliberately **not** built as
+part of this fix — it would extend the documented `ok-storage` contract
+(new class in the `ok-storage` repo, README/ADR-Platform-009 update, its own
+verify test), which is a bigger decision than a cleanup script. Tracked as a
+follow-on option in [OK-118](https://kubernauts.atlassian.net/browse/OK-118)
+if the reaper script turns out not to be enough on its own.

--- a/longhorn-orphan-reaper.sh
+++ b/longhorn-orphan-reaper.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# longhorn-orphan-reaper.sh — find/clean orphaned Longhorn volumes (OK-118)
+#
+# Background: ok-storage-block uses reclaimPolicy: Retain by design (protects
+# VM disks from accidental data loss on PVC delete — see ok-storage repo,
+# ADR-Platform-009). `make teardown` already cleans up Retain-policy PVs and
+# their Longhorn volumes for PVCs still present in the torn-down cluster's
+# namespace at teardown time. But CDI's own transient import artifacts
+# (prime-*/*-scratch PVCs, created during a KubeVirt VM disk import) are
+# deleted by CDI itself *before* teardown ever runs — so `make teardown`
+# never sees them, and they never get cleaned up.
+#
+# Left unchecked this accumulates orphaned Longhorn volumes that eat the
+# per-disk scheduling budget (storageScheduled vs storageMaximum minus
+# storageReserved) until Longhorn can no longer place new replicas AT ALL —
+# silently, until some unrelated fresh cluster's VM disk gets stuck
+# ImportScheduled/Pending indefinitely. 61 such orphans (some 3+ weeks old,
+# several in namespaces that no longer exist at all) were found and cleaned
+# up manually on 2026-07-27; this script is the repeatable version of that
+# cleanup. See docs/longhorn-orphaned-volumes.md for the full incident + the
+# diagnostic this was built from.
+#
+# "Orphaned" here = a Longhorn Volume with status.state == detached AND
+# status.kubernetesStatus.lastPVCRefAt set (its PVC is gone) AND that
+# timestamp is older than MIN_AGE_HOURS. The age gate exists because a
+# volume can legitimately show this exact signature for a few minutes during
+# an in-flight CDI import (its prime/scratch PVC cycles through
+# create -> use -> delete) — without it, this script could delete a volume
+# that's mid-provisioning for a cluster being built RIGHT NOW.
+#
+# Usage:
+#   ./longhorn-orphan-reaper.sh                      # dry-run, list only
+#   CONFIRM=yes ./longhorn-orphan-reaper.sh           # actually delete
+#   MIN_AGE_HOURS=1 ./longhorn-orphan-reaper.sh       # tighter/looser age gate
+#   EXCLUDE_NAMESPACES=ok-obs-verify,ok-foo ./longhorn-orphan-reaper.sh
+#
+# Config via env:
+#   KUBECONFIG_FILE     default: $HOME/.kube/ok-infra.yaml (the Longhorn host cluster)
+#   LONGHORN_NAMESPACE  default: longhorn-system
+#   MIN_AGE_HOURS       default: 24 -- only touch orphans older than this
+#   EXCLUDE_NAMESPACES  default: "" -- comma-separated namespaces to never touch
+#   CONFIRM             default: "" -- must be "yes" to actually delete anything
+#
+# Dependencies: kubectl, jq, date (GNU or BSD both supported).
+set -euo pipefail
+
+KUBECONFIG_FILE="${KUBECONFIG_FILE:-$HOME/.kube/ok-infra.yaml}"
+LONGHORN_NAMESPACE="${LONGHORN_NAMESPACE:-longhorn-system}"
+MIN_AGE_HOURS="${MIN_AGE_HOURS:-24}"
+EXCLUDE_NAMESPACES="${EXCLUDE_NAMESPACES:-}"
+CONFIRM="${CONFIRM:-}"
+
+for bin in kubectl jq; do
+  command -v "$bin" >/dev/null 2>&1 || { echo "ERROR: '$bin' required" >&2; exit 2; }
+done
+
+K() { kubectl --kubeconfig "${KUBECONFIG_FILE}" "$@"; }
+
+to_epoch() {
+  # Accepts RFC3339 (e.g. 2026-07-27T11:51:17Z). GNU date and BSD date (macOS)
+  # take this differently -- try GNU first, fall back to BSD syntax.
+  local ts="$1"
+  if date -u -d "$ts" +%s 2>/dev/null; then
+    return 0
+  fi
+  date -u -j -f "%Y-%m-%dT%H:%M:%SZ" "$ts" +%s 2>/dev/null || echo 0
+}
+
+echo "→ Scanning Longhorn volumes in ${LONGHORN_NAMESPACE} (kubeconfig: ${KUBECONFIG_FILE})"
+echo "  min age: ${MIN_AGE_HOURS}h · exclude namespaces: [${EXCLUDE_NAMESPACES:-none}] · mode: $( [ "${CONFIRM}" = "yes" ] && echo DELETE || echo DRY-RUN )"
+echo
+
+RAW_JSON="$(K -n "${LONGHORN_NAMESPACE}" get volumes.longhorn.io -o json)"
+
+NOW="$(date -u +%s)"
+MIN_AGE_SECONDS=$(( MIN_AGE_HOURS * 3600 ))
+
+TOTAL_BYTES=0
+KEPT=0
+TO_DELETE=()
+
+while IFS=$'\t' read -r NAME NS PVC SIZE LASTREF; do
+  [ -z "${NAME}" ] && continue
+
+  if [ -n "${EXCLUDE_NAMESPACES}" ] && [[ ",${EXCLUDE_NAMESPACES}," == *",${NS},"* ]]; then
+    echo "  SKIP    ${NAME}  (namespace ${NS} excluded)"
+    continue
+  fi
+
+  REF_EPOCH="$(to_epoch "${LASTREF}")"
+  AGE_SECONDS=$(( NOW - REF_EPOCH ))
+  AGE_H=$(( AGE_SECONDS / 3600 ))
+
+  if [ "${REF_EPOCH}" -eq 0 ] || [ "${AGE_SECONDS}" -lt "${MIN_AGE_SECONDS}" ]; then
+    echo "  KEEP    ${NAME}  ns=${NS} pvc=${PVC} age=${AGE_H}h (< ${MIN_AGE_HOURS}h threshold)"
+    KEPT=$((KEPT + 1))
+    continue
+  fi
+
+  SIZE_GI=$(( SIZE / 1073741824 ))
+  echo "  ORPHAN  ${NAME}  ns=${NS} pvc=${PVC} size=${SIZE_GI}Gi age=${AGE_H}h"
+  TOTAL_BYTES=$(( TOTAL_BYTES + SIZE ))
+  TO_DELETE+=("${NAME}")
+done < <(echo "${RAW_JSON}" | jq -r '
+  .items[]
+  | select(.status.state=="detached")
+  | select(.status.kubernetesStatus.lastPVCRefAt != "" and .status.kubernetesStatus.lastPVCRefAt != null)
+  | [.metadata.name, (.status.kubernetesStatus.namespace // "?"), (.status.kubernetesStatus.pvcName // "?"), (.spec.size // 0), .status.kubernetesStatus.lastPVCRefAt]
+  | @tsv
+')
+
+TOTAL_GI=$(( TOTAL_BYTES / 1073741824 ))
+echo
+echo "----"
+echo "orphans found (>= ${MIN_AGE_HOURS}h old): ${#TO_DELETE[@]}"
+echo "phantom scheduling budget: ~${TOTAL_GI}Gi"
+echo "kept (too young / excluded): ${KEPT}"
+
+if [ "${#TO_DELETE[@]}" -eq 0 ]; then
+  echo "RESULT: nothing to do."
+  exit 0
+fi
+
+if [ "${CONFIRM}" != "yes" ]; then
+  echo
+  echo "DRY-RUN only. Re-run with CONFIRM=yes to actually delete the ${#TO_DELETE[@]} volume(s) above."
+  exit 0
+fi
+
+echo
+echo "→ Deleting ${#TO_DELETE[@]} orphaned volume(s)..."
+for name in "${TO_DELETE[@]}"; do
+  echo "  deleting ${name}"
+  K -n "${LONGHORN_NAMESPACE}" delete volumes.longhorn.io "${name}" --ignore-not-found
+done
+echo "RESULT: reaped ${#TO_DELETE[@]} orphaned Longhorn volume(s), freed ~${TOTAL_GI}Gi of scheduling budget."


### PR DESCRIPTION
Fixes OK-118 (reaper-script part, scope A: no new StorageClass — see ticket). Adds `longhorn-orphan-reaper.sh` (dry-run by default, MIN_AGE_HOURS gate, EXCLUDE_NAMESPACES, CONFIRM=yes to delete), a `make reap-orphaned-volumes` target, and `docs/longhorn-orphaned-volumes.md` explaining the failure mode (CDI's own prime/scratch PVCs are deleted before `make teardown` ever runs, so their Longhorn volumes are never cleaned up, silently exhausting the per-disk scheduling budget).