### PR TITLE
feat(observability): pinned install-vso + OBSERVABILITY_SECRET_SOURCE=file|vault

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,38 @@ OBSERVABILITY_VALUES  ?= $(OK_OBSERVABILITY_PATH)/$(CLUSTER).provider-values.yam
 # (ADR-Platform-024 open item 1, OK-109).
 OK_OBSERVABILITY_REF  ?= $(shell cat $(SCRIPT_DIR)/ok-observability.ref 2>/dev/null)
 
+# ── datacenter secret profile: Vault + VSO (ADR-Platform-025, OK-117) ─────────
+# Which mechanism populates ok-observability-credentials:
+#   file  — ok-cluster writes it from a git-ignored provider-values file. The
+#           offline-reconcilable profile: edge/air-gapped, and any cluster with no
+#           Vault mount yet. Default, and it stays — not a phase to be replaced.
+#   vault — a VaultStaticSecret (VSO) syncs it from the central Vault on ok-shared.
+#           The datacenter-envelope profile.
+# The two coexist by envelope (Secret Contract, ADR-Platform-011).
+OBSERVABILITY_SECRET_SOURCE ?= file
+OBSERVABILITY_SECRET_SOURCES := file vault
+
+# VSO add-on, pinned and versioned as ADR-025 §Implementation & placement requires.
+# 1.5.0 is the version proven on ok-robotics — pinned to the proven one, not to latest.
+VSO_CHART_VERSION ?= 1.5.0
+VSO_NAMESPACE     ?= vault-secrets-operator
+
+# Provider Values for the vault path. Defaults match the ok-robotics evidence and
+# ADR-025 Path A; VAULT_ADDR is environment-specific (the stable host-level LB for
+# ok-shared ingress, MetalLB on ok-infra — not a VM node IP).
+VAULT_ADDR            ?= https://192.168.100.207:443
+VAULT_TLS_SERVER_NAME ?= vault.ok-shared.internal
+VAULT_CA_SECRET       ?= vault-ca
+KV_MOUNT              ?= secret
+KV_PATH               ?= $(CLUSTER)/obs/observability-credentials
+# The Vault role and the Kubernetes ServiceAccount are distinct identities that
+# coincide by convention (the VaultConfig composition derives roleName from
+# role.name). Kept separate on purpose — the role is *bound to* the SA, which is
+# not the same as being named after it.
+VAULT_ROLE            ?= sa-obs
+VSO_SERVICE_ACCOUNT   ?= sa-obs
+REFRESH_AFTER         ?= 60s
+
 # ── guard helper ──────────────────────────────────────────────────────────────
 require-cluster:
 	@test -n "$(CLUSTER)" || (echo "ERROR: CLUSTER is required, e.g. make $(MAKECMDGOALS) CLUSTER=ok3"; exit 1)
@@ -157,13 +189,37 @@ install-ingress: require-cluster kubeconfig ## ingress controller (Traefik) + In
 	done; \
 	echo "⚠️  No LoadBalancer IP after 60s — check MetalLB pool ok-pool on RKE2 host cluster"; exit 1
 
-install-observability: require-cluster kubeconfig ## Install ok-observability-standard profile + run the gated Contract Test (OK-79). Vars: OK_OBSERVABILITY_PATH, OK_OBSERVABILITY_REF, OBSERVABILITY_VALUES, CONTRACT_TEST_TIMEOUT, CONTRACT_TEST_RECEIVER_CAPTURE_URL
+install-vso: require-cluster kubeconfig ## Install the pinned Vault Secrets Operator (datacenter envelope, ADR-025). Vars: VSO_CHART_VERSION, VSO_NAMESPACE
+	@echo "Installing Vault Secrets Operator $(VSO_CHART_VERSION) on $(CLUSTER) (ns $(VSO_NAMESPACE))..."
+	@helm repo add hashicorp https://helm.releases.hashicorp.com 2>/dev/null || true
+	@helm repo update hashicorp 2>/dev/null
+	@# --version pins it (ADR-025 wants explicit + versioned, not latest);
+	@# upgrade --install makes it idempotent; --wait so the CRDs are established
+	@# before anything applies a VaultConnection/VaultAuth/VaultStaticSecret.
+	helm upgrade --install vault-secrets-operator hashicorp/vault-secrets-operator \
+		--version $(VSO_CHART_VERSION) \
+		--kubeconfig $(HOME)/.kube/$(CLUSTER).yaml \
+		--namespace $(VSO_NAMESPACE) --create-namespace \
+		--wait --timeout 5m
+	@echo "✅ Vault Secrets Operator $(VSO_CHART_VERSION) installed on $(CLUSTER)"
+
+install-observability: require-cluster kubeconfig ## Install ok-observability-standard profile + run the gated Contract Test (OK-79). Vars: OBSERVABILITY_SECRET_SOURCE=file|vault, OK_OBSERVABILITY_PATH, OK_OBSERVABILITY_REF, OBSERVABILITY_VALUES, CONTRACT_TEST_TIMEOUT, CONTRACT_TEST_RECEIVER_CAPTURE_URL
 	@CLUSTER=$(CLUSTER) \
 	 KUBECONFIG_PATH=$(HOME)/.kube/$(CLUSTER).yaml \
 	 OK_OBSERVABILITY_PATH=$(OK_OBSERVABILITY_PATH) \
 	 OK_OBSERVABILITY_REF=$(OK_OBSERVABILITY_REF) \
 	 OBSERVABILITY_VALUES=$(OBSERVABILITY_VALUES) \
 	 OBSERVABILITY_HELM_VALUES=$(OBSERVABILITY_HELM_VALUES) \
+	 OBSERVABILITY_SECRET_SOURCE=$(OBSERVABILITY_SECRET_SOURCE) \
+	 OBSERVABILITY_SECRET_SOURCES="$(OBSERVABILITY_SECRET_SOURCES)" \
+	 VAULT_ADDR=$(VAULT_ADDR) \
+	 VAULT_TLS_SERVER_NAME=$(VAULT_TLS_SERVER_NAME) \
+	 VAULT_CA_SECRET=$(VAULT_CA_SECRET) \
+	 KV_MOUNT=$(KV_MOUNT) \
+	 KV_PATH=$(KV_PATH) \
+	 VAULT_ROLE=$(VAULT_ROLE) \
+	 VSO_SERVICE_ACCOUNT=$(VSO_SERVICE_ACCOUNT) \
+	 REFRESH_AFTER=$(REFRESH_AFTER) \
 	 CONTRACT_TEST_TIMEOUT=$(CONTRACT_TEST_TIMEOUT) \
 	 CONTRACT_TEST_RECEIVER_CAPTURE_URL=$(CONTRACT_TEST_RECEIVER_CAPTURE_URL) \
 	 bash $(SCRIPT_DIR)/install-observability.sh

--- a/Makefile
+++ b/Makefile
@@ -191,6 +191,19 @@ install-ingress: require-cluster kubeconfig ## ingress controller (Traefik) + In
 
 install-vso: require-cluster kubeconfig ## Install the pinned Vault Secrets Operator (datacenter envelope, ADR-025). Vars: VSO_CHART_VERSION, VSO_NAMESPACE
 	@echo "Installing Vault Secrets Operator $(VSO_CHART_VERSION) on $(CLUSTER) (ns $(VSO_NAMESPACE))..."
+	@# Namespace FIRST, labelled BEFORE any workload is admitted. The upstream chart sets
+	@# neither capabilities.drop=[ALL] nor a seccompProfile, so a cluster ENFORCING Pod
+	@# Security "restricted" rejects the install — including its pre-upgrade-crds hook Job.
+	@# Labelling after helm would be too late: the pods are admitted during helm, not after.
+	@# `baseline` is the least level that admits it; unlike node-exporter/fluent-bit, VSO's
+	@# manager needs no host access, so `privileged` would over-grant.
+	@kubectl --kubeconfig $(HOME)/.kube/$(CLUSTER).yaml create namespace $(VSO_NAMESPACE) \
+		--dry-run=client -o yaml | kubectl --kubeconfig $(HOME)/.kube/$(CLUSTER).yaml apply -f -
+	@kubectl --kubeconfig $(HOME)/.kube/$(CLUSTER).yaml label namespace $(VSO_NAMESPACE) \
+		pod-security.kubernetes.io/enforce=baseline \
+		pod-security.kubernetes.io/warn=baseline \
+		pod-security.kubernetes.io/audit=baseline \
+		--overwrite
 	@helm repo add hashicorp https://helm.releases.hashicorp.com 2>/dev/null || true
 	@helm repo update hashicorp 2>/dev/null
 	@# --version pins it (ADR-025 wants explicit + versioned, not latest);
@@ -199,7 +212,7 @@ install-vso: require-cluster kubeconfig ## Install the pinned Vault Secrets Oper
 	helm upgrade --install vault-secrets-operator hashicorp/vault-secrets-operator \
 		--version $(VSO_CHART_VERSION) \
 		--kubeconfig $(HOME)/.kube/$(CLUSTER).yaml \
-		--namespace $(VSO_NAMESPACE) --create-namespace \
+		--namespace $(VSO_NAMESPACE) \
 		--wait --timeout 5m
 	@echo "✅ Vault Secrets Operator $(VSO_CHART_VERSION) installed on $(CLUSTER)"
 

--- a/install-observability.sh
+++ b/install-observability.sh
@@ -26,6 +26,18 @@
 #   OK_OBSERVABILITY_PATH  path to the ok-observability repo checkout
 #   OBSERVABILITY_VALUES   path to the provider-values file (see schema below)
 #
+# Secret source (OK-117) — which mechanism populates the credentials Secret:
+#   OBSERVABILITY_SECRET_SOURCE  file (default) | vault
+#     file  — this script writes the Secret from OBSERVABILITY_VALUES. The
+#             offline-reconcilable profile; required env is OBSERVABILITY_VALUES.
+#     vault — a VaultStaticSecret (VSO) syncs it from the central Vault, applied and
+#             waited on BEFORE the helm release. Requires VSO installed
+#             (`make install-vso`) and, per cluster, the Vault auth mount/role, the
+#             ServiceAccount and the CA secret. No provider-values file is used;
+#             the gate's passwords are read back from the materialised Secret.
+#     Vault-path env: VAULT_ADDR, VAULT_TLS_SERVER_NAME, VAULT_CA_SECRET, KV_MOUNT,
+#     KV_PATH, VAULT_ROLE, VSO_SERVICE_ACCOUNT, REFRESH_AFTER, VSS_SYNC_TIMEOUT.
+#
 # Optional env (forwarded to the gate; unset => the gate's own default):
 #   OK_OBSERVABILITY_REF              assert which ok-observability revision may
 #                                     be consumed (see "provenance" below)
@@ -50,13 +62,40 @@ done
 [ -n "${CLUSTER:-}" ]              || { echo "❌ CLUSTER is required"; exit 2; }
 [ -f "${KUBECONFIG_PATH:-}" ]      || { echo "❌ kubeconfig not found: ${KUBECONFIG_PATH:-<unset>} — run 'make kubeconfig CLUSTER=${CLUSTER}' first"; exit 2; }
 [ -d "$PROFILE" ]                  || { echo "❌ profile not found: $PROFILE — set OK_OBSERVABILITY_PATH to your ok-observability checkout"; exit 2; }
-if [ ! -f "${OBSERVABILITY_VALUES:-}" ]; then
+# OK-117: which mechanism populates the credentials Secret. Validated against the
+# allowed set so a typo fails loudly instead of silently selecting a profile — the
+# same class of defect as OK-119's TYPE default.
+SECRET_SOURCE="${OBSERVABILITY_SECRET_SOURCE:-file}"
+case " ${OBSERVABILITY_SECRET_SOURCES:-file vault} " in
+  *" $SECRET_SOURCE "*) ;;
+  *) echo "❌ OBSERVABILITY_SECRET_SOURCE='$SECRET_SOURCE' is not one of: ${OBSERVABILITY_SECRET_SOURCES:-file vault}"; exit 2 ;;
+esac
+
+# The provider-values file is a precondition of the FILE profile only. Requiring it
+# on the vault path would force a datacenter cluster to supply passwords it never
+# uses — the Secret comes from Vault there.
+if [ "$SECRET_SOURCE" = file ] && [ ! -f "${OBSERVABILITY_VALUES:-}" ]; then
   echo "❌ provider-values file not found: ${OBSERVABILITY_VALUES:-<unset>}"
   echo "   Create a git-ignored file with:"
   echo "     grafanaAdminPassword: \"...\""
   echo "     opensearchAdminPassword: \"...\""
   echo "   and pass it via OBSERVABILITY_VALUES=<path> (or place it at the default path)."
+  echo "   Or select the datacenter profile: OBSERVABILITY_SECRET_SOURCE=vault"
   exit 2
+fi
+
+if [ "$SECRET_SOURCE" = vault ]; then
+  VSS_TEMPLATE="${OK_OBSERVABILITY_PATH}/implementations/vault-secrets-operator/vault-secret-sync.template.yaml"
+  [ -f "$VSS_TEMPLATE" ] || {
+    echo "❌ VaultStaticSecret template not found: $VSS_TEMPLATE"
+    echo "   The capability repo checkout predates OK-117. Update ok-observability, or"
+    echo "   use OBSERVABILITY_SECRET_SOURCE=file."
+    exit 2
+  }
+  command -v envsubst >/dev/null 2>&1 || {
+    echo "❌ envsubst is required to render the VaultStaticSecret template (gettext package)"
+    exit 2
+  }
 fi
 
 export KUBECONFIG="$KUBECONFIG_PATH"
@@ -100,12 +139,25 @@ echo "  consumed ok-observability: ${OBSERVABILITY_SHA} (${OBSERVABILITY_STATE})
 [ "$OK_CLUSTER_STATE" = clean ] && [ "$OBSERVABILITY_STATE" = clean ] || \
   echo "  ⚠️  a consumed checkout is DIRTY — this run is not reproducible conformance evidence"
 
-# --- read passwords from provider-values ----------------------------------
-read_val() { python3 -c "import sys,yaml; print(yaml.safe_load(open('$OBSERVABILITY_VALUES')).get('$1',''))"; }
-GRAFANA_PASSWORD="$(read_val grafanaAdminPassword)"
-OPENSEARCH_PASSWORD="$(read_val opensearchAdminPassword)"
-[ -n "$GRAFANA_PASSWORD" ]    || { echo "❌ grafanaAdminPassword empty in $OBSERVABILITY_VALUES"; exit 2; }
-[ -n "$OPENSEARCH_PASSWORD" ] || { echo "❌ opensearchAdminPassword empty in $OBSERVABILITY_VALUES"; exit 2; }
+# --- read passwords from provider-values (FILE profile only) ---------------
+# On the vault path the Secret is authored by VSO, so the values are read back
+# from the materialised Secret after it syncs (see [2/6]) — there is no
+# provider-values file to read.
+if [ "$SECRET_SOURCE" = file ]; then
+  read_val() { python3 -c "import sys,yaml; print(yaml.safe_load(open('$OBSERVABILITY_VALUES')).get('$1',''))"; }
+  GRAFANA_PASSWORD="$(read_val grafanaAdminPassword)"
+  OPENSEARCH_PASSWORD="$(read_val opensearchAdminPassword)"
+  [ -n "$GRAFANA_PASSWORD" ]    || { echo "❌ grafanaAdminPassword empty in $OBSERVABILITY_VALUES"; exit 2; }
+  [ -n "$OPENSEARCH_PASSWORD" ] || { echo "❌ opensearchAdminPassword empty in $OBSERVABILITY_VALUES"; exit 2; }
+else
+  # VSO's CRDs must be registered before we can apply its resources. Checking here
+  # turns "no matches for kind VaultStaticSecret" into an actionable instruction.
+  kubectl get crd vaultstaticsecrets.secrets.hashicorp.com >/dev/null 2>&1 || {
+    echo "❌ VaultStaticSecret CRD not registered on ${CLUSTER}."
+    echo "   Run: make install-vso CLUSTER=${CLUSTER}"
+    exit 2
+  }
+fi
 
 # --- [1/6] namespace + Pod Security Admission labels ----------------------
 echo "  [1/6] namespace ${NAMESPACE} + PSA privileged labels (node-exporter/fluent-bit need host access)"
@@ -128,7 +180,8 @@ kubectl label namespace "$NAMESPACE" \
 # 0600 files in a umask-077 temp dir and feed them via `--from-file`; wipe the
 # dir immediately and on any exit. The rendered Secret YAML is piped straight to
 # `kubectl apply` and never echoed/tee'd/logged.
-echo "  [2/6] Secret ${SECRET_NAME} (grafana-admin-user/password, opensearch-admin-password)"
+if [ "$SECRET_SOURCE" = file ]; then
+echo "  [2/6] Secret ${SECRET_NAME} from provider-values (offline profile)"
 _old_umask="$(umask)"; umask 077
 _cred_dir="$(mktemp -d)"
 trap 'rm -rf "$_cred_dir"' EXIT INT TERM
@@ -141,6 +194,56 @@ kubectl -n "$NAMESPACE" create secret generic "$SECRET_NAME" \
   --from-file=opensearch-admin-password="$_cred_dir/opensearch-admin-password" \
   --dry-run=client -o yaml | kubectl apply -f -
 rm -rf "$_cred_dir"; trap - EXIT INT TERM; umask "$_old_umask"
+else
+# Datacenter profile: VSO authors the Secret from Vault. The template is owned by
+# the capability repo (ok-cluster installs, does not own) and rendered per cluster.
+# The explicit envsubst variable list is required, not stylistic: a bare envsubst
+# substitutes every ${VAR} in the input and would blank unrelated placeholders.
+# VAULT_ROLE may be unused by an older template — a listed-but-absent variable is a
+# harmless no-op, so this works against both template revisions.
+echo "  [2/6] Secret ${SECRET_NAME} via VaultStaticSecret (VSO, datacenter profile)"
+echo "        vault=${VAULT_ADDR} mount=kubernetes/${CLUSTER} kv=${KV_MOUNT}/${KV_PATH}"
+CLUSTER="$CLUSTER" \
+OBS_NAMESPACE="$NAMESPACE" \
+SECRET_NAME="$SECRET_NAME" \
+VAULT_ADDR="${VAULT_ADDR}" \
+VAULT_TLS_SERVER_NAME="${VAULT_TLS_SERVER_NAME}" \
+VAULT_CA_SECRET="${VAULT_CA_SECRET}" \
+KV_MOUNT="${KV_MOUNT}" \
+KV_PATH="${KV_PATH}" \
+VAULT_ROLE="${VAULT_ROLE:-$VSO_SERVICE_ACCOUNT}" \
+VSO_SERVICE_ACCOUNT="${VSO_SERVICE_ACCOUNT}" \
+REFRESH_AFTER="${REFRESH_AFTER}" \
+  envsubst '$CLUSTER $OBS_NAMESPACE $SECRET_NAME $VAULT_ADDR $VAULT_TLS_SERVER_NAME $VAULT_CA_SECRET $KV_MOUNT $KV_PATH $VAULT_ROLE $VSO_SERVICE_ACCOUNT $REFRESH_AFTER' \
+  < "$VSS_TEMPLATE" | kubectl apply -f -
+
+# ORDERING IS THE DELIVERABLE (ADR-025 criterion 7): the Secret must exist before
+# the Helm release, because OpenSearch 2.12+ refuses to start without the admin
+# password at first boot. Waiting here — not after helm — is what makes this
+# fresh-install ordering rather than a migration.
+echo "        waiting for VaultStaticSecret to report SecretSynced (before helm)"
+kubectl -n "$NAMESPACE" wait --for=condition=SecretSynced \
+  "vaultstaticsecret/${SECRET_NAME}" --timeout="${VSS_SYNC_TIMEOUT:-120}s" || {
+    echo "❌ VaultStaticSecret did not sync. Common causes:"
+    echo "   - Vault auth mount kubernetes/${CLUSTER} or role ${VAULT_ROLE:-$VSO_SERVICE_ACCOUNT} missing (VaultConfig XR)"
+    echo "   - ServiceAccount ${VSO_SERVICE_ACCOUNT} absent in ${NAMESPACE}"
+    echo "   - CA secret ${VAULT_CA_SECRET} absent in ${NAMESPACE}, or ${VAULT_ADDR} unreachable"
+    echo "   - no credentials at ${KV_MOUNT}/${KV_PATH}"
+    kubectl -n "$NAMESPACE" get vaultstaticsecret "${SECRET_NAME}" -o wide 2>/dev/null || true
+    exit 1
+  }
+
+# The gate needs the admin passwords to query Grafana and OpenSearch. On this path
+# Vault is the source of truth, so read them back from the materialised Secret.
+# Captured into shell variables — never argv, never echoed (ADR-024 invariant).
+GRAFANA_PASSWORD="$(kubectl -n "$NAMESPACE" get secret "$SECRET_NAME" -o jsonpath='{.data.grafana-admin-password}' | base64 -d)"
+OPENSEARCH_PASSWORD="$(kubectl -n "$NAMESPACE" get secret "$SECRET_NAME" -o jsonpath='{.data.opensearch-admin-password}' | base64 -d)"
+[ -n "$GRAFANA_PASSWORD" ] && [ -n "$OPENSEARCH_PASSWORD" ] || {
+  echo "❌ Secret ${SECRET_NAME} synced but a password key is empty — check the Vault KV payload keys"
+  exit 1
+}
+echo "        ✅ ${SECRET_NAME} materialised by VSO"
+fi
 
 # --- [3/6] helm dependency build + install ---------------------------------
 # `build` reuses the existing Chart.lock and does NOT refresh every configured


### PR DESCRIPTION
The ok-cluster half of OK-117 — the two obligations ADR-025 §Implementation & placement declares. With these, crit. 7 evidence is an **ok-cluster-driven install** rather than a hand-assembled ordering.

## 1. `make install-vso`

`hashicorp/vault-secrets-operator` pinned to chart **1.5.0** — the version proven on ok-robotics, not `latest`. `upgrade --install` for idempotence, `--wait` so the CRDs are established before anything applies a `VaultConnection`/`VaultAuth`/`VaultStaticSecret`.

## 2. `OBSERVABILITY_SECRET_SOURCE=file|vault`

| | |
|---|---|
| `file` *(default)* | today's behaviour, byte-for-byte. Nothing existing changes. |
| `vault` | renders the capability repo's template per cluster, applies it, and **waits for `SecretSynced` before helm**. |

**The wait placement is the deliverable, not an implementation detail.** The Secret must exist before the Helm release because OpenSearch 2.12+ refuses to start without the admin password at first boot. Waiting *after* helm would demonstrate migration (criterion 6, already proven on ok-robotics) rather than fresh-install ordering (criterion 7, the open one).

Three further changes that follow from that:

- **The value is validated** against the allowed set, so `OBSERVABILITY_SECRET_SOURCE=Vault` aborts rather than silently selecting a profile — the same defect class as OK-119's `TYPE` default.
- **The provider-values precondition is now conditional on `file`.** Requiring it on the vault path would force a datacenter cluster to supply passwords it never uses.
- **The gate's passwords come from the materialised Secret** on the vault path, since Vault is the source of truth there. Captured into shell variables — never argv, never echoed, per the ADR-024 invariant.

## Things I checked rather than assumed

- **`SecretSynced` is the real condition name** — read off the live proven `VaultStaticSecret` on ok-robotics (`SecretSynced`/`Healthy`/`Ready`), not inferred from the `kubectl get` column headers.
- **No merge-order dependency on ok-observability#7.** `VAULT_ROLE` and `VSO_SERVICE_ACCOUNT` are passed separately; a listed-but-unused `envsubst` variable is a harmless no-op, verified, so this renders correctly against both the current template and the `VAULT_ROLE` revision.
- **Two preconditions that would otherwise fail cryptically**: the CRD check turns *"no matches for kind VaultStaticSecret"* into `Run: make install-vso CLUSTER=…`, and a capability checkout predating the template says so explicitly. Sync failure prints the four things that actually cause it — auth mount/role, ServiceAccount, CA secret or Vault reachability, or missing KV credentials.

## Verification (no cluster needed)

```
default (no SECRET_SOURCE)        -> unchanged behaviour
OBSERVABILITY_SECRET_SOURCE=Vault -> aborts: not one of: file vault
vault + no provider-values        -> does NOT demand the file
vault, CRD absent                 -> "Run: make install-vso CLUSTER=fake"
vault, old capability checkout    -> "checkout predates OK-117"
render via the exact invocation   -> 3 valid resources,
                                    mount=kubernetes/ok-obs-verify role=sa-obs sa=sa-obs
                                    kv=secret/<cluster>/obs/observability-credentials
```

`bash -n` and `make -n` clean.

**Not yet exercised end-to-end**: the actual vault path on a live cluster. That is crit. 7 / pass 2 itself, which needs the Vault auth mount for `ok-obs-verify` — the pairing step. I did not fake it, and I did not run it against ok-robotics, which is load-bearing for OK-110's evidence.

## Disclosure: secret-guard override

The `aios` secret guard flagged four lines and I committed with `ALLOW_SECRET=1`. Verified false positives before overriding:

- All four are assignments whose RHS is a **command substitution** — no literal values anywhere in the diff.
- **Two of them are pre-existing on `main`**; my change only wrapped them in an `if`.
- The new pair reference key *names* in a jsonpath (`{.data.grafana-admin-password}`), not values.
- No literal credential assignment and no opaque blob in the diff.

The guard is pattern-matching `PASSWORD="…"`. Flagging it here so the override is visible rather than buried in git history.

Refs OK-117. Companion: ok-observability#6 (merged), #7 (open).
