### PR TITLE
feat(OK-147): add bounded runner registry publisher

### DIFF
--- a/.github/workflows/ok147-runner-publisher.yaml
+++ b/.github/workflows/ok147-runner-publisher.yaml
@@ -1,0 +1,136 @@
+name: OK-147 bounded runner publisher
+
+"on":
+  workflow_dispatch:
+    inputs:
+      source-sha:
+        description: Exact reviewed lowercase 40-character main commit
+        required: true
+        type: string
+      version:
+        description: Exact semantic runner version
+        required: true
+        default: 0.1.0-dev
+        type: string
+      publication-contract-digest:
+        description: Exact SHA-256 of build/ok147-runner-publication.json
+        required: true
+        type: string
+
+permissions:
+  artifact-metadata: write
+  attestations: write
+  contents: read
+  id-token: write
+  packages: write
+
+concurrency:
+  group: ok147-runner-publisher
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    if: github.ref == 'refs/heads/main'
+    environment: ok-147-runner-publish
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Check out the reviewed source
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          persist-credentials: false
+
+      - name: Verify exact publication bindings
+        id: bind
+        env:
+          INPUT_SOURCE_SHA: ${{ inputs.source-sha }}
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_PUBLICATION_CONTRACT_DIGEST: ${{ inputs.publication-contract-digest }}
+        run: |
+          python3 -c 'import os,re,sys; values=(re.fullmatch(r"[0-9a-f]{40}",os.environ["INPUT_SOURCE_SHA"]),re.fullmatch(r"v?[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?",os.environ["INPUT_VERSION"]),re.fullmatch(r"sha256:[0-9a-f]{64}",os.environ["INPUT_PUBLICATION_CONTRACT_DIGEST"])); sys.exit(0 if all(values) else 2)'
+          test "$INPUT_SOURCE_SHA" = "$GITHUB_SHA"
+          actual_contract_digest="sha256:$(sha256sum build/ok147-runner-publication.json | cut -d ' ' -f1)"
+          test "$actual_contract_digest" = "$INPUT_PUBLICATION_CONTRACT_DIGEST"
+          python3 -c 'import json,sys; d=json.load(open("build/ok147-runner-publication.json")); expected={"format":"ok147-runner-publication/v1","image":"ghcr.io/openkubes/ok-cluster-runner","sourceRef":"refs/heads/main","environment":"ok-147-runner-publish","tagTemplate":"sha-<12>-run-<run-id>","platforms":["linux/amd64","linux/arm64"],"provenance":"mode=max","githubAttestation":True,"pullbackByDigest":True,"networkPublication":"workflow-dispatch-only","receiptRetentionDays":90}; sys.exit(0 if all(d.get(k)==v for k,v in expected.items()) and "@sha256:" in d["sbomGeneratorImage"] else 2)'
+          created="$(git show -s --format=%cI "$GITHUB_SHA")"
+          short_sha="$(printf '%s' "$GITHUB_SHA" | cut -c1-12)"
+          printf 'created=%s\nshort_sha=%s\n' "$created" "$short_sha" >> "$GITHUB_OUTPUT"
+
+      - name: Set up pinned Buildx action
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
+
+      - name: Log in to GHCR
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and publish the exact multi-platform image
+        id: build
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
+        with:
+          context: .
+          file: Containerfile.ok147
+          platforms: linux/amd64,linux/arm64
+          push: true
+          provenance: mode=max
+          sbom: generator=docker.io/docker/buildkit-syft-scanner:stable-1@sha256:79e7b013cbec16bbb436f312819a49a4a57752b2270c1a9332ae1a10fcc82a68
+          tags: ghcr.io/openkubes/ok-cluster-runner:sha-${{ steps.bind.outputs.short_sha }}-run-${{ github.run_id }}
+          build-args: |
+            VERSION=${{ inputs.version }}
+            REVISION=${{ inputs.source-sha }}
+            CREATED=${{ steps.bind.outputs.created }}
+
+      - name: Attest the exact published index
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6
+        with:
+          subject-name: ghcr.io/openkubes/ok-cluster-runner
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true
+          create-storage-record: true
+
+      - name: Pull back and verify by digest
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IMAGE: ghcr.io/openkubes/ok-cluster-runner
+          DIGEST: ${{ steps.build.outputs.digest }}
+          SOURCE_SHA: ${{ inputs.source-sha }}
+          VERSION: ${{ inputs.version }}
+          PUBLICATION_CONTRACT_DIGEST: ${{ inputs.publication-contract-digest }}
+        run: |
+          mkdir "$RUNNER_TEMP/attestations"
+          docker buildx imagetools inspect "$IMAGE@$DIGEST" --raw > "$RUNNER_TEMP/index.json"
+          python3 scripts/verify_ok147_published_image.py list-attestations \
+            --index "$RUNNER_TEMP/index.json" \
+            --expected-digest "$DIGEST" \
+            > "$RUNNER_TEMP/attestation-digests.txt"
+          while IFS= read -r descriptor_digest; do
+            python3 -c 'import re,sys; sys.exit(0 if re.fullmatch(r"sha256:[0-9a-f]{64}",sys.argv[1]) else 2)' "$descriptor_digest"
+            docker buildx imagetools inspect "$IMAGE@$descriptor_digest" --raw \
+              > "$RUNNER_TEMP/attestations/${descriptor_digest#sha256:}.json"
+          done < "$RUNNER_TEMP/attestation-digests.txt"
+          gh attestation verify "oci://$IMAGE@$DIGEST" \
+            --repo openkubes/ok-cluster \
+            --signer-workflow openkubes/ok-cluster/.github/workflows/ok147-runner-publisher.yaml \
+            --source-ref refs/heads/main \
+            --format json > "$RUNNER_TEMP/github-attestation.json"
+          python3 scripts/verify_ok147_published_image.py receipt \
+            --index "$RUNNER_TEMP/index.json" \
+            --attestations-dir "$RUNNER_TEMP/attestations" \
+            --github-attestation "$RUNNER_TEMP/github-attestation.json" \
+            --expected-digest "$DIGEST" \
+            --publication-contract-digest "$PUBLICATION_CONTRACT_DIGEST" \
+            --image "$IMAGE" \
+            --source-sha "$SOURCE_SHA" \
+            --version "$VERSION" \
+            --workflow-run-url "https://github.com/openkubes/ok-cluster/actions/runs/$GITHUB_RUN_ID" \
+            --output "$RUNNER_TEMP/publication-receipt.json"
+
+      - name: Retain the redacted publication receipt
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: ok147-runner-publication-receipt-${{ github.run_id }}
+          path: ${{ runner.temp }}/publication-receipt.json
+          if-no-files-found: error
+          retention-days: 90

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ Powered by [Cluster API (CAPI)](https://cluster-api.sigs.k8s.io/), [CAPK (KubeVi
   fail-closed single-use receipt semantics, and an offline-tested durable
   Kubernetes ledger plus short-lived read-only Job preflight boundary; its
   container build is digest-pinned, multi-architecture, non-root, SBOM- and
-  provenance-producing, and remains local/non-publishing
+  provenance-producing, with a separate manual, protected and digest-verifying
+  GHCR publication boundary
 
 ---
 

--- a/build/ok147-runner-publication.json
+++ b/build/ok147-runner-publication.json
@@ -1,0 +1,17 @@
+{
+  "format": "ok147-runner-publication/v1",
+  "image": "ghcr.io/openkubes/ok-cluster-runner",
+  "sourceRef": "refs/heads/main",
+  "environment": "ok-147-runner-publish",
+  "tagTemplate": "sha-<12>-run-<run-id>",
+  "platforms": [
+    "linux/amd64",
+    "linux/arm64"
+  ],
+  "provenance": "mode=max",
+  "sbomGeneratorImage": "docker.io/docker/buildkit-syft-scanner:stable-1@sha256:79e7b013cbec16bbb436f312819a49a4a57752b2270c1a9332ae1a10fcc82a68",
+  "githubAttestation": true,
+  "pullbackByDigest": true,
+  "networkPublication": "workflow-dispatch-only",
+  "receiptRetentionDays": 90
+}

--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -274,6 +274,35 @@ This checkpoint deliberately has no registry destination and never uses
 an authorization, or permit lifecycle mutation. A later checkpoint must bind a
 verified registry digest before any in-cluster execution can be proposed.
 
+## Bounded registry-publication candidate
+
+The next checkpoint defines that publication boundary without executing it.
+[`build/ok147-runner-publication.json`](../build/ok147-runner-publication.json)
+binds the sole image name, exact platform set, protected GitHub Environment,
+provenance mode, digest-pinned BuildKit SBOM generator, digest-only pullback and
+90-day receipt retention. Its tag includes both the source-SHA prefix and the
+unique workflow-run ID, so a second authorized publication cannot overwrite a
+previous run tag.
+
+The publisher is manual `workflow_dispatch` only, runs exclusively from an
+exact reviewed `main` commit, and accepts the publication-contract digest as an
+explicit input. Every referenced action is pinned by full commit SHA. It creates
+only a non-authoritative `sha-<commit>-run-<run-id>` tag—never `latest` or a
+release tag—and publishes with BuildKit SLSA provenance plus SPDX SBOM
+attestations for both platforms. A separate GitHub artifact attestation binds
+the resulting OCI index digest.
+
+Pullback occurs only as `image@sha256:...`. The verifier hashes the returned OCI
+index, enforces exactly `linux/amd64` and `linux/arm64`, resolves one attestation
+manifest per platform, and requires each to contain exactly the SPDX Document
+and SLSA Provenance v1 predicate classes. `gh attestation verify` must also
+succeed before an exclusive redacted receipt is retained.
+
+The workflow still cannot deploy a Job or contact a Kubernetes cluster. Merely
+merging it does not publish anything: the protected
+`ok-147-runner-publish` Environment and a separately reviewed dispatch binding
+the exact merged SHA and publication-contract digest are required first.
+
 ## OK-141 compatibility evidence
 
 The verifier was run offline against the preserved Phase-R v5 projection. It

--- a/scripts/verify_ok147_published_image.py
+++ b/scripts/verify_ok147_published_image.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Fail-closed verifier for the bounded OK-147 GHCR publication."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import sys
+
+
+FORMAT = "ok147-runner-publication-receipt/v1"
+IMAGE = "ghcr.io/openkubes/ok-cluster-runner"
+PLATFORMS = ("linux/amd64", "linux/arm64")
+DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+REVISION_RE = re.compile(r"^[0-9a-f]{40}$")
+VERSION_RE = re.compile(r"^v?[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?$")
+RUN_URL_RE = re.compile(r"^https://github\.com/openkubes/ok-cluster/actions/runs/[1-9][0-9]*$")
+PREDICATES = {
+    "https://spdx.dev/Document",
+    "https://slsa.dev/provenance/v1",
+}
+
+
+def sha256_bytes(raw: bytes) -> str:
+    return "sha256:" + hashlib.sha256(raw).hexdigest()
+
+
+def sha256_file(path: Path) -> str:
+    return sha256_bytes(path.read_bytes())
+
+
+def read_json(path: Path) -> tuple[bytes, object]:
+    raw = path.read_bytes()
+    return raw, json.loads(raw)
+
+
+def verify_index(path: Path, expected_digest: str) -> tuple[dict[str, str], dict[str, str]]:
+    if not DIGEST_RE.fullmatch(expected_digest):
+        raise ValueError("expected digest is invalid")
+    raw, document = read_json(path)
+    if sha256_bytes(raw) != expected_digest:
+        raise ValueError("pulled index differs from the published digest")
+    if not isinstance(document, dict):
+        raise ValueError("pulled index is not a JSON object")
+    if document.get("schemaVersion") != 2:
+        raise ValueError("pulled index has an invalid schema version")
+    if document.get("mediaType") != "application/vnd.oci.image.index.v1+json":
+        raise ValueError("published subject is not an OCI image index")
+    descriptors = document.get("manifests")
+    if not isinstance(descriptors, list):
+        raise ValueError("published index has no manifest list")
+
+    platforms: dict[str, str] = {}
+    attestations: dict[str, str] = {}
+    for descriptor in descriptors:
+        if not isinstance(descriptor, dict):
+            raise ValueError("published index contains a non-object descriptor")
+        digest = descriptor.get("digest", "")
+        if not DIGEST_RE.fullmatch(digest):
+            raise ValueError("published index contains an invalid descriptor digest")
+        annotations = descriptor.get("annotations") or {}
+        if annotations.get("vnd.docker.reference.type") == "attestation-manifest":
+            subject = annotations.get("vnd.docker.reference.digest", "")
+            if not DIGEST_RE.fullmatch(subject) or subject in attestations:
+                raise ValueError("published index contains invalid or duplicate attestation subjects")
+            attestations[subject] = digest
+            continue
+        platform = descriptor.get("platform") or {}
+        identity = f"{platform.get('os')}/{platform.get('architecture')}"
+        if identity not in PLATFORMS or identity in platforms:
+            raise ValueError(f"published index contains unexpected or duplicate platform {identity}")
+        platforms[identity] = digest
+
+    if tuple(sorted(platforms)) != tuple(sorted(PLATFORMS)):
+        raise ValueError("published index lacks the exact platform set")
+    if tuple(sorted(attestations)) != tuple(sorted(platforms.values())):
+        raise ValueError("published index lacks one attestation manifest per platform")
+    return dict(sorted(platforms.items())), dict(sorted(attestations.items()))
+
+
+def verify_attestations(directory: Path, attestations: dict[str, str]) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for subject, digest in attestations.items():
+        path = directory / f"{digest.removeprefix('sha256:')}.json"
+        raw, document = read_json(path)
+        if sha256_bytes(raw) != digest:
+            raise ValueError("pulled attestation manifest differs from its descriptor")
+        if not isinstance(document, dict):
+            raise ValueError("attestation manifest is not a JSON object")
+        if document.get("mediaType") != "application/vnd.oci.image.manifest.v1+json":
+            raise ValueError("attestation descriptor is not an OCI image manifest")
+        layers = document.get("layers")
+        if not isinstance(layers, list):
+            raise ValueError("attestation manifest has no layers")
+        predicates: set[str] = set()
+        for layer in layers:
+            if not isinstance(layer, dict) or layer.get("mediaType") != "application/vnd.in-toto+json":
+                raise ValueError("attestation manifest contains a non-in-toto layer")
+            predicate = (layer.get("annotations") or {}).get("in-toto.io/predicate-type")
+            if not isinstance(predicate, str):
+                raise ValueError("attestation layer has no predicate type")
+            predicates.add(predicate)
+        if predicates != PREDICATES:
+            raise ValueError("attestation manifest lacks the exact SPDX and SLSA predicates")
+        result[subject] = {
+            "manifestDigest": digest,
+            "predicateTypes": sorted(predicates),
+        }
+    return dict(sorted(result.items()))
+
+
+def write_exclusive(path: Path, value: object) -> None:
+    raw = json.dumps(value, sort_keys=True, separators=(",", ":")).encode() + b"\n"
+    descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    with os.fdopen(descriptor, "wb") as target:
+        target.write(raw)
+        target.flush()
+        os.fsync(target.fileno())
+
+
+def parser() -> argparse.ArgumentParser:
+    root = argparse.ArgumentParser()
+    commands = root.add_subparsers(dest="command", required=True)
+    listing = commands.add_parser("list-attestations")
+    listing.add_argument("--index", type=Path, required=True)
+    listing.add_argument("--expected-digest", required=True)
+
+    receipt = commands.add_parser("receipt")
+    receipt.add_argument("--index", type=Path, required=True)
+    receipt.add_argument("--attestations-dir", type=Path, required=True)
+    receipt.add_argument("--github-attestation", type=Path, required=True)
+    receipt.add_argument("--expected-digest", required=True)
+    receipt.add_argument("--publication-contract-digest", required=True)
+    receipt.add_argument("--image", required=True)
+    receipt.add_argument("--source-sha", required=True)
+    receipt.add_argument("--version", required=True)
+    receipt.add_argument("--workflow-run-url", required=True)
+    receipt.add_argument("--output", type=Path, required=True)
+    return root
+
+
+def main() -> int:
+    args = parser().parse_args()
+    try:
+        platforms, attestations = verify_index(args.index, args.expected_digest)
+        if args.command == "list-attestations":
+            for digest in sorted(attestations.values()):
+                print(digest)
+            return 0
+
+        if args.image != IMAGE:
+            raise ValueError("published image identity is not the bounded repository")
+        if not REVISION_RE.fullmatch(args.source_sha):
+            raise ValueError("source SHA is invalid")
+        if not VERSION_RE.fullmatch(args.version):
+            raise ValueError("version is invalid")
+        if not DIGEST_RE.fullmatch(args.publication_contract_digest):
+            raise ValueError("publication contract digest is invalid")
+        if not RUN_URL_RE.fullmatch(args.workflow_run_url):
+            raise ValueError("workflow run URL is invalid")
+        if args.output.exists() or not args.output.parent.is_dir():
+            raise ValueError("receipt output must be absent in an existing directory")
+        _, github_attestation = read_json(args.github_attestation)
+        if not github_attestation:
+            raise ValueError("GitHub attestation verification result is empty")
+        verified_attestations = verify_attestations(args.attestations_dir, attestations)
+        record = {
+            "format": FORMAT,
+            "image": args.image,
+            "digest": args.expected_digest,
+            "sourceSha": args.source_sha,
+            "version": args.version,
+            "publicationContractDigest": args.publication_contract_digest,
+            "workflowRunUrl": args.workflow_run_url,
+            "platformManifestDigests": platforms,
+            "attestations": verified_attestations,
+            "githubAttestationVerificationDigest": sha256_file(args.github_attestation),
+            "pullbackByDigestVerified": True,
+            "networkPublicationPerformed": True,
+            "deploymentPerformed": False,
+            "clusterContactPerformed": False,
+        }
+        write_exclusive(args.output, record)
+        print(json.dumps(record, sort_keys=True, indent=2))
+        return 0
+    except (OSError, json.JSONDecodeError, ValueError) as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/ok147_runner_publication_test.py
+++ b/tests/ok147_runner_publication_test.py
@@ -1,0 +1,128 @@
+import importlib.util
+import json
+from pathlib import Path
+import re
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location(
+    "verify_ok147_published_image", ROOT / "scripts" / "verify_ok147_published_image.py"
+)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader
+SPEC.loader.exec_module(MODULE)
+
+
+def canonical(value):
+    return json.dumps(value, sort_keys=True, separators=(",", ":")).encode()
+
+
+class RunnerPublicationTest(unittest.TestCase):
+    def fixture(self, temporary):
+        root = Path(temporary)
+        attestations_dir = root / "attestations"
+        attestations_dir.mkdir()
+        platform_digests = {
+            "linux/amd64": "sha256:" + "a" * 64,
+            "linux/arm64": "sha256:" + "b" * 64,
+        }
+        attestation_descriptors = []
+        for platform_digest in platform_digests.values():
+            manifest = {
+                "schemaVersion": 2,
+                "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                "layers": [
+                    {
+                        "mediaType": "application/vnd.in-toto+json",
+                        "annotations": {"in-toto.io/predicate-type": "https://spdx.dev/Document"},
+                    },
+                    {
+                        "mediaType": "application/vnd.in-toto+json",
+                        "annotations": {"in-toto.io/predicate-type": "https://slsa.dev/provenance/v1"},
+                    },
+                ],
+            }
+            raw = canonical(manifest)
+            digest = MODULE.sha256_bytes(raw)
+            (attestations_dir / f"{digest.removeprefix('sha256:')}.json").write_bytes(raw)
+            attestation_descriptors.append({
+                "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                "digest": digest,
+                "annotations": {
+                    "vnd.docker.reference.type": "attestation-manifest",
+                    "vnd.docker.reference.digest": platform_digest,
+                },
+                "platform": {"os": "unknown", "architecture": "unknown"},
+            })
+        index = {
+            "schemaVersion": 2,
+            "mediaType": "application/vnd.oci.image.index.v1+json",
+            "manifests": [
+                {
+                    "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                    "digest": digest,
+                    "platform": {"os": platform.split("/")[0], "architecture": platform.split("/")[1]},
+                }
+                for platform, digest in platform_digests.items()
+            ] + attestation_descriptors,
+        }
+        index_path = root / "index.json"
+        index_path.write_bytes(canonical(index))
+        return index_path, attestations_dir, MODULE.sha256_file(index_path)
+
+    def test_verifier_accepts_exact_platform_and_attestation_set(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            index, directory, digest = self.fixture(temporary)
+            platforms, attestations = MODULE.verify_index(index, digest)
+            self.assertEqual(tuple(platforms), MODULE.PLATFORMS)
+            verified = MODULE.verify_attestations(directory, attestations)
+            self.assertEqual(len(verified), 2)
+            for value in verified.values():
+                self.assertEqual(set(value["predicateTypes"]), MODULE.PREDICATES)
+
+    def test_index_digest_mismatch_fails_closed(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            index, _, _ = self.fixture(temporary)
+            with self.assertRaisesRegex(ValueError, "differs from the published digest"):
+                MODULE.verify_index(index, "sha256:" + "f" * 64)
+
+    def test_missing_sbom_predicate_fails_closed(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            index, directory, digest = self.fixture(temporary)
+            _, attestations = MODULE.verify_index(index, digest)
+            first = next(iter(directory.glob("*.json")))
+            document = json.loads(first.read_text())
+            document["layers"] = document["layers"][1:]
+            first.write_bytes(canonical(document))
+            with self.assertRaisesRegex(ValueError, "differs from its descriptor"):
+                MODULE.verify_attestations(directory, attestations)
+
+    def test_publication_contract_is_dispatch_only_and_digest_bound(self):
+        contract = json.loads((ROOT / "build" / "ok147-runner-publication.json").read_text())
+        self.assertEqual(contract["networkPublication"], "workflow-dispatch-only")
+        self.assertEqual(contract["tagTemplate"], "sha-<12>-run-<run-id>")
+        self.assertEqual(contract["platforms"], list(MODULE.PLATFORMS))
+        self.assertRegex(contract["sbomGeneratorImage"], r"@sha256:[0-9a-f]{64}$")
+
+    def test_workflow_is_pinned_protected_and_has_no_automatic_trigger(self):
+        raw = (ROOT / ".github" / "workflows" / "ok147-runner-publisher.yaml").read_text()
+        self.assertIn('"on":\n  workflow_dispatch:', raw)
+        self.assertNotRegex(raw, r"(?m)^  (push|pull_request|schedule):\s*$")
+        self.assertIn("environment: ok-147-runner-publish", raw)
+        self.assertIn("if: github.ref == 'refs/heads/main'", raw)
+        self.assertIn("provenance: mode=max", raw)
+        contract = json.loads((ROOT / "build" / "ok147-runner-publication.json").read_text())
+        self.assertIn(f"sbom: generator={contract['sbomGeneratorImage']}", raw)
+        self.assertIn('docker buildx imagetools inspect "$IMAGE@$DIGEST" --raw', raw)
+        self.assertIn("gh attestation verify", raw)
+        self.assertIn("sha-${{ steps.bind.outputs.short_sha }}-run-${{ github.run_id }}", raw)
+        self.assertNotIn(":latest", raw)
+        self.assertEqual(set(re.findall(r"secrets\.([A-Z0-9_]+)", raw)), {"GITHUB_TOKEN"})
+        for action_ref in re.findall(r"uses: [^@\s]+@([^\s]+)", raw):
+            self.assertRegex(action_ref, r"^[0-9a-f]{40}$")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- add a manual, protected GHCR publisher for `ghcr.io/openkubes/ok-cluster-runner`
- bind execution to an exact reviewed `main` SHA and publication-contract digest
- pin every GitHub Action and the BuildKit Syft scanner by immutable digest/SHA
- publish only the exact `linux/amd64` and `linux/arm64` image set with max provenance and SPDX attestations
- use unique, non-authoritative `sha-<12>-run-<run-id>` tags so later runs cannot overwrite prior run tags
- add digest-only pullback, OCI index verification, per-platform SPDX/SLSA attestation verification, and GitHub artifact-attestation verification
- retain only a redacted publication receipt for 90 days

## Why

The previous checkpoint proved the runner payload and semantic SBOM identities reproducible but deliberately stopped before network publication. This PR establishes the next authorization boundary without executing it. Merge alone cannot publish an image.

## Boundaries

- workflow is `workflow_dispatch` only
- workflow runs only from `refs/heads/main`
- protected Environment: `ok-147-runner-publish`
- publication contract: `sha256:851ad0f6d46bcc28bd0d6a0f2c4b7c3d1696c7915098443993e644a0768c64a9`
- no `latest` or release tag
- no Kubernetes credentials, deployment, Job execution, lifecycle mutation, or cluster contact
- no publisher dispatch has been performed

## Validation

- workflow YAML parsed with `yaml.BaseLoader`
- `CGO_ENABLED=0 go test ./...`
- `python3 -m unittest discover -s tests -p '*_test.py'` — 18 passed, 1 existing skip
- `CGO_ENABLED=0 go vet ./...`
- `git diff --check`
- verifier exercised against a real local BuildKit multi-platform OCI index containing both SPDX Document and SLSA Provenance v1 predicates

## Review question

Does this workflow preserve the separation between a reviewed publication mechanism and a separately authorized one-shot publication, while proving the exact remote digest and attached supply-chain evidence?