### PR TITLE
docs(kagent): align OK-129 access help

### DIFF
--- a/ok-kagent/kagent/Makefile
+++ b/ok-kagent/kagent/Makefile
@@ -57,7 +57,7 @@ help:
 	@echo "  make verify-clean     Fail if kagent objects remain"
 	@echo ""
 	@echo "Permissions come from $(ACCESS_CONFIG) (mode: read-only | read-write)."
-	@echo "OK-129 only permits approval-gated ConfigMap writes in kagent-lab."
+	@echo "OK-129 permits approval-gated writes to the configured supported resources in kagent-lab."
 	@echo "Override with ACCESS_CONFIG=<path>"
 	@echo "to keep several profiles side by side."
 


### PR DESCRIPTION
## Summary

Corrects the standalone-kagent Make help text after the OK-129 write scope was expanded from ConfigMaps-only to the supported namespaced resource allow-list.

The functional consumer configuration and installer guards are already present on `ok-cluster/main` through #27. This PR removes the last contradictory operator-facing sentence.

## Why

`openkubes/openkubes#145` restores the shared renderer consumed by this repository and supports the ten resource kinds selected in `ok-kagent/kagent/access-config.yaml`. The existing help text still claimed that OK-129 permitted only ConfigMap writes, which no longer matched the merged configuration or the restored renderer.

## Validation

- `make help` shows the corrected scope.
- `make access-test OPENKUBES_DIR=<openkubes #145 checkout>` passes, including all 38 installer-guard tests.
- The real `ok-cluster/main` profile renders all ten selected resources with exactly `get/list/watch/create/update/patch/delete` in `kagent-lab`.
- No `ClusterRole` or `ClusterRoleBinding` is rendered.
- No remaining ConfigMaps-only claim under `ok-kagent`.
- `git diff --check` passes.

Companion provider PR: https://github.com/openkubes/openkubes/pull/145

Jira: https://kubernauts.atlassian.net/browse/OK-129
