### PR TITLE
fix(OK-141): Pin the KubeVirt API service namespace

### DIFF
--- a/templates/talos/providers/kubevirt/cluster-base.yaml.tpl
+++ b/templates/talos/providers/kubevirt/cluster-base.yaml.tpl
@@ -81,6 +81,8 @@ metadata:
   namespace: ${CLUSTER_NAME}
 spec:
 ${INFRA_CLUSTER_SECRET_REF}  controlPlaneServiceTemplate:
+    metadata:
+      namespace: ${CLUSTER_NAME}
     spec:
       type: LoadBalancer
 ---

--- a/tests/ok141_kubevirt_infra_secret_ref_test.py
+++ b/tests/ok141_kubevirt_infra_secret_ref_test.py
@@ -64,6 +64,14 @@ def main() -> None:
         "namespace": "disposable-ok141",
     }
     assert document["spec"]["controlPlaneServiceTemplate"]["spec"]["type"] == "LoadBalancer"
+    assert document["spec"]["controlPlaneServiceTemplate"]["metadata"] == {
+        "namespace": "disposable-ok141"
+    }
+
+    same_cluster_document = kubevirt_cluster_document(same_cluster)
+    assert same_cluster_document["spec"]["controlPlaneServiceTemplate"]["metadata"] == {
+        "namespace": "disposable-ok141"
+    }
 
     incomplete = base_config()
     incomplete["infraClusterSecretRef"] = {"name": "missing-namespace"}


### PR DESCRIPTION
## What changed

- render `KubevirtCluster.spec.controlPlaneServiceTemplate.metadata.namespace` as the workload cluster namespace
- cover both same-cluster and external-infrastructure rendering in the OK-141 contract test

## Why

CAPK v0.11.2 defaults the control-plane Service namespace to the current-context namespace embedded in the external-infrastructure kubeconfig. A developer kubeconfig can carry an unrelated default namespace, causing the LoadBalancer Service to be created outside the VMI namespace. Kubernetes Service selectors are namespace-scoped, so that Service has no endpoints even when the control-plane VMI is healthy.

Binding the Service namespace in desired state makes the projection deterministic and independent of local kubeconfig defaults.

## Impact

This changes future Talos/KubeVirt renders only. It performs no live-cluster mutation and does not modify credentials.

## Validation

- `PYTHONDONTWRITEBYTECODE=1 python3 tests/ok141_kubevirt_infra_secret_ref_test.py`
- `git diff --check`