### PR TITLE
feat(observability): scoped metrics-only install path for ok-shared — OK-138

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # OpenKubes Cluster Templating — Makefile
 # Usage: make new CLUSTER=ok3 TYPE=ubuntu|talos|talos-mgmt|flatcar [HA=true] [WORKERS=3] [SCHEDULING_PROFILE=ok-gpu|ok-gpu-single-replica]
 #        TYPE is REQUIRED — no silent default (OK-119).
-.PHONY: new render install kubeconfig install-cni install-storage install-ingress install-observability install-keycloak register-cluster unregister-cluster bootstrap annotate-pvcs upgrade clean teardown teardown-all reap-orphaned-volumes e2e e2e-verify list status help prepare-cilium-chart verify-cilium-chart cilium-chart-tool-test configure-kubevirt-expand-disks
+.PHONY: new render install kubeconfig install-cni install-storage install-ingress install-observability install-observability-metrics install-keycloak register-cluster unregister-cluster bootstrap annotate-pvcs upgrade clean teardown teardown-all reap-orphaned-volumes e2e e2e-verify list status help prepare-cilium-chart verify-cilium-chart cilium-chart-tool-test configure-kubevirt-expand-disks
 .DEFAULT_GOAL := help
 
 CLUSTER       ?=
@@ -171,7 +171,7 @@ cilium-chart-tool-test: ## Offline-test Cilium acquisition/cache guards
 
 # OK-125 candidate evidence is intentionally outside the ordinary TYPE allowlist.
 # It consumes ok-linux profile truth and never applies resources.
-.PHONY: ok125-render ok125-management-test ok125-management-ignition ok125-runtime-test ok125-runtime-preflight ok125-node-ready ok125-replacement ok125-cleanup flatcar-promotion-test flatcar-preflight install-flatcar teardown-flatcar ok128-benchmark-test ok128-benchmark-preflight ok128-benchmark-flatcar ok128-benchmark-talos ok128-benchmark-compare ok128-benchmark-cleanup-verify ok130-test ok135-test ok136-test talos-golden-preflight talos-golden-runtime-evidence talos-golden-replacement-preflight talos-golden-replacement-apply
+.PHONY: ok125-render ok125-management-test ok125-management-ignition ok125-runtime-test ok125-runtime-preflight ok125-node-ready ok125-replacement ok125-cleanup flatcar-promotion-test flatcar-preflight install-flatcar teardown-flatcar ok128-benchmark-test ok128-benchmark-preflight ok128-benchmark-flatcar ok128-benchmark-talos ok128-benchmark-compare ok128-benchmark-cleanup-verify ok130-test ok135-test ok136-test ok138-observability-metrics-test talos-golden-preflight talos-golden-runtime-evidence talos-golden-replacement-preflight talos-golden-replacement-apply
 ok125-render: ## Render and validate the non-deployable OK-125 Flatcar candidate
 	@OK_LINUX_PATH="$(OK_LINUX_PATH)" \
 		python3 $(SCRIPT_DIR)/tests/ok125_flatcar_render_test.py \
@@ -219,6 +219,10 @@ flatcar-promotion-test: ## Offline-test the exact ordinary Flatcar profile
 		python3 $(SCRIPT_DIR)/tests/flatcar_promotion_test.py
 
 ok135-test: flatcar-promotion-test ok128-benchmark-test ## Offline-test Flatcar Longhorn clone contract
+
+ok138-observability-metrics-test: ## Offline-test metrics-only render and live-verifier guards
+	@PYTHONDONTWRITEBYTECODE=1 \
+		python3 $(SCRIPT_DIR)/tests/ok138_observability_metrics_test.py
 
 flatcar-preflight: require-cluster ## Read-only production Flatcar preflight
 	@OK_LINUX_PATH="$(OK_LINUX_PATH)" \
@@ -619,6 +623,29 @@ install-observability: require-cluster kubeconfig ## Install ok-observability-st
 	 CONTRACT_TEST_RECEIVER_CAPTURE_URL=$(CONTRACT_TEST_RECEIVER_CAPTURE_URL) \
 	 bash $(SCRIPT_DIR)/install-observability.sh
 
+install-observability-metrics: require-cluster kubeconfig ## Install metrics + alerting only and verify zot scraping (OK-138). Vars: OK_OBSERVABILITY_PATH, OK_OBSERVABILITY_REF, OBSERVABILITY_HELM_VALUES, OBSERVABILITY_METRICS_VERIFY_TIMEOUT
+	@CLUSTER=$(CLUSTER) \
+	 KUBECONFIG_PATH=$(HOME)/.kube/$(CLUSTER).yaml \
+	 OK_OBSERVABILITY_PATH=$(OK_OBSERVABILITY_PATH) \
+	 OK_OBSERVABILITY_REF=$(OK_OBSERVABILITY_REF) \
+	 OBSERVABILITY_VALUES=$(OBSERVABILITY_VALUES) \
+	 OBSERVABILITY_HELM_VALUES=$(OBSERVABILITY_HELM_VALUES) \
+	 OBSERVABILITY_SECRET_SOURCE=$(OBSERVABILITY_SECRET_SOURCE) \
+	 OBSERVABILITY_SECRET_SOURCES="$(OBSERVABILITY_SECRET_SOURCES)" \
+	 VAULT_ADDR=$(VAULT_ADDR) \
+	 VAULT_TLS_SERVER_NAME=$(VAULT_TLS_SERVER_NAME) \
+	 VAULT_CA_SECRET=$(VAULT_CA_SECRET) \
+	 KV_MOUNT=$(KV_MOUNT) \
+	 KV_PATH=$(KV_PATH) \
+	 VAULT_ROLE=$(VAULT_ROLE) \
+	 VSO_SERVICE_ACCOUNT=$(VSO_SERVICE_ACCOUNT) \
+	 REFRESH_AFTER=$(REFRESH_AFTER) \
+	 CONTRACT_TEST_TIMEOUT=$(CONTRACT_TEST_TIMEOUT) \
+	 CONTRACT_TEST_RECEIVER_CAPTURE_URL=$(CONTRACT_TEST_RECEIVER_CAPTURE_URL) \
+	 OBSERVABILITY_COMPONENTS=metrics \
+	 OBSERVABILITY_METRICS_VERIFY_TIMEOUT=$(OBSERVABILITY_METRICS_VERIFY_TIMEOUT) \
+	 bash $(SCRIPT_DIR)/install-observability.sh
+
 bootstrap: require-not-flatcar
 	@echo "Bootstrapping Talos cluster $(CLUSTER)..."
 	@$(MAKE) --no-print-directory talos-golden-preflight CLUSTER=$(CLUSTER)
@@ -642,6 +669,7 @@ bootstrap: require-not-flatcar
 	@echo "   make install-storage       CLUSTER=$(CLUSTER)"
 	@echo "   make install-ingress       CLUSTER=$(CLUSTER)"
 	@echo "   make install-observability CLUSTER=$(CLUSTER)   # OK-79: deploy + gated contract test"
+	@echo "   make install-observability-metrics CLUSTER=$(CLUSTER) # OK-138: Prometheus + zot scrape verification"
 	@echo "   make status                CLUSTER=$(CLUSTER)"
 
 annotate-pvcs: require-cluster
@@ -992,6 +1020,7 @@ help:
 	@echo "  make install-storage CLUSTER=ok-ai # local-path StorageClass (Talos)"
 	@echo "  make install-ingress CLUSTER=ok-ai # ingress controller (Traefik) + IngressClass ok-ingress"
 	@echo "  make install-observability CLUSTER=ok-ai [OBSERVABILITY_VALUES=<path>] # OK-79: ok-observability-standard + gated contract test"
+	@echo "  make install-observability-metrics CLUSTER=ok-shared # OK-138: Prometheus + Alertmanager only; verify zot scraping"
 	@echo "  make install-keycloak CLUSTER=ok-shared # OK-81: central Keycloak from a pinned openkubes revision (stops before the approval-gated steps)"
 	@echo "  make register-cluster CLUSTER=ok2-rmf [KUBECONFIG_SRC=~/path/kubeconfig] [MGMT_CLUSTER=ok-mgmt]  # ADR-013: secret + ProviderConfig in ok-mgmt"
 	@echo "  make bootstrap     CLUSTER=ok-ai  # talos: apply + annotate PVCs + cilium"

--- a/README.md
+++ b/README.md
@@ -331,6 +331,7 @@ make install-cni   CLUSTER=<name>                    # install Cilium (manual)
 make install-storage CLUSTER=<name>                  # install local-path-provisioner *inside* the workload cluster
 make install-ingress CLUSTER=<name>                  # Traefik + IngressClass ok-ingress + host-cluster LB proxy
 make install-observability CLUSTER=<name> [OBSERVABILITY_VALUES=<path>]  # OK-79: deploy ok-observability-standard + run the GATED contract test
+make install-observability-metrics CLUSTER=<name>    # OK-138: Prometheus + Alertmanager only; verify zot scraping
 make register-cluster CLUSTER=<name> [KUBECONFIG_SRC=<path>] [MGMT_CLUSTER=ok-mgmt]  # register with ok-mgmt (ADR-013)
 make unregister-cluster CLUSTER=<name> [FORCE=true] [MGMT_CLUSTER=ok-mgmt]           # deregister from ok-mgmt (OK-62)
 make annotate-pvcs CLUSTER=<name>                    # annotate PVCs for node binding
@@ -376,6 +377,27 @@ make list                                            # list all defined clusters
 > ok-shared by a `VaultStaticSecret` via the Vault Secrets Operator
 > (ADR-Platform-025) instead, with no chart change. The two profiles coexist by
 > envelope rather than in sequence (Secret Contract, ADR-Platform-011).
+
+> **`install-observability-metrics` is the deliberately scoped OK-138 path.**
+> Its capability assets come from the materialized
+> `implementations/prometheus` chart and `alerting/prometheus-rules.yaml`; an
+> optional `OBSERVABILITY_HELM_VALUES` file
+> can supply cluster-specific storage, retention, and resource Provider Values.
+> It installs into namespace `ok-observability` using Helm release
+> `ok-observability-standard`, so a later full-profile install upgrades the same
+> release instead of colliding over resource ownership. This path does not
+> require provider credential values or Vault, does not create the observability
+> credential Secret or Vault resources, does not apply Grafana dashboards or
+> OpenSearch assets, and does not run the full contract test. Before install, a
+> YAML-aware render guard requires a Prometheus resource, requires the bundled
+> Grafana subchart to be explicitly disabled, and rejects any Grafana/OpenSearch
+> Deployment or StatefulSet as well as any creation or reference of
+> `ok-observability-credentials`. After install, the scoped gate connects to
+> waits for both the Prometheus and Alertmanager resources to become Available,
+> then connects to Prometheus and requires both an active `health=up` target whose discovered
+> Kubernetes namespace and Service are `zot`, and a real sample returned by
+> `{__name__=~"zot_.+"}`; it prints the selected target discriminator and metric
+> value.
 
 ---
 

--- a/install-observability.sh
+++ b/install-observability.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# install-observability.sh — install the ok-observability-standard profile on a
-# workload cluster and run its Contract Test Gate (OK-79, ADR-Platform-018).
+# install-observability.sh — install the standard observability profile or its
+# scoped metrics component on a workload cluster (OK-79/OK-138, ADR-Platform-018).
 #
 # ok-cluster INSTALLS the capability; it does not OWN it. All assets (profile,
 # alerting rules, dashboards, contract test) come from the ok-observability repo
@@ -39,6 +39,7 @@
 #     KV_PATH, VAULT_ROLE, VSO_SERVICE_ACCOUNT, REFRESH_AFTER, VSS_SYNC_TIMEOUT.
 #
 # Optional env:
+#   OBSERVABILITY_COMPONENTS            standard (default) | metrics
 #   OK_OBSERVABILITY_REF              revision to materialise and consume
 #   OK_OBSERVABILITY_MODE             pinned (default) | worktree
 #   OK_OBSERVABILITY_CACHE            materialised-tree cache root (default:
@@ -59,6 +60,7 @@ RELEASE="${OBSERVABILITY_RELEASE:-ok-observability-standard}"
 SECRET_NAME="${OBSERVABILITY_SECRET:-ok-observability-credentials}"
 OBSERVABILITY_SOURCE_PATH="${OK_OBSERVABILITY_PATH:-}"
 OBSERVABILITY_MODE="${OK_OBSERVABILITY_MODE:-pinned}"
+OBSERVABILITY_COMPONENTS="${OBSERVABILITY_COMPONENTS:-standard}"
 _materialise_tmp=""
 _cred_dir=""
 
@@ -81,6 +83,20 @@ case "$OBSERVABILITY_MODE" in
   pinned|worktree) ;;
   *) echo "❌ OK_OBSERVABILITY_MODE='$OBSERVABILITY_MODE' is not one of: pinned worktree"; exit 2 ;;
 esac
+case "$OBSERVABILITY_COMPONENTS" in
+  standard|metrics) ;;
+  *) echo "❌ OBSERVABILITY_COMPONENTS='$OBSERVABILITY_COMPONENTS' is not one of: standard metrics"; exit 2 ;;
+esac
+if [ "$OBSERVABILITY_COMPONENTS" = metrics ]; then
+  [ "$NAMESPACE" = ok-observability ] || {
+    echo "❌ metrics mode requires OBSERVABILITY_NAMESPACE=ok-observability"
+    exit 2
+  }
+  [ "$RELEASE" = ok-observability-standard ] || {
+    echo "❌ metrics mode requires OBSERVABILITY_RELEASE=ok-observability-standard"
+    exit 2
+  }
+fi
 if [ "$OBSERVABILITY_MODE" = pinned ] && [ -z "${OK_OBSERVABILITY_REF:-}" ]; then
   echo "❌ OK_OBSERVABILITY_REF is required in pinned mode"
   echo "   Set it to a locally available commit/tag, or explicitly opt into the"
