### PR TITLE
OK-147: Bind signed authorization to verified create plans

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -194,7 +194,7 @@ cilium-chart-tool-test: ## Offline-test Cilium acquisition/cache guards
 
 # ── bounded Contract Executor MVP (OK-147) ──────────────────────────────────
 contract-executor-test: ## Test the side-effect-free Go Contract Executor core
-	@go test ./cmd/ok ./internal/contract
+	@go test ./...
 
 contract-executor-dry-run: ## Reproduce the OK-141 R and emit a non-mutating plan
 	@go run ./cmd/ok cluster create \

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ Powered by [Cluster API (CAPI)](https://cluster-api.sigs.k8s.io/), [CAPK (KubeVi
 - **GitOps-ready** — all cluster state is declarative YAML, rendered from templates
 - **Single Makefile UX** — `make new`, `make install`, `make status`, `make upgrade`
 - **Bounded Contract Executor MVP** — a shared Go core for local CLI and future
-  short-lived `ok-mgmt` Jobs; the first checkpoint is deliberately dry-run-only
-  and reproduces the OK-141 semantic contract revision
+  short-lived `ok-mgmt` Jobs; it remains dry-run-only while verifying the
+  OK-141 revision, existing projection, authority split, and signed grant binding
 
 ---
 

--- a/cmd/ok/main.go
+++ b/cmd/ok/main.go
@@ -7,22 +7,29 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"time"
 
+	"github.com/openkubes/ok-cluster/internal/authorization"
 	"github.com/openkubes/ok-cluster/internal/contract"
+	"github.com/openkubes/ok-cluster/internal/executor"
+	"github.com/openkubes/ok-cluster/internal/projection"
 )
 
 const version = "0.0.0-dev"
 
 type createPlan struct {
-	Format                  string            `json:"format"`
-	Operation               string            `json:"operation"`
-	ContractIdentity        contract.Identity `json:"contractIdentity"`
-	ContractRevision        string            `json:"contractRevision"`
-	CanonicalizationProfile string            `json:"canonicalizationProfile"`
-	RawArtifactDigest       string            `json:"rawArtifactDigest"`
-	SchemaDigest            string            `json:"schemaDigest"`
-	AuthorizationState      string            `json:"authorizationState"`
-	MutationAllowed         bool              `json:"mutationAllowed"`
+	Format                  string                  `json:"format"`
+	Operation               string                  `json:"operation"`
+	ContractIdentity        contract.Identity       `json:"contractIdentity"`
+	ContractRevision        string                  `json:"contractRevision"`
+	CanonicalizationProfile string                  `json:"canonicalizationProfile"`
+	RawArtifactDigest       string                  `json:"rawArtifactDigest"`
+	SchemaDigest            string                  `json:"schemaDigest"`
+	AuthorizationState      string                  `json:"authorizationState"`
+	MutationAllowed         bool                    `json:"mutationAllowed"`
+	Request                 *executor.CreateRequest `json:"request,omitempty"`
+	RequestDigest           string                  `json:"requestDigest,omitempty"`
+	Authorization           *authorization.Receipt  `json:"authorization,omitempty"`
 }
 
 func main() {
@@ -38,13 +45,18 @@ func run(arguments []string, stdout, stderr io.Writer) error {
 		return nil
 	}
 	if len(arguments) < 2 || arguments[0] != "cluster" || arguments[1] != "create" {
-		return errors.New("usage: ok cluster create --contract PATH --schema PATH --dry-run")
+		return errors.New("usage: ok cluster create --contract PATH --schema PATH --dry-run [--projection-manifest PATH] [--authorization PATH --authorization-key PATH --evaluation-time RFC3339]")
 	}
 	flags := flag.NewFlagSet("ok cluster create", flag.ContinueOnError)
 	flags.SetOutput(stderr)
 	contractPath := flags.String("contract", "", "path to the versioned cluster contract")
 	schemaPath := flags.String("schema", "", "path to the contract test schema")
 	dryRun := flags.Bool("dry-run", false, "validate and emit an immutable create plan without mutation")
+	projectionManifest := flags.String("projection-manifest", "", "path to an immutable projection manifest produced by the authoritative renderer")
+	projectionRoot := flags.String("projection-root", "", "directory containing projection artifacts (defaults to manifest directory)")
+	authorizationPath := flags.String("authorization", "", "path to a signed create authorization JSON document")
+	authorizationKeyPath := flags.String("authorization-key", "", "path to the trusted base64-encoded raw Ed25519 public key")
+	evaluationTime := flags.String("evaluation-time", "", "explicit RFC3339 authorization evaluation time")
 	if err := flags.Parse(arguments[2:]); err != nil {
 		return err
 	}
@@ -56,6 +68,9 @@ func run(arguments []string, stdout, stderr io.Writer) error {
 	}
 	if *contractPath == "" || *schemaPath == "" {
 		return errors.New("--contract and --schema are required")
+	}
+	if *projectionRoot != "" && *projectionManifest == "" {
+		return errors.New("--projection-root requires --projection-manifest")
 	}
 	raw, err := os.ReadFile(*contractPath)
 	if err != nil {
@@ -84,8 +99,62 @@ func run(arguments []string, stdout, stderr io.Writer) error {
 		AuthorizationState:      "NOT_EVALUATED",
 		MutationAllowed:         false,
 	}
+	if *projectionManifest != "" {
+		binding, err := projection.Verify(*projectionManifest, *projectionRoot, result.NormalizedDigest, identity)
+		if err != nil {
+			return err
+		}
+		request, err := executor.NewCreateRequest(result, identity, binding)
+		if err != nil {
+			return err
+		}
+		requestDigest, err := executor.Digest(request)
+		if err != nil {
+			return fmt.Errorf("digest create request: %w", err)
+		}
+		plan.Format = "ok147-create-plan/v2"
+		plan.Request = &request
+		plan.RequestDigest = requestDigest
+	}
+	providedAuthorizationInputs := countNonEmpty(*authorizationPath, *authorizationKeyPath, *evaluationTime)
+	if providedAuthorizationInputs != 0 {
+		if plan.Request == nil {
+			return errors.New("--authorization requires --projection-manifest")
+		}
+		if providedAuthorizationInputs != 3 {
+			return errors.New("--authorization, --authorization-key, and --evaluation-time must be provided together")
+		}
+		authorizationRaw, err := os.ReadFile(*authorizationPath)
+		if err != nil {
+			return fmt.Errorf("read authorization: %w", err)
+		}
+		keyRaw, err := os.ReadFile(*authorizationKeyPath)
+		if err != nil {
+			return fmt.Errorf("read authorization key: %w", err)
+		}
+		at, err := time.Parse(time.RFC3339, *evaluationTime)
+		if err != nil {
+			return fmt.Errorf("parse evaluation time: %w", err)
+		}
+		receipt, err := authorization.Verify(authorizationRaw, keyRaw, *plan.Request, at)
+		if err != nil {
+			return err
+		}
+		plan.AuthorizationState = "VERIFIED"
+		plan.Authorization = &receipt
+	}
 	encoder := json.NewEncoder(stdout)
 	encoder.SetEscapeHTML(false)
 	encoder.SetIndent("", "  ")
 	return encoder.Encode(plan)
+}
+
+func countNonEmpty(values ...string) int {
+	count := 0
+	for _, value := range values {
+		if value != "" {
+			count++
+		}
+	}
+	return count
 }

--- a/cmd/ok/main_test.go
+++ b/cmd/ok/main_test.go
@@ -56,6 +56,27 @@ func TestCreateWithoutDryRunFailsClosed(t *testing.T) {
 	}
 }
 
+func TestCreateRejectsIncompleteProjectionAndAuthorizationInputs(t *testing.T) {
+	base := []string{
+		"cluster", "create",
+		"--contract", fixturePath(t, "ok141-contract-v5.yaml"),
+		"--schema", fixturePath(t, "ok141-contract-v3.schema.json"),
+		"--dry-run",
+	}
+	for name, extra := range map[string][]string{
+		"projection root without manifest": {"--projection-root", "/tmp/projection"},
+		"authorization without projection": {"--authorization", "/tmp/grant.json", "--authorization-key", "/tmp/key", "--evaluation-time", "2026-08-16T10:00:00Z"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			arguments := append(append([]string{}, base...), extra...)
+			if err := run(arguments, &stdout, &stderr); err == nil {
+				t.Fatal("unsafe incomplete input was accepted")
+			}
+		})
+	}
+}
+
 func TestArbitraryCommandsAreAbsent(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	for _, arguments := range [][]string{

--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -1,7 +1,8 @@
 # OK-147 bounded Contract Executor MVP
 
-The first implementation checkpoint establishes the shared, side-effect-free
-core for local CLI and future in-cluster Job execution.
+The implementation establishes a shared, side-effect-free core for local CLI
+and future in-cluster Job execution. The second checkpoint adds verified
+projection and authorization boundaries without adding Kubernetes access.
 
 ```text
 versioned contract + test schema
@@ -41,3 +42,82 @@ The fixtures are test-only copies of the Phase-R v5 OK-141 contract and schema.
 They preserve the proven semantic revision
 `sha256:166504ae61fd558d391daedde50986cbc7a28f5f4e9d57f4acbd0433b448aa0f`;
 they are not a stable public OpenKubes API.
+
+## Verified projection boundary
+
+The CLI can consume an immutable projection already produced by the existing
+authoritative renderer:
+
+```bash
+go run ./cmd/ok cluster create \
+  --contract internal/contract/testdata/ok141-contract-v5.yaml \
+  --schema internal/contract/testdata/ok141-contract-v3.schema.json \
+  --projection-manifest /path/to/projection-manifest.json \
+  --dry-run
+```
+
+The verifier checks `R`, contract identity, every referenced raw artifact,
+authority-map identity, resource counts, and the split between `ok-infra`
+provider prerequisites and the `ok-mgmt` single lifecycle writer. It rejects
+path traversal and altered artifacts. It deliberately does not render CAPI
+objects, so the Go code cannot become a second Contract-to-CAPI compiler.
+
+This emits an internal `ok147-create-plan/v2` and a canonical
+`ok147-create-request/v1` digest. The source projection remains
+`authorizationState: NO-GO`; a projection is evidence, not authorization.
+
+## Signed authorization boundary
+
+An optional authorization document can bind exactly one request:
+
+```text
+format:                    ok147-create-authorization/v1
+audience:                  ok-cluster-contract-executor
+decision:                  ALLOW
+operation:                 CreateCluster
+requestDigest:             exact ok147-create-request/v1 digest
+contractRevision:          exact R
+projectionManifestDigest:  exact projection manifest
+contractIdentity:          exact namespace/name
+notBefore / notAfter:      RFC3339, maximum 30 minutes
+maxUses:                   1
+signature:                 Ed25519 over canonical payload JSON
+```
+
+The trusted key file contains standard Base64 of the raw 32-byte Ed25519 public
+key. The CLI requires an explicit evaluation time to keep tests deterministic:
+
+```bash
+ok cluster create ... --dry-run \
+  --projection-manifest /path/to/projection-manifest.json \
+  --authorization /path/to/authorization.json \
+  --authorization-key /path/to/trusted-ed25519-public-key.base64 \
+  --evaluation-time 2026-08-16T10:00:00Z
+```
+
+Verification covers the signature, key fingerprint, request digest, operation,
+contract identity and revision, projection digest, audience, validity window,
+and the one-use declaration. The output receipt intentionally excludes the
+signature and all source paths.
+
+Even a verified decision still produces `mutationAllowed: false`. This
+checkpoint proves content binding and trust verification only. It does not yet
+provide grant consumption, idempotency, credentials, Kubernetes submission,
+retry, rollback, or evidence publication.
+
+## OK-141 compatibility evidence
+
+The verifier was run offline against the preserved Phase-R v5 projection. It
+accepted all six bound artifacts and produced:
+
+```text
+R:                         sha256:166504ae61fd558d391daedde50986cbc7a28f5f4e9d57f4acbd0433b448aa0f
+projectionManifestDigest:  sha256:37b65b7ff1f7f46e5809000d8a469f423943c6b7f4f043a7bc6123d033ee765b
+authorityMapDigest:        sha256:c872b0378dfb58b845adc709aad864f07fa416f529698e050cebe80c407e927a
+requestDigest:             sha256:0c64e26a3697c7f19c25783c8c26b044413a07a5dc0c3e131a8647c1bba9db26
+ok-infra resources:        3
+ok-mgmt resources:         8
+```
+
+This is compatibility evidence for the preserved OK-141 fixture, not a new
+authorization and not permission to recreate the disposable cluster.

--- a/internal/authorization/authorization.go
+++ b/internal/authorization/authorization.go
@@ -1,0 +1,188 @@
+// Package authorization verifies a content-bound, signed, single-use decision.
+// It does not issue grants or decide policy.
+package authorization
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"regexp"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/contract"
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/executor"
+	"github.com/openkubes/ok-cluster/internal/jsonstrict"
+)
+
+const (
+	Format        = "ok147-create-authorization/v1"
+	Audience      = "ok-cluster-contract-executor"
+	MaximumWindow = 30 * time.Minute
+)
+
+// Payload is the exact decision signed by an external authority.
+type Payload struct {
+	Audience                 string            `json:"audience"`
+	GrantID                  string            `json:"grantId"`
+	Decision                 string            `json:"decision"`
+	Operation                string            `json:"operation"`
+	RequestDigest            string            `json:"requestDigest"`
+	ContractIdentity         contract.Identity `json:"contractIdentity"`
+	ContractRevision         string            `json:"contractRevision"`
+	ProjectionManifestDigest string            `json:"projectionManifestDigest"`
+	NotBefore                string            `json:"notBefore"`
+	NotAfter                 string            `json:"notAfter"`
+	MaxUses                  int               `json:"maxUses"`
+}
+
+type signature struct {
+	Algorithm string `json:"algorithm"`
+	KeyID     string `json:"keyId"`
+	Value     string `json:"value"`
+}
+
+type envelope struct {
+	Format    string    `json:"format"`
+	Payload   Payload   `json:"payload"`
+	Signature signature `json:"signature"`
+}
+
+// Receipt records what was cryptographically checked. It is not evidence that
+// the grant has been consumed; single-use enforcement belongs to submission.
+type Receipt struct {
+	Format              string `json:"format"`
+	State               string `json:"state"`
+	AuthorizationDigest string `json:"authorizationDigest"`
+	GrantID             string `json:"grantId"`
+	KeyID               string `json:"keyId"`
+	NotAfter            string `json:"notAfter"`
+	MaxUses             int    `json:"maxUses"`
+}
+
+// Verify checks the signature, trust key identity, time window, single-use
+// declaration, and every request binding.
+func Verify(raw, publicKeyPEM []byte, request executor.CreateRequest, at time.Time) (Receipt, error) {
+	var document envelope
+	if err := jsonstrict.Decode(raw, &document); err != nil {
+		return Receipt{}, fmt.Errorf("decode authorization: %w", err)
+	}
+	if document.Format != Format {
+		return Receipt{}, fmt.Errorf("authorization format %q is not supported", document.Format)
+	}
+	publicKey, keyID, err := parsePublicKey(publicKeyPEM)
+	if err != nil {
+		return Receipt{}, err
+	}
+	if document.Signature.Algorithm != "Ed25519" {
+		return Receipt{}, fmt.Errorf("signature algorithm %q is not supported", document.Signature.Algorithm)
+	}
+	if document.Signature.KeyID != keyID {
+		return Receipt{}, fmt.Errorf("authorization keyId %s does not match trusted key %s", document.Signature.KeyID, keyID)
+	}
+	signatureBytes, err := base64.StdEncoding.Strict().DecodeString(document.Signature.Value)
+	if err != nil {
+		return Receipt{}, fmt.Errorf("decode authorization signature: %w", err)
+	}
+	signed, err := SigningBytes(document.Payload)
+	if err != nil {
+		return Receipt{}, err
+	}
+	if !ed25519.Verify(publicKey, signed, signatureBytes) {
+		return Receipt{}, errors.New("authorization signature verification failed")
+	}
+	if err := verifyPayload(document.Payload, request, at); err != nil {
+		return Receipt{}, err
+	}
+	return Receipt{
+		Format:              "ok147-authorization-receipt/v1",
+		State:               "VERIFIED",
+		AuthorizationDigest: digest.SHA256(raw),
+		GrantID:             document.Payload.GrantID,
+		KeyID:               keyID,
+		NotAfter:            document.Payload.NotAfter,
+		MaxUses:             document.Payload.MaxUses,
+	}, nil
+}
+
+// SigningBytes returns the canonical bytes an authority signs.
+func SigningBytes(payload Payload) ([]byte, error) {
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	var value any
+	if err := decoder.Decode(&value); err != nil {
+		return nil, err
+	}
+	return contract.JCS(value)
+}
+
+func verifyPayload(payload Payload, request executor.CreateRequest, at time.Time) error {
+	if payload.Audience != Audience {
+		return fmt.Errorf("authorization audience %q is not accepted", payload.Audience)
+	}
+	if !regexp.MustCompile(`^[a-z0-9][a-z0-9.-]{2,127}$`).MatchString(payload.GrantID) {
+		return errors.New("authorization grantId is invalid")
+	}
+	if payload.Decision != "ALLOW" {
+		return fmt.Errorf("authorization decision is %q, not ALLOW", payload.Decision)
+	}
+	if payload.Operation != request.Operation {
+		return errors.New("authorization operation differs from request")
+	}
+	requestDigest, err := executor.Digest(request)
+	if err != nil {
+		return err
+	}
+	if payload.RequestDigest != requestDigest {
+		return errors.New("authorization request digest differs from request")
+	}
+	if payload.ContractIdentity != request.ContractIdentity {
+		return errors.New("authorization contract identity differs from request")
+	}
+	if payload.ContractRevision != request.ContractRevision {
+		return errors.New("authorization contract revision differs from request")
+	}
+	if payload.ProjectionManifestDigest != request.Projection.ManifestDigest {
+		return errors.New("authorization projection manifest digest differs from request")
+	}
+	if payload.MaxUses != 1 {
+		return errors.New("authorization must declare exactly one use")
+	}
+	notBefore, err := time.Parse(time.RFC3339, payload.NotBefore)
+	if err != nil {
+		return fmt.Errorf("authorization notBefore: %w", err)
+	}
+	notAfter, err := time.Parse(time.RFC3339, payload.NotAfter)
+	if err != nil {
+		return fmt.Errorf("authorization notAfter: %w", err)
+	}
+	if !notAfter.After(notBefore) {
+		return errors.New("authorization time window is empty")
+	}
+	if notAfter.Sub(notBefore) > MaximumWindow {
+		return fmt.Errorf("authorization time window exceeds %s", MaximumWindow)
+	}
+	if at.Before(notBefore) || !at.Before(notAfter) {
+		return errors.New("authorization is not active at the evaluation time")
+	}
+	return nil
+}
+
+func parsePublicKey(raw []byte) (ed25519.PublicKey, string, error) {
+	decoded, err := base64.StdEncoding.Strict().DecodeString(string(bytes.TrimSpace(raw)))
+	if err != nil {
+		return nil, "", fmt.Errorf("decode trusted Ed25519 public key: %w", err)
+	}
+	if len(decoded) != ed25519.PublicKeySize {
+		return nil, "", fmt.Errorf("trusted Ed25519 public key has %d bytes, expected %d", len(decoded), ed25519.PublicKeySize)
+	}
+	publicKey := ed25519.PublicKey(decoded)
+	return publicKey, digest.SHA256(decoded), nil
+}

--- a/internal/authorization/authorization_test.go
+++ b/internal/authorization/authorization_test.go
@@ -1,0 +1,139 @@
+package authorization
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/contract"
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/executor"
+	"github.com/openkubes/ok-cluster/internal/projection"
+)
+
+func TestVerifyAcceptsExactSignedRequest(t *testing.T) {
+	request := testRequest()
+	at := time.Date(2026, 8, 16, 10, 0, 0, 0, time.UTC)
+	raw, publicPEM := signAuthorization(t, request, at)
+	receipt, err := Verify(raw, publicPEM, request, at)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if receipt.State != "VERIFIED" || receipt.GrantID != "ok147-create-20260816-01" || receipt.MaxUses != 1 {
+		t.Fatalf("unexpected receipt: %#v", receipt)
+	}
+	if receipt.AuthorizationDigest != digest.SHA256(raw) {
+		t.Fatal("authorization digest differs from raw document")
+	}
+}
+
+func TestVerifyFailsClosed(t *testing.T) {
+	request := testRequest()
+	at := time.Date(2026, 8, 16, 10, 0, 0, 0, time.UTC)
+	raw, publicPEM := signAuthorization(t, request, at)
+
+	t.Run("changed request", func(t *testing.T) {
+		changed := request
+		changed.Projection.ManifestDigest = "sha256:" + strings.Repeat("9", 64)
+		if _, err := Verify(raw, publicPEM, changed, at); err == nil || !strings.Contains(err.Error(), "request digest") {
+			t.Fatalf("expected request mismatch, got %v", err)
+		}
+	})
+	t.Run("expired", func(t *testing.T) {
+		if _, err := Verify(raw, publicPEM, request, at.Add(31*time.Minute)); err == nil || !strings.Contains(err.Error(), "not active") {
+			t.Fatalf("expected expiry rejection, got %v", err)
+		}
+	})
+	t.Run("wrong trust key", func(t *testing.T) {
+		otherPublic, _, err := ed25519.GenerateKey(rand.Reader)
+		if err != nil {
+			t.Fatal(err)
+		}
+		other := []byte(base64.StdEncoding.EncodeToString(otherPublic))
+		if _, err := Verify(raw, other, request, at); err == nil || !strings.Contains(err.Error(), "keyId") {
+			t.Fatalf("expected trust-key rejection, got %v", err)
+		}
+	})
+	t.Run("tampered signature", func(t *testing.T) {
+		var document envelope
+		if err := json.Unmarshal(raw, &document); err != nil {
+			t.Fatal(err)
+		}
+		document.Payload.Decision = "DENY"
+		tampered, _ := json.Marshal(document)
+		if _, err := Verify(tampered, publicPEM, request, at); err == nil || !strings.Contains(err.Error(), "signature verification") {
+			t.Fatalf("expected signature rejection, got %v", err)
+		}
+	})
+}
+
+func testRequest() executor.CreateRequest {
+	identity := contract.Identity{Name: "disposable-ok141", Namespace: "disposable-ok141"}
+	return executor.CreateRequest{
+		Format:                  executor.RequestFormat,
+		Operation:               "CreateCluster",
+		ContractIdentity:        identity,
+		ContractRevision:        "sha256:" + strings.Repeat("1", 64),
+		CanonicalizationProfile: contract.CanonicalizationProfile,
+		RawArtifactDigest:       "sha256:" + strings.Repeat("2", 64),
+		SchemaDigest:            "sha256:" + strings.Repeat("3", 64),
+		Projection: projection.Binding{
+			Format:              projection.BindingFormat,
+			SourceFormat:        "ok141-contract-to-capi-projection/v2",
+			ManifestDigest:      "sha256:" + strings.Repeat("4", 64),
+			AuthorityMapDigest:  "sha256:" + strings.Repeat("5", 64),
+			IntentRevision:      "sha256:" + strings.Repeat("1", 64),
+			ContractIdentity:    identity,
+			InfrastructurePlane: projection.Plane{Identity: "ok-infra", Role: "provider-runtime-and-golden-image-prerequisites", ResourceCount: 3},
+			ManagementPlane:     projection.Plane{Identity: "ok-mgmt", Role: "single-lifecycle-writer", ResourceCount: 8},
+			Artifacts:           []projection.Artifact{{Name: "authority-map.json", Digest: "sha256:" + strings.Repeat("5", 64)}},
+		},
+	}
+}
+
+func signAuthorization(t *testing.T, request executor.CreateRequest, at time.Time) ([]byte, []byte) {
+	t.Helper()
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	requestDigest, err := executor.Digest(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload := Payload{
+		Audience:                 Audience,
+		GrantID:                  "ok147-create-20260816-01",
+		Decision:                 "ALLOW",
+		Operation:                request.Operation,
+		RequestDigest:            requestDigest,
+		ContractIdentity:         request.ContractIdentity,
+		ContractRevision:         request.ContractRevision,
+		ProjectionManifestDigest: request.Projection.ManifestDigest,
+		NotBefore:                at.Add(-time.Minute).Format(time.RFC3339),
+		NotAfter:                 at.Add(29 * time.Minute).Format(time.RFC3339),
+		MaxUses:                  1,
+	}
+	signed, err := SigningBytes(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	document := envelope{
+		Format:  Format,
+		Payload: payload,
+		Signature: signature{
+			Algorithm: "Ed25519",
+			KeyID:     digest.SHA256(publicKey),
+			Value:     base64.StdEncoding.EncodeToString(ed25519.Sign(privateKey, signed)),
+		},
+	}
+	raw, err := json.Marshal(document)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return raw, []byte(base64.StdEncoding.EncodeToString(publicKey) + "\n")
+}

--- a/internal/digest/digest.go
+++ b/internal/digest/digest.go
@@ -1,0 +1,13 @@
+// Package digest provides the content identities shared by executor packages.
+package digest
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+)
+
+// SHA256 returns the lowercase sha256:<hex> identity of data.
+func SHA256(data []byte) string {
+	sum := sha256.Sum256(data)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}

--- a/internal/executor/request.go
+++ b/internal/executor/request.go
@@ -1,0 +1,68 @@
+// Package executor defines the immutable request passed between validation,
+// authorization, and a future bounded submitter.
+package executor
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/openkubes/ok-cluster/internal/contract"
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/projection"
+)
+
+const RequestFormat = "ok147-create-request/v1"
+
+// CreateRequest contains semantic intent and verified projection identities.
+// It contains no credentials, paths, commands, or Kubernetes client options.
+type CreateRequest struct {
+	Format                  string             `json:"format"`
+	Operation               string             `json:"operation"`
+	ContractIdentity        contract.Identity  `json:"contractIdentity"`
+	ContractRevision        string             `json:"contractRevision"`
+	CanonicalizationProfile string             `json:"canonicalizationProfile"`
+	RawArtifactDigest       string             `json:"rawArtifactDigest"`
+	SchemaDigest            string             `json:"schemaDigest"`
+	Projection              projection.Binding `json:"projection"`
+}
+
+// NewCreateRequest binds a canonical contract to an independently rendered and
+// verified projection.
+func NewCreateRequest(result contract.Result, identity contract.Identity, binding projection.Binding) (CreateRequest, error) {
+	if binding.IntentRevision != result.NormalizedDigest {
+		return CreateRequest{}, fmt.Errorf("projection revision %s differs from contract revision %s", binding.IntentRevision, result.NormalizedDigest)
+	}
+	if binding.ContractIdentity != identity {
+		return CreateRequest{}, fmt.Errorf("projection identity differs from contract identity")
+	}
+	return CreateRequest{
+		Format:                  RequestFormat,
+		Operation:               "CreateCluster",
+		ContractIdentity:        identity,
+		ContractRevision:        result.NormalizedDigest,
+		CanonicalizationProfile: result.CanonicalizationProfile,
+		RawArtifactDigest:       result.RawArtifactDigest,
+		SchemaDigest:            result.SchemaDigest,
+		Projection:              binding,
+	}, nil
+}
+
+// Digest returns the canonical semantic identity of a request.
+func Digest(request CreateRequest) (string, error) {
+	raw, err := json.Marshal(request)
+	if err != nil {
+		return "", err
+	}
+	var value any
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	if err := decoder.Decode(&value); err != nil {
+		return "", err
+	}
+	canonical, err := contract.JCS(value)
+	if err != nil {
+		return "", err
+	}
+	return digest.SHA256(canonical), nil
+}

--- a/internal/executor/request_test.go
+++ b/internal/executor/request_test.go
@@ -1,0 +1,34 @@
+package executor
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/openkubes/ok-cluster/internal/contract"
+	"github.com/openkubes/ok-cluster/internal/projection"
+)
+
+func TestDigestIsDeterministicAndBindsProjection(t *testing.T) {
+	identity := contract.Identity{Name: "disposable-ok141", Namespace: "disposable-ok141"}
+	request := CreateRequest{
+		Format: RequestFormat, Operation: "CreateCluster", ContractIdentity: identity,
+		ContractRevision: "sha256:" + strings.Repeat("1", 64),
+		Projection:       projection.Binding{Format: projection.BindingFormat, IntentRevision: "sha256:" + strings.Repeat("1", 64), ContractIdentity: identity, ManifestDigest: "sha256:" + strings.Repeat("2", 64)},
+	}
+	first, err := Digest(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := Digest(request)
+	if err != nil || first != second {
+		t.Fatalf("digest is not deterministic: %s %s %v", first, second, err)
+	}
+	request.Projection.ManifestDigest = "sha256:" + strings.Repeat("3", 64)
+	changed, err := Digest(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first == changed {
+		t.Fatal("projection change did not alter request digest")
+	}
+}

--- a/internal/jsonstrict/jsonstrict.go
+++ b/internal/jsonstrict/jsonstrict.go
@@ -1,0 +1,103 @@
+// Package jsonstrict decodes security-relevant JSON without accepting duplicate
+// object keys, trailing values, or unknown fields.
+package jsonstrict
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+)
+
+// Decode validates raw JSON and decodes it into target.
+func Decode(raw []byte, target any) error {
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	if err := consumeValue(decoder, "$", nil); err != nil {
+		return err
+	}
+	if token, err := decoder.Token(); err != io.EOF {
+		if err == nil {
+			return fmt.Errorf("$: trailing JSON token %v", token)
+		}
+		return fmt.Errorf("$: trailing JSON: %w", err)
+	}
+
+	typed := json.NewDecoder(bytes.NewReader(raw))
+	typed.DisallowUnknownFields()
+	typed.UseNumber()
+	if err := typed.Decode(target); err != nil {
+		return err
+	}
+	if err := requireEOF(typed); err != nil {
+		return err
+	}
+	return nil
+}
+
+func consumeValue(decoder *json.Decoder, path string, first json.Token) error {
+	token := first
+	var err error
+	if token == nil {
+		token, err = decoder.Token()
+		if err != nil {
+			return fmt.Errorf("%s: %w", path, err)
+		}
+	}
+	delimiter, composite := token.(json.Delim)
+	if !composite {
+		return nil
+	}
+	switch delimiter {
+	case '{':
+		seen := map[string]struct{}{}
+		for decoder.More() {
+			keyToken, err := decoder.Token()
+			if err != nil {
+				return fmt.Errorf("%s: %w", path, err)
+			}
+			key, ok := keyToken.(string)
+			if !ok {
+				return fmt.Errorf("%s: object key is not a string", path)
+			}
+			if _, exists := seen[key]; exists {
+				return fmt.Errorf("%s: duplicate object key %q", path, key)
+			}
+			seen[key] = struct{}{}
+			if err := consumeValue(decoder, path+"."+key, nil); err != nil {
+				return err
+			}
+		}
+		closing, err := decoder.Token()
+		if err != nil || closing != json.Delim('}') {
+			return fmt.Errorf("%s: malformed object", path)
+		}
+	case '[':
+		index := 0
+		for decoder.More() {
+			if err := consumeValue(decoder, fmt.Sprintf("%s[%d]", path, index), nil); err != nil {
+				return err
+			}
+			index++
+		}
+		closing, err := decoder.Token()
+		if err != nil || closing != json.Delim(']') {
+			return fmt.Errorf("%s: malformed array", path)
+		}
+	default:
+		return fmt.Errorf("%s: unexpected delimiter %q", path, delimiter)
+	}
+	return nil
+}
+
+func requireEOF(decoder *json.Decoder) error {
+	var extra any
+	if err := decoder.Decode(&extra); err != io.EOF {
+		if err == nil {
+			return errors.New("multiple JSON values are not allowed")
+		}
+		return err
+	}
+	return nil
+}

--- a/internal/jsonstrict/jsonstrict_test.go
+++ b/internal/jsonstrict/jsonstrict_test.go
@@ -1,0 +1,39 @@
+package jsonstrict
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDecodeRejectsDuplicateAndUnknownFields(t *testing.T) {
+	type document struct {
+		Name string `json:"name"`
+	}
+	for name, raw := range map[string]string{
+		"duplicate": `{"name":"one","name":"two"}`,
+		"unknown":   `{"name":"one","extra":true}`,
+		"trailing":  `{"name":"one"} {"name":"two"}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			var value document
+			if err := Decode([]byte(raw), &value); err == nil {
+				t.Fatal("unsafe JSON was accepted")
+			}
+		})
+	}
+}
+
+func TestDecodeAcceptsNestedJSON(t *testing.T) {
+	var value struct {
+		Items []map[string]int `json:"items"`
+	}
+	if err := Decode([]byte(`{"items":[{"value":1}]}`), &value); err != nil {
+		t.Fatal(err)
+	}
+	if got := value.Items[0]["value"]; got != 1 {
+		t.Fatalf("value = %d", got)
+	}
+	if err := Decode([]byte(`{"items":[{"value":1,"value":2}]}`), &value); err == nil || !strings.Contains(err.Error(), "duplicate") {
+		t.Fatalf("expected nested duplicate error, got %v", err)
+	}
+}

--- a/internal/projection/projection.go
+++ b/internal/projection/projection.go
@@ -1,0 +1,226 @@
+// Package projection verifies immutable output produced by an authoritative
+// Contract-to-CAPI renderer. It does not render or mutate Kubernetes objects.
+package projection
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/openkubes/ok-cluster/internal/contract"
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/jsonstrict"
+)
+
+const BindingFormat = "ok147-verified-projection/v1"
+
+type objectSet struct {
+	Count  int    `json:"count"`
+	Digest string `json:"digest"`
+}
+
+type manifest struct {
+	Format             string               `json:"format"`
+	R                  string               `json:"R"`
+	AuthorizationState string               `json:"authorizationState"`
+	Artifacts          map[string]string    `json:"artifacts"`
+	ObjectSets         map[string]objectSet `json:"objectSets"`
+	ProviderAccess     json.RawMessage      `json:"providerAccess"`
+	Source             json.RawMessage      `json:"source"`
+}
+
+type resource struct {
+	APIVersion string `json:"apiVersion"`
+	Kind       string `json:"kind"`
+	Name       string `json:"name"`
+	Namespace  string `json:"namespace,omitempty"`
+}
+
+type plane struct {
+	Identity  string     `json:"identity"`
+	Role      string     `json:"role"`
+	Resources []resource `json:"resources"`
+}
+
+type authorityMap struct {
+	Format                    string            `json:"format"`
+	ContractIdentity          contract.Identity `json:"contractIdentity"`
+	IntentRevision            string            `json:"intentRevision"`
+	InfrastructurePlane       plane             `json:"infrastructurePlane"`
+	ManagementPlane           plane             `json:"managementPlane"`
+	ProviderAccess            json.RawMessage   `json:"providerAccess"`
+	ExcludedRendererArtifacts json.RawMessage   `json:"excludedRendererArtifacts"`
+}
+
+// Artifact records the verified raw identity of one renderer artifact.
+type Artifact struct {
+	Name   string `json:"name"`
+	Digest string `json:"digest"`
+}
+
+// Plane is a verified authority domain, not a credential or Kubernetes context.
+type Plane struct {
+	Identity      string `json:"identity"`
+	Role          string `json:"role"`
+	ResourceCount int    `json:"resourceCount"`
+}
+
+// Binding is the bounded proof returned after all referenced files and
+// authority metadata have been checked.
+type Binding struct {
+	Format              string            `json:"format"`
+	SourceFormat        string            `json:"sourceFormat"`
+	ManifestDigest      string            `json:"manifestDigest"`
+	AuthorityMapDigest  string            `json:"authorityMapDigest"`
+	IntentRevision      string            `json:"intentRevision"`
+	ContractIdentity    contract.Identity `json:"contractIdentity"`
+	InfrastructurePlane Plane             `json:"infrastructurePlane"`
+	ManagementPlane     Plane             `json:"managementPlane"`
+	Artifacts           []Artifact        `json:"artifacts"`
+}
+
+// Verify validates an existing projection manifest and every artifact it
+// references. Artifact paths must be plain file names below root.
+func Verify(manifestPath, root, expectedRevision string, expectedIdentity contract.Identity) (Binding, error) {
+	raw, err := os.ReadFile(manifestPath)
+	if err != nil {
+		return Binding{}, fmt.Errorf("read projection manifest: %w", err)
+	}
+	var source manifest
+	if err := jsonstrict.Decode(raw, &source); err != nil {
+		return Binding{}, fmt.Errorf("decode projection manifest: %w", err)
+	}
+	if source.Format == "" || source.Format != "ok141-contract-to-capi-projection/v2" {
+		return Binding{}, fmt.Errorf("projection format %q is not supported", source.Format)
+	}
+	if source.R != expectedRevision {
+		return Binding{}, fmt.Errorf("projection revision %s does not match contract revision %s", source.R, expectedRevision)
+	}
+	if source.AuthorizationState != "NO-GO" {
+		return Binding{}, errors.New("projection artifact must remain non-authorizing (authorizationState NO-GO)")
+	}
+	if len(source.Artifacts) == 0 {
+		return Binding{}, errors.New("projection manifest has no artifacts")
+	}
+	if root == "" {
+		root = filepath.Dir(manifestPath)
+	}
+	root, err = filepath.Abs(root)
+	if err != nil {
+		return Binding{}, fmt.Errorf("resolve projection root: %w", err)
+	}
+
+	artifacts := make([]Artifact, 0, len(source.Artifacts))
+	var authorityRaw []byte
+	for name, expected := range source.Artifacts {
+		if err := validateArtifactName(name); err != nil {
+			return Binding{}, err
+		}
+		artifactRaw, err := os.ReadFile(filepath.Join(root, name))
+		if err != nil {
+			return Binding{}, fmt.Errorf("read projection artifact %s: %w", name, err)
+		}
+		actual := digest.SHA256(artifactRaw)
+		if actual != expected {
+			return Binding{}, fmt.Errorf("projection artifact %s digest %s does not match %s", name, actual, expected)
+		}
+		artifacts = append(artifacts, Artifact{Name: name, Digest: actual})
+		if name == "authority-map.json" {
+			authorityRaw = artifactRaw
+		}
+	}
+	if authorityRaw == nil {
+		return Binding{}, errors.New("projection manifest does not bind authority-map.json")
+	}
+	sort.Slice(artifacts, func(i, j int) bool { return artifacts[i].Name < artifacts[j].Name })
+
+	var authority authorityMap
+	if err := jsonstrict.Decode(authorityRaw, &authority); err != nil {
+		return Binding{}, fmt.Errorf("decode authority map: %w", err)
+	}
+	if authority.Format != source.Format {
+		return Binding{}, errors.New("authority map format differs from projection format")
+	}
+	if authority.IntentRevision != expectedRevision {
+		return Binding{}, errors.New("authority map intent revision differs from contract revision")
+	}
+	if authority.ContractIdentity != expectedIdentity {
+		return Binding{}, fmt.Errorf("authority map identity %#v differs from contract identity %#v", authority.ContractIdentity, expectedIdentity)
+	}
+	if err := validatePlane(authority.InfrastructurePlane, "provider-runtime-and-golden-image-prerequisites"); err != nil {
+		return Binding{}, fmt.Errorf("infrastructure plane: %w", err)
+	}
+	if err := validatePlane(authority.ManagementPlane, "single-lifecycle-writer"); err != nil {
+		return Binding{}, fmt.Errorf("management plane: %w", err)
+	}
+	if authority.InfrastructurePlane.Identity == authority.ManagementPlane.Identity {
+		return Binding{}, errors.New("infrastructure and management authority identities must differ")
+	}
+	if err := matchCount(source.ObjectSets, "okInfraPrerequisites", len(authority.InfrastructurePlane.Resources)); err != nil {
+		return Binding{}, err
+	}
+	if err := matchCount(source.ObjectSets, "okMgmtLifecycle", len(authority.ManagementPlane.Resources)); err != nil {
+		return Binding{}, err
+	}
+
+	return Binding{
+		Format:              BindingFormat,
+		SourceFormat:        source.Format,
+		ManifestDigest:      digest.SHA256(raw),
+		AuthorityMapDigest:  digest.SHA256(authorityRaw),
+		IntentRevision:      expectedRevision,
+		ContractIdentity:    expectedIdentity,
+		InfrastructurePlane: Plane{Identity: authority.InfrastructurePlane.Identity, Role: authority.InfrastructurePlane.Role, ResourceCount: len(authority.InfrastructurePlane.Resources)},
+		ManagementPlane:     Plane{Identity: authority.ManagementPlane.Identity, Role: authority.ManagementPlane.Role, ResourceCount: len(authority.ManagementPlane.Resources)},
+		Artifacts:           artifacts,
+	}, nil
+}
+
+func validateArtifactName(name string) error {
+	if name == "" || filepath.Base(name) != name || name == "." || strings.ContainsAny(name, `/\\`) {
+		return fmt.Errorf("projection artifact path %q is not a plain file name", name)
+	}
+	return nil
+}
+
+func validatePlane(value plane, role string) error {
+	if value.Identity == "" {
+		return errors.New("identity is empty")
+	}
+	if value.Role != role {
+		return fmt.Errorf("role %q does not match required %q", value.Role, role)
+	}
+	if len(value.Resources) == 0 {
+		return errors.New("resource set is empty")
+	}
+	seen := map[string]struct{}{}
+	for _, object := range value.Resources {
+		if object.APIVersion == "" || object.Kind == "" || object.Name == "" {
+			return errors.New("resource identity is incomplete")
+		}
+		key := strings.Join([]string{object.APIVersion, object.Kind, object.Namespace, object.Name}, "|")
+		if _, exists := seen[key]; exists {
+			return fmt.Errorf("duplicate resource identity %s", key)
+		}
+		seen[key] = struct{}{}
+	}
+	return nil
+}
+
+func matchCount(sets map[string]objectSet, name string, resources int) error {
+	set, ok := sets[name]
+	if !ok {
+		return fmt.Errorf("projection object set %s is missing", name)
+	}
+	if set.Count != resources {
+		return fmt.Errorf("projection object set %s count %d differs from authority resource count %d", name, set.Count, resources)
+	}
+	if !strings.HasPrefix(set.Digest, "sha256:") || len(set.Digest) != 71 {
+		return fmt.Errorf("projection object set %s has invalid digest", name)
+	}
+	return nil
+}

--- a/internal/projection/projection_test.go
+++ b/internal/projection/projection_test.go
@@ -1,0 +1,102 @@
+package projection
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/openkubes/ok-cluster/internal/contract"
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+func TestVerifyBindsArtifactsAndAuthority(t *testing.T) {
+	root := t.TempDir()
+	identity := contract.Identity{Namespace: "disposable-ok141", Name: "disposable-ok141"}
+	revision := "sha256:" + strings.Repeat("1", 64)
+	authority := authorityMap{
+		Format:           "ok141-contract-to-capi-projection/v2",
+		ContractIdentity: identity,
+		IntentRevision:   revision,
+		InfrastructurePlane: plane{Identity: "ok-infra", Role: "provider-runtime-and-golden-image-prerequisites", Resources: []resource{
+			{APIVersion: "v1", Kind: "Namespace", Name: identity.Name},
+		}},
+		ManagementPlane: plane{Identity: "ok-mgmt", Role: "single-lifecycle-writer", Resources: []resource{
+			{APIVersion: "v1", Kind: "Namespace", Name: identity.Name},
+			{APIVersion: "cluster.x-k8s.io/v1beta2", Kind: "Cluster", Namespace: identity.Namespace, Name: identity.Name},
+		}},
+		ProviderAccess:            json.RawMessage(`{}`),
+		ExcludedRendererArtifacts: json.RawMessage(`[]`),
+	}
+	authorityRaw, err := json.Marshal(authority)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, root, "authority-map.json", authorityRaw)
+	writeFile(t, root, "ok-infra-prerequisites.yaml", []byte("infra\n"))
+	writeFile(t, root, "ok-mgmt-lifecycle.yaml", []byte("mgmt\n"))
+
+	source := manifest{
+		Format:             authority.Format,
+		R:                  revision,
+		AuthorizationState: "NO-GO",
+		Artifacts: map[string]string{
+			"authority-map.json":          digest.SHA256(authorityRaw),
+			"ok-infra-prerequisites.yaml": digest.SHA256([]byte("infra\n")),
+			"ok-mgmt-lifecycle.yaml":      digest.SHA256([]byte("mgmt\n")),
+		},
+		ObjectSets: map[string]objectSet{
+			"okInfraPrerequisites": {Count: 1, Digest: "sha256:" + strings.Repeat("2", 64)},
+			"okMgmtLifecycle":      {Count: 2, Digest: "sha256:" + strings.Repeat("3", 64)},
+		},
+		ProviderAccess: json.RawMessage(`{}`),
+		Source:         json.RawMessage(`{}`),
+	}
+	manifestRaw, err := json.Marshal(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifestPath := writeFile(t, root, "projection-manifest.json", manifestRaw)
+
+	binding, err := Verify(manifestPath, root, revision, identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if binding.Format != BindingFormat || binding.ManagementPlane.Role != "single-lifecycle-writer" || binding.InfrastructurePlane.Identity != "ok-infra" {
+		t.Fatalf("unexpected binding: %#v", binding)
+	}
+
+	writeFile(t, root, "ok-mgmt-lifecycle.yaml", []byte("tampered\n"))
+	if _, err := Verify(manifestPath, root, revision, identity); err == nil || !strings.Contains(err.Error(), "digest") {
+		t.Fatalf("expected tamper rejection, got %v", err)
+	}
+}
+
+func TestVerifyRejectsArtifactTraversal(t *testing.T) {
+	root := t.TempDir()
+	source := manifest{
+		Format:             "ok141-contract-to-capi-projection/v2",
+		R:                  "sha256:" + strings.Repeat("1", 64),
+		AuthorizationState: "NO-GO",
+		Artifacts:          map[string]string{"../authority-map.json": "sha256:" + strings.Repeat("2", 64)},
+		ObjectSets:         map[string]objectSet{},
+		ProviderAccess:     json.RawMessage(`{}`),
+		Source:             json.RawMessage(`{}`),
+	}
+	raw, _ := json.Marshal(source)
+	path := writeFile(t, root, "projection-manifest.json", raw)
+	_, err := Verify(path, root, source.R, contract.Identity{Name: "x", Namespace: "x"})
+	if err == nil || !strings.Contains(err.Error(), "plain file name") {
+		t.Fatalf("expected path rejection, got %v", err)
+	}
+}
+
+func writeFile(t *testing.T, root, name string, raw []byte) string {
+	t.Helper()
+	path := filepath.Join(root, name)
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}


### PR DESCRIPTION
## What changed

- verify an immutable projection produced by the existing authoritative renderer
- bind the OK-141 contract revision, all projection artifacts, and the ok-infra/ok-mgmt authority split into a deterministic CreateRequest
- verify an Ed25519-signed, maximum-30-minute, single-use authorization decision
- reject duplicate/unknown JSON fields, artifact tampering, path traversal, wrong trust keys, changed requests, and expired grants
- keep `ok cluster create` strictly dry-run-only with `mutationAllowed: false`

## Why

OK-147 needs a bounded executor path without introducing a second Contract→CAPI compiler or treating an unsigned `ALLOW` document as authority. This checkpoint proves projection and authorization binding while leaving submission, credentials, idempotency, grant consumption, evidence publication, and Kubernetes access out of scope.

The preserved OK-141 Phase-R-v5 projection verifies as:

- R: `sha256:166504ae61fd558d391daedde50986cbc7a28f5f4e9d57f4acbd0433b448aa0f`
- projection manifest: `sha256:37b65b7ff1f7f46e5809000d8a469f423943c6b7f4f043a7bc6123d033ee765b`
- CreateRequest: `sha256:0c64e26a3697c7f19c25783c8c26b044413a07a5dc0c3e131a8647c1bba9db26`

## Impact

No Kubernetes client, credential, cluster contact, mutation, retry, rollback, operator, CRD, or public API is introduced.

## Validation

- `go test -race ./...`
- `go test -cover ./...`
- `go vet ./...`
- `python3 -m unittest discover -s tests -p '*test.py'` (7 pass, 1 existing skip)
- offline verification against the preserved OK-141 Phase-R-v5 projection