### PR TITLE
feat(talos): opt-in per-cluster registry trust — OK-138 kubelet-pull prerequisite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # OpenKubes Cluster Templating — Makefile
 # Usage: make new CLUSTER=ok3 TYPE=ubuntu|talos|talos-mgmt|flatcar [HA=true] [WORKERS=3] [SCHEDULING_PROFILE=ok-gpu|ok-gpu-single-replica]
 #        TYPE is REQUIRED — no silent default (OK-119).
-.PHONY: new render install kubeconfig install-cni install-storage install-ingress install-observability install-observability-metrics install-keycloak register-cluster unregister-cluster bootstrap annotate-pvcs upgrade clean teardown teardown-all reap-orphaned-volumes e2e e2e-verify list status help prepare-cilium-chart verify-cilium-chart cilium-chart-tool-test configure-kubevirt-expand-disks
+.PHONY: new render install kubeconfig install-cni install-storage install-ingress install-observability install-observability-metrics install-keycloak register-cluster unregister-cluster bootstrap annotate-pvcs upgrade clean teardown teardown-all reap-orphaned-volumes e2e e2e-verify list status help prepare-cilium-chart verify-cilium-chart cilium-chart-tool-test configure-kubevirt-expand-disks talos-registry-trust-review talos-registry-trust-dry-run talos-registry-trust-apply ok138-registry-trust-test
 .DEFAULT_GOAL := help
 
 CLUSTER       ?=
@@ -24,6 +24,19 @@ NODE_SELECTOR ?= $(NODE)
 SCHEDULING_PROFILE ?=
 START_IP      ?=
 DRY_RUN       ?= false
+REGISTRY_TRUST ?= false
+REGISTRY_HOST ?= registry.ok-shared.internal
+REGISTRY_CA_SECRET_NAMESPACE ?= cert-manager
+REGISTRY_CA_SECRET_NAME ?= ok-shared-internal-ca
+REGISTRY_CA_SECRET_KEY ?= ca.crt
+REGISTRY_SERVICE_NAMESPACE ?= ok-shared
+REGISTRY_SERVICE_NAME ?= ok-shared-ingress
+REGISTRY_TALOSCONFIG_SECRET_NAMESPACE ?=
+REGISTRY_TALOSCONFIG_SECRET_NAME ?=
+REGISTRY_TALOSCONFIG_SECRET_KEY ?= talosconfig
+REGISTRY_CA_KUBECONFIG ?= $(HOME)/.kube/ok-shared.yaml
+REGISTRY_ADDRESS ?=
+REGISTRY_TRUST_APPLY ?= no
 
 SCRIPT_DIR    := $(shell pwd)
 CLUSTERS_DIR  := $(SCRIPT_DIR)
@@ -149,6 +162,15 @@ new: require-cluster require-type
 	 PROVIDER=$(PROVIDER) ARCHITECTURE=$(ARCHITECTURE) \
 	 NODE_SELECTOR=$(NODE_SELECTOR) SCHEDULING_PROFILE=$(SCHEDULING_PROFILE) \
 	 START_IP=$(START_IP) \
+	 REGISTRY_TRUST=$(REGISTRY_TRUST) REGISTRY_HOST=$(REGISTRY_HOST) \
+	 REGISTRY_CA_SECRET_NAMESPACE=$(REGISTRY_CA_SECRET_NAMESPACE) \
+	 REGISTRY_CA_SECRET_NAME=$(REGISTRY_CA_SECRET_NAME) \
+	 REGISTRY_CA_SECRET_KEY=$(REGISTRY_CA_SECRET_KEY) \
+	 REGISTRY_SERVICE_NAMESPACE=$(REGISTRY_SERVICE_NAMESPACE) \
+	 REGISTRY_SERVICE_NAME=$(REGISTRY_SERVICE_NAME) \
+	 REGISTRY_TALOSCONFIG_SECRET_NAMESPACE=$(REGISTRY_TALOSCONFIG_SECRET_NAMESPACE) \
+	 REGISTRY_TALOSCONFIG_SECRET_NAME=$(REGISTRY_TALOSCONFIG_SECRET_NAME) \
+	 REGISTRY_TALOSCONFIG_SECRET_KEY=$(REGISTRY_TALOSCONFIG_SECRET_KEY) \
 	 OK_LINUX_PATH=$(OK_LINUX_PATH) \
 	 bash $(SCRIPT_DIR)/new-cluster.sh
 
@@ -223,6 +245,29 @@ ok135-test: flatcar-promotion-test ok128-benchmark-test ## Offline-test Flatcar 
 ok138-observability-metrics-test: ## Offline-test metrics-only render and live-verifier guards
 	@PYTHONDONTWRITEBYTECODE=1 \
 		python3 $(SCRIPT_DIR)/tests/ok138_observability_metrics_test.py
+
+ok138-registry-trust-test: ## Offline-test opt-in Talos registry trust and secret guards
+	@PYTHONDONTWRITEBYTECODE=1 python3 $(SCRIPT_DIR)/tests/ok138_registry_trust_test.py
+
+talos-registry-trust-review: require-cluster ## Resolve and TLS-probe registry trust without contacting Talos
+	@REGISTRY_CA_KUBECONFIG="$(REGISTRY_CA_KUBECONFIG)" \
+	 python3 $(SCRIPT_DIR)/scripts/talos_registry_trust.py review \
+		--cluster "$(CLUSTER)" --infra-kubeconfig "$(TALOS_INFRA_KUBECONFIG)" \
+		$(if $(REGISTRY_ADDRESS),--address "$(REGISTRY_ADDRESS)")
+
+talos-registry-trust-dry-run: require-cluster ## TLS preflight then dry-run trust patch on every Talos node
+	@REGISTRY_CA_KUBECONFIG="$(REGISTRY_CA_KUBECONFIG)" \
+	 python3 $(SCRIPT_DIR)/scripts/talos_registry_trust.py dry-run \
+		--cluster "$(CLUSTER)" --infra-kubeconfig "$(TALOS_INFRA_KUBECONFIG)" \
+		$(if $(REGISTRY_ADDRESS),--address "$(REGISTRY_ADDRESS)")
+
+talos-registry-trust-apply: require-cluster ## Apply trust to every node, no reboot (REGISTRY_TRUST_APPLY=yes)
+	@test "$(REGISTRY_TRUST_APPLY)" = yes || \
+		(echo "ERROR: apply requires REGISTRY_TRUST_APPLY=yes after review and dry-run"; exit 1)
+	@REGISTRY_CA_KUBECONFIG="$(REGISTRY_CA_KUBECONFIG)" REGISTRY_TRUST_APPLY=yes \
+	 python3 $(SCRIPT_DIR)/scripts/talos_registry_trust.py apply \
+		--cluster "$(CLUSTER)" --infra-kubeconfig "$(TALOS_INFRA_KUBECONFIG)" \
+		$(if $(REGISTRY_ADDRESS),--address "$(REGISTRY_ADDRESS)")
 
 flatcar-preflight: require-cluster ## Read-only production Flatcar preflight
 	@OK_LINUX_PATH="$(OK_LINUX_PATH)" \
@@ -649,7 +694,15 @@ install-observability-metrics: require-cluster kubeconfig ## Install metrics + a
 bootstrap: require-not-flatcar
 	@echo "Bootstrapping Talos cluster $(CLUSTER)..."
 	@$(MAKE) --no-print-directory talos-golden-preflight CLUSTER=$(CLUSTER)
-	$(OKB) apply -f $(CLUSTERS_DIR)/$(CLUSTER)/cluster-base.yaml
+	@set -e; REGISTRY_TRUST_ENABLED="$$(cd "$(SCRIPT_DIR)" && python3 -c 'import sys,yaml,render; c=yaml.safe_load(open(sys.argv[1])) or {}; render.validate_registry_trust(c); print(str((c.get("registryTrust") or {}).get("enabled") is True).lower())' "$(CLUSTERS_DIR)/$(CLUSTER)/cluster-config.yaml")"; \
+	if [ "$$REGISTRY_TRUST_ENABLED" = true ]; then \
+		REGISTRY_CA_KUBECONFIG="$(REGISTRY_CA_KUBECONFIG)" \
+		python3 $(SCRIPT_DIR)/scripts/talos_registry_trust.py hydrate \
+			--cluster "$(CLUSTER)" --infra-kubeconfig "$(TALOS_INFRA_KUBECONFIG)" \
+			$(if $(REGISTRY_ADDRESS),--address "$(REGISTRY_ADDRESS)"); \
+	else \
+		$(OKB) apply -f $(CLUSTERS_DIR)/$(CLUSTER)/cluster-base.yaml; \
+	fi
 	@echo ""
 	@$(MAKE) --no-print-directory annotate-pvcs CLUSTER=$(CLUSTER)
 	@echo ""