@@ -90,30 +106,32 @@ fi
 # OK-117: which mechanism populates the credentials Secret. Validated against the
 # allowed set so a typo fails loudly instead of silently selecting a profile — the
 # same class of defect as OK-119's TYPE default.
-SECRET_SOURCE="${OBSERVABILITY_SECRET_SOURCE:-file}"
-case " ${OBSERVABILITY_SECRET_SOURCES:-file vault} " in
-  *" $SECRET_SOURCE "*) ;;
-  *) echo "❌ OBSERVABILITY_SECRET_SOURCE='$SECRET_SOURCE' is not one of: ${OBSERVABILITY_SECRET_SOURCES:-file vault}"; exit 2 ;;
-esac
+if [ "$OBSERVABILITY_COMPONENTS" = standard ]; then
+  SECRET_SOURCE="${OBSERVABILITY_SECRET_SOURCE:-file}"
+  case " ${OBSERVABILITY_SECRET_SOURCES:-file vault} " in
+    *" $SECRET_SOURCE "*) ;;
+    *) echo "❌ OBSERVABILITY_SECRET_SOURCE='$SECRET_SOURCE' is not one of: ${OBSERVABILITY_SECRET_SOURCES:-file vault}"; exit 2 ;;
+  esac
 
-# The provider-values file is a precondition of the FILE profile only. Requiring it
-# on the vault path would force a datacenter cluster to supply passwords it never
-# uses — the Secret comes from Vault there.
-if [ "$SECRET_SOURCE" = file ] && [ ! -f "${OBSERVABILITY_VALUES:-}" ]; then
-  echo "❌ provider-values file not found: ${OBSERVABILITY_VALUES:-<unset>}"
-  echo "   Create a git-ignored file with:"
-  echo "     grafanaAdminPassword: \"...\""
-  echo "     opensearchAdminPassword: \"...\""
-  echo "   and pass it via OBSERVABILITY_VALUES=<path> (or place it at the default path)."
-  echo "   Or select the datacenter profile: OBSERVABILITY_SECRET_SOURCE=vault"
-  exit 2
-fi
-
-if [ "$SECRET_SOURCE" = vault ]; then
-  command -v envsubst >/dev/null 2>&1 || {
-    echo "❌ envsubst is required to render the VaultStaticSecret template (gettext package)"
+  # The provider-values file is a precondition of the FILE profile only. Requiring it
+  # on the vault path would force a datacenter cluster to supply passwords it never
+  # uses — the Secret comes from Vault there.
+  if [ "$SECRET_SOURCE" = file ] && [ ! -f "${OBSERVABILITY_VALUES:-}" ]; then
+    echo "❌ provider-values file not found: ${OBSERVABILITY_VALUES:-<unset>}"
+    echo "   Create a git-ignored file with:"
+    echo "     grafanaAdminPassword: \"...\""
+    echo "     opensearchAdminPassword: \"...\""
+    echo "   and pass it via OBSERVABILITY_VALUES=<path> (or place it at the default path)."
+    echo "   Or select the datacenter profile: OBSERVABILITY_SECRET_SOURCE=vault"
     exit 2
-  }
+  fi
+
+  if [ "$SECRET_SOURCE" = vault ]; then
+    command -v envsubst >/dev/null 2>&1 || {
+      echo "❌ envsubst is required to render the VaultStaticSecret template (gettext package)"
+      exit 2
+    }
+  fi
 fi
 
 export KUBECONFIG="$KUBECONFIG_PATH"
@@ -155,6 +173,11 @@ build_observability_deps() {
     helm dependency build "$profile" 2>/dev/null || helm dependency update --skip-refresh "$profile"
   fi
 }
+build_metrics_deps() {
+  local tree="$1"
+  local profile="$tree/implementations/prometheus"
+  helm dependency build "$profile"
+}
 
 OK_CLUSTER_SHA="$(sha_of "$_here")"
 OK_CLUSTER_STATE="$(tracked_state_of "$_here")"
@@ -181,31 +204,60 @@ if [ "$OBSERVABILITY_MODE" = pinned ]; then
     echo "❌ cannot choose an observability cache: set OK_OBSERVABILITY_CACHE, XDG_CACHE_HOME, or HOME"
     exit 2
   fi
-  _cache_tree="${_cache_root}/${OBSERVABILITY_SHA}"
+  _cache_suffix=""
+  _cache_marker_value="$OBSERVABILITY_SHA"
+  if [ "$OBSERVABILITY_COMPONENTS" = metrics ]; then
+    # A metrics-only cache is separate because it intentionally builds only the
+    # standalone Prometheus wrapper. It must never make a later standard install
+    # mistake the full two-level dependency closure for ready.
+    _cache_suffix="-metrics"
+    _cache_marker_value="${OBSERVABILITY_SHA}:metrics"
+  fi
+  _cache_tree="${_cache_root}/${OBSERVABILITY_SHA}${_cache_suffix}"
   _cache_marker="${_cache_tree}/.ok-cluster-cache-ready"
   mkdir -p "${_cache_root}/locks"
   chmod 700 "$_cache_root" "${_cache_root}/locks"
   exec 9>"${_cache_root}/locks/${OBSERVABILITY_SHA}.lock"
   flock 9
 
+  _cache_assets_ready=false
+  if [ "$OBSERVABILITY_COMPONENTS" = standard ]; then
+    [ -x "${_cache_tree}/tests/contract-test.sh" ] && _cache_assets_ready=true
+  else
+    [ -f "${_cache_tree}/implementations/prometheus/values.yaml" ] &&
+      [ -f "${_cache_tree}/alerting/prometheus-rules.yaml" ] &&
+      _cache_assets_ready=true
+  fi
   if [ -f "$_cache_marker" ] &&
-     [ "$(< "$_cache_marker")" = "$OBSERVABILITY_SHA" ] &&
-     [ -x "${_cache_tree}/tests/contract-test.sh" ]; then
+     [ "$(< "$_cache_marker")" = "$_cache_marker_value" ] &&
+     [ "$_cache_assets_ready" = true ]; then
     OBSERVABILITY_CACHE_RESULT="reused"
   else
     echo "  materialising ok-observability ${OBSERVABILITY_SHA} and building cached dependencies"
     _materialise_tmp="$(mktemp -d "${_cache_root}/.${OBSERVABILITY_SHA}.tmp.XXXXXX")"
     git -C "$OBSERVABILITY_SOURCE_PATH" archive "$OBSERVABILITY_SHA" | tar -x -C "$_materialise_tmp"
-    [ -d "${_materialise_tmp}/profiles/ok-observability-standard" ] || {
-      echo "❌ pinned revision ${OBSERVABILITY_SHA} has no ok-observability-standard profile"
-      exit 2
-    }
-    [ -x "${_materialise_tmp}/tests/contract-test.sh" ] || {
-      echo "❌ contract test is not executable in pinned revision ${OBSERVABILITY_SHA}"
-      exit 2
-    }
-    build_observability_deps "$_materialise_tmp"
-    printf '%s\n' "$OBSERVABILITY_SHA" > "${_materialise_tmp}/.ok-cluster-cache-ready"
+    if [ "$OBSERVABILITY_COMPONENTS" = standard ]; then
+      [ -d "${_materialise_tmp}/profiles/ok-observability-standard" ] || {
+        echo "❌ pinned revision ${OBSERVABILITY_SHA} has no ok-observability-standard profile"
+        exit 2
+      }
+      [ -x "${_materialise_tmp}/tests/contract-test.sh" ] || {
+        echo "❌ contract test is not executable in pinned revision ${OBSERVABILITY_SHA}"
+        exit 2
+      }
+      build_observability_deps "$_materialise_tmp"
+    else
+      [ -f "${_materialise_tmp}/implementations/prometheus/values.yaml" ] || {
+        echo "❌ pinned revision ${OBSERVABILITY_SHA} has no Prometheus implementation"
+        exit 2
+      }
+      [ -f "${_materialise_tmp}/alerting/prometheus-rules.yaml" ] || {
+        echo "❌ pinned revision ${OBSERVABILITY_SHA} has no Prometheus rules"
+        exit 2
+      }
+      build_metrics_deps "$_materialise_tmp"
+    fi
+    printf '%s\n' "$_cache_marker_value" > "${_materialise_tmp}/.ok-cluster-cache-ready"
     # The published cache is a read-only derived object. This prevents an
     # accidental edit from recreating the working-tree provenance hole.
     chmod -R a-w "$_materialise_tmp"
@@ -230,9 +282,17 @@ else
   OBSERVABILITY_STATE="WORKTREE ${SOURCE_OBSERVABILITY_STATE}; NON-REPRODUCIBLE"
 fi
 
-PROFILE="${OK_OBSERVABILITY_PATH}/profiles/ok-observability-standard"
+if [ "$OBSERVABILITY_COMPONENTS" = standard ]; then
+  PROFILE="${OK_OBSERVABILITY_PATH}/profiles/ok-observability-standard"
+else
+  PROFILE="${OK_OBSERVABILITY_PATH}/implementations/prometheus"
+fi
 [ -d "$PROFILE" ] || { echo "❌ profile not found: $PROFILE"; exit 2; }
-if [ "$SECRET_SOURCE" = vault ]; then
+PROMETHEUS_RULES="${OK_OBSERVABILITY_PATH}/alerting/prometheus-rules.yaml"
+if [ "$OBSERVABILITY_COMPONENTS" = metrics ]; then
+  [ -f "$PROMETHEUS_RULES" ] || { echo "❌ Prometheus rules not found: $PROMETHEUS_RULES"; exit 2; }
+fi
+if [ "$OBSERVABILITY_COMPONENTS" = standard ] && [ "$SECRET_SOURCE" = vault ]; then
   VSS_TEMPLATE="${OK_OBSERVABILITY_PATH}/implementations/vault-secrets-operator/vault-secret-sync.template.yaml"
   [ -f "$VSS_TEMPLATE" ] || {
     echo "❌ VaultStaticSecret template not found: $VSS_TEMPLATE"
@@ -253,6 +313,95 @@ else
   echo "  consumed ok-observability: ${OBSERVABILITY_SHA} (${OBSERVABILITY_STATE})"
   echo "  ⚠️  WORKING-TREE ESCAPE HATCH ACTIVE — ignored, untracked, and modified files may be rendered"
   echo "  ⚠️  this run is NOT reproducible conformance evidence; OK_OBSERVABILITY_REF is not applied"
+fi
+
+if [ "$OBSERVABILITY_COMPONENTS" = metrics ]; then
+  # Metrics is deliberately not the full ADR-018 contract profile. It creates no
+  # credential Secret or Vault resource, and it does not apply dashboards,
+  # OpenSearch assets, or the full contract gate. Capability-owned Prometheus
+  # rules remain part of this metrics-and-alerting component.
+  echo "  selected component: metrics (Prometheus + Alertmanager only)"
+  if [ "$OBSERVABILITY_MODE" = worktree ]; then
+    build_metrics_deps "$OK_OBSERVABILITY_PATH"
+  fi
+
+  echo "  [1/5] namespace ${NAMESPACE} + PSA privileged labels (node-exporter needs host access)"
+  kubectl create namespace "$NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
+  kubectl label namespace "$NAMESPACE" \
+    pod-security.kubernetes.io/enforce=privileged \
+    pod-security.kubernetes.io/warn=privileged \
+    pod-security.kubernetes.io/audit=privileged \
+    --overwrite
+
+  # The standalone wrapper's vendored defaults contain a self-consistent local
+  # Alertmanager receiver. Do not layer alerting/alertmanager-values.yaml here:
+  # its receiver-list override retains the upstream nested `null` route and the
+  # operator correctly rejects that merged config. A real receiver remains a
+  # Provider Value supplied through OBSERVABILITY_HELM_VALUES.
+  metrics_values=( -f "$PROFILE/values.yaml" )
+  if [ -n "${OBSERVABILITY_HELM_VALUES:-}" ]; then
+    metrics_values+=( -f "$OBSERVABILITY_HELM_VALUES" )
+  fi
+  echo "  [2/5] structural render guard"
+  helm template "$RELEASE" "$PROFILE" \
+    --namespace "$NAMESPACE" \
+    "${metrics_values[@]}" \
+    | python3 "${_here}/scripts/verify_observability_metrics.py" \
+        render-guard \
+        --values "$PROFILE/values.yaml" \
+        --forbidden-secret "$SECRET_NAME"
+
+  # Keep the standard release identity: installing the standard profile later is
+  # an upgrade of this release, not a second owner contending for the same objects.
+  echo "  [3/5] Helm upgrade + capability-owned PrometheusRules"
+  helm upgrade --install "$RELEASE" "$PROFILE" \
+    --namespace "$NAMESPACE" \
+    "${metrics_values[@]}" \
+    --timeout "${HELM_TIMEOUT:-10m}"
+  kubectl -n "$NAMESPACE" apply -f "$PROMETHEUS_RULES"
+
+  echo "  [4/5] waiting for Prometheus + Alertmanager and metrics pods to become Ready"
+  kubectl -n "$NAMESPACE" wait --for=condition=Available \
+    prometheus/ok-observability-prometheus \
+    --timeout="${OBSERVABILITY_READY_TIMEOUT:-420}s"
+  kubectl -n "$NAMESPACE" wait --for=condition=Available \
+    alertmanager/ok-observability-alertmanager \
+    --timeout="${OBSERVABILITY_READY_TIMEOUT:-420}s"
+  deadline=$(( $(date +%s) + ${OBSERVABILITY_READY_TIMEOUT:-420} ))
+  while :; do
+    notready=$(kubectl -n "$NAMESPACE" get pods -o json | python3 -c '
+import json, sys
+pods = json.load(sys.stdin).get("items", [])
+for pod in pods:
+    statuses = pod.get("status", {}).get("containerStatuses") or []
+    phase = pod.get("status", {}).get("phase")
+    if phase == "Succeeded":
+        continue
+    if not statuses or not all(status.get("ready") is True for status in statuses):
+        print(pod.get("metadata", {}).get("name", "<unnamed>"))
+' | paste -sd" " -)
+    [ -z "$notready" ] && { echo "    ✅ all metrics pods Ready"; break; }
+    if [ "$(date +%s)" -ge "$deadline" ]; then
+      echo "    ⚠️  not Ready after ${OBSERVABILITY_READY_TIMEOUT:-420}s, continuing to scoped verification: $notready"
+      break
+    fi
+    echo "    ⏳ $notready"
+    sleep 15
+  done
+
+  echo "  [5/5] verifying zot target and zot metric sample through Prometheus"
+  python3 "${_here}/scripts/verify_observability_metrics.py" live \
+    --namespace "$NAMESPACE" \
+    --service ok-observability-prometheus \
+    --target-namespace zot \
+    --target-service zot \
+    --metric-regex 'zot_.+' \
+    --timeout "${OBSERVABILITY_METRICS_VERIFY_TIMEOUT:-180}"
+
+  echo ""
+  echo "✅ install-observability metrics complete on ${CLUSTER} — zot target and sample verified."
+  echo "   evidence: ok-cluster ${OK_CLUSTER_SHA} (${OK_CLUSTER_STATE}) · ok-observability ${OBSERVABILITY_SHA} (${OBSERVABILITY_STATE})"
+  exit 0
 fi
 
 # --- read passwords from provider-values (FILE profile only) ---------------

--- a/scripts/verify_observability_metrics.py
+++ b/scripts/verify_observability_metrics.py
@@ -1,0 +1,354 @@
+#!/usr/bin/env python3
+"""Structural and live checks for the scoped observability metrics install."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import re
+import socket
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+FORBIDDEN_WORKLOAD_TOKENS = ("grafana", "opensearch")
+WORKLOAD_KINDS = {"Deployment", "StatefulSet"}
+
+
+class VerificationError(RuntimeError):
+    """Raised when a metrics-only invariant is not satisfied."""
+
+
+def scalar_strings(value: Any):
+    if isinstance(value, dict):
+        for key, child in value.items():
+            yield str(key)
+            yield from scalar_strings(child)
+    elif isinstance(value, list):
+        for child in value:
+            yield from scalar_strings(child)
+    elif isinstance(value, str):
+        yield value
+
+
+def render_guard(
+    documents: list[dict[str, Any]],
+    values: dict[str, Any],
+    forbidden_secret: str = "ok-observability-credentials",
+) -> None:
+    stack = values.get("kube-prometheus-stack")
+    if not isinstance(stack, dict):
+        raise VerificationError(
+            "metrics values have no kube-prometheus-stack mapping"
+        )
+    grafana = stack.get("grafana")
+    if not isinstance(grafana, dict) or grafana.get("enabled") is not False:
+        raise VerificationError(
+            "kube-prometheus-stack.grafana.enabled must be boolean false"
+        )
+
+    prometheus_objects = [
+        document
+        for document in documents
+        if isinstance(document, dict) and document.get("kind") == "Prometheus"
+    ]
+    if not prometheus_objects:
+        raise VerificationError("render contains no Prometheus custom resource")
+    alertmanager_objects = [
+        document
+        for document in documents
+        if isinstance(document, dict) and document.get("kind") == "Alertmanager"
+    ]
+    if not alertmanager_objects:
+        raise VerificationError("render contains no Alertmanager custom resource")
+
+    forbidden: list[str] = []
+    for document in documents:
+        if not isinstance(document, dict) or document.get("kind") not in WORKLOAD_KINDS:
+            continue
+        identity = " ".join(scalar_strings(document)).lower()
+        matches = [token for token in FORBIDDEN_WORKLOAD_TOKENS if token in identity]
+        if matches:
+            name = document.get("metadata", {}).get("name", "<unnamed>")
+            forbidden.append(
+                f"{document.get('kind')}/{name} ({', '.join(matches)})"
+            )
+    if forbidden:
+        raise VerificationError(
+            "render contains forbidden metrics-only workload(s): "
+            + ", ".join(forbidden)
+        )
+
+    secret_references: list[str] = []
+    for document in documents:
+        if not isinstance(document, dict):
+            continue
+        kind = str(document.get("kind", "<unknown>"))
+        name = str(document.get("metadata", {}).get("name", "<unnamed>"))
+        if forbidden_secret in scalar_strings(document):
+            secret_references.append(f"{kind}/{name}")
+    if secret_references:
+        raise VerificationError(
+            f"render creates or references forbidden credential Secret {forbidden_secret}: "
+            + ", ".join(secret_references)
+        )
+
+    names = sorted(
+        str(document.get("metadata", {}).get("name", "<unnamed>"))
+        for document in prometheus_objects
+    )
+    alertmanager_names = sorted(
+        str(document.get("metadata", {}).get("name", "<unnamed>"))
+        for document in alertmanager_objects
+    )
+    print(
+        "PASS metrics render: Prometheus="
+        + ",".join(names)
+        + "; Alertmanager="
+        + ",".join(alertmanager_names)
+        + "; Grafana disabled; no Grafana/OpenSearch Deployment or StatefulSet"
+    )
+
+
+def kubectl_json(arguments: list[str]) -> dict[str, Any]:
+    completed = subprocess.run(
+        ["kubectl", *arguments],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode:
+        detail = completed.stderr.strip() or completed.stdout.strip()
+        raise VerificationError(f"kubectl {' '.join(arguments)} failed: {detail}")
+    try:
+        value = json.loads(completed.stdout)
+    except json.JSONDecodeError as error:
+        raise VerificationError("kubectl returned invalid JSON for Prometheus Service") from error
+    if not isinstance(value, dict):
+        raise VerificationError("kubectl returned a non-object for Prometheus Service")
+    return value
+
+
+def available_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listener:
+        listener.bind(("127.0.0.1", 0))
+        return int(listener.getsockname()[1])
+
+
+def api_json(base_url: str, path: str, parameters: dict[str, str] | None = None):
+    query = "" if not parameters else "?" + urllib.parse.urlencode(parameters)
+    with urllib.request.urlopen(base_url + path + query, timeout=3) as response:
+        payload = json.load(response)
+    if not isinstance(payload, dict) or payload.get("status") != "success":
+        raise VerificationError(f"Prometheus API did not return success for {path}")
+    return payload
+
+
+def target_namespace(target: dict[str, Any]) -> str | None:
+    labels = target.get("labels") or {}
+    discovered = target.get("discoveredLabels") or {}
+    return labels.get("namespace") or discovered.get("__meta_kubernetes_namespace")
+
+
+def target_service(target: dict[str, Any]) -> str | None:
+    discovered = target.get("discoveredLabels") or {}
+    return discovered.get("__meta_kubernetes_service_name")
+
+
+def target_discriminator(target: dict[str, Any]) -> str:
+    labels = target.get("labels") or {}
+    fields = {
+        "job": labels.get("job"),
+        "instance": labels.get("instance"),
+        "scrapePool": target.get("scrapePool"),
+        "scrapeUrl": target.get("scrapeUrl"),
+    }
+    return " ".join(f"{key}={value}" for key, value in fields.items() if value)
+
+
+def first_real_sample(results: list[dict[str, Any]], metric_pattern: re.Pattern[str]):
+    for result in results:
+        metric = result.get("metric") or {}
+        metric_name = metric.get("__name__")
+        value = result.get("value")
+        if not isinstance(metric_name, str) or not metric_pattern.fullmatch(metric_name):
+            continue
+        if not isinstance(value, list) or len(value) != 2:
+            continue
+        try:
+            numeric_value = float(value[1])
+        except (TypeError, ValueError):
+            continue
+        if math.isfinite(numeric_value):
+            return metric_name, str(value[1]), metric
+    return None
+
+
+def live_check(
+    namespace: str,
+    service: str,
+    target_ns: str,
+    target_svc: str,
+    metric_regex: str,
+    timeout: int,
+) -> None:
+    service_object = kubectl_json(
+        ["-n", namespace, "get", "service", service, "-o", "json"]
+    )
+    ports = service_object.get("spec", {}).get("ports") or []
+    if not any(
+        port.get("port") == 9090 or port.get("name") in {"http-web", "web"}
+        for port in ports
+        if isinstance(port, dict)
+    ):
+        raise VerificationError(
+            f"Service/{service} exposes no structurally identifiable Prometheus port"
+        )
+
+    local_port = available_port()
+    process = subprocess.Popen(
+        [
+            "kubectl",
+            "-n",
+            namespace,
+            "port-forward",
+            f"service/{service}",
+            f"{local_port}:9090",
+            "--address=127.0.0.1",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    base_url = f"http://127.0.0.1:{local_port}"
+    deadline = time.monotonic() + timeout
+    selected_target = None
+    sample = None
+    query = f'{{__name__=~"{metric_regex}"}}'
+    pattern = re.compile(metric_regex)
+    last_error = "Prometheus API did not become ready"
+    try:
+        while time.monotonic() < deadline:
+            if process.poll() is not None:
+                stdout, stderr = process.communicate()
+                detail = stderr.strip() or stdout.strip()
+                raise VerificationError(f"Prometheus port-forward stopped: {detail}")
+            try:
+                payload = api_json(base_url, "/api/v1/targets", {"state": "active"})
+                targets = payload.get("data", {}).get("activeTargets") or []
+                selected_target = next(
+                    (
+                        target
+                        for target in targets
+                        if isinstance(target, dict)
+                        and target.get("health") == "up"
+                        and target_namespace(target) == target_ns
+                        and target_service(target) == target_svc
+                    ),
+                    None,
+                )
+                if selected_target is None:
+                    last_error = (
+                        "no active health=up target discovered for "
+                        f"namespace={target_ns} service={target_svc}"
+                    )
+                else:
+                    payload = api_json(base_url, "/api/v1/query", {"query": query})
+                    result_type = payload.get("data", {}).get("resultType")
+                    results = payload.get("data", {}).get("result") or []
+                    if result_type != "vector":
+                        last_error = f"zot metric query returned resultType={result_type!r}"
+                    else:
+                        sample = first_real_sample(results, pattern)
+                        if sample is not None:
+                            break
+                        last_error = "zot metric query returned no finite sample"
+            except (OSError, urllib.error.URLError, json.JSONDecodeError, VerificationError) as error:
+                last_error = str(error)
+            time.sleep(2)
+        if selected_target is None or sample is None:
+            raise VerificationError(last_error)
+
+        metric_name, metric_value, metric_labels = sample
+        label_discriminator = ",".join(
+            f"{key}={value}"
+            for key, value in sorted(metric_labels.items())
+            if key != "__name__"
+        )
+        print(
+            f"PASS target namespace={target_ns} service={target_svc} health=up "
+            f"{target_discriminator(selected_target)}"
+        )
+        print(
+            f"PASS sample metric={metric_name} value={metric_value} "
+            f"labels={label_discriminator or '<none>'}"
+        )
+    finally:
+        if process.poll() is None:
+            process.terminate()
+            try:
+                process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait(timeout=5)
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser(description=__doc__)
+    subcommands = result.add_subparsers(dest="command", required=True)
+    render = subcommands.add_parser("render-guard")
+    render.add_argument("--values", type=Path, required=True)
+    render.add_argument(
+        "--forbidden-secret", default="ok-observability-credentials"
+    )
+    live = subcommands.add_parser("live")
+    live.add_argument("--namespace", default="ok-observability")
+    live.add_argument("--service", default="ok-observability-prometheus")
+    live.add_argument("--target-namespace", default="zot")
+    live.add_argument("--target-service", default="zot")
+    live.add_argument("--metric-regex", default=r"zot_.+")
+    live.add_argument("--timeout", type=int, default=180)
+    return result
+
+
+def main() -> int:
+    arguments = parser().parse_args()
+    try:
+        if arguments.command == "render-guard":
+            with arguments.values.open(encoding="utf-8") as stream:
+                values = yaml.safe_load(stream) or {}
+            if not isinstance(values, dict):
+                raise VerificationError("metrics values document is not a mapping")
+            documents = [
+                document
+                for document in yaml.safe_load_all(sys.stdin)
+                if document is not None
+            ]
+            render_guard(documents, values, arguments.forbidden_secret)
+        else:
+            live_check(
+                arguments.namespace,
+                arguments.service,
+                arguments.target_namespace,
+                arguments.target_service,
+                arguments.metric_regex,
+                arguments.timeout,
+            )
+    except (OSError, yaml.YAMLError, VerificationError) as error:
+        print(f"FAIL {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/ok138_observability_metrics_test.py
+++ b/tests/ok138_observability_metrics_test.py
@@ -1,0 +1,354 @@
+#!/usr/bin/env python3
+"""Offline positive and negative tests for the OK-138 metrics-only installer."""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+VERIFIER = ROOT / "scripts" / "verify_observability_metrics.py"
+SPEC = importlib.util.spec_from_file_location("metrics_verifier", VERIFIER)
+assert SPEC and SPEC.loader
+verifier = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(verifier)
+
+
+def check(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+    print(f"PASS {message}")
+
+
+def expect_rejected(function, expected: str, message: str) -> None:
+    try:
+        function()
+    except verifier.VerificationError as error:
+        check(expected in str(error), f"{message}: {error}")
+    else:
+        raise AssertionError(f"guard accepted violation: {message}")
+
+
+def values(grafana_enabled: bool = False) -> dict:
+    return {
+        "kube-prometheus-stack": {
+            "fullnameOverride": "ok-observability",
+            "grafana": {"enabled": grafana_enabled},
+        }
+    }
+
+
+def prometheus_document() -> dict:
+    return {
+        "apiVersion": "monitoring.coreos.com/v1",
+        "kind": "Prometheus",
+        "metadata": {"name": "ok-observability-prometheus"},
+    }
+
+
+def alertmanager_document() -> dict:
+    return {
+        "apiVersion": "monitoring.coreos.com/v1",
+        "kind": "Alertmanager",
+        "metadata": {"name": "ok-observability-alertmanager"},
+    }
+
+
+def metrics_documents(*extra: dict) -> list[dict]:
+    return [prometheus_document(), alertmanager_document(), *extra]
+
+
+class FakePortForward:
+    def __init__(self) -> None:
+        self.returncode = None
+
+    def poll(self):
+        return self.returncode
+
+    def communicate(self):
+        return "", ""
+
+    def terminate(self):
+        self.returncode = 0
+
+    def wait(self, timeout=None):
+        self.returncode = 0
+        return 0
+
+    def kill(self):
+        self.returncode = -9
+
+
+SERVICE = {"spec": {"ports": [{"name": "http-web", "port": 9090}]}}
+UP_TARGET = {
+    "health": "up",
+    "labels": {"namespace": "zot", "job": "zot", "instance": "zot:5000"},
+    "discoveredLabels": {
+        "__meta_kubernetes_namespace": "zot",
+        "__meta_kubernetes_service_name": "zot",
+    },
+    "scrapePool": "serviceMonitor/zot/zot/0",
+    "scrapeUrl": "http://zot.zot.svc:5000/metrics",
+}
+DOWN_TARGET = {**UP_TARGET, "health": "down"}
+
+
+def api_payload(target, result=None):
+    targets = {
+        "status": "success",
+        "data": {"activeTargets": [target]},
+    }
+    query = {
+        "status": "success",
+        "data": {"resultType": "vector", "result": result or []},
+    }
+    return targets, query
+
+
+def run_live_with(responses, monotonic_values):
+    with (
+        mock.patch.object(verifier, "kubectl_json", return_value=SERVICE),
+        mock.patch.object(verifier, "available_port", return_value=19090),
+        mock.patch.object(verifier.subprocess, "Popen", return_value=FakePortForward()),
+        mock.patch.object(verifier, "api_json", side_effect=responses),
+        mock.patch.object(verifier.time, "monotonic", side_effect=monotonic_values),
+        mock.patch.object(verifier.time, "sleep", return_value=None),
+    ):
+        verifier.live_check(
+            "ok-observability",
+            "ok-observability-prometheus",
+            "zot",
+            "zot",
+            r"zot_.+",
+            1,
+        )
+
+
+def make_recipe(name: str) -> str:
+    lines = (ROOT / "Makefile").read_text(encoding="utf-8").splitlines()
+    start = next(index for index, line in enumerate(lines) if line.startswith(name + ":"))
+    body = []
+    for line in lines[start + 1 :]:
+        if line and not line.startswith(("\t", " ")):
+            break
+        body.append(line)
+    return "\n".join(body)
+
+
+def main() -> int:
+    expect_rejected(
+        lambda: verifier.render_guard([], values()),
+        "no Prometheus",
+        "render guard rejects missing Prometheus",
+    )
+    expect_rejected(
+        lambda: verifier.render_guard(metrics_documents(), values(True)),
+        "must be boolean false",
+        "render guard rejects enabled Grafana structurally",
+    )
+    expect_rejected(
+        lambda: verifier.render_guard([prometheus_document()], values()),
+        "no Alertmanager",
+        "render guard rejects missing Alertmanager",
+    )
+    forbidden = {
+        "apiVersion": "apps/v1",
+        "kind": "StatefulSet",
+        "metadata": {"name": "search"},
+        "spec": {
+            "template": {
+                "spec": {"containers": [{"name": "db", "image": "opensearch:2"}]}
+            }
+        },
+    }
+    expect_rejected(
+        lambda: verifier.render_guard(metrics_documents(forbidden), values()),
+        "forbidden metrics-only workload",
+        "render guard rejects OpenSearch workload structurally",
+    )
+    credential_secret = {
+        "apiVersion": "v1",
+        "kind": "Secret",
+        "metadata": {"name": "ok-observability-credentials"},
+    }
+    expect_rejected(
+        lambda: verifier.render_guard(
+            metrics_documents(credential_secret), values()
+        ),
+        "forbidden credential Secret",
+        "render guard rejects the observability credential Secret",
+    )
+    credential_reference = {
+        "apiVersion": "apps/v1",
+        "kind": "Deployment",
+        "metadata": {"name": "metrics-consumer"},
+        "spec": {
+            "template": {
+                "spec": {
+                    "containers": [
+                        {
+                            "name": "consumer",
+                            "image": "example.invalid/consumer",
+                            "envFrom": [
+                                {
+                                    "secretRef": {
+                                        "name": "ok-observability-credentials"
+                                    }
+                                }
+                            ],
+                        }
+                    ]
+                }
+            }
+        },
+    }
+    expect_rejected(
+        lambda: verifier.render_guard(
+            metrics_documents(credential_reference), values()
+        ),
+        "forbidden credential Secret",
+        "render guard rejects a reference to the observability credential Secret",
+    )
+    verifier.render_guard(metrics_documents(), values())
+    check(True, "render guard accepts metrics-and-alerting output")
+
+    down_targets, _ = api_payload(DOWN_TARGET)
+    expect_rejected(
+        lambda: run_live_with([down_targets], [0, 0, 2]),
+        "no active health=up target",
+        "live verifier rejects a down zot target",
+    )
+    wrong_service = {
+        **UP_TARGET,
+        "discoveredLabels": {
+            **UP_TARGET["discoveredLabels"],
+            "__meta_kubernetes_service_name": "another-service",
+        },
+    }
+    wrong_service_targets, _ = api_payload(wrong_service)
+    expect_rejected(
+        lambda: run_live_with([wrong_service_targets], [0, 0, 2]),
+        "service=zot",
+        "live verifier rejects another service in the zot namespace",
+    )
+    up_targets, empty_query = api_payload(UP_TARGET)
+    expect_rejected(
+        lambda: run_live_with(
+            [up_targets, empty_query],
+            [0, 0, 2],
+        ),
+        "no finite sample",
+        "live verifier rejects an empty zot metric query",
+    )
+    sample = {
+        "metric": {"__name__": "zot_requests_total", "instance": "zot:5000"},
+        "value": [1786350000.0, "7"],
+    }
+    up_targets, real_query = api_payload(UP_TARGET, [sample])
+    run_live_with([up_targets, real_query], [0, 0])
+    check(True, "live verifier accepts an up zot target and real zot sample")
+
+    standard_recipe = make_recipe("install-observability")
+    metrics_recipe = make_recipe("install-observability-metrics")
+    assignments = (
+        "CLUSTER",
+        "KUBECONFIG_PATH",
+        "OK_OBSERVABILITY_PATH",
+        "OK_OBSERVABILITY_REF",
+        "OBSERVABILITY_VALUES",
+        "OBSERVABILITY_HELM_VALUES",
+        "OBSERVABILITY_SECRET_SOURCE",
+        "OBSERVABILITY_SECRET_SOURCES",
+        "VAULT_ADDR",
+        "VAULT_TLS_SERVER_NAME",
+        "VAULT_CA_SECRET",
+        "KV_MOUNT",
+        "KV_PATH",
+        "VAULT_ROLE",
+        "VSO_SERVICE_ACCOUNT",
+        "REFRESH_AFTER",
+        "CONTRACT_TEST_TIMEOUT",
+        "CONTRACT_TEST_RECEIVER_CAPTURE_URL",
+    )
+    check(
+        all(f"{name}=" in standard_recipe and f"{name}=" in metrics_recipe for name in assignments)
+        and "OBSERVABILITY_COMPONENTS=metrics" in metrics_recipe,
+        "metrics Make target preserves standard variable passing and selects metrics",
+    )
+
+    installer = (ROOT / "install-observability.sh").read_text(encoding="utf-8")
+    check(
+        'OBSERVABILITY_COMPONENTS="${OBSERVABILITY_COMPONENTS:-standard}"'
+        in installer
+        and "standard|metrics" in installer,
+        "component enum defaults an unset value to standard",
+    )
+    check(
+        'NAMESPACE="${OBSERVABILITY_NAMESPACE:-ok-observability}"' in installer
+        and 'RELEASE="${OBSERVABILITY_RELEASE:-ok-observability-standard}"'
+        in installer
+        and "metrics mode requires OBSERVABILITY_NAMESPACE=ok-observability"
+        in installer
+        and "metrics mode requires OBSERVABILITY_RELEASE=ok-observability-standard"
+        in installer,
+        "metrics mode pins the standard namespace and release identity",
+    )
+    check(
+        'metrics_values+=( -f "$OBSERVABILITY_HELM_VALUES" )' in installer
+        and 'kubectl -n "$NAMESPACE" apply -f "$PROMETHEUS_RULES"' in installer
+        and 'apply -f "${OK_OBSERVABILITY_PATH}/dashboards/"' in installer,
+        "metrics layers Provider Values and rules while standard retains dashboards",
+    )
+    check(
+        "[1/6]" in installer
+        and "[2/6]" in installer
+        and "[3/6]" in installer
+        and "[4/6]" in installer
+        and "[5/6]" in installer
+        and "[6/6]" in installer
+        and 'GATE="${OK_OBSERVABILITY_PATH}/tests/contract-test.sh"' in installer,
+        "standard mode retains all six steps and the full contract gate",
+    )
+
+    with tempfile.NamedTemporaryFile() as kubeconfig:
+        environment = dict(
+            os.environ,
+            CLUSTER="offline-test",
+            KUBECONFIG_PATH=kubeconfig.name,
+            OK_OBSERVABILITY_PATH=str(ROOT.parent / "ok-observability"),
+            OK_OBSERVABILITY_MODE="worktree",
+            OBSERVABILITY_COMPONENTS="invalid",
+        )
+        invalid_component = subprocess.run(
+            ["bash", str(ROOT / "install-observability.sh")],
+            env=environment,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    check(
+        invalid_component.returncode == 2
+        and "is not one of: standard metrics" in invalid_component.stdout,
+        "component enum rejects an invalid value before any cluster access",
+    )
+
+    syntax = subprocess.run(
+        ["bash", "-n", str(ROOT / "install-observability.sh")],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    check(syntax.returncode == 0, "installer has valid Bash syntax")
+    ast.parse(VERIFIER.read_text(encoding="utf-8"), filename=str(VERIFIER))
+    check(True, "metrics verifier has valid Python syntax")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes OK-138's remaining metrics criterion by giving `ok-shared` a scraper, without dragging in the rest of the profile.

## Why not just run `install-observability`

zot on ok-shared already exposes authenticated `/metrics` and ships a ServiceMonitor, but nothing scraped it — the cluster had no observability stack, no Helm releases and no Prometheus CRs. The existing target installs the whole `ok-observability-standard` profile: Grafana and OpenSearch too, their admin credentials, and on a datacenter cluster a `VaultStaticSecret` needing a privileged Vault role that does not exist for ok-shared. That is materially more than this criterion requires.

`ok-observability` already decomposes per guarantee: `implementations/prometheus` is a standalone implementation of ADR-Platform-018 guarantees \#1 and \#4, with Grafana deliberately disabled, no credential references, and its `kube-prometheus-stack` dependency vendored. So metrics-only needs **no change to the capability-owning repository**. Adding `condition:`/`tags:` to the standard umbrella was rejected: it would let something named after the standard profile install a fraction of what ADR-018 defines it to be.

## What this adds

`OBSERVABILITY_COMPONENTS=standard|metrics` on the **existing** installer rather than a second script, so the pinned-revision materialisation, read-only cache tree and provenance reporting are shared instead of reimplemented, plus `make install-observability-metrics`.

Metrics mode pins namespace `ok-observability` and release `ok-observability-standard`, so installing the full profile later is an **upgrade of the same release**, not a colliding second install. It skips the five-guarantee contract test deliberately — that gate asserts dashboards and log search, which are absent here by design, so running it would fail correctly and prove nothing about metrics.

## Verified on ok-shared

Asserted by effect, not exit code — a healthy Prometheus is not evidence it scrapes anything:

```
serviceMonitor/zot/zot/0   health=up   https://10.35.1.133:5000/metrics   lastError=''
zot_repo_uploads_total{repo="openkubes/human/oidc-20260810t083452z-30161"} = 1
zot_repo_uploads_total{repo="openkubes/machine/charts/demo-20260810t083408z"} = 1
```

Those repo labels come from the OK-138 registry conformance runs, so this is a real end-to-end link rather than a synthetic probe.

Also verified:
- **The default path is unchanged.** With `OBSERVABILITY_COMPONENTS` unset, `install-observability` still refuses with the identical provider-values precondition and exit 2.
- **The new verifier can fail.** Wrong service → `FAIL no active health=up target`, exit 1. Non-existent metric → `FAIL … no finite sample`, exit 1. Real arguments → exit 0.
- No Grafana or OpenSearch workload anywhere; no `ok-observability-credentials` Secret; no VaultAuth/VaultStaticSecret created; no Vault or ok-mgmt operation performed.
- The pre-existing orphaned `alertmanager-…` PVC in namespace `default` is untouched — same UID and creation timestamp. It has no ownerReferences, but deleting or adopting stateful data was out of scope.

## What this does NOT claim

This does **not** make ok-shared conformant with ADR-Platform-018. Guarantees \#2 (dashboards) and \#3 (log search) remain unmet by design. Those are served either by the rest of the per-cluster stack or by ADR-Platform-020's federated layer under OK-81 — which is additive: "Thanos requires per-cluster Prometheus — the ADR-018 stack is the foundation of the federated model, not its alternative."

Refs: OK-138, OK-81 · ADR-Platform-018, ADR-Platform-020, ADR-Platform-025
