### PR TITLE
feat(kagent): configure OK-129 verbs per resource

### DIFF
--- a/ok-kagent/kagent/README.md
+++ b/ok-kagent/kagent/README.md
@@ -34,7 +34,7 @@ hand, so nothing can drift out of sync with the documentation.
 | `mode` | `read-only` \| `read-write` | whether a write identity exists at all |
 | `write.scope` | `namespaces` | cluster scope is refused by this installer |
 | `write.namespaces` | `[kagent-lab]` | the only evidenced write target |
-| `write.resources` | supported resource list | exact namespaced kinds that may be changed |
+| `write.resources` | resource-to-verb mapping | exact namespaced API verbs kagent may use |
 | `write.requireApproval` | `true` | Approve/Reject gate per write tool |
 
 Switch a profile:
@@ -45,7 +45,7 @@ sed -i'' -e 's/^mode: .*/mode: read-only/' access-config.yaml
 make install          # removes the write identity, Role, tool server and Agent
 
 # approval-gated writes for selected kinds in the lab namespace
-$EDITOR access-config.yaml   # mode: read-write; select write.resources
+$EDITOR access-config.yaml   # mode: read-write; set write.resources per kind/verb
 make install
 make verify-access
 ```
@@ -54,7 +54,8 @@ The cluster installer adds an independent fail-closed OK-129 guard before the
 shared renderer. Both layers refuse cluster scope, ungated writes, unsupported
 or sensitive resources, and targets other than `kagent-lab`. Supported kinds
 are ConfigMaps, Pods, Services, Deployments, StatefulSets, DaemonSets,
-ReplicaSets, Jobs, CronJobs and Ingresses; any non-empty subset can be selected.
+ReplicaSets, Jobs, CronJobs and Ingresses; each selected kind receives only the
+verbs explicitly configured for it.
 
 Full reference: `openkubes/research/kagent-standalone/access/README.md`.
 

--- a/ok-kagent/kagent/access-config.yaml
+++ b/ok-kagent/kagent/access-config.yaml
@@ -15,7 +15,7 @@ kind: KagentAccessProfile
 
 # read-only  : diagnosis only. No write identity, Role, tool server or Agent.
 # read-write : additionally deploys one scoped write path (see `write:` below).
-mode: read-write
+mode: read-only
 
 install:
   namespace: kagent

--- a/ok-kagent/kagent/access-config.yaml
+++ b/ok-kagent/kagent/access-config.yaml
@@ -39,20 +39,20 @@ write:
   namespaces:
     - kagent-lab
 
-  # Select any non-empty subset of the supported namespaced resource kinds.
-  # Unlisted kinds are denied; Secrets, RBAC and cluster-scoped resources are
-  # never grantable by this installer.
+  # Declare the exact API verbs per supported resource kind. There is no global
+  # CRUD default: unlisted kinds and unlisted verbs are denied. Secrets, RBAC
+  # and cluster-scoped resources are never grantable by this installer.
   resources:
-    - configmaps
-    - deployments
-    - statefulsets
-    - daemonsets
-    - replicasets
-    - jobs
-    - cronjobs
-    - pods
-    - services
-    - ingresses
+    configmaps: [get, list, watch, create, update, patch, delete]
+    pods: [get, list, watch, delete]
+    services: [get, list, watch, update, patch]
+    deployments: [get, list, watch, update, patch]
+    statefulsets: [get, list, watch, update, patch]
+    daemonsets: [get, list, watch, update, patch]
+    replicasets: [get, list, watch, update, patch]
+    jobs: [get, list, watch, delete]
+    cronjobs: [get, list, watch, update, patch]
+    ingresses: [get, list, watch, update, patch]
 
   # Approve/Reject in the UI for every write tool. The installer refuses false.
   requireApproval: true

--- a/ok-kagent/kagent/ok129_access.py
+++ b/ok-kagent/kagent/ok129_access.py
@@ -51,6 +51,7 @@ ALLOWED_WRITE_RESOURCES = {
     "ingresses",
 }
 READ_VERBS = {"get", "list", "watch"}
+ALLOWED_RESOURCE_VERBS = READ_VERBS | {"create", "update", "patch", "delete"}
 
 # Candidate detector only. Other teams may install the same upstream chart, so
 # this prefix must never be treated as ownership evidence by itself. The bundled
@@ -119,23 +120,47 @@ def validate_ok129(raw: dict[str, Any]) -> None:
             "OK-129 write.namespaces must be exactly: "
             + ", ".join(sorted(ALLOWED_WRITE_NAMESPACES))
         )
-    if not isinstance(resources, list) or not resources:
+    if not isinstance(resources, dict) or not resources:
         raise AccessError(
-            "OK-129 write.resources must be a non-empty list"
+            "OK-129 write.resources must be a non-empty mapping of resource names to verb lists"
         )
-    if any(not isinstance(resource, str) for resource in resources):
-        raise AccessError("OK-129 write.resources entries must be strings")
-    normalized_resources = [resource.lower() for resource in resources]
-    if len(normalized_resources) != len(set(normalized_resources)):
-        raise AccessError("OK-129 write.resources contains a duplicate entry")
-    unsupported = sorted(set(normalized_resources) - ALLOWED_WRITE_RESOURCES)
-    if unsupported:
-        raise AccessError(
-            "OK-129 write.resources contains unsupported resource(s): "
-            + ", ".join(unsupported)
-            + ". Supported: "
-            + ", ".join(sorted(ALLOWED_WRITE_RESOURCES))
-        )
+    normalized_resources: set[str] = set()
+    for resource, verbs in resources.items():
+        if not isinstance(resource, str):
+            raise AccessError("OK-129 write.resources keys must be strings")
+        normalized = resource.lower()
+        if normalized in normalized_resources:
+            raise AccessError(
+                "OK-129 write.resources contains a duplicate resource after normalization: "
+                + normalized
+            )
+        normalized_resources.add(normalized)
+        if normalized not in ALLOWED_WRITE_RESOURCES:
+            raise AccessError(
+                "OK-129 write.resources contains unsupported resource: "
+                + normalized
+                + ". Supported: "
+                + ", ".join(sorted(ALLOWED_WRITE_RESOURCES))
+            )
+        if not isinstance(verbs, list) or not verbs:
+            raise AccessError(
+                f"OK-129 write.resources.{normalized} must be a non-empty verb list"
+            )
+        if any(not isinstance(verb, str) for verb in verbs):
+            raise AccessError(
+                f"OK-129 write.resources.{normalized} verbs must be strings"
+            )
+        normalized_verbs = [verb.lower() for verb in verbs]
+        if len(normalized_verbs) != len(set(normalized_verbs)):
+            raise AccessError(
+                f"OK-129 write.resources.{normalized} contains a duplicate verb"
+            )
+        unsupported_verbs = sorted(set(normalized_verbs) - ALLOWED_RESOURCE_VERBS)
+        if unsupported_verbs:
+            raise AccessError(
+                f"OK-129 write.resources.{normalized} contains unsupported verb(s): "
+                + ", ".join(unsupported_verbs)
+            )
     if approval is not True:
         raise AccessError("OK-129 requires write.requireApproval=true")
 
@@ -220,7 +245,7 @@ def _matrix_row(
 
 
 def _declared_verbs(
-    docs: list[dict[str, Any]], namespace: str, resources: set[str]
+    docs: list[dict[str, Any]], namespace: str, expected: dict[str, set[str]]
 ) -> dict[str, set[str]]:
     """Read the verbs the rendered Role actually grants in one namespace."""
     roles = [
@@ -234,7 +259,7 @@ def _declared_verbs(
             f"expected exactly one rendered Role in {namespace}, found {len(roles)}"
         )
 
-    declared: dict[str, set[str]] = {resource: set() for resource in resources}
+    declared: dict[str, set[str]] = {resource: set() for resource in expected}
     nonconfigured_mutating: set[str] = set()
     for rule in roles[0].get("rules") or []:
         verbs = {str(verb) for verb in (rule.get("verbs") or [])}
@@ -254,6 +279,16 @@ def _declared_verbs(
         raise AccessError(
             f"rendered Role in {namespace} grants mutations to non-configured resource(s): "
             + ", ".join(sorted(nonconfigured_mutating))
+        )
+    mismatches = {
+        resource: {"configured": sorted(expected[resource]), "rendered": sorted(verbs)}
+        for resource, verbs in declared.items()
+        if verbs != expected[resource]
+    }
+    if mismatches:
+        raise AccessError(
+            f"rendered Role in {namespace} does not match the configured resource verbs: "
+            + json.dumps(mismatches, sort_keys=True)
         )
     return declared
 
@@ -305,7 +340,10 @@ def verification_matrix(
 
     write = raw["write"]
     namespaces = [str(value) for value in write["namespaces"]]
-    resources = {str(resource).lower() for resource in write["resources"]}
+    resources = {
+        str(resource).lower(): {str(verb).lower() for verb in verbs}
+        for resource, verbs in write["resources"].items()
+    }
     docs = yaml_documents(rbac_path)
     writers: set[str] = set()
 
@@ -336,7 +374,7 @@ def verification_matrix(
                 if verb not in READ_VERBS:
                     mutating_verbs.add(verb)
 
-        unconfigured = sorted(ALLOWED_WRITE_RESOURCES - resources)
+        unconfigured = sorted(ALLOWED_WRITE_RESOURCES - set(resources))
         if unconfigured:
             for verb in sorted(mutating_verbs):
                 rows.append(

--- a/ok-kagent/kagent/ok129_access_test.py
+++ b/ok-kagent/kagent/ok129_access_test.py
@@ -22,7 +22,7 @@ def profile(**write_overrides):
     write = {
         "scope": "namespaces",
         "namespaces": ["kagent-lab"],
-        "resources": ["configmaps"],
+        "resources": {"configmaps": ["get", "patch"]},
         "requireApproval": True,
         "toolServer": {
             "namespace": "kagent-write",
@@ -58,20 +58,26 @@ class ValidationTests(unittest.TestCase):
         with self.assertRaisesRegex(access.AccessError, "requireApproval=true"):
             access.validate_ok129(profile(requireApproval=False))
 
-    def test_supported_resource_subset_is_allowed(self):
-        access.validate_ok129(profile(resources=["deployments", "pods", "services"]))
+    def test_supported_resource_verbs_are_allowed(self):
+        access.validate_ok129(
+            profile(resources={"deployments": ["get", "patch"], "pods": ["get", "delete"], "services": ["get", "update"]})
+        )
 
     def test_unsupported_resource_is_refused(self):
         with self.assertRaisesRegex(access.AccessError, "unsupported resource"):
-            access.validate_ok129(profile(resources=["configmaps", "widgets"]))
+            access.validate_ok129(profile(resources={"configmaps": ["get"], "widgets": ["get"]}))
 
-    def test_empty_resource_list_is_refused(self):
-        with self.assertRaisesRegex(access.AccessError, "non-empty list"):
-            access.validate_ok129(profile(resources=[]))
+    def test_empty_resource_mapping_is_refused(self):
+        with self.assertRaisesRegex(access.AccessError, "non-empty mapping"):
+            access.validate_ok129(profile(resources={}))
 
-    def test_duplicate_resource_is_refused(self):
-        with self.assertRaisesRegex(access.AccessError, "duplicate"):
-            access.validate_ok129(profile(resources=["pods", "pods"]))
+    def test_duplicate_resource_verb_is_refused(self):
+        with self.assertRaisesRegex(access.AccessError, "duplicate verb"):
+            access.validate_ok129(profile(resources={"pods": ["get", "get"]}))
+
+    def test_unsupported_resource_verb_is_refused(self):
+        with self.assertRaisesRegex(access.AccessError, "unsupported verb"):
+            access.validate_ok129(profile(resources={"pods": ["exec"]}))
 
     def test_non_lab_namespace_is_refused(self):
         with self.assertRaisesRegex(access.AccessError, "exactly: kagent-lab"):
@@ -215,7 +221,7 @@ class MatrixTests(unittest.TestCase):
                 {
                     "kind": "Role",
                     "metadata": {"name": "tools", "namespace": namespace},
-                    "rules": [{"resources": ["configmaps"], "verbs": ["patch"]}],
+                    "rules": [{"resources": ["configmaps"], "verbs": ["get", "patch"]}],
                 }
             )
             docs.append(
@@ -248,7 +254,7 @@ class MatrixTests(unittest.TestCase):
             {
                 "kind": "Role",
                 "metadata": {"name": "tools", "namespace": "kagent-lab"},
-                "rules": [{"resources": ["configmaps"], "verbs": ["patch"]}],
+                "rules": [{"resources": ["configmaps"], "verbs": ["get", "patch"]}],
             },
             {
                 "kind": "RoleBinding",
@@ -290,6 +296,25 @@ class MatrixTests(unittest.TestCase):
             rbac = Path(directory) / "rbac.yaml"
             rbac.write_text(yaml.safe_dump_all([role, binding]), encoding="utf-8")
             with self.assertRaisesRegex(access.AccessError, "non-configured"):
+                access.verification_matrix(profile(), rbac)
+
+    def test_rendered_verbs_must_match_the_resource_mapping(self):
+        role = {
+            "kind": "Role",
+            "metadata": {"name": "tools", "namespace": "kagent-lab"},
+            "rules": [{"resources": ["configmaps"], "verbs": ["get", "patch", "delete"]}],
+        }
+        binding = {
+            "kind": "RoleBinding",
+            "metadata": {"name": "tools", "namespace": "kagent-lab"},
+            "subjects": [
+                {"kind": "ServiceAccount", "name": "tools", "namespace": "write"}
+            ],
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            rbac = Path(directory) / "rbac.yaml"
+            rbac.write_text(yaml.safe_dump_all([role, binding]), encoding="utf-8")
+            with self.assertRaisesRegex(access.AccessError, "does not match the configured resource verbs"):
                 access.verification_matrix(profile(), rbac)
 
 


### PR DESCRIPTION
## Summary

Keeps `mode: read-only` as the shipped OK-129 default and changes the real lab profile from a resource list to a resource-to-verb mapping.

Each supported Kubernetes resource now declares its exact permitted API verbs. There is no global CRUD default: resource/verb pairs omitted from `write.resources` are denied.

The independent installer guard validates the mapping and rejects rendered RBAC when any configured resource receives a different verb set. This is coupled to openkubes/openkubes#145.

## Validation

- `python3 ok129_access_test.py` — 40 tests PASS
- coupled `make access-test OPENKUBES_DIR=<openkubes #145 checkout>` — PASS
- `git diff --check` — PASS

Ref: OK-129.