@@ -1000,6 +1053,7 @@ help:
 	@echo "  make new       CLUSTER=ok-iot TYPE=talos WORKERS=3 SCHEDULING_PROFILE=ok-gpu-single-replica"
 	@echo "  make bootstrap CLUSTER=ok-ai   # apply + annotate PVCs + Cilium CNI"
 	@echo "  make kubeconfig CLUSTER=ok-ai  # once nodes Running"
+	@echo "  make new CLUSTER=ok-ai TYPE=talos REGISTRY_TRUST=true # opt in to registry.ok-shared.internal trust"
 	@echo ""
 	@echo "── Constrained Flatcar Workflow (ADR-009) ───────────────────────────"
 	@echo "  make prepare-cilium-chart"
@@ -1022,6 +1076,10 @@ help:
 	@echo "  make install-observability CLUSTER=ok-ai [OBSERVABILITY_VALUES=<path>] # OK-79: ok-observability-standard + gated contract test"
 	@echo "  make install-observability-metrics CLUSTER=ok-shared # OK-138: Prometheus + Alertmanager only; verify zot scraping"
 	@echo "  make install-keycloak CLUSTER=ok-shared # OK-81: central Keycloak from a pinned openkubes revision (stops before the approval-gated steps)"
+	@echo "  make talos-registry-trust-review CLUSTER=ok-shared # render/validate/TLS-probe; no Talos call"
+	@echo "  make talos-registry-trust-dry-run CLUSTER=ok-shared # Arash: API no-reboot dry-run on all nodes"
+	@echo "  make talos-registry-trust-apply CLUSTER=ok-shared REGISTRY_TRUST_APPLY=yes # Arash: apply after dry-run"
+	@echo "  make ok138-registry-trust-test # offline structural + Talos v1.9.5 validation"
 	@echo "  make register-cluster CLUSTER=ok2-rmf [KUBECONFIG_SRC=~/path/kubeconfig] [MGMT_CLUSTER=ok-mgmt]  # ADR-013: secret + ProviderConfig in ok-mgmt"
 	@echo "  make bootstrap     CLUSTER=ok-ai  # talos: apply + annotate PVCs + cilium"
 	@echo "  make annotate-pvcs CLUSTER=ok-ai  # annotate PVCs manually"

