### PR TITLE
fix: bind external KubeVirt infrastructure authority

### DIFF
--- a/README.md
+++ b/README.md
@@ -525,12 +525,24 @@ network:
 
 nodeSelector: ""     # pin VMs to a specific host node (required for Talos PVC binding)
 
+# Optional: required when CAPK runs on a separate management cluster and the
+# KubeVirt runtime is external. The referenced Secret must already exist on
+# the management cluster; ok-cluster never renders credential contents.
+infraClusterSecretRef:
+  name: external-infra-kubeconfig-my-cluster
+  namespace: my-cluster
+
 upgrade:
   strategy: blue-green
   workloadMigration:
     stateless: gitops
     stateful: app-native
 ```
+
+If `infraClusterSecretRef` is absent, CAPK intentionally uses its management
+cluster as the KubeVirt infrastructure cluster. For a split `ok-mgmt` / external
+`ok-infra` topology, bind the per-cluster Secret explicitly; otherwise CAPK can
+create the control-plane LoadBalancer Service in the wrong authority domain.
 
 ### Auto-Allocation Pools
 

--- a/cluster-config.yaml.example
+++ b/cluster-config.yaml.example
@@ -49,5 +49,12 @@ network:
 # Leave empty for no pinning (workers scheduled freely).
 nodeSelector: ok-gpu      # kubernetes.io/hostname value
 
+# Set only when CAPK runs on a different cluster than the KubeVirt runtime.
+# This Secret is materialized separately on the management cluster and is
+# referenced here by identity only; never put kubeconfig bytes in this file.
+# infraClusterSecretRef:
+#   name: external-infra-kubeconfig-my-cluster
+#   namespace: my-cluster
+
 upgrade:
   strategy: blue-green    # blue-green | in-place

--- a/render.py
+++ b/render.py
@@ -175,6 +175,44 @@ def validate_registry_trust(cfg: dict) -> None:
             "ERROR: registryTrust.host must be registry.ok-shared.internal"
         )
 
+
+def render_infra_cluster_secret_ref(cfg: dict) -> str:
+    """Render an explicit CAPK external-infrastructure credential reference.
+
+    The reference is optional because CAPK can legitimately manage KubeVirt in
+    the management cluster itself.  When an external provider cluster is
+    intended, callers must opt in explicitly; silently inventing this reference
+    would blur the lifecycle authority boundary.
+    """
+    reference = cfg.get("infraClusterSecretRef")
+    if reference is None:
+        return ""
+    if cfg.get("type") != "talos" or cfg.get("provider", "kubevirt") != "kubevirt":
+        raise SystemExit(
+            "ERROR: infraClusterSecretRef is supported only for Talos on KubeVirt"
+        )
+    if not isinstance(reference, dict) or set(reference) != {"name", "namespace"}:
+        raise SystemExit(
+            "ERROR: infraClusterSecretRef requires exactly name and namespace"
+        )
+    name = reference["name"]
+    namespace = reference["namespace"]
+    dns_subdomain = re.compile(
+        r"^(?=.{1,253}$)[a-z0-9](?:[-a-z0-9.]*[a-z0-9])?$"
+    )
+    dns_label = re.compile(r"^(?=.{1,63}$)[a-z0-9](?:[-a-z0-9]*[a-z0-9])?$")
+    if not isinstance(name, str) or not dns_subdomain.fullmatch(name):
+        raise SystemExit("ERROR: infraClusterSecretRef.name is not a DNS subdomain")
+    if not isinstance(namespace, str) or not dns_label.fullmatch(namespace):
+        raise SystemExit("ERROR: infraClusterSecretRef.namespace is not a DNS label")
+    return (
+        "  infraClusterSecretRef:\n"
+        "    apiVersion: v1\n"
+        "    kind: Secret\n"
+        f"    name: {name}\n"
+        f"    namespace: {namespace}\n"
+    )
+
 def resolve_config(cfg: dict, cluster_name: str) -> dict:
     cfg = yaml.safe_load(yaml.dump(cfg))
     validate_registry_trust(cfg)
@@ -259,6 +297,7 @@ def build_context(cfg: dict) -> dict:
         "CLUSTER_NAME":       cfg["name"],
         "CLUSTER_TYPE":       cfg.get("type", "ubuntu"),
         "INFRA_PROVIDER":     cfg.get("provider", "kubevirt"),
+        "INFRA_CLUSTER_SECRET_REF": render_infra_cluster_secret_ref(cfg),
         "OS_IMAGE_NAME":      _osp.get("image", "talos-openstack-amd64"),
         "OS_CP_FLAVOR":       _osp.get("controlPlaneFlavor", "m1.large"),
         "OS_NODE_FLAVOR":     _osp.get("nodeFlavor", "m1.large"),

--- a/templates/talos/providers/kubevirt/cluster-base.yaml.tpl
+++ b/templates/talos/providers/kubevirt/cluster-base.yaml.tpl
@@ -80,7 +80,7 @@ metadata:
   name: ${CLUSTER_NAME}
   namespace: ${CLUSTER_NAME}
 spec:
-  controlPlaneServiceTemplate:
+${INFRA_CLUSTER_SECRET_REF}  controlPlaneServiceTemplate:
     spec:
       type: LoadBalancer
 ---

--- a/tests/ok141_kubevirt_infra_secret_ref_test.py
+++ b/tests/ok141_kubevirt_infra_secret_ref_test.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Offline contract tests for the OK-141 external CAPK authority seam."""
+
+from pathlib import Path
+from string import Template
+import sys
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+import render  # noqa: E402
+
+
+def base_config() -> dict:
+    return {
+        "name": "disposable-ok141",
+        "type": "talos",
+        "provider": "kubevirt",
+        "versions": {"kubernetes": "v1.36.2", "talos": "v1.9.6"},
+        "network": {
+            "endpoint": "provider-allocated",
+            "podCIDR": "10.40.0.0/16",
+            "serviceCIDR": "10.100.0.0/20",
+        },
+    }
+
+
+def kubevirt_cluster_document(config: dict) -> dict:
+    template = Template(
+        (ROOT / "templates/talos/providers/kubevirt/cluster-base.yaml.tpl").read_text()
+    )
+    rendered = template.safe_substitute(render.build_context(config))
+    return next(
+        document
+        for document in yaml.safe_load_all(rendered)
+        if document and document.get("kind") == "KubevirtCluster"
+    )
+
+
+def expect_error(config: dict, message: str) -> None:
+    try:
+        render.render_infra_cluster_secret_ref(config)
+    except SystemExit as error:
+        assert message in str(error)
+    else:
+        raise AssertionError("invalid infraClusterSecretRef was accepted")
+
+
+def main() -> None:
+    same_cluster = base_config()
+    assert "infraClusterSecretRef" not in kubevirt_cluster_document(same_cluster)["spec"]
+
+    external = base_config()
+    external["infraClusterSecretRef"] = {
+        "name": "external-infra-kubeconfig-disposable-ok141",
+        "namespace": "disposable-ok141",
+    }
+    document = kubevirt_cluster_document(external)
+    assert document["spec"]["infraClusterSecretRef"] == {
+        "apiVersion": "v1",
+        "kind": "Secret",
+        "name": "external-infra-kubeconfig-disposable-ok141",
+        "namespace": "disposable-ok141",
+    }
+    assert document["spec"]["controlPlaneServiceTemplate"]["spec"]["type"] == "LoadBalancer"
+
+    incomplete = base_config()
+    incomplete["infraClusterSecretRef"] = {"name": "missing-namespace"}
+    expect_error(incomplete, "requires exactly name and namespace")
+
+    unsafe = base_config()
+    unsafe["infraClusterSecretRef"] = {
+        "name": "$(unsafe)",
+        "namespace": "disposable-ok141",
+    }
+    expect_error(unsafe, "not a DNS subdomain")
+
+    wrong_provider = base_config()
+    wrong_provider["provider"] = "openstack"
+    wrong_provider["infraClusterSecretRef"] = {
+        "name": "external-infra-kubeconfig-disposable-ok141",
+        "namespace": "disposable-ok141",
+    }
+    expect_error(wrong_provider, "supported only for Talos on KubeVirt")
+
+    print("OK-141 infraClusterSecretRef tests: PASS")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What changed

- add an explicit, validated `infraClusterSecretRef` input for Talos/KubeVirt renders
- render the CAPK `KubevirtCluster.spec.infraClusterSecretRef` only when requested
- preserve existing same-cluster CAPK behavior when the reference is absent
- document the split `ok-mgmt` / external `ok-infra` topology
- add offline positive and fail-closed tests

## Root cause

The OK-141 GO1-L execution proved that the rendered `KubevirtCluster` named `ok-infra` semantically but did not carry an executable external-infrastructure credential reference. CAPK therefore created the control-plane LoadBalancer Service on `ok-mgmt`, where it remained pending, instead of on `ok-infra`.

## Impact

Split management/provider deployments can now bind the exact per-cluster external-infrastructure Secret without embedding credentials in the rendered configuration. Existing in-cluster CAPK users are unchanged unless they opt in.

## Validation

- all `tests/*_test.py` passed locally
- new `tests/ok141_kubevirt_infra_secret_ref_test.py` covers explicit rendering, unchanged same-cluster behavior, incomplete references, unsafe names, and unsupported providers
- `git diff --check` passed

## Safety

This PR changes rendering only. It performs no cluster mutation, creates no Secret, and does not authorize the OK-141 retry or cleanup.