### PR TITLE
OK-147: add bounded Job preflight envelope

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Powered by [Cluster API (CAPI)](https://cluster-api.sigs.k8s.io/), [CAPK (KubeVi
   short-lived `ok-mgmt` Jobs; it remains dry-run-only while verifying the
   OK-141 revision, existing projection, authority split, signed grant binding,
   fail-closed single-use receipt semantics, and an offline-tested durable
-  Kubernetes ledger boundary
+  Kubernetes ledger plus short-lived read-only Job preflight boundary
 
 ---
 

--- a/cmd/ok/main.go
+++ b/cmd/ok/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -12,10 +13,15 @@ import (
 	"github.com/openkubes/ok-cluster/internal/authorization"
 	"github.com/openkubes/ok-cluster/internal/contract"
 	"github.com/openkubes/ok-cluster/internal/executor"
+	"github.com/openkubes/ok-cluster/internal/ledger"
 	"github.com/openkubes/ok-cluster/internal/projection"
+	"github.com/openkubes/ok-cluster/internal/runner"
 )
 
-const version = "0.0.0-dev"
+const (
+	version         = "0.0.0-dev"
+	ledgerNamespace = "openkubes-execution-system"
+)
 
 type createPlan struct {
 	Format                  string                  `json:"format"`
@@ -30,6 +36,7 @@ type createPlan struct {
 	Request                 *executor.CreateRequest `json:"request,omitempty"`
 	RequestDigest           string                  `json:"requestDigest,omitempty"`
 	Authorization           *authorization.Receipt  `json:"authorization,omitempty"`
+	Ledger                  *ledger.Inspection      `json:"ledger,omitempty"`
 }
 
 func main() {
@@ -45,7 +52,7 @@ func run(arguments []string, stdout, stderr io.Writer) error {
 		return nil
 	}
 	if len(arguments) < 2 || arguments[0] != "cluster" || arguments[1] != "create" {
-		return errors.New("usage: ok cluster create --contract PATH --schema PATH --dry-run [--projection-manifest PATH] [--authorization PATH --authorization-key PATH --evaluation-time RFC3339]")
+		return errors.New("usage: ok cluster create --contract PATH --schema PATH --dry-run [--projection-manifest PATH] [--authorization PATH --authorization-key PATH --evaluation-time RFC3339] [--ledger-inspect --ledger-api-endpoint URL --ledger-token-file PATH --ledger-ca-file PATH]")
 	}
 	flags := flag.NewFlagSet("ok cluster create", flag.ContinueOnError)
 	flags.SetOutput(stderr)
@@ -57,6 +64,10 @@ func run(arguments []string, stdout, stderr io.Writer) error {
 	authorizationPath := flags.String("authorization", "", "path to a signed create authorization JSON document")
 	authorizationKeyPath := flags.String("authorization-key", "", "path to the trusted base64-encoded raw Ed25519 public key")
 	evaluationTime := flags.String("evaluation-time", "", "explicit RFC3339 authorization evaluation time")
+	ledgerInspect := flags.Bool("ledger-inspect", false, "read the exact durable grant state without claiming it")
+	ledgerAPIEndpoint := flags.String("ledger-api-endpoint", "", "TLS Kubernetes API endpoint for the durable ledger")
+	ledgerTokenFile := flags.String("ledger-token-file", "", "path to a projected short-lived ledger ServiceAccount token")
+	ledgerCAFile := flags.String("ledger-ca-file", "", "path to the projected Kubernetes API CA bundle")
 	if err := flags.Parse(arguments[2:]); err != nil {
 		return err
 	}
@@ -117,6 +128,7 @@ func run(arguments []string, stdout, stderr io.Writer) error {
 		plan.RequestDigest = requestDigest
 	}
 	providedAuthorizationInputs := countNonEmpty(*authorizationPath, *authorizationKeyPath, *evaluationTime)
+	var verifiedGrant authorization.VerifiedGrant
 	if providedAuthorizationInputs != 0 {
 		if plan.Request == nil {
 			return errors.New("--authorization requires --projection-manifest")
@@ -140,9 +152,30 @@ func run(arguments []string, stdout, stderr io.Writer) error {
 		if err != nil {
 			return err
 		}
+		verifiedGrant = grant
 		receipt := grant.Receipt()
 		plan.AuthorizationState = "VERIFIED"
 		plan.Authorization = &receipt
+	}
+	providedLedgerInputs := countNonEmpty(*ledgerAPIEndpoint, *ledgerTokenFile, *ledgerCAFile)
+	if !*ledgerInspect && providedLedgerInputs != 0 {
+		return errors.New("Kubernetes ledger inputs require --ledger-inspect")
+	}
+	if *ledgerInspect {
+		if plan.Authorization == nil {
+			return errors.New("--ledger-inspect requires a verified authorization")
+		}
+		if providedLedgerInputs != 3 {
+			return errors.New("--ledger-api-endpoint, --ledger-token-file, and --ledger-ca-file must be provided together")
+		}
+		inspection, err := runner.InspectKubernetesLedger(context.Background(), verifiedGrant, runner.KubernetesLedgerConfig{
+			Endpoint: *ledgerAPIEndpoint, Namespace: ledgerNamespace, TokenFile: *ledgerTokenFile, CAFile: *ledgerCAFile,
+		})
+		if err != nil {
+			return fmt.Errorf("inspect durable grant ledger: %w", err)
+		}
+		plan.Format = "ok147-create-plan/v3"
+		plan.Ledger = &inspection
 	}
 	encoder := json.NewEncoder(stdout)
 	encoder.SetEscapeHTML(false)

--- a/cmd/ok/main_test.go
+++ b/cmd/ok/main_test.go
@@ -64,8 +64,10 @@ func TestCreateRejectsIncompleteProjectionAndAuthorizationInputs(t *testing.T) {
 		"--dry-run",
 	}
 	for name, extra := range map[string][]string{
-		"projection root without manifest": {"--projection-root", "/tmp/projection"},
-		"authorization without projection": {"--authorization", "/tmp/grant.json", "--authorization-key", "/tmp/key", "--evaluation-time", "2026-08-16T10:00:00Z"},
+		"projection root without manifest":     {"--projection-root", "/tmp/projection"},
+		"authorization without projection":     {"--authorization", "/tmp/grant.json", "--authorization-key", "/tmp/key", "--evaluation-time", "2026-08-16T10:00:00Z"},
+		"ledger inspect without authorization": {"--ledger-inspect", "--ledger-api-endpoint", "https://10.43.0.1:443", "--ledger-token-file", "/tmp/token", "--ledger-ca-file", "/tmp/ca"},
+		"ledger inputs without inspect":        {"--ledger-api-endpoint", "https://10.43.0.1:443"},
 	} {
 		t.Run(name, func(t *testing.T) {
 			var stdout, stderr bytes.Buffer

--- a/deploy/contract-executor-job.yaml.tpl
+++ b/deploy/contract-executor-job.yaml.tpl
@@ -1,0 +1,125 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "${OK147_RUN_ID}"
+  namespace: openkubes-execution-system
+  labels:
+    app.kubernetes.io/name: ok-cluster-contract-executor
+    openkubes.io/execution-id: "${OK147_RUN_ID}"
+spec:
+  backoffLimit: 0
+  completions: 1
+  parallelism: 1
+  activeDeadlineSeconds: 600
+  ttlSecondsAfterFinished: 3600
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ok-cluster-contract-executor
+        openkubes.io/execution-id: "${OK147_RUN_ID}"
+    spec:
+      serviceAccountName: ok147-contract-executor-preflight
+      automountServiceAccountToken: false
+      enableServiceLinks: false
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: DoesNotExist
+      containers:
+        - name: executor
+          image: "${OK147_IMAGE_DIGEST}"
+          imagePullPolicy: IfNotPresent
+          command: ["/ok"]
+          args:
+            - cluster
+            - create
+            - --dry-run
+            - --contract
+            - /var/run/openkubes/input/contract.yaml
+            - --schema
+            - /var/run/openkubes/input/schema.json
+            - --projection-manifest
+            - /var/run/openkubes/input/projection-manifest.json
+            - --projection-root
+            - /var/run/openkubes/input
+            - --authorization
+            - /var/run/openkubes/input/authorization.json
+            - --authorization-key
+            - /var/run/openkubes/input/trusted-ed25519-public-key.base64
+            - --evaluation-time
+            - "${OK147_EVALUATION_TIME}"
+            - --ledger-inspect
+            - --ledger-api-endpoint
+            - "${OK147_KUBERNETES_API_URL}"
+            - --ledger-token-file
+            - /var/run/openkubes/kubernetes/token
+            - --ledger-ca-file
+            - /var/run/openkubes/kubernetes/ca.crt
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+              ephemeral-storage: 32Mi
+            limits:
+              cpu: 250m
+              memory: 128Mi
+              ephemeral-storage: 64Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+            - name: input
+              mountPath: /var/run/openkubes/input
+              readOnly: true
+            - name: kubernetes-api
+              mountPath: /var/run/openkubes/kubernetes
+              readOnly: true
+      volumes:
+        - name: input
+          configMap:
+            name: "${OK147_INPUT_CONFIGMAP}"
+            defaultMode: 0444
+        - name: kubernetes-api
+          projected:
+            defaultMode: 0400
+            sources:
+              - serviceAccountToken:
+                  path: token
+                  expirationSeconds: 600
+              - configMap:
+                  name: kube-root-ca.crt
+                  items:
+                    - key: ca.crt
+                      path: ca.crt
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: "${OK147_RUN_ID}"
+  namespace: openkubes-execution-system
+spec:
+  podSelector:
+    matchLabels:
+      openkubes.io/execution-id: "${OK147_RUN_ID}"
+  policyTypes: ["Ingress", "Egress"]
+  ingress: []
+  egress:
+    - to:
+        - ipBlock:
+            cidr: "${OK147_KUBERNETES_API_CIDR}"
+      ports:
+        - protocol: TCP
+          port: 443

--- a/deploy/contract-executor-ledger.yaml
+++ b/deploy/contract-executor-ledger.yaml
@@ -34,6 +34,37 @@ subjects:
     name: ok147-contract-executor
     namespace: openkubes-execution-system
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ok147-contract-executor-preflight
+  namespace: openkubes-execution-system
+automountServiceAccountToken: false
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ok147-ledger-reader
+  namespace: openkubes-execution-system
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ok147-ledger-reader
+  namespace: openkubes-execution-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ok147-ledger-reader
+subjects:
+  - kind: ServiceAccount
+    name: ok147-contract-executor-preflight
+    namespace: openkubes-execution-system
+---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:

--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -182,11 +182,53 @@ that equality check on every create response and read. Likewise, RBAC cannot
 restrict `create` to one exact body. Signed request binding and strict receipt
 validation remain required application-level controls.
 
-The Service Account deliberately has no mutation authority over CAPI, provider,
-enablement, GitOps, or workload resources in this checkpoint. The manifest is
-not deployed, the Kubernetes store is not yet wired to a Job, and no cluster was
-contacted. Tests use an in-memory API transport and prove that a replacement
-executor observes the original claim and cannot reuse it.
+The ledger identities deliberately have no mutation authority over CAPI,
+provider, enablement, GitOps, or workload resources. The manifest is not
+deployed and no cluster was contacted. Tests use an in-memory API transport and
+prove that a replacement executor observes the original claim and cannot reuse
+it. The read-only Job integration is described next.
+
+## Read-only Job preflight envelope
+
+The fifth checkpoint wires the same `ok` binary to a short-lived `ok-mgmt` Job
+in read-only preflight mode. With an exact signed authorization already
+verified, `--ledger-inspect` reads only the deterministic claim/outcome names
+and emits `ok147-create-plan/v3` with the current restart decision:
+
+```bash
+ok cluster create --dry-run \
+  --contract /var/run/openkubes/input/contract.yaml \
+  --schema /var/run/openkubes/input/schema.json \
+  --projection-manifest /var/run/openkubes/input/projection-manifest.json \
+  --projection-root /var/run/openkubes/input \
+  --authorization /var/run/openkubes/input/authorization.json \
+  --authorization-key /var/run/openkubes/input/trusted-ed25519-public-key.base64 \
+  --evaluation-time 2026-08-16T10:00:00Z \
+  --ledger-inspect \
+  --ledger-api-endpoint https://10.43.0.1:443 \
+  --ledger-token-file /var/run/openkubes/kubernetes/token \
+  --ledger-ca-file /var/run/openkubes/kubernetes/ca.crt
+```
+
+The TLS adapter accepts bounded projected token and CA files, requires an exact
+HTTPS endpoint, disables proxies, compression and redirects, and does not
+include credential paths or contents in returned errors. The preflight uses a
+separate Service Account whose Role contains only `get` on ConfigMaps. It cannot
+create a ledger claim even though the later execution identity has
+`get`/`create`.
+
+[`deploy/contract-executor-job.yaml.tpl`](../deploy/contract-executor-job.yaml.tpl)
+defines one non-retrying Job and its NetworkPolicy. The Pod runs off the control
+plane, has explicit requests/limits, uses a read-only root filesystem, drops all
+capabilities, mounts a ten-minute projected token, and can egress only to one
+exact Kubernetes API IP on TCP 443. The image must be SHA-256 digest-bound.
+Typed Go materialization rejects mutable images, DNS API endpoints, broad CIDRs,
+shell-like names, invalid timestamps and unknown placeholders.
+
+This checkpoint still does **not** claim the grant, submit CAPI/provider
+resources, observe cluster convergence, or publish an outcome. The template is
+not applied and no image is built or published. It proves only that local mode
+and the future Job can use the same binary and read-only ledger boundary.
 
 ## OK-141 compatibility evidence
 

--- a/internal/ledger/deployment_test.go
+++ b/internal/ledger/deployment_test.go
@@ -24,7 +24,7 @@ func TestKubernetesLedgerDeploymentBoundary(t *testing.T) {
 	}
 
 	decoder := yaml.NewDecoder(bytes.NewReader(raw))
-	objects := map[string]map[string]any{}
+	objects := map[string][]map[string]any{}
 	for {
 		var object map[string]any
 		if err := decoder.Decode(&object); err != nil {
@@ -34,15 +34,16 @@ func TestKubernetesLedgerDeploymentBoundary(t *testing.T) {
 			t.Fatal(err)
 		}
 		kind, _ := object["kind"].(string)
-		objects[kind] = object
+		objects[kind] = append(objects[kind], object)
 	}
 
 	for _, kind := range []string{"Namespace", "ServiceAccount", "Role", "RoleBinding", "ValidatingAdmissionPolicy", "ValidatingAdmissionPolicyBinding"} {
-		if objects[kind] == nil {
+		if len(objects[kind]) == 0 {
 			t.Fatalf("deployment lacks %s", kind)
 		}
 	}
-	roleRules := nestedSlice(t, objects["Role"], "rules")
+	writerRole := namedObject(t, objects["Role"], "ok147-ledger-writer")
+	roleRules := nestedSlice(t, writerRole, "rules")
 	if len(roleRules) != 1 {
 		t.Fatalf("ledger Role has %d rules, want 1", len(roleRules))
 	}
@@ -56,8 +57,17 @@ func TestKubernetesLedgerDeploymentBoundary(t *testing.T) {
 	if len(resources) != 1 || resources[0] != "configmaps" {
 		t.Fatalf("ledger Role resources = %v, want only configmaps", resources)
 	}
+	readerRole := namedObject(t, objects["Role"], "ok147-ledger-reader")
+	readerRules := nestedSlice(t, readerRole, "rules")
+	if len(readerRules) != 1 {
+		t.Fatalf("ledger reader Role has %d rules, want 1", len(readerRules))
+	}
+	readerVerbs := stringsFrom(t, readerRules[0].(map[string]any)["verbs"])
+	if len(readerVerbs) != 1 || readerVerbs[0] != "get" {
+		t.Fatalf("ledger reader verbs = %v, want only get", readerVerbs)
+	}
 
-	policy := objects["ValidatingAdmissionPolicy"]
+	policy := objects["ValidatingAdmissionPolicy"][0]
 	spec := nestedMap(t, policy, "spec")
 	if spec["failurePolicy"] != "Fail" {
 		t.Fatalf("admission failurePolicy = %v, want Fail", spec["failurePolicy"])
@@ -84,6 +94,18 @@ func TestKubernetesLedgerDeploymentBoundary(t *testing.T) {
 	if !serviceAccountBound {
 		t.Fatal("admission validations do not bind the exact ServiceAccount")
 	}
+}
+
+func namedObject(t *testing.T, objects []map[string]any, name string) map[string]any {
+	t.Helper()
+	for _, object := range objects {
+		metadata, ok := object["metadata"].(map[string]any)
+		if ok && metadata["name"] == name {
+			return object
+		}
+	}
+	t.Fatalf("object %q not found", name)
+	return nil
 }
 
 func nestedMap(t *testing.T, object map[string]any, key string) map[string]any {

--- a/internal/runner/job_template.go
+++ b/internal/runner/job_template.go
@@ -1,0 +1,76 @@
+package runner
+
+import (
+	"errors"
+	"fmt"
+	"net/netip"
+	"net/url"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// JobTemplateValues are the complete environment-specific identities required
+// to materialize the bounded Job and its exact API NetworkPolicy.
+type JobTemplateValues struct {
+	RunID             string
+	ImageDigest       string
+	EvaluationTime    string
+	KubernetesAPIURL  string
+	KubernetesAPICIDR string
+	InputConfigMap    string
+}
+
+var jobPlaceholders = map[string]func(JobTemplateValues) string{
+	"${OK147_RUN_ID}":              func(values JobTemplateValues) string { return values.RunID },
+	"${OK147_IMAGE_DIGEST}":        func(values JobTemplateValues) string { return values.ImageDigest },
+	"${OK147_EVALUATION_TIME}":     func(values JobTemplateValues) string { return values.EvaluationTime },
+	"${OK147_KUBERNETES_API_URL}":  func(values JobTemplateValues) string { return values.KubernetesAPIURL },
+	"${OK147_KUBERNETES_API_CIDR}": func(values JobTemplateValues) string { return values.KubernetesAPICIDR },
+	"${OK147_INPUT_CONFIGMAP}":     func(values JobTemplateValues) string { return values.InputConfigMap },
+}
+
+// RenderJobTemplate validates every substituted identity before performing
+// literal replacement. It does not execute a template language or shell.
+func RenderJobTemplate(template []byte, values JobTemplateValues) ([]byte, error) {
+	if len(template) == 0 || len(template) > 1024*1024 {
+		return nil, errors.New("runner Job template size is invalid")
+	}
+	dnsLabel := regexp.MustCompile(`^[a-z0-9](?:[-a-z0-9]*[a-z0-9])?$`)
+	if !dnsLabel.MatchString(values.RunID) || len(values.RunID) > 63 || !strings.HasPrefix(values.RunID, "ok147-") {
+		return nil, errors.New("runner Job run ID is invalid")
+	}
+	if !dnsLabel.MatchString(values.InputConfigMap) || len(values.InputConfigMap) > 63 {
+		return nil, errors.New("runner input ConfigMap name is invalid")
+	}
+	if !regexp.MustCompile(`^[a-z0-9][a-z0-9./:_-]*@sha256:[0-9a-f]{64}$`).MatchString(values.ImageDigest) {
+		return nil, errors.New("runner image is not bound to a SHA-256 digest")
+	}
+	if _, err := time.Parse(time.RFC3339, values.EvaluationTime); err != nil {
+		return nil, errors.New("runner evaluation time is not RFC3339")
+	}
+	endpoint, err := url.Parse(values.KubernetesAPIURL)
+	if err != nil || endpoint.Scheme != "https" || endpoint.User != nil || endpoint.Path != "" || endpoint.RawQuery != "" || endpoint.Fragment != "" || endpoint.Port() != "443" {
+		return nil, errors.New("runner Kubernetes API URL must be an exact HTTPS IP endpoint on port 443")
+	}
+	apiAddress, err := netip.ParseAddr(endpoint.Hostname())
+	if err != nil {
+		return nil, errors.New("runner Kubernetes API URL must use an IP address")
+	}
+	prefix, err := netip.ParsePrefix(values.KubernetesAPICIDR)
+	if err != nil || prefix.Bits() != apiAddress.BitLen() || prefix.Addr() != apiAddress {
+		return nil, errors.New("runner Kubernetes API CIDR must bind only the endpoint IP")
+	}
+
+	result := string(template)
+	for placeholder, extract := range jobPlaceholders {
+		if !strings.Contains(result, placeholder) {
+			return nil, fmt.Errorf("runner Job template lacks %s", placeholder)
+		}
+		result = strings.ReplaceAll(result, placeholder, extract(values))
+	}
+	if strings.Contains(result, "${") {
+		return nil, errors.New("runner Job template contains an unknown placeholder")
+	}
+	return []byte(result), nil
+}

--- a/internal/runner/job_template_test.go
+++ b/internal/runner/job_template_test.go
@@ -1,0 +1,185 @@
+package runner
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestJobTemplateIsBoundedAndReadOnly(t *testing.T) {
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("cannot resolve test path")
+	}
+	raw, err := os.ReadFile(filepath.Join(filepath.Dir(filename), "..", "..", "deploy", "contract-executor-job.yaml.tpl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(raw, []byte("system:masters")) || bytes.Contains(raw, []byte("privileged: true")) {
+		t.Fatal("job template contains a privileged execution boundary")
+	}
+	values := validJobTemplateValues()
+	materializedRaw, err := RenderJobTemplate(raw, values)
+	if err != nil {
+		t.Fatal(err)
+	}
+	materialized := string(materializedRaw)
+	if strings.Contains(materialized, "${") {
+		t.Fatal("job template has an unbound placeholder")
+	}
+
+	decoder := yaml.NewDecoder(strings.NewReader(materialized))
+	objects := map[string]map[string]any{}
+	for {
+		var object map[string]any
+		if err := decoder.Decode(&object); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			t.Fatal(err)
+		}
+		kind, _ := object["kind"].(string)
+		objects[kind] = object
+	}
+	job := objects["Job"]
+	policy := objects["NetworkPolicy"]
+	if job == nil || policy == nil {
+		t.Fatal("template must contain one Job and one NetworkPolicy")
+	}
+	jobSpec := objectAt(t, job, "spec")
+	if jobSpec["backoffLimit"] != 0 || jobSpec["parallelism"] != 1 || jobSpec["completions"] != 1 {
+		t.Fatalf("job retry/singleton boundary differs: %#v", jobSpec)
+	}
+	podSpec := objectAt(t, objectAt(t, jobSpec, "template"), "spec")
+	if podSpec["serviceAccountName"] != "ok147-contract-executor-preflight" || podSpec["automountServiceAccountToken"] != false || podSpec["restartPolicy"] != "Never" {
+		t.Fatalf("pod identity/restart boundary differs: %#v", podSpec)
+	}
+	podSecurity := objectAt(t, podSpec, "securityContext")
+	if podSecurity["runAsNonRoot"] != true || podSecurity["seccompProfile"].(map[string]any)["type"] != "RuntimeDefault" {
+		t.Fatalf("pod security context differs: %#v", podSecurity)
+	}
+	containers := arrayAt(t, podSpec, "containers")
+	if len(containers) != 1 {
+		t.Fatalf("containers=%d, want 1", len(containers))
+	}
+	container := containers[0].(map[string]any)
+	image, _ := container["image"].(string)
+	if !strings.Contains(image, "@sha256:") {
+		t.Fatalf("image is not digest-bound: %q", image)
+	}
+	command := stringArray(t, container, "command")
+	if len(command) != 1 || command[0] != "/ok" {
+		t.Fatalf("command=%v, want only /ok", command)
+	}
+	args := stringArray(t, container, "args")
+	for _, required := range []string{"cluster", "create", "--dry-run", "--projection-manifest", "--authorization", "--ledger-inspect"} {
+		if !contains(args, required) {
+			t.Fatalf("job args do not bind %s: %v", required, args)
+		}
+	}
+	for _, forbidden := range []string{"shell", "apply", "delete", "--command"} {
+		if contains(args, forbidden) {
+			t.Fatalf("job args contain forbidden operation %s", forbidden)
+		}
+	}
+	containerSecurity := objectAt(t, container, "securityContext")
+	if containerSecurity["allowPrivilegeEscalation"] != false || containerSecurity["readOnlyRootFilesystem"] != true {
+		t.Fatalf("container security context differs: %#v", containerSecurity)
+	}
+	resources := objectAt(t, container, "resources")
+	if len(objectAt(t, resources, "requests")) == 0 || len(objectAt(t, resources, "limits")) == 0 {
+		t.Fatal("job lacks explicit resource requests or limits")
+	}
+
+	policySpec := objectAt(t, policy, "spec")
+	if ingress, ok := policySpec["ingress"].([]any); !ok || len(ingress) != 0 {
+		t.Fatalf("NetworkPolicy ingress is not deny-all: %#v", policySpec["ingress"])
+	}
+	if len(arrayAt(t, policySpec, "egress")) != 1 {
+		t.Fatal("NetworkPolicy must contain exactly one API egress rule")
+	}
+}
+
+func TestRenderJobTemplateFailsClosed(t *testing.T) {
+	template := []byte(strings.Join([]string{
+		"${OK147_RUN_ID}", "${OK147_IMAGE_DIGEST}", "${OK147_EVALUATION_TIME}",
+		"${OK147_KUBERNETES_API_URL}", "${OK147_KUBERNETES_API_CIDR}", "${OK147_INPUT_CONFIGMAP}",
+	}, "\n"))
+	for name, mutate := range map[string]func(*JobTemplateValues){
+		"shell-like run ID": func(values *JobTemplateValues) { values.RunID = "ok147-x;id" },
+		"mutable image":     func(values *JobTemplateValues) { values.ImageDigest = "ghcr.io/openkubes/ok-cluster:latest" },
+		"DNS API endpoint":  func(values *JobTemplateValues) { values.KubernetesAPIURL = "https://kubernetes.default.svc:443" },
+		"broad API CIDR":    func(values *JobTemplateValues) { values.KubernetesAPICIDR = "10.43.0.0/24" },
+	} {
+		t.Run(name, func(t *testing.T) {
+			values := validJobTemplateValues()
+			candidate := append([]byte(nil), template...)
+			mutate(&values)
+			if _, err := RenderJobTemplate(candidate, values); err == nil {
+				t.Fatal("unsafe Job template input was accepted")
+			}
+		})
+	}
+	if _, err := RenderJobTemplate(append(template, []byte("\n${UNKNOWN}")...), validJobTemplateValues()); err == nil {
+		t.Fatal("unknown template placeholder was accepted")
+	}
+}
+
+func validJobTemplateValues() JobTemplateValues {
+	return JobTemplateValues{
+		RunID:             "ok147-create-20260816-01",
+		ImageDigest:       "ghcr.io/openkubes/ok-cluster@sha256:" + strings.Repeat("a", 64),
+		EvaluationTime:    "2026-08-16T10:00:00Z",
+		KubernetesAPIURL:  "https://10.43.0.1:443",
+		KubernetesAPICIDR: "10.43.0.1/32",
+		InputConfigMap:    "ok147-create-20260816-01-input",
+	}
+}
+
+func objectAt(t *testing.T, object map[string]any, key string) map[string]any {
+	t.Helper()
+	value, ok := object[key].(map[string]any)
+	if !ok {
+		t.Fatalf("%s is not an object", key)
+	}
+	return value
+}
+
+func arrayAt(t *testing.T, object map[string]any, key string) []any {
+	t.Helper()
+	value, ok := object[key].([]any)
+	if !ok {
+		t.Fatalf("%s is not an array", key)
+	}
+	return value
+}
+
+func stringArray(t *testing.T, object map[string]any, key string) []string {
+	t.Helper()
+	values := arrayAt(t, object, key)
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		text, ok := value.(string)
+		if !ok {
+			t.Fatalf("%s contains non-string %T", key, value)
+		}
+		result = append(result, text)
+	}
+	return result
+}
+
+func contains(values []string, expected string) bool {
+	for _, value := range values {
+		if value == expected {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/runner/kubernetes.go
+++ b/internal/runner/kubernetes.go
@@ -1,0 +1,110 @@
+// Package runner contains execution-environment adapters for the bounded
+// Contract Executor. It does not own contract projection or lifecycle state.
+package runner
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/authorization"
+	"github.com/openkubes/ok-cluster/internal/ledger"
+)
+
+const (
+	maximumTokenBytes = 64 * 1024
+	maximumCABytes    = 1024 * 1024
+)
+
+// KubernetesLedgerConfig binds the only credential and API inputs used by the
+// Job preflight. Source paths never appear in receipts or returned errors.
+type KubernetesLedgerConfig struct {
+	Endpoint  string
+	Namespace string
+	TokenFile string
+	CAFile    string
+}
+
+// InspectKubernetesLedger performs a read-only restart decision. It does not
+// claim the grant and therefore cannot authorize a later mutation by itself.
+func InspectKubernetesLedger(ctx context.Context, grant authorization.VerifiedGrant, config KubernetesLedgerConfig) (ledger.Inspection, error) {
+	store, err := OpenKubernetesLedger(config)
+	if err != nil {
+		return ledger.Inspection{}, err
+	}
+	return store.Inspect(ctx, grant)
+}
+
+// OpenKubernetesLedger materializes a TLS-only, redirect-denying client from
+// bounded projected files. The caller is responsible for using a short-lived
+// token with the dedicated ledger ServiceAccount.
+func OpenKubernetesLedger(config KubernetesLedgerConfig) (*ledger.Ledger, error) {
+	if config.Endpoint == "" || config.Namespace == "" || config.TokenFile == "" || config.CAFile == "" {
+		return nil, errors.New("Kubernetes ledger endpoint, namespace, token file, and CA file are required")
+	}
+	tokenRaw, err := readBoundedRegular(config.TokenFile, maximumTokenBytes)
+	if err != nil {
+		return nil, errors.New("read projected Kubernetes ledger token")
+	}
+	token := string(tokenRaw)
+	if token == "" || strings.TrimSpace(token) != token || strings.ContainsAny(token, "\r\n") {
+		return nil, errors.New("projected Kubernetes ledger token is invalid")
+	}
+	caRaw, err := readBoundedRegular(config.CAFile, maximumCABytes)
+	if err != nil {
+		return nil, errors.New("read projected Kubernetes API CA")
+	}
+	roots := x509.NewCertPool()
+	if !roots.AppendCertsFromPEM(caRaw) {
+		return nil, errors.New("projected Kubernetes API CA contains no certificate")
+	}
+	client := &http.Client{
+		Timeout: 15 * time.Second,
+		Transport: &http.Transport{
+			Proxy:              nil,
+			DisableCompression: true,
+			ForceAttemptHTTP2:  true,
+			TLSClientConfig: &tls.Config{
+				MinVersion: tls.VersionTLS12,
+				RootCAs:    roots,
+			},
+		},
+	}
+	backend, err := ledger.NewKubernetesStore(ledger.KubernetesStoreConfig{
+		Endpoint: config.Endpoint, Namespace: config.Namespace, BearerToken: token, Client: client,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return ledger.New(backend)
+}
+
+func readBoundedRegular(path string, maximum int64) ([]byte, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil {
+		return nil, err
+	}
+	if !info.Mode().IsRegular() || info.Size() <= 0 || info.Size() > maximum {
+		return nil, fmt.Errorf("projected file metadata is invalid")
+	}
+	raw, err := io.ReadAll(io.LimitReader(file, maximum+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(raw)) > maximum {
+		return nil, errors.New("projected file exceeds size limit")
+	}
+	return raw, nil
+}

--- a/internal/runner/kubernetes_test.go
+++ b/internal/runner/kubernetes_test.go
@@ -1,0 +1,82 @@
+package runner
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestOpenKubernetesLedgerValidatesProjectedInputs(t *testing.T) {
+	root := t.TempDir()
+	tokenPath := filepath.Join(root, "token")
+	caPath := filepath.Join(root, "ca.crt")
+	if err := os.WriteFile(tokenPath, []byte("short-lived-token"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(caPath, testCA(t), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := OpenKubernetesLedger(KubernetesLedgerConfig{
+		Endpoint: "https://10.43.0.1:443", Namespace: "openkubes-execution-system", TokenFile: tokenPath, CAFile: caPath,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("token newline fails closed without path disclosure", func(t *testing.T) {
+		if err := os.WriteFile(tokenPath, []byte("token\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		_, err := OpenKubernetesLedger(KubernetesLedgerConfig{
+			Endpoint: "https://10.43.0.1:443", Namespace: "openkubes-execution-system", TokenFile: tokenPath, CAFile: caPath,
+		})
+		if err == nil || strings.Contains(err.Error(), root) {
+			t.Fatalf("unsafe token error: %v", err)
+		}
+	})
+
+	t.Run("invalid CA fails closed without path disclosure", func(t *testing.T) {
+		if err := os.WriteFile(tokenPath, []byte("short-lived-token"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(caPath, []byte("not-a-certificate"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		_, err := OpenKubernetesLedger(KubernetesLedgerConfig{
+			Endpoint: "https://10.43.0.1:443", Namespace: "openkubes-execution-system", TokenFile: tokenPath, CAFile: caPath,
+		})
+		if err == nil || strings.Contains(err.Error(), root) {
+			t.Fatalf("unsafe CA error: %v", err)
+		}
+	})
+}
+
+func testCA(t *testing.T) []byte {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "ok147-test-ca"},
+		NotBefore:             time.Date(2026, 8, 16, 0, 0, 0, 0, time.UTC),
+		NotAfter:              time.Date(2026, 8, 17, 0, 0, 0, 0, time.UTC),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+	raw, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: raw})
+}


### PR DESCRIPTION
## What changed

- add `--ledger-inspect` to the existing `ok cluster create --dry-run` path
- materialize a TLS-only Kubernetes ledger client from bounded projected token and CA files
- add a separate ConfigMap `get`-only ServiceAccount for read-only preflight
- add a versioned short-lived Job and exact-API NetworkPolicy template
- add typed template materialization that rejects mutable images, broad API CIDRs, DNS endpoints, invalid names/times, and unknown placeholders
- harden the Job with no retries, no shell, no token automount, explicit requests/limits, non-root execution, read-only root filesystem, dropped capabilities, and worker-only scheduling

## Why

OK-147 requires local and in-cluster execution to use the same Go implementation. This checkpoint proves the Job packaging and durable restart inspection boundary without granting claim, CAPI, provider, CAAPH, Argo, or workload mutation authority.

## Current boundary

The Job can verify the contract, projection, signed authorization, and exact durable ledger state. It cannot consume the grant, submit resources, observe convergence, or publish an outcome. The template was not applied and no image was built or published.

## Validation

- `CGO_ENABLED=0 go test ./...`
- `CGO_ENABLED=0 go vet ./...`
- `python3 -m unittest discover -s tests -p '*_test.py'` (7 pass, 1 existing skip)
- `git diff --check`

No infrastructure was contacted or mutated.