--- a/README.md
+++ b/README.md
@@ -423,6 +423,19 @@ make new CLUSTER=ok-ai TYPE=talos WORKERS=2
 make bootstrap CLUSTER=ok-ai
 ```
 
+### Opt-in trust for the shared internal registry
+
+Talos clusters that pull from `registry.ok-shared.internal` opt in explicitly:
+
+```bash
+make new CLUSTER=my-cluster TYPE=talos REGISTRY_TRUST=true
+make bootstrap CLUSTER=my-cluster
+```
+
+The CA and ingress address are resolved only at execution time; neither is
+stored in rendered files. Existing clusters use the review/dry-run/apply
+targets documented in [Talos registry trust](docs/registry-trust.md).
+
 For a complete disposable `ok-infra` meetup deployment with independent
 control-plane/worker sizing, timed warm provisioning, runtime verification,
 and Golden-Image-preserving cleanup, see the

--- a/docs/registry-trust.md
+++ b/docs/registry-trust.md
@@ -1,0 +1,226 @@
+# Talos registry trust (`registry.ok-shared.internal`)
+
+This is an opt-in Talos building block. It gives every node in one cluster the
+same two settings:
+
+```yaml
+machine:
+  registries:
+    config:
+      registry.ok-shared.internal:
+        tls:
+          ca: <base64-encoded ok-shared-internal-ca>
+  network:
+    extraHostEntries:
+    - ip: <discovered ingress address>
+      aliases:
+      - registry.ok-shared.internal
+```
+
+The committed fragment contains placeholders only. The CA, concrete address,
+and Talos client configuration are read at execution time and kept in memory or
+anonymous file descriptors.
+
+## Why this shape
+
+`machine.registries.config` is the trust decision. `extraHostEntries` is the
+temporary name-resolution mechanism until internal DNS exists. A registry
+mirror would mean "redirect this image namespace to a different endpoint"; it
+does not express trust, does not copy artifacts, and a literal-IP mirror would
+break the registry certificate's hostname and Traefik Host/SNI routing.
+
+Use the ingress address published for `ok-shared` on the infrastructure
+cluster, not the Traefik ClusterIP inside `ok-shared`. A kubelet pull originates
+in the node host namespace; ClusterIP reachability there depends on Cilium's
+service programming and is not a portable inter-cluster contract. The
+infrastructure ingress path is the established host/SNI path and is usable by
+all consuming clusters. The tooling discovers the address in this order:
+
+1. `REGISTRY_ADDRESS` operator override;
+2. one IPv4 answer from DNS;
+3. exactly one IPv4 address in the configured infrastructure Service status.
+
+When that address moves, existing static host entries remain stale until this
+target is rerun. Real DNS removes that reconciliation requirement. A mirror
+pointed at a literal address would also need reconfiguration when it moves.
+
+## New clusters
+
+Opt in while scaffolding:
+
+```bash
+make new CLUSTER=<consumer> TYPE=talos REGISTRY_TRUST=true
+make bootstrap CLUSTER=<consumer>
+```
+
+`bootstrap` fetches the CA and address, hydrates both the `TalosControlPlane`
+and worker `TalosConfigTemplate` patches in memory, and applies that manifest to
+ok-infra. A cluster without `registryTrust.enabled: true` still applies its
+original committed manifest byte-for-byte. Existing parent-level registry and
+host-entry patches are merged without losing mirrors, auth, or unrelated
+aliases. A nested patch under either owned parent is rejected with a request to
+consolidate it first, because appending a parent operation would make the result
+order-dependent.
+
+## Existing `ok-shared`: Arash-only runtime procedure
+
+The commands below require Talos node access. They have not been run by the
+author of this change and must not be treated as acceptance evidence until
+Arash runs them.
+
+Prerequisites are `~/.kube/ok-shared.yaml`, `~/.kube/ok-infra.yaml`, and
+`talosctl` v1.9.5. The target dynamically selects every CAPI Machine in
+namespace `ok-shared` (the control plane and all workers); do not patch only the
+node chosen for the proof Pod, because rescheduling must retain the
+cluster-level capability. Replacement-node handling is called out after the
+apply step because the existing worker bootstrap template is immutable.
+
+1. Review the exact hydrated patch and prove the TLS/SNI route before any Talos
+   call:
+
+   ```bash
+   make talos-registry-trust-review CLUSTER=ok-shared
+   ```
+
+   Expected: the registry `/v2/` probe succeeds and Talos v1.9.5 validates
+   complete control-plane and worker configs. The command prints the exact
+   runtime patch; it contains the public CA and discovered estate address, so
+   review it but do not commit or attach it as a file.
+
+2. Ask the live Talos API whether the exact change is accepted without reboot:
+
+   ```bash
+   make talos-registry-trust-dry-run CLUSTER=ok-shared
+   ```
+
+   The effective invocation uses anonymous descriptors, not secret files:
+
+   ```text
+   talosctl patch machineconfig \
+     --talosconfig /proc/self/fd/<fd> \
+     --nodes <one-discovered-machine-InternalIP> \
+     --patch-file /proc/self/fd/<fd> \
+     --mode no-reboot --dry-run
+   ```
+
+   Talos documents both `.machine.network` and `.machine.registries` as
+   immediately applicable, but the live API response is authoritative. This
+   target runs that invocation serially for every node and deliberately requests
+   `no-reboot`: if any node rejects it or reports
+   that a reboot is required, stop. Do not substitute `auto` or `reboot`; decide
+   that live-cluster cost separately.
+
+3. Apply once, behind the explicit gate. The target repeats the same
+   `no-reboot` dry-run immediately before the real call:
+
+   ```bash
+   make talos-registry-trust-apply \
+     CLUSTER=ok-shared \
+     REGISTRY_TRUST_APPLY=yes
+   ```
+
+   After every node's dry-run passes, the final per-node invocations are
+   identical to the text above without `--dry-run`.
+   Expected: all four current CAPI Machines are reported patched without a
+   reboot.
+
+   This deliberately does not mutate the existing CAPI bootstrap objects:
+   `TalosConfigTemplate.spec` is immutable, and changing the worker template
+   reference would initiate a rollout. If a replacement Machine is created
+   before this cluster is recreated from the opt-in manifest, rerun the same
+   target for the newly discovered node. The target is idempotent. A failure
+   midway leaves already reported nodes configured and later nodes unchanged;
+   correct the reported failure and rerun to converge all nodes.
+
+4. Read the configuration back from each discovered node. Keep the talosconfig
+   in a pipe, not a file:
+
+   ```bash
+   nodes="$(kubectl --kubeconfig ~/.kube/ok-infra.yaml -n ok-shared \
+     get machines -l cluster.x-k8s.io/cluster-name=ok-shared -o jsonpath='{range .items[*].status.addresses[?(@.type=="InternalIP")]}{.address}{","}{end}' | sed 's/,$//')"
+   talosctl --talosconfig <(
+     kubectl --kubeconfig ~/.kube/ok-infra.yaml -n ok-shared \
+       get secret ok-shared-talosconfig -o jsonpath='{.data.talosconfig}' | base64 -d
+   ) --nodes "$nodes" get machineconfig -o yaml |
+     yq '.spec.machine | {registryCAConfigured: (.registries.config."registry.ok-shared.internal".tls.ca != null), extraHostEntries: [.network.extraHostEntries[] | select(.aliases[] == "registry.ok-shared.internal")]}'
+   ```
+
+   Before the application those two entries are absent. Afterwards every node
+   must show the registry CA setting and exactly one alias mapping for the
+   registry hostname.
+
+## Kubelet-pull acceptance proof (Arash only)
+
+Use a runnable image pushed into the registry and pin the Pod by digest. Before
+creating the Pod, choose its node and prove that digest is absent from that
+node's Talos image list:
+
+```bash
+NODE=<worker-kubernetes-node-name>
+NODE_IP=<that-node-InternalIP>
+IMAGE='registry.ok-shared.internal/openkubes/staging/ok138-kubelet-pull@sha256:<pushed-digest>'
+images="$({ talosctl --talosconfig <(
+  kubectl --kubeconfig ~/.kube/ok-infra.yaml -n ok-shared \
+    get secret ok-shared-talosconfig -o jsonpath='{.data.talosconfig}' | base64 -d
+) --nodes "$NODE_IP" images; })" || {
+  echo 'could not prove the node image inventory' >&2
+  exit 1
+}
+if grep -F 'sha256:<pushed-digest>' <<<"$images"; then
+  echo 'digest is already cached; push/select another digest' >&2
+  false
+fi
+```
+
+The digest must come from the registry's own push result. Use a new run/repo or
+new image config, and keep the push transcript. Record Zot's request counter or
+log position before creating the Pod so a new manifest request can be
+correlated with this pull.
+
+```bash
+cleanup() {
+  kubectl --kubeconfig ~/.kube/ok-shared.yaml delete pod ok138-kubelet-pull \
+    --ignore-not-found --wait=true
+}
+trap cleanup EXIT INT TERM
+kubectl --kubeconfig ~/.kube/ok-shared.yaml create -f - <<EOF
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ok138-kubelet-pull
+  namespace: default
+spec:
+  nodeName: ${NODE}
+  restartPolicy: Never
+  containers:
+  - name: proof
+    image: ${IMAGE}
+    command: ["sh", "-c", "sleep 600"]
+EOF
+kubectl --kubeconfig ~/.kube/ok-shared.yaml wait \
+  --for=jsonpath='{.status.phase}'=Running pod/ok138-kubelet-pull --timeout=2m
+image_id="$(kubectl --kubeconfig ~/.kube/ok-shared.yaml get pod ok138-kubelet-pull \
+  -o jsonpath='{.status.containerStatuses[0].imageID}')"
+test "${image_id##*@}" = 'sha256:<pushed-digest>'
+kubectl --kubeconfig ~/.kube/ok-shared.yaml delete pod ok138-kubelet-pull --wait=true
+trap - EXIT INT TERM
+```
+
+Pass requires all of: phase `Running`, `imageID` equal to the pushed digest, the
+pre-check showing that digest was not cached on the selected node, and a new
+correlated Zot request/metric. Delete the Pod afterward.
+
+Failure is diagnostic:
+
+- `dial tcp ... timeout`, `no route to host`, or `connection refused`: the
+  chosen host-network ingress path is not reachable; this is the signal that
+  the ingress-VIP choice is wrong for the node namespace.
+- `x509: certificate signed by unknown authority`: the CA did not land or is
+  not the issuer used by the registry.
+- `x509` hostname/SAN error: traffic reached TLS through the wrong name/path.
+- `401` or `403`: DNS/routing/TLS succeeded; fix image-pull authorization.
+- `manifest unknown`: the repository or pushed digest is wrong.
+
+Do not claim OK-138's workload-pull criterion from local validation, CAPI
+hydration, a Talos dry-run, or a cached image. The criterion is met only by the
+uncached real Pod proof above.

--- a/new-cluster.sh
+++ b/new-cluster.sh
@@ -43,6 +43,16 @@ fi
 NODE_SELECTOR="${NODE_SELECTOR:-${NODE:-}}"   # OK-82: NODE= accepted as alias
 SCHEDULING_PROFILE="${SCHEDULING_PROFILE:-}"
 START_IP="${START_IP:-}"   # OK-83: optional override for MetalLB IP allocation
+REGISTRY_TRUST="${REGISTRY_TRUST:-false}"
+REGISTRY_HOST="${REGISTRY_HOST:-registry.ok-shared.internal}"
+REGISTRY_CA_SECRET_NAMESPACE="${REGISTRY_CA_SECRET_NAMESPACE:-cert-manager}"
+REGISTRY_CA_SECRET_NAME="${REGISTRY_CA_SECRET_NAME:-ok-shared-internal-ca}"
+REGISTRY_CA_SECRET_KEY="${REGISTRY_CA_SECRET_KEY:-ca.crt}"
+REGISTRY_SERVICE_NAMESPACE="${REGISTRY_SERVICE_NAMESPACE:-ok-shared}"
+REGISTRY_SERVICE_NAME="${REGISTRY_SERVICE_NAME:-ok-shared-ingress}"
+REGISTRY_TALOSCONFIG_SECRET_NAMESPACE="${REGISTRY_TALOSCONFIG_SECRET_NAMESPACE:-}"
+REGISTRY_TALOSCONFIG_SECRET_NAME="${REGISTRY_TALOSCONFIG_SECRET_NAME:-}"
+REGISTRY_TALOSCONFIG_SECRET_KEY="${REGISTRY_TALOSCONFIG_SECRET_KEY:-talosconfig}"
 if [[ "$TYPE" == "flatcar" ]]; then
   GOLDEN_IMAGE_STORAGE_CLASS="${GOLDEN_IMAGE_STORAGE_CLASS:-ok-storage-block}"
 else
@@ -52,6 +62,30 @@ fi
 if [[ -z "$CLUSTER" ]]; then
   echo "ERROR: CLUSTER is required."
   exit 1
+fi
+
+if [[ "$REGISTRY_TRUST" != "false" && "$REGISTRY_TRUST" != "true" ]]; then
+  echo "ERROR: REGISTRY_TRUST must be exactly true or false"
+  exit 1
+fi
+if [[ "$REGISTRY_TRUST" == "true" ]]; then
+  if [[ "$TYPE" != "talos" ]]; then
+    echo "ERROR: REGISTRY_TRUST=true is supported only for TYPE=talos"
+    exit 1
+  fi
+  if [[ "$REGISTRY_HOST" != "registry.ok-shared.internal" ]]; then
+    echo "ERROR: REGISTRY_HOST must be registry.ok-shared.internal"
+    exit 1
+  fi
+  REGISTRY_TALOSCONFIG_SECRET_NAMESPACE="${REGISTRY_TALOSCONFIG_SECRET_NAMESPACE:-${CLUSTER}}"
+  REGISTRY_TALOSCONFIG_SECRET_NAME="${REGISTRY_TALOSCONFIG_SECRET_NAME:-${CLUSTER}-talosconfig}"
+  for value in REGISTRY_CA_SECRET_NAMESPACE REGISTRY_CA_SECRET_NAME \
+    REGISTRY_SERVICE_NAMESPACE REGISTRY_SERVICE_NAME; do
+    if [[ -z "${!value}" ]]; then
+      echo "ERROR: ${value} is required when REGISTRY_TRUST=true"
+      exit 1
+    fi
+  done
 fi
 
 # The OK-136 Talos KubeVirt path uses reviewed provider profiles rather than a
@@ -201,6 +235,25 @@ $(if [[ "$TYPE" == "talos" ]]; then cat <<TALOSPROVIDERBLOCK
 providerProfile:
   name: ${SCHEDULING_PROFILE}
 TALOSPROVIDERBLOCK
+fi)
+$(if [[ "$TYPE" == "talos" && "$REGISTRY_TRUST" == "true" ]]; then cat <<REGISTRYTRUSTBLOCK
+
+# Opt-in registry trust. CA, resolved address and talosconfig are runtime-only.
+registryTrust:
+  enabled: true
+  host: ${REGISTRY_HOST}
+  caSecret:
+    namespace: ${REGISTRY_CA_SECRET_NAMESPACE}
+    name: ${REGISTRY_CA_SECRET_NAME}
+    key: ${REGISTRY_CA_SECRET_KEY}
+  address:
+    serviceNamespace: ${REGISTRY_SERVICE_NAMESPACE}
+    serviceName: ${REGISTRY_SERVICE_NAME}
+  talosconfigSecret:
+    namespace: ${REGISTRY_TALOSCONFIG_SECRET_NAMESPACE}
+    name: ${REGISTRY_TALOSCONFIG_SECRET_NAME}
+    key: ${REGISTRY_TALOSCONFIG_SECRET_KEY}
+REGISTRYTRUSTBLOCK
 fi)
 $(if [[ "$TYPE" == "flatcar" ]]; then cat <<FLATCARBLOCK
 

--- a/ok-shared/cluster-config.yaml
+++ b/ok-shared/cluster-config.yaml
@@ -13,6 +13,20 @@ os:
   profile: kubevirt
   schematic_id: ce4c980550dd2ab1b17bbf2b08801c7eb59418eafe8f279833297925d67c7515
 type: talos
+registryTrust:
+  enabled: true
+  host: registry.ok-shared.internal
+  caSecret:
+    namespace: cert-manager
+    name: ok-shared-internal-ca
+    key: ca.crt
+  address:
+    serviceNamespace: ok-shared
+    serviceName: ok-shared-ingress
+  talosconfigSecret:
+    namespace: ok-shared
+    name: ok-shared-talosconfig
+    key: talosconfig
 upgrade:
   strategy: blue-green
   workloadMigration:

--- a/render.py
+++ b/render.py
@@ -138,8 +138,46 @@ def next_free_svc_cidr(used):
             return str(net)
     raise RuntimeError("Service CIDR space exhausted")
 
+
+def validate_registry_trust(cfg: dict) -> None:
+    """Validate the opt-in shape without resolving runtime CA/address values."""
+    if "registryTrust" not in cfg:
+        return
+    trust = cfg["registryTrust"]
+    if not isinstance(trust, dict) or trust.get("enabled") is not True:
+        raise SystemExit(
+            "ERROR: registryTrust must be absent or set enabled: true explicitly"
+        )
+    if cfg.get("type") != "talos":
+        raise SystemExit("ERROR: registryTrust is supported only for type: talos")
+    required = {
+        "host": trust.get("host"),
+        "caSecret.namespace": (trust.get("caSecret") or {}).get("namespace"),
+        "caSecret.name": (trust.get("caSecret") or {}).get("name"),
+        "caSecret.key": (trust.get("caSecret") or {}).get("key"),
+        "address.serviceNamespace": (trust.get("address") or {}).get(
+            "serviceNamespace"
+        ),
+        "address.serviceName": (trust.get("address") or {}).get("serviceName"),
+        "talosconfigSecret.namespace": (trust.get("talosconfigSecret") or {}).get(
+            "namespace"
+        ),
+        "talosconfigSecret.name": (trust.get("talosconfigSecret") or {}).get("name"),
+        "talosconfigSecret.key": (trust.get("talosconfigSecret") or {}).get("key"),
+    }
+    missing = [key for key, value in required.items() if not isinstance(value, str) or not value]
+    if missing:
+        raise SystemExit(
+            "ERROR: registryTrust is incomplete: " + ", ".join(missing)
+        )
+    if trust["host"] != "registry.ok-shared.internal":
+        raise SystemExit(
+            "ERROR: registryTrust.host must be registry.ok-shared.internal"
+        )
+
 def resolve_config(cfg: dict, cluster_name: str) -> dict:
     cfg = yaml.safe_load(yaml.dump(cfg))
+    validate_registry_trust(cfg)
     clusters = discover_clusters()
     others = [c for c in clusters if c["name"] != cluster_name]
     net = cfg.setdefault("network", {})

--- a/scripts/talos_registry_trust.py
+++ b/scripts/talos_registry_trust.py
@@ -1,0 +1,527 @@
+#!/usr/bin/env python3
+"""Hydrate and operate the opt-in Talos registry-trust building block.
+
+Secret values stay in process memory or anonymous file descriptors.  No CA,
+registry address, talosconfig, or complete machine config is written to disk.
+"""
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+from pathlib import Path
+import re
+import socket
+import ssl
+import subprocess
+import sys
+from string import Template
+from typing import Any
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+PATCH_TEMPLATE = ROOT / "templates/talos/patches/registry-trust.yaml.tpl"
+EXPECTED_HOST = "registry.ok-shared.internal"
+
+
+class TrustError(RuntimeError):
+    pass
+
+
+def run(argv: list[str], *, stdin: bytes | None = None) -> bytes:
+    try:
+        return subprocess.run(
+            argv, input=stdin, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            check=True,
+        ).stdout
+    except FileNotFoundError as exc:
+        raise TrustError(f"required command not found: {argv[0]}") from exc
+    except subprocess.CalledProcessError as exc:
+        # Never echo stderr: kubectl/talosctl may include Secret or config data.
+        raise TrustError(f"{argv[0]} failed (exit {exc.returncode})") from exc
+
+
+def load_config(cluster: str) -> tuple[dict[str, Any], dict[str, Any]]:
+    path = ROOT / cluster / "cluster-config.yaml"
+    try:
+        cfg = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    except OSError as exc:
+        raise TrustError(f"cannot read {path}") from exc
+    trust = cfg.get("registryTrust")
+    if not isinstance(trust, dict) or trust.get("enabled") is not True:
+        raise TrustError("registryTrust.enabled must be explicitly true")
+    if cfg.get("type") != "talos":
+        raise TrustError("registry trust is supported only for type: talos")
+    required = {
+        "host": trust.get("host"),
+        "caSecret.namespace": (trust.get("caSecret") or {}).get("namespace"),
+        "caSecret.name": (trust.get("caSecret") or {}).get("name"),
+        "caSecret.key": (trust.get("caSecret") or {}).get("key"),
+        "address.serviceNamespace": (trust.get("address") or {}).get("serviceNamespace"),
+        "address.serviceName": (trust.get("address") or {}).get("serviceName"),
+        "talosconfigSecret.namespace": (trust.get("talosconfigSecret") or {}).get("namespace"),
+        "talosconfigSecret.name": (trust.get("talosconfigSecret") or {}).get("name"),
+        "talosconfigSecret.key": (trust.get("talosconfigSecret") or {}).get("key"),
+    }
+    missing = [name for name, value in required.items() if not value]
+    if missing:
+        raise TrustError("registryTrust is incomplete: " + ", ".join(missing))
+    if trust["host"] != EXPECTED_HOST:
+        raise TrustError(f"registryTrust.host must be {EXPECTED_HOST}")
+    return cfg, trust
+
+
+def secret_value(kubeconfig: str, ref: dict[str, str]) -> bytes:
+    raw = run([
+        "kubectl", "--kubeconfig", kubeconfig, "-n", ref["namespace"],
+        "get", "secret", ref["name"], "-o", "json",
+    ])
+    try:
+        encoded = json.loads(raw)["data"][ref["key"]]
+        value = base64.b64decode(encoded, validate=True)
+    except (KeyError, ValueError, TypeError, json.JSONDecodeError) as exc:
+        raise TrustError(
+            f"Secret {ref['namespace']}/{ref['name']} lacks valid key {ref['key']}"
+        ) from exc
+    if not value:
+        raise TrustError("Secret value is empty")
+    return value
+
+
+def _single_ip(values: list[str], source: str) -> str:
+    concrete: list[str] = []
+    for value in values:
+        try:
+            concrete.append(str(socket.inet_ntop(socket.AF_INET, socket.inet_pton(socket.AF_INET, value))))
+        except OSError as exc:
+            raise TrustError(f"{source} contains a non-IPv4 value") from exc
+    concrete = sorted(set(concrete))
+    if len(concrete) != 1:
+        raise TrustError(f"{source} must resolve to exactly one concrete IPv4 address")
+    return concrete[0]
+
+
+def discover_address(
+    trust: dict[str, Any], infra_kubeconfig: str, override: str | None
+) -> tuple[str, str]:
+    if override:
+        return _single_ip([override], "explicit REGISTRY_ADDRESS"), "explicit override"
+    try:
+        answers = socket.getaddrinfo(trust["host"], 443, socket.AF_INET, socket.SOCK_STREAM)
+        ips = [answer[4][0] for answer in answers]
+        return _single_ip(ips, "DNS"), "DNS"
+    except socket.gaierror:
+        pass
+    address = trust["address"]
+    raw = run([
+        "kubectl", "--kubeconfig", infra_kubeconfig, "-n", address["serviceNamespace"],
+        "get", "service", address["serviceName"], "-o", "json",
+    ])
+    try:
+        ingress = json.loads(raw).get("status", {}).get("loadBalancer", {}).get("ingress", [])
+        if any(item.get("hostname") for item in ingress if isinstance(item, dict)):
+            raise TrustError(
+                "ok-infra Service status contains a hostname; extraHostEntries requires IPv4"
+            )
+        ips = [item.get("ip", "") for item in ingress if isinstance(item, dict)]
+    except json.JSONDecodeError as exc:
+        raise TrustError("invalid Service JSON while discovering registry address") from exc
+    return _single_ip(ips, "ok-infra Service status.loadBalancer.ingress"), "ok-infra Service"
+
+
+def validate_ca(ca: bytes) -> None:
+    try:
+        ca_text = ca.decode("utf-8")
+        ssl.PEM_cert_to_DER_cert(ca_text)
+    except (UnicodeDecodeError, ValueError) as exc:
+        raise TrustError("registry CA is not UTF-8 PEM") from exc
+
+
+def semantic_patch(host: str, address: str, ca: bytes) -> dict[str, Any]:
+    validate_ca(ca)
+    return {
+        "machine": {
+            "registries": {
+                "config": {
+                    host: {
+                        "tls": {
+                            # Talos v1.9 RegistryTLSConfig.ca is Base64Bytes.
+                            "ca": base64.b64encode(ca).decode("ascii")
+                        }
+                    }
+                }
+            },
+            "network": {"extraHostEntries": [{"ip": address, "aliases": [host]}]},
+        }
+    }
+
+
+def render_patch(host: str, address: str, ca: bytes) -> bytes:
+    # Render the committed fragment, then parse/re-emit it to guarantee the
+    # runtime and declarative forms come from the same semantic object.
+    rendered = Template(PATCH_TEMPLATE.read_text(encoding="utf-8")).substitute(
+        REGISTRY_HOST=json.dumps(host),
+        REGISTRY_ADDRESS=json.dumps(address),
+        REGISTRY_CA_BASE64=json.dumps(base64.b64encode(ca).decode("ascii")),
+    )
+    parsed = yaml.safe_load(rendered)
+    expected = semantic_patch(host, address, ca)
+    if parsed != expected:
+        raise TrustError("committed registry patch fragment changed semantics")
+    return yaml.safe_dump(expected, sort_keys=False).encode()
+
+
+def capi_ops(host: str, address: str, ca: bytes) -> list[dict[str, Any]]:
+    machine = semantic_patch(host, address, ca)["machine"]
+    return [
+        {"op": "add", "path": "/machine/registries", "value": machine["registries"]},
+        {"op": "add", "path": "/machine/network/extraHostEntries", "value": machine["network"]["extraHostEntries"]},
+    ]
+
+
+def upsert_capi_patches(
+    existing: list[dict[str, Any]], host: str, address: str, ca: bytes
+) -> list[dict[str, Any]]:
+    if not isinstance(existing, list) or not all(
+        isinstance(item, dict) for item in existing
+    ):
+        raise TrustError("live CAPI configPatches is not an object list")
+    owned_paths = {"/machine/registries", "/machine/network/extraHostEntries"}
+    preserved: list[dict[str, Any]] = []
+    registries: dict[str, Any] = {}
+    entries: list[dict[str, Any]] = []
+    for item in existing:
+        path = item.get("path")
+        if isinstance(path, str) and (
+            path.startswith("/machine/registries/")
+            or path.startswith("/machine/network/extraHostEntries/")
+        ):
+            raise TrustError(
+                f"cannot safely compose registry trust with nested CAPI patch {path}; "
+                "consolidate it at the parent path first"
+            )
+        if path not in owned_paths:
+            preserved.append(item)
+            continue
+        if item.get("op") not in ("add", "replace"):
+            raise TrustError(f"cannot safely merge CAPI patch operation at {path}")
+        value = json.loads(json.dumps(item.get("value")))
+        if path == "/machine/registries":
+            if not isinstance(value, dict):
+                raise TrustError("CAPI /machine/registries patch is not a mapping")
+            registries = value
+        else:
+            if not isinstance(value, list):
+                raise TrustError("CAPI extraHostEntries patch is not a list")
+            entries = value
+    merged = runtime_ops(
+        {
+            "machine": {
+                "registries": registries,
+                "network": {"extraHostEntries": entries},
+            }
+        },
+        host,
+        address,
+        ca,
+    )
+    return [*preserved, *merged]
+
+
+def hydrate_manifest(raw: bytes, host: str, address: str, ca: bytes) -> bytes:
+    docs = list(yaml.safe_load_all(raw))
+    matched: list[str] = []
+    for doc in docs:
+        if not isinstance(doc, dict):
+            continue
+        kind = doc.get("kind")
+        if kind == "TalosControlPlane":
+            spec = doc["spec"]["controlPlaneConfig"]["controlplane"]
+            matched.append(kind)
+        elif kind == "TalosConfigTemplate":
+            spec = doc["spec"]["template"]["spec"]
+            matched.append(kind)
+        else:
+            continue
+        spec["configPatches"] = upsert_capi_patches(
+            spec.setdefault("configPatches", []), host, address, ca
+        )
+    if matched.count("TalosControlPlane") != 1 or matched.count("TalosConfigTemplate") != 1:
+        raise TrustError("manifest must contain exactly one control-plane and one worker Talos config")
+    return yaml.safe_dump_all(docs, sort_keys=False).encode()
+
+
+def anonymous_fd(data: bytes) -> tuple[int, str]:
+    if not hasattr(os, "memfd_create"):
+        raise TrustError("anonymous memfd support is required")
+    fd = os.memfd_create("ok-registry-trust", flags=0)
+    os.write(fd, data)
+    os.lseek(fd, 0, os.SEEK_SET)
+    os.set_inheritable(fd, True)
+    return fd, f"/proc/self/fd/{fd}"
+
+
+def run_with_fds(
+    argv: list[str], fds: list[int], *, include_stderr: bool = False
+) -> bytes:
+    try:
+        result = subprocess.run(
+            argv, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True,
+            pass_fds=tuple(fds),
+        )
+        return result.stdout + (result.stderr if include_stderr else b"")
+    except FileNotFoundError as exc:
+        raise TrustError(f"required command not found: {argv[0]}") from exc
+    except subprocess.CalledProcessError as exc:
+        raise TrustError(f"{argv[0]} failed (exit {exc.returncode})") from exc
+    finally:
+        for fd in fds:
+            os.close(fd)
+
+
+def validate_with_talosctl(patch: bytes) -> None:
+    version = run(["talosctl", "version", "--client"]).decode("utf-8", "replace")
+    if not re.search(r"(?m)^\s*Tag:\s+v1\.9\.5\s*$", version):
+        raise TrustError("talosctl v1.9.5 is required")
+    for role in ("controlplane", "worker"):
+        patch_fd, patch_path = anonymous_fd(patch)
+        generated = run_with_fds([
+            "talosctl", "gen", "config", "ok138-validation",
+            "https://192.0.2.10:6443",
+            "--talos-version", "v1.9",
+            "--output-types", role,
+            "--output", "-",
+            "--with-cluster-discovery=false",
+            "--with-docs=false",
+            "--with-examples=false",
+            "--config-patch", "@" + patch_path,
+        ], [patch_fd])
+        config_fd, config_path = anonymous_fd(generated)
+        run_with_fds([
+            "talosctl", "validate", "--config", config_path,
+            "--mode", "cloud", "--strict",
+        ], [config_fd])
+
+
+def probe_registry(host: str, address: str, ca: bytes) -> None:
+    context = ssl.create_default_context(cadata=ca.decode("utf-8"))
+    try:
+        with socket.create_connection((address, 443), timeout=10) as sock:
+            with context.wrap_socket(sock, server_hostname=host) as tls:
+                tls.sendall(
+                    f"GET /v2/ HTTP/1.1\r\nHost: {host}\r\nConnection: close\r\n\r\n".encode()
+                )
+                first = tls.recv(4096).split(b"\r\n", 1)[0]
+    except (OSError, ssl.SSLError) as exc:
+        raise TrustError("registry TLS/SNI preflight failed") from exc
+    if not first.startswith((b"HTTP/1.1 200", b"HTTP/1.1 401", b"HTTP/2 200", b"HTTP/2 401")):
+        raise TrustError("registry /v2/ preflight returned an unexpected status")
+
+
+def discover_nodes(cluster: str, infra_kubeconfig: str) -> list[str]:
+    raw = run([
+        "kubectl", "--kubeconfig", infra_kubeconfig, "-n", cluster, "get", "machines",
+        "-l", f"cluster.x-k8s.io/cluster-name={cluster}", "-o", "json",
+    ])
+    try:
+        items = json.loads(raw).get("items", [])
+        values = []
+        for item in items:
+            machine_ips = [
+                address["address"]
+                for address in item.get("status", {}).get("addresses", [])
+                if address.get("type") == "InternalIP"
+            ]
+            if len(set(machine_ips)) != 1:
+                raise TrustError(
+                    "every CAPI Machine must expose exactly one InternalIP"
+                )
+            values.append(machine_ips[0])
+    except (KeyError, TypeError, json.JSONDecodeError) as exc:
+        raise TrustError("invalid Machine address data") from exc
+    nodes = sorted(set(values))
+    if not nodes or len(nodes) != len(items):
+        raise TrustError("every CAPI Machine must expose exactly one unique InternalIP")
+    for node in nodes:
+        _single_ip([node], "Machine InternalIP")
+    return nodes
+
+
+def runtime_ops(
+    current: dict[str, Any], host: str, address: str, ca: bytes
+) -> list[dict[str, Any]]:
+    """Upsert our two fields while preserving unrelated node configuration."""
+    machine = current.get("machine")
+    if not isinstance(machine, dict):
+        raise TrustError("live MachineConfig spec has no machine mapping")
+
+    registries = json.loads(json.dumps(machine.get("registries") or {}))
+    if not isinstance(registries, dict):
+        raise TrustError("live machine.registries is not a mapping")
+    config = registries.setdefault("config", {})
+    if not isinstance(config, dict):
+        raise TrustError("live machine.registries.config is not a mapping")
+    registry = config.setdefault(host, {})
+    if not isinstance(registry, dict):
+        raise TrustError("live registry-specific config is not a mapping")
+    tls = registry.setdefault("tls", {})
+    if not isinstance(tls, dict):
+        raise TrustError("live registry-specific TLS config is not a mapping")
+    tls["ca"] = base64.b64encode(ca).decode("ascii")
+
+    network = machine.get("network") or {}
+    if not isinstance(network, dict):
+        raise TrustError("live machine.network is not a mapping")
+    entries = network.get("extraHostEntries") or []
+    if not isinstance(entries, list):
+        raise TrustError("live machine.network.extraHostEntries is not a list")
+    preserved: list[dict[str, Any]] = []
+    for entry in entries:
+        if not isinstance(entry, dict) or not isinstance(entry.get("aliases", []), list):
+            raise TrustError("live extraHostEntries contains an invalid entry")
+        kept = json.loads(json.dumps(entry))
+        kept["aliases"] = [alias for alias in kept.get("aliases", []) if alias != host]
+        if kept["aliases"]:
+            preserved.append(kept)
+    preserved.append({"ip": address, "aliases": [host]})
+
+    return [
+        {"op": "add", "path": "/machine/registries", "value": registries},
+        {
+            "op": "add",
+            "path": "/machine/network/extraHostEntries",
+            "value": preserved,
+        },
+    ]
+
+
+def get_machine_config(node: str, talosconfig: bytes) -> dict[str, Any]:
+    config_fd, config_path = anonymous_fd(talosconfig)
+    raw = run_with_fds([
+        "talosctl", "--talosconfig", config_path, "--nodes", node,
+        "get", "machineconfig", "--output", "json",
+    ], [config_fd])
+    try:
+        resource = json.loads(raw)
+        spec = resource["spec"]
+    except (json.JSONDecodeError, KeyError, TypeError) as exc:
+        raise TrustError(f"Talos returned an invalid MachineConfig for node {node}") from exc
+    if not isinstance(spec, dict):
+        raise TrustError(f"Talos returned a non-mapping MachineConfig spec for node {node}")
+    return spec
+
+
+def assert_applied(
+    current: dict[str, Any], host: str, address: str, ca: bytes
+) -> None:
+    machine = current.get("machine") or {}
+    actual_ca = (
+        ((machine.get("registries") or {}).get("config") or {})
+        .get(host, {}).get("tls", {}).get("ca")
+    )
+    aliases = [
+        entry for entry in ((machine.get("network") or {}).get("extraHostEntries") or [])
+        if isinstance(entry, dict) and host in entry.get("aliases", [])
+    ]
+    alias_ok = (
+        len(aliases) == 1
+        and aliases[0].get("ip") == address
+        and aliases[0].get("aliases") == [host]
+    )
+    if actual_ca != base64.b64encode(ca).decode("ascii") or not alias_ok:
+        raise TrustError("post-apply MachineConfig readback does not match registry trust")
+
+
+def runtime_talos(
+    action: str, cluster: str, trust: dict[str, Any], infra: str,
+    patch: bytes, address: str, ca: bytes,
+) -> None:
+    probe_registry(trust["host"], address, ca)
+    validate_with_talosctl(patch)
+    nodes = discover_nodes(cluster, infra)
+    talosconfig = secret_value(infra, trust["talosconfigSecret"])
+    patches: dict[str, bytes] = {}
+    for node in nodes:
+        current = get_machine_config(node, talosconfig)
+        patches[node] = yaml.safe_dump(
+            runtime_ops(current, trust["host"], address, ca), sort_keys=False
+        ).encode()
+
+    def invoke(node: str, *, dry_run: bool) -> None:
+        patch_fd, patch_path = anonymous_fd(patches[node])
+        config_fd, config_path = anonymous_fd(talosconfig)
+        argv = [
+            "talosctl", "patch", "machineconfig", "--talosconfig", config_path,
+            "--nodes", node, "--patch-file", patch_path,
+            "--mode", "no-reboot",
+        ]
+        if dry_run:
+            argv.append("--dry-run")
+        # A current config may contain existing registry auth. Capture and
+        # discard Talos' patch preview rather than risk echoing it.
+        run_with_fds(argv, [patch_fd, config_fd])
+
+    for node in nodes:
+        invoke(node, dry_run=True)
+    print(
+        f"Talos API accepted --mode=no-reboot dry-run for all {len(nodes)} CAPI Machines"
+    )
+    if action == "apply":
+        for node in nodes:
+            invoke(node, dry_run=False)
+        for node in nodes:
+            assert_applied(
+                get_machine_config(node, talosconfig),
+                trust["host"], address, ca,
+            )
+            print(f"readback PASS node={node}: registry CA and host alias landed")
+        print(f"apply succeeded for all {len(nodes)} CAPI Machines without reboot")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("action", choices=("hydrate", "review", "dry-run", "apply"))
+    parser.add_argument("--cluster", required=True)
+    parser.add_argument("--infra-kubeconfig", required=True)
+    parser.add_argument("--ca-kubeconfig")
+    parser.add_argument("--address")
+    args = parser.parse_args()
+    try:
+        _, trust = load_config(args.cluster)
+        ca_kubeconfig = args.ca_kubeconfig or os.environ.get("REGISTRY_CA_KUBECONFIG")
+        if not ca_kubeconfig:
+            raise TrustError("REGISTRY_CA_KUBECONFIG is required")
+        ca = secret_value(ca_kubeconfig, trust["caSecret"])
+        address, source = discover_address(trust, args.infra_kubeconfig, args.address)
+        patch = render_patch(trust["host"], address, ca)
+        if args.action == "hydrate":
+            manifest = (ROOT / args.cluster / "cluster-base.yaml").read_bytes()
+            hydrated = hydrate_manifest(manifest, trust["host"], address, ca)
+            run(["kubectl", "--kubeconfig", args.infra_kubeconfig, "apply", "-f", "-"], stdin=hydrated)
+            print(f"hydrated CAPI control-plane and worker configs from {source}")
+        elif args.action == "review":
+            probe_registry(trust["host"], address, ca)
+            validate_with_talosctl(patch)
+            print(f"registry trust review: host={trust['host']} address-source={source}")
+            print("semantic patch: machine.registries.config CA + machine.network.extraHostEntries")
+            print("Talos v1.9.5 control-plane and worker validation passed")
+            print("registry TLS/SNI /v2/ probe succeeded")
+            print("exact hydrated patch (runtime-only; do not commit):")
+            print(patch.decode("utf-8"), end="")
+        else:
+            if args.action == "apply" and os.environ.get("REGISTRY_TRUST_APPLY") != "yes":
+                raise TrustError("apply requires REGISTRY_TRUST_APPLY=yes")
+            runtime_talos(
+                args.action, args.cluster, trust, args.infra_kubeconfig,
+                patch, address, ca,
+            )
+        return 0
+    except (TrustError, OSError, UnicodeError, yaml.YAMLError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/templates/talos/patches/registry-trust.yaml.tpl
+++ b/templates/talos/patches/registry-trust.yaml.tpl
@@ -1,0 +1,14 @@
+# Parameterized Talos machine-config patch for an internal TLS registry.
+# Values are hydrated in memory by scripts/talos_registry_trust.py. This file
+# deliberately contains no estate address or CA material.
+machine:
+  registries:
+    config:
+      ${REGISTRY_HOST}:
+        tls:
+          ca: ${REGISTRY_CA_BASE64}
+  network:
+    extraHostEntries:
+    - ip: ${REGISTRY_ADDRESS}
+      aliases:
+      - ${REGISTRY_HOST}

--- a/tests/ok138_registry_trust_test.py
+++ b/tests/ok138_registry_trust_test.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""Offline acceptance checks for OK-138 Talos registry trust."""
+from __future__ import annotations
+
+import importlib.util
+import base64
+import ipaddress
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+SPEC = importlib.util.spec_from_file_location(
+    "talos_registry_trust", ROOT / "scripts/talos_registry_trust.py"
+)
+assert SPEC and SPEC.loader
+trust = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(trust)
+RENDER_SPEC = importlib.util.spec_from_file_location("render", ROOT / "render.py")
+assert RENDER_SPEC and RENDER_SPEC.loader
+renderer = importlib.util.module_from_spec(RENDER_SPEC)
+RENDER_SPEC.loader.exec_module(renderer)
+
+HOST = "registry.ok-shared.internal"
+ADDRESS = "198.51.100.27"
+CA = b"""-----BEGIN CERTIFICATE-----
+MIIDEzCCAfugAwIBAgIUfEe/v6k2f0HSSgLT7RppPHBXZm4wDQYJKoZIhvcNAQEL
+BQAwGTEXMBUGA1UEAwwOT0stMTM4IFRlc3QgQ0EwHhcNMjYwODExMDUwMTI1WhcN
+MzYwODA4MDUwMTI1WjAZMRcwFQYDVQQDDA5PSy0xMzggVGVzdCBDQTCCASIwDQYJ
+KoZIhvcNAQEBBQADggEPADCCAQoCggEBAK9EDcgg1mGkQ7M/+n6eM7CkEPBBEKrm
+jKgzBelgBMHRUE1JV8XNSgnRJDOkIS9IWW5jLdkQko0v6JuLYb1BaCR5tSmlDyq+
+Yykyit4nqJuKPyUpHqCm73ICqD9ZwgLWCJ+0oBuzOzyBzOt2VoBJFLhyccMlg+aw
+m87JAVsuuC7GTwqGgVjVcl/ZMvD96/lLg3zCTFM+GQFf34GfwXHD029vzWCxgQur
+2ZCAu9yav54WPTT6cVBDisBg+CllliKJfdlK1MUvT1/AK6OxTrUKfHHI9l/JFRKG
+2EUaDMWJJIcJSfaYvqtCkc6oS+TfXjFDEjT01bv7+jc7MSgh3gdx0GsCAwEAAaNT
+MFEwHQYDVR0OBBYEFHgHRp1y31Yv3tSfAF6WbA4iBsu1MB8GA1UdIwQYMBaAFHgH
+Rp1y31Yv3tSfAF6WbA4iBsu1MA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZIhvcNAQEL
+BQADggEBAB+GsgezWyKh8cP6k+PBGOKEy4ZifSZr+UOaWCBXSbWd/2z5YCfh9koC
+Nw+XAZzcO6kHEw9A99DIcGnKCRyHmbrmi052cDANblvSwcZ19jJJoehSk6b+cThv
+23p/vvvYocScehaCo8ydVgu3WWdZg2Rab0AY9i5QiHpCdQM8DJG/fTQO3pfSyOAr
+YCsDRWTmZxY0YGNmKcODUY0W/6mgL0xCdllyqxA2bSNVKkGiCYNjHNs3lnOofG1a
+tXGR1YHWKK+tzJAfXwpGZlrAbYGR0Z176qaNMD0C8A6/HbwLM2YhxhjXB2OM77FP
+kh1bGN4EJWU6UI/A5gk7iaLQ/Bv1uCE=
+-----END CERTIFICATE-----
+"""
+
+
+def base_manifest() -> bytes:
+    return yaml.safe_dump_all([
+        {
+            "apiVersion": "controlplane.cluster.x-k8s.io/v1alpha3",
+            "kind": "TalosControlPlane",
+            "spec": {"controlPlaneConfig": {"controlplane": {"configPatches": []}}},
+        },
+        {
+            "apiVersion": "bootstrap.cluster.x-k8s.io/v1alpha3",
+            "kind": "TalosConfigTemplate",
+            "spec": {"template": {"spec": {"configPatches": []}}},
+        },
+    ], sort_keys=False).encode()
+
+
+class RegistryTrustTest(unittest.TestCase):
+    def test_default_off_has_no_rendered_effect(self) -> None:
+        for path in ROOT.glob("ok-*/cluster-config.yaml"):
+            cfg = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+            if "registryTrust" not in cfg:
+                self.assertNotIn("registry.ok-shared.internal", path.read_text(encoding="utf-8"))
+        source = (ROOT / "new-cluster.sh").read_text(encoding="utf-8")
+        self.assertIn('REGISTRY_TRUST="${REGISTRY_TRUST:-false}"', source)
+        cfg = {"name": "default-off", "type": "talos"}
+        before = dict(cfg)
+        renderer.validate_registry_trust(cfg)
+        self.assertEqual(cfg, before)
+        source_cfg = yaml.safe_load(
+            (ROOT / "ok-ai" / "cluster-config.yaml").read_text(encoding="utf-8")
+        )
+        with tempfile.TemporaryDirectory(
+            prefix=".ok138-default-off-", dir=ROOT
+        ) as temp:
+            output = Path(temp)
+            renderer.render_cluster("ok-ai", output, source_cfg)
+            rendered = "\n".join(
+                path.read_text(encoding="utf-8")
+                for path in output.iterdir()
+                if path.is_file()
+            )
+        self.assertNotIn("registryTrust", rendered)
+        self.assertNotIn(HOST, rendered)
+
+    def test_opt_in_control_plane_worker_parity(self) -> None:
+        docs = list(yaml.safe_load_all(trust.hydrate_manifest(base_manifest(), HOST, ADDRESS, CA)))
+        cp = docs[0]["spec"]["controlPlaneConfig"]["controlplane"]["configPatches"]
+        worker = docs[1]["spec"]["template"]["spec"]["configPatches"]
+        self.assertEqual(cp, worker)
+        self.assertEqual(cp, trust.capi_ops(HOST, ADDRESS, CA))
+        existing = [
+            {"op": "add", "path": "/cluster/proxy", "value": {"disabled": True}},
+            {
+                "op": "add",
+                "path": "/machine/registries",
+                "value": {
+                    "mirrors": {"docker.io": {"endpoints": ["https://cache.invalid"]}},
+                    "config": {HOST: {"auth": {"username": "kept"}}},
+                },
+            },
+            {
+                "op": "add",
+                "path": "/machine/network/extraHostEntries",
+                "value": [
+                    {"ip": "198.51.100.9", "aliases": ["kept.invalid", HOST]}
+                ],
+            },
+        ]
+        updated = trust.upsert_capi_patches(existing, HOST, ADDRESS, CA)
+        self.assertEqual(updated[0], existing[0])
+        self.assertIn("docker.io", updated[1]["value"]["mirrors"])
+        self.assertEqual(
+            updated[1]["value"]["config"][HOST]["auth"]["username"], "kept"
+        )
+        self.assertEqual(
+            updated[2]["value"],
+            [
+                {"ip": "198.51.100.9", "aliases": ["kept.invalid"]},
+                {"ip": ADDRESS, "aliases": [HOST]},
+            ],
+        )
+        self.assertEqual(
+            trust.upsert_capi_patches(updated, HOST, ADDRESS, CA), updated
+        )
+        with self.assertRaises(trust.TrustError):
+            trust.upsert_capi_patches(
+                [
+                    {
+                        "op": "add",
+                        "path": "/machine/registries/mirrors",
+                        "value": {"docker.io": {"endpoints": ["https://cache.invalid"]}},
+                    }
+                ],
+                HOST,
+                ADDRESS,
+                CA,
+            )
+
+    def test_runtime_and_declarative_semantics_are_equivalent(self) -> None:
+        runtime = yaml.safe_load(trust.render_patch(HOST, ADDRESS, CA))
+        ops = trust.capi_ops(HOST, ADDRESS, CA)
+        self.assertEqual(ops[0]["value"], runtime["machine"]["registries"])
+        self.assertEqual(
+            ops[1]["value"], runtime["machine"]["network"]["extraHostEntries"]
+        )
+        encoded = runtime["machine"]["registries"]["config"][HOST]["tls"]["ca"]
+        self.assertEqual(base64.b64decode(encoded), CA)
+
+    def test_runtime_upsert_preserves_unrelated_config_and_is_idempotent(self) -> None:
+        current = {
+            "machine": {
+                "registries": {
+                    "mirrors": {"docker.io": {"endpoints": ["https://cache.invalid"]}},
+                    "config": {HOST: {"auth": {"username": "kept"}}},
+                },
+                "network": {
+                    "extraHostEntries": [
+                        {"ip": "198.51.100.10", "aliases": ["kept.invalid", HOST]},
+                    ]
+                },
+            }
+        }
+        first = trust.runtime_ops(current, HOST, ADDRESS, CA)
+        registries = first[0]["value"]
+        entries = first[1]["value"]
+        self.assertIn("docker.io", registries["mirrors"])
+        self.assertEqual(registries["config"][HOST]["auth"]["username"], "kept")
+        self.assertEqual(entries[0], {"ip": "198.51.100.10", "aliases": ["kept.invalid"]})
+        self.assertEqual(entries[1], {"ip": ADDRESS, "aliases": [HOST]})
+        reapplied = trust.runtime_ops(
+            {"machine": {"registries": registries, "network": {"extraHostEntries": entries}}},
+            HOST, ADDRESS, CA,
+        )
+        self.assertEqual(reapplied, first)
+
+    def test_fragment_and_normal_render_contain_no_hydrated_values(self) -> None:
+        fragment = trust.PATCH_TEMPLATE.read_text(encoding="utf-8")
+        self.assertIn("${REGISTRY_CA_BASE64}", fragment)
+        self.assertIn("${REGISTRY_ADDRESS}", fragment)
+        for path in list((ROOT / "templates").rglob("*.tpl")) + list(ROOT.glob("ok-*/*.yaml")):
+            text = path.read_text(encoding="utf-8")
+            self.assertNotIn(ADDRESS, text, str(path))
+            self.assertNotIn(CA.decode(), text, str(path))
+
+        capability_files = [
+            ROOT / "docs/registry-trust.md",
+            ROOT / "scripts/talos_registry_trust.py",
+            ROOT / "templates/talos/patches/registry-trust.yaml.tpl",
+        ]
+        for path in capability_files:
+            text = path.read_text(encoding="utf-8")
+            self.assertNotIn("-----BEGIN CERTIFICATE-----", text, str(path))
+            for token in text.replace("'", " ").replace('"', " ").split():
+                candidate = token.strip("<>()[]{},:;`$\\")
+                try:
+                    address = ipaddress.ip_address(candidate)
+                except ValueError:
+                    continue
+                self.assertTrue(address.is_reserved, f"estate-like IP in {path}: {address}")
+
+    def test_negative_guards(self) -> None:
+        with self.assertRaises(trust.TrustError):
+            trust._single_ip([], "test")
+        with self.assertRaises(trust.TrustError):
+            trust._single_ip([ADDRESS, "198.51.100.28"], "test")
+        with self.assertRaises(trust.TrustError):
+            trust._single_ip(["registry.invalid"], "test")
+        with self.assertRaises(SystemExit):
+            renderer.validate_registry_trust(
+                {"name": "bad", "type": "talos", "registryTrust": {"enabled": False}}
+            )
+        source = (ROOT / "scripts/talos_registry_trust.py").read_text(encoding="utf-8")
+        self.assertIn('os.environ.get("REGISTRY_TRUST_APPLY") != "yes"', source)
+        self.assertIn('"--mode", "no-reboot"', source)
+        self.assertIn('argv.append("--dry-run")', source)
+        self.assertNotIn("tempfile", source)
+        self.assertIn("os.memfd_create", source)
+
+    def test_talosctl_v195_complete_config_validation(self) -> None:
+        trust.validate_with_talosctl(trust.render_patch(HOST, ADDRESS, CA))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Builds the opt-in per-cluster registry-trust capability for OK-138's remaining hard criterion, **pull by at least one real Kubernetes workload**.

