### PR TITLE
OK-147: add bounded submission primitive

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -303,6 +303,53 @@ merging it does not publish anything: the protected
 `ok-147-runner-publish` Environment and a separately reviewed dispatch binding
 the exact merged SHA and publication-contract digest are required first.
 
+## Bounded submission primitive
+
+The next offline checkpoint implements, but does not activate, the exact-create
+submission primitive needed by a future executor. It consumes only a projection
+that already passed the authoritative renderer verifier. Immediately before
+use it re-reads and digest-verifies both projection YAML artifacts and checks
+every object, in order, against the authority map.
+
+```text
+verified projection
+        |
+        v
+re-verify exact artifact bytes
+        |
+        v
+hard-coded resource allow-list + exact REST paths
+        |
+        +-- ok-infra: exact GET, then at most one collection POST
+        |
+        `-- ok-mgmt:  exact GET, then at most one collection POST
+                              |
+                              v
+                  SUBMITTED_OBSERVATION_PENDING
+```
+
+Only the eleven resources bound by the OK-141 projection are accepted:
+Namespace, Role, RoleBinding, Cluster, KubevirtCluster,
+KubevirtMachineTemplate, TalosControlPlane, TalosConfigTemplate and
+MachineDeployment objects in their exact API versions. The implementation has
+no list, watch, discovery, update, patch, apply, delete, retry, rollback or
+arbitrary-resource path. Separate TLS clients and authority identities are
+required for `ok-infra` and `ok-mgmt`, and infrastructure submission must
+complete before management lifecycle submission starts.
+
+An existing object is accepted only when it contains every exact projected
+field; Kubernetes-added metadata and defaulted fields may be additional. A
+missing object receives one create attempt. Conflict after an observed absence,
+drift, redirect, malformed API response, partial submission or an authority
+mismatch stops fail-closed and preserves the exact completed receipt prefix.
+
+Successful submission is deliberately classified as
+`SUBMITTED_OBSERVATION_PENDING`, never as lifecycle success. The primitive is
+not wired to the CLI or Job because claim consumption and generation-correct
+observation still need to be composed into one crash-safe execution path.
+Therefore this checkpoint does not contact Kubernetes, consume a grant, deploy
+the published image or authorize any mutation.
+
 ## OK-141 compatibility evidence
 
 The verifier was run offline against the preserved Phase-R v5 projection. It

--- a/internal/projection/projection.go
+++ b/internal/projection/projection.go
@@ -62,11 +62,24 @@ type Artifact struct {
 	Digest string `json:"digest"`
 }
 
+// ResourceIdentity is the exact Kubernetes identity authorized by the
+// renderer's authority map. It is deliberately excluded from CreateRequest
+// JSON because AuthorityMapDigest already binds the complete resource set.
+// Keeping it in memory lets bounded submitters validate projection documents
+// without creating a second renderer or trusting file names alone.
+type ResourceIdentity struct {
+	APIVersion string `json:"apiVersion"`
+	Kind       string `json:"kind"`
+	Name       string `json:"name"`
+	Namespace  string `json:"namespace,omitempty"`
+}
+
 // Plane is a verified authority domain, not a credential or Kubernetes context.
 type Plane struct {
-	Identity      string `json:"identity"`
-	Role          string `json:"role"`
-	ResourceCount int    `json:"resourceCount"`
+	Identity      string             `json:"identity"`
+	Role          string             `json:"role"`
+	ResourceCount int                `json:"resourceCount"`
+	Resources     []ResourceIdentity `json:"-"`
 }
 
 // Binding is the bounded proof returned after all referenced files and
@@ -133,6 +146,11 @@ func Verify(manifestPath, root, expectedRevision string, expectedIdentity contra
 			authorityRaw = artifactRaw
 		}
 	}
+	for _, required := range []string{"authority-map.json", "ok-infra-prerequisites.yaml", "ok-mgmt-lifecycle.yaml"} {
+		if _, ok := source.Artifacts[required]; !ok {
+			return Binding{}, fmt.Errorf("projection manifest does not bind %s", required)
+		}
+	}
 	if authorityRaw == nil {
 		return Binding{}, errors.New("projection manifest does not bind authority-map.json")
 	}
@@ -174,10 +192,23 @@ func Verify(manifestPath, root, expectedRevision string, expectedIdentity contra
 		AuthorityMapDigest:  digest.SHA256(authorityRaw),
 		IntentRevision:      expectedRevision,
 		ContractIdentity:    expectedIdentity,
-		InfrastructurePlane: Plane{Identity: authority.InfrastructurePlane.Identity, Role: authority.InfrastructurePlane.Role, ResourceCount: len(authority.InfrastructurePlane.Resources)},
-		ManagementPlane:     Plane{Identity: authority.ManagementPlane.Identity, Role: authority.ManagementPlane.Role, ResourceCount: len(authority.ManagementPlane.Resources)},
+		InfrastructurePlane: Plane{Identity: authority.InfrastructurePlane.Identity, Role: authority.InfrastructurePlane.Role, ResourceCount: len(authority.InfrastructurePlane.Resources), Resources: exportResources(authority.InfrastructurePlane.Resources)},
+		ManagementPlane:     Plane{Identity: authority.ManagementPlane.Identity, Role: authority.ManagementPlane.Role, ResourceCount: len(authority.ManagementPlane.Resources), Resources: exportResources(authority.ManagementPlane.Resources)},
 		Artifacts:           artifacts,
 	}, nil
+}
+
+func exportResources(resources []resource) []ResourceIdentity {
+	result := make([]ResourceIdentity, 0, len(resources))
+	for _, object := range resources {
+		result = append(result, ResourceIdentity{
+			APIVersion: object.APIVersion,
+			Kind:       object.Kind,
+			Name:       object.Name,
+			Namespace:  object.Namespace,
+		})
+	}
+	return result
 }
 
 func validateArtifactName(name string) error {

--- a/internal/runner/kubernetes.go
+++ b/internal/runner/kubernetes.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/openkubes/ok-cluster/internal/authorization"
 	"github.com/openkubes/ok-cluster/internal/ledger"
+	"github.com/openkubes/ok-cluster/internal/submission"
 )
 
 const (
@@ -30,6 +31,16 @@ type KubernetesLedgerConfig struct {
 	Namespace string
 	TokenFile string
 	CAFile    string
+}
+
+// KubernetesAuthorityConfig binds one short-lived credential to exactly one
+// authority plane. A caller must use separate instances for ok-infra and
+// ok-mgmt; no reusable multi-cluster administrator client is constructed.
+type KubernetesAuthorityConfig struct {
+	Endpoint          string
+	AuthorityIdentity string
+	TokenFile         string
+	CAFile            string
 }
 
 // InspectKubernetesLedger performs a read-only restart decision. It does not
@@ -49,21 +60,51 @@ func OpenKubernetesLedger(config KubernetesLedgerConfig) (*ledger.Ledger, error)
 	if config.Endpoint == "" || config.Namespace == "" || config.TokenFile == "" || config.CAFile == "" {
 		return nil, errors.New("Kubernetes ledger endpoint, namespace, token file, and CA file are required")
 	}
-	tokenRaw, err := readBoundedRegular(config.TokenFile, maximumTokenBytes)
+	token, client, err := openBoundedKubernetesHTTP(config.TokenFile, config.CAFile)
 	if err != nil {
-		return nil, errors.New("read projected Kubernetes ledger token")
+		return nil, err
+	}
+	backend, err := ledger.NewKubernetesStore(ledger.KubernetesStoreConfig{
+		Endpoint: config.Endpoint, Namespace: config.Namespace, BearerToken: token, Client: client,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return ledger.New(backend)
+}
+
+// OpenKubernetesSubmissionClient materializes a redirect-denying TLS client
+// for one exact authority plane. Paths and credential contents are never
+// returned in errors or receipts.
+func OpenKubernetesSubmissionClient(config KubernetesAuthorityConfig) (*submission.KubernetesClient, error) {
+	if config.Endpoint == "" || config.AuthorityIdentity == "" || config.TokenFile == "" || config.CAFile == "" {
+		return nil, errors.New("Kubernetes authority endpoint, identity, token file, and CA file are required")
+	}
+	token, client, err := openBoundedKubernetesHTTP(config.TokenFile, config.CAFile)
+	if err != nil {
+		return nil, err
+	}
+	return submission.NewKubernetesClient(submission.KubernetesClientConfig{
+		Endpoint: config.Endpoint, AuthorityIdentity: config.AuthorityIdentity, BearerToken: token, Client: client,
+	})
+}
+
+func openBoundedKubernetesHTTP(tokenFile, caFile string) (string, *http.Client, error) {
+	tokenRaw, err := readBoundedRegular(tokenFile, maximumTokenBytes)
+	if err != nil {
+		return "", nil, errors.New("read projected Kubernetes token")
 	}
 	token := string(tokenRaw)
 	if token == "" || strings.TrimSpace(token) != token || strings.ContainsAny(token, "\r\n") {
-		return nil, errors.New("projected Kubernetes ledger token is invalid")
+		return "", nil, errors.New("projected Kubernetes token is invalid")
 	}
-	caRaw, err := readBoundedRegular(config.CAFile, maximumCABytes)
+	caRaw, err := readBoundedRegular(caFile, maximumCABytes)
 	if err != nil {
-		return nil, errors.New("read projected Kubernetes API CA")
+		return "", nil, errors.New("read projected Kubernetes API CA")
 	}
 	roots := x509.NewCertPool()
 	if !roots.AppendCertsFromPEM(caRaw) {
-		return nil, errors.New("projected Kubernetes API CA contains no certificate")
+		return "", nil, errors.New("projected Kubernetes API CA contains no certificate")
 	}
 	client := &http.Client{
 		Timeout: 15 * time.Second,
@@ -77,13 +118,7 @@ func OpenKubernetesLedger(config KubernetesLedgerConfig) (*ledger.Ledger, error)
 			},
 		},
 	}
-	backend, err := ledger.NewKubernetesStore(ledger.KubernetesStoreConfig{
-		Endpoint: config.Endpoint, Namespace: config.Namespace, BearerToken: token, Client: client,
-	})
-	if err != nil {
-		return nil, err
-	}
-	return ledger.New(backend)
+	return token, client, nil
 }
 
 func readBoundedRegular(path string, maximum int64) ([]byte, error) {

--- a/internal/runner/kubernetes_test.go
+++ b/internal/runner/kubernetes_test.go
@@ -59,6 +59,44 @@ func TestOpenKubernetesLedgerValidatesProjectedInputs(t *testing.T) {
 	})
 }
 
+func TestOpenKubernetesSubmissionClientBindsOneAuthority(t *testing.T) {
+	root := t.TempDir()
+	tokenPath := filepath.Join(root, "token")
+	caPath := filepath.Join(root, "ca.crt")
+	if err := os.WriteFile(tokenPath, []byte("short-lived-token"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(caPath, testCA(t), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := OpenKubernetesSubmissionClient(KubernetesAuthorityConfig{
+		Endpoint:          "https://10.43.0.1:443",
+		AuthorityIdentity: "ok-mgmt",
+		TokenFile:         tokenPath,
+		CAFile:            caPath,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	for name, config := range map[string]KubernetesAuthorityConfig{
+		"missing identity": {
+			Endpoint: "https://10.43.0.1:443", TokenFile: tokenPath, CAFile: caPath,
+		},
+		"invalid identity": {
+			Endpoint: "https://10.43.0.1:443", AuthorityIdentity: "ok.mgmt", TokenFile: tokenPath, CAFile: caPath,
+		},
+		"endpoint path": {
+			Endpoint: "https://10.43.0.1:443/api", AuthorityIdentity: "ok-mgmt", TokenFile: tokenPath, CAFile: caPath,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := OpenKubernetesSubmissionClient(config); err == nil || strings.Contains(err.Error(), root) {
+				t.Fatalf("unsafe authority config accepted or disclosed a path: %v", err)
+			}
+		})
+	}
+}
+
 func testCA(t *testing.T) []byte {
 	t.Helper()
 	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)

--- a/internal/submission/executor.go
+++ b/internal/submission/executor.go
@@ -1,0 +1,56 @@
+package submission
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+// Executor preserves the projection's authority order: provider prerequisites
+// first, then management-plane lifecycle objects. It has no retry or rollback
+// capability.
+type Executor struct {
+	Infrastructure *KubernetesClient
+	Management     *KubernetesClient
+}
+
+// Receipt exposes the exact completed prefix if execution stops. It is
+// submission evidence only; it is never lifecycle-success evidence.
+type Receipt struct {
+	Format         string        `json:"format"`
+	IntentRevision string        `json:"intentRevision"`
+	State          string        `json:"state"`
+	Infrastructure *PlaneReceipt `json:"infrastructure,omitempty"`
+	Management     *PlaneReceipt `json:"management,omitempty"`
+}
+
+// Execute performs one bounded pass and never retries. A successful receipt
+// means the desired objects were accepted or already matched; reconciliation
+// and Ready remain separate observation responsibilities.
+func (executor Executor) Execute(ctx context.Context, plan Plan) (Receipt, error) {
+	receipt := Receipt{
+		Format:         "ok147-bounded-submission-run-receipt/v1",
+		IntentRevision: plan.IntentRevision,
+		State:          "IN_PROGRESS",
+	}
+	if plan.Format != PlanFormat {
+		return receipt, errors.New("submission plan format is not supported")
+	}
+	if executor.Infrastructure == nil || executor.Management == nil {
+		return receipt, errors.New("both authority-plane submission clients are required")
+	}
+	infrastructure, err := executor.Infrastructure.Submit(ctx, plan.Infrastructure)
+	receipt.Infrastructure = &infrastructure
+	if err != nil {
+		receipt.State = "STOPPED_PARTIAL_OR_UNKNOWN"
+		return receipt, fmt.Errorf("infrastructure authority submission: %w", err)
+	}
+	management, err := executor.Management.Submit(ctx, plan.Management)
+	receipt.Management = &management
+	if err != nil {
+		receipt.State = "STOPPED_PARTIAL_OR_UNKNOWN"
+		return receipt, fmt.Errorf("management authority submission: %w", err)
+	}
+	receipt.State = "SUBMITTED_OBSERVATION_PENDING"
+	return receipt, nil
+}

--- a/internal/submission/kubernetes.go
+++ b/internal/submission/kubernetes.go
@@ -1,0 +1,275 @@
+package submission
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"reflect"
+	"strings"
+	"time"
+)
+
+const maximumAPIResponseBytes = 4 * 1024 * 1024
+
+// KubernetesClientConfig binds one client to one authority plane. Credentials
+// are supplied by an execution-environment adapter and are never retained in a
+// receipt.
+type KubernetesClientConfig struct {
+	Endpoint          string
+	BearerToken       string
+	AuthorityIdentity string
+	Client            *http.Client
+}
+
+// KubernetesClient performs only exact GET and collection POST operations.
+type KubernetesClient struct {
+	endpoint  *url.URL
+	token     string
+	authority string
+	client    *http.Client
+}
+
+// ObjectResult records only redacted, immutable submission identity.
+type ObjectResult struct {
+	Identity projectionIdentity `json:"identity"`
+	Digest   string             `json:"digest"`
+	State    string             `json:"state"`
+}
+
+// PlaneReceipt is useful even on failure: Results contains the exact prefix
+// completed before STOP-PRESERVE-NO-RETRY.
+type PlaneReceipt struct {
+	Format    string         `json:"format"`
+	Authority string         `json:"authority"`
+	Role      string         `json:"role"`
+	State     string         `json:"state"`
+	Results   []ObjectResult `json:"results"`
+}
+
+// projectionIdentity mirrors only the public, non-secret resource identity in
+// receipts while avoiding an import cycle through JSON helpers.
+type projectionIdentity struct {
+	APIVersion string `json:"apiVersion"`
+	Kind       string `json:"kind"`
+	Name       string `json:"name"`
+	Namespace  string `json:"namespace,omitempty"`
+}
+
+// SubmissionError retains the redacted partial receipt and wraps the cause.
+type SubmissionError struct {
+	Receipt PlaneReceipt
+	Cause   error
+}
+
+func (err *SubmissionError) Error() string {
+	return fmt.Sprintf("bounded submission stopped: %v", err.Cause)
+}
+func (err *SubmissionError) Unwrap() error { return err.Cause }
+
+func NewKubernetesClient(config KubernetesClientConfig) (*KubernetesClient, error) {
+	endpoint, err := url.Parse(config.Endpoint)
+	if err != nil || endpoint.Host == "" || endpoint.User != nil || endpoint.RawQuery != "" || endpoint.Fragment != "" {
+		return nil, errors.New("submission Kubernetes endpoint is invalid")
+	}
+	if endpoint.Path != "" && endpoint.Path != "/" {
+		return nil, errors.New("submission Kubernetes endpoint must not contain a path")
+	}
+	host := endpoint.Hostname()
+	if endpoint.Scheme != "https" && !(endpoint.Scheme == "http" && (host == "127.0.0.1" || host == "::1" || host == "localhost")) {
+		return nil, errors.New("submission Kubernetes endpoint must use HTTPS")
+	}
+	if config.BearerToken == "" || strings.TrimSpace(config.BearerToken) != config.BearerToken || strings.ContainsAny(config.BearerToken, "\r\n") {
+		return nil, errors.New("submission Kubernetes bearer token is invalid")
+	}
+	if !validName(config.AuthorityIdentity, 63) || strings.Contains(config.AuthorityIdentity, ".") {
+		return nil, errors.New("submission authority identity is invalid")
+	}
+	if config.Client == nil {
+		return nil, errors.New("submission requires an explicitly configured HTTP client")
+	}
+	client := *config.Client
+	client.CheckRedirect = func(_ *http.Request, _ []*http.Request) error { return http.ErrUseLastResponse }
+	if client.Timeout == 0 {
+		client.Timeout = 15 * time.Second
+	}
+	endpoint.Path = ""
+	return &KubernetesClient{endpoint: endpoint, token: config.BearerToken, authority: config.AuthorityIdentity, client: &client}, nil
+}
+
+// Submit verifies existing objects or creates missing objects in projection
+// order. It never updates, patches, deletes, lists, watches, discovers, or
+// retries. A conflict after an absence observation is indeterminate and stops.
+func (client *KubernetesClient) Submit(ctx context.Context, plane Plane) (PlaneReceipt, error) {
+	receipt := PlaneReceipt{
+		Format:    "ok147-bounded-submission-receipt/v1",
+		Authority: plane.Identity,
+		Role:      plane.Role,
+		State:     "IN_PROGRESS",
+		Results:   make([]ObjectResult, 0, len(plane.Objects)),
+	}
+	if plane.Identity != client.authority {
+		return stopped(receipt, errors.New("submission client authority differs from projection plane"))
+	}
+	if len(plane.Objects) == 0 {
+		return stopped(receipt, errors.New("submission plane has no objects"))
+	}
+	for _, object := range plane.Objects {
+		state, err := client.submitObject(ctx, object)
+		if err != nil {
+			return stopped(receipt, err)
+		}
+		receipt.Results = append(receipt.Results, ObjectResult{
+			Identity: projectionIdentity{APIVersion: object.Identity.APIVersion, Kind: object.Identity.Kind, Name: object.Identity.Name, Namespace: object.Identity.Namespace},
+			Digest:   object.Digest,
+			State:    state,
+		})
+	}
+	receipt.State = "SUBMITTED"
+	return receipt, nil
+}
+
+func stopped(receipt PlaneReceipt, cause error) (PlaneReceipt, error) {
+	receipt.State = "STOPPED_PARTIAL_OR_UNKNOWN"
+	return receipt, &SubmissionError{Receipt: receipt, Cause: cause}
+}
+
+func (client *KubernetesClient) submitObject(ctx context.Context, object Object) (string, error) {
+	response, status, err := client.request(ctx, http.MethodGet, object.ObjectPath, nil)
+	if err != nil {
+		return "", err
+	}
+	switch status {
+	case http.StatusOK:
+		if err := verifyObservedObject(response, object); err != nil {
+			return "", fmt.Errorf("existing %s/%s differs from projection: %w", object.Identity.Kind, object.Identity.Name, err)
+		}
+		return "UNCHANGED", nil
+	case http.StatusNotFound:
+		// Continue to the one authorized create attempt.
+	default:
+		return "", apiStatusError(http.MethodGet, status, response)
+	}
+
+	response, status, err = client.request(ctx, http.MethodPost, object.CollectionPath, object.Raw)
+	if err != nil {
+		return "", err
+	}
+	if status == http.StatusConflict {
+		return "", errors.New("Kubernetes create conflicted after exact absence observation")
+	}
+	if status != http.StatusCreated {
+		return "", apiStatusError(http.MethodPost, status, response)
+	}
+	if err := verifyObservedObject(response, object); err != nil {
+		return "", fmt.Errorf("created %s/%s response differs from projection: %w", object.Identity.Kind, object.Identity.Name, err)
+	}
+	return "CREATED", nil
+}
+
+func (client *KubernetesClient) request(ctx context.Context, method, path string, body []byte) ([]byte, int, error) {
+	endpoint := *client.endpoint
+	endpoint.Path = path
+	request, err := http.NewRequestWithContext(ctx, method, endpoint.String(), bytes.NewReader(body))
+	if err != nil {
+		return nil, 0, errors.New("construct bounded Kubernetes request")
+	}
+	request.Header.Set("Accept", "application/json")
+	request.Header.Set("Authorization", "Bearer "+client.token)
+	if body != nil {
+		request.Header.Set("Content-Type", "application/json")
+	}
+	response, err := client.client.Do(request)
+	if err != nil {
+		return nil, 0, fmt.Errorf("bounded Kubernetes %s request failed", method)
+	}
+	defer response.Body.Close()
+	raw, err := io.ReadAll(io.LimitReader(response.Body, maximumAPIResponseBytes+1))
+	if err != nil || len(raw) > maximumAPIResponseBytes {
+		return nil, 0, errors.New("bounded Kubernetes response exceeds accepted size")
+	}
+	return raw, response.StatusCode, nil
+}
+
+func verifyObservedObject(raw []byte, desired Object) error {
+	observed, err := decodeJSONObject(raw)
+	if err != nil {
+		return errors.New("Kubernetes API returned invalid object JSON")
+	}
+	expected, err := decodeJSONObject(desired.Raw)
+	if err != nil {
+		return errors.New("verified projection object is invalid JSON")
+	}
+	if !isSubset(expected, observed) {
+		return errors.New("observed object does not contain the exact projected fields")
+	}
+	metadata, _ := observed["metadata"].(map[string]any)
+	if text(metadata["uid"]) == "" || text(metadata["resourceVersion"]) == "" {
+		return errors.New("Kubernetes API response lacks UID or resourceVersion")
+	}
+	return nil
+}
+
+func decodeJSONObject(raw []byte) (map[string]any, error) {
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	var value map[string]any
+	if err := decoder.Decode(&value); err != nil {
+		return nil, err
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		return nil, errors.New("trailing JSON")
+	}
+	return value, nil
+}
+
+func isSubset(expected, observed any) bool {
+	switch expectedValue := expected.(type) {
+	case map[string]any:
+		observedValue, ok := observed.(map[string]any)
+		if !ok {
+			return false
+		}
+		for key, expectedChild := range expectedValue {
+			observedChild, exists := observedValue[key]
+			if !exists || !isSubset(expectedChild, observedChild) {
+				return false
+			}
+		}
+		return true
+	case []any:
+		observedValue, ok := observed.([]any)
+		if !ok || len(expectedValue) != len(observedValue) {
+			return false
+		}
+		for index := range expectedValue {
+			if !isSubset(expectedValue[index], observedValue[index]) {
+				return false
+			}
+		}
+		return true
+	default:
+		return reflect.DeepEqual(expected, observed)
+	}
+}
+
+func text(value any) string {
+	result, _ := value.(string)
+	return result
+}
+
+func apiStatusError(method string, status int, raw []byte) error {
+	var response struct {
+		Reason string `json:"reason"`
+	}
+	_ = json.Unmarshal(raw, &response)
+	if response.Reason == "" {
+		response.Reason = http.StatusText(status)
+	}
+	return fmt.Errorf("bounded Kubernetes %s returned status %d (%s)", method, status, response.Reason)
+}

--- a/internal/submission/kubernetes_test.go
+++ b/internal/submission/kubernetes_test.go
@@ -1,0 +1,240 @@
+package submission
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestKubernetesSubmitIsExactCreateOnlyAndIdempotent(t *testing.T) {
+	root, binding := validProjection(t)
+	plan, err := Load(root, binding)
+	if err != nil {
+		t.Fatal(err)
+	}
+	api := newFakeObjectAPI(t)
+	client := newSubmissionClient(t, "ok-infra", api.client())
+
+	first, err := client.Submit(context.Background(), plan.Infrastructure)
+	if err != nil || first.State != "SUBMITTED" || len(first.Results) != 1 || first.Results[0].State != "CREATED" {
+		t.Fatalf("first submission: %#v %v", first, err)
+	}
+	second, err := client.Submit(context.Background(), plan.Infrastructure)
+	if err != nil || second.Results[0].State != "UNCHANGED" {
+		t.Fatalf("second submission: %#v %v", second, err)
+	}
+	if api.posts != 1 {
+		t.Fatalf("POST count=%d, want 1", api.posts)
+	}
+	for _, request := range api.requests {
+		if request.method != http.MethodGet && request.method != http.MethodPost {
+			t.Fatalf("unbounded method observed: %#v", request)
+		}
+		if strings.Contains(request.path, "?") || strings.HasSuffix(request.path, "/namespaces") && request.method == http.MethodGet {
+			t.Fatalf("collection GET observed: %#v", request)
+		}
+	}
+}
+
+func TestKubernetesSubmitFailsClosedForDriftConflictAndAuthority(t *testing.T) {
+	root, binding := validProjection(t)
+	plan, err := Load(root, binding)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("wrong authority", func(t *testing.T) {
+		api := newFakeObjectAPI(t)
+		client := newSubmissionClient(t, "ok-mgmt", api.client())
+		receipt, err := client.Submit(context.Background(), plan.Infrastructure)
+		if err == nil || receipt.State != "STOPPED_PARTIAL_OR_UNKNOWN" || len(api.requests) != 0 {
+			t.Fatalf("authority mismatch did not fail locally: %#v %v", receipt, err)
+		}
+	})
+
+	t.Run("existing drift", func(t *testing.T) {
+		api := newFakeObjectAPI(t)
+		object := apiObject(t, plan.Infrastructure.Objects[0].Raw)
+		metadata := object["metadata"].(map[string]any)
+		metadata["name"] = "different"
+		api.objects[plan.Infrastructure.Objects[0].ObjectPath] = object
+		client := newSubmissionClient(t, "ok-infra", api.client())
+		receipt, err := client.Submit(context.Background(), plan.Infrastructure)
+		if err == nil || receipt.State != "STOPPED_PARTIAL_OR_UNKNOWN" || api.posts != 0 {
+			t.Fatalf("drift accepted: %#v %v", receipt, err)
+		}
+	})
+
+	t.Run("create conflict after absence", func(t *testing.T) {
+		api := newFakeObjectAPI(t)
+		api.conflict = true
+		client := newSubmissionClient(t, "ok-infra", api.client())
+		receipt, err := client.Submit(context.Background(), plan.Infrastructure)
+		if err == nil || receipt.State != "STOPPED_PARTIAL_OR_UNKNOWN" || !strings.Contains(err.Error(), "conflicted") {
+			t.Fatalf("conflict accepted: %#v %v", receipt, err)
+		}
+	})
+
+	t.Run("redirect is not followed", func(t *testing.T) {
+		calls := 0
+		client := newSubmissionClient(t, "ok-infra", &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			calls++
+			return jsonResponse(http.StatusTemporaryRedirect, nil, map[string]string{"Location": "http://127.0.0.1:12346/redirected"}), nil
+		})})
+		if _, err := client.Submit(context.Background(), plan.Infrastructure); err == nil || calls != 1 {
+			t.Fatalf("redirect followed or accepted: calls=%d err=%v", calls, err)
+		}
+	})
+}
+
+func TestExecutorPreservesAuthorityOrderAndPartialReceipt(t *testing.T) {
+	root, binding := validProjection(t)
+	plan, err := Load(root, binding)
+	if err != nil {
+		t.Fatal(err)
+	}
+	infraAPI := newFakeObjectAPI(t)
+	mgmtAPI := newFakeObjectAPI(t)
+	mgmtAPI.failStatus = http.StatusForbidden
+	executor := Executor{
+		Infrastructure: newSubmissionClient(t, "ok-infra", infraAPI.client()),
+		Management:     newSubmissionClient(t, "ok-mgmt", mgmtAPI.client()),
+	}
+	receipt, err := executor.Execute(context.Background(), plan)
+	if err == nil || receipt.State != "STOPPED_PARTIAL_OR_UNKNOWN" || receipt.Infrastructure == nil || receipt.Management == nil {
+		t.Fatalf("partial execution receipt: %#v %v", receipt, err)
+	}
+	if receipt.Infrastructure.State != "SUBMITTED" || receipt.Management.State != "STOPPED_PARTIAL_OR_UNKNOWN" || infraAPI.posts != 1 || mgmtAPI.posts != 0 {
+		t.Fatalf("authority order/stop differs: %#v infraPosts=%d mgmtPosts=%d", receipt, infraAPI.posts, mgmtAPI.posts)
+	}
+}
+
+func TestExecutorSuccessfulReceiptIsNotLifecycleSuccess(t *testing.T) {
+	root, binding := validProjection(t)
+	plan, err := Load(root, binding)
+	if err != nil {
+		t.Fatal(err)
+	}
+	executor := Executor{
+		Infrastructure: newSubmissionClient(t, "ok-infra", newFakeObjectAPI(t).client()),
+		Management:     newSubmissionClient(t, "ok-mgmt", newFakeObjectAPI(t).client()),
+	}
+	receipt, err := executor.Execute(context.Background(), plan)
+	if err != nil || receipt.State != "SUBMITTED_OBSERVATION_PENDING" {
+		t.Fatalf("submission outcome incorrectly classified: %#v %v", receipt, err)
+	}
+}
+
+type recordedRequest struct {
+	method string
+	path   string
+}
+
+type fakeObjectAPI struct {
+	t          *testing.T
+	mu         sync.Mutex
+	objects    map[string]map[string]any
+	requests   []recordedRequest
+	posts      int
+	conflict   bool
+	failStatus int
+}
+
+func newFakeObjectAPI(t *testing.T) *fakeObjectAPI {
+	t.Helper()
+	return &fakeObjectAPI{t: t, objects: map[string]map[string]any{}}
+}
+
+func (api *fakeObjectAPI) client() *http.Client {
+	return &http.Client{Transport: roundTripFunc(api.roundTrip)}
+}
+
+func (api *fakeObjectAPI) roundTrip(request *http.Request) (*http.Response, error) {
+	api.mu.Lock()
+	defer api.mu.Unlock()
+	api.requests = append(api.requests, recordedRequest{method: request.Method, path: request.URL.Path})
+	if request.Header.Get("Authorization") != "Bearer short-lived-test-token" {
+		return jsonResponse(http.StatusUnauthorized, nil, nil), nil
+	}
+	if api.failStatus != 0 {
+		return jsonResponse(api.failStatus, map[string]any{"reason": "Denied"}, nil), nil
+	}
+	switch request.Method {
+	case http.MethodGet:
+		object, ok := api.objects[request.URL.Path]
+		if !ok {
+			return jsonResponse(http.StatusNotFound, map[string]any{"reason": "NotFound"}, nil), nil
+		}
+		return jsonResponse(http.StatusOK, object, nil), nil
+	case http.MethodPost:
+		api.posts++
+		if api.conflict {
+			return jsonResponse(http.StatusConflict, map[string]any{"reason": "AlreadyExists"}, nil), nil
+		}
+		var object map[string]any
+		decoder := json.NewDecoder(request.Body)
+		decoder.UseNumber()
+		if err := decoder.Decode(&object); err != nil {
+			api.t.Error(err)
+			return jsonResponse(http.StatusBadRequest, nil, nil), nil
+		}
+		metadata := object["metadata"].(map[string]any)
+		metadata["uid"] = "test-uid"
+		metadata["resourceVersion"] = "1"
+		name := metadata["name"].(string)
+		path := request.URL.Path + "/" + name
+		api.objects[path] = object
+		return jsonResponse(http.StatusCreated, object, nil), nil
+	default:
+		return jsonResponse(http.StatusMethodNotAllowed, nil, nil), nil
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (function roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return function(request)
+}
+
+func jsonResponse(status int, value any, headers map[string]string) *http.Response {
+	var raw []byte
+	if value != nil {
+		raw, _ = json.Marshal(value)
+	}
+	header := make(http.Header)
+	header.Set("Content-Type", "application/json")
+	for key, value := range headers {
+		header.Set(key, value)
+	}
+	return &http.Response{StatusCode: status, Header: header, Body: io.NopCloser(bytes.NewReader(raw))}
+}
+
+func apiObject(t *testing.T, raw []byte) map[string]any {
+	t.Helper()
+	var value map[string]any
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	if err := decoder.Decode(&value); err != nil {
+		t.Fatal(err)
+	}
+	metadata := value["metadata"].(map[string]any)
+	metadata["uid"] = "existing-uid"
+	metadata["resourceVersion"] = "7"
+	return value
+}
+
+func newSubmissionClient(t *testing.T, authority string, client *http.Client) *KubernetesClient {
+	t.Helper()
+	result, err := NewKubernetesClient(KubernetesClientConfig{
+		Endpoint: "http://127.0.0.1:12345", BearerToken: "short-lived-test-token", AuthorityIdentity: authority, Client: client,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return result
+}

--- a/internal/submission/plan.go
+++ b/internal/submission/plan.go
@@ -1,0 +1,341 @@
+// Package submission turns an already verified renderer projection into a
+// bounded exact-create plan. It never renders Contract intent and accepts only
+// the resource kinds required by the OK-141 CreateCluster reference path.
+package submission
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"regexp"
+	"strings"
+
+	"github.com/openkubes/ok-cluster/internal/contract"
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/projection"
+	"gopkg.in/yaml.v3"
+)
+
+const PlanFormat = "ok147-bounded-submission-plan/v1"
+
+const maximumProjectionArtifactBytes = 4 * 1024 * 1024
+
+// Object is one exact, digest-bound Kubernetes create candidate.
+type Object struct {
+	Identity       projection.ResourceIdentity `json:"identity"`
+	Digest         string                      `json:"digest"`
+	CollectionPath string                      `json:"collectionPath"`
+	ObjectPath     string                      `json:"objectPath"`
+	Raw            json.RawMessage             `json:"-"`
+}
+
+// Plane is a submission group owned by exactly one authority plane.
+type Plane struct {
+	Identity string   `json:"identity"`
+	Role     string   `json:"role"`
+	Objects  []Object `json:"objects"`
+}
+
+// Plan preserves the authority split from the verified projection.
+type Plan struct {
+	Format             string `json:"format"`
+	IntentRevision     string `json:"intentRevision"`
+	AuthorityMapDigest string `json:"authorityMapDigest"`
+	Infrastructure     Plane  `json:"infrastructure"`
+	Management         Plane  `json:"management"`
+}
+
+// Load re-reads and re-verifies the two renderer artifacts to close the
+// verify/use gap. Resource identity, order, revision metadata and REST routes
+// must all match the verified authority map.
+func Load(root string, binding projection.Binding) (Plan, error) {
+	if binding.Format != projection.BindingFormat {
+		return Plan{}, fmt.Errorf("projection binding format %q is not supported", binding.Format)
+	}
+	if root == "" {
+		return Plan{}, errors.New("projection root is required")
+	}
+	abs, err := filepath.Abs(root)
+	if err != nil {
+		return Plan{}, fmt.Errorf("resolve projection root: %w", err)
+	}
+	if binding.InfrastructurePlane.Identity == binding.ManagementPlane.Identity {
+		return Plan{}, errors.New("submission authority identities must differ")
+	}
+	infrastructure, err := loadPlane(abs, "ok-infra-prerequisites.yaml", binding.InfrastructurePlane, binding, binding.IntentRevision)
+	if err != nil {
+		return Plan{}, fmt.Errorf("infrastructure submission plane: %w", err)
+	}
+	management, err := loadPlane(abs, "ok-mgmt-lifecycle.yaml", binding.ManagementPlane, binding, binding.IntentRevision)
+	if err != nil {
+		return Plan{}, fmt.Errorf("management submission plane: %w", err)
+	}
+	return Plan{
+		Format:             PlanFormat,
+		IntentRevision:     binding.IntentRevision,
+		AuthorityMapDigest: binding.AuthorityMapDigest,
+		Infrastructure:     infrastructure,
+		Management:         management,
+	}, nil
+}
+
+func loadPlane(root, artifactName string, expected projection.Plane, binding projection.Binding, revision string) (Plane, error) {
+	if expected.ResourceCount <= 0 || expected.ResourceCount != len(expected.Resources) {
+		return Plane{}, errors.New("verified projection plane has no complete resource identities")
+	}
+	expectedDigest, ok := artifactDigest(binding.Artifacts, artifactName)
+	if !ok {
+		return Plane{}, fmt.Errorf("verified projection does not bind %s", artifactName)
+	}
+	raw, err := readBoundedArtifact(filepath.Join(root, artifactName))
+	if err != nil {
+		return Plane{}, err
+	}
+	if actual := digest.SHA256(raw); actual != expectedDigest {
+		return Plane{}, fmt.Errorf("projection artifact %s changed after verification", artifactName)
+	}
+	objects, err := decodeObjects(raw, expected.Resources, binding.ContractIdentity, revision)
+	if err != nil {
+		return Plane{}, err
+	}
+	return Plane{Identity: expected.Identity, Role: expected.Role, Objects: objects}, nil
+}
+
+func artifactDigest(artifacts []projection.Artifact, name string) (string, bool) {
+	for _, artifact := range artifacts {
+		if artifact.Name == name {
+			return artifact.Digest, true
+		}
+	}
+	return "", false
+}
+
+func readBoundedArtifact(path string) ([]byte, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("read projection artifact: %w", err)
+	}
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil {
+		return nil, errors.New("inspect projection artifact")
+	}
+	if !info.Mode().IsRegular() || info.Size() <= 0 || info.Size() > maximumProjectionArtifactBytes {
+		return nil, errors.New("projection artifact metadata is invalid")
+	}
+	raw, err := io.ReadAll(io.LimitReader(file, maximumProjectionArtifactBytes+1))
+	if err != nil || len(raw) > maximumProjectionArtifactBytes {
+		return nil, errors.New("read bounded projection artifact")
+	}
+	return raw, nil
+}
+
+func decodeObjects(raw []byte, expected []projection.ResourceIdentity, contractIdentity contract.Identity, revision string) ([]Object, error) {
+	decoder := yaml.NewDecoder(bytes.NewReader(raw))
+	objects := make([]Object, 0, len(expected))
+	for {
+		var document yaml.Node
+		if err := decoder.Decode(&document); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return nil, fmt.Errorf("decode projection YAML: %w", err)
+		}
+		if len(document.Content) == 0 {
+			continue
+		}
+		if err := rejectAliases(document.Content[0]); err != nil {
+			return nil, err
+		}
+		var decoded any
+		if err := document.Content[0].Decode(&decoded); err != nil {
+			return nil, fmt.Errorf("decode projection object: %w", err)
+		}
+		value, err := jsonValue(decoded)
+		if err != nil {
+			return nil, err
+		}
+		objectMap, ok := value.(map[string]any)
+		if !ok {
+			return nil, errors.New("projection document is not a Kubernetes object")
+		}
+		object, err := validateObject(objectMap, contractIdentity, revision)
+		if err != nil {
+			return nil, fmt.Errorf("projection document %d: %w", len(objects)+1, err)
+		}
+		objects = append(objects, object)
+	}
+	if len(objects) != len(expected) {
+		return nil, fmt.Errorf("projection contains %d objects, authority map requires %d", len(objects), len(expected))
+	}
+	for index := range expected {
+		if objects[index].Identity != expected[index] {
+			return nil, fmt.Errorf("projection object %d identity %#v differs from authority map %#v", index+1, objects[index].Identity, expected[index])
+		}
+	}
+	return objects, nil
+}
+
+func rejectAliases(node *yaml.Node) error {
+	if node.Kind == yaml.AliasNode || node.Anchor != "" {
+		return errors.New("projection YAML aliases and anchors are not accepted")
+	}
+	for _, child := range node.Content {
+		if err := rejectAliases(child); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func jsonValue(value any) (any, error) {
+	switch typed := value.(type) {
+	case map[string]any:
+		result := make(map[string]any, len(typed))
+		for key, child := range typed {
+			converted, err := jsonValue(child)
+			if err != nil {
+				return nil, err
+			}
+			result[key] = converted
+		}
+		return result, nil
+	case map[any]any:
+		result := make(map[string]any, len(typed))
+		for rawKey, child := range typed {
+			key, ok := rawKey.(string)
+			if !ok {
+				return nil, errors.New("projection YAML contains a non-string map key")
+			}
+			converted, err := jsonValue(child)
+			if err != nil {
+				return nil, err
+			}
+			result[key] = converted
+		}
+		return result, nil
+	case []any:
+		result := make([]any, len(typed))
+		for index, child := range typed {
+			converted, err := jsonValue(child)
+			if err != nil {
+				return nil, err
+			}
+			result[index] = converted
+		}
+		return result, nil
+	case string, bool, nil, int, int64, uint64, float64:
+		return typed, nil
+	default:
+		reflected := reflect.ValueOf(value)
+		switch reflected.Kind() {
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			return reflected.Int(), nil
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+			return reflected.Uint(), nil
+		case reflect.Float32, reflect.Float64:
+			return reflected.Float(), nil
+		default:
+			return nil, fmt.Errorf("projection YAML value type %T is not JSON-compatible", value)
+		}
+	}
+}
+
+func validateObject(value map[string]any, identity contract.Identity, revision string) (Object, error) {
+	if _, exists := value["status"]; exists {
+		return Object{}, errors.New("projection object must not contain status")
+	}
+	apiVersion, _ := value["apiVersion"].(string)
+	kind, _ := value["kind"].(string)
+	metadata, _ := value["metadata"].(map[string]any)
+	name, _ := metadata["name"].(string)
+	namespace, _ := metadata["namespace"].(string)
+	resourceIdentity := projection.ResourceIdentity{APIVersion: apiVersion, Kind: kind, Name: name, Namespace: namespace}
+	if apiVersion == "" || kind == "" || name == "" {
+		return Object{}, errors.New("projection object identity is incomplete")
+	}
+	for _, forbidden := range []string{"generateName", "uid", "resourceVersion", "generation", "creationTimestamp", "deletionTimestamp", "deletionGracePeriodSeconds", "managedFields", "ownerReferences", "finalizers"} {
+		if _, exists := metadata[forbidden]; exists {
+			return Object{}, fmt.Errorf("projection metadata.%s is not accepted", forbidden)
+		}
+	}
+	annotations, _ := metadata["annotations"].(map[string]any)
+	if annotations["openkubes.io/contract-name"] != identity.Name || annotations["openkubes.io/contract-namespace"] != identity.Namespace || annotations["openkubes.io/intent-revision"] != revision {
+		return Object{}, errors.New("projection object lacks exact contract and intent annotations")
+	}
+	collectionPath, objectPath, err := resourcePaths(resourceIdentity)
+	if err != nil {
+		return Object{}, err
+	}
+	raw, err := canonicalJSON(value)
+	if err != nil {
+		return Object{}, err
+	}
+	return Object{Identity: resourceIdentity, Digest: digest.SHA256(raw), CollectionPath: collectionPath, ObjectPath: objectPath, Raw: raw}, nil
+}
+
+type route struct {
+	group      string
+	version    string
+	resource   string
+	namespaced bool
+}
+
+var allowedRoutes = map[string]route{
+	"v1|Namespace":                                                     {version: "v1", resource: "namespaces"},
+	"rbac.authorization.k8s.io/v1|Role":                                {group: "rbac.authorization.k8s.io", version: "v1", resource: "roles", namespaced: true},
+	"rbac.authorization.k8s.io/v1|RoleBinding":                         {group: "rbac.authorization.k8s.io", version: "v1", resource: "rolebindings", namespaced: true},
+	"cluster.x-k8s.io/v1beta2|Cluster":                                 {group: "cluster.x-k8s.io", version: "v1beta2", resource: "clusters", namespaced: true},
+	"cluster.x-k8s.io/v1beta2|MachineDeployment":                       {group: "cluster.x-k8s.io", version: "v1beta2", resource: "machinedeployments", namespaced: true},
+	"infrastructure.cluster.x-k8s.io/v1alpha1|KubevirtCluster":         {group: "infrastructure.cluster.x-k8s.io", version: "v1alpha1", resource: "kubevirtclusters", namespaced: true},
+	"infrastructure.cluster.x-k8s.io/v1alpha1|KubevirtMachineTemplate": {group: "infrastructure.cluster.x-k8s.io", version: "v1alpha1", resource: "kubevirtmachinetemplates", namespaced: true},
+	"controlplane.cluster.x-k8s.io/v1alpha3|TalosControlPlane":         {group: "controlplane.cluster.x-k8s.io", version: "v1alpha3", resource: "taloscontrolplanes", namespaced: true},
+	"bootstrap.cluster.x-k8s.io/v1alpha3|TalosConfigTemplate":          {group: "bootstrap.cluster.x-k8s.io", version: "v1alpha3", resource: "talosconfigtemplates", namespaced: true},
+}
+
+func resourcePaths(identity projection.ResourceIdentity) (string, string, error) {
+	route, ok := allowedRoutes[identity.APIVersion+"|"+identity.Kind]
+	if !ok {
+		return "", "", fmt.Errorf("resource %s %s is not in the CreateCluster submission allow-list", identity.APIVersion, identity.Kind)
+	}
+	if !validName(identity.Name, 253) {
+		return "", "", errors.New("projection resource name is invalid")
+	}
+	base := "/api/" + route.version
+	if route.group != "" {
+		base = "/apis/" + route.group + "/" + route.version
+	}
+	if route.namespaced {
+		if !validName(identity.Namespace, 63) || strings.Contains(identity.Namespace, ".") {
+			return "", "", errors.New("namespaced projection resource has an invalid namespace")
+		}
+		base += "/namespaces/" + identity.Namespace
+	} else if identity.Namespace != "" {
+		return "", "", errors.New("cluster-scoped projection resource must not declare a namespace")
+	}
+	collection := base + "/" + route.resource
+	return collection, collection + "/" + identity.Name, nil
+}
+
+func validName(value string, maximum int) bool {
+	return len(value) > 0 && len(value) <= maximum && regexp.MustCompile(`^[a-z0-9](?:[-a-z0-9.]*[a-z0-9])?$`).MatchString(value)
+}
+
+func canonicalJSON(value any) ([]byte, error) {
+	raw, err := json.Marshal(value)
+	if err != nil {
+		return nil, fmt.Errorf("encode projection object: %w", err)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	var generic any
+	if err := decoder.Decode(&generic); err != nil {
+		return nil, err
+	}
+	return contract.JCS(generic)
+}

--- a/internal/submission/plan_test.go
+++ b/internal/submission/plan_test.go
@@ -1,0 +1,133 @@
+package submission
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/openkubes/ok-cluster/internal/contract"
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/projection"
+)
+
+func TestLoadBindsExactProjectionObjectsAndRoutes(t *testing.T) {
+	root, binding := validProjection(t)
+	plan, err := Load(root, binding)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plan.Format != PlanFormat || plan.IntentRevision != binding.IntentRevision {
+		t.Fatalf("unexpected plan: %#v", plan)
+	}
+	if len(plan.Infrastructure.Objects) != 1 || plan.Infrastructure.Objects[0].CollectionPath != "/api/v1/namespaces" {
+		t.Fatalf("unexpected infrastructure objects: %#v", plan.Infrastructure.Objects)
+	}
+	if len(plan.Management.Objects) != 1 || plan.Management.Objects[0].ObjectPath != "/apis/cluster.x-k8s.io/v1beta2/namespaces/disposable-ok141/clusters/disposable-ok141" {
+		t.Fatalf("unexpected management objects: %#v", plan.Management.Objects)
+	}
+}
+
+func TestLoadReverifiesArtifactAtUseTime(t *testing.T) {
+	root, binding := validProjection(t)
+	path := filepath.Join(root, "ok-infra-prerequisites.yaml")
+	if err := os.WriteFile(path, []byte("tampered\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Load(root, binding); err == nil || !strings.Contains(err.Error(), "changed after verification") {
+		t.Fatalf("tampered projection accepted: %v", err)
+	}
+}
+
+func TestLoadFailsClosedForIdentityAndYAMLGaps(t *testing.T) {
+	for name, mutate := range map[string]func(string, *projection.Binding){
+		"authority identity mismatch": func(_ string, binding *projection.Binding) {
+			binding.ManagementPlane.Resources[0].Name = "different"
+		},
+		"unsupported kind": func(_ string, binding *projection.Binding) {
+			binding.ManagementPlane.Resources[0].APIVersion = "apps/v1"
+			binding.ManagementPlane.Resources[0].Kind = "Deployment"
+		},
+		"incomplete resource inventory": func(_ string, binding *projection.Binding) {
+			binding.ManagementPlane.Resources = nil
+		},
+		"alias in YAML": func(root string, binding *projection.Binding) {
+			raw := []byte("apiVersion: v1\nkind: Namespace\nmetadata: &meta\n  name: disposable-ok141\n  annotations:\n    openkubes.io/contract-name: disposable-ok141\n    openkubes.io/contract-namespace: disposable-ok141\n    openkubes.io/intent-revision: " + binding.IntentRevision + "\n")
+			writeBoundArtifact(t, root, "ok-infra-prerequisites.yaml", raw, binding)
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			root, binding := validProjection(t)
+			mutate(root, &binding)
+			if _, err := Load(root, binding); err == nil {
+				t.Fatal("unsafe projection accepted")
+			}
+		})
+	}
+}
+
+func TestAllowedResourceRoutesAreExact(t *testing.T) {
+	for key, expected := range map[projection.ResourceIdentity]string{
+		{APIVersion: "v1", Kind: "Namespace", Name: "disposable-ok141"}:                                                                            "/api/v1/namespaces",
+		{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role", Namespace: "ok-images", Name: "cloner"}:                                         "/apis/rbac.authorization.k8s.io/v1/namespaces/ok-images/roles",
+		{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "RoleBinding", Namespace: "ok-images", Name: "cloner"}:                                  "/apis/rbac.authorization.k8s.io/v1/namespaces/ok-images/rolebindings",
+		{APIVersion: "cluster.x-k8s.io/v1beta2", Kind: "Cluster", Namespace: "disposable-ok141", Name: "disposable-ok141"}:                         "/apis/cluster.x-k8s.io/v1beta2/namespaces/disposable-ok141/clusters",
+		{APIVersion: "cluster.x-k8s.io/v1beta2", Kind: "MachineDeployment", Namespace: "disposable-ok141", Name: "workers"}:                        "/apis/cluster.x-k8s.io/v1beta2/namespaces/disposable-ok141/machinedeployments",
+		{APIVersion: "infrastructure.cluster.x-k8s.io/v1alpha1", Kind: "KubevirtCluster", Namespace: "disposable-ok141", Name: "disposable-ok141"}: "/apis/infrastructure.cluster.x-k8s.io/v1alpha1/namespaces/disposable-ok141/kubevirtclusters",
+		{APIVersion: "infrastructure.cluster.x-k8s.io/v1alpha1", Kind: "KubevirtMachineTemplate", Namespace: "disposable-ok141", Name: "template"}: "/apis/infrastructure.cluster.x-k8s.io/v1alpha1/namespaces/disposable-ok141/kubevirtmachinetemplates",
+		{APIVersion: "controlplane.cluster.x-k8s.io/v1alpha3", Kind: "TalosControlPlane", Namespace: "disposable-ok141", Name: "cp"}:               "/apis/controlplane.cluster.x-k8s.io/v1alpha3/namespaces/disposable-ok141/taloscontrolplanes",
+		{APIVersion: "bootstrap.cluster.x-k8s.io/v1alpha3", Kind: "TalosConfigTemplate", Namespace: "disposable-ok141", Name: "workers"}:           "/apis/bootstrap.cluster.x-k8s.io/v1alpha3/namespaces/disposable-ok141/talosconfigtemplates",
+	} {
+		collection, _, err := resourcePaths(key)
+		if err != nil || collection != expected {
+			t.Fatalf("route for %#v = %q %v, want %q", key, collection, err, expected)
+		}
+	}
+	if _, _, err := resourcePaths(projection.ResourceIdentity{APIVersion: "apps/v1", Kind: "Deployment", Namespace: "x", Name: "x"}); err == nil {
+		t.Fatal("arbitrary resource route accepted")
+	}
+}
+
+func validProjection(t *testing.T) (string, projection.Binding) {
+	t.Helper()
+	root := t.TempDir()
+	revision := "sha256:" + strings.Repeat("1", 64)
+	identity := contract.Identity{Name: "disposable-ok141", Namespace: "disposable-ok141"}
+	infra := []byte("apiVersion: v1\nkind: Namespace\nmetadata:\n  name: disposable-ok141\n  annotations:\n    openkubes.io/contract-name: disposable-ok141\n    openkubes.io/contract-namespace: disposable-ok141\n    openkubes.io/intent-revision: " + revision + "\n")
+	mgmt := []byte("apiVersion: cluster.x-k8s.io/v1beta2\nkind: Cluster\nmetadata:\n  name: disposable-ok141\n  namespace: disposable-ok141\n  annotations:\n    openkubes.io/contract-name: disposable-ok141\n    openkubes.io/contract-namespace: disposable-ok141\n    openkubes.io/intent-revision: " + revision + "\nspec:\n  clusterNetwork:\n    services:\n      cidrBlocks: [10.100.0.0/20]\n")
+	if err := os.WriteFile(filepath.Join(root, "ok-infra-prerequisites.yaml"), infra, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "ok-mgmt-lifecycle.yaml"), mgmt, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	binding := projection.Binding{
+		Format: projection.BindingFormat, IntentRevision: revision, ContractIdentity: identity,
+		AuthorityMapDigest: "sha256:" + strings.Repeat("2", 64),
+		InfrastructurePlane: projection.Plane{Identity: "ok-infra", Role: "provider-runtime-and-golden-image-prerequisites", ResourceCount: 1, Resources: []projection.ResourceIdentity{
+			{APIVersion: "v1", Kind: "Namespace", Name: "disposable-ok141"},
+		}},
+		ManagementPlane: projection.Plane{Identity: "ok-mgmt", Role: "single-lifecycle-writer", ResourceCount: 1, Resources: []projection.ResourceIdentity{
+			{APIVersion: "cluster.x-k8s.io/v1beta2", Kind: "Cluster", Name: "disposable-ok141", Namespace: "disposable-ok141"},
+		}},
+		Artifacts: []projection.Artifact{
+			{Name: "ok-infra-prerequisites.yaml", Digest: digest.SHA256(infra)},
+			{Name: "ok-mgmt-lifecycle.yaml", Digest: digest.SHA256(mgmt)},
+		},
+	}
+	return root, binding
+}
+
+func writeBoundArtifact(t *testing.T, root, name string, raw []byte, binding *projection.Binding) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(root, name), raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for index := range binding.Artifacts {
+		if binding.Artifacts[index].Name == name {
+			binding.Artifacts[index].Digest = digest.SHA256(raw)
+			return
+		}
+	}
+	t.Fatalf("artifact %s not found", name)
+}


### PR DESCRIPTION
## What changed

- add an offline `internal/submission` primitive that re-verifies the exact renderer artifacts before use
- bind every object and REST path to the verified authority map and a closed OK-141 resource allow-list
- execute only exact GET plus at most one collection POST, in `ok-infra` then `ok-mgmt` authority order
- preserve fail-closed partial receipts and classify success as `SUBMITTED_OBSERVATION_PENDING`
- add separate TLS credential adapters for each authority plane
- document why the primitive is not yet wired to the CLI or Job

## Why

OK-147 needs a bounded executor path without turning the runner into a second Contract-to-CAPI compiler or treating process success as lifecycle success. This checkpoint proves the exact-create submission mechanism offline while leaving claim/observation composition and any live execution for later review.

## Impact

There is no infrastructure or runtime impact. The CLI remains dry-run-only, no Kubernetes endpoint is contacted, no grant is consumed, and the published runner image is unchanged.

## Validation

- `CGO_ENABLED=0 go test ./...`
- `CGO_ENABLED=0 go vet ./...`
- `CGO_ENABLED=0 go test -race ./internal/submission ./internal/projection ./internal/runner`
- `python3 -m unittest tests.ok147_runner_image_test tests.ok147_runner_publication_test` (11 tests)
- `git diff --check`

## Review question

Does this primitive enforce the intended exact-create and split-authority boundary without prematurely activating mutation or claiming lifecycle success?
