### PR TITLE
feat(cluster): declare ok-flatcar workload cluster

### DIFF
--- a/ok-flatcar/cilium-values.yaml
+++ b/ok-flatcar/cilium-values.yaml
@@ -1,0 +1,24 @@
+# OK-125 Flatcar-only CNI profile.
+# Chart: cilium 1.19.6
+# Chart SHA-256: 21c43cf53841f9ab0375047d95aa4c64051ea52bbd2c679416e6408f5f1c9179
+#
+# The KubeVirt control-plane Service is bound to ENDPOINT_IP by the sibling
+# cluster template. No Talos KubePrism or Ubuntu runtime-discovery value is
+# inherited here.
+operator:
+  replicas: 1
+
+ipam:
+  mode: kubernetes
+
+kubeProxyReplacement: true
+k8sServiceHost: 192.168.100.211
+k8sServicePort: 6443
+
+routingMode: tunnel
+tunnelProtocol: vxlan
+
+cgroup:
+  autoMount:
+    enabled: true
+  hostRoot: /sys/fs/cgroup

--- a/ok-flatcar/cluster-config.yaml
+++ b/ok-flatcar/cluster-config.yaml
@@ -1,0 +1,47 @@
+controlPlane:
+  cores: 2
+  disk: 20Gi
+  memory: 4Gi
+  replicas: 1
+name: ok-flatcar
+network:
+  endpoint: 192.168.100.211
+  podCIDR: 10.35.0.0/16
+  serviceCIDR: 10.96.48.0/20
+nodeSelector: ok-infra
+os:
+  architecture: amd64
+  profile: flatcar-kubevirt
+  contractRef: ADR-Platform-016
+  distribution: flatcar
+  version: 4593.2.4
+  imageDigest: sha256:49b72cf26d27d4747d6252c64582f17fdbd7d629993beebbcf997794333a978a
+  identity: sha256:afd862491620adbaeb3c25aa82ae89a3bd748ae5976cf66fbf9613a732ba35bb
+  profileRevision: 1
+  status: production-constrained
+  deployable: true
+  supportDecision: docs/adr/ADR-009-flatcar-kubevirt-constrained-support.md
+  goldenImage:
+    namespace: ok-images
+    claim: flatcar-stable-4593-2-4-amd64-kubevirt
+    published: true
+    storageClass: local-path
+provider: kubevirt
+providerProfile:
+  goldenImageStorageClass: local-path
+type: flatcar
+upgrade:
+  strategy: blue-green
+  workloadMigration:
+    stateless: gitops
+    stateful: app-native
+versions:
+  kubernetes: v1.34.1
+workers:
+  cores: 2
+  disk: 20Gi
+  memory: 4Gi
+  replicas: 1
+bootstrap:
+  format: ignition
+  virtualMachineBootstrapCheck: none

--- a/ok-flatcar/cluster-v2.yaml
+++ b/ok-flatcar/cluster-v2.yaml
@@ -1,0 +1,481 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ok-flatcar
+  labels:
+    openkubes.io/type: flatcar
+    openkubes.io/provider: kubevirt
+    openkubes.io/profile: flatcar-kubevirt
+    openkubes.io/profile-revision: "1"
+    openkubes.io/os-identity: afd862491620
+    openkubes.io/adoption-status: production-constrained
+    openkubes.io/deployable: "true"
+  annotations:
+    openkubes.io/os-identity-full: sha256:afd862491620adbaeb3c25aa82ae89a3bd748ae5976cf66fbf9613a732ba35bb
+    openkubes.io/os-image-digest: sha256:49b72cf26d27d4747d6252c64582f17fdbd7d629993beebbcf997794333a978a
+    openkubes.io/golden-image-published: "true"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ok-flatcar-golden-image-cloner
+  namespace: ok-images
+  labels:
+    openkubes.io/type: flatcar
+    openkubes.io/provider: kubevirt
+    openkubes.io/profile: flatcar-kubevirt
+    openkubes.io/adoption-status: production-constrained
+    openkubes.io/deployable: "true"
+rules:
+  - apiGroups:
+      - cdi.kubevirt.io
+    resources:
+      - datavolumes/source
+    verbs:
+      - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ok-flatcar-golden-image-cloner
+  namespace: ok-images
+  labels:
+    openkubes.io/type: flatcar
+    openkubes.io/provider: kubevirt
+    openkubes.io/profile: flatcar-kubevirt
+    openkubes.io/adoption-status: production-constrained
+    openkubes.io/deployable: "true"
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: ok-flatcar
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ok-flatcar-golden-image-cloner
+---
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: Cluster
+metadata:
+  name: ok-flatcar
+  namespace: ok-flatcar
+  labels:
+    openkubes.io/type: flatcar
+    openkubes.io/provider: kubevirt
+    openkubes.io/profile: flatcar-kubevirt
+    openkubes.io/profile-revision: "1"
+    openkubes.io/os-identity: afd862491620
+    openkubes.io/adoption-status: production-constrained
+    openkubes.io/deployable: "true"
+  annotations:
+    openkubes.io/os-identity-full: sha256:afd862491620adbaeb3c25aa82ae89a3bd748ae5976cf66fbf9613a732ba35bb
+    openkubes.io/os-image-digest: sha256:49b72cf26d27d4747d6252c64582f17fdbd7d629993beebbcf997794333a978a
+    openkubes.io/golden-image-published: "true"
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+        - 10.35.0.0/16
+    services:
+      cidrBlocks:
+        - 10.96.48.0/20
+  controlPlaneRef:
+    apiGroup: controlplane.cluster.x-k8s.io
+    kind: KubeadmControlPlane
+    name: ok-flatcar-cp
+  infrastructureRef:
+    apiGroup: infrastructure.cluster.x-k8s.io
+    kind: KubevirtCluster
+    name: ok-flatcar
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+kind: KubevirtCluster
+metadata:
+  name: ok-flatcar
+  namespace: ok-flatcar
+  labels:
+    openkubes.io/type: flatcar
+    openkubes.io/provider: kubevirt
+    openkubes.io/profile: flatcar-kubevirt
+    openkubes.io/profile-revision: "1"
+    openkubes.io/os-identity: afd862491620
+    openkubes.io/adoption-status: production-constrained
+    openkubes.io/deployable: "true"
+spec:
+  controlPlaneServiceTemplate:
+    metadata:
+      annotations:
+        metallb.universe.tf/loadBalancerIPs: 192.168.100.211
+    spec:
+      type: LoadBalancer
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+kind: KubevirtMachineTemplate
+metadata:
+  name: ok-flatcar-cp-afd862491620
+  namespace: ok-flatcar
+  labels:
+    openkubes.io/type: flatcar
+    openkubes.io/provider: kubevirt
+    openkubes.io/profile: flatcar-kubevirt
+    openkubes.io/profile-revision: "1"
+    openkubes.io/os-identity: afd862491620
+    openkubes.io/adoption-status: production-constrained
+    openkubes.io/deployable: "true"
+  annotations:
+    openkubes.io/os-identity-full: sha256:afd862491620adbaeb3c25aa82ae89a3bd748ae5976cf66fbf9613a732ba35bb
+    openkubes.io/os-image-digest: sha256:49b72cf26d27d4747d6252c64582f17fdbd7d629993beebbcf997794333a978a
+    openkubes.io/golden-image-published: "true"
+spec:
+  template:
+    spec:
+      virtualMachineBootstrapCheck:
+        checkStrategy: none
+      virtualMachineTemplate:
+        metadata:
+          namespace: ok-flatcar
+          labels:
+            openkubes.io/type: flatcar
+            openkubes.io/provider: kubevirt
+            openkubes.io/profile: flatcar-kubevirt
+            openkubes.io/profile-revision: "1"
+            openkubes.io/os-identity: afd862491620
+            openkubes.io/adoption-status: production-constrained
+            openkubes.io/deployable: "true"
+        spec:
+          runStrategy: Always
+          dataVolumeTemplates:
+            - metadata:
+                name: ok-flatcar-cp-afd862491620-boot
+              spec:
+                source:
+                  pvc:
+                    namespace: ok-images
+                    name: flatcar-stable-4593-2-4-amd64-kubevirt
+                storage:
+                  accessModes:
+                    - ReadWriteOnce
+                  resources:
+                    requests:
+                      storage: 20Gi
+                  storageClassName: local-path
+          template:
+            metadata:
+              labels:
+                openkubes.io/type: flatcar
+                openkubes.io/provider: kubevirt
+                openkubes.io/profile: flatcar-kubevirt
+                openkubes.io/profile-revision: "1"
+                openkubes.io/os-identity: afd862491620
+                openkubes.io/adoption-status: production-constrained
+                openkubes.io/deployable: "true"
+            spec:
+              nodeSelector:
+                kubernetes.io/hostname: ok-infra
+              domain:
+                cpu:
+                  cores: 2
+                devices:
+                  disks:
+                    - disk:
+                        bus: virtio
+                      name: rootdisk
+                  networkInterfaceMultiqueue: true
+                memory:
+                  guest: 4Gi
+              evictionStrategy: External
+              volumes:
+                - dataVolume:
+                    name: ok-flatcar-cp-afd862491620-boot
+                  name: rootdisk
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+kind: KubeadmControlPlane
+metadata:
+  name: ok-flatcar-cp
+  namespace: ok-flatcar
+  labels:
+    openkubes.io/type: flatcar
+    openkubes.io/provider: kubevirt
+    openkubes.io/profile: flatcar-kubevirt
+    openkubes.io/profile-revision: "1"
+    openkubes.io/os-identity: afd862491620
+    openkubes.io/adoption-status: production-constrained
+    openkubes.io/deployable: "true"
+spec:
+  replicas: 1
+  version: v1.34.1
+  rollout:
+    strategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxSurge: 1
+  machineTemplate:
+    spec:
+      infrastructureRef:
+        apiGroup: infrastructure.cluster.x-k8s.io
+        kind: KubevirtMachineTemplate
+        name: ok-flatcar-cp-afd862491620
+  kubeadmConfigSpec:
+    format: ignition
+    ignition:
+      containerLinuxConfig:
+        additionalConfig: |
+          systemd:
+            units:
+              - name: kubeadm.service
+                enabled: true
+                dropins:
+                  - name: 10-flatcar.conf
+                    contents: |
+                      [Unit]
+                      Requires=containerd.service
+                      Wants=kubelet.service
+                      After=containerd.service
+                      OnFailure=ok125-kubeadm-failure.service
+                      [Service]
+                      Environment=PATH=/opt/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
+                      TimeoutStartSec=0
+                      StandardError=journal+console
+                      ExecStartPost=/bin/sh -c 'echo OK125_KUBEADM_SUCCEEDED >/dev/ttyS0'
+              - name: ok125-kubeadm-failure.service
+                contents: |
+                  [Unit]
+                  Description=OK-125 redacted kubeadm failure marker
+
+                  [Service]
+                  Type=oneshot
+                  ExecStart=/bin/sh -c '/bin/systemctl show kubeadm.service --property=Result --property=ExecMainStatus >/dev/ttyS0'
+                  ExecStart=/bin/sh -c '/bin/journalctl -u kubeadm.service -b --no-pager -n 200 -o cat | /bin/grep -Ei "([[]ERROR |error execution phase|kubelet-check|control-plane|timed out|unable to|failed to|not found|unsupported|connection refused|deadline exceeded|CRI)" | /bin/grep -Eiv "(token|password|secret|certificate|private[ -]?key|client-key|key-data|discovery)" >/dev/ttyS0 || true'
+              - name: kubelet.service
+                enabled: true
+                contents: |
+                  [Unit]
+                  Description=kubelet: Kubernetes Node Agent (Flatcar profile)
+                  Wants=network-online.target
+                  Requires=containerd.service
+                  After=network-online.target containerd.service
+                  StartLimitIntervalSec=0
+
+                  [Service]
+                  Environment="KUBELET_KUBECONFIG_ARGS=--bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --kubeconfig=/etc/kubernetes/kubelet.conf"
+                  Environment=KUBELET_CONFIG_ARGS=--config=/var/lib/kubelet/config.yaml
+                  EnvironmentFile=-/var/lib/kubelet/kubeadm-flags.env
+                  EnvironmentFile=-/etc/default/kubelet
+                  ExecStart=/opt/bin/kubelet $KUBELET_KUBECONFIG_ARGS $KUBELET_CONFIG_ARGS $KUBELET_KUBEADM_ARGS $KUBELET_EXTRA_ARGS
+                  Restart=always
+                  RestartSec=10
+
+                  [Install]
+                  WantedBy=multi-user.target
+    initConfiguration:
+      skipPhases:
+        - addon/kube-proxy
+      nodeRegistration:
+        criSocket: /var/run/containerd/containerd.sock
+        kubeletExtraArgs:
+          - name: node-labels
+            value: openkubes.io/os-identity=afd862491620,openkubes.io/profile-revision=1
+    joinConfiguration:
+      nodeRegistration:
+        criSocket: /var/run/containerd/containerd.sock
+        kubeletExtraArgs:
+          - name: node-labels
+            value: openkubes.io/os-identity=afd862491620,openkubes.io/profile-revision=1
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+kind: KubevirtMachineTemplate
+metadata:
+  name: ok-flatcar-workers-afd862491620
+  namespace: ok-flatcar
+  labels:
+    openkubes.io/type: flatcar
+    openkubes.io/provider: kubevirt
+    openkubes.io/profile: flatcar-kubevirt
+    openkubes.io/profile-revision: "1"
+    openkubes.io/os-identity: afd862491620
+    openkubes.io/adoption-status: production-constrained
+    openkubes.io/deployable: "true"
+  annotations:
+    openkubes.io/os-identity-full: sha256:afd862491620adbaeb3c25aa82ae89a3bd748ae5976cf66fbf9613a732ba35bb
+    openkubes.io/os-image-digest: sha256:49b72cf26d27d4747d6252c64582f17fdbd7d629993beebbcf997794333a978a
+    openkubes.io/golden-image-published: "true"
+spec:
+  template:
+    spec:
+      virtualMachineBootstrapCheck:
+        checkStrategy: none
+      virtualMachineTemplate:
+        metadata:
+          namespace: ok-flatcar
+          labels:
+            openkubes.io/type: flatcar
+            openkubes.io/provider: kubevirt
+            openkubes.io/profile: flatcar-kubevirt
+            openkubes.io/profile-revision: "1"
+            openkubes.io/os-identity: afd862491620
+            openkubes.io/adoption-status: production-constrained
+            openkubes.io/deployable: "true"
+        spec:
+          runStrategy: Always
+          dataVolumeTemplates:
+            - metadata:
+                name: ok-flatcar-workers-afd862491620-boot
+              spec:
+                source:
+                  pvc:
+                    namespace: ok-images
+                    name: flatcar-stable-4593-2-4-amd64-kubevirt
+                storage:
+                  accessModes:
+                    - ReadWriteOnce
+                  resources:
+                    requests:
+                      storage: 20Gi
+                  storageClassName: local-path
+          template:
+            metadata:
+              labels:
+                openkubes.io/type: flatcar
+                openkubes.io/provider: kubevirt
+                openkubes.io/profile: flatcar-kubevirt
+                openkubes.io/profile-revision: "1"
+                openkubes.io/os-identity: afd862491620
+                openkubes.io/adoption-status: production-constrained
+                openkubes.io/deployable: "true"
+            spec:
+              nodeSelector:
+                kubernetes.io/hostname: ok-infra
+              domain:
+                cpu:
+                  cores: 2
+                devices:
+                  disks:
+                    - disk:
+                        bus: virtio
+                      name: rootdisk
+                  networkInterfaceMultiqueue: true
+                memory:
+                  guest: 4Gi
+              evictionStrategy: External
+              volumes:
+                - dataVolume:
+                    name: ok-flatcar-workers-afd862491620-boot
+                  name: rootdisk
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
+kind: KubeadmConfigTemplate
+metadata:
+  name: ok-flatcar-workers-afd862491620
+  namespace: ok-flatcar
+  labels:
+    openkubes.io/type: flatcar
+    openkubes.io/provider: kubevirt
+    openkubes.io/profile: flatcar-kubevirt
+    openkubes.io/profile-revision: "1"
+    openkubes.io/os-identity: afd862491620
+    openkubes.io/adoption-status: production-constrained
+    openkubes.io/deployable: "true"
+spec:
+  template:
+    spec:
+      format: ignition
+      ignition:
+        containerLinuxConfig:
+          additionalConfig: |
+            systemd:
+              units:
+                - name: kubeadm.service
+                  enabled: true
+                  dropins:
+                    - name: 10-flatcar.conf
+                      contents: |
+                        [Unit]
+                        Requires=containerd.service
+                        Wants=kubelet.service
+                        After=containerd.service
+                        OnFailure=ok125-kubeadm-failure.service
+                        [Service]
+                        Environment=PATH=/opt/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
+                        TimeoutStartSec=0
+                        StandardError=journal+console
+                        ExecStartPost=/bin/sh -c 'echo OK125_KUBEADM_SUCCEEDED >/dev/ttyS0'
+                - name: ok125-kubeadm-failure.service
+                  contents: |
+                    [Unit]
+                    Description=OK-125 redacted kubeadm failure marker
+
+                    [Service]
+                    Type=oneshot
+                    ExecStart=/bin/sh -c '/bin/systemctl show kubeadm.service --property=Result --property=ExecMainStatus >/dev/ttyS0'
+                    ExecStart=/bin/sh -c '/bin/journalctl -u kubeadm.service -b --no-pager -n 200 -o cat | /bin/grep -Ei "([[]ERROR |error execution phase|kubelet-check|control-plane|timed out|unable to|failed to|not found|unsupported|connection refused|deadline exceeded|CRI)" | /bin/grep -Eiv "(token|password|secret|certificate|private[ -]?key|client-key|key-data|discovery)" >/dev/ttyS0 || true'
+                - name: kubelet.service
+                  enabled: true
+                  contents: |
+                    [Unit]
+                    Description=kubelet: Kubernetes Node Agent (Flatcar profile)
+                    Wants=network-online.target
+                    Requires=containerd.service
+                    After=network-online.target containerd.service
+                    StartLimitIntervalSec=0
+
+                    [Service]
+                    Environment="KUBELET_KUBECONFIG_ARGS=--bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --kubeconfig=/etc/kubernetes/kubelet.conf"
+                    Environment=KUBELET_CONFIG_ARGS=--config=/var/lib/kubelet/config.yaml
+                    EnvironmentFile=-/var/lib/kubelet/kubeadm-flags.env
+                    EnvironmentFile=-/etc/default/kubelet
+                    ExecStart=/opt/bin/kubelet $KUBELET_KUBECONFIG_ARGS $KUBELET_CONFIG_ARGS $KUBELET_KUBEADM_ARGS $KUBELET_EXTRA_ARGS
+                    Restart=always
+                    RestartSec=10
+
+                    [Install]
+                    WantedBy=multi-user.target
+      joinConfiguration:
+        nodeRegistration:
+          criSocket: /var/run/containerd/containerd.sock
+          kubeletExtraArgs:
+            - name: node-labels
+              value: openkubes.io/os-identity=afd862491620,openkubes.io/profile-revision=1
+---
+apiVersion: cluster.x-k8s.io/v1beta2
+kind: MachineDeployment
+metadata:
+  name: ok-flatcar-workers
+  namespace: ok-flatcar
+  labels:
+    openkubes.io/type: flatcar
+    openkubes.io/provider: kubevirt
+    openkubes.io/profile: flatcar-kubevirt
+    openkubes.io/profile-revision: "1"
+    openkubes.io/os-identity: afd862491620
+    openkubes.io/adoption-status: production-constrained
+    openkubes.io/deployable: "true"
+spec:
+  clusterName: ok-flatcar
+  replicas: 1
+  rollout:
+    strategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxSurge: 1
+        maxUnavailable: 0
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/cluster-name: ok-flatcar
+  template:
+    metadata:
+      labels:
+        cluster.x-k8s.io/cluster-name: ok-flatcar
+    spec:
+      clusterName: ok-flatcar
+      version: v1.34.1
+      bootstrap:
+        configRef:
+          apiGroup: bootstrap.cluster.x-k8s.io
+          kind: KubeadmConfigTemplate
+          name: ok-flatcar-workers-afd862491620
+      infrastructureRef:
+        apiGroup: infrastructure.cluster.x-k8s.io
+        kind: KubevirtMachineTemplate
+        name: ok-flatcar-workers-afd862491620


### PR DESCRIPTION
## Summary

Declare `ok-flatcar`, the first ordinary workload cluster consuming the production-constrained Flatcar profile accepted by OK-125 and ADR-009.

This PR commits only the deterministic cluster inputs and rendered manifests. It does not install or mutate live cluster resources.

## Declared envelope

- Flatcar stable 4593.2.4, amd64
- KubeVirt provider on `ok-infra`
- Kubernetes v1.34.1
- one control-plane and one worker
- endpoint `192.168.100.211`
- target storage class `local-path`
- golden image `ok-images/flatcar-stable-4593-2-4-amd64-kubevirt`
- OS identity `sha256:afd862491620adbaeb3c25aa82ae89a3bd748ae5976cf66fbf9613a732ba35bb`
- Secret-backed Ignition bootstrap and replacement-only lifecycle

## Files

- `ok-flatcar/cluster-config.yaml` — fully resolved declarative input
- `ok-flatcar/cluster-v2.yaml` — deterministic CAPI/CAPK render
- `ok-flatcar/cilium-values.yaml` — profile-scoped Cilium values

## Validation

The branch is clean and pushed at `2d77daa`.

The read-only production preflight passed against the explicit `ok-infra` kubeconfig and the locally cached Cilium 1.19.6 chart:

```text
[flatcar] validating exact profile, manifest, and local Cilium artifact
[flatcar] checking source state and management-cluster preconditions
[flatcar] PASS constrained Flatcar production preflight
```

The Cilium chart matched the required SHA-256:

```text
21c43cf53841f9ab0375047d95aa4c64051ea52bbd2c679416e6408f5f1c9179
```

The preflight also verified the accepted CAPI/CABPK/KCP, CAPK, KubeVirt and Ignition management envelope, the bound golden-image identity, and that the endpoint was unused.

## Deployment boundary

After review and merge, installation remains a separate explicit action requiring a repeated green preflight and `FLATCAR_APPLY=yes`. No SSH, remote shell, package-manager maintenance, inline Secret value, or imperative guest mutation is introduced.