The registry is live on `ok-shared` and its OCI contract is proven, but the **kubelet** cannot pull from it: containerd on the node performs the pull, and the node neither trusts `ok-shared-internal-ca` nor resolves `registry.ok-shared.internal`. Every artifact in the registry shelf says so explicitly rather than implying otherwise.

## Shape

Per the decision on OK-138: one building block that distributes the CA via `machine.registries.config` **and** resolves the name via `machine.network.extraHostEntries`, **opt-in per cluster**. Not a fleet-wide trust push — not every cluster will ever pull from this registry — and not a publicly-trusted certificate for a service that is internal by design. OK-99 set the precedent by scoping `extraHostEntries` to `ok-mgmt` rather than the fleet.

The committed fragment (`templates/talos/patches/registry-trust.yaml.tpl`) carries **no estate address and no CA material**. Both are hydrated in memory at run time, the address discovered from the Service the infrastructure cluster publishes for this cluster's ingress — matching what the registry shelf itself now does.

**The declarative and runtime forms are generated from one semantic object and checked against each other**, so a cluster created later cannot end up in a different state from one patched now. Renaming a single key in the fragment fails the suite on exactly that assertion.

## The access boundary is explicit

We cannot apply the runtime half. The Talos API is unreachable from an operator workstation — port 50000 times out, the same isolation that makes the ingress VIP necessary — and node access belongs to the platform owner.

| Target | Who |
|---|---|
| `make new CLUSTER=… REGISTRY_TRUST=true` | anyone, at cluster creation |
| `make talos-registry-trust-review` | **us** — render, validate, TLS probe; no Talos call |
| `make talos-registry-trust-dry-run` | **Arash** — API no-reboot dry-run |
| `make talos-registry-trust-apply` | **Arash** — gated apply |
| `make ok138-registry-trust-test` | anyone — offline + real `talosctl` v1.9.5 validation |

`docs/registry-trust.md` gives the exact invocations, expected before/after, and how a wrong address would show itself. Its acceptance section refuses the easy mistake: before creating the proof Pod it requires showing the digest is **absent from that node's image list**, because a Pod that pulls a cached image proves nothing about trust.

## Verified

- Offline suite passes and validates **real Talos v1.9.5** control-plane and worker configs
- `talos-registry-trust-review` against ok-shared: address discovered, validation passed, live TLS/SNI probe of `/v2/` succeeded
- The suite **can fail** — renaming one key in the fragment trips the semantics-equivalence assertion, exit 2
- Only `ok-shared/cluster-config.yaml` gained the opt-in flag; **no other cluster touched**, and **no rendered manifest changed**, so nothing is redeployed by this commit
- Test fixtures use RFC 5737 documentation addresses and their own generated CA, not live material

## What this does NOT close

The **kubelet-pull criterion is not met by this PR**. It is met when a real Pod pulls by digest, which we cannot cause. The ADR-Platform-020 amendment for platform-wide trust follows that evidence, deliberately, rather than preceding it.

Refs: OK-138, OK-99 · ADR-Platform-020, ADR-Platform-028, ADR-Platform-007
