### PR TITLE
OK-147: add durable Kubernetes grant ledger

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ Powered by [Cluster API (CAPI)](https://cluster-api.sigs.k8s.io/), [CAPK (KubeVi
 - **Bounded Contract Executor MVP** — a shared Go core for local CLI and future
   short-lived `ok-mgmt` Jobs; it remains dry-run-only while verifying the
   OK-141 revision, existing projection, authority split, signed grant binding,
-  and fail-closed single-use receipt semantics
+  fail-closed single-use receipt semantics, and an offline-tested durable
+  Kubernetes ledger boundary
 
 ---
 

--- a/deploy/contract-executor-ledger.yaml
+++ b/deploy/contract-executor-ledger.yaml
@@ -1,0 +1,96 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openkubes-execution-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ok147-contract-executor
+  namespace: openkubes-execution-system
+automountServiceAccountToken: false
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ok147-ledger-writer
+  namespace: openkubes-execution-system
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["create", "get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ok147-ledger-writer
+  namespace: openkubes-execution-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ok147-ledger-writer
+subjects:
+  - kind: ServiceAccount
+    name: ok147-contract-executor
+    namespace: openkubes-execution-system
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: ok147-contract-executor-ledger
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+      - apiGroups: [""]
+        apiVersions: ["v1"]
+        operations: ["CREATE"]
+        resources: ["configmaps"]
+        scope: Namespaced
+  matchConditions:
+    - name: exact-ledger-namespace
+      expression: request.namespace == 'openkubes-execution-system'
+  validations:
+    - expression: >-
+        request.userInfo.username ==
+        'system:serviceaccount:openkubes-execution-system:ok147-contract-executor'
+      message: only the bounded contract executor may create ledger ConfigMaps
+    - expression: >-
+        object.metadata.name.matches('^ok147-(claim|outcome)-[0-9a-f]{48}$')
+      message: ledger ConfigMap name must bind an exact claim or outcome key
+    - expression: has(object.immutable) && object.immutable == true
+      message: ledger ConfigMaps must be immutable
+    - expression: >-
+        has(object.data) && size(object.data) == 1 &&
+        'receipt.json' in object.data &&
+        (!has(object.binaryData) || size(object.binaryData) == 0)
+      message: ledger ConfigMaps may contain only data.receipt.json
+    - expression: >-
+        has(object.metadata.labels) && size(object.metadata.labels) == 2 &&
+        object.metadata.labels['app.kubernetes.io/managed-by'] ==
+        'ok-cluster-contract-executor' &&
+        object.metadata.labels['openkubes.io/ledger-record'] in ['claim', 'outcome']
+      message: ledger ConfigMap labels are invalid
+    - expression: >-
+        (object.metadata.name.startsWith('ok147-claim-') &&
+        object.metadata.labels['openkubes.io/ledger-record'] == 'claim') ||
+        (object.metadata.name.startsWith('ok147-outcome-') &&
+        object.metadata.labels['openkubes.io/ledger-record'] == 'outcome')
+      message: ledger record label must match its name
+    - expression: >-
+        has(object.metadata.annotations) && size(object.metadata.annotations) == 2 &&
+        object.metadata.annotations['openkubes.io/record-key'].matches('^[0-9a-f]{64}$') &&
+        object.metadata.annotations['openkubes.io/content-digest'].matches('^sha256:[0-9a-f]{64}$')
+      message: ledger identity annotations are invalid
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: ok147-contract-executor-ledger
+spec:
+  policyName: ok147-contract-executor-ledger
+  validationActions: [Deny]
+  matchResources:
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: openkubes-execution-system

--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -138,10 +138,55 @@ Ledger directories must be real private directories and records must remain
 regular `0600` files. Non-canonical or modified records are rejected. Tests
 prove that 24 concurrent claim attempts produce exactly one winner.
 
-This local ledger proves the consumption and restart algorithm only. A real
-Job must use a durable, authority-controlled backing store that survives Job and
-node loss; an `emptyDir` alone cannot enforce single use across Job recreation.
-Selecting and integrating that backing store remains a later checkpoint.
+The filesystem backend proves the consumption algorithm for local execution.
+It is not sufficient for a Job because an `emptyDir` cannot enforce single use
+across Job recreation.
+
+## Durable Kubernetes ledger boundary
+
+The fourth checkpoint adds a `RecordStore` implementation that persists the
+same canonical receipts as immutable ConfigMaps on `ok-mgmt`. It is a durable
+execution-evidence store, not a second lifecycle source of truth:
+
+```text
+verified grant
+      |
+      v
+POST immutable claim ConfigMap (create-if-absent)
+      |
+      +-- executor disappears --> replacement GETs the same exact name
+      |                          --> CLAIMED_INDETERMINATE_STOP
+      v
+future bounded operation
+      |
+      v
+POST immutable outcome ConfigMap
+```
+
+The client performs only exact-name `GET` requests and collection `POST`
+creates. It never lists, watches, updates, patches, deletes, or follows an API
+redirect. A `409 Conflict` consumes the grant fail-closed. Every object uses a
+deterministic name derived from the full grant-key digest, is `immutable: true`,
+and carries the full key plus the canonical receipt digest. Responses are
+verified before they are trusted.
+
+[`deploy/contract-executor-ledger.yaml`](../deploy/contract-executor-ledger.yaml)
+is an offline deployment candidate containing a dedicated namespace, Service
+Account, `get`/`create`-only Role, and a fail-closed
+`ValidatingAdmissionPolicy`. Within the dedicated namespace, the admission
+policy denies ConfigMap creation by every identity except the exact Service
+Account and binds object-name shape, immutable flag, receipt-only data shape,
+exact labels, and digest syntax. Kubernetes CEL has no SHA-256 primitive, so admission
+cannot prove that `content-digest` equals `receipt.json`; the Go client performs
+that equality check on every create response and read. Likewise, RBAC cannot
+restrict `create` to one exact body. Signed request binding and strict receipt
+validation remain required application-level controls.
+
+The Service Account deliberately has no mutation authority over CAPI, provider,
+enablement, GitOps, or workload resources in this checkpoint. The manifest is
+not deployed, the Kubernetes store is not yet wired to a Job, and no cluster was
+contacted. Tests use an in-memory API transport and prove that a replacement
+executor observes the original claim and cannot reuse it.
 
 ## OK-141 compatibility evidence
 

--- a/internal/ledger/deployment_test.go
+++ b/internal/ledger/deployment_test.go
@@ -1,0 +1,122 @@
+package ledger
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestKubernetesLedgerDeploymentBoundary(t *testing.T) {
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("cannot resolve test path")
+	}
+	raw, err := os.ReadFile(filepath.Join(filepath.Dir(filename), "..", "..", "deploy", "contract-executor-ledger.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	decoder := yaml.NewDecoder(bytes.NewReader(raw))
+	objects := map[string]map[string]any{}
+	for {
+		var object map[string]any
+		if err := decoder.Decode(&object); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			t.Fatal(err)
+		}
+		kind, _ := object["kind"].(string)
+		objects[kind] = object
+	}
+
+	for _, kind := range []string{"Namespace", "ServiceAccount", "Role", "RoleBinding", "ValidatingAdmissionPolicy", "ValidatingAdmissionPolicyBinding"} {
+		if objects[kind] == nil {
+			t.Fatalf("deployment lacks %s", kind)
+		}
+	}
+	roleRules := nestedSlice(t, objects["Role"], "rules")
+	if len(roleRules) != 1 {
+		t.Fatalf("ledger Role has %d rules, want 1", len(roleRules))
+	}
+	rule := roleRules[0].(map[string]any)
+	verbs := stringsFrom(t, rule["verbs"])
+	sort.Strings(verbs)
+	if len(verbs) != 2 || verbs[0] != "create" || verbs[1] != "get" {
+		t.Fatalf("ledger Role verbs = %v, want only create/get", verbs)
+	}
+	resources := stringsFrom(t, rule["resources"])
+	if len(resources) != 1 || resources[0] != "configmaps" {
+		t.Fatalf("ledger Role resources = %v, want only configmaps", resources)
+	}
+
+	policy := objects["ValidatingAdmissionPolicy"]
+	spec := nestedMap(t, policy, "spec")
+	if spec["failurePolicy"] != "Fail" {
+		t.Fatalf("admission failurePolicy = %v, want Fail", spec["failurePolicy"])
+	}
+	conditions := nestedSlice(t, spec, "matchConditions")
+	if len(conditions) != 1 {
+		t.Fatalf("admission matchConditions = %d, want 1", len(conditions))
+	}
+	conditionExpression := conditions[0].(map[string]any)["expression"].(string)
+	if !bytes.Contains([]byte(conditionExpression), []byte("openkubes-execution-system")) {
+		t.Fatal("admission match condition does not bind the ledger namespace")
+	}
+	validations := nestedSlice(t, spec, "validations")
+	if len(validations) < 7 {
+		t.Fatalf("admission has %d validations, want at least 7", len(validations))
+	}
+	serviceAccountBound := false
+	for _, validation := range validations {
+		expression, _ := validation.(map[string]any)["expression"].(string)
+		if bytes.Contains([]byte(expression), []byte("ok147-contract-executor")) {
+			serviceAccountBound = true
+		}
+	}
+	if !serviceAccountBound {
+		t.Fatal("admission validations do not bind the exact ServiceAccount")
+	}
+}
+
+func nestedMap(t *testing.T, object map[string]any, key string) map[string]any {
+	t.Helper()
+	value, ok := object[key].(map[string]any)
+	if !ok {
+		t.Fatalf("%s is not an object", key)
+	}
+	return value
+}
+
+func nestedSlice(t *testing.T, object map[string]any, key string) []any {
+	t.Helper()
+	value, ok := object[key].([]any)
+	if !ok {
+		t.Fatalf("%s is not an array", key)
+	}
+	return value
+}
+
+func stringsFrom(t *testing.T, value any) []string {
+	t.Helper()
+	items, ok := value.([]any)
+	if !ok {
+		t.Fatalf("value %T is not an array", value)
+	}
+	result := make([]string, 0, len(items))
+	for _, item := range items {
+		text, ok := item.(string)
+		if !ok {
+			t.Fatalf("array item %T is not a string", item)
+		}
+		result = append(result, text)
+	}
+	return result
+}

--- a/internal/ledger/kubernetes.go
+++ b/internal/ledger/kubernetes.go
@@ -1,0 +1,295 @@
+package ledger
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/contract"
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+const receiptDataKey = "receipt.json"
+
+// KubernetesStoreConfig contains an already trust-configured HTTP client and a
+// short-lived bearer token. TLS and credential materialization stay outside the
+// ledger so local CLI and in-cluster Job adapters can use different sources.
+type KubernetesStoreConfig struct {
+	Endpoint    string
+	Namespace   string
+	BearerToken string
+	Client      *http.Client
+}
+
+// KubernetesStore persists immutable receipts as exact-name ConfigMaps. It
+// performs only POST collection creates and GET-by-name requests.
+type KubernetesStore struct {
+	endpoint  *url.URL
+	namespace string
+	token     string
+	client    *http.Client
+}
+
+// NewKubernetesStore validates the transport boundary. Non-TLS endpoints are
+// accepted only for loopback test servers.
+func NewKubernetesStore(config KubernetesStoreConfig) (*KubernetesStore, error) {
+	endpoint, err := url.Parse(config.Endpoint)
+	if err != nil || endpoint.Host == "" || endpoint.User != nil || endpoint.RawQuery != "" || endpoint.Fragment != "" {
+		return nil, errors.New("Kubernetes ledger endpoint is invalid")
+	}
+	if endpoint.Path != "" && endpoint.Path != "/" {
+		return nil, errors.New("Kubernetes ledger endpoint must not contain a path")
+	}
+	host := endpoint.Hostname()
+	if endpoint.Scheme != "https" && !(endpoint.Scheme == "http" && (host == "127.0.0.1" || host == "::1" || host == "localhost")) {
+		return nil, errors.New("Kubernetes ledger endpoint must use HTTPS")
+	}
+	if !regexp.MustCompile(`^[a-z0-9](?:[-a-z0-9]*[a-z0-9])?$`).MatchString(config.Namespace) || len(config.Namespace) > 63 {
+		return nil, errors.New("Kubernetes ledger namespace is invalid")
+	}
+	if config.BearerToken == "" || strings.TrimSpace(config.BearerToken) != config.BearerToken || strings.ContainsAny(config.BearerToken, "\r\n") {
+		return nil, errors.New("Kubernetes ledger bearer token is invalid")
+	}
+	if config.Client == nil {
+		return nil, errors.New("Kubernetes ledger requires an explicitly configured HTTP client")
+	}
+	client := *config.Client
+	client.CheckRedirect = func(_ *http.Request, _ []*http.Request) error { return http.ErrUseLastResponse }
+	if client.Timeout == 0 {
+		client.Timeout = 15 * time.Second
+	}
+	endpoint.Path = ""
+	return &KubernetesStore{endpoint: endpoint, namespace: config.Namespace, token: config.BearerToken, client: &client}, nil
+}
+
+func (store *KubernetesStore) Create(ctx context.Context, category, key string, raw []byte) error {
+	name, recordType, err := kubernetesRecordIdentity(category, key)
+	if err != nil {
+		return err
+	}
+	if err := validateCanonicalReceipt(raw); err != nil {
+		return err
+	}
+	object := configMap{
+		APIVersion: "v1",
+		Kind:       "ConfigMap",
+		Metadata: objectMeta{
+			Name:      name,
+			Namespace: store.namespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/managed-by": "ok-cluster-contract-executor",
+				"openkubes.io/ledger-record":   recordType,
+			},
+			Annotations: map[string]string{
+				"openkubes.io/record-key":     key,
+				"openkubes.io/content-digest": digest.SHA256(raw),
+			},
+		},
+		Immutable: boolPointer(true),
+		Data:      map[string]string{receiptDataKey: string(raw)},
+	}
+	body, err := json.Marshal(object)
+	if err != nil {
+		return err
+	}
+	response, status, err := store.request(ctx, http.MethodPost, store.collectionPath(), body)
+	if err != nil {
+		return err
+	}
+	if status == http.StatusConflict {
+		return ErrRecordExists
+	}
+	if status != http.StatusCreated {
+		return apiStatusError(http.MethodPost, status, response)
+	}
+	return verifyConfigMap(response, object, raw, true)
+}
+
+func (store *KubernetesStore) Get(ctx context.Context, category, key string) ([]byte, error) {
+	name, recordType, err := kubernetesRecordIdentity(category, key)
+	if err != nil {
+		return nil, err
+	}
+	expected := configMap{
+		APIVersion: "v1",
+		Kind:       "ConfigMap",
+		Metadata: objectMeta{
+			Name: name, Namespace: store.namespace,
+			Labels:      map[string]string{"app.kubernetes.io/managed-by": "ok-cluster-contract-executor", "openkubes.io/ledger-record": recordType},
+			Annotations: map[string]string{"openkubes.io/record-key": key},
+		},
+	}
+	response, status, err := store.request(ctx, http.MethodGet, store.objectPath(name), nil)
+	if err != nil {
+		return nil, err
+	}
+	if status == http.StatusNotFound {
+		return nil, ErrRecordNotFound
+	}
+	if status != http.StatusOK {
+		return nil, apiStatusError(http.MethodGet, status, response)
+	}
+	var observed configMap
+	if err := json.Unmarshal(response, &observed); err != nil {
+		return nil, errors.New("Kubernetes API returned an invalid ConfigMap")
+	}
+	raw, ok := observed.Data[receiptDataKey]
+	if !ok {
+		return nil, errors.New("Kubernetes ledger ConfigMap has no receipt.json")
+	}
+	expected.Metadata.Annotations["openkubes.io/content-digest"] = digest.SHA256([]byte(raw))
+	expected.Immutable = boolPointer(true)
+	expected.Data = map[string]string{receiptDataKey: raw}
+	if err := verifyConfigMap(response, expected, []byte(raw), true); err != nil {
+		return nil, err
+	}
+	if err := validateCanonicalReceipt([]byte(raw)); err != nil {
+		return nil, err
+	}
+	return []byte(raw), nil
+}
+
+type objectMeta struct {
+	Name            string            `json:"name"`
+	Namespace       string            `json:"namespace,omitempty"`
+	UID             string            `json:"uid,omitempty"`
+	ResourceVersion string            `json:"resourceVersion,omitempty"`
+	Labels          map[string]string `json:"labels,omitempty"`
+	Annotations     map[string]string `json:"annotations,omitempty"`
+}
+
+type configMap struct {
+	APIVersion string            `json:"apiVersion"`
+	Kind       string            `json:"kind"`
+	Metadata   objectMeta        `json:"metadata"`
+	Immutable  *bool             `json:"immutable,omitempty"`
+	Data       map[string]string `json:"data,omitempty"`
+	BinaryData map[string]string `json:"binaryData,omitempty"`
+}
+
+func (store *KubernetesStore) request(ctx context.Context, method, path string, body []byte) ([]byte, int, error) {
+	endpoint := *store.endpoint
+	endpoint.Path = path
+	request, err := http.NewRequestWithContext(ctx, method, endpoint.String(), bytes.NewReader(body))
+	if err != nil {
+		return nil, 0, err
+	}
+	request.Header.Set("Accept", "application/json")
+	request.Header.Set("Authorization", "Bearer "+store.token)
+	if body != nil {
+		request.Header.Set("Content-Type", "application/json")
+	}
+	response, err := store.client.Do(request)
+	if err != nil {
+		return nil, 0, fmt.Errorf("Kubernetes ledger %s request failed", method)
+	}
+	defer response.Body.Close()
+	raw, err := io.ReadAll(io.LimitReader(response.Body, 1<<20))
+	if err != nil {
+		return nil, 0, fmt.Errorf("read Kubernetes ledger response: %w", err)
+	}
+	return raw, response.StatusCode, nil
+}
+
+func (store *KubernetesStore) collectionPath() string {
+	return "/api/v1/namespaces/" + store.namespace + "/configmaps"
+}
+
+func (store *KubernetesStore) objectPath(name string) string {
+	return store.collectionPath() + "/" + name
+}
+
+func kubernetesRecordIdentity(category, key string) (string, string, error) {
+	if !regexp.MustCompile(`^[0-9a-f]{64}$`).MatchString(key) {
+		return "", "", errors.New("Kubernetes ledger record key is invalid")
+	}
+	var recordType string
+	switch category {
+	case "claims":
+		recordType = "claim"
+	case "outcomes":
+		recordType = "outcome"
+	default:
+		return "", "", fmt.Errorf("Kubernetes ledger record category %q is invalid", category)
+	}
+	return "ok147-" + recordType + "-" + key[:48], recordType, nil
+}
+
+func validateCanonicalReceipt(raw []byte) error {
+	if len(raw) == 0 || len(raw) > 256*1024 {
+		return errors.New("Kubernetes ledger receipt size is invalid")
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	var value any
+	if err := decoder.Decode(&value); err != nil {
+		return errors.New("Kubernetes ledger receipt is invalid JSON")
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		return errors.New("Kubernetes ledger receipt has trailing JSON")
+	}
+	canonical, err := contract.JCS(value)
+	if err != nil {
+		return fmt.Errorf("canonicalize Kubernetes ledger receipt: %w", err)
+	}
+	if !bytes.Equal(raw, canonical) {
+		return errors.New("Kubernetes ledger receipt is not canonical JSON")
+	}
+	return nil
+}
+
+func verifyConfigMap(raw []byte, expected configMap, receipt []byte, requireServerIdentity bool) error {
+	var observed configMap
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	if err := decoder.Decode(&observed); err != nil {
+		return errors.New("Kubernetes API returned an invalid ConfigMap")
+	}
+	if observed.APIVersion != expected.APIVersion || observed.Kind != expected.Kind || observed.Metadata.Name != expected.Metadata.Name || observed.Metadata.Namespace != expected.Metadata.Namespace {
+		return errors.New("Kubernetes API returned a different ledger ConfigMap identity")
+	}
+	if requireServerIdentity && (observed.Metadata.UID == "" || observed.Metadata.ResourceVersion == "") {
+		return errors.New("Kubernetes API response lacks ConfigMap UID or resourceVersion")
+	}
+	if observed.Immutable == nil || !*observed.Immutable || len(observed.BinaryData) != 0 || len(observed.Data) != 1 || observed.Data[receiptDataKey] != string(receipt) {
+		return errors.New("Kubernetes ledger ConfigMap payload or immutable flag differs")
+	}
+	for key, value := range expected.Metadata.Labels {
+		if observed.Metadata.Labels[key] != value {
+			return fmt.Errorf("Kubernetes ledger ConfigMap label %s differs", key)
+		}
+	}
+	if len(observed.Metadata.Labels) != len(expected.Metadata.Labels) {
+		return errors.New("Kubernetes ledger ConfigMap has unexpected labels")
+	}
+	for key, value := range expected.Metadata.Annotations {
+		if observed.Metadata.Annotations[key] != value {
+			return fmt.Errorf("Kubernetes ledger ConfigMap annotation %s differs", key)
+		}
+	}
+	if len(observed.Metadata.Annotations) != len(expected.Metadata.Annotations) {
+		return errors.New("Kubernetes ledger ConfigMap has unexpected annotations")
+	}
+	return nil
+}
+
+func apiStatusError(method string, status int, raw []byte) error {
+	var response struct {
+		Reason string `json:"reason"`
+	}
+	_ = json.Unmarshal(raw, &response)
+	if response.Reason == "" {
+		response.Reason = http.StatusText(status)
+	}
+	return fmt.Errorf("Kubernetes ledger %s returned status %d (%s)", method, status, response.Reason)
+}
+
+func boolPointer(value bool) *bool { return &value }

--- a/internal/ledger/kubernetes_test.go
+++ b/internal/ledger/kubernetes_test.go
@@ -1,0 +1,260 @@
+package ledger
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestKubernetesStoreSurvivesExecutorRecreation(t *testing.T) {
+	api := newFakeConfigMapAPI(t)
+	store := newTestKubernetesStore(t, api.client())
+	firstLedger, err := New(store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	at := time.Date(2026, 8, 16, 10, 0, 0, 0, time.UTC)
+	grant := verifiedGrant(t, at)
+	ctx := context.Background()
+
+	initial, err := firstLedger.Inspect(ctx, grant)
+	if err != nil || initial.State != "AVAILABLE" || !initial.ClaimAllowed {
+		t.Fatalf("initial inspection: %#v %v", initial, err)
+	}
+	claim, err := firstLedger.Claim(ctx, grant, at)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// A new store and ledger model a replacement Job/process.
+	replacementLedger, err := New(newTestKubernetesStore(t, api.client()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	indeterminate, err := replacementLedger.Inspect(ctx, grant)
+	if err != nil || indeterminate.State != "CLAIMED_INDETERMINATE_STOP" || indeterminate.ClaimAllowed {
+		t.Fatalf("replacement inspection: %#v %v", indeterminate, err)
+	}
+	if _, err := replacementLedger.Claim(ctx, grant, at.Add(time.Second)); err != ErrGrantConsumed {
+		t.Fatalf("replacement reused grant: %v", err)
+	}
+	evidence := "sha256:" + strings.Repeat("e", 64)
+	if _, err := replacementLedger.Complete(ctx, claim, "SUCCEEDED", "ATTEMPTED", evidence, at.Add(2*time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	completed, err := firstLedger.Inspect(ctx, grant)
+	if err != nil || completed.State != "COMPLETED" || completed.Outcome == nil {
+		t.Fatalf("completed inspection: %#v %v", completed, err)
+	}
+	if api.nonExactRequests.Load() != 0 {
+		t.Fatalf("store issued %d non-exact requests", api.nonExactRequests.Load())
+	}
+}
+
+func TestKubernetesStoreAtomicClaim(t *testing.T) {
+	api := newFakeConfigMapAPI(t)
+	at := time.Date(2026, 8, 16, 10, 0, 0, 0, time.UTC)
+	grant := verifiedGrant(t, at)
+	ctx := context.Background()
+	var winners atomic.Int32
+	var consumed atomic.Int32
+	var wait sync.WaitGroup
+	for index := 0; index < 24; index++ {
+		wait.Add(1)
+		go func() {
+			defer wait.Done()
+			store, err := New(newTestKubernetesStore(t, api.client()))
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			if _, err := store.Claim(ctx, grant, at); err == nil {
+				winners.Add(1)
+			} else if err == ErrGrantConsumed {
+				consumed.Add(1)
+			} else {
+				t.Errorf("claim: %v", err)
+			}
+		}()
+	}
+	wait.Wait()
+	if winners.Load() != 1 || consumed.Load() != 23 {
+		t.Fatalf("winners=%d consumed=%d", winners.Load(), consumed.Load())
+	}
+}
+
+func TestKubernetesStoreFailsClosed(t *testing.T) {
+	t.Run("requires HTTPS outside loopback", func(t *testing.T) {
+		_, err := NewKubernetesStore(KubernetesStoreConfig{Endpoint: "http://api.example.test", Namespace: "openkubes-execution-system", BearerToken: "token", Client: http.DefaultClient})
+		if err == nil || !strings.Contains(err.Error(), "HTTPS") {
+			t.Fatalf("expected TLS rejection, got %v", err)
+		}
+	})
+	t.Run("rejects noncanonical receipt before request", func(t *testing.T) {
+		api := newFakeConfigMapAPI(t)
+		store := newTestKubernetesStore(t, api.client())
+		err := store.Create(context.Background(), "claims", strings.Repeat("a", 64), []byte(" {\"format\":\"x\"}"))
+		if err == nil || !strings.Contains(err.Error(), "canonical") || api.requests.Load() != 0 {
+			t.Fatalf("expected local canonical rejection, requests=%d err=%v", api.requests.Load(), err)
+		}
+	})
+	t.Run("does not follow API redirect", func(t *testing.T) {
+		var calls atomic.Int32
+		client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			calls.Add(1)
+			return jsonResponse(http.StatusTemporaryRedirect, nil, map[string]string{"Location": "http://127.0.0.1:12346/redirected"}), nil
+		})}
+		store := newTestKubernetesStore(t, client)
+		_, err := store.Get(context.Background(), "claims", strings.Repeat("a", 64))
+		if err == nil || calls.Load() != 1 {
+			t.Fatalf("redirect was followed or accepted: calls=%d err=%v", calls.Load(), err)
+		}
+	})
+	t.Run("maps create conflict to immutable existence", func(t *testing.T) {
+		api := newFakeConfigMapAPI(t)
+		store := newTestKubernetesStore(t, api.client())
+		key := strings.Repeat("a", 64)
+		receipt := []byte("{\"format\":\"x\"}")
+		if err := store.Create(context.Background(), "claims", key, receipt); err != nil {
+			t.Fatal(err)
+		}
+		if err := store.Create(context.Background(), "claims", key, receipt); err != ErrRecordExists {
+			t.Fatalf("second create = %v, want ErrRecordExists", err)
+		}
+	})
+}
+
+func TestKubernetesStoreRejectsTamperedConfigMap(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		mutate func(*configMap)
+	}{
+		{name: "content digest", mutate: func(object *configMap) {
+			object.Metadata.Annotations["openkubes.io/content-digest"] = "sha256:" + strings.Repeat("b", 64)
+		}},
+		{name: "unexpected label", mutate: func(object *configMap) {
+			object.Metadata.Labels["unexpected"] = "value"
+		}},
+		{name: "missing server identity", mutate: func(object *configMap) {
+			object.Metadata.UID = ""
+		}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			api := newFakeConfigMapAPI(t)
+			store := newTestKubernetesStore(t, api.client())
+			key := strings.Repeat("a", 64)
+			if err := store.Create(context.Background(), "claims", key, []byte("{\"format\":\"x\"}")); err != nil {
+				t.Fatal(err)
+			}
+			name, _, err := kubernetesRecordIdentity("claims", key)
+			if err != nil {
+				t.Fatal(err)
+			}
+			api.mu.Lock()
+			object := api.objects[name]
+			test.mutate(&object)
+			api.objects[name] = object
+			api.mu.Unlock()
+			if _, err := store.Get(context.Background(), "claims", key); err == nil {
+				t.Fatal("tampered ConfigMap was accepted")
+			}
+		})
+	}
+}
+
+type fakeConfigMapAPI struct {
+	t                *testing.T
+	mu               sync.Mutex
+	objects          map[string]configMap
+	requests         atomic.Int32
+	nonExactRequests atomic.Int32
+}
+
+func newFakeConfigMapAPI(t *testing.T) *fakeConfigMapAPI {
+	t.Helper()
+	return &fakeConfigMapAPI{t: t, objects: map[string]configMap{}}
+}
+
+func (api *fakeConfigMapAPI) client() *http.Client {
+	return &http.Client{Transport: roundTripFunc(api.roundTrip)}
+}
+
+func (api *fakeConfigMapAPI) roundTrip(request *http.Request) (*http.Response, error) {
+	api.requests.Add(1)
+	if request.Header.Get("Authorization") != "Bearer short-lived-test-token" {
+		api.t.Errorf("authorization header differs")
+		return jsonResponse(http.StatusUnauthorized, nil, nil), nil
+	}
+	prefix := "/api/v1/namespaces/openkubes-execution-system/configmaps"
+	if request.Method == http.MethodPost && request.URL.Path == prefix {
+		if request.Header.Get("Content-Type") != "application/json" {
+			api.t.Errorf("POST content type differs")
+		}
+		var object configMap
+		if err := json.NewDecoder(request.Body).Decode(&object); err != nil {
+			return jsonResponse(http.StatusBadRequest, nil, nil), nil
+		}
+		api.mu.Lock()
+		defer api.mu.Unlock()
+		if _, exists := api.objects[object.Metadata.Name]; exists {
+			return jsonResponse(http.StatusConflict, nil, nil), nil
+		}
+		object.Metadata.UID = "test-uid-" + object.Metadata.Name
+		object.Metadata.ResourceVersion = "1"
+		api.objects[object.Metadata.Name] = object
+		return jsonResponse(http.StatusCreated, object, nil), nil
+	}
+	if request.Method == http.MethodGet && strings.HasPrefix(request.URL.Path, prefix+"/") && !strings.Contains(strings.TrimPrefix(request.URL.Path, prefix+"/"), "/") {
+		name := strings.TrimPrefix(request.URL.Path, prefix+"/")
+		api.mu.Lock()
+		defer api.mu.Unlock()
+		object, exists := api.objects[name]
+		if !exists {
+			return jsonResponse(http.StatusNotFound, nil, nil), nil
+		}
+		return jsonResponse(http.StatusOK, object, nil), nil
+	}
+	api.nonExactRequests.Add(1)
+	return jsonResponse(http.StatusMethodNotAllowed, nil, nil), nil
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (function roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return function(request)
+}
+
+func jsonResponse(status int, value any, headers map[string]string) *http.Response {
+	var body []byte
+	if value != nil {
+		body, _ = json.Marshal(value)
+	}
+	header := make(http.Header)
+	header.Set("Content-Type", "application/json")
+	for key, value := range headers {
+		header.Set(key, value)
+	}
+	return &http.Response{
+		StatusCode: status,
+		Header:     header,
+		Body:       io.NopCloser(bytes.NewReader(body)),
+	}
+}
+
+func newTestKubernetesStore(t *testing.T, client *http.Client) *KubernetesStore {
+	t.Helper()
+	store, err := NewKubernetesStore(KubernetesStoreConfig{
+		Endpoint: "http://127.0.0.1:12345", Namespace: "openkubes-execution-system", BearerToken: "short-lived-test-token", Client: client,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return store
+}

--- a/internal/ledger/ledger.go
+++ b/internal/ledger/ledger.go
@@ -5,6 +5,7 @@ package ledger
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -27,11 +28,21 @@ const (
 
 var ErrGrantConsumed = errors.New("authorization grant is already consumed")
 
+var (
+	ErrRecordExists   = errors.New("ledger record already exists")
+	ErrRecordNotFound = errors.New("ledger record not found")
+)
+
+// RecordStore is the only persistence capability required by the ledger.
+// Implementations must provide atomic create-if-absent and exact-name reads.
+type RecordStore interface {
+	Create(context.Context, string, string, []byte) error
+	Get(context.Context, string, string) ([]byte, error)
+}
+
 // Ledger stores immutable claim and outcome files below a private directory.
 type Ledger struct {
-	root     string
-	claims   string
-	outcomes string
+	store RecordStore
 }
 
 // ClaimReceipt is written atomically before a future operation begins.
@@ -84,19 +95,27 @@ func Open(root string) (*Ledger, error) {
 	if err := secureDirectory(abs); err != nil {
 		return nil, err
 	}
-	result := &Ledger{root: abs, claims: filepath.Join(abs, "claims"), outcomes: filepath.Join(abs, "outcomes")}
-	if err := secureDirectory(result.claims); err != nil {
+	store := &fileStore{claims: filepath.Join(abs, "claims"), outcomes: filepath.Join(abs, "outcomes")}
+	if err := secureDirectory(store.claims); err != nil {
 		return nil, err
 	}
-	if err := secureDirectory(result.outcomes); err != nil {
+	if err := secureDirectory(store.outcomes); err != nil {
 		return nil, err
 	}
-	return result, nil
+	return New(store)
+}
+
+// New constructs a ledger around a durable RecordStore.
+func New(store RecordStore) (*Ledger, error) {
+	if store == nil {
+		return nil, errors.New("ledger record store is required")
+	}
+	return &Ledger{store: store}, nil
 }
 
 // Claim atomically consumes a verified grant. A second call always returns
 // ErrGrantConsumed, including after a process crash.
-func (ledger *Ledger) Claim(grant authorization.VerifiedGrant, at time.Time) (ClaimReceipt, error) {
+func (ledger *Ledger) Claim(ctx context.Context, grant authorization.VerifiedGrant, at time.Time) (ClaimReceipt, error) {
 	binding, err := grant.ConsumptionBinding()
 	if err != nil {
 		return ClaimReceipt{}, err
@@ -124,9 +143,9 @@ func (ledger *Ledger) Claim(grant authorization.VerifiedGrant, at time.Time) (Cl
 	if err != nil {
 		return ClaimReceipt{}, err
 	}
-	path := ledger.claimPath(binding.GrantID)
-	if err := writeExclusive(path, raw, ledger.claims); err != nil {
-		if errors.Is(err, os.ErrExist) {
+	key := recordKey(binding.GrantID)
+	if err := ledger.store.Create(ctx, "claims", key, raw); err != nil {
+		if errors.Is(err, ErrRecordExists) {
 			return ClaimReceipt{}, ErrGrantConsumed
 		}
 		return ClaimReceipt{}, fmt.Errorf("write grant claim: %w", err)
@@ -136,7 +155,7 @@ func (ledger *Ledger) Claim(grant authorization.VerifiedGrant, at time.Time) (Cl
 
 // Complete writes one outcome. Repeating the exact completion is idempotent;
 // a conflicting completion fails closed.
-func (ledger *Ledger) Complete(claim ClaimReceipt, outcome, mutationState, evidenceDigest string, at time.Time) (OutcomeReceipt, error) {
+func (ledger *Ledger) Complete(ctx context.Context, claim ClaimReceipt, outcome, mutationState, evidenceDigest string, at time.Time) (OutcomeReceipt, error) {
 	if !allowed(outcome, "SUCCEEDED", "FAILED", "STOPPED") {
 		return OutcomeReceipt{}, fmt.Errorf("unsupported outcome %q", outcome)
 	}
@@ -149,7 +168,7 @@ func (ledger *Ledger) Complete(claim ClaimReceipt, outcome, mutationState, evide
 	if !validDigest(evidenceDigest) {
 		return OutcomeReceipt{}, errors.New("evidence digest is invalid")
 	}
-	stored, claimDigest, err := ledger.readClaim(claim.GrantID)
+	stored, claimDigest, err := ledger.readClaim(ctx, claim.GrantID)
 	if err != nil {
 		return OutcomeReceipt{}, err
 	}
@@ -180,12 +199,12 @@ func (ledger *Ledger) Complete(claim ClaimReceipt, outcome, mutationState, evide
 	if err != nil {
 		return OutcomeReceipt{}, err
 	}
-	path := ledger.outcomePath(claim.GrantID)
-	if err := writeExclusive(path, raw, ledger.outcomes); err != nil {
-		if !errors.Is(err, os.ErrExist) {
+	key := recordKey(claim.GrantID)
+	if err := ledger.store.Create(ctx, "outcomes", key, raw); err != nil {
+		if !errors.Is(err, ErrRecordExists) {
 			return OutcomeReceipt{}, fmt.Errorf("write operation outcome: %w", err)
 		}
-		existing, existingDigest, readErr := ledger.readOutcome(claim.GrantID)
+		existing, existingDigest, readErr := ledger.readOutcome(ctx, claim.GrantID)
 		if readErr != nil {
 			return OutcomeReceipt{}, readErr
 		}
@@ -199,13 +218,13 @@ func (ledger *Ledger) Complete(claim ClaimReceipt, outcome, mutationState, evide
 
 // Inspect returns AVAILABLE, CLAIMED_INDETERMINATE_STOP, or COMPLETED. It never
 // recommends retrying an already claimed grant.
-func (ledger *Ledger) Inspect(grant authorization.VerifiedGrant) (Inspection, error) {
+func (ledger *Ledger) Inspect(ctx context.Context, grant authorization.VerifiedGrant) (Inspection, error) {
 	binding, err := grant.ConsumptionBinding()
 	if err != nil {
 		return Inspection{}, err
 	}
-	claim, claimDigest, err := ledger.readClaim(binding.GrantID)
-	if errors.Is(err, os.ErrNotExist) {
+	claim, claimDigest, err := ledger.readClaim(ctx, binding.GrantID)
+	if errors.Is(err, ErrRecordNotFound) {
 		return Inspection{State: "AVAILABLE", ClaimAllowed: true}, nil
 	}
 	if err != nil {
@@ -214,8 +233,8 @@ func (ledger *Ledger) Inspect(grant authorization.VerifiedGrant) (Inspection, er
 	if err := matchBinding(claim, binding); err != nil {
 		return Inspection{}, err
 	}
-	outcome, outcomeDigest, err := ledger.readOutcome(binding.GrantID)
-	if errors.Is(err, os.ErrNotExist) {
+	outcome, outcomeDigest, err := ledger.readOutcome(ctx, binding.GrantID)
+	if errors.Is(err, ErrRecordNotFound) {
 		return Inspection{State: "CLAIMED_INDETERMINATE_STOP", ClaimAllowed: false, ClaimDigest: claimDigest}, nil
 	}
 	if err != nil {
@@ -227,9 +246,9 @@ func (ledger *Ledger) Inspect(grant authorization.VerifiedGrant) (Inspection, er
 	return Inspection{State: "COMPLETED", ClaimAllowed: false, ClaimDigest: claimDigest, OutcomeDigest: outcomeDigest, Outcome: &outcome}, nil
 }
 
-func (ledger *Ledger) readClaim(grantID string) (ClaimReceipt, string, error) {
+func (ledger *Ledger) readClaim(ctx context.Context, grantID string) (ClaimReceipt, string, error) {
 	var value ClaimReceipt
-	raw, err := readRegular(ledger.claimPath(grantID))
+	raw, err := ledger.store.Get(ctx, "claims", recordKey(grantID))
 	if err != nil {
 		return value, "", err
 	}
@@ -246,9 +265,9 @@ func (ledger *Ledger) readClaim(grantID string) (ClaimReceipt, string, error) {
 	return value, identity, validateClaim(value)
 }
 
-func (ledger *Ledger) readOutcome(grantID string) (OutcomeReceipt, string, error) {
+func (ledger *Ledger) readOutcome(ctx context.Context, grantID string) (OutcomeReceipt, string, error) {
 	var value OutcomeReceipt
-	raw, err := readRegular(ledger.outcomePath(grantID))
+	raw, err := ledger.store.Get(ctx, "outcomes", recordKey(grantID))
 	if err != nil {
 		return value, "", err
 	}
@@ -265,12 +284,8 @@ func (ledger *Ledger) readOutcome(grantID string) (OutcomeReceipt, string, error
 	return value, identity, validateOutcome(value)
 }
 
-func (ledger *Ledger) claimPath(grantID string) string {
-	return filepath.Join(ledger.claims, digest.SHA256([]byte(grantID))[7:]+".json")
-}
-
-func (ledger *Ledger) outcomePath(grantID string) string {
-	return filepath.Join(ledger.outcomes, digest.SHA256([]byte(grantID))[7:]+".json")
+func recordKey(grantID string) string {
+	return digest.SHA256([]byte(grantID))[7:]
 }
 
 func canonicalRecord(value any) ([]byte, string, error) {
@@ -306,6 +321,59 @@ func secureDirectory(path string) error {
 		return fmt.Errorf("ledger directory %s permissions are broader than 0700", path)
 	}
 	return nil
+}
+
+type fileStore struct {
+	claims   string
+	outcomes string
+}
+
+func (store *fileStore) Create(ctx context.Context, category, key string, raw []byte) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	path, directory, err := store.path(category, key)
+	if err != nil {
+		return err
+	}
+	if err := writeExclusive(path, raw, directory); err != nil {
+		if errors.Is(err, os.ErrExist) {
+			return ErrRecordExists
+		}
+		return err
+	}
+	return nil
+}
+
+func (store *fileStore) Get(ctx context.Context, category, key string) ([]byte, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	path, _, err := store.path(category, key)
+	if err != nil {
+		return nil, err
+	}
+	raw, err := readRegular(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, ErrRecordNotFound
+	}
+	return raw, err
+}
+
+func (store *fileStore) path(category, key string) (string, string, error) {
+	if !regexp.MustCompile(`^[0-9a-f]{64}$`).MatchString(key) {
+		return "", "", errors.New("ledger record key is invalid")
+	}
+	var directory string
+	switch category {
+	case "claims":
+		directory = store.claims
+	case "outcomes":
+		directory = store.outcomes
+	default:
+		return "", "", fmt.Errorf("ledger record category %q is invalid", category)
+	}
+	return filepath.Join(directory, key+".json"), directory, nil
 }
 
 func writeExclusive(path string, raw []byte, directory string) (returnErr error) {

--- a/internal/ledger/ledger_test.go
+++ b/internal/ledger/ledger_test.go
@@ -1,6 +1,7 @@
 package ledger
 
 import (
+	"context"
 	"crypto/ed25519"
 	"crypto/rand"
 	"encoding/base64"
@@ -28,7 +29,8 @@ func TestClaimIsAtomicAndSingleUse(t *testing.T) {
 	}
 	at := time.Date(2026, 8, 16, 10, 0, 0, 0, time.UTC)
 	grant := verifiedGrant(t, at)
-	available, err := store.Inspect(grant)
+	ctx := context.Background()
+	available, err := store.Inspect(ctx, grant)
 	if err != nil || available.State != "AVAILABLE" || !available.ClaimAllowed {
 		t.Fatalf("grant is not initially available: %#v %v", available, err)
 	}
@@ -40,7 +42,7 @@ func TestClaimIsAtomicAndSingleUse(t *testing.T) {
 		wait.Add(1)
 		go func() {
 			defer wait.Done()
-			if _, err := store.Claim(grant, at); err == nil {
+			if _, err := store.Claim(ctx, grant, at); err == nil {
 				acquired.Add(1)
 			} else if errors.Is(err, ErrGrantConsumed) {
 				consumed.Add(1)
@@ -53,7 +55,7 @@ func TestClaimIsAtomicAndSingleUse(t *testing.T) {
 	if acquired.Load() != 1 || consumed.Load() != 23 {
 		t.Fatalf("acquired=%d consumed=%d", acquired.Load(), consumed.Load())
 	}
-	inspection, err := store.Inspect(grant)
+	inspection, err := store.Inspect(ctx, grant)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -69,26 +71,27 @@ func TestCompleteIsImmutableAndIdempotent(t *testing.T) {
 	}
 	at := time.Date(2026, 8, 16, 10, 0, 0, 0, time.UTC)
 	grant := verifiedGrant(t, at)
-	claim, err := store.Claim(grant, at)
+	ctx := context.Background()
+	claim, err := store.Claim(ctx, grant, at)
 	if err != nil {
 		t.Fatal(err)
 	}
 	evidence := "sha256:" + strings.Repeat("e", 64)
-	if _, err := store.Complete(claim, "SUCCEEDED", "NOT_ATTEMPTED", evidence, at.Add(time.Second)); err == nil {
+	if _, err := store.Complete(ctx, claim, "SUCCEEDED", "NOT_ATTEMPTED", evidence, at.Add(time.Second)); err == nil {
 		t.Fatal("successful CreateCluster without attempted mutation was accepted")
 	}
-	first, err := store.Complete(claim, "SUCCEEDED", "ATTEMPTED", evidence, at.Add(time.Second))
+	first, err := store.Complete(ctx, claim, "SUCCEEDED", "ATTEMPTED", evidence, at.Add(time.Second))
 	if err != nil {
 		t.Fatal(err)
 	}
-	second, err := store.Complete(claim, "SUCCEEDED", "ATTEMPTED", evidence, at.Add(time.Second))
+	second, err := store.Complete(ctx, claim, "SUCCEEDED", "ATTEMPTED", evidence, at.Add(time.Second))
 	if err != nil || second != first {
 		t.Fatalf("identical completion was not idempotent: %#v %v", second, err)
 	}
-	if _, err := store.Complete(claim, "FAILED", "UNKNOWN", evidence, at.Add(2*time.Second)); err == nil || !strings.Contains(err.Error(), "conflicting") {
+	if _, err := store.Complete(ctx, claim, "FAILED", "UNKNOWN", evidence, at.Add(2*time.Second)); err == nil || !strings.Contains(err.Error(), "conflicting") {
 		t.Fatalf("expected conflicting completion rejection, got %v", err)
 	}
-	inspection, err := store.Inspect(grant)
+	inspection, err := store.Inspect(ctx, grant)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -104,11 +107,16 @@ func TestTamperedClaimFailsClosed(t *testing.T) {
 	}
 	at := time.Date(2026, 8, 16, 10, 0, 0, 0, time.UTC)
 	grant := verifiedGrant(t, at)
-	claim, err := store.Claim(grant, at)
+	ctx := context.Background()
+	claim, err := store.Claim(ctx, grant, at)
 	if err != nil {
 		t.Fatal(err)
 	}
-	path := store.claimPath(claim.GrantID)
+	fileBackend := store.store.(*fileStore)
+	path, _, err := fileBackend.path("claims", recordKey(claim.GrantID))
+	if err != nil {
+		t.Fatal(err)
+	}
 	raw, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatal(err)
@@ -117,7 +125,7 @@ func TestTamperedClaimFailsClosed(t *testing.T) {
 	if err := os.WriteFile(path, tampered, 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := store.Inspect(grant); err == nil || !strings.Contains(err.Error(), "canonical") {
+	if _, err := store.Inspect(ctx, grant); err == nil || !strings.Contains(err.Error(), "canonical") {
 		t.Fatalf("expected tamper rejection, got %v", err)
 	}
 }


### PR DESCRIPTION
## What changed

- extract the single-use ledger behind an atomic `RecordStore` interface while retaining the local filesystem backend
- add an exact-name Kubernetes ConfigMap store for immutable claim and outcome receipts
- add a dedicated namespace, `get`/`create`-only RBAC, and fail-closed ValidatingAdmissionPolicy candidate
- prove executor replacement, 24-way atomic claim contention, tamper rejection, redirect rejection, and manifest boundaries entirely offline
- document the remaining Create-content and SHA-256 admission limits explicitly

## Why

A short-lived runner Job must preserve a consumed grant across process, Job, and node replacement. `emptyDir` cannot provide that boundary. This checkpoint makes the receipt algorithm durable without making the ledger a lifecycle source of truth or granting any CAPI/provider/GitOps mutation authority.

## Validation

- `CGO_ENABLED=0 go test ./...`
- `CGO_ENABLED=0 go vet ./...`
- `git diff --check`

`go test -race ./...` reached the ledger package but the local Go/macOS toolchain aborted its test binary with `missing LC_UUID`; the ordinary suite, including the concurrent Kubernetes-store test, passes. No cluster was contacted successfully and no infrastructure was changed.