### PR TITLE
feat(ok-135): use Longhorn for Flatcar boot clones

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,7 +160,7 @@ cilium-chart-tool-test: ## Offline-test Cilium acquisition/cache guards
 
 # OK-125 candidate evidence is intentionally outside the ordinary TYPE allowlist.
 # It consumes ok-linux profile truth and never applies resources.
-.PHONY: ok125-render ok125-management-test ok125-management-ignition ok125-runtime-test ok125-runtime-preflight ok125-node-ready ok125-replacement ok125-cleanup flatcar-promotion-test flatcar-preflight install-flatcar teardown-flatcar ok128-benchmark-test ok128-benchmark-preflight ok128-benchmark-flatcar ok128-benchmark-talos ok128-benchmark-compare ok128-benchmark-cleanup-verify ok130-test talos-golden-preflight talos-golden-runtime-evidence talos-golden-replacement-preflight talos-golden-replacement-apply
+.PHONY: ok125-render ok125-management-test ok125-management-ignition ok125-runtime-test ok125-runtime-preflight ok125-node-ready ok125-replacement ok125-cleanup flatcar-promotion-test flatcar-preflight install-flatcar teardown-flatcar ok128-benchmark-test ok128-benchmark-preflight ok128-benchmark-flatcar ok128-benchmark-talos ok128-benchmark-compare ok128-benchmark-cleanup-verify ok130-test ok135-test talos-golden-preflight talos-golden-runtime-evidence talos-golden-replacement-preflight talos-golden-replacement-apply
 ok125-render: ## Render and validate the non-deployable OK-125 Flatcar candidate
 	@OK_LINUX_PATH="$(OK_LINUX_PATH)" \
 		python3 $(SCRIPT_DIR)/tests/ok125_flatcar_render_test.py \
@@ -206,6 +206,8 @@ ok125-cleanup: ## Delete only the owned disposable OK-125 runtime
 flatcar-promotion-test: ## Offline-test the exact ordinary Flatcar profile
 	@OK_LINUX_PATH="$(OK_LINUX_PATH)" \
 		python3 $(SCRIPT_DIR)/tests/flatcar_promotion_test.py
+
+ok135-test: flatcar-promotion-test ok128-benchmark-test ## Offline-test Flatcar Longhorn clone contract
 
 flatcar-preflight: require-cluster ## Read-only production Flatcar preflight
 	@OK_LINUX_PATH="$(OK_LINUX_PATH)" \

--- a/README.md
+++ b/README.md
@@ -355,6 +355,13 @@ make install CLUSTER=ok1
 Consumes only the promoted `ok-linux` `flatcar-kubevirt` profile. The ordinary
 resolver is fail-closed to the exact amd64/KubeVirt envelope and uses
 replacement-only Day-2 convergence without SSH or guest mutation.
+Its immutable Golden PVC remains in `ok-images`; profile revision 4 creates
+control-plane and worker CDI snapshot clones on Longhorn
+`ok-storage-block`. The preflight requires the exact StorageClass/CDI
+StorageProfile, `ok-storage-block-snapshot`, and KubeVirt `ExpandDisks`
+contracts. The supported teardown removes retained clone PVs, Longhorn
+volumes, temporary CDI snapshots, and clone RBAC while preserving the shared
+Golden PVC.
 See [Constrained Flatcar Cluster](#constrained-flatcar-cluster) for the
 canonical scaffold, preflight, install, and verified-runtime procedure.
 

--- a/docs/adoption/OK-128/benchmark-runbook.md
+++ b/docs/adoption/OK-128/benchmark-runbook.md
@@ -10,13 +10,17 @@ Results are single-run observations and must not be presented as an SLO.
 - KubeVirt, `amd64`, Kubernetes `v1.34.1`
 - one control-plane and one worker VM
 - 2 vCPU, 4 GiB RAM, and 20 GiB disk per VM
-- scheduling node `ok-infra`; the shared Golden PVCs are on
-  `ok-storage-block`. Each OS retains its validated clone-target semantics:
-  Flatcar `local-path`, Talos `ok-storage-block`
+- scheduling node `ok-infra`; both shared Golden PVCs and both operating
+  systems' clone targets are on `ok-storage-block`
 - Cilium chart `1.19.6`, SHA-256
   `21c43cf53841f9ab0375047d95aa4c64051ea52bbd2c679416e6408f5f1c9179`
 - sequential order: Flatcar first, complete cleanup, then Talos
 - no other intentional management-cluster workload during either run
+
+The evidence already recorded in this directory predates OK-135 and remains a
+historical comparison of Flatcar `local-path` against Talos
+`ok-storage-block`; it must not be relabelled as storage-identical. A new fair
+replay uses Flatcar profile revision 4 and the fixed envelope above.
 
 The benchmark records the exact repository revisions, input file digests,
 Golden-Image identity, node versions, management load before/after, command

--- a/docs/adoption/OK-135/evidence-plan.md
+++ b/docs/adoption/OK-135/evidence-plan.md
@@ -1,0 +1,88 @@
+# OK-135 Flatcar Longhorn clone-target evidence plan
+
+OK-135 changes only the constrained Flatcar/KubeVirt consumer profile. The
+verified Flatcar Golden Image, its digest and its immutable `ok-images` PVC do
+not change. Talos and ADR-Platform-016 remain unchanged.
+
+## Contract and acceptance gates
+
+1. `ok-linux` profile revision 4 owns the exact `ok-storage-block` Longhorn,
+   RWO filesystem, `Retain`/`Immediate`, expansion and `ExpandDisks` contract.
+   Revisions 2 and 3 remain reserved by the historical OK-125 replacement
+   evidence.
+2. The `ok-cluster` resolver rejects `local-path` and every other override.
+   Rendered CP/worker boot DataVolumes use `ok-storage-block`; immutable
+   KubeVirtMachineTemplate, DataVolume and KubeadmConfigTemplate names include
+   both the unchanged OS identity and profile revision.
+3. The read-only management preflight requires KubeVirt v1.8.1 with only
+   `ExpandDisks`, the exact Longhorn StorageClass, the
+   `ok-storage-block-snapshot` class, and CDI snapshot clone strategy.
+4. Cross-namespace clone RBAC remains limited to `datavolumes/source:create`
+   for the consumer namespace's default ServiceAccount. Ignition/bootstrap
+   Secrets remain dynamic and no credential enters the Golden Image or
+   rendered manifests.
+5. Teardown identifies clone PVs and temporary snapshots before deletion,
+   validates their ownership/source, removes retained PVs and same-named
+   Longhorn volumes plus CDI snapshots and RBAC, and verifies the shared Golden
+   PVC identity remains Bound.
+
+## Executable offline evidence
+
+From clean sibling `ok-cluster` and `ok-linux` checkouts on their OK-135
+branches:
+
+```sh
+cd ../ok-linux
+make ok125-static
+
+cd ../ok-cluster
+make ok135-test
+python3 -m py_compile \
+  profile_resolvers/flatcar.py \
+  scripts/flatcar_lifecycle.py \
+  scripts/provisioning_benchmark.py
+```
+
+Review `git diff --check`, render assertions, negative storage override tests,
+and scan the changed files for private keys, tokens, passwords, inline Secrets,
+public image fetches and SSH inputs. Generated `.evidence` files are not
+runtime acceptance.
+
+## Guarded management and runtime evidence
+
+Runtime work needs a separate explicit Runtime GO. After both implementation
+branches are reviewed, committed, pushed and clean:
+
+```sh
+make prepare-cilium-chart
+make new CLUSTER=ok135-flatcar TYPE=flatcar WORKERS=1 \
+  K8S_VERSION=v1.34.1 PROVIDER=kubevirt ARCHITECTURE=amd64 \
+  NODE_SELECTOR=ok-infra START_IP=<approved-ip>
+
+make flatcar-preflight CLUSTER=ok135-flatcar \
+  FLATCAR_INFRA_KUBECONFIG="$HOME/.kube/ok-infra.yaml" \
+  FLATCAR_CILIUM_CHART="$(pwd)/.tools/cilium-1.19.6.tgz"
+```
+
+After explicit Runtime GO, run `install-flatcar`, verify one Ready CP and one
+Ready worker, Cilium, DataVolume source/phase, PVC/PV StorageClass, requested
+and guest disk capacity, Longhorn volume identity, and absence of credentials
+in manifests/evidence. Repeat with an explicitly supported disk-size case only
+if the constrained envelope is deliberately expanded and reviewed.
+
+For the fair warm replay, run the OK-128 observer sequentially for Flatcar and
+Talos with identical 1+1, CPU, memory, 20 GiB, Cilium and
+`ok-storage-block` inputs. Record both durations as observations, not an SLO;
+cold Golden publication remains excluded.
+
+Cleanup requires a second explicit approval:
+
+```sh
+FLATCAR_TEARDOWN=yes make teardown-flatcar CLUSTER=ok135-flatcar \
+  FLATCAR_INFRA_KUBECONFIG="$HOME/.kube/ok-infra.yaml" \
+  FLATCAR_WORKLOAD_KUBECONFIG="$HOME/.kube/ok135-flatcar.yaml"
+```
+
+Then verify namespace, clone PVCs/PVs, Longhorn volumes, CDI snapshots, clone
+RBAC and local workload kubeconfig are absent, while the Flatcar Golden PVC
+has the same UID, digest annotation and Bound phase.

--- a/new-cluster.sh
+++ b/new-cluster.sh
@@ -38,7 +38,11 @@ if [[ -z "$WORKER_DISK" ]]; then
 fi
 NODE_SELECTOR="${NODE_SELECTOR:-${NODE:-}}"   # OK-82: NODE= accepted as alias
 START_IP="${START_IP:-}"   # OK-83: optional override for MetalLB IP allocation
-GOLDEN_IMAGE_STORAGE_CLASS="${GOLDEN_IMAGE_STORAGE_CLASS:-local-path}"
+if [[ "$TYPE" == "flatcar" ]]; then
+  GOLDEN_IMAGE_STORAGE_CLASS="${GOLDEN_IMAGE_STORAGE_CLASS:-ok-storage-block}"
+else
+  GOLDEN_IMAGE_STORAGE_CLASS="${GOLDEN_IMAGE_STORAGE_CLASS:-local-path}"
+fi
 
 if [[ -z "$CLUSTER" ]]; then
   echo "ERROR: CLUSTER is required."
@@ -168,7 +172,8 @@ os:
   profile: flatcar-kubevirt
   architecture: ${ARCHITECTURE}
 
-# KubeVirt consumer mechanics remain owned by ok-cluster.
+# The Flatcar profile owns the supported clone-target storage contract;
+# ok-cluster implements it with KubeVirt/CDI.
 providerProfile:
   goldenImageStorageClass: ${GOLDEN_IMAGE_STORAGE_CLASS}
 FLATCARBLOCK

--- a/profile_resolvers/flatcar.py
+++ b/profile_resolvers/flatcar.py
@@ -34,10 +34,10 @@ EXPECTED_PROFILE = {
     "identity": (
         "sha256:afd862491620adbaeb3c25aa82ae89a3bd748ae5976cf66fbf9613a732ba35bb"
     ),
-    "profile_revision": 1,
+    "profile_revision": 4,
     "golden_namespace": "ok-images",
     "golden_claim": "flatcar-stable-4593-2-4-amd64-kubevirt",
-    "golden_target_storage_class": "local-path",
+    "golden_target_storage_class": "ok-storage-block",
     "node_selector": "ok-infra",
 }
 EXPECTED_CONTROL_PLANE = {
@@ -53,6 +53,16 @@ EXPECTED_WORKERS = {
     "disk": "20Gi",
 }
 DNS_LABEL = re.compile(r"^[a-z0-9](?:[-a-z0-9]*[a-z0-9])?$")
+EXPECTED_CLONE_TARGET = {
+    "storage_class": "ok-storage-block",
+    "provisioner": "driver.longhorn.io",
+    "access_mode": "ReadWriteOnce",
+    "volume_mode": "Filesystem",
+    "reclaim_policy": "Retain",
+    "volume_binding_mode": "Immediate",
+    "allow_volume_expansion": True,
+    "kubevirt_feature_gates": ["ExpandDisks"],
+}
 
 
 class FlatcarProfileError(ValueError):
@@ -128,6 +138,7 @@ def validate_profile(profile: dict) -> None:
         or support.get("provider") != "kubevirt"
         or support.get("runtime_validated_topology")
         != {"control_plane_replicas": 1, "worker_replicas": 1}
+        or support.get("clone_target") != EXPECTED_CLONE_TARGET
         or support.get("continuous_control_plane_api_slo") is not False
         or "arm64" not in support.get("exclusions", [])
     ):

--- a/scripts/flatcar_lifecycle.py
+++ b/scripts/flatcar_lifecycle.py
@@ -933,10 +933,30 @@ def teardown(
         management,
         ["get", "persistentvolume"],
     ).get("items", [])
-    owned_pvs = sorted(
-        item["metadata"]["name"]
+    owned_pv_objects = [
+        item
         for item in pvs
         if item.get("spec", {}).get("claimRef", {}).get("namespace") == cluster
+    ]
+    invalid_pvs = [
+        item.get("metadata", {}).get("name", "<unnamed>")
+        for item in owned_pv_objects
+        if (
+            item.get("spec", {}).get("storageClassName")
+            != EXPECTED_CLONE_TARGET["storage_class"]
+            or item.get("spec", {}).get("csi", {}).get("driver")
+            != EXPECTED_CLONE_TARGET["provisioner"]
+            or item.get("spec", {}).get("csi", {}).get("volumeHandle")
+            != item.get("metadata", {}).get("name")
+            or not item.get("spec", {}).get("claimRef", {}).get("name")
+        )
+    ]
+    if invalid_pvs:
+        raise FlatcarLifecycleError(
+            f"refusing cleanup: non-profile PVs are cluster-bound: {invalid_pvs}"
+        )
+    owned_pvs = sorted(
+        item["metadata"]["name"] for item in owned_pv_objects
     )
     data_volumes = kubectl_json(
         kubectl_bin,
@@ -950,22 +970,60 @@ def teardown(
             "name": golden_source["claim"],
         }
     }
-    if any(
-        item.get("spec", {}).get("source") != expected_source
+    invalid_data_volumes = [
+        item.get("metadata", {}).get("name", "<unnamed>")
         for item in data_volumes
-    ):
+        if (
+            item.get("spec", {}).get("source") != expected_source
+            or item.get("spec", {})
+            .get("storage", {})
+            .get("storageClassName")
+            != EXPECTED_CLONE_TARGET["storage_class"]
+            or not item.get("metadata", {}).get("uid")
+        )
+    ]
+    if invalid_data_volumes:
         raise FlatcarLifecycleError(
-            "refusing cleanup: a cluster DataVolume has a non-Golden source"
+            "refusing cleanup: invalid cluster DataVolumes: "
+            f"{invalid_data_volumes}"
         )
     data_volume_uids = {
         item.get("metadata", {}).get("uid") for item in data_volumes
     } - {None}
+    longhorn_volumes = {}
+    for pv in owned_pv_objects:
+        name = pv["metadata"]["name"]
+        volume = kubectl_json(
+            kubectl_bin,
+            management,
+            [
+                "-n",
+                "longhorn-system",
+                "get",
+                "volumes.longhorn.io",
+                name,
+            ],
+        )
+        kubernetes_status = volume.get("status", {}).get(
+            "kubernetesStatus", {}
+        )
+        if (
+            kubernetes_status.get("namespace") != cluster
+            or kubernetes_status.get("pvName") != name
+            or kubernetes_status.get("pvcName")
+            != pv["spec"]["claimRef"]["name"]
+        ):
+            raise FlatcarLifecycleError(
+                f"refusing cleanup: Longhorn ownership mismatch for {name}"
+            )
+        longhorn_volumes[name] = volume["metadata"]["uid"]
     clone_name = f"{cluster}-golden-image-cloner"
     golden_namespace = config["os"]["goldenImage"]["namespace"]
     progress(
         "teardown targets: "
         f"namespace={cluster}, clone_authorization="
-        f"{golden_namespace}/{clone_name}, pvs={owned_pvs}"
+        f"{golden_namespace}/{clone_name}, pvs={owned_pvs}, "
+        f"longhorn_uids={longhorn_volumes}"
     )
 
     kubectl(

--- a/scripts/flatcar_lifecycle.py
+++ b/scripts/flatcar_lifecycle.py
@@ -21,6 +21,7 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
 from profile_resolvers.flatcar import (  # noqa: E402
+    EXPECTED_CLONE_TARGET,
     EXPECTED_PROFILE,
     resolve_flatcar_config,
     validate_cluster_name,
@@ -434,13 +435,94 @@ def management_preflight(
             f"expected one KubeVirt installation, observed {len(kubevirt_items)}"
         )
     kubevirt_status = kubevirt_items[0].get("status", {})
+    kubevirt_gates = (
+        kubevirt_items[0]
+        .get("spec", {})
+        .get("configuration", {})
+        .get("developerConfiguration", {})
+        .get("featureGates", [])
+    )
     if (
         kubevirt_status.get("phase") != "Deployed"
         or kubevirt_status.get("observedKubeVirtVersion") != "v1.8.1"
         or kubevirt_status.get("targetKubeVirtVersion") != "v1.8.1"
+        or kubevirt_gates != EXPECTED_CLONE_TARGET["kubevirt_feature_gates"]
     ):
         raise FlatcarLifecycleError(
-            "management KubeVirt must be deployed at exact version v1.8.1"
+            "management KubeVirt must be v1.8.1 with only ExpandDisks enabled"
+        )
+
+    storage_class = kubectl_json(
+        kubectl_bin,
+        paths["management"],
+        ["get", "storageclass", EXPECTED_CLONE_TARGET["storage_class"]],
+    )
+    observed_storage = {
+        "provisioner": storage_class.get("provisioner"),
+        "reclaim_policy": storage_class.get("reclaimPolicy"),
+        "volume_binding_mode": storage_class.get("volumeBindingMode"),
+        "allow_volume_expansion": storage_class.get("allowVolumeExpansion"),
+    }
+    expected_storage = {
+        key: EXPECTED_CLONE_TARGET[key]
+        for key in observed_storage
+    }
+    if observed_storage != expected_storage:
+        raise FlatcarLifecycleError(
+            f"clone-target StorageClass contract mismatch: {observed_storage}"
+        )
+
+    snapshot_classes = kubectl_json(
+        kubectl_bin,
+        paths["management"],
+        ["get", "volumesnapshotclass"],
+    ).get("items", [])
+    snapshot_class = next(
+        (
+            item
+            for item in snapshot_classes
+            if item.get("metadata", {}).get("name")
+            == "ok-storage-block-snapshot"
+        ),
+        None,
+    )
+    if (
+        snapshot_class is None
+        or snapshot_class.get("driver") != EXPECTED_CLONE_TARGET["provisioner"]
+        or snapshot_class.get("deletionPolicy") != "Delete"
+        or snapshot_class.get("parameters") != {"type": "snap"}
+    ):
+        raise FlatcarLifecycleError(
+            "ok-storage-block-snapshot must be the Longhorn Delete/snap class"
+        )
+
+    storage_profile = kubectl_json(
+        kubectl_bin,
+        paths["management"],
+        [
+            "get",
+            "storageprofile.cdi.kubevirt.io",
+            EXPECTED_CLONE_TARGET["storage_class"],
+        ],
+    ).get("status", {})
+    if (
+        storage_profile.get("provisioner")
+        != EXPECTED_CLONE_TARGET["provisioner"]
+        or storage_profile.get("storageClass")
+        != EXPECTED_CLONE_TARGET["storage_class"]
+        or storage_profile.get("snapshotClass")
+        != "ok-storage-block-snapshot"
+        or storage_profile.get("cloneStrategy") != "snapshot"
+        or storage_profile.get("claimPropertySets")
+        != [
+            {
+                "accessModes": [EXPECTED_CLONE_TARGET["access_mode"]],
+                "volumeMode": EXPECTED_CLONE_TARGET["volume_mode"],
+            }
+        ]
+    ):
+        raise FlatcarLifecycleError(
+            "CDI ok-storage-block profile is not the expected snapshot clone path"
         )
 
     for expected_deployment in GATE_DEPLOYMENTS:
@@ -856,6 +938,28 @@ def teardown(
         for item in pvs
         if item.get("spec", {}).get("claimRef", {}).get("namespace") == cluster
     )
+    data_volumes = kubectl_json(
+        kubectl_bin,
+        management,
+        ["-n", cluster, "get", "datavolumes"],
+    ).get("items", [])
+    golden_source = config["os"]["goldenImage"]
+    expected_source = {
+        "pvc": {
+            "namespace": golden_source["namespace"],
+            "name": golden_source["claim"],
+        }
+    }
+    if any(
+        item.get("spec", {}).get("source") != expected_source
+        for item in data_volumes
+    ):
+        raise FlatcarLifecycleError(
+            "refusing cleanup: a cluster DataVolume has a non-Golden source"
+        )
+    data_volume_uids = {
+        item.get("metadata", {}).get("uid") for item in data_volumes
+    } - {None}
     clone_name = f"{cluster}-golden-image-cloner"
     golden_namespace = config["os"]["goldenImage"]["namespace"]
     progress(
@@ -902,6 +1006,52 @@ def teardown(
             management,
             ["delete", "persistentvolume", pv, "--ignore-not-found"],
         )
+        kubectl(
+            kubectl_bin,
+            management,
+            [
+                "-n",
+                "longhorn-system",
+                "delete",
+                "volumes.longhorn.io",
+                pv,
+                "--ignore-not-found",
+            ],
+        )
+
+    removed_snapshots = []
+    snapshots = kubectl_json(
+        kubectl_bin,
+        management,
+        ["-n", golden_namespace, "get", "volumesnapshots"],
+    ).get("items", [])
+    for snapshot in snapshots:
+        metadata = snapshot.get("metadata", {})
+        labels = metadata.get("labels", {})
+        if labels.get("cdi.kubevirt.io/OwnedByUID") not in data_volume_uids:
+            continue
+        if (
+            labels.get("app") != "containerized-data-importer"
+            or snapshot.get("spec", {})
+            .get("source", {})
+            .get("persistentVolumeClaimName")
+            != golden_source["claim"]
+        ):
+            raise FlatcarLifecycleError(
+                "cluster-owned CDI snapshot source is invalid"
+            )
+        kubectl(
+            kubectl_bin,
+            management,
+            [
+                "-n",
+                golden_namespace,
+                "delete",
+                "volumesnapshot",
+                metadata["name"],
+            ],
+        )
+        removed_snapshots.append(metadata["name"])
 
     absent = kubectl(
         kubectl_bin,
@@ -912,6 +1062,39 @@ def teardown(
     if absent.returncode == 0:
         raise FlatcarLifecycleError(
             f"namespace {cluster} still exists after teardown"
+        )
+    for pv in owned_pvs:
+        for resource, namespace in (
+            ("persistentvolume", None),
+            ("volumes.longhorn.io", "longhorn-system"),
+        ):
+            command = ["get", resource, pv, "-o", "name"]
+            if namespace:
+                command = ["-n", namespace, *command]
+            remaining = kubectl(
+                kubectl_bin,
+                management,
+                command,
+                expected=(0, 1),
+            )
+            if remaining.returncode == 0:
+                raise FlatcarLifecycleError(
+                    f"cluster-owned storage remains after teardown: {resource}/{pv}"
+                )
+    remaining_snapshots = kubectl_json(
+        kubectl_bin,
+        management,
+        ["-n", golden_namespace, "get", "volumesnapshots"],
+    ).get("items", [])
+    if any(
+        item.get("metadata", {})
+        .get("labels", {})
+        .get("cdi.kubevirt.io/OwnedByUID")
+        in data_volume_uids
+        for item in remaining_snapshots
+    ):
+        raise FlatcarLifecycleError(
+            "cluster-owned CDI snapshots remain after teardown"
         )
     golden = kubectl_json(
         kubectl_bin,
@@ -942,7 +1125,10 @@ def teardown(
     if cluster_dir.parent != ROOT.resolve() or cluster_dir.name != cluster:
         raise FlatcarLifecycleError("refusing unsafe local directory removal")
     shutil.rmtree(cluster_dir)
-    progress(f"PASS {cluster}: exact constrained Flatcar teardown completed")
+    progress(
+        f"PASS {cluster}: exact constrained Flatcar teardown completed; "
+        f"pvs={len(owned_pvs)} snapshots={len(removed_snapshots)}"
+    )
     return 0
 
 
@@ -951,6 +1137,9 @@ def self_test() -> int:
         EXPECTED_PROFILE["architecture"] != "amd64"
         or EXPECTED_PROFILE["provider"] != "kubevirt"
         or EXPECTED_PROFILE["node_selector"] != "ok-infra"
+        or EXPECTED_PROFILE["golden_target_storage_class"]
+        != "ok-storage-block"
+        or EXPECTED_CLONE_TARGET["kubevirt_feature_gates"] != ["ExpandDisks"]
         or EXPECTED_CILIUM_CHART_SHA256
         != "21c43cf53841f9ab0375047d95aa4c64051ea52bbd2c679416e6408f5f1c9179"
         or len(EXPECTED_PROVIDER_INVENTORY) != 4

--- a/scripts/provisioning_benchmark.py
+++ b/scripts/provisioning_benchmark.py
@@ -179,9 +179,7 @@ def validate_envelope(config: dict, os_name: str, cluster: str) -> dict:
             f"versions.kubernetes={version!r}, expected {EXPECTED_KUBERNETES!r}"
         )
     golden = config.get("os", {}).get("goldenImage", {})
-    expected_storage = (
-        "local-path" if os_name == "flatcar" else EXPECTED_STORAGE_CLASS
-    )
+    expected_storage = EXPECTED_STORAGE_CLASS
     storage = golden.get("storageClass")
     if storage not in (None, expected_storage):
         failures.append(

--- a/templates/flatcar/cluster-v2.yaml.tpl
+++ b/templates/flatcar/cluster-v2.yaml.tpl
@@ -113,7 +113,7 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
 kind: KubevirtMachineTemplate
 metadata:
-  name: ${CLUSTER_NAME}-cp-${OS_IDENTITY_SHORT}
+  name: ${CLUSTER_NAME}-cp-${OS_IDENTITY_SHORT}-r${OS_PROFILE_REVISION}
   namespace: ${CLUSTER_NAME}
   labels:
     openkubes.io/type: flatcar
@@ -147,7 +147,7 @@ spec:
           runStrategy: Always
           dataVolumeTemplates:
             - metadata:
-                name: ${CLUSTER_NAME}-cp-${OS_IDENTITY_SHORT}-boot
+                name: ${CLUSTER_NAME}-cp-${OS_IDENTITY_SHORT}-r${OS_PROFILE_REVISION}-boot
               spec:
                 source:
                   pvc:
@@ -187,7 +187,7 @@ spec:
               evictionStrategy: External
               volumes:
                 - dataVolume:
-                    name: ${CLUSTER_NAME}-cp-${OS_IDENTITY_SHORT}-boot
+                    name: ${CLUSTER_NAME}-cp-${OS_IDENTITY_SHORT}-r${OS_PROFILE_REVISION}-boot
                   name: rootdisk
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta2
@@ -216,7 +216,7 @@ spec:
       infrastructureRef:
         apiGroup: infrastructure.cluster.x-k8s.io
         kind: KubevirtMachineTemplate
-        name: ${CLUSTER_NAME}-cp-${OS_IDENTITY_SHORT}
+        name: ${CLUSTER_NAME}-cp-${OS_IDENTITY_SHORT}-r${OS_PROFILE_REVISION}
   kubeadmConfigSpec:
     format: ${BOOTSTRAP_FORMAT}
     ignition:
@@ -287,7 +287,7 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
 kind: KubevirtMachineTemplate
 metadata:
-  name: ${CLUSTER_NAME}-workers-${OS_IDENTITY_SHORT}
+  name: ${CLUSTER_NAME}-workers-${OS_IDENTITY_SHORT}-r${OS_PROFILE_REVISION}
   namespace: ${CLUSTER_NAME}
   labels:
     openkubes.io/type: flatcar
@@ -321,7 +321,7 @@ spec:
           runStrategy: Always
           dataVolumeTemplates:
             - metadata:
-                name: ${CLUSTER_NAME}-workers-${OS_IDENTITY_SHORT}-boot
+                name: ${CLUSTER_NAME}-workers-${OS_IDENTITY_SHORT}-r${OS_PROFILE_REVISION}-boot
               spec:
                 source:
                   pvc:
@@ -361,13 +361,13 @@ spec:
               evictionStrategy: External
               volumes:
                 - dataVolume:
-                    name: ${CLUSTER_NAME}-workers-${OS_IDENTITY_SHORT}-boot
+                    name: ${CLUSTER_NAME}-workers-${OS_IDENTITY_SHORT}-r${OS_PROFILE_REVISION}-boot
                   name: rootdisk
 ---
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta2
 kind: KubeadmConfigTemplate
 metadata:
-  name: ${CLUSTER_NAME}-workers-${OS_IDENTITY_SHORT}
+  name: ${CLUSTER_NAME}-workers-${OS_IDENTITY_SHORT}-r${OS_PROFILE_REVISION}
   namespace: ${CLUSTER_NAME}
   labels:
     openkubes.io/type: flatcar
@@ -474,8 +474,8 @@ spec:
         configRef:
           apiGroup: bootstrap.cluster.x-k8s.io
           kind: KubeadmConfigTemplate
-          name: ${CLUSTER_NAME}-workers-${OS_IDENTITY_SHORT}
+          name: ${CLUSTER_NAME}-workers-${OS_IDENTITY_SHORT}-r${OS_PROFILE_REVISION}
       infrastructureRef:
         apiGroup: infrastructure.cluster.x-k8s.io
         kind: KubevirtMachineTemplate
-        name: ${CLUSTER_NAME}-workers-${OS_IDENTITY_SHORT}
+        name: ${CLUSTER_NAME}-workers-${OS_IDENTITY_SHORT}-r${OS_PROFILE_REVISION}

--- a/tests/flatcar_promotion_test.py
+++ b/tests/flatcar_promotion_test.py
@@ -59,7 +59,7 @@ def base_config() -> dict:
             "serviceCIDR": "10.112.0.0/20",
         },
         "nodeSelector": "ok-infra",
-        "providerProfile": {"goldenImageStorageClass": "local-path"},
+        "providerProfile": {"goldenImageStorageClass": "ok-storage-block"},
         "os": {
             "profile": "flatcar-kubevirt",
             "architecture": "amd64",
@@ -109,7 +109,7 @@ def negative_cases() -> None:
     cases.append(("KubeVirt scheduling override", cfg))
 
     cfg = base_config()
-    cfg["providerProfile"]["goldenImageStorageClass"] = "ok-storage-block"
+    cfg["providerProfile"]["goldenImageStorageClass"] = "local-path"
     cases.append(("target storage override", cfg))
 
     cfg = base_config()
@@ -192,7 +192,7 @@ def main() -> int:
             "namespace": "ok-images",
             "claim": "flatcar-stable-4593-2-4-amd64-kubevirt",
             "published": True,
-            "storageClass": "local-path",
+            "storageClass": "ok-storage-block",
         },
         "bootstrap and KubeVirt image transport remain profile-bound",
     )
@@ -248,6 +248,53 @@ def main() -> int:
             and "https://" not in rendered,
             "promoted render contains no secret, SSH, or public fetch input",
         )
+        revision_suffix = (
+            resolved["os"]["identity"].removeprefix("sha256:")[:12]
+            + f"-r{resolved['os']['profileRevision']}"
+        )
+        machine_templates = [
+            item for item in docs if item.get("kind") == "KubevirtMachineTemplate"
+        ]
+        data_volume_templates = [
+            data_volume
+            for item in machine_templates
+            for data_volume in item["spec"]["template"]["spec"][
+                "virtualMachineTemplate"
+            ]["spec"]["dataVolumeTemplates"]
+        ]
+        check(
+            len(machine_templates) == 2
+            and all(
+                item["metadata"]["name"].endswith(revision_suffix)
+                for item in machine_templates
+            )
+            and all(
+                item["spec"]["storage"]["storageClassName"]
+                == "ok-storage-block"
+                and item["metadata"]["name"].endswith(
+                    f"{revision_suffix}-boot"
+                )
+                for item in data_volume_templates
+            ),
+            "templates and boot clones bind profile revision 4 to Longhorn",
+        )
+
+    lifecycle_source = (
+        ROOT / "scripts" / "flatcar_lifecycle.py"
+    ).read_text(encoding="utf-8")
+    check(
+        all(
+            term in lifecycle_source
+            for term in (
+                '"ExpandDisks"',
+                '"ok-storage-block-snapshot"',
+                '"cloneStrategy") != "snapshot"',
+                '"volumes.longhorn.io"',
+                '"cdi.kubevirt.io/OwnedByUID"',
+            )
+        ),
+        "preflight and teardown guard Longhorn snapshot-clone lifecycle",
+    )
 
     allowlist = subprocess.run(
         [

--- a/tests/flatcar_promotion_test.py
+++ b/tests/flatcar_promotion_test.py
@@ -291,6 +291,8 @@ def main() -> int:
                 '"cloneStrategy") != "snapshot"',
                 '"volumes.longhorn.io"',
                 '"cdi.kubevirt.io/OwnedByUID"',
+                '"refusing cleanup: non-profile PVs are cluster-bound',
+                '"refusing cleanup: Longhorn ownership mismatch',
             )
         ),
         "preflight and teardown guard Longhorn snapshot-clone lifecycle",

--- a/tests/ok125_flatcar_render_test.py
+++ b/tests/ok125_flatcar_render_test.py
@@ -164,11 +164,14 @@ def validate_manifest(manifest: Path, cfg: dict) -> None:
 
     identity = cfg["os"]["identity"]
     identity_short = identity.removeprefix("sha256:")[:12]
+    template_identity = (
+        f"{identity_short}-r{cfg['os']['profileRevision']}"
+    )
     machine_templates = by_kind(docs, "KubevirtMachineTemplate")
     check(
         len(machine_templates) == 2
         and all(
-            template["metadata"]["name"].endswith(identity_short)
+            template["metadata"]["name"].endswith(template_identity)
             and template["metadata"]["labels"][
                 "openkubes.io/profile-revision"
             ]
@@ -203,7 +206,7 @@ def validate_manifest(manifest: Path, cfg: dict) -> None:
     worker = by_kind(docs, "KubeadmConfigTemplate")[0]
     machine_deployment = by_kind(docs, "MachineDeployment")[0]
     check(
-        worker["metadata"]["name"].endswith(identity_short)
+        worker["metadata"]["name"].endswith(template_identity)
         and machine_deployment["spec"]["template"]["spec"]["bootstrap"][
             "configRef"
         ]["name"]
@@ -396,7 +399,7 @@ def validate_manifest(manifest: Path, cfg: dict) -> None:
     check(
         machine_deployment["spec"]["template"]["spec"]["infrastructureRef"][
             "name"
-        ].endswith(identity_short),
+        ].endswith(template_identity),
         "worker lifecycle references the identity-bound infrastructure template",
     )
 


### PR DESCRIPTION
## Summary

- resolve constrained Flatcar clone targets to `ok-storage-block`
- bind immutable MachineTemplate, DataVolume, and bootstrap-template names to profile revision 4
- require the exact Longhorn StorageClass, VolumeSnapshotClass, CDI snapshot strategy, and KubeVirt `ExpandDisks` during read-only preflight
- remove cluster-owned retained PVs, Longhorn volumes, CDI snapshots, and clone RBAC during guarded teardown while preserving the Golden PVC
- make the OK-128 warm benchmark storage-identical and document historical evidence separately
- add the executable OK-135 evidence and runtime plan

## Dependency

Depends on [openkubes/ok-linux#5](https://github.com/openkubes/ok-linux/pull/5), which owns the revised Flatcar provider-storage contract. Merge and synchronize that PR first.

## Validation

- `make ok135-test`
- `make ok125-render`
- `python3 scripts/flatcar_lifecycle.py --self-test`
- Python compile, Bash syntax, diff and secret checks
- read-only observation of the current `ok-infra` StorageClass, VolumeSnapshotClass, CDI StorageProfile, and KubeVirt feature gates

No live resource was created, modified, or deleted.

Jira: [OK-135](https://kubernauts.atlassian.net/browse/OK-135)