### PR TITLE
OK-147: Enforce single-use grant receipts

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ Powered by [Cluster API (CAPI)](https://cluster-api.sigs.k8s.io/), [CAPK (KubeVi
 - **Single Makefile UX** — `make new`, `make install`, `make status`, `make upgrade`
 - **Bounded Contract Executor MVP** — a shared Go core for local CLI and future
   short-lived `ok-mgmt` Jobs; it remains dry-run-only while verifying the
-  OK-141 revision, existing projection, authority split, and signed grant binding
+  OK-141 revision, existing projection, authority split, signed grant binding,
+  and fail-closed single-use receipt semantics
 
 ---
 

--- a/cmd/ok/main.go
+++ b/cmd/ok/main.go
@@ -136,10 +136,11 @@ func run(arguments []string, stdout, stderr io.Writer) error {
 		if err != nil {
 			return fmt.Errorf("parse evaluation time: %w", err)
 		}
-		receipt, err := authorization.Verify(authorizationRaw, keyRaw, *plan.Request, at)
+		grant, err := authorization.Verify(authorizationRaw, keyRaw, *plan.Request, at)
 		if err != nil {
 			return err
 		}
+		receipt := grant.Receipt()
 		plan.AuthorizationState = "VERIFIED"
 		plan.Authorization = &receipt
 	}

--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -101,9 +101,47 @@ and the one-use declaration. The output receipt intentionally excludes the
 signature and all source paths.
 
 Even a verified decision still produces `mutationAllowed: false`. This
-checkpoint proves content binding and trust verification only. It does not yet
-provide grant consumption, idempotency, credentials, Kubernetes submission,
-retry, rollback, or evidence publication.
+boundary proves content binding and trust verification only. It does not by
+itself consume the grant or authorize Kubernetes submission.
+
+## Single-use and crash boundary
+
+The third checkpoint adds a filesystem-backed ledger for a future short-lived
+executor. It is not wired to the dry-run CLI and still has no Kubernetes client.
+
+Before any future external write, the executor must atomically create an
+immutable `ok147-grant-claim/v1` using `O_CREATE|O_EXCL`:
+
+```text
+verified signed grant
+        |
+        v
+atomic immutable claim
+        |
+        +-- process stops before outcome --> CLAIMED_INDETERMINATE_STOP
+        |                                    no automatic retry
+        v
+future bounded operation
+        |
+        v
+separate immutable ok147-operation-receipt/v1
+```
+
+The claim binds the authorization, key, operation, request, `R`, and projection
+digests. A concurrent or later attempt using the same grant is rejected. A
+completion receipt additionally binds the claim and evidence digest. Repeating
+the exact completion write is idempotent; a conflicting completion fails
+closed. A successful `CreateCluster` receipt cannot claim that no mutation was
+attempted.
+
+Ledger directories must be real private directories and records must remain
+regular `0600` files. Non-canonical or modified records are rejected. Tests
+prove that 24 concurrent claim attempts produce exactly one winner.
+
+This local ledger proves the consumption and restart algorithm only. A real
+Job must use a durable, authority-controlled backing store that survives Job and
+node loss; an `emptyDir` alone cannot enforce single use across Job recreation.
+Selecting and integrating that backing store remains a later checkpoint.
 
 ## OK-141 compatibility evidence
 

--- a/internal/authorization/authorization.go
+++ b/internal/authorization/authorization.go
@@ -63,41 +63,73 @@ type Receipt struct {
 	MaxUses             int    `json:"maxUses"`
 }
 
+// ConsumptionBinding is the minimum verified identity required by the local
+// single-use ledger. It contains no signature, key material, or source path.
+type ConsumptionBinding struct {
+	AuthorizationDigest      string
+	GrantID                  string
+	KeyID                    string
+	Operation                string
+	RequestDigest            string
+	ContractRevision         string
+	ProjectionManifestDigest string
+	NotAfter                 string
+}
+
+// VerifiedGrant can only be produced by Verify. The unexported marker prevents
+// callers from manufacturing a grant by constructing a Receipt value.
+type VerifiedGrant struct {
+	receipt  Receipt
+	binding  ConsumptionBinding
+	verified bool
+}
+
+// Receipt returns the redacted verification result for plan output.
+func (grant VerifiedGrant) Receipt() Receipt { return grant.receipt }
+
+// ConsumptionBinding returns verified fields for a single-use claim.
+func (grant VerifiedGrant) ConsumptionBinding() (ConsumptionBinding, error) {
+	if !grant.verified {
+		return ConsumptionBinding{}, errors.New("authorization grant was not produced by verification")
+	}
+	return grant.binding, nil
+}
+
 // Verify checks the signature, trust key identity, time window, single-use
 // declaration, and every request binding.
-func Verify(raw, publicKeyPEM []byte, request executor.CreateRequest, at time.Time) (Receipt, error) {
+func Verify(raw, publicKeyRaw []byte, request executor.CreateRequest, at time.Time) (VerifiedGrant, error) {
 	var document envelope
 	if err := jsonstrict.Decode(raw, &document); err != nil {
-		return Receipt{}, fmt.Errorf("decode authorization: %w", err)
+		return VerifiedGrant{}, fmt.Errorf("decode authorization: %w", err)
 	}
 	if document.Format != Format {
-		return Receipt{}, fmt.Errorf("authorization format %q is not supported", document.Format)
+		return VerifiedGrant{}, fmt.Errorf("authorization format %q is not supported", document.Format)
 	}
-	publicKey, keyID, err := parsePublicKey(publicKeyPEM)
+	publicKey, keyID, err := parsePublicKey(publicKeyRaw)
 	if err != nil {
-		return Receipt{}, err
+		return VerifiedGrant{}, err
 	}
 	if document.Signature.Algorithm != "Ed25519" {
-		return Receipt{}, fmt.Errorf("signature algorithm %q is not supported", document.Signature.Algorithm)
+		return VerifiedGrant{}, fmt.Errorf("signature algorithm %q is not supported", document.Signature.Algorithm)
 	}
 	if document.Signature.KeyID != keyID {
-		return Receipt{}, fmt.Errorf("authorization keyId %s does not match trusted key %s", document.Signature.KeyID, keyID)
+		return VerifiedGrant{}, fmt.Errorf("authorization keyId %s does not match trusted key %s", document.Signature.KeyID, keyID)
 	}
 	signatureBytes, err := base64.StdEncoding.Strict().DecodeString(document.Signature.Value)
 	if err != nil {
-		return Receipt{}, fmt.Errorf("decode authorization signature: %w", err)
+		return VerifiedGrant{}, fmt.Errorf("decode authorization signature: %w", err)
 	}
 	signed, err := SigningBytes(document.Payload)
 	if err != nil {
-		return Receipt{}, err
+		return VerifiedGrant{}, err
 	}
 	if !ed25519.Verify(publicKey, signed, signatureBytes) {
-		return Receipt{}, errors.New("authorization signature verification failed")
+		return VerifiedGrant{}, errors.New("authorization signature verification failed")
 	}
 	if err := verifyPayload(document.Payload, request, at); err != nil {
-		return Receipt{}, err
+		return VerifiedGrant{}, err
 	}
-	return Receipt{
+	receipt := Receipt{
 		Format:              "ok147-authorization-receipt/v1",
 		State:               "VERIFIED",
 		AuthorizationDigest: digest.SHA256(raw),
@@ -105,6 +137,20 @@ func Verify(raw, publicKeyPEM []byte, request executor.CreateRequest, at time.Ti
 		KeyID:               keyID,
 		NotAfter:            document.Payload.NotAfter,
 		MaxUses:             document.Payload.MaxUses,
+	}
+	return VerifiedGrant{
+		receipt: receipt,
+		binding: ConsumptionBinding{
+			AuthorizationDigest:      receipt.AuthorizationDigest,
+			GrantID:                  document.Payload.GrantID,
+			KeyID:                    keyID,
+			Operation:                document.Payload.Operation,
+			RequestDigest:            document.Payload.RequestDigest,
+			ContractRevision:         document.Payload.ContractRevision,
+			ProjectionManifestDigest: document.Payload.ProjectionManifestDigest,
+			NotAfter:                 document.Payload.NotAfter,
+		},
+		verified: true,
 	}, nil
 }
 

--- a/internal/authorization/authorization_test.go
+++ b/internal/authorization/authorization_test.go
@@ -19,15 +19,26 @@ func TestVerifyAcceptsExactSignedRequest(t *testing.T) {
 	request := testRequest()
 	at := time.Date(2026, 8, 16, 10, 0, 0, 0, time.UTC)
 	raw, publicPEM := signAuthorization(t, request, at)
-	receipt, err := Verify(raw, publicPEM, request, at)
+	grant, err := Verify(raw, publicPEM, request, at)
 	if err != nil {
 		t.Fatal(err)
 	}
+	receipt := grant.Receipt()
 	if receipt.State != "VERIFIED" || receipt.GrantID != "ok147-create-20260816-01" || receipt.MaxUses != 1 {
 		t.Fatalf("unexpected receipt: %#v", receipt)
 	}
 	if receipt.AuthorizationDigest != digest.SHA256(raw) {
 		t.Fatal("authorization digest differs from raw document")
+	}
+	binding, err := grant.ConsumptionBinding()
+	if err != nil || binding.RequestDigest == "" || binding.Operation != "CreateCluster" {
+		t.Fatalf("invalid consumption binding: %#v %v", binding, err)
+	}
+}
+
+func TestZeroGrantCannotProduceConsumptionBinding(t *testing.T) {
+	if _, err := (VerifiedGrant{}).ConsumptionBinding(); err == nil {
+		t.Fatal("zero grant was accepted")
 	}
 }
 

--- a/internal/ledger/ledger.go
+++ b/internal/ledger/ledger.go
@@ -1,0 +1,408 @@
+// Package ledger provides an atomic, local single-use boundary for verified
+// grants. It records intent before any future external write and never retries
+// an indeterminate operation.
+package ledger
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/authorization"
+	"github.com/openkubes/ok-cluster/internal/contract"
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/jsonstrict"
+)
+
+const (
+	ClaimFormat   = "ok147-grant-claim/v1"
+	OutcomeFormat = "ok147-operation-receipt/v1"
+)
+
+var ErrGrantConsumed = errors.New("authorization grant is already consumed")
+
+// Ledger stores immutable claim and outcome files below a private directory.
+type Ledger struct {
+	root     string
+	claims   string
+	outcomes string
+}
+
+// ClaimReceipt is written atomically before a future operation begins.
+type ClaimReceipt struct {
+	Format                   string `json:"format"`
+	State                    string `json:"state"`
+	AuthorizationDigest      string `json:"authorizationDigest"`
+	GrantID                  string `json:"grantId"`
+	KeyID                    string `json:"keyId"`
+	Operation                string `json:"operation"`
+	RequestDigest            string `json:"requestDigest"`
+	ContractRevision         string `json:"contractRevision"`
+	ProjectionManifestDigest string `json:"projectionManifestDigest"`
+	ClaimedAt                string `json:"claimedAt"`
+}
+
+// OutcomeReceipt is a separate immutable completion record. Absence after a
+// claim means STOP/INDETERMINATE, never permission to retry.
+type OutcomeReceipt struct {
+	Format         string `json:"format"`
+	State          string `json:"state"`
+	GrantID        string `json:"grantId"`
+	Operation      string `json:"operation"`
+	RequestDigest  string `json:"requestDigest"`
+	ClaimDigest    string `json:"claimDigest"`
+	Outcome        string `json:"outcome"`
+	MutationState  string `json:"mutationState"`
+	EvidenceDigest string `json:"evidenceDigest"`
+	CompletedAt    string `json:"completedAt"`
+}
+
+// Inspection is the fail-closed restart decision for a verified grant.
+type Inspection struct {
+	State         string          `json:"state"`
+	ClaimAllowed  bool            `json:"claimAllowed"`
+	ClaimDigest   string          `json:"claimDigest,omitempty"`
+	OutcomeDigest string          `json:"outcomeDigest,omitempty"`
+	Outcome       *OutcomeReceipt `json:"outcome,omitempty"`
+}
+
+// Open creates or verifies a private, non-symlink ledger directory.
+func Open(root string) (*Ledger, error) {
+	if root == "" {
+		return nil, errors.New("ledger root is required")
+	}
+	abs, err := filepath.Abs(root)
+	if err != nil {
+		return nil, fmt.Errorf("resolve ledger root: %w", err)
+	}
+	if err := secureDirectory(abs); err != nil {
+		return nil, err
+	}
+	result := &Ledger{root: abs, claims: filepath.Join(abs, "claims"), outcomes: filepath.Join(abs, "outcomes")}
+	if err := secureDirectory(result.claims); err != nil {
+		return nil, err
+	}
+	if err := secureDirectory(result.outcomes); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// Claim atomically consumes a verified grant. A second call always returns
+// ErrGrantConsumed, including after a process crash.
+func (ledger *Ledger) Claim(grant authorization.VerifiedGrant, at time.Time) (ClaimReceipt, error) {
+	binding, err := grant.ConsumptionBinding()
+	if err != nil {
+		return ClaimReceipt{}, err
+	}
+	expires, err := time.Parse(time.RFC3339, binding.NotAfter)
+	if err != nil {
+		return ClaimReceipt{}, fmt.Errorf("grant expiration: %w", err)
+	}
+	if !at.Before(expires) {
+		return ClaimReceipt{}, errors.New("grant expired before consumption")
+	}
+	receipt := ClaimReceipt{
+		Format:                   ClaimFormat,
+		State:                    "CLAIMED",
+		AuthorizationDigest:      binding.AuthorizationDigest,
+		GrantID:                  binding.GrantID,
+		KeyID:                    binding.KeyID,
+		Operation:                binding.Operation,
+		RequestDigest:            binding.RequestDigest,
+		ContractRevision:         binding.ContractRevision,
+		ProjectionManifestDigest: binding.ProjectionManifestDigest,
+		ClaimedAt:                at.UTC().Format(time.RFC3339Nano),
+	}
+	raw, _, err := canonicalRecord(receipt)
+	if err != nil {
+		return ClaimReceipt{}, err
+	}
+	path := ledger.claimPath(binding.GrantID)
+	if err := writeExclusive(path, raw, ledger.claims); err != nil {
+		if errors.Is(err, os.ErrExist) {
+			return ClaimReceipt{}, ErrGrantConsumed
+		}
+		return ClaimReceipt{}, fmt.Errorf("write grant claim: %w", err)
+	}
+	return receipt, nil
+}
+
+// Complete writes one outcome. Repeating the exact completion is idempotent;
+// a conflicting completion fails closed.
+func (ledger *Ledger) Complete(claim ClaimReceipt, outcome, mutationState, evidenceDigest string, at time.Time) (OutcomeReceipt, error) {
+	if !allowed(outcome, "SUCCEEDED", "FAILED", "STOPPED") {
+		return OutcomeReceipt{}, fmt.Errorf("unsupported outcome %q", outcome)
+	}
+	if !allowed(mutationState, "NOT_ATTEMPTED", "ATTEMPTED", "UNKNOWN") {
+		return OutcomeReceipt{}, fmt.Errorf("unsupported mutation state %q", mutationState)
+	}
+	if claim.Operation == "CreateCluster" && outcome == "SUCCEEDED" && mutationState != "ATTEMPTED" {
+		return OutcomeReceipt{}, errors.New("successful CreateCluster outcome requires mutationState ATTEMPTED")
+	}
+	if !validDigest(evidenceDigest) {
+		return OutcomeReceipt{}, errors.New("evidence digest is invalid")
+	}
+	stored, claimDigest, err := ledger.readClaim(claim.GrantID)
+	if err != nil {
+		return OutcomeReceipt{}, err
+	}
+	_, providedDigest, err := canonicalRecord(claim)
+	if err != nil {
+		return OutcomeReceipt{}, err
+	}
+	if claimDigest != providedDigest || stored != claim {
+		return OutcomeReceipt{}, errors.New("provided claim differs from immutable ledger claim")
+	}
+	claimedAt, err := time.Parse(time.RFC3339Nano, claim.ClaimedAt)
+	if err != nil || at.Before(claimedAt) {
+		return OutcomeReceipt{}, errors.New("completion time precedes claim")
+	}
+	receipt := OutcomeReceipt{
+		Format:         OutcomeFormat,
+		State:          "COMPLETED",
+		GrantID:        claim.GrantID,
+		Operation:      claim.Operation,
+		RequestDigest:  claim.RequestDigest,
+		ClaimDigest:    claimDigest,
+		Outcome:        outcome,
+		MutationState:  mutationState,
+		EvidenceDigest: evidenceDigest,
+		CompletedAt:    at.UTC().Format(time.RFC3339Nano),
+	}
+	raw, expectedDigest, err := canonicalRecord(receipt)
+	if err != nil {
+		return OutcomeReceipt{}, err
+	}
+	path := ledger.outcomePath(claim.GrantID)
+	if err := writeExclusive(path, raw, ledger.outcomes); err != nil {
+		if !errors.Is(err, os.ErrExist) {
+			return OutcomeReceipt{}, fmt.Errorf("write operation outcome: %w", err)
+		}
+		existing, existingDigest, readErr := ledger.readOutcome(claim.GrantID)
+		if readErr != nil {
+			return OutcomeReceipt{}, readErr
+		}
+		if existingDigest == expectedDigest && existing == receipt {
+			return existing, nil
+		}
+		return OutcomeReceipt{}, errors.New("conflicting operation outcome already exists")
+	}
+	return receipt, nil
+}
+
+// Inspect returns AVAILABLE, CLAIMED_INDETERMINATE_STOP, or COMPLETED. It never
+// recommends retrying an already claimed grant.
+func (ledger *Ledger) Inspect(grant authorization.VerifiedGrant) (Inspection, error) {
+	binding, err := grant.ConsumptionBinding()
+	if err != nil {
+		return Inspection{}, err
+	}
+	claim, claimDigest, err := ledger.readClaim(binding.GrantID)
+	if errors.Is(err, os.ErrNotExist) {
+		return Inspection{State: "AVAILABLE", ClaimAllowed: true}, nil
+	}
+	if err != nil {
+		return Inspection{}, err
+	}
+	if err := matchBinding(claim, binding); err != nil {
+		return Inspection{}, err
+	}
+	outcome, outcomeDigest, err := ledger.readOutcome(binding.GrantID)
+	if errors.Is(err, os.ErrNotExist) {
+		return Inspection{State: "CLAIMED_INDETERMINATE_STOP", ClaimAllowed: false, ClaimDigest: claimDigest}, nil
+	}
+	if err != nil {
+		return Inspection{}, err
+	}
+	if outcome.ClaimDigest != claimDigest || outcome.GrantID != claim.GrantID || outcome.RequestDigest != claim.RequestDigest || outcome.Operation != claim.Operation {
+		return Inspection{}, errors.New("operation outcome does not match immutable claim")
+	}
+	return Inspection{State: "COMPLETED", ClaimAllowed: false, ClaimDigest: claimDigest, OutcomeDigest: outcomeDigest, Outcome: &outcome}, nil
+}
+
+func (ledger *Ledger) readClaim(grantID string) (ClaimReceipt, string, error) {
+	var value ClaimReceipt
+	raw, err := readRegular(ledger.claimPath(grantID))
+	if err != nil {
+		return value, "", err
+	}
+	if err := jsonstrict.Decode(raw, &value); err != nil {
+		return value, "", fmt.Errorf("decode grant claim: %w", err)
+	}
+	canonical, identity, err := canonicalRecord(value)
+	if err != nil {
+		return value, "", err
+	}
+	if !bytes.Equal(raw, canonical) {
+		return value, "", errors.New("grant claim is not canonical or was modified")
+	}
+	return value, identity, validateClaim(value)
+}
+
+func (ledger *Ledger) readOutcome(grantID string) (OutcomeReceipt, string, error) {
+	var value OutcomeReceipt
+	raw, err := readRegular(ledger.outcomePath(grantID))
+	if err != nil {
+		return value, "", err
+	}
+	if err := jsonstrict.Decode(raw, &value); err != nil {
+		return value, "", fmt.Errorf("decode operation outcome: %w", err)
+	}
+	canonical, identity, err := canonicalRecord(value)
+	if err != nil {
+		return value, "", err
+	}
+	if !bytes.Equal(raw, canonical) {
+		return value, "", errors.New("operation outcome is not canonical or was modified")
+	}
+	return value, identity, validateOutcome(value)
+}
+
+func (ledger *Ledger) claimPath(grantID string) string {
+	return filepath.Join(ledger.claims, digest.SHA256([]byte(grantID))[7:]+".json")
+}
+
+func (ledger *Ledger) outcomePath(grantID string) string {
+	return filepath.Join(ledger.outcomes, digest.SHA256([]byte(grantID))[7:]+".json")
+}
+
+func canonicalRecord(value any) ([]byte, string, error) {
+	raw, err := json.Marshal(value)
+	if err != nil {
+		return nil, "", err
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	var generic any
+	if err := decoder.Decode(&generic); err != nil {
+		return nil, "", err
+	}
+	canonical, err := contract.JCS(generic)
+	if err != nil {
+		return nil, "", err
+	}
+	return canonical, digest.SHA256(canonical), nil
+}
+
+func secureDirectory(path string) error {
+	if err := os.MkdirAll(path, 0o700); err != nil {
+		return fmt.Errorf("create private ledger directory: %w", err)
+	}
+	info, err := os.Lstat(path)
+	if err != nil {
+		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.IsDir() {
+		return fmt.Errorf("ledger path %s is not a real directory", path)
+	}
+	if info.Mode().Perm()&0o077 != 0 {
+		return fmt.Errorf("ledger directory %s permissions are broader than 0700", path)
+	}
+	return nil
+}
+
+func writeExclusive(path string, raw []byte, directory string) (returnErr error) {
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := file.Close(); returnErr == nil && err != nil {
+			returnErr = err
+		}
+	}()
+	if _, err := file.Write(raw); err != nil {
+		return err
+	}
+	if err := file.Sync(); err != nil {
+		return err
+	}
+	dir, err := os.Open(directory)
+	if err != nil {
+		return err
+	}
+	defer dir.Close()
+	return dir.Sync()
+}
+
+func readRegular(path string) ([]byte, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return nil, err
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("ledger record %s is not a regular file", path)
+	}
+	if info.Mode().Perm()&0o077 != 0 {
+		return nil, fmt.Errorf("ledger record %s permissions are broader than 0600", path)
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	return io.ReadAll(io.LimitReader(file, 1<<20))
+}
+
+func validateClaim(value ClaimReceipt) error {
+	if value.Format != ClaimFormat || value.State != "CLAIMED" || value.GrantID == "" || value.Operation == "" {
+		return errors.New("grant claim is incomplete")
+	}
+	for _, identity := range []string{value.AuthorizationDigest, value.KeyID, value.RequestDigest, value.ContractRevision, value.ProjectionManifestDigest} {
+		if !validDigest(identity) {
+			return errors.New("grant claim contains an invalid digest")
+		}
+	}
+	if _, err := time.Parse(time.RFC3339Nano, value.ClaimedAt); err != nil {
+		return errors.New("grant claim has an invalid timestamp")
+	}
+	return nil
+}
+
+func matchBinding(claim ClaimReceipt, binding authorization.ConsumptionBinding) error {
+	if claim.AuthorizationDigest != binding.AuthorizationDigest || claim.GrantID != binding.GrantID || claim.KeyID != binding.KeyID || claim.Operation != binding.Operation || claim.RequestDigest != binding.RequestDigest || claim.ContractRevision != binding.ContractRevision || claim.ProjectionManifestDigest != binding.ProjectionManifestDigest {
+		return errors.New("stored grant claim differs from verified authorization")
+	}
+	return nil
+}
+
+func validateOutcome(value OutcomeReceipt) error {
+	if value.Format != OutcomeFormat || value.State != "COMPLETED" || value.GrantID == "" || value.Operation == "" {
+		return errors.New("operation outcome is incomplete")
+	}
+	if !allowed(value.Outcome, "SUCCEEDED", "FAILED", "STOPPED") || !allowed(value.MutationState, "NOT_ATTEMPTED", "ATTEMPTED", "UNKNOWN") {
+		return errors.New("operation outcome contains an invalid state")
+	}
+	for _, identity := range []string{value.RequestDigest, value.ClaimDigest, value.EvidenceDigest} {
+		if !validDigest(identity) {
+			return errors.New("operation outcome contains an invalid digest")
+		}
+	}
+	if _, err := time.Parse(time.RFC3339Nano, value.CompletedAt); err != nil {
+		return errors.New("operation outcome has an invalid timestamp")
+	}
+	if value.Operation == "CreateCluster" && value.Outcome == "SUCCEEDED" && value.MutationState != "ATTEMPTED" {
+		return errors.New("successful CreateCluster outcome lacks attempted mutation state")
+	}
+	return nil
+}
+
+func validDigest(value string) bool {
+	return regexp.MustCompile(`^sha256:[0-9a-f]{64}$`).MatchString(value)
+}
+
+func allowed(value string, choices ...string) bool {
+	for _, choice := range choices {
+		if value == choice {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/ledger/ledger_test.go
+++ b/internal/ledger/ledger_test.go
@@ -1,0 +1,180 @@
+package ledger
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/authorization"
+	"github.com/openkubes/ok-cluster/internal/contract"
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/executor"
+	"github.com/openkubes/ok-cluster/internal/projection"
+)
+
+func TestClaimIsAtomicAndSingleUse(t *testing.T) {
+	store, err := Open(filepath.Join(t.TempDir(), "ledger"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	at := time.Date(2026, 8, 16, 10, 0, 0, 0, time.UTC)
+	grant := verifiedGrant(t, at)
+	available, err := store.Inspect(grant)
+	if err != nil || available.State != "AVAILABLE" || !available.ClaimAllowed {
+		t.Fatalf("grant is not initially available: %#v %v", available, err)
+	}
+
+	var acquired atomic.Int32
+	var consumed atomic.Int32
+	var wait sync.WaitGroup
+	for index := 0; index < 24; index++ {
+		wait.Add(1)
+		go func() {
+			defer wait.Done()
+			if _, err := store.Claim(grant, at); err == nil {
+				acquired.Add(1)
+			} else if errors.Is(err, ErrGrantConsumed) {
+				consumed.Add(1)
+			} else {
+				t.Errorf("claim: %v", err)
+			}
+		}()
+	}
+	wait.Wait()
+	if acquired.Load() != 1 || consumed.Load() != 23 {
+		t.Fatalf("acquired=%d consumed=%d", acquired.Load(), consumed.Load())
+	}
+	inspection, err := store.Inspect(grant)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if inspection.State != "CLAIMED_INDETERMINATE_STOP" || inspection.ClaimAllowed {
+		t.Fatalf("unsafe restart decision: %#v", inspection)
+	}
+}
+
+func TestCompleteIsImmutableAndIdempotent(t *testing.T) {
+	store, err := Open(filepath.Join(t.TempDir(), "ledger"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	at := time.Date(2026, 8, 16, 10, 0, 0, 0, time.UTC)
+	grant := verifiedGrant(t, at)
+	claim, err := store.Claim(grant, at)
+	if err != nil {
+		t.Fatal(err)
+	}
+	evidence := "sha256:" + strings.Repeat("e", 64)
+	if _, err := store.Complete(claim, "SUCCEEDED", "NOT_ATTEMPTED", evidence, at.Add(time.Second)); err == nil {
+		t.Fatal("successful CreateCluster without attempted mutation was accepted")
+	}
+	first, err := store.Complete(claim, "SUCCEEDED", "ATTEMPTED", evidence, at.Add(time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := store.Complete(claim, "SUCCEEDED", "ATTEMPTED", evidence, at.Add(time.Second))
+	if err != nil || second != first {
+		t.Fatalf("identical completion was not idempotent: %#v %v", second, err)
+	}
+	if _, err := store.Complete(claim, "FAILED", "UNKNOWN", evidence, at.Add(2*time.Second)); err == nil || !strings.Contains(err.Error(), "conflicting") {
+		t.Fatalf("expected conflicting completion rejection, got %v", err)
+	}
+	inspection, err := store.Inspect(grant)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if inspection.State != "COMPLETED" || inspection.ClaimAllowed || inspection.Outcome == nil || inspection.Outcome.Outcome != "SUCCEEDED" {
+		t.Fatalf("unexpected completion inspection: %#v", inspection)
+	}
+}
+
+func TestTamperedClaimFailsClosed(t *testing.T) {
+	store, err := Open(filepath.Join(t.TempDir(), "ledger"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	at := time.Date(2026, 8, 16, 10, 0, 0, 0, time.UTC)
+	grant := verifiedGrant(t, at)
+	claim, err := store.Claim(grant, at)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := store.claimPath(claim.GrantID)
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tampered := append([]byte(" "), raw...)
+	if err := os.WriteFile(path, tampered, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.Inspect(grant); err == nil || !strings.Contains(err.Error(), "canonical") {
+		t.Fatalf("expected tamper rejection, got %v", err)
+	}
+}
+
+func TestOpenRejectsBroadDirectoryPermissions(t *testing.T) {
+	root := t.TempDir()
+	if err := os.Chmod(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Open(root); err == nil || !strings.Contains(err.Error(), "permissions") {
+		t.Fatalf("expected permission rejection, got %v", err)
+	}
+}
+
+func verifiedGrant(t *testing.T, at time.Time) authorization.VerifiedGrant {
+	t.Helper()
+	identity := contract.Identity{Name: "disposable-ok141", Namespace: "disposable-ok141"}
+	request := executor.CreateRequest{
+		Format: executor.RequestFormat, Operation: "CreateCluster", ContractIdentity: identity,
+		ContractRevision: "sha256:" + strings.Repeat("1", 64),
+		Projection: projection.Binding{
+			Format: projection.BindingFormat, IntentRevision: "sha256:" + strings.Repeat("1", 64), ContractIdentity: identity,
+			ManifestDigest: "sha256:" + strings.Repeat("2", 64),
+		},
+	}
+	requestDigest, err := executor.Digest(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload := authorization.Payload{
+		Audience: authorization.Audience, GrantID: "ok147-create-20260816-01", Decision: "ALLOW", Operation: request.Operation,
+		RequestDigest: requestDigest, ContractIdentity: identity, ContractRevision: request.ContractRevision,
+		ProjectionManifestDigest: request.Projection.ManifestDigest,
+		NotBefore:                at.Add(-time.Minute).Format(time.RFC3339), NotAfter: at.Add(20 * time.Minute).Format(time.RFC3339), MaxUses: 1,
+	}
+	signed, err := authorization.SigningBytes(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	document := map[string]any{
+		"format":  authorization.Format,
+		"payload": payload,
+		"signature": map[string]any{
+			"algorithm": "Ed25519", "keyId": digest.SHA256(publicKey), "value": base64.StdEncoding.EncodeToString(ed25519.Sign(privateKey, signed)),
+		},
+	}
+	raw, err := json.Marshal(document)
+	if err != nil {
+		t.Fatal(err)
+	}
+	grant, err := authorization.Verify(raw, []byte(base64.StdEncoding.EncodeToString(publicKey)), request, at)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return grant
+}


### PR DESCRIPTION
## What changed

- introduce an atomic local ledger for verified OK-147 grants
- consume a grant before any future external write using `O_CREATE|O_EXCL`
- persist immutable claim and outcome receipts as canonical JSON
- bind authorization, key, operation, request, R, projection, and evidence digests
- return `CLAIMED_INDETERMINATE_STOP` after a claim without an outcome
- allow idempotent replay of the exact completion receipt while rejecting conflicts
- prevent a successful `CreateCluster` receipt from claiming that no mutation was attempted
- prevent callers from manufacturing a verified grant from a plain receipt value

## Why

A signed `ALLOW` decision is not single-use until consumption is atomic and durable. The OK-141 execution evidence showed that a consumed grant must never be reused after an uncertain or failed process. This checkpoint makes that restart rule executable without adding a Kubernetes client or performing infrastructure mutation.

## Impact and boundary

The dry-run CLI remains non-mutating. The ledger is currently an internal filesystem implementation used to prove the algorithm. A real short-lived Job must use authority-controlled storage that survives Job and node loss; `emptyDir` is explicitly insufficient. Selecting that durable backend is intentionally left for a later checkpoint.

## Validation

- `go test -race ./...`
- `go test -cover ./...` (ledger 72.6%)
- `go vet ./...`
- existing Python suite: 7 pass, 1 existing skip
- concurrency proof: 24 simultaneous claims produce exactly one winner
- tampered/non-canonical records and conflicting outcomes fail closed

No cluster contact, credential use, Kubernetes mutation, retry, rollback, or evidence publication was performed.