### PR TITLE
feat(OK-147): establish bounded executor contract core

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # OpenKubes Cluster Templating — Makefile
 # Usage: make new CLUSTER=ok3 TYPE=ubuntu|talos|talos-mgmt|flatcar [HA=true] [WORKERS=3] [SCHEDULING_PROFILE=ok-gpu|ok-gpu-single-replica]
 #        TYPE is REQUIRED — no silent default (OK-119).
-.PHONY: new render install kubeconfig install-cni install-storage install-ingress install-observability install-observability-metrics install-keycloak register-cluster unregister-cluster bootstrap annotate-pvcs upgrade clean teardown teardown-all reap-orphaned-volumes e2e e2e-verify list status help prepare-cilium-chart verify-cilium-chart cilium-chart-tool-test configure-kubevirt-expand-disks talos-registry-trust-review talos-registry-trust-dry-run talos-registry-trust-apply ok138-registry-trust-test
+.PHONY: new render install kubeconfig install-cni install-storage install-ingress install-observability install-observability-metrics install-keycloak register-cluster unregister-cluster bootstrap annotate-pvcs upgrade clean teardown teardown-all reap-orphaned-volumes e2e e2e-verify list status help prepare-cilium-chart verify-cilium-chart cilium-chart-tool-test configure-kubevirt-expand-disks talos-registry-trust-review talos-registry-trust-dry-run talos-registry-trust-apply ok138-registry-trust-test contract-executor-test contract-executor-dry-run
 .DEFAULT_GOAL := help
 
 CLUSTER       ?=
@@ -191,6 +191,16 @@ verify-cilium-chart: ## Offline-verify an existing pinned Cilium chart
 cilium-chart-tool-test: ## Offline-test Cilium acquisition/cache guards
 	@PYTHONDONTWRITEBYTECODE=1 \
 		python3 $(SCRIPT_DIR)/tests/cilium_chart_tool_test.py
+
+# ── bounded Contract Executor MVP (OK-147) ──────────────────────────────────
+contract-executor-test: ## Test the side-effect-free Go Contract Executor core
+	@go test ./cmd/ok ./internal/contract
+
+contract-executor-dry-run: ## Reproduce the OK-141 R and emit a non-mutating plan
+	@go run ./cmd/ok cluster create \
+		--contract internal/contract/testdata/ok141-contract-v5.yaml \
+		--schema internal/contract/testdata/ok141-contract-v3.schema.json \
+		--dry-run
 
 # OK-125 candidate evidence is intentionally outside the ordinary TYPE allowlist.
 # It consumes ok-linux profile truth and never applies resources.
@@ -1069,6 +1079,8 @@ help:
 	@echo "── All targets ──────────────────────────────────────────────────────"
 	@echo "  make prepare-cilium-chart [CILIUM_CHART_SOURCE=<predownloaded.tgz>]"
 	@echo "  make verify-cilium-chart"
+	@echo "  make contract-executor-test          # OK-147: offline Go core tests"
+	@echo "  make contract-executor-dry-run       # OK-147: immutable plan; no cluster contact"
 	@echo "  make new           CLUSTER=ok1 TYPE=ubuntu|talos|talos-mgmt|flatcar [HA=true] [WORKERS=2] [NODE_SELECTOR=ok-gpu|NODE=ok-gpu] [START_IP=192.168.100.210]   # TYPE is required (OK-119)"
 	@echo "  make render        CLUSTER=ok1"
 	@echo "  make install       CLUSTER=ok1        # ubuntu: apply + cilium"

--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ Powered by [Cluster API (CAPI)](https://cluster-api.sigs.k8s.io/), [CAPK (KubeVi
 - **Blue/Green upgrades** — rolling Kubernetes version upgrades with workload migration
 - **GitOps-ready** — all cluster state is declarative YAML, rendered from templates
 - **Single Makefile UX** — `make new`, `make install`, `make status`, `make upgrade`
+- **Bounded Contract Executor MVP** — a shared Go core for local CLI and future
+  short-lived `ok-mgmt` Jobs; the first checkpoint is deliberately dry-run-only
+  and reproduces the OK-141 semantic contract revision
 
 ---
 

--- a/cmd/ok/main.go
+++ b/cmd/ok/main.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/openkubes/ok-cluster/internal/contract"
+)
+
+const version = "0.0.0-dev"
+
+type createPlan struct {
+	Format                  string            `json:"format"`
+	Operation               string            `json:"operation"`
+	ContractIdentity        contract.Identity `json:"contractIdentity"`
+	ContractRevision        string            `json:"contractRevision"`
+	CanonicalizationProfile string            `json:"canonicalizationProfile"`
+	RawArtifactDigest       string            `json:"rawArtifactDigest"`
+	SchemaDigest            string            `json:"schemaDigest"`
+	AuthorizationState      string            `json:"authorizationState"`
+	MutationAllowed         bool              `json:"mutationAllowed"`
+}
+
+func main() {
+	if err := run(os.Args[1:], os.Stdout, os.Stderr); err != nil {
+		fmt.Fprintln(os.Stderr, "ERROR:", err)
+		os.Exit(2)
+	}
+}
+
+func run(arguments []string, stdout, stderr io.Writer) error {
+	if len(arguments) == 1 && arguments[0] == "version" {
+		fmt.Fprintln(stdout, version)
+		return nil
+	}
+	if len(arguments) < 2 || arguments[0] != "cluster" || arguments[1] != "create" {
+		return errors.New("usage: ok cluster create --contract PATH --schema PATH --dry-run")
+	}
+	flags := flag.NewFlagSet("ok cluster create", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	contractPath := flags.String("contract", "", "path to the versioned cluster contract")
+	schemaPath := flags.String("schema", "", "path to the contract test schema")
+	dryRun := flags.Bool("dry-run", false, "validate and emit an immutable create plan without mutation")
+	if err := flags.Parse(arguments[2:]); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return errors.New("positional arguments are not accepted")
+	}
+	if !*dryRun {
+		return errors.New("the OK-147 MVP currently requires --dry-run; submission is not implemented")
+	}
+	if *contractPath == "" || *schemaPath == "" {
+		return errors.New("--contract and --schema are required")
+	}
+	raw, err := os.ReadFile(*contractPath)
+	if err != nil {
+		return fmt.Errorf("read contract: %w", err)
+	}
+	schema, err := os.ReadFile(*schemaPath)
+	if err != nil {
+		return fmt.Errorf("read schema: %w", err)
+	}
+	result, err := contract.Canonicalize(raw, schema)
+	if err != nil {
+		return err
+	}
+	identity, err := contract.ContractIdentity(result.Normalized)
+	if err != nil {
+		return err
+	}
+	plan := createPlan{
+		Format:                  "ok147-create-plan/v1",
+		Operation:               "CreateCluster",
+		ContractIdentity:        identity,
+		ContractRevision:        result.NormalizedDigest,
+		CanonicalizationProfile: result.CanonicalizationProfile,
+		RawArtifactDigest:       result.RawArtifactDigest,
+		SchemaDigest:            result.SchemaDigest,
+		AuthorizationState:      "NOT_EVALUATED",
+		MutationAllowed:         false,
+	}
+	encoder := json.NewEncoder(stdout)
+	encoder.SetEscapeHTML(false)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(plan)
+}

--- a/cmd/ok/main_test.go
+++ b/cmd/ok/main_test.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func fixturePath(t *testing.T, name string) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("cannot resolve test path")
+	}
+	return filepath.Join(filepath.Dir(file), "..", "..", "internal", "contract", "testdata", name)
+}
+
+func TestCreateDryRunProducesNonMutatingPlan(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	err := run([]string{
+		"cluster", "create",
+		"--contract", fixturePath(t, "ok141-contract-v5.yaml"),
+		"--schema", fixturePath(t, "ok141-contract-v3.schema.json"),
+		"--dry-run",
+	}, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("run: %v; stderr=%s", err, stderr.String())
+	}
+	var plan createPlan
+	if err := json.Unmarshal(stdout.Bytes(), &plan); err != nil {
+		t.Fatal(err)
+	}
+	if plan.Format != "ok147-create-plan/v1" || plan.Operation != "CreateCluster" || plan.MutationAllowed {
+		t.Fatalf("unsafe plan: %#v", plan)
+	}
+	if plan.AuthorizationState != "NOT_EVALUATED" {
+		t.Fatalf("authorization = %s", plan.AuthorizationState)
+	}
+}
+
+func TestCreateWithoutDryRunFailsClosed(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	err := run([]string{
+		"cluster", "create",
+		"--contract", fixturePath(t, "ok141-contract-v5.yaml"),
+		"--schema", fixturePath(t, "ok141-contract-v3.schema.json"),
+	}, &stdout, &stderr)
+	if err == nil || !strings.Contains(err.Error(), "requires --dry-run") {
+		t.Fatalf("error = %v", err)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("unexpected stdout: %s", stdout.String())
+	}
+}
+
+func TestArbitraryCommandsAreAbsent(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	for _, arguments := range [][]string{
+		{"shell", "echo", "unsafe"},
+		{"cluster", "apply", "--file", "anything.yaml"},
+		{"cluster", "create", "unexpected-positional-command"},
+	} {
+		if err := run(arguments, &stdout, &stderr); err == nil {
+			t.Fatalf("arguments unexpectedly accepted: %v", arguments)
+		}
+	}
+}

--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -1,0 +1,43 @@
+# OK-147 bounded Contract Executor MVP
+
+The first implementation checkpoint establishes the shared, side-effect-free
+core for local CLI and future in-cluster Job execution.
+
+```text
+versioned contract + test schema
+              |
+              v
+schema-driven normalization
+              |
+              v
+semantic projection + canonical JSON
+              |
+              v
+R = SHA-256(canonical contract)
+              |
+              v
+non-mutating CreateCluster plan
+```
+
+The command is intentionally dry-run-only:
+
+```bash
+go run ./cmd/ok cluster create \
+  --contract internal/contract/testdata/ok141-contract-v5.yaml \
+  --schema internal/contract/testdata/ok141-contract-v3.schema.json \
+  --dry-run
+```
+
+It performs no cluster discovery, credential read, API contact, submission, or
+observation. A command without `--dry-run` fails closed. Submission will be
+added only after the authorization, projection, idempotency, and evidence
+interfaces have executable tests.
+
+The emitted `ok147-create-plan/v1` document is an internal, test-only format.
+It is deliberately not shaped as a Kubernetes API object and does not establish
+a public OpenKubes API.
+
+The fixtures are test-only copies of the Phase-R v5 OK-141 contract and schema.
+They preserve the proven semantic revision
+`sha256:166504ae61fd558d391daedde50986cbc7a28f5f4e9d57f4acbd0433b448aa0f`;
+they are not a stable public OpenKubes API.

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/openkubes/ok-cluster
+
+go 1.21
+
+require gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/contract/canonical.go
+++ b/internal/contract/canonical.go
@@ -1,0 +1,605 @@
+// Package contract implements the deterministic, side-effect-free part of the
+// OpenKubes Contract Executor. It deliberately knows nothing about Kubernetes
+// clients, credentials, submission, or reconciliation.
+package contract
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/netip"
+	"reflect"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"unicode/utf16"
+	"unicode/utf8"
+
+	"gopkg.in/yaml.v3"
+)
+
+const CanonicalizationProfile = "openkubes-contract-c14n/v1"
+
+// Result is the immutable identity produced from a raw contract and its test
+// schema. CanonicalJSON contains semantic fields only.
+type Result struct {
+	CanonicalizationProfile string
+	RawArtifactDigest       string
+	SchemaDigest            string
+	NormalizedDigest        string
+	CanonicalJSON           []byte
+	Normalized              any
+}
+
+// Identity is the stable contract identity needed by a typed operation.
+type Identity struct {
+	Namespace string `json:"namespace"`
+	Name      string `json:"name"`
+}
+
+// Canonicalize parses a single YAML or JSON document, validates and normalizes
+// it with the versioned schema subset used by OK-141, removes fields explicitly
+// declared non-semantic, and hashes canonical JSON.
+func Canonicalize(raw, schemaRaw []byte) (Result, error) {
+	schema, err := parseJSON(schemaRaw)
+	if err != nil {
+		return Result{}, fmt.Errorf("parse schema: %w", err)
+	}
+	source, err := parseYAML(raw)
+	if err != nil {
+		return Result{}, fmt.Errorf("parse contract: %w", err)
+	}
+	normalized, err := normalize(source, schema, "$")
+	if err != nil {
+		return Result{}, err
+	}
+	if err := validateClusterSemantics(normalized); err != nil {
+		return Result{}, err
+	}
+	semantic, included, err := semanticProjection(normalized, schema)
+	if err != nil {
+		return Result{}, err
+	}
+	if !included {
+		return Result{}, errors.New("$: entire contract is declared non-semantic")
+	}
+	canonical, err := JCS(semantic)
+	if err != nil {
+		return Result{}, fmt.Errorf("canonical JSON: %w", err)
+	}
+	return Result{
+		CanonicalizationProfile: CanonicalizationProfile,
+		RawArtifactDigest:       digest(raw),
+		SchemaDigest:            digest(schemaRaw),
+		NormalizedDigest:        digest(canonical),
+		CanonicalJSON:           canonical,
+		Normalized:              normalized,
+	}, nil
+}
+
+// ContractIdentity extracts the stable name and namespace after validation.
+func ContractIdentity(normalized any) (Identity, error) {
+	root, ok := normalized.(map[string]any)
+	if !ok {
+		return Identity{}, errors.New("$: normalized contract is not an object")
+	}
+	metadata, ok := root["metadata"].(map[string]any)
+	if !ok {
+		return Identity{}, errors.New("$.metadata: normalized metadata is not an object")
+	}
+	name, nameOK := metadata["name"].(string)
+	namespace, namespaceOK := metadata["namespace"].(string)
+	if !nameOK || name == "" || !namespaceOK || namespace == "" {
+		return Identity{}, errors.New("$.metadata: name and namespace are required")
+	}
+	return Identity{Namespace: namespace, Name: name}, nil
+}
+
+func digest(data []byte) string {
+	sum := sha256.Sum256(data)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+func parseJSON(raw []byte) (map[string]any, error) {
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	var value map[string]any
+	if err := decoder.Decode(&value); err != nil {
+		return nil, err
+	}
+	if err := requireEOF(decoder); err != nil {
+		return nil, err
+	}
+	return value, nil
+}
+
+func requireEOF(decoder *json.Decoder) error {
+	var extra any
+	if err := decoder.Decode(&extra); err != io.EOF {
+		if err == nil {
+			return errors.New("multiple JSON values are not allowed")
+		}
+		return err
+	}
+	return nil
+}
+
+func parseYAML(raw []byte) (any, error) {
+	decoder := yaml.NewDecoder(bytes.NewReader(raw))
+	var document yaml.Node
+	if err := decoder.Decode(&document); err != nil {
+		return nil, err
+	}
+	if len(document.Content) != 1 {
+		return nil, errors.New("exactly one YAML document is required")
+	}
+	if err := validateYAMLNode(document.Content[0], "$"); err != nil {
+		return nil, err
+	}
+	var extra yaml.Node
+	if err := decoder.Decode(&extra); err != io.EOF {
+		if err == nil && len(extra.Content) > 0 {
+			return nil, errors.New("multiple YAML documents are not allowed")
+		}
+		if err != nil {
+			return nil, err
+		}
+	}
+	var value any
+	if err := document.Content[0].Decode(&value); err != nil {
+		return nil, err
+	}
+	return value, nil
+}
+
+func validateYAMLNode(node *yaml.Node, path string) error {
+	switch node.Kind {
+	case yaml.AliasNode:
+		return fmt.Errorf("%s: YAML aliases are not allowed", path)
+	case yaml.MappingNode:
+		seen := map[string]struct{}{}
+		for index := 0; index < len(node.Content); index += 2 {
+			key := node.Content[index]
+			if key.Kind != yaml.ScalarNode || key.Tag != "!!str" {
+				return fmt.Errorf("%s: all object keys must be strings", path)
+			}
+			if _, exists := seen[key.Value]; exists {
+				return fmt.Errorf("%s: duplicate mapping key %q", path, key.Value)
+			}
+			seen[key.Value] = struct{}{}
+			if err := validateYAMLNode(node.Content[index+1], path+"."+key.Value); err != nil {
+				return err
+			}
+		}
+	case yaml.SequenceNode:
+		for index, child := range node.Content {
+			if err := validateYAMLNode(child, fmt.Sprintf("%s[%d]", path, index)); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func normalize(value any, schema map[string]any, path string) (any, error) {
+	expected, _ := schema["type"].(string)
+	if expected != "" && !typeMatches(value, expected) {
+		return nil, fmt.Errorf("%s: expected %s, got %T", path, expected, value)
+	}
+	if constant, exists := schema["const"]; exists {
+		equal, err := canonicalEqual(value, constant)
+		if err != nil || !equal {
+			return nil, fmt.Errorf("%s: value differs from the declared constant", path)
+		}
+	}
+	if values, ok := schema["enum"].([]any); ok {
+		matched := false
+		for _, candidate := range values {
+			equal, err := canonicalEqual(value, candidate)
+			if err == nil && equal {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return nil, fmt.Errorf("%s: value is not in the declared enum", path)
+		}
+	}
+
+	switch expected {
+	case "object":
+		object := value.(map[string]any)
+		properties, _ := schema["properties"].(map[string]any)
+		additional, hasAdditional := schema["additionalProperties"].(bool)
+		if !hasAdditional {
+			additional = true
+		}
+		if !additional {
+			var unknown []string
+			for key := range object {
+				if _, exists := properties[key]; !exists {
+					unknown = append(unknown, key)
+				}
+			}
+			sort.Strings(unknown)
+			if len(unknown) > 0 {
+				return nil, fmt.Errorf("%s: unknown fields: %s", path, strings.Join(unknown, ", "))
+			}
+		}
+		required := stringSet(schema["required"])
+		result := make(map[string]any, len(object))
+		for name, rawChildSchema := range properties {
+			childSchema, ok := rawChildSchema.(map[string]any)
+			if !ok {
+				return nil, fmt.Errorf("%s.%s: invalid schema", path, name)
+			}
+			child, exists := object[name]
+			if !exists {
+				if defaultValue, hasDefault := childSchema["default"]; hasDefault {
+					child = defaultValue
+					exists = true
+				} else if _, isRequired := required[name]; isRequired {
+					return nil, fmt.Errorf("%s.%s: required field is missing", path, name)
+				}
+			}
+			if exists {
+				normalized, err := normalize(child, childSchema, path+"."+name)
+				if err != nil {
+					return nil, err
+				}
+				result[name] = normalized
+			}
+		}
+		if additional {
+			for name, child := range object {
+				if _, declared := properties[name]; !declared {
+					result[name] = child
+				}
+			}
+		}
+		return result, nil
+	case "array":
+		itemsSchema, ok := schema["items"].(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("%s: array schema has no items schema", path)
+		}
+		input := value.([]any)
+		result := make([]any, 0, len(input))
+		unique := map[string]struct{}{}
+		for index, item := range input {
+			normalized, err := normalize(item, itemsSchema, fmt.Sprintf("%s[%d]", path, index))
+			if err != nil {
+				return nil, err
+			}
+			if schema["uniqueItems"] == true {
+				encoded, err := JCS(normalized)
+				if err != nil {
+					return nil, err
+				}
+				key := string(encoded)
+				if _, exists := unique[key]; exists {
+					return nil, fmt.Errorf("%s: array items must be unique", path)
+				}
+				unique[key] = struct{}{}
+			}
+			result = append(result, normalized)
+		}
+		if minimum, ok := schemaInteger(schema["minItems"]); ok && int64(len(result)) < minimum {
+			return nil, fmt.Errorf("%s: requires at least %d items", path, minimum)
+		}
+		if maximum, ok := schemaInteger(schema["maxItems"]); ok && int64(len(result)) > maximum {
+			return nil, fmt.Errorf("%s: allows at most %d items", path, maximum)
+		}
+		return result, nil
+	case "string":
+		text := value.(string)
+		if minimum, ok := schemaInteger(schema["minLength"]); ok && int64(utf8.RuneCountInString(text)) < minimum {
+			return nil, fmt.Errorf("%s: string is shorter than %d", path, minimum)
+		}
+		if pattern, ok := schema["pattern"].(string); ok {
+			expression, err := regexp.Compile("^(?:" + pattern + ")$")
+			if err != nil {
+				return nil, fmt.Errorf("%s: invalid schema pattern: %w", path, err)
+			}
+			if !expression.MatchString(text) {
+				return nil, fmt.Errorf("%s: string does not match the declared pattern", path)
+			}
+		}
+		switch schema["format"] {
+		case "sha256":
+			if !regexp.MustCompile(`^sha256:[0-9a-f]{64}$`).MatchString(text) {
+				return nil, fmt.Errorf("%s: expected sha256:<64 lowercase hex>", path)
+			}
+		case "ipv4-cidr":
+			prefix, err := netip.ParsePrefix(text)
+			if err != nil || !prefix.Addr().Is4() || prefix.Masked() != prefix || prefix.String() != text {
+				return nil, fmt.Errorf("%s: invalid canonical IPv4 CIDR", path)
+			}
+		}
+		return text, nil
+	case "integer":
+		integer, ok := integerValue(value)
+		if !ok {
+			return nil, fmt.Errorf("%s: expected integer", path)
+		}
+		if minimum, ok := schemaInteger(schema["minimum"]); ok && integer < minimum {
+			return nil, fmt.Errorf("%s: integer must be >= %d", path, minimum)
+		}
+		return integer, nil
+	case "boolean", "null":
+		return value, nil
+	case "":
+		return value, nil
+	default:
+		return nil, fmt.Errorf("%s: unsupported schema type %q", path, expected)
+	}
+}
+
+func typeMatches(value any, expected string) bool {
+	switch expected {
+	case "object":
+		_, ok := value.(map[string]any)
+		return ok
+	case "array":
+		_, ok := value.([]any)
+		return ok
+	case "string":
+		_, ok := value.(string)
+		return ok
+	case "integer":
+		_, ok := integerValue(value)
+		return ok
+	case "boolean":
+		_, ok := value.(bool)
+		return ok
+	case "null":
+		return value == nil
+	default:
+		return false
+	}
+}
+
+func integerValue(value any) (int64, bool) {
+	switch number := value.(type) {
+	case int:
+		return int64(number), true
+	case int8:
+		return int64(number), true
+	case int16:
+		return int64(number), true
+	case int32:
+		return int64(number), true
+	case int64:
+		return number, true
+	case uint:
+		if uint64(number) > uint64(^uint64(0)>>1) {
+			return 0, false
+		}
+		return int64(number), true
+	case uint8:
+		return int64(number), true
+	case uint16:
+		return int64(number), true
+	case uint32:
+		return int64(number), true
+	case uint64:
+		if number > uint64(^uint64(0)>>1) {
+			return 0, false
+		}
+		return int64(number), true
+	case json.Number:
+		integer, err := number.Int64()
+		return integer, err == nil
+	default:
+		return 0, false
+	}
+}
+
+func schemaInteger(value any) (int64, bool) {
+	if value == nil {
+		return 0, false
+	}
+	return integerValue(value)
+}
+
+func stringSet(value any) map[string]struct{} {
+	result := map[string]struct{}{}
+	items, _ := value.([]any)
+	for _, item := range items {
+		if text, ok := item.(string); ok {
+			result[text] = struct{}{}
+		}
+	}
+	return result
+}
+
+func canonicalEqual(left, right any) (bool, error) {
+	leftJSON, err := JCS(left)
+	if err != nil {
+		return false, err
+	}
+	rightJSON, err := JCS(right)
+	if err != nil {
+		return false, err
+	}
+	return bytes.Equal(leftJSON, rightJSON), nil
+}
+
+func semanticProjection(value any, schema map[string]any) (any, bool, error) {
+	if semantic, exists := schema["x-openkubes-semantic"].(bool); exists && !semantic {
+		return nil, false, nil
+	}
+	switch schema["type"] {
+	case "object":
+		object := value.(map[string]any)
+		properties, _ := schema["properties"].(map[string]any)
+		result := map[string]any{}
+		for name, child := range object {
+			childSchema, declared := properties[name].(map[string]any)
+			if !declared {
+				result[name] = child
+				continue
+			}
+			projected, include, err := semanticProjection(child, childSchema)
+			if err != nil {
+				return nil, false, err
+			}
+			if include {
+				result[name] = projected
+			}
+		}
+		return result, true, nil
+	case "array":
+		itemsSchema, ok := schema["items"].(map[string]any)
+		if !ok {
+			return nil, false, errors.New("array schema has no items schema")
+		}
+		items := value.([]any)
+		result := make([]any, 0, len(items))
+		for _, item := range items {
+			projected, include, err := semanticProjection(item, itemsSchema)
+			if err != nil {
+				return nil, false, err
+			}
+			if include {
+				result = append(result, projected)
+			}
+		}
+		return result, true, nil
+	default:
+		return value, true, nil
+	}
+}
+
+func validateClusterSemantics(value any) error {
+	root, ok := value.(map[string]any)
+	if !ok {
+		return errors.New("$: expected contract object")
+	}
+	spec, ok := root["spec"].(map[string]any)
+	if !ok {
+		return errors.New("$.spec: expected object")
+	}
+	connectivity, ok := spec["connectivity"].(map[string]any)
+	if !ok {
+		return errors.New("$.spec.connectivity: expected object")
+	}
+	pod, err := netip.ParsePrefix(connectivity["podCIDR"].(string))
+	if err != nil {
+		return fmt.Errorf("$.spec.connectivity.podCIDR: %w", err)
+	}
+	service, err := netip.ParsePrefix(connectivity["serviceCIDR"].(string))
+	if err != nil {
+		return fmt.Errorf("$.spec.connectivity.serviceCIDR: %w", err)
+	}
+	if connectivity["profile"] == "datacenter-isolated-v1" {
+		if pod.Bits() != 16 {
+			return errors.New("$.spec.connectivity.podCIDR: profile requires /16")
+		}
+		if service.Bits() != 20 {
+			return errors.New("$.spec.connectivity.serviceCIDR: profile requires /20")
+		}
+	}
+	if pod.Overlaps(service) {
+		return errors.New("Pod and Service CIDRs must not overlap")
+	}
+	for _, raw := range connectivity["forbiddenCIDRs"].([]any) {
+		forbidden, err := netip.ParsePrefix(raw.(string))
+		if err != nil {
+			return err
+		}
+		if pod.Overlaps(forbidden) || service.Overlaps(forbidden) {
+			return fmt.Errorf("Cluster CIDR overlaps forbidden range %s", forbidden)
+		}
+	}
+	return nil
+}
+
+// JCS encodes the no-float JSON subset used by the versioned OK-141 profile.
+// Object keys are ordered by UTF-16 code units, matching RFC 8785.
+func JCS(value any) ([]byte, error) {
+	var output bytes.Buffer
+	if err := appendJCS(&output, value); err != nil {
+		return nil, err
+	}
+	return output.Bytes(), nil
+}
+
+func appendJCS(output *bytes.Buffer, value any) error {
+	switch typed := value.(type) {
+	case nil:
+		output.WriteString("null")
+	case bool:
+		output.WriteString(strconv.FormatBool(typed))
+	case string:
+		var encoded bytes.Buffer
+		encoder := json.NewEncoder(&encoded)
+		encoder.SetEscapeHTML(false)
+		if err := encoder.Encode(typed); err != nil {
+			return err
+		}
+		output.Write(bytes.TrimSuffix(encoded.Bytes(), []byte("\n")))
+	case map[string]any:
+		keys := make([]string, 0, len(typed))
+		for key := range typed {
+			keys = append(keys, key)
+		}
+		sort.Slice(keys, func(left, right int) bool {
+			return utf16Less(keys[left], keys[right])
+		})
+		output.WriteByte('{')
+		for index, key := range keys {
+			if index > 0 {
+				output.WriteByte(',')
+			}
+			if err := appendJCS(output, key); err != nil {
+				return err
+			}
+			output.WriteByte(':')
+			if err := appendJCS(output, typed[key]); err != nil {
+				return err
+			}
+		}
+		output.WriteByte('}')
+	case []any:
+		output.WriteByte('[')
+		for index, item := range typed {
+			if index > 0 {
+				output.WriteByte(',')
+			}
+			if err := appendJCS(output, item); err != nil {
+				return err
+			}
+		}
+		output.WriteByte(']')
+	default:
+		integer, ok := integerValue(value)
+		if !ok {
+			return fmt.Errorf("unsupported canonical JSON type %T", value)
+		}
+		output.WriteString(strconv.FormatInt(integer, 10))
+	}
+	return nil
+}
+
+func utf16Less(left, right string) bool {
+	a := utf16.Encode([]rune(left))
+	b := utf16.Encode([]rune(right))
+	for index := 0; index < len(a) && index < len(b); index++ {
+		if a[index] != b[index] {
+			return a[index] < b[index]
+		}
+	}
+	return len(a) < len(b)
+}
+
+// EqualNormalized is useful to prove equivalence without exposing internal
+// normalized representations to callers.
+func EqualNormalized(left, right Result) bool {
+	return left.NormalizedDigest == right.NormalizedDigest && reflect.DeepEqual(left.CanonicalJSON, right.CanonicalJSON)
+}

--- a/internal/contract/canonical_test.go
+++ b/internal/contract/canonical_test.go
@@ -1,0 +1,137 @@
+package contract
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+)
+
+const ok141Revision = "sha256:166504ae61fd558d391daedde50986cbc7a28f5f4e9d57f4acbd0433b448aa0f"
+
+func fixture(t *testing.T) ([]byte, []byte) {
+	t.Helper()
+	raw, err := os.ReadFile("testdata/ok141-contract-v5.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	schema, err := os.ReadFile("testdata/ok141-contract-v3.schema.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return raw, schema
+}
+
+func TestCanonicalizeReproducesOK141Revision(t *testing.T) {
+	raw, schema := fixture(t)
+	result, err := Canonicalize(raw, schema)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.NormalizedDigest != ok141Revision {
+		t.Fatalf("revision = %s, want %s", result.NormalizedDigest, ok141Revision)
+	}
+	identity, err := ContractIdentity(result.Normalized)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if identity != (Identity{Name: "disposable-ok141", Namespace: "disposable-ok141"}) {
+		t.Fatalf("identity = %#v", identity)
+	}
+}
+
+func TestEquivalentContractHasSameSemanticRevision(t *testing.T) {
+	raw, schema := fixture(t)
+	original, err := Canonicalize(raw, schema)
+	if err != nil {
+		t.Fatal(err)
+	}
+	equivalent := bytes.Replace(raw,
+		[]byte("  namespace: disposable-ok141\n"),
+		[]byte("  namespace: disposable-ok141\n  uid: historical-runtime-uid\n  generation: 7\n"), 1)
+	equivalent = append(equivalent, []byte("status: {}\n")...)
+	changed, err := Canonicalize(equivalent, schema)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !EqualNormalized(original, changed) {
+		t.Fatalf("equivalent contracts differ: %s != %s", original.NormalizedDigest, changed.NormalizedDigest)
+	}
+	if original.RawArtifactDigest == changed.RawArtifactDigest {
+		t.Fatal("raw artifact digest did not change")
+	}
+}
+
+func TestSemanticChangeChangesRevision(t *testing.T) {
+	raw, schema := fixture(t)
+	original, err := Canonicalize(raw, schema)
+	if err != nil {
+		t.Fatal(err)
+	}
+	changedRaw := bytes.Replace(raw, []byte("v1.36.2"), []byte("v1.36.3"), 1)
+	changed, err := Canonicalize(changedRaw, schema)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if original.NormalizedDigest == changed.NormalizedDigest {
+		t.Fatal("semantic change retained the same revision")
+	}
+}
+
+func TestUnknownAndDuplicateFieldsFailClosed(t *testing.T) {
+	raw, schema := fixture(t)
+	cases := map[string][]byte{
+		"unknown":   append(append([]byte{}, raw...), []byte("unexpected: true\n")...),
+		"duplicate": append(append([]byte{}, raw...), []byte("kind: ClusterIntentFixture\n")...),
+	}
+	for name, candidate := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := Canonicalize(candidate, schema); err == nil {
+				t.Fatal("invalid contract was accepted")
+			}
+		})
+	}
+}
+
+func TestCIDRPolicyFailsClosed(t *testing.T) {
+	raw, schema := fixture(t)
+	overlap := bytes.Replace(raw, []byte("serviceCIDR: 10.100.0.0/20"), []byte("serviceCIDR: 10.40.0.0/20"), 1)
+	if _, err := Canonicalize(overlap, schema); err == nil || !strings.Contains(err.Error(), "must not overlap") {
+		t.Fatalf("overlap error = %v", err)
+	}
+	nonCanonical := bytes.Replace(raw, []byte("podCIDR: 10.40.0.0/16"), []byte("podCIDR: 10.40.1.0/16"), 1)
+	if _, err := Canonicalize(nonCanonical, schema); err == nil || !strings.Contains(err.Error(), "canonical IPv4 CIDR") {
+		t.Fatalf("non-canonical error = %v", err)
+	}
+}
+
+func TestSchemaDefaultIsAppliedBeforeHashing(t *testing.T) {
+	raw, schema := fixture(t)
+	withoutForbidden := bytes.Replace(raw, []byte("    forbiddenCIDRs: [192.168.100.0/24]\n"), nil, 1)
+	result, err := Canonicalize(withoutForbidden, schema)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root := result.Normalized.(map[string]any)
+	spec := root["spec"].(map[string]any)
+	connectivity := spec["connectivity"].(map[string]any)
+	forbidden := connectivity["forbiddenCIDRs"].([]any)
+	if len(forbidden) != 0 {
+		t.Fatalf("default forbiddenCIDRs = %#v", forbidden)
+	}
+}
+
+func TestFloatAndYAMLAliasAreRejected(t *testing.T) {
+	raw, schema := fixture(t)
+	floating := bytes.Replace(raw, []byte("cores: 2"), []byte("cores: 2.5"), 1)
+	if _, err := Canonicalize(floating, schema); err == nil {
+		t.Fatal("floating-point contract was accepted")
+	}
+	alias := bytes.Replace(raw,
+		[]byte("metadata:\n  name: disposable-ok141"),
+		[]byte("metadata: &metadata\n  name: disposable-ok141"), 1)
+	alias = append(alias, []byte("status: *metadata\n")...)
+	if _, err := Canonicalize(alias, schema); err == nil || !strings.Contains(err.Error(), "aliases are not allowed") {
+		t.Fatalf("alias error = %v", err)
+	}
+}

--- a/internal/contract/testdata/ok141-contract-v3.schema.json
+++ b/internal/contract/testdata/ok141-contract-v3.schema.json
@@ -1,0 +1,233 @@
+{
+  "$id": "openkubes-contract-test/v3",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["apiVersion", "kind", "metadata", "spec"],
+  "properties": {
+    "apiVersion": {"const": "test.openkubes.io/v1alpha3"},
+    "kind": {"const": "ClusterIntentFixture"},
+    "metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "namespace"],
+      "properties": {
+        "name": {"type": "string", "minLength": 1},
+        "namespace": {"type": "string", "minLength": 1},
+        "uid": {"type": "string", "x-openkubes-semantic": false},
+        "resourceVersion": {"type": "string", "x-openkubes-semantic": false},
+        "generation": {"type": "integer", "minimum": 1, "x-openkubes-semantic": false},
+        "creationTimestamp": {"type": "string", "x-openkubes-semantic": false}
+      }
+    },
+    "spec": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kubernetesVersion",
+        "infrastructure",
+        "operatingSystem",
+        "topology",
+        "connectivity",
+        "enablement",
+        "platform",
+        "conditions"
+      ],
+      "properties": {
+        "kubernetesVersion": {"type": "string", "minLength": 1},
+        "infrastructure": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["provider", "profile", "providerAccess", "controlPlaneEndpoint"],
+          "properties": {
+            "provider": {"const": "kubevirt"},
+            "profile": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "name",
+                "identity",
+                "nodeSelector",
+                "cloneTargetStorageClass",
+                "replicaCount",
+                "snapshotClass"
+              ],
+              "properties": {
+                "name": {"const": "ok-infra"},
+                "identity": {"type": "string", "format": "sha256"},
+                "nodeSelector": {"const": "ok-infra"},
+                "cloneTargetStorageClass": {"const": "ok-storage-block"},
+                "replicaCount": {"const": 2},
+                "snapshotClass": {"const": "ok-storage-block-snapshot"}
+              }
+            },
+            "providerAccess": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["mode", "managementPlane", "providerPlane", "secretRef", "targetNamespace"],
+              "properties": {
+                "mode": {"const": "external-cluster-secret"},
+                "managementPlane": {"const": "ok-mgmt"},
+                "providerPlane": {"const": "ok-infra"},
+                "secretRef": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": ["apiVersion", "kind", "name", "namespace"],
+                  "properties": {
+                    "apiVersion": {"const": "v1"},
+                    "kind": {"const": "Secret"},
+                    "name": {"type": "string", "minLength": 1},
+                    "namespace": {"type": "string", "minLength": 1}
+                  }
+                },
+                "targetNamespace": {"type": "string", "minLength": 1}
+              }
+            },
+            "controlPlaneEndpoint": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["mode", "serviceType", "addressFamily", "allocationAuthority"],
+              "properties": {
+                "mode": {"const": "provider-allocated"},
+                "serviceType": {"const": "LoadBalancer"},
+                "addressFamily": {"const": "IPv4"},
+                "allocationAuthority": {"const": "CAPK+MetalLB"}
+              }
+            }
+          }
+        },
+        "operatingSystem": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "distribution",
+            "profile",
+            "version",
+            "architecture",
+            "schematicID",
+            "imageDigest",
+            "identity",
+            "goldenImage"
+          ],
+          "properties": {
+            "distribution": {"const": "ok-linux"},
+            "profile": {"const": "kubevirt"},
+            "version": {"const": "v1.9.6"},
+            "architecture": {"const": "amd64"},
+            "schematicID": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+            "imageDigest": {"type": "string", "format": "sha256"},
+            "identity": {"type": "string", "format": "sha256"},
+            "goldenImage": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["namespace", "claim", "storageClass"],
+              "properties": {
+                "namespace": {"const": "ok-images"},
+                "claim": {"type": "string", "minLength": 1},
+                "storageClass": {"const": "ok-storage-block"}
+              }
+            }
+          }
+        },
+        "topology": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["controlPlane", "workers"],
+          "properties": {
+            "controlPlane": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["replicas", "machine"],
+              "properties": {
+                "replicas": {"type": "integer", "minimum": 1},
+                "machine": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": ["cores", "memory", "disk"],
+                  "properties": {
+                    "cores": {"type": "integer", "minimum": 1},
+                    "memory": {"type": "string", "pattern": "^[1-9][0-9]*Gi$"},
+                    "disk": {"type": "string", "pattern": "^[1-9][0-9]*Gi$"}
+                  }
+                }
+              }
+            },
+            "workers": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["replicas", "machine"],
+              "properties": {
+                "replicas": {"type": "integer", "minimum": 1},
+                "machine": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": ["cores", "memory", "disk"],
+                  "properties": {
+                    "cores": {"type": "integer", "minimum": 1},
+                    "memory": {"type": "string", "pattern": "^[1-9][0-9]*Gi$"},
+                    "disk": {"type": "string", "pattern": "^[1-9][0-9]*Gi$"}
+                  }
+                }
+              }
+            }
+          }
+        },
+        "connectivity": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["profile", "podCIDR", "serviceCIDR"],
+          "properties": {
+            "profile": {"const": "datacenter-isolated-v1"},
+            "podCIDR": {"type": "string", "format": "ipv4-cidr"},
+            "serviceCIDR": {"type": "string", "format": "ipv4-cidr"},
+            "forbiddenCIDRs": {
+              "type": "array",
+              "items": {"type": "string", "format": "ipv4-cidr"},
+              "uniqueItems": true,
+              "default": []
+            }
+          }
+        },
+        "enablement": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["profile", "revision"],
+          "properties": {
+            "profile": {"type": "string", "minLength": 1},
+            "revision": {"type": "string", "format": "sha256"}
+          }
+        },
+        "platform": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["profile", "revision"],
+          "properties": {
+            "profile": {"type": "string", "minLength": 1},
+            "revision": {"type": "string", "format": "sha256"}
+          }
+        },
+        "conditions": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["required"],
+          "properties": {
+            "required": {
+              "type": "array",
+              "minItems": 1,
+              "uniqueItems": true,
+              "items": {
+                "type": "string",
+                "enum": ["InfrastructureReady", "ControlPlaneAvailable", "NetworkReady", "PlatformReady"]
+              }
+            }
+          }
+        }
+      }
+    },
+    "status": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {},
+      "x-openkubes-semantic": false
+    }
+  }
+}

--- a/internal/contract/testdata/ok141-contract-v5.yaml
+++ b/internal/contract/testdata/ok141-contract-v5.yaml
@@ -1,0 +1,63 @@
+apiVersion: test.openkubes.io/v1alpha3
+kind: ClusterIntentFixture
+metadata:
+  name: disposable-ok141
+  namespace: disposable-ok141
+spec:
+  kubernetesVersion: v1.36.2
+  infrastructure:
+    provider: kubevirt
+    profile:
+      name: ok-infra
+      identity: sha256:60fc84a67c33a41661c68ffadd646a13fd5ffd09f2a3d536f0eac1b909befc89
+      nodeSelector: ok-infra
+      cloneTargetStorageClass: ok-storage-block
+      replicaCount: 2
+      snapshotClass: ok-storage-block-snapshot
+    providerAccess:
+      mode: external-cluster-secret
+      managementPlane: ok-mgmt
+      providerPlane: ok-infra
+      secretRef:
+        apiVersion: v1
+        kind: Secret
+        name: external-infra-kubeconfig-disposable-ok141
+        namespace: disposable-ok141
+      targetNamespace: disposable-ok141
+    controlPlaneEndpoint:
+      mode: provider-allocated
+      serviceType: LoadBalancer
+      addressFamily: IPv4
+      allocationAuthority: CAPK+MetalLB
+  operatingSystem:
+    distribution: ok-linux
+    profile: kubevirt
+    version: v1.9.6
+    architecture: amd64
+    schematicID: ce4c980550dd2ab1b17bbf2b08801c7eb59418eafe8f279833297925d67c7515
+    imageDigest: sha256:461d72d30750b9e18cf0656239e0274764b1e391bde5bbc41084a887b8a55ed5
+    identity: sha256:7f5dd4276432f522727a50e604538b6befc0cac51ee2b90d4b1ccbfcac774a2d
+    goldenImage:
+      namespace: ok-images
+      claim: talos-v1-9-6-ce4c980550dd-461d72d30750-amd64
+      storageClass: ok-storage-block
+  topology:
+    controlPlane:
+      replicas: 1
+      machine: {cores: 2, memory: 4Gi, disk: 20Gi}
+    workers:
+      replicas: 1
+      machine: {cores: 2, memory: 4Gi, disk: 15Gi}
+  connectivity:
+    profile: datacenter-isolated-v1
+    podCIDR: 10.40.0.0/16
+    serviceCIDR: 10.100.0.0/20
+    forbiddenCIDRs: [192.168.100.0/24]
+  enablement:
+    profile: cilium-fixture-v2
+    revision: sha256:2a849d69e9c64344e907c1bce3bb1abf3d8f77217377081a5be055d62c213300
+  platform:
+    profile: minimal-observability-v4
+    revision: sha256:b0f25c639a45d895b889997f5ecc2325db45dd5d51b0684998c94d5e17bd47bf
+  conditions:
+    required: [InfrastructureReady, ControlPlaneAvailable, NetworkReady, PlatformReady]


### PR DESCRIPTION
## Outcome

Establish the first side-effect-free Go core shared by the future local `ok` CLI and short-lived `ok-mgmt` runner Job.

## Scope

- add schema-driven YAML/JSON normalization and semantic projection
- implement RFC-8785-compatible canonical JSON for the no-float contract subset
- reproduce the exact OK-141 Phase-R v5 contract revision
- add `ok cluster create --dry-run` with an internal, non-public plan format
- reject unknown/duplicate fields, YAML aliases, floats, unsafe CIDRs and execution without `--dry-run`
- add Make targets and architecture notes

## Evidence

- OK-141 R reproduced: `sha256:166504ae61fd558d391daedde50986cbc7a28f5f4e9d57f4acbd0433b448aa0f`
- contract and schema fixtures are byte-identical to the merged OK-141 baseline
- `go test -race ./...` PASS
- `go vet ./...` PASS
- existing Python discovery suite: 7 tests, PASS with 1 existing skip
- Go statement coverage: 74.9%
- `git diff --check` PASS

## Boundaries

- no Kubernetes client or cluster contact
- no credentials
- no submission or reconciliation
- no public CRD/API commitment
- no second Contract-to-CAPI renderer
- mutation remains structurally disabled