### PR TITLE
feat(OK-147): bind reproducible runner image provenance

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+**
+!go.mod
+!go.sum
+!cmd/
+!cmd/ok/
+!cmd/ok/**
+!internal/
+!internal/**

--- a/Containerfile.ok147
+++ b/Containerfile.ok147
@@ -1,0 +1,34 @@
+# syntax=docker/dockerfile:1.7.1@sha256:a57df69d0ea827fb7266491f2813635de6f17269be881f696fbfdf2d83dda33e
+
+ARG GO_IMAGE=docker.io/library/golang:1.24.6-alpine3.22@sha256:c8c5f95d64aa79b6547f3b626eb84b16a7ce18a139e3e9ca19a8c078b85ba80d
+ARG RUNTIME_IMAGE=gcr.io/distroless/static-debian12:nonroot@sha256:1b7b9f0f0e0a1d2155f531db587cc48ec26aaf97ab64364225f5bf18a054e66a
+
+FROM --platform=$BUILDPLATFORM ${GO_IMAGE} AS build
+ARG TARGETOS
+ARG TARGETARCH
+ARG VERSION
+ARG REVISION
+WORKDIR /src
+ENV CGO_ENABLED=0 GOTOOLCHAIN=local
+COPY go.mod go.sum ./
+RUN go mod download
+COPY cmd/ok ./cmd/ok
+COPY internal ./internal
+RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
+    go build -mod=readonly -trimpath -buildvcs=false \
+    -ldflags="-s -w -buildid= -X main.version=${VERSION} -X main.revision=${REVISION}" \
+    -o /out/ok ./cmd/ok
+
+FROM ${RUNTIME_IMAGE}
+ARG VERSION
+ARG REVISION
+ARG CREATED
+LABEL org.opencontainers.image.title="OpenKubes bounded Contract Executor" \
+      org.opencontainers.image.description="Short-lived OK-147 Contract Executor MVP" \
+      org.opencontainers.image.source="https://github.com/openkubes/ok-cluster" \
+      org.opencontainers.image.version="${VERSION}" \
+      org.opencontainers.image.revision="${REVISION}" \
+      org.opencontainers.image.created="${CREATED}"
+COPY --from=build --chown=65532:65532 /out/ok /ok
+USER 65532:65532
+ENTRYPOINT ["/ok"]

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # OpenKubes Cluster Templating — Makefile
 # Usage: make new CLUSTER=ok3 TYPE=ubuntu|talos|talos-mgmt|flatcar [HA=true] [WORKERS=3] [SCHEDULING_PROFILE=ok-gpu|ok-gpu-single-replica]
 #        TYPE is REQUIRED — no silent default (OK-119).
-.PHONY: new render install kubeconfig install-cni install-storage install-ingress install-observability install-observability-metrics install-keycloak register-cluster unregister-cluster bootstrap annotate-pvcs upgrade clean teardown teardown-all reap-orphaned-volumes e2e e2e-verify list status help prepare-cilium-chart verify-cilium-chart cilium-chart-tool-test configure-kubevirt-expand-disks talos-registry-trust-review talos-registry-trust-dry-run talos-registry-trust-apply ok138-registry-trust-test contract-executor-test contract-executor-dry-run
+.PHONY: new render install kubeconfig install-cni install-storage install-ingress install-observability install-observability-metrics install-keycloak register-cluster unregister-cluster bootstrap annotate-pvcs upgrade clean teardown teardown-all reap-orphaned-volumes e2e e2e-verify list status help prepare-cilium-chart verify-cilium-chart cilium-chart-tool-test configure-kubevirt-expand-disks talos-registry-trust-review talos-registry-trust-dry-run talos-registry-trust-apply ok138-registry-trust-test contract-executor-test contract-executor-dry-run ok147-runner-image-plan ok147-runner-image-build
 .DEFAULT_GOAL := help
 
 CLUSTER       ?=
@@ -201,6 +201,27 @@ contract-executor-dry-run: ## Reproduce the OK-141 R and emit a non-mutating pla
 		--contract internal/contract/testdata/ok141-contract-v5.yaml \
 		--schema internal/contract/testdata/ok141-contract-v3.schema.json \
 		--dry-run
+
+OK147_IMAGE_VERSION ?= 0.1.0-dev
+OK147_IMAGE_REVISION ?= $(shell git rev-parse HEAD)
+OK147_IMAGE_CREATED ?= $(shell git show -s --format=%cI HEAD)
+OK147_IMAGE_OUTPUT ?= /private/tmp/ok147-runner.oci.tar
+
+ok147-runner-image-plan: ## Emit the non-publishing reproducible image build plan
+	@python3 scripts/build_ok147_runner.py \
+		--version "$(OK147_IMAGE_VERSION)" \
+		--revision "$(OK147_IMAGE_REVISION)" \
+		--created "$(OK147_IMAGE_CREATED)" \
+		--output "$(OK147_IMAGE_OUTPUT)"
+
+ok147-runner-image-build: ## Build OCI+SBOM locally (requires OK147_IMAGE_BUILD=yes)
+	@OK147_IMAGE_BUILD="$(OK147_IMAGE_BUILD)" \
+		python3 scripts/build_ok147_runner.py \
+		--version "$(OK147_IMAGE_VERSION)" \
+		--revision "$(OK147_IMAGE_REVISION)" \
+		--created "$(OK147_IMAGE_CREATED)" \
+		--output "$(OK147_IMAGE_OUTPUT)" \
+		--execute
 
 # OK-125 candidate evidence is intentionally outside the ordinary TYPE allowlist.
 # It consumes ok-linux profile truth and never applies resources.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ Powered by [Cluster API (CAPI)](https://cluster-api.sigs.k8s.io/), [CAPK (KubeVi
   short-lived `ok-mgmt` Jobs; it remains dry-run-only while verifying the
   OK-141 revision, existing projection, authority split, signed grant binding,
   fail-closed single-use receipt semantics, and an offline-tested durable
-  Kubernetes ledger plus short-lived read-only Job preflight boundary
+  Kubernetes ledger plus short-lived read-only Job preflight boundary; its
+  container build is digest-pinned, multi-architecture, non-root, SBOM- and
+  provenance-producing, and remains local/non-publishing
 
 ---
 

--- a/build/ok147-runner-image-reproducibility-evidence.json
+++ b/build/ok147-runner-image-reproducibility-evidence.json
@@ -1,0 +1,62 @@
+{
+  "format": "ok147-runner-image-reproducibility-evidence/v1",
+  "sourceRevision": "51ecd4e72c4105ab42cd461285f12d1cf5524712",
+  "version": "0.1.0-dev",
+  "created": "2026-08-16T08:27:25Z",
+  "buildCount": 2,
+  "tools": {
+    "buildx": {
+      "version": "v0.36.1",
+      "binaryDigest": "sha256:52a39ee4012d18f83373656712102ebda55656121dcdabbbb1ccfbd41b7debe8"
+    },
+    "syft": {
+      "version": "1.50.0"
+    }
+  },
+  "supplyChainContractDigest": "sha256:dafe84745eb684bc7c5db0b68c6c073d390b22b0fb5fe2b2996ea6ee73d1768e",
+  "platformManifestDigests": {
+    "linux/amd64": "sha256:61a9ff0061eb4950b0841a5ada4195ae8f2b43de4c824a0d47a503c83edff172",
+    "linux/arm64": "sha256:a21f2d234f64f5e8b963b56fe37b942fbe6518bc1edc3eb7666b396c0b11b7ce"
+  },
+  "sbomSemanticDigests": {
+    "linux/amd64": "sha256:93a8fe93c14371fac4c700c387055f3d81ed08cb9881555510006926ac9ed841",
+    "linux/arm64": "sha256:86783605fce5384025c87a73c3c8c65cb59e545c3324cf3aa22f835dd5eda5ac"
+  },
+  "claims": {
+    "exactPlatformSetVerified": true,
+    "platformImageManifestsReproduced": true,
+    "semanticSbomsReproduced": true,
+    "slsaProvenanceV1PresentPerPlatform": true,
+    "rawEnvelopeIdentitiesExpectedToVary": true,
+    "networkPublicationPerformed": false,
+    "clusterContactPerformed": false
+  },
+  "runs": [
+    {
+      "buildRecordDigest": "sha256:c348c62d417510a47b546037964a7469a247c05949dac8a5f625ddf51b730016",
+      "ociArchiveDigest": "sha256:9c431e2e16bf8f48639b45c9a278382f80f89def9cd65d5629e7ef6156521a56",
+      "ociIndexDigest": "sha256:0a53d812d80a9d42c07ab58b1634c169f5749ea1f1399fda64cd058b41c35502",
+      "provenanceManifestDigests": [
+        "sha256:0f8904788ea8b64676a75951c76af2b03b7dfce934640e7e8f5655861a7ae50e",
+        "sha256:9e69610d83beda2384ea43d301c602a3a23e48b489ece7d327d984a96841a730"
+      ],
+      "sbomDigests": {
+        "linux/amd64": "sha256:d34a71c2dd5bc63fbb04074dbc348c88e8dd451a5766417f02d1c40656dd59fe",
+        "linux/arm64": "sha256:0dfb17933e3be586fa2721eba4ab048ca20ad448b85a36bfb5d6f400ce1d8cdc"
+      }
+    },
+    {
+      "buildRecordDigest": "sha256:ffdc6454c9a426ace160bbcdaa2d543d8de8251b5ab39dd7fc277a47666e9d3b",
+      "ociArchiveDigest": "sha256:025e7ac48b9031388a6b3c127cb14d1633c0935ae919dd4f199b62b5b6907e2b",
+      "ociIndexDigest": "sha256:47b370f58f1ccf4d2b70ef93b101b0a615f78531c42ddc2005aab68d796ce5ab",
+      "provenanceManifestDigests": [
+        "sha256:2523612bab62190de240ed4c4fa2a9a89e00a9120ac92395df573eecd9fb6280",
+        "sha256:609606aa65f09a5af21a7ebafbe10900b117e72a39205783ad3e7aa060c17050"
+      ],
+      "sbomDigests": {
+        "linux/amd64": "sha256:405c6646e7d816f2d9b21bf65ecc282160c1e725389ea4ef121077b8c02f27ec",
+        "linux/arm64": "sha256:0c71a50e4efed8859d7264ce28ba2cc9a71cfceb5543c3f25471234de1ab865a"
+      }
+    }
+  ]
+}

--- a/build/ok147-runner-image.json
+++ b/build/ok147-runner-image.json
@@ -1,0 +1,13 @@
+{
+  "format": "ok147-runner-image-build/v1",
+  "dockerfileFrontend": "docker/dockerfile:1.7.1@sha256:a57df69d0ea827fb7266491f2813635de6f17269be881f696fbfdf2d83dda33e",
+  "builderImage": "docker.io/library/golang:1.24.6-alpine3.22@sha256:c8c5f95d64aa79b6547f3b626eb84b16a7ce18a139e3e9ca19a8c078b85ba80d",
+  "runtimeImage": "gcr.io/distroless/static-debian12:nonroot@sha256:1b7b9f0f0e0a1d2155f531db587cc48ec26aaf97ab64364225f5bf18a054e66a",
+  "platforms": [
+    "linux/amd64",
+    "linux/arm64"
+  ],
+  "binary": "/ok",
+  "user": "65532:65532",
+  "networkPublication": "disabled"
+}

--- a/cmd/ok/main.go
+++ b/cmd/ok/main.go
@@ -19,8 +19,12 @@ import (
 )
 
 const (
-	version         = "0.0.0-dev"
 	ledgerNamespace = "openkubes-execution-system"
+)
+
+var (
+	version  = "0.0.0-dev"
+	revision = "unknown"
 )
 
 type createPlan struct {
@@ -48,7 +52,7 @@ func main() {
 
 func run(arguments []string, stdout, stderr io.Writer) error {
 	if len(arguments) == 1 && arguments[0] == "version" {
-		fmt.Fprintln(stdout, version)
+		fmt.Fprintf(stdout, "%s %s\n", version, revision)
 		return nil
 	}
 	if len(arguments) < 2 || arguments[0] != "cluster" || arguments[1] != "create" {

--- a/cmd/ok/main_test.go
+++ b/cmd/ok/main_test.go
@@ -18,6 +18,16 @@ func fixturePath(t *testing.T, name string) string {
 	return filepath.Join(filepath.Dir(file), "..", "..", "internal", "contract", "testdata", name)
 }
 
+func TestVersionIncludesExecutableRevision(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	if err := run([]string{"version"}, &stdout, &stderr); err != nil {
+		t.Fatal(err)
+	}
+	if stdout.String() != "0.0.0-dev unknown\n" {
+		t.Fatalf("version output = %q", stdout.String())
+	}
+}
+
 func TestCreateDryRunProducesNonMutatingPlan(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	err := run([]string{

--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -230,6 +230,42 @@ resources, observe cluster convergence, or publish an outcome. The template is
 not applied and no image is built or published. It proves only that local mode
 and the future Job can use the same binary and read-only ledger boundary.
 
+## Reproducible container boundary
+
+The sixth checkpoint defines the container supply-chain boundary for the same
+`ok` binary. [`Containerfile.ok147`](../Containerfile.ok147) pins the Dockerfile
+frontend, Go builder and distroless runtime by SHA-256 digest. The build context
+is deny-by-default and admits only the Go module plus `cmd/ok` and `internal`;
+kubeconfigs, credentials, evidence and unrelated worktree files cannot enter the
+image context.
+
+The binary is cross-compiled with `CGO_ENABLED=0`, `-trimpath`, an empty build
+ID, and explicit version and full Git revision. The runtime contains no shell,
+runs as UID/GID `65532`, and exposes only `/ok` as its entrypoint. The pinned
+supply-chain identities and exact `linux/amd64` plus `linux/arm64` platform set
+are recorded in
+[`build/ok147-runner-image.json`](../build/ok147-runner-image.json).
+
+Planning is non-executing and non-publishing:
+
+```bash
+make ok147-runner-image-plan \
+  OK147_IMAGE_VERSION=0.1.0-dev \
+  OK147_IMAGE_OUTPUT=/private/tmp/ok147-runner.oci.tar
+```
+
+An actual local build additionally requires a clean worktree, the exact checked
+out 40-character revision, and `OK147_IMAGE_BUILD=yes`. It produces only a local
+multi-platform OCI archive, BuildKit `mode=max` provenance attestations, a Syft
+SPDX JSON SBOM and an exclusive `0600` build record. The verifier rejects a
+missing or extra platform, absent per-platform provenance, a changed pinned base
+image, or a revision mismatch.
+
+This checkpoint deliberately has no registry destination and never uses
+`--push`. It does not publish an image, deploy a Job, contact Kubernetes, consume
+an authorization, or permit lifecycle mutation. A later checkpoint must bind a
+verified registry digest before any in-cluster execution can be proposed.
+
 ## OK-141 compatibility evidence
 
 The verifier was run offline against the preserved Phase-R v5 projection. It

--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -256,10 +256,18 @@ make ok147-runner-image-plan \
 
 An actual local build additionally requires a clean worktree, the exact checked
 out 40-character revision, and `OK147_IMAGE_BUILD=yes`. It produces only a local
-multi-platform OCI archive, BuildKit `mode=max` provenance attestations, a Syft
-SPDX JSON SBOM and an exclusive `0600` build record. The verifier rejects a
-missing or extra platform, absent per-platform provenance, a changed pinned base
-image, or a revision mismatch.
+multi-platform OCI archive, BuildKit `mode=max` provenance attestations, one
+Syft SPDX JSON SBOM per platform and an exclusive `0600` build record. The
+record keeps both each raw SBOM digest and a deterministic semantic digest that
+excludes only the generated SPDX document namespace and creation timestamp. The
+verifier rejects a missing or extra platform, absent per-platform provenance, a
+changed pinned base image, or a revision mismatch.
+
+Repeated builds must reproduce the two platform image-manifest digests and the
+semantic SBOM digests. The overall OCI index, provenance manifests and raw SBOM
+files are run evidence and may differ because their envelopes contain build
+timestamps or generated document identities; they are bound exactly per build,
+not presented as reproducible payload identities.
 
 This checkpoint deliberately has no registry destination and never uses
 `--push`. It does not publish an image, deploy a Job, contact Kubernetes, consume

--- a/scripts/build_ok147_runner.py
+++ b/scripts/build_ok147_runner.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Plan or explicitly build the bounded OK-147 runner OCI archive."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+import tarfile
+
+
+FORMAT = "ok147-runner-image-build-plan/v1"
+PLATFORMS = "linux/amd64,linux/arm64"
+REVISION_RE = re.compile(r"^[0-9a-f]{40}$")
+VERSION_RE = re.compile(r"^v?[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?$")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--revision", required=True)
+    parser.add_argument("--created", required=True)
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--execute", action="store_true")
+    return parser.parse_args()
+
+
+def validate(args: argparse.Namespace, root: Path) -> tuple[Path, dt.datetime]:
+    if not VERSION_RE.fullmatch(args.version):
+        raise ValueError("version must be an explicit semantic version")
+    if not REVISION_RE.fullmatch(args.revision):
+        raise ValueError("revision must be a full lowercase Git commit")
+    try:
+        created = dt.datetime.fromisoformat(args.created.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise ValueError("created must be RFC3339") from error
+    if created.tzinfo is None:
+        raise ValueError("created must include a timezone")
+    output = Path(args.output).expanduser().resolve()
+    if output.suffix != ".tar":
+        raise ValueError("output must be an OCI .tar archive")
+    if output.exists() or output.with_suffix(".sbom.spdx.json").exists() or output.with_suffix(".build-record.json").exists():
+        raise ValueError("output, SBOM, or build record already exists")
+    if not output.parent.is_dir():
+        raise ValueError("output parent directory does not exist")
+    if not (root / "Containerfile.ok147").is_file():
+        raise ValueError("Containerfile.ok147 is missing")
+    return output, created
+
+
+def supply_chain_contract(root: Path) -> tuple[dict[str, object], str]:
+    path = root / "build" / "ok147-runner-image.json"
+    raw = path.read_bytes()
+    document = json.loads(raw)
+    if document.get("format") != "ok147-runner-image-build/v1":
+        raise ValueError("runner image build contract format is invalid")
+    if document.get("platforms") != PLATFORMS.split(","):
+        raise ValueError("runner image platforms differ from the build contract")
+    if document.get("networkPublication") != "disabled":
+        raise ValueError("runner image build contract permits publication")
+    containerfile = (root / "Containerfile.ok147").read_text()
+    for field in ("dockerfileFrontend", "builderImage", "runtimeImage"):
+        identity = document.get(field)
+        if not isinstance(identity, str) or not re.search(r"@sha256:[0-9a-f]{64}$", identity):
+            raise ValueError(f"{field} is not digest-bound")
+        if identity not in containerfile:
+            raise ValueError(f"{field} differs from Containerfile.ok147")
+    return document, "sha256:" + hashlib.sha256(raw).hexdigest()
+
+
+def build_command(root: Path, args: argparse.Namespace, output: Path, created: dt.datetime) -> list[str]:
+    created_value = created.astimezone(dt.timezone.utc).isoformat().replace("+00:00", "Z")
+    return [
+        "docker", "buildx", "build",
+        "--file", str(root / "Containerfile.ok147"),
+        "--platform", PLATFORMS,
+        "--provenance=mode=max",
+        "--build-arg", f"VERSION={args.version}",
+        "--build-arg", f"REVISION={args.revision}",
+        "--build-arg", f"CREATED={created_value}",
+        "--output", f"type=oci,dest={output}",
+        str(root),
+    ]
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for block in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(block)
+    return "sha256:" + digest.hexdigest()
+
+
+def inspect_oci_archive(path: Path) -> dict[str, object]:
+    with tarfile.open(path, "r") as archive:
+        try:
+            member = archive.getmember("index.json")
+        except KeyError as error:
+            raise ValueError("OCI archive has no index.json") from error
+        source = archive.extractfile(member)
+        if source is None:
+            raise ValueError("OCI archive has no readable index.json")
+        raw = source.read()
+    index = json.loads(raw)
+    if index.get("schemaVersion") != 2 or not isinstance(index.get("manifests"), list):
+        raise ValueError("OCI archive index is invalid")
+    platforms: dict[str, str] = {}
+    attestations: list[str] = []
+    for descriptor in index["manifests"]:
+        digest = descriptor.get("digest", "")
+        if not re.fullmatch(r"sha256:[0-9a-f]{64}", digest):
+            raise ValueError("OCI index contains an invalid manifest digest")
+        annotations = descriptor.get("annotations") or {}
+        if annotations.get("vnd.docker.reference.type") == "attestation-manifest":
+            attestations.append(digest)
+            continue
+        platform = descriptor.get("platform") or {}
+        identity = f"{platform.get('os')}/{platform.get('architecture')}"
+        if identity not in PLATFORMS.split(","):
+            raise ValueError(f"OCI archive contains unexpected platform {identity}")
+        if identity in platforms:
+            raise ValueError(f"OCI archive contains duplicate platform {identity}")
+        platforms[identity] = digest
+    if sorted(platforms) != sorted(PLATFORMS.split(",")):
+        raise ValueError("OCI archive lacks an exact platform manifest set")
+    if len(attestations) < 2:
+        raise ValueError("OCI archive lacks per-platform provenance attestations")
+    return {
+        "ociIndexDigest": "sha256:" + hashlib.sha256(raw).hexdigest(),
+        "platformManifestDigests": dict(sorted(platforms.items())),
+        "provenanceManifestDigests": sorted(attestations),
+    }
+
+
+def write_exclusive(path: Path, value: object) -> None:
+    raw = json.dumps(value, sort_keys=True, separators=(",", ":")).encode() + b"\n"
+    descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    with os.fdopen(descriptor, "wb") as target:
+        target.write(raw)
+        target.flush()
+        os.fsync(target.fileno())
+
+
+def main() -> int:
+    args = parse_args()
+    root = Path(__file__).resolve().parents[1]
+    try:
+        output, created = validate(args, root)
+        supply_chain, supply_chain_digest = supply_chain_contract(root)
+        command = build_command(root, args, output, created)
+        plan = {
+            "format": FORMAT,
+            "version": args.version,
+            "revision": args.revision,
+            "created": created.astimezone(dt.timezone.utc).isoformat().replace("+00:00", "Z"),
+            "platforms": PLATFORMS.split(","),
+            "output": str(output),
+            "publish": False,
+            "execute": args.execute,
+            "supplyChainContractDigest": supply_chain_digest,
+            "builderImage": supply_chain["builderImage"],
+            "runtimeImage": supply_chain["runtimeImage"],
+            "command": command,
+        }
+        if not args.execute:
+            print(json.dumps(plan, sort_keys=True, indent=2))
+            return 0
+        if os.environ.get("OK147_IMAGE_BUILD") != "yes":
+            raise ValueError("execution requires OK147_IMAGE_BUILD=yes")
+        status = subprocess.run(["git", "status", "--porcelain"], cwd=root, check=True, capture_output=True, text=True)
+        if status.stdout:
+            raise ValueError("image build requires a clean worktree")
+        head = subprocess.run(["git", "rev-parse", "HEAD"], cwd=root, check=True, capture_output=True, text=True).stdout.strip()
+        if head != args.revision:
+            raise ValueError("revision differs from the checked-out commit")
+        subprocess.run(command, cwd=root, check=True)
+        oci_identity = inspect_oci_archive(output)
+        sbom = output.with_suffix(".sbom.spdx.json")
+        subprocess.run(["syft", "scan", f"oci-archive:{output}", "--output", f"spdx-json={sbom}"], cwd=root, check=True)
+        record = {
+            **{key: value for key, value in plan.items() if key != "command"},
+            "format": "ok147-runner-image-build-record/v1",
+            "ociArchiveDigest": sha256(output),
+            "sbomDigest": sha256(sbom),
+            **oci_identity,
+        }
+        write_exclusive(output.with_suffix(".build-record.json"), record)
+        print(json.dumps(record, sort_keys=True, indent=2))
+        return 0
+    except (OSError, subprocess.CalledProcessError, ValueError) as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build_ok147_runner.py
+++ b/scripts/build_ok147_runner.py
@@ -31,6 +31,10 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
+def sbom_path(output: Path, platform: str) -> Path:
+    return output.with_suffix(f".{platform.replace('/', '-')}.sbom.spdx.json")
+
+
 def validate(args: argparse.Namespace, root: Path) -> tuple[Path, dt.datetime]:
     if not VERSION_RE.fullmatch(args.version):
         raise ValueError("version must be an explicit semantic version")
@@ -45,8 +49,10 @@ def validate(args: argparse.Namespace, root: Path) -> tuple[Path, dt.datetime]:
     output = Path(args.output).expanduser().resolve()
     if output.suffix != ".tar":
         raise ValueError("output must be an OCI .tar archive")
-    if output.exists() or output.with_suffix(".sbom.spdx.json").exists() or output.with_suffix(".build-record.json").exists():
-        raise ValueError("output, SBOM, or build record already exists")
+    generated = [output, output.with_suffix(".build-record.json")]
+    generated.extend(sbom_path(output, platform) for platform in PLATFORMS.split(","))
+    if any(path.exists() for path in generated):
+        raise ValueError("output, platform SBOM, or build record already exists")
     if not output.parent.is_dir():
         raise ValueError("output parent directory does not exist")
     if not (root / "Containerfile.ok147").is_file():
@@ -95,6 +101,19 @@ def sha256(path: Path) -> str:
         for block in iter(lambda: source.read(1024 * 1024), b""):
             digest.update(block)
     return "sha256:" + digest.hexdigest()
+
+
+def semantic_sbom_digest(path: Path) -> str:
+    document = json.loads(path.read_bytes())
+    if document.get("spdxVersion") != "SPDX-2.3" or not isinstance(document.get("packages"), list):
+        raise ValueError("generated SBOM is not SPDX 2.3 JSON")
+    normalized = dict(document)
+    normalized.pop("documentNamespace", None)
+    creation = dict(normalized.get("creationInfo") or {})
+    creation.pop("created", None)
+    normalized["creationInfo"] = creation
+    raw = json.dumps(normalized, sort_keys=True, separators=(",", ":")).encode()
+    return "sha256:" + hashlib.sha256(raw).hexdigest()
 
 
 def inspect_oci_archive(path: Path) -> dict[str, object]:
@@ -223,13 +242,25 @@ def main() -> int:
             raise ValueError("revision differs from the checked-out commit")
         subprocess.run(command, cwd=root, check=True)
         oci_identity = inspect_oci_archive(output)
-        sbom = output.with_suffix(".sbom.spdx.json")
-        subprocess.run(["syft", "scan", f"oci-archive:{output}", "--output", f"spdx-json={sbom}"], cwd=root, check=True)
+        sbom_digests: dict[str, str] = {}
+        sbom_semantic_digests: dict[str, str] = {}
+        for platform, manifest_digest in oci_identity["platformManifestDigests"].items():
+            sbom = sbom_path(output, platform)
+            subprocess.run([
+                "syft", "scan", f"oci-archive:{output}",
+                "--platform", platform,
+                "--source-name", "ghcr.io/openkubes/ok-cluster-runner",
+                "--source-version", manifest_digest,
+                "--output", f"spdx-json={sbom}",
+            ], cwd=root, check=True)
+            sbom_digests[platform] = sha256(sbom)
+            sbom_semantic_digests[platform] = semantic_sbom_digest(sbom)
         record = {
             **{key: value for key, value in plan.items() if key != "command"},
             "format": "ok147-runner-image-build-record/v1",
             "ociArchiveDigest": sha256(output),
-            "sbomDigest": sha256(sbom),
+            "sbomDigests": sbom_digests,
+            "sbomSemanticDigests": sbom_semantic_digests,
             **oci_identity,
         }
         write_exclusive(output.with_suffix(".build-record.json"), record)

--- a/scripts/build_ok147_runner.py
+++ b/scripts/build_ok147_runner.py
@@ -98,43 +98,85 @@ def sha256(path: Path) -> str:
 
 
 def inspect_oci_archive(path: Path) -> dict[str, object]:
-    with tarfile.open(path, "r") as archive:
+    def read_member(archive: tarfile.TarFile, name: str) -> bytes:
         try:
-            member = archive.getmember("index.json")
+            member = archive.getmember(name)
         except KeyError as error:
-            raise ValueError("OCI archive has no index.json") from error
+            raise ValueError(f"OCI archive has no {name}") from error
         source = archive.extractfile(member)
         if source is None:
-            raise ValueError("OCI archive has no readable index.json")
-        raw = source.read()
-    index = json.loads(raw)
-    if index.get("schemaVersion") != 2 or not isinstance(index.get("manifests"), list):
-        raise ValueError("OCI archive index is invalid")
-    platforms: dict[str, str] = {}
-    attestations: list[str] = []
-    for descriptor in index["manifests"]:
-        digest = descriptor.get("digest", "")
+            raise ValueError(f"OCI archive has no readable {name}")
+        return source.read()
+
+    def read_blob(archive: tarfile.TarFile, digest: str) -> dict[str, object]:
         if not re.fullmatch(r"sha256:[0-9a-f]{64}", digest):
-            raise ValueError("OCI index contains an invalid manifest digest")
-        annotations = descriptor.get("annotations") or {}
-        if annotations.get("vnd.docker.reference.type") == "attestation-manifest":
-            attestations.append(digest)
-            continue
-        platform = descriptor.get("platform") or {}
-        identity = f"{platform.get('os')}/{platform.get('architecture')}"
-        if identity not in PLATFORMS.split(","):
-            raise ValueError(f"OCI archive contains unexpected platform {identity}")
-        if identity in platforms:
-            raise ValueError(f"OCI archive contains duplicate platform {identity}")
-        platforms[identity] = digest
-    if sorted(platforms) != sorted(PLATFORMS.split(",")):
-        raise ValueError("OCI archive lacks an exact platform manifest set")
-    if len(attestations) < 2:
-        raise ValueError("OCI archive lacks per-platform provenance attestations")
+            raise ValueError("OCI descriptor has an invalid digest")
+        raw = read_member(archive, "blobs/sha256/" + digest.removeprefix("sha256:"))
+        if "sha256:" + hashlib.sha256(raw).hexdigest() != digest:
+            raise ValueError("OCI blob content differs from its descriptor digest")
+        document = json.loads(raw)
+        if not isinstance(document, dict):
+            raise ValueError("OCI blob is not a JSON object")
+        return document
+
+    with tarfile.open(path, "r") as archive:
+        raw = read_member(archive, "index.json")
+        layout_index = json.loads(raw)
+        if layout_index.get("schemaVersion") != 2 or not isinstance(layout_index.get("manifests"), list):
+            raise ValueError("OCI archive index is invalid")
+
+        index = layout_index
+        index_digest = "sha256:" + hashlib.sha256(raw).hexdigest()
+        if len(layout_index["manifests"]) == 1:
+            root_descriptor = layout_index["manifests"][0]
+            if root_descriptor.get("mediaType") == "application/vnd.oci.image.index.v1+json":
+                index_digest = root_descriptor.get("digest", "")
+                index = read_blob(archive, index_digest)
+        if index.get("schemaVersion") != 2 or not isinstance(index.get("manifests"), list):
+            raise ValueError("OCI image index is invalid")
+
+        platforms: dict[str, str] = {}
+        attestations: dict[str, str] = {}
+        for descriptor in index["manifests"]:
+            digest = descriptor.get("digest", "")
+            if not re.fullmatch(r"sha256:[0-9a-f]{64}", digest):
+                raise ValueError("OCI index contains an invalid manifest digest")
+            annotations = descriptor.get("annotations") or {}
+            if annotations.get("vnd.docker.reference.type") == "attestation-manifest":
+                subject = annotations.get("vnd.docker.reference.digest", "")
+                if subject in attestations:
+                    raise ValueError("OCI archive contains duplicate provenance for one subject")
+                provenance = read_blob(archive, digest)
+                layers = provenance.get("layers")
+                if not isinstance(layers, list) or len(layers) != 1:
+                    raise ValueError("provenance manifest must contain exactly one layer")
+                layer = layers[0]
+                if layer.get("mediaType") != "application/vnd.in-toto+json":
+                    raise ValueError("provenance layer is not an in-toto statement")
+                predicate = (layer.get("annotations") or {}).get("in-toto.io/predicate-type")
+                if predicate != "https://slsa.dev/provenance/v1":
+                    raise ValueError("provenance layer is not SLSA provenance v1")
+                attestations[subject] = digest
+                continue
+            platform = descriptor.get("platform") or {}
+            identity = f"{platform.get('os')}/{platform.get('architecture')}"
+            if identity not in PLATFORMS.split(","):
+                raise ValueError(f"OCI archive contains unexpected platform {identity}")
+            if identity in platforms:
+                raise ValueError(f"OCI archive contains duplicate platform {identity}")
+            image_manifest = read_blob(archive, digest)
+            if image_manifest.get("mediaType") != "application/vnd.oci.image.manifest.v1+json":
+                raise ValueError("platform descriptor does not reference an OCI image manifest")
+            platforms[identity] = digest
+        if sorted(platforms) != sorted(PLATFORMS.split(",")):
+            raise ValueError("OCI archive lacks an exact platform manifest set")
+        if sorted(attestations) != sorted(platforms.values()):
+            raise ValueError("OCI archive lacks exact per-platform provenance attestations")
     return {
-        "ociIndexDigest": "sha256:" + hashlib.sha256(raw).hexdigest(),
+        "ociLayoutIndexDigest": "sha256:" + hashlib.sha256(raw).hexdigest(),
+        "ociIndexDigest": index_digest,
         "platformManifestDigests": dict(sorted(platforms.items())),
-        "provenanceManifestDigests": sorted(attestations),
+        "provenanceManifestDigests": sorted(attestations.values()),
     }
 
 
@@ -193,7 +235,7 @@ def main() -> int:
         write_exclusive(output.with_suffix(".build-record.json"), record)
         print(json.dumps(record, sort_keys=True, indent=2))
         return 0
-    except (OSError, subprocess.CalledProcessError, ValueError) as error:
+    except (OSError, subprocess.CalledProcessError, tarfile.TarError, ValueError) as error:
         print(f"ERROR: {error}", file=sys.stderr)
         return 2
 

--- a/tests/ok147_runner_image_test.py
+++ b/tests/ok147_runner_image_test.py
@@ -1,0 +1,94 @@
+import importlib.util
+import json
+from pathlib import Path
+import tarfile
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location(
+    "build_ok147_runner", ROOT / "scripts" / "build_ok147_runner.py"
+)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader
+SPEC.loader.exec_module(MODULE)
+
+
+class RunnerImageTest(unittest.TestCase):
+    def test_containerfile_binds_supply_chain_and_nonroot_runtime(self):
+        raw = (ROOT / "Containerfile.ok147").read_text()
+        manifest = json.loads((ROOT / "build" / "ok147-runner-image.json").read_text())
+        for image in (
+            manifest["dockerfileFrontend"],
+            manifest["builderImage"],
+            manifest["runtimeImage"],
+        ):
+            self.assertRegex(image, r"@sha256:[0-9a-f]{64}$")
+            self.assertIn(image, raw)
+        self.assertIn("CGO_ENABLED=0", raw)
+        self.assertIn("-trimpath", raw)
+        self.assertIn("-buildid=", raw)
+        self.assertIn("USER 65532:65532", raw)
+        self.assertIn('ENTRYPOINT ["/ok"]', raw)
+        self.assertNotIn("COPY .", raw)
+
+    def test_dockerignore_is_allowlist(self):
+        lines = (ROOT / ".dockerignore").read_text().splitlines()
+        self.assertEqual(lines[0], "**")
+        self.assertIn("!go.mod", lines)
+        self.assertIn("!cmd/ok/**", lines)
+        self.assertIn("!internal/**", lines)
+        self.assertFalse(any("kube" in line.lower() for line in lines[1:]))
+
+    def test_plan_is_nonpublishing_and_digest_bound(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            output = Path(temporary) / "runner.oci.tar"
+            args = type("Args", (), {
+                "version": "0.1.0-dev",
+                "revision": "a" * 40,
+                "created": "2026-08-16T08:00:00Z",
+                "output": str(output),
+                "execute": False,
+            })()
+            resolved, created = MODULE.validate(args, ROOT)
+            command = MODULE.build_command(ROOT, args, resolved, created)
+            contract, contract_digest = MODULE.supply_chain_contract(ROOT)
+            self.assertIn("--provenance=mode=max", command)
+            self.assertIn("linux/amd64,linux/arm64", command)
+            self.assertIn(f"type=oci,dest={resolved}", command)
+            self.assertNotIn("--push", command)
+            self.assertEqual(contract["networkPublication"], "disabled")
+            self.assertRegex(contract_digest, r"^sha256:[0-9a-f]{64}$")
+
+    def test_invalid_build_inputs_fail_closed(self):
+        invalid = [
+            ("version", "latest"),
+            ("revision", "abc"),
+            ("created", "now"),
+        ]
+        with tempfile.TemporaryDirectory() as temporary:
+            for field, value in invalid:
+                args = type("Args", (), {
+                    "version": "0.1.0-dev",
+                    "revision": "a" * 40,
+                    "created": "2026-08-16T08:00:00Z",
+                    "output": str(Path(temporary) / f"{field}.tar"),
+                    "execute": False,
+                })()
+                setattr(args, field, value)
+                with self.subTest(field=field):
+                    with self.assertRaises(ValueError):
+                        MODULE.validate(args, ROOT)
+
+    def test_archive_without_index_fails_closed(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            path = Path(temporary) / "invalid.tar"
+            with tarfile.open(path, "w"):
+                pass
+            with self.assertRaisesRegex(ValueError, "has no index.json"):
+                MODULE.inspect_oci_archive(path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/ok147_runner_image_test.py
+++ b/tests/ok147_runner_image_test.py
@@ -89,6 +89,25 @@ class RunnerImageTest(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, "has no index.json"):
                 MODULE.inspect_oci_archive(path)
 
+    def test_semantic_sbom_digest_ignores_only_envelope_identity(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            first = Path(temporary) / "first.json"
+            second = Path(temporary) / "second.json"
+            document = {
+                "spdxVersion": "SPDX-2.3",
+                "documentNamespace": "urn:first",
+                "creationInfo": {"created": "2026-08-16T08:00:00Z", "creators": ["Tool: syft"]},
+                "packages": [{"name": "ok", "versionInfo": "1"}],
+            }
+            first.write_text(json.dumps(document))
+            document["documentNamespace"] = "urn:second"
+            document["creationInfo"]["created"] = "2026-08-16T09:00:00Z"
+            second.write_text(json.dumps(document))
+            self.assertEqual(MODULE.semantic_sbom_digest(first), MODULE.semantic_sbom_digest(second))
+            document["packages"][0]["versionInfo"] = "2"
+            second.write_text(json.dumps(document))
+            self.assertNotEqual(MODULE.semantic_sbom_digest(first), MODULE.semantic_sbom_digest(second))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What changed

- add a digest-pinned, distroless, non-root multi-architecture `Containerfile.ok147`
- add a deny-by-default build context and embed explicit version plus full Git revision in `ok version`
- add fail-closed local build planning/execution with no registry destination or `--push`
- verify the exact `linux/amd64` and `linux/arm64` OCI manifest set and per-platform SLSA provenance v1 attestations
- generate a Syft SPDX 2.3 SBOM for each platform and bind raw plus deterministic semantic SBOM digests
- record two-run reproducibility evidence for both platform manifests and semantic SBOM identities

## Why

The previous OK-147 checkpoint defined a read-only in-cluster Job envelope but intentionally left its image digest unresolved. This checkpoint establishes a reproducible and auditable container supply-chain boundary before any registry publication or Job deployment is considered.

## Evidence and boundaries

- source revision: `51ecd4e72c4105ab42cd461285f12d1cf5524712`
- supply-chain contract: `sha256:dafe84745eb684bc7c5db0b68c6c073d390b22b0fb5fe2b2996ea6ee73d1768e`
- reproducible amd64 manifest: `sha256:61a9ff0061eb4950b0841a5ada4195ae8f2b43de4c824a0d47a503c83edff172`
- reproducible arm64 manifest: `sha256:a21f2d234f64f5e8b963b56fe37b942fbe6518bc1edc3eb7666b396c0b11b7ce`
- no image was pushed, no Job was deployed, and no cluster was contacted
- raw OCI archives, SBOM files, and local build records remain under `/private/tmp` and are not committed

## Validation

- `CGO_ENABLED=0 go test ./...`
- `python3 -m unittest discover -s tests -p '*_test.py'` — 13 passed, 1 existing skip
- `CGO_ENABLED=0 go vet ./...`
- `git diff --check`
- two successful Buildx v0.36.1 multi-platform builds with matching image-manifest and semantic-SBOM digests

## Review question

Does this checkpoint establish a sufficiently bounded and reproducible runner-image identity without prematurely publishing the image or authorizing in-cluster execution?