### PR TITLE
feat(ok-135): validate 50Gi Flatcar boot clones

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,13 +355,13 @@ make install CLUSTER=ok1
 Consumes only the promoted `ok-linux` `flatcar-kubevirt` profile. The ordinary
 resolver is fail-closed to the exact amd64/KubeVirt envelope and uses
 replacement-only Day-2 convergence without SSH or guest mutation.
-Its immutable Golden PVC remains in `ok-images`; profile revision 4 creates
+Its immutable Golden PVC remains in `ok-images`; profile revision 5 creates
 control-plane and worker CDI snapshot clones on Longhorn
-`ok-storage-block`. The preflight requires the exact StorageClass/CDI
-StorageProfile, `ok-storage-block-snapshot`, and KubeVirt `ExpandDisks`
-contracts. The supported teardown removes retained clone PVs, Longhorn
-volumes, temporary CDI snapshots, and clone RBAC while preserving the shared
-Golden PVC.
+`ok-storage-block` with 50 GiB boot capacity. The preflight requires the exact
+StorageClass/CDI StorageProfile, `ok-storage-block-snapshot`, and KubeVirt
+`ExpandDisks` contracts. The supported teardown removes retained clone PVs,
+Longhorn volumes, temporary CDI snapshots, and clone RBAC while preserving the
+shared Golden PVC.
 See [Constrained Flatcar Cluster](#constrained-flatcar-cluster) for the
 canonical scaffold, preflight, install, and verified-runtime procedure.
 

--- a/docs/adoption/OK-128/benchmark-runbook.md
+++ b/docs/adoption/OK-128/benchmark-runbook.md
@@ -57,12 +57,14 @@ unused endpoints/CIDRs appropriate for the approved runtime:
 ```sh
 make new CLUSTER=ok128-flatcar TYPE=flatcar WORKERS=1 \
   K8S_VERSION=v1.34.1 PROVIDER=kubevirt ARCHITECTURE=amd64 \
+  CP_DISK=50Gi WORKER_DISK=50Gi \
   NODE_SELECTOR=ok-infra START_IP=<approved-ip>
 make render CLUSTER=ok128-flatcar
 
 make new CLUSTER=ok128-talos TYPE=talos WORKERS=1 \
   K8S_VERSION=v1.34.1 TALOS_VERSION=v1.9.5 \
   PROVIDER=kubevirt ARCHITECTURE=amd64 \
+  CP_DISK=50Gi WORKER_DISK=50Gi \
   NODE_SELECTOR=ok-infra START_IP=<approved-ip>
 make render CLUSTER=ok128-talos
 ```

--- a/docs/adoption/OK-128/benchmark-runbook.md
+++ b/docs/adoption/OK-128/benchmark-runbook.md
@@ -9,7 +9,7 @@ Results are single-run observations and must not be presented as an SLO.
 
 - KubeVirt, `amd64`, Kubernetes `v1.34.1`
 - one control-plane and one worker VM
-- 2 vCPU, 4 GiB RAM, and 20 GiB disk per VM
+- 2 vCPU, 4 GiB RAM, and 50 GiB disk per VM
 - scheduling node `ok-infra`; both shared Golden PVCs and both operating
   systems' clone targets are on `ok-storage-block`
 - Cilium chart `1.19.6`, SHA-256
@@ -20,7 +20,7 @@ Results are single-run observations and must not be presented as an SLO.
 The evidence already recorded in this directory predates OK-135 and remains a
 historical comparison of Flatcar `local-path` against Talos
 `ok-storage-block`; it must not be relabelled as storage-identical. A new fair
-replay uses Flatcar profile revision 4 and the fixed envelope above.
+replay uses Flatcar profile revision 5 and the fixed envelope above.
 
 The benchmark records the exact repository revisions, input file digests,
 Golden-Image identity, node versions, management load before/after, command

--- a/docs/adoption/OK-135/evidence-plan.md
+++ b/docs/adoption/OK-135/evidence-plan.md
@@ -6,8 +6,9 @@ not change. Talos and ADR-Platform-016 remain unchanged.
 
 ## Contract and acceptance gates
 
-1. `ok-linux` profile revision 4 owns the exact `ok-storage-block` Longhorn,
-   RWO filesystem, `Retain`/`Immediate`, expansion and `ExpandDisks` contract.
+1. `ok-linux` profile revision 5 owns the exact `ok-storage-block` Longhorn,
+   50 GiB RWO filesystem, `Retain`/`Immediate`, expansion and `ExpandDisks`
+   contract.
    Revisions 2 and 3 remain reserved by the historical OK-125 replacement
    evidence.
 2. The `ok-cluster` resolver rejects `local-path` and every other override.
@@ -66,12 +67,11 @@ make flatcar-preflight CLUSTER=ok135-flatcar \
 
 After explicit Runtime GO, run `install-flatcar`, verify one Ready CP and one
 Ready worker, Cilium, DataVolume source/phase, PVC/PV StorageClass, requested
-and guest disk capacity, Longhorn volume identity, and absence of credentials
-in manifests/evidence. Repeat with an explicitly supported disk-size case only
-if the constrained envelope is deliberately expanded and reviewed.
+and 50 GiB guest disk capacity, Longhorn volume identity, and absence of
+credentials in manifests/evidence.
 
 For the fair warm replay, run the OK-128 observer sequentially for Flatcar and
-Talos with identical 1+1, CPU, memory, 20 GiB, Cilium and
+Talos with identical 1+1, CPU, memory, 50 GiB, Cilium and
 `ok-storage-block` inputs. Record both durations as observations, not an SLO;
 cold Golden publication remains excluded.
 

--- a/docs/adoption/OK-135/evidence-plan.md
+++ b/docs/adoption/OK-135/evidence-plan.md
@@ -58,6 +58,7 @@ branches are reviewed, committed, pushed and clean:
 make prepare-cilium-chart
 make new CLUSTER=ok135-flatcar TYPE=flatcar WORKERS=1 \
   K8S_VERSION=v1.34.1 PROVIDER=kubevirt ARCHITECTURE=amd64 \
+  CP_DISK=50Gi WORKER_DISK=50Gi \
   NODE_SELECTOR=ok-infra START_IP=<approved-ip>
 
 make flatcar-preflight CLUSTER=ok135-flatcar \

--- a/new-cluster.sh
+++ b/new-cluster.sh
@@ -25,13 +25,17 @@ PROVIDER="${PROVIDER:-kubevirt}"
 ARCHITECTURE="${ARCHITECTURE:-amd64}"
 CP_CORES="${CP_CORES:-2}"
 CP_MEMORY="${CP_MEMORY:-4Gi}"
-CP_DISK="${CP_DISK:-20Gi}"
+if [[ "$TYPE" == "flatcar" ]]; then
+  CP_DISK="${CP_DISK:-50Gi}"
+else
+  CP_DISK="${CP_DISK:-20Gi}"
+fi
 WORKER_CORES="${WORKER_CORES:-2}"
 WORKER_MEMORY="${WORKER_MEMORY:-4Gi}"
 WORKER_DISK="${WORKER_DISK:-}"
 if [[ -z "$WORKER_DISK" ]]; then
   if [[ "$TYPE" == "flatcar" ]]; then
-    WORKER_DISK="20Gi"
+    WORKER_DISK="50Gi"
   else
     WORKER_DISK="15Gi"
   fi

--- a/new-cluster.sh
+++ b/new-cluster.sh
@@ -147,7 +147,7 @@ controlPlane:
   replicas: ${CP_REPLICAS}
   cores: ${CP_CORES}
   memory: ${CP_MEMORY}
-$(if [[ "$TYPE" == "flatcar" ]]; then echo "  disk: ${CP_DISK}"; fi)
+$(if [[ "$TYPE" == "flatcar" || "$TYPE" == "talos" ]]; then echo "  disk: ${CP_DISK}"; fi)
 
 workers:
   replicas: ${WORKERS}

--- a/profile_resolvers/flatcar.py
+++ b/profile_resolvers/flatcar.py
@@ -34,7 +34,7 @@ EXPECTED_PROFILE = {
     "identity": (
         "sha256:afd862491620adbaeb3c25aa82ae89a3bd748ae5976cf66fbf9613a732ba35bb"
     ),
-    "profile_revision": 4,
+    "profile_revision": 5,
     "golden_namespace": "ok-images",
     "golden_claim": "flatcar-stable-4593-2-4-amd64-kubevirt",
     "golden_target_storage_class": "ok-storage-block",
@@ -44,17 +44,18 @@ EXPECTED_CONTROL_PLANE = {
     "replicas": 1,
     "cores": 2,
     "memory": "4Gi",
-    "disk": "20Gi",
+    "disk": "50Gi",
 }
 EXPECTED_WORKERS = {
     "replicas": 1,
     "cores": 2,
     "memory": "4Gi",
-    "disk": "20Gi",
+    "disk": "50Gi",
 }
 DNS_LABEL = re.compile(r"^[a-z0-9](?:[-a-z0-9]*[a-z0-9])?$")
 EXPECTED_CLONE_TARGET = {
     "storage_class": "ok-storage-block",
+    "boot_disk_capacity": "50Gi",
     "provisioner": "driver.longhorn.io",
     "access_mode": "ReadWriteOnce",
     "volume_mode": "Filesystem",

--- a/scripts/flatcar_lifecycle.py
+++ b/scripts/flatcar_lifecycle.py
@@ -1197,6 +1197,7 @@ def self_test() -> int:
         or EXPECTED_PROFILE["node_selector"] != "ok-infra"
         or EXPECTED_PROFILE["golden_target_storage_class"]
         != "ok-storage-block"
+        or EXPECTED_CLONE_TARGET["boot_disk_capacity"] != "50Gi"
         or EXPECTED_CLONE_TARGET["kubevirt_feature_gates"] != ["ExpandDisks"]
         or EXPECTED_CILIUM_CHART_SHA256
         != "21c43cf53841f9ab0375047d95aa4c64051ea52bbd2c679416e6408f5f1c9179"

--- a/scripts/provisioning_benchmark.py
+++ b/scripts/provisioning_benchmark.py
@@ -162,12 +162,12 @@ def validate_envelope(config: dict, os_name: str, cluster: str) -> dict:
         ),
         "controlPlane.disk": (
             config.get("controlPlane", {}).get("disk"),
-            "20Gi",
+            "50Gi",
         ),
         "workers.replicas": (config.get("workers", {}).get("replicas"), 1),
         "workers.cores": (config.get("workers", {}).get("cores"), 2),
         "workers.memory": (config.get("workers", {}).get("memory"), "4Gi"),
-        "workers.disk": (config.get("workers", {}).get("disk"), "20Gi"),
+        "workers.disk": (config.get("workers", {}).get("disk"), "50Gi"),
         "nodeSelector": (config.get("nodeSelector"), EXPECTED_NODE),
     }
     for key, (actual, expected) in checks.items():
@@ -199,6 +199,7 @@ def validate_envelope(config: dict, os_name: str, cluster: str) -> dict:
         "worker_replicas": 1,
         "expected_nodes": EXPECTED_NODES,
         "node_selector": EXPECTED_NODE,
+        "boot_disk_capacity": "50Gi",
     }
 
 

--- a/tests/flatcar_promotion_test.py
+++ b/tests/flatcar_promotion_test.py
@@ -286,6 +286,13 @@ def main() -> int:
     lifecycle_source = (
         ROOT / "scripts" / "flatcar_lifecycle.py"
     ).read_text(encoding="utf-8")
+    scaffold_source = (ROOT / "new-cluster.sh").read_text(encoding="utf-8")
+    check(
+        '"$TYPE" == "flatcar" || "$TYPE" == "talos"' in scaffold_source
+        and 'CP_DISK="${CP_DISK:-50Gi}"' in scaffold_source
+        and 'WORKER_DISK="50Gi"' in scaffold_source,
+        "scaffold materializes explicit 50Gi Flatcar and Talos benchmark disks",
+    )
     check(
         all(
             term in lifecycle_source

--- a/tests/flatcar_promotion_test.py
+++ b/tests/flatcar_promotion_test.py
@@ -44,13 +44,13 @@ def base_config() -> dict:
             "replicas": 1,
             "cores": 2,
             "memory": "4Gi",
-            "disk": "20Gi",
+            "disk": "50Gi",
         },
         "workers": {
             "replicas": 1,
             "cores": 2,
             "memory": "4Gi",
-            "disk": "20Gi",
+            "disk": "50Gi",
         },
         "versions": {"kubernetes": "v1.34.1"},
         "network": {
@@ -271,12 +271,16 @@ def main() -> int:
             and all(
                 item["spec"]["storage"]["storageClassName"]
                 == "ok-storage-block"
+                and item["spec"]["storage"]["resources"]["requests"][
+                    "storage"
+                ]
+                == "50Gi"
                 and item["metadata"]["name"].endswith(
                     f"{revision_suffix}-boot"
                 )
                 for item in data_volume_templates
             ),
-            "templates and boot clones bind profile revision 4 to Longhorn",
+            "templates and 50Gi boot clones bind profile revision 5 to Longhorn",
         )
 
     lifecycle_source = (

--- a/tests/ok128_provisioning_benchmark_test.py
+++ b/tests/ok128_provisioning_benchmark_test.py
@@ -118,13 +118,13 @@ def main() -> int:
             "replicas": 1,
             "cores": 2,
             "memory": "4Gi",
-            "disk": "20Gi",
+            "disk": "50Gi",
         },
         "workers": {
             "replicas": 1,
             "cores": 2,
             "memory": "4Gi",
-            "disk": "20Gi",
+            "disk": "50Gi",
         },
         "nodeSelector": "ok-infra",
     }


### PR DESCRIPTION
## Summary

- make 50 GiB the exact CP/worker disk default for constrained Flatcar
- bind generated immutable templates to Flatcar profile revision 5
- verify rendered boot DataVolumes request 50 GiB on `ok-storage-block`
- move the controlled Flatcar/Talos benchmark envelope to identical 50 GiB disks
- update lifecycle self-tests and OK-135 evidence instructions

## Dependency

Depends on [openkubes/ok-linux#6](https://github.com/openkubes/ok-linux/pull/6). Merge and synchronize that source-of-truth change first.

## Validation

- `make ok135-test`
- `python3 scripts/flatcar_lifecycle.py --self-test`
- Python compile, Bash syntax, diff and secret checks

No live resource was created, modified, or deleted.

Jira: [OK-135](https://kubernauts.atlassian.net/browse/OK-135)