### PR TITLE
OK-147: compose crash-safe execution

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -350,6 +350,54 @@ observation still need to be composed into one crash-safe execution path.
 Therefore this checkpoint does not contact Kubernetes, consume a grant, deploy
 the published image or authorize any mutation.
 
+## Crash-safe execution composition
+
+The following offline checkpoint composes the previously separate mechanisms
+without activating them in the CLI or Job:
+
+```text
+reverify Contract, request, grant, projection and condition policy
+        |
+        v
+atomically claim the one-use grant
+        |
+        v
+exact-create submission v2
+        |
+        v
+bind the CAPI Cluster UID from the API response
+        |
+        v
+bounded aggregate observation for current R, E and P
+        |
+        v
+immutable ledger outcome
+```
+
+Every check that can be completed without external writes occurs before the
+claim. After the claim, an observer or persistence failure leaves
+`CLAIMED_INDETERMINATE_STOP`; a replacement must not retry the operation.
+Known submission failure is retained as `STOPPED`. Current authoritative
+failure is retained as `FAILED`. `SUCCEEDED` is possible only when at least one
+write was attempted and all required Conditions evaluate `True` for the exact
+runtime policy after the claim.
+
+The aggregate evaluator derives its required membership and `R`/`E`/`P`
+identities from the normalized Contract. CAPI evidence must carry the exact
+submitted Cluster UID and current `observedGeneration == generation`.
+Network and Platform evidence must carry the same target UID and exact `E` or
+`P`; they must not invent Kubernetes generation fields for sources that do not
+expose them. Missing, stale, foreign, conflicting or revision-mismatched
+evidence cannot produce `Ready=True`. `False` takes precedence over `Unknown`,
+matching the OK-141 aggregate evaluation model.
+
+The submission receipt is versioned as v2 because it now records per-object
+UIDs plus whether a write was attempted. This runtime identity is required to
+reject a same-name foreign Cluster during observation. The composition remains
+an internal offline primitive: there is still no mutating CLI flag, observer
+HTTP adapter, Job wiring, deployment or infrastructure contact in this
+checkpoint.
+
 ## OK-141 compatibility evidence
 
 The verifier was run offline against the preserved Phase-R v5 projection. It

--- a/internal/authorization/authorization.go
+++ b/internal/authorization/authorization.go
@@ -73,6 +73,7 @@ type ConsumptionBinding struct {
 	RequestDigest            string
 	ContractRevision         string
 	ProjectionManifestDigest string
+	NotBefore                string
 	NotAfter                 string
 }
 
@@ -148,6 +149,7 @@ func Verify(raw, publicKeyRaw []byte, request executor.CreateRequest, at time.Ti
 			RequestDigest:            document.Payload.RequestDigest,
 			ContractRevision:         document.Payload.ContractRevision,
 			ProjectionManifestDigest: document.Payload.ProjectionManifestDigest,
+			NotBefore:                document.Payload.NotBefore,
 			NotAfter:                 document.Payload.NotAfter,
 		},
 		verified: true,

--- a/internal/execution/execution.go
+++ b/internal/execution/execution.go
@@ -1,0 +1,263 @@
+// Package execution composes verified authorization, immutable claim,
+// exact-create submission and bounded observation. It contains no rendering,
+// policy decision, retry, rollback or controller loop.
+package execution
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/authorization"
+	"github.com/openkubes/ok-cluster/internal/contract"
+	"github.com/openkubes/ok-cluster/internal/digest"
+	requestpkg "github.com/openkubes/ok-cluster/internal/executor"
+	"github.com/openkubes/ok-cluster/internal/ledger"
+	"github.com/openkubes/ok-cluster/internal/observation"
+	"github.com/openkubes/ok-cluster/internal/submission"
+)
+
+const ReceiptFormat = "ok147-bounded-execution-receipt/v1"
+
+// Submitter is deliberately narrower than a Kubernetes client.
+type Submitter interface {
+	Execute(context.Context, submission.Plan) (submission.Receipt, error)
+}
+
+// Observer must return a result produced by the deterministic evaluator. An
+// operational observer failure leaves the already claimed grant indeterminate.
+type Observer interface {
+	Observe(context.Context, observation.Policy) (observation.VerifiedResult, error)
+}
+
+// Operation requires explicit durable persistence, bounded capabilities and a
+// clock. None has a permissive default.
+type Operation struct {
+	Ledger    *ledger.Ledger
+	Submitter Submitter
+	Observer  Observer
+	Clock     func() time.Time
+}
+
+// Receipt is safe to retain as redacted execution evidence. Absence of Outcome
+// after Claim means CLAIMED_INDETERMINATE_STOP.
+type Receipt struct {
+	Format         string                 `json:"format"`
+	State          string                 `json:"state"`
+	RequestDigest  string                 `json:"requestDigest"`
+	Claim          *ledger.ClaimReceipt   `json:"claim,omitempty"`
+	Submission     *submission.Receipt    `json:"submission,omitempty"`
+	Observation    *observation.Receipt   `json:"observation,omitempty"`
+	EvidenceDigest string                 `json:"evidenceDigest,omitempty"`
+	Outcome        *ledger.OutcomeReceipt `json:"outcome,omitempty"`
+}
+
+// ResultError means the operation reached a durable non-success outcome. It is
+// distinct from an indeterminate infrastructure/program error.
+type ResultError struct {
+	State string
+}
+
+func (err *ResultError) Error() string { return "bounded execution completed with " + err.State }
+
+// Run performs all non-mutating validation before consuming the grant. Once a
+// claim exists, every unexpected composition/observer/persistence error stops
+// without retry and leaves restart inspection indeterminate.
+func (operation Operation) Run(ctx context.Context, result contract.Result, request requestpkg.CreateRequest, grant authorization.VerifiedGrant, projectionRoot string) (Receipt, error) {
+	receipt := Receipt{Format: ReceiptFormat, State: "PRECLAIM"}
+	if operation.Ledger == nil || operation.Submitter == nil || operation.Observer == nil || operation.Clock == nil {
+		return receipt, errors.New("execution ledger, submitter, observer, and clock are required")
+	}
+	requestDigest, policy, plan, err := preclaim(result, request, grant, projectionRoot)
+	if err != nil {
+		return receipt, err
+	}
+	receipt.RequestDigest = requestDigest
+	claim, err := operation.Ledger.Claim(ctx, grant, operation.Clock())
+	if err != nil {
+		return receipt, err
+	}
+	receipt.Claim = &claim
+	receipt.State = "CLAIMED_INDETERMINATE_STOP"
+
+	submissionReceipt, submissionErr := operation.Submitter.Execute(ctx, plan)
+	receipt.Submission = &submissionReceipt
+	if submissionErr != nil {
+		return operation.complete(ctx, receipt, "STOPPED", submissionReceipt.MutationState, operation.Clock())
+	}
+	clusterUID, err := submittedClusterUID(submissionReceipt, plan, request.ContractIdentity, request.ContractRevision)
+	if err != nil {
+		return receipt, fmt.Errorf("correlate submitted Cluster identity: %w", err)
+	}
+	policy, err = observation.BindTarget(policy, clusterUID)
+	if err != nil {
+		return receipt, err
+	}
+	verifiedObservation, err := operation.Observer.Observe(ctx, policy)
+	if err != nil {
+		return receipt, fmt.Errorf("bounded observation failed after claim: %w", err)
+	}
+	observationReceipt, err := verifiedObservation.Receipt()
+	if err != nil {
+		return receipt, err
+	}
+	receipt.Observation = &observationReceipt
+	expectedPolicyDigest, err := observation.PolicyDigest(policy)
+	if err != nil || observationReceipt.IntentRevision != request.ContractRevision || observationReceipt.PolicyDigest != expectedPolicyDigest {
+		return receipt, errors.New("verified observation does not bind the execution policy")
+	}
+	claimTime, claimTimeErr := time.Parse(time.RFC3339Nano, claim.ClaimedAt)
+	observationTime, observationTimeErr := time.Parse(time.RFC3339Nano, observationReceipt.EvaluatedAt)
+	completedAt := operation.Clock()
+	currentObservation := claimTimeErr == nil && observationTimeErr == nil && !observationTime.Before(claimTime) && !observationTime.After(completedAt)
+
+	outcome := "STOPPED"
+	if observationReceipt.Ready == "False" {
+		outcome = "FAILED"
+	} else if observationReceipt.Ready == "True" && currentObservation && submissionReceipt.MutationState == "ATTEMPTED" {
+		outcome = "SUCCEEDED"
+	}
+	return operation.complete(ctx, receipt, outcome, submissionReceipt.MutationState, completedAt)
+}
+
+func preclaim(result contract.Result, request requestpkg.CreateRequest, grant authorization.VerifiedGrant, projectionRoot string) (string, observation.Policy, submission.Plan, error) {
+	if request.Format != requestpkg.RequestFormat || request.Operation != "CreateCluster" || request.ContractRevision != result.NormalizedDigest || request.Projection.IntentRevision != result.NormalizedDigest || request.Projection.ContractIdentity != request.ContractIdentity {
+		return "", observation.Policy{}, submission.Plan{}, errors.New("Contract result and CreateRequest do not describe one operation")
+	}
+	requestDigest, err := requestpkg.Digest(request)
+	if err != nil {
+		return "", observation.Policy{}, submission.Plan{}, err
+	}
+	binding, err := grant.ConsumptionBinding()
+	if err != nil {
+		return "", observation.Policy{}, submission.Plan{}, err
+	}
+	if binding.Operation != request.Operation || binding.RequestDigest != requestDigest || binding.ContractRevision != request.ContractRevision || binding.ProjectionManifestDigest != request.Projection.ManifestDigest {
+		return "", observation.Policy{}, submission.Plan{}, errors.New("verified grant does not bind the CreateRequest")
+	}
+	policy, err := observation.PolicyFromContract(result)
+	if err != nil {
+		return "", observation.Policy{}, submission.Plan{}, err
+	}
+	plan, err := submission.Load(projectionRoot, request.Projection)
+	if err != nil {
+		return "", observation.Policy{}, submission.Plan{}, err
+	}
+	if plan.IntentRevision != request.ContractRevision || plan.AuthorityMapDigest != request.Projection.AuthorityMapDigest {
+		return "", observation.Policy{}, submission.Plan{}, errors.New("submission plan differs from CreateRequest")
+	}
+	return requestDigest, policy, plan, nil
+}
+
+func submittedClusterUID(receipt submission.Receipt, plan submission.Plan, identity contract.Identity, revision string) (string, error) {
+	if receipt.Format != submission.RunReceiptFormat || receipt.IntentRevision != revision || receipt.State != "SUBMITTED_OBSERVATION_PENDING" || receipt.Infrastructure == nil || receipt.Management == nil {
+		return "", errors.New("submission did not reach observation boundary")
+	}
+	infraMutation, err := validatePlaneReceipt(*receipt.Infrastructure, plan.Infrastructure)
+	if err != nil {
+		return "", fmt.Errorf("infrastructure submission receipt: %w", err)
+	}
+	managementMutation, err := validatePlaneReceipt(*receipt.Management, plan.Management)
+	if err != nil {
+		return "", fmt.Errorf("management submission receipt: %w", err)
+	}
+	expectedMutation := "NOT_ATTEMPTED"
+	if infraMutation == "ATTEMPTED" || managementMutation == "ATTEMPTED" {
+		expectedMutation = "ATTEMPTED"
+	}
+	if receipt.MutationState != expectedMutation {
+		return "", errors.New("submission mutation state is inconsistent")
+	}
+	var uid string
+	for _, result := range receipt.Management.Results {
+		if result.Identity.APIVersion == "cluster.x-k8s.io/v1beta2" && result.Identity.Kind == "Cluster" && result.Identity.Name == identity.Name && result.Identity.Namespace == identity.Namespace {
+			if uid != "" || result.UID == "" {
+				return "", errors.New("submission has ambiguous Cluster runtime identity")
+			}
+			uid = result.UID
+		}
+	}
+	if uid == "" {
+		return "", errors.New("submission has no exact Cluster runtime identity")
+	}
+	return uid, nil
+}
+
+func validatePlaneReceipt(receipt submission.PlaneReceipt, plan submission.Plane) (string, error) {
+	if receipt.Format != submission.PlaneReceiptFormat || receipt.Authority != plan.Identity || receipt.Role != plan.Role || receipt.State != "SUBMITTED" || len(receipt.Results) != len(plan.Objects) {
+		return "", errors.New("identity, state, or result count differs from submission plan")
+	}
+	expectedMutation := "NOT_ATTEMPTED"
+	for index, result := range receipt.Results {
+		expected := plan.Objects[index]
+		if result.Identity.APIVersion != expected.Identity.APIVersion || result.Identity.Kind != expected.Identity.Kind || result.Identity.Name != expected.Identity.Name || result.Identity.Namespace != expected.Identity.Namespace || result.Digest != expected.Digest || result.UID == "" || len(result.UID) > 128 {
+			return "", fmt.Errorf("object result %d differs from submission plan", index+1)
+		}
+		switch result.State {
+		case "CREATED":
+			expectedMutation = "ATTEMPTED"
+		case "UNCHANGED":
+		default:
+			return "", fmt.Errorf("object result %d has invalid state", index+1)
+		}
+	}
+	if receipt.MutationState != expectedMutation {
+		return "", errors.New("plane mutation state is inconsistent")
+	}
+	return expectedMutation, nil
+}
+
+func (operation Operation) complete(ctx context.Context, receipt Receipt, outcome, mutationState string, completedAt time.Time) (Receipt, error) {
+	receipt.State = "COMPLETION_PENDING"
+	evidence := struct {
+		Format        string               `json:"format"`
+		RequestDigest string               `json:"requestDigest"`
+		Claim         *ledger.ClaimReceipt `json:"claim"`
+		Submission    *submission.Receipt  `json:"submission"`
+		Observation   *observation.Receipt `json:"observation,omitempty"`
+		Outcome       string               `json:"outcome"`
+		MutationState string               `json:"mutationState"`
+	}{
+		Format: "ok147-bounded-execution-evidence/v1", RequestDigest: receipt.RequestDigest,
+		Claim: receipt.Claim, Submission: receipt.Submission, Observation: receipt.Observation,
+		Outcome: outcome, MutationState: mutationState,
+	}
+	evidenceDigest, err := canonicalDigest(evidence)
+	if err != nil {
+		receipt.State = "CLAIMED_INDETERMINATE_STOP"
+		return receipt, err
+	}
+	receipt.EvidenceDigest = evidenceDigest
+	completed, err := operation.Ledger.Complete(ctx, *receipt.Claim, outcome, mutationState, evidenceDigest, completedAt)
+	if err != nil {
+		receipt.State = "CLAIMED_INDETERMINATE_STOP"
+		return receipt, fmt.Errorf("persist bounded execution outcome: %w", err)
+	}
+	receipt.Outcome = &completed
+	receipt.State = "COMPLETED_" + outcome
+	if outcome != "SUCCEEDED" {
+		return receipt, &ResultError{State: receipt.State}
+	}
+	return receipt, nil
+}
+
+func canonicalDigest(value any) (string, error) {
+	raw, err := json.Marshal(value)
+	if err != nil {
+		return "", err
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	var generic any
+	if err := decoder.Decode(&generic); err != nil {
+		return "", err
+	}
+	canonical, err := contract.JCS(generic)
+	if err != nil {
+		return "", err
+	}
+	return digest.SHA256(canonical), nil
+}

--- a/internal/execution/execution_test.go
+++ b/internal/execution/execution_test.go
@@ -1,0 +1,307 @@
+package execution
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/authorization"
+	"github.com/openkubes/ok-cluster/internal/contract"
+	"github.com/openkubes/ok-cluster/internal/digest"
+	requestpkg "github.com/openkubes/ok-cluster/internal/executor"
+	"github.com/openkubes/ok-cluster/internal/ledger"
+	"github.com/openkubes/ok-cluster/internal/observation"
+	"github.com/openkubes/ok-cluster/internal/projection"
+	"github.com/openkubes/ok-cluster/internal/submission"
+)
+
+func TestRunCompletesOnlyAfterCurrentReadyObservation(t *testing.T) {
+	fixture := executionFixture(t)
+	store, err := ledger.Open(filepath.Join(t.TempDir(), "ledger"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	operation := Operation{
+		Ledger: store, Submitter: successfulSubmitter{mutationState: "ATTEMPTED"},
+		Observer: observerFunc(readyObservation), Clock: advancingClock(fixture.at),
+	}
+	receipt, err := operation.Run(context.Background(), fixture.result, fixture.request, fixture.grant, fixture.root)
+	if err != nil || receipt.State != "COMPLETED_SUCCEEDED" || receipt.Outcome == nil || receipt.Outcome.Outcome != "SUCCEEDED" {
+		t.Fatalf("unexpected execution result: %#v %v", receipt, err)
+	}
+	inspection, err := store.Inspect(context.Background(), fixture.grant)
+	if err != nil || inspection.State != "COMPLETED" || inspection.Outcome == nil || inspection.Outcome.EvidenceDigest != receipt.EvidenceDigest {
+		t.Fatalf("durable outcome differs: %#v %v", inspection, err)
+	}
+}
+
+func TestRunStaleObservationCompletesStopped(t *testing.T) {
+	fixture := executionFixture(t)
+	store, _ := ledger.Open(filepath.Join(t.TempDir(), "ledger"))
+	operation := Operation{
+		Ledger: store, Submitter: successfulSubmitter{mutationState: "ATTEMPTED"},
+		Observer: observerFunc(func(_ context.Context, policy observation.Policy) (observation.VerifiedResult, error) {
+			bundle := readyBundle(policy)
+			bundle.Evidence[0].ObservedGeneration = 1
+			bundle.Evidence[0].Generation = 2
+			return observation.Evaluate(policy, bundle)
+		}), Clock: advancingClock(fixture.at),
+	}
+	receipt, err := operation.Run(context.Background(), fixture.result, fixture.request, fixture.grant, fixture.root)
+	var resultErr *ResultError
+	if !errors.As(err, &resultErr) || receipt.State != "COMPLETED_STOPPED" || receipt.Observation == nil || receipt.Observation.Ready != "Unknown" {
+		t.Fatalf("stale evidence did not stop durably: %#v %v", receipt, err)
+	}
+}
+
+func TestRunHistoricalReadyObservationCannotSucceed(t *testing.T) {
+	fixture := executionFixture(t)
+	store, _ := ledger.Open(filepath.Join(t.TempDir(), "ledger"))
+	operation := Operation{
+		Ledger: store, Submitter: successfulSubmitter{mutationState: "ATTEMPTED"},
+		Observer: observerFunc(func(_ context.Context, policy observation.Policy) (observation.VerifiedResult, error) {
+			bundle := readyBundle(policy)
+			bundle.EvaluatedAt = fixture.at.Add(-time.Second).Format(time.RFC3339Nano)
+			return observation.Evaluate(policy, bundle)
+		}), Clock: advancingClock(fixture.at),
+	}
+	receipt, err := operation.Run(context.Background(), fixture.result, fixture.request, fixture.grant, fixture.root)
+	if err == nil || receipt.State != "COMPLETED_STOPPED" || receipt.Observation == nil || receipt.Observation.Ready != "True" {
+		t.Fatalf("historical Ready was treated as current success: %#v %v", receipt, err)
+	}
+}
+
+func TestRunObserverFailureLeavesClaimIndeterminate(t *testing.T) {
+	fixture := executionFixture(t)
+	store, _ := ledger.Open(filepath.Join(t.TempDir(), "ledger"))
+	operation := Operation{
+		Ledger: store, Submitter: successfulSubmitter{mutationState: "ATTEMPTED"},
+		Observer: observerFunc(func(context.Context, observation.Policy) (observation.VerifiedResult, error) {
+			return observation.VerifiedResult{}, errors.New("observer unavailable")
+		}), Clock: advancingClock(fixture.at),
+	}
+	receipt, err := operation.Run(context.Background(), fixture.result, fixture.request, fixture.grant, fixture.root)
+	if err == nil || receipt.State != "CLAIMED_INDETERMINATE_STOP" || receipt.Outcome != nil {
+		t.Fatalf("observer failure was not indeterminate: %#v %v", receipt, err)
+	}
+	inspection, inspectErr := store.Inspect(context.Background(), fixture.grant)
+	if inspectErr != nil || inspection.State != "CLAIMED_INDETERMINATE_STOP" || inspection.ClaimAllowed {
+		t.Fatalf("unsafe restart state: %#v %v", inspection, inspectErr)
+	}
+}
+
+func TestRunRejectsObservationForDifferentRuntimePolicy(t *testing.T) {
+	fixture := executionFixture(t)
+	store, _ := ledger.Open(filepath.Join(t.TempDir(), "ledger"))
+	operation := Operation{
+		Ledger: store, Submitter: successfulSubmitter{mutationState: "ATTEMPTED"},
+		Observer: observerFunc(func(_ context.Context, policy observation.Policy) (observation.VerifiedResult, error) {
+			policy.TargetClusterUID = "different-cluster-uid"
+			return observation.Evaluate(policy, readyBundle(policy))
+		}), Clock: advancingClock(fixture.at),
+	}
+	receipt, err := operation.Run(context.Background(), fixture.result, fixture.request, fixture.grant, fixture.root)
+	if err == nil || receipt.State != "CLAIMED_INDETERMINATE_STOP" || receipt.Outcome != nil {
+		t.Fatalf("foreign observation policy was accepted: %#v %v", receipt, err)
+	}
+}
+
+func TestRunValidatesProjectionBeforeClaim(t *testing.T) {
+	fixture := executionFixture(t)
+	if err := os.WriteFile(filepath.Join(fixture.root, "ok-mgmt-lifecycle.yaml"), []byte("tampered\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	store, _ := ledger.Open(filepath.Join(t.TempDir(), "ledger"))
+	operation := Operation{Ledger: store, Submitter: staticSubmitter{}, Observer: observerFunc(readyObservation), Clock: advancingClock(fixture.at)}
+	if _, err := operation.Run(context.Background(), fixture.result, fixture.request, fixture.grant, fixture.root); err == nil {
+		t.Fatal("tampered projection accepted")
+	}
+	inspection, err := store.Inspect(context.Background(), fixture.grant)
+	if err != nil || inspection.State != "AVAILABLE" || !inspection.ClaimAllowed {
+		t.Fatalf("preclaim failure consumed grant: %#v %v", inspection, err)
+	}
+}
+
+func TestRunSubmissionFailureIsDurablyStoppedWithoutObservation(t *testing.T) {
+	fixture := executionFixture(t)
+	store, _ := ledger.Open(filepath.Join(t.TempDir(), "ledger"))
+	observerCalls := 0
+	operation := Operation{
+		Ledger:    store,
+		Submitter: staticSubmitter{receipt: submission.Receipt{Format: submission.RunReceiptFormat, IntentRevision: fixture.result.NormalizedDigest, State: "STOPPED_PARTIAL_OR_UNKNOWN", MutationState: "ATTEMPTED"}, err: errors.New("create denied")},
+		Observer: observerFunc(func(context.Context, observation.Policy) (observation.VerifiedResult, error) {
+			observerCalls++
+			return observation.VerifiedResult{}, nil
+		}), Clock: advancingClock(fixture.at),
+	}
+	receipt, err := operation.Run(context.Background(), fixture.result, fixture.request, fixture.grant, fixture.root)
+	var resultErr *ResultError
+	if !errors.As(err, &resultErr) || receipt.State != "COMPLETED_STOPPED" || receipt.Outcome == nil || receipt.Outcome.MutationState != "ATTEMPTED" || observerCalls != 0 {
+		t.Fatalf("submission failure handling differs: %#v calls=%d err=%v", receipt, observerCalls, err)
+	}
+}
+
+func TestRunDoesNotCallNoWriteIdempotencyLifecycleSuccess(t *testing.T) {
+	fixture := executionFixture(t)
+	store, _ := ledger.Open(filepath.Join(t.TempDir(), "ledger"))
+	operation := Operation{
+		Ledger: store, Submitter: successfulSubmitter{mutationState: "NOT_ATTEMPTED"},
+		Observer: observerFunc(readyObservation), Clock: advancingClock(fixture.at),
+	}
+	receipt, err := operation.Run(context.Background(), fixture.result, fixture.request, fixture.grant, fixture.root)
+	if err == nil || receipt.State != "COMPLETED_STOPPED" || receipt.Outcome == nil || receipt.Outcome.MutationState != "NOT_ATTEMPTED" {
+		t.Fatalf("no-write operation claimed lifecycle success: %#v %v", receipt, err)
+	}
+}
+
+type fixtureState struct {
+	root    string
+	at      time.Time
+	result  contract.Result
+	request requestpkg.CreateRequest
+	grant   authorization.VerifiedGrant
+}
+
+func executionFixture(t *testing.T) fixtureState {
+	t.Helper()
+	raw, err := os.ReadFile("../contract/testdata/ok141-contract-v5.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	schema, err := os.ReadFile("../contract/testdata/ok141-contract-v3.schema.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := contract.Canonicalize(raw, schema)
+	if err != nil {
+		t.Fatal(err)
+	}
+	identity, _ := contract.ContractIdentity(result.Normalized)
+	root := t.TempDir()
+	infra := projectionYAML("v1", "Namespace", "", identity.Name, identity, result.NormalizedDigest)
+	mgmt := projectionYAML("cluster.x-k8s.io/v1beta2", "Cluster", identity.Namespace, identity.Name, identity, result.NormalizedDigest)
+	authority, _ := json.Marshal(map[string]any{
+		"format": "ok141-contract-to-capi-projection/v2", "contractIdentity": identity, "intentRevision": result.NormalizedDigest,
+		"infrastructurePlane": map[string]any{"identity": "ok-infra", "role": "provider-runtime-and-golden-image-prerequisites", "resources": []map[string]any{{"apiVersion": "v1", "kind": "Namespace", "name": identity.Name}}},
+		"managementPlane":     map[string]any{"identity": "ok-mgmt", "role": "single-lifecycle-writer", "resources": []map[string]any{{"apiVersion": "cluster.x-k8s.io/v1beta2", "kind": "Cluster", "namespace": identity.Namespace, "name": identity.Name}}},
+	})
+	for name, value := range map[string][]byte{"authority-map.json": authority, "ok-infra-prerequisites.yaml": infra, "ok-mgmt-lifecycle.yaml": mgmt} {
+		if err := os.WriteFile(filepath.Join(root, name), value, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	binding := projection.Binding{
+		Format: projection.BindingFormat, SourceFormat: "ok141-contract-to-capi-projection/v2",
+		ManifestDigest: "sha256:" + strings.Repeat("b", 64), AuthorityMapDigest: digest.SHA256(authority),
+		IntentRevision: result.NormalizedDigest, ContractIdentity: identity,
+		InfrastructurePlane: projection.Plane{Identity: "ok-infra", Role: "provider-runtime-and-golden-image-prerequisites", ResourceCount: 1},
+		ManagementPlane:     projection.Plane{Identity: "ok-mgmt", Role: "single-lifecycle-writer", ResourceCount: 1},
+		Artifacts:           []projection.Artifact{{Name: "authority-map.json", Digest: digest.SHA256(authority)}, {Name: "ok-infra-prerequisites.yaml", Digest: digest.SHA256(infra)}, {Name: "ok-mgmt-lifecycle.yaml", Digest: digest.SHA256(mgmt)}},
+	}
+	request, err := requestpkg.NewCreateRequest(result, identity, binding)
+	if err != nil {
+		t.Fatal(err)
+	}
+	at := time.Date(2026, 8, 16, 10, 0, 0, 0, time.UTC)
+	grant := signedGrant(t, request, at)
+	return fixtureState{root: root, at: at, result: result, request: request, grant: grant}
+}
+
+func projectionYAML(apiVersion, kind, namespace, name string, identity contract.Identity, revision string) []byte {
+	namespaceLine := ""
+	if namespace != "" {
+		namespaceLine = "  namespace: " + namespace + "\n"
+	}
+	return []byte("apiVersion: " + apiVersion + "\nkind: " + kind + "\nmetadata:\n  name: " + name + "\n" + namespaceLine + "  annotations:\n    openkubes.io/contract-name: " + identity.Name + "\n    openkubes.io/contract-namespace: " + identity.Namespace + "\n    openkubes.io/intent-revision: " + revision + "\n")
+}
+
+func signedGrant(t *testing.T, request requestpkg.CreateRequest, at time.Time) authorization.VerifiedGrant {
+	t.Helper()
+	requestDigest, _ := requestpkg.Digest(request)
+	publicKey, privateKey, _ := ed25519.GenerateKey(rand.Reader)
+	payload := authorization.Payload{
+		Audience: authorization.Audience, GrantID: "ok147-execution-20260816-01", Decision: "ALLOW", Operation: request.Operation,
+		RequestDigest: requestDigest, ContractIdentity: request.ContractIdentity, ContractRevision: request.ContractRevision,
+		ProjectionManifestDigest: request.Projection.ManifestDigest, NotBefore: at.Add(-time.Minute).Format(time.RFC3339), NotAfter: at.Add(20 * time.Minute).Format(time.RFC3339), MaxUses: 1,
+	}
+	signed, _ := authorization.SigningBytes(payload)
+	document, _ := json.Marshal(map[string]any{"format": authorization.Format, "payload": payload, "signature": map[string]any{"algorithm": "Ed25519", "keyId": digest.SHA256(publicKey), "value": base64.StdEncoding.EncodeToString(ed25519.Sign(privateKey, signed))}})
+	grant, err := authorization.Verify(document, []byte(base64.StdEncoding.EncodeToString(publicKey)), request, at)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return grant
+}
+
+type staticSubmitter struct {
+	receipt submission.Receipt
+	err     error
+}
+
+func (submitter staticSubmitter) Execute(context.Context, submission.Plan) (submission.Receipt, error) {
+	return submitter.receipt, submitter.err
+}
+
+type successfulSubmitter struct{ mutationState string }
+
+func (submitter successfulSubmitter) Execute(_ context.Context, plan submission.Plan) (submission.Receipt, error) {
+	state := "CREATED"
+	if submitter.mutationState == "NOT_ATTEMPTED" {
+		state = "UNCHANGED"
+	}
+	planeReceipt := func(plane submission.Plane) *submission.PlaneReceipt {
+		results := make([]submission.ObjectResult, 0, len(plane.Objects))
+		for _, object := range plane.Objects {
+			uid := "uid-" + object.Identity.Name
+			if object.Identity.APIVersion == "cluster.x-k8s.io/v1beta2" && object.Identity.Kind == "Cluster" {
+				uid = "capi-cluster-uid-1"
+			}
+			results = append(results, submission.ObjectResult{
+				Identity: submission.ObjectIdentity{APIVersion: object.Identity.APIVersion, Kind: object.Identity.Kind, Name: object.Identity.Name, Namespace: object.Identity.Namespace},
+				Digest:   object.Digest, UID: uid, State: state,
+			})
+		}
+		return &submission.PlaneReceipt{Format: submission.PlaneReceiptFormat, Authority: plane.Identity, Role: plane.Role, State: "SUBMITTED", MutationState: submitter.mutationState, Results: results}
+	}
+	return submission.Receipt{
+		Format: submission.RunReceiptFormat, IntentRevision: plan.IntentRevision,
+		State: "SUBMITTED_OBSERVATION_PENDING", MutationState: submitter.mutationState,
+		Infrastructure: planeReceipt(plan.Infrastructure), Management: planeReceipt(plan.Management),
+	}, nil
+}
+
+type observerFunc func(context.Context, observation.Policy) (observation.VerifiedResult, error)
+
+func (function observerFunc) Observe(ctx context.Context, policy observation.Policy) (observation.VerifiedResult, error) {
+	return function(ctx, policy)
+}
+
+func readyObservation(_ context.Context, policy observation.Policy) (observation.VerifiedResult, error) {
+	return observation.Evaluate(policy, readyBundle(policy))
+}
+
+func readyBundle(policy observation.Policy) observation.Bundle {
+	evidenceDigest := "sha256:" + strings.Repeat("e", 64)
+	return observation.Bundle{Format: observation.BundleFormat, IntentRevision: policy.IntentRevision, EvaluatedAt: "2026-08-16T10:00:01Z", Evidence: []observation.Evidence{
+		{Type: "InfrastructureReady", Source: "CAPICluster", SourceUID: policy.TargetClusterUID, TargetClusterUID: policy.TargetClusterUID, Status: "True", Reason: "InfrastructureReady", DesiredRevision: policy.IntentRevision, ObservedRevision: policy.IntentRevision, Generation: 1, ObservedGeneration: 1, EvidenceDigest: evidenceDigest},
+		{Type: "ControlPlaneAvailable", Source: "CAPICluster", SourceUID: policy.TargetClusterUID, TargetClusterUID: policy.TargetClusterUID, Status: "True", Reason: "ControlPlaneAvailable", DesiredRevision: policy.IntentRevision, ObservedRevision: policy.IntentRevision, Generation: 1, ObservedGeneration: 1, EvidenceDigest: evidenceDigest},
+		{Type: "NetworkReady", Source: "BoundedNetworkEvaluator", SourceUID: "network-evidence-1", TargetClusterUID: policy.TargetClusterUID, Status: "True", Reason: "NetworkReady", DesiredRevision: policy.EnablementRevision, ObservedRevision: policy.EnablementRevision, EvidenceDigest: evidenceDigest},
+		{Type: "PlatformReady", Source: "BoundedPlatformEvaluator", SourceUID: "platform-evidence-1", TargetClusterUID: policy.TargetClusterUID, Status: "True", Reason: "PlatformReady", DesiredRevision: policy.PlatformRevision, ObservedRevision: policy.PlatformRevision, EvidenceDigest: evidenceDigest},
+	}}
+}
+
+func advancingClock(start time.Time) func() time.Time {
+	current := start.Add(-time.Second)
+	return func() time.Time {
+		current = current.Add(time.Second)
+		return current
+	}
+}

--- a/internal/ledger/ledger.go
+++ b/internal/ledger/ledger.go
@@ -120,12 +120,16 @@ func (ledger *Ledger) Claim(ctx context.Context, grant authorization.VerifiedGra
 	if err != nil {
 		return ClaimReceipt{}, err
 	}
+	starts, err := time.Parse(time.RFC3339, binding.NotBefore)
+	if err != nil {
+		return ClaimReceipt{}, fmt.Errorf("grant start: %w", err)
+	}
 	expires, err := time.Parse(time.RFC3339, binding.NotAfter)
 	if err != nil {
 		return ClaimReceipt{}, fmt.Errorf("grant expiration: %w", err)
 	}
-	if !at.Before(expires) {
-		return ClaimReceipt{}, errors.New("grant expired before consumption")
+	if at.Before(starts) || !at.Before(expires) {
+		return ClaimReceipt{}, errors.New("grant is not active at consumption time")
 	}
 	receipt := ClaimReceipt{
 		Format:                   ClaimFormat,

--- a/internal/ledger/ledger_test.go
+++ b/internal/ledger/ledger_test.go
@@ -64,6 +64,21 @@ func TestClaimIsAtomicAndSingleUse(t *testing.T) {
 	}
 }
 
+func TestClaimRechecksGrantWindowAtConsumption(t *testing.T) {
+	store, err := Open(filepath.Join(t.TempDir(), "ledger"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	at := time.Date(2026, 8, 16, 10, 0, 0, 0, time.UTC)
+	grant := verifiedGrant(t, at)
+	if _, err := store.Claim(context.Background(), grant, at.Add(-2*time.Minute)); err == nil || !strings.Contains(err.Error(), "not active") {
+		t.Fatalf("inactive grant was consumed: %v", err)
+	}
+	if _, err := store.Claim(context.Background(), grant, at); err != nil {
+		t.Fatalf("active grant was consumed by the rejected attempt: %v", err)
+	}
+}
+
 func TestCompleteIsImmutableAndIdempotent(t *testing.T) {
 	store, err := Open(filepath.Join(t.TempDir(), "ledger"))
 	if err != nil {

--- a/internal/observation/evaluator.go
+++ b/internal/observation/evaluator.go
@@ -1,0 +1,373 @@
+// Package observation implements the bounded aggregate evaluator proven by
+// OK-141. It normalizes already authoritative source evidence; it does not
+// query Kubernetes, publish status, or repair any source resource.
+package observation
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"regexp"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/contract"
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+const (
+	PolicyFormat = "ok147-required-condition-policy/v1"
+	BundleFormat = "ok147-observation-bundle/v1"
+	ResultFormat = "ok147-aggregate-observation/v1"
+)
+
+var supportedConditions = map[string]struct{}{
+	"InfrastructureReady":   {},
+	"ControlPlaneAvailable": {},
+	"NetworkReady":          {},
+	"PlatformReady":         {},
+}
+
+// Policy is derived from the normalized Contract and therefore bound by R.
+type Policy struct {
+	Format             string   `json:"format"`
+	IntentRevision     string   `json:"intentRevision"`
+	EnablementRevision string   `json:"enablementRevision"`
+	PlatformRevision   string   `json:"platformRevision"`
+	TargetClusterUID   string   `json:"targetClusterUid"`
+	Required           []string `json:"required"`
+}
+
+// Evidence is one normalized statement from an authoritative source-specific
+// observer. CAPI sources use generation correlation; bounded Network and
+// Platform evaluators use exact revision correlation without inventing an
+// observedGeneration field.
+type Evidence struct {
+	Type               string `json:"type"`
+	Source             string `json:"source"`
+	SourceUID          string `json:"sourceUid"`
+	TargetClusterUID   string `json:"targetClusterUid"`
+	Status             string `json:"status"`
+	Reason             string `json:"reason"`
+	DesiredRevision    string `json:"desiredRevision"`
+	ObservedRevision   string `json:"observedRevision"`
+	Generation         int64  `json:"generation,omitempty"`
+	ObservedGeneration int64  `json:"observedGeneration,omitempty"`
+	EvidenceDigest     string `json:"evidenceDigest"`
+}
+
+// BindTarget returns a runtime policy correlated to the immutable CAPI Cluster
+// UID observed in the exact submission response.
+func BindTarget(policy Policy, clusterUID string) (Policy, error) {
+	if err := validatePolicy(policy, false); err != nil {
+		return Policy{}, err
+	}
+	if !validUID(clusterUID) {
+		return Policy{}, errors.New("target Cluster UID is invalid")
+	}
+	policy.TargetClusterUID = clusterUID
+	return policy, nil
+}
+
+// Bundle is one bounded observation input. Missing required entries remain a
+// valid input and evaluate to Unknown rather than being silently accepted.
+type Bundle struct {
+	Format         string     `json:"format"`
+	IntentRevision string     `json:"intentRevision"`
+	EvaluatedAt    string     `json:"evaluatedAt"`
+	Evidence       []Evidence `json:"evidence"`
+}
+
+// Condition is the fail-closed normalized result for one required fact.
+type Condition struct {
+	Type   string `json:"type"`
+	Status string `json:"status"`
+	Reason string `json:"reason"`
+	Source string `json:"source,omitempty"`
+}
+
+// Receipt is deterministic aggregate evidence. It is not a durable status
+// publication and cannot repair any source resource.
+type Receipt struct {
+	Format         string      `json:"format"`
+	IntentRevision string      `json:"intentRevision"`
+	PolicyDigest   string      `json:"policyDigest"`
+	InputDigest    string      `json:"inputDigest"`
+	Ready          string      `json:"ready"`
+	Reason         string      `json:"reason"`
+	Conditions     []Condition `json:"conditions"`
+	EvaluatedAt    string      `json:"evaluatedAt"`
+}
+
+// VerifiedResult cannot be manufactured outside this package.
+type VerifiedResult struct {
+	receipt  Receipt
+	digest   string
+	verified bool
+}
+
+func (result VerifiedResult) Receipt() (Receipt, error) {
+	if !result.verified {
+		return Receipt{}, errors.New("observation result was not produced by evaluation")
+	}
+	return result.receipt, nil
+}
+
+func (result VerifiedResult) EvidenceDigest() (string, error) {
+	if !result.verified {
+		return "", errors.New("observation result was not produced by evaluation")
+	}
+	return result.digest, nil
+}
+
+// PolicyDigest returns the exact runtime policy identity, including the bound
+// target Cluster UID.
+func PolicyDigest(policy Policy) (string, error) {
+	if err := validatePolicy(policy, true); err != nil {
+		return "", err
+	}
+	return canonicalDigest(policy)
+}
+
+// PolicyFromContract extracts only immutable condition inputs from an already
+// normalized Contract result.
+func PolicyFromContract(result contract.Result) (Policy, error) {
+	if !validDigest(result.NormalizedDigest) {
+		return Policy{}, errors.New("normalized Contract revision is invalid")
+	}
+	root, ok := result.Normalized.(map[string]any)
+	if !ok {
+		return Policy{}, errors.New("normalized Contract is not an object")
+	}
+	spec, ok := root["spec"].(map[string]any)
+	if !ok {
+		return Policy{}, errors.New("normalized Contract spec is not an object")
+	}
+	enablement, _ := spec["enablement"].(map[string]any)
+	platform, _ := spec["platform"].(map[string]any)
+	conditionSpec, _ := spec["conditions"].(map[string]any)
+	eRevision, _ := enablement["revision"].(string)
+	pRevision, _ := platform["revision"].(string)
+	rawRequired, _ := conditionSpec["required"].([]any)
+	if !validDigest(eRevision) || !validDigest(pRevision) || len(rawRequired) == 0 {
+		return Policy{}, errors.New("normalized Contract lacks condition revision inputs")
+	}
+	required := make([]string, 0, len(rawRequired))
+	seen := map[string]struct{}{}
+	for _, raw := range rawRequired {
+		name, ok := raw.(string)
+		if !ok {
+			return Policy{}, errors.New("required condition name is invalid")
+		}
+		if _, ok := supportedConditions[name]; !ok {
+			return Policy{}, fmt.Errorf("required condition %q is unsupported", name)
+		}
+		if _, duplicate := seen[name]; duplicate {
+			return Policy{}, fmt.Errorf("required condition %q is duplicated", name)
+		}
+		seen[name] = struct{}{}
+		required = append(required, name)
+	}
+	return Policy{
+		Format: PolicyFormat, IntentRevision: result.NormalizedDigest,
+		EnablementRevision: eRevision, PlatformRevision: pRevision, Required: required,
+	}, nil
+}
+
+// Evaluate applies False-over-Unknown aggregation. Missing, stale, foreign or
+// revision-mismatched evidence can never produce Ready=True.
+func Evaluate(policy Policy, bundle Bundle) (VerifiedResult, error) {
+	if err := validatePolicy(policy, true); err != nil {
+		return VerifiedResult{}, err
+	}
+	if bundle.Format != BundleFormat || bundle.IntentRevision != policy.IntentRevision {
+		return VerifiedResult{}, errors.New("observation bundle format or intent revision differs from policy")
+	}
+	if _, err := time.Parse(time.RFC3339Nano, bundle.EvaluatedAt); err != nil {
+		return VerifiedResult{}, errors.New("observation evaluation time is invalid")
+	}
+	if len(bundle.Evidence) > len(policy.Required)+4 {
+		return VerifiedResult{}, errors.New("observation bundle contains too many source statements")
+	}
+	required := make(map[string]struct{}, len(policy.Required))
+	for _, name := range policy.Required {
+		required[name] = struct{}{}
+	}
+	byType := make(map[string][]Evidence, len(bundle.Evidence))
+	for _, item := range bundle.Evidence {
+		if _, ok := supportedConditions[item.Type]; !ok {
+			return VerifiedResult{}, fmt.Errorf("observation condition %q is unsupported", item.Type)
+		}
+		if _, ok := required[item.Type]; !ok {
+			return VerifiedResult{}, fmt.Errorf("observation condition %q is not in the required profile", item.Type)
+		}
+		if err := validateEvidenceShape(item); err != nil {
+			return VerifiedResult{}, fmt.Errorf("observation condition %s: %w", item.Type, err)
+		}
+		byType[item.Type] = append(byType[item.Type], item)
+	}
+
+	conditions := make([]Condition, 0, len(policy.Required))
+	hasFalse := false
+	hasUnknown := false
+	for _, name := range policy.Required {
+		items := byType[name]
+		var result Condition
+		switch len(items) {
+		case 0:
+			result = Condition{Type: name, Status: "Unknown", Reason: "RequiredEvidenceMissing"}
+		case 1:
+			result = evaluateEvidence(policy, items[0])
+		default:
+			result = Condition{Type: name, Status: "Unknown", Reason: "ConflictingAuthority"}
+		}
+		conditions = append(conditions, result)
+		hasFalse = hasFalse || result.Status == "False"
+		hasUnknown = hasUnknown || result.Status == "Unknown"
+	}
+
+	ready, reason := "True", "AllRequiredConditionsSatisfied"
+	if hasFalse {
+		ready, reason = "False", "RequiredConditionFailed"
+	} else if hasUnknown {
+		ready, reason = "Unknown", aggregateUnknownReason(conditions)
+	}
+	policyDigest, err := PolicyDigest(policy)
+	if err != nil {
+		return VerifiedResult{}, err
+	}
+	inputDigest, err := canonicalDigest(bundle)
+	if err != nil {
+		return VerifiedResult{}, err
+	}
+	receipt := Receipt{
+		Format: ResultFormat, IntentRevision: policy.IntentRevision, PolicyDigest: policyDigest,
+		InputDigest: inputDigest, Ready: ready, Reason: reason, Conditions: conditions,
+		EvaluatedAt: bundle.EvaluatedAt,
+	}
+	receiptDigest, err := canonicalDigest(receipt)
+	if err != nil {
+		return VerifiedResult{}, err
+	}
+	return VerifiedResult{receipt: receipt, digest: receiptDigest, verified: true}, nil
+}
+
+func validatePolicy(policy Policy, requireTarget bool) error {
+	if policy.Format != PolicyFormat || !validDigest(policy.IntentRevision) || !validDigest(policy.EnablementRevision) || !validDigest(policy.PlatformRevision) || len(policy.Required) == 0 {
+		return errors.New("observation policy is invalid")
+	}
+	if requireTarget && !validUID(policy.TargetClusterUID) {
+		return errors.New("observation policy has no valid target Cluster UID")
+	}
+	seen := map[string]struct{}{}
+	for _, name := range policy.Required {
+		if _, ok := supportedConditions[name]; !ok {
+			return fmt.Errorf("observation policy condition %q is unsupported", name)
+		}
+		if _, duplicate := seen[name]; duplicate {
+			return fmt.Errorf("observation policy condition %q is duplicated", name)
+		}
+		seen[name] = struct{}{}
+	}
+	return nil
+}
+
+func validateEvidenceShape(value Evidence) error {
+	if !validUID(value.SourceUID) || !validUID(value.TargetClusterUID) || !regexp.MustCompile(`^[A-Za-z][A-Za-z0-9]{0,127}$`).MatchString(value.Reason) || !validDigest(value.DesiredRevision) || !validDigest(value.ObservedRevision) || !validDigest(value.EvidenceDigest) {
+		return errors.New("identity, revision, reason, or evidence digest is invalid")
+	}
+	if value.Status != "True" && value.Status != "False" && value.Status != "Unknown" {
+		return errors.New("status is invalid")
+	}
+	expectedSource := sourceFor(value.Type)
+	if value.Source != expectedSource {
+		return fmt.Errorf("source %q differs from required %q", value.Source, expectedSource)
+	}
+	if isCAPISource(value.Type) {
+		if value.Generation <= 0 || value.ObservedGeneration < 0 {
+			return errors.New("CAPI generation fields are invalid")
+		}
+	} else if value.Generation != 0 || value.ObservedGeneration != 0 {
+		return errors.New("non-CAPI evidence must not invent generation fields")
+	}
+	return nil
+}
+
+func evaluateEvidence(policy Policy, value Evidence) Condition {
+	condition := Condition{Type: value.Type, Source: value.Source}
+	if value.TargetClusterUID != policy.TargetClusterUID || isCAPISource(value.Type) && value.SourceUID != policy.TargetClusterUID {
+		condition.Status, condition.Reason = "Unknown", "RevisionCorrelationUnproven"
+		return condition
+	}
+	expectedRevision := policy.IntentRevision
+	if value.Type == "NetworkReady" {
+		expectedRevision = policy.EnablementRevision
+	} else if value.Type == "PlatformReady" {
+		expectedRevision = policy.PlatformRevision
+	}
+	if value.DesiredRevision != expectedRevision || value.ObservedRevision != expectedRevision {
+		condition.Status, condition.Reason = "Unknown", "RevisionCorrelationUnproven"
+		return condition
+	}
+	if isCAPISource(value.Type) && value.ObservedGeneration != value.Generation {
+		condition.Status, condition.Reason = "Unknown", "SourceObservationStale"
+		return condition
+	}
+	condition.Status = value.Status
+	condition.Reason = value.Reason
+	return condition
+}
+
+func aggregateUnknownReason(conditions []Condition) string {
+	for _, preferred := range []string{"ConflictingAuthority", "RevisionCorrelationUnproven", "SourceObservationStale", "RequiredEvidenceMissing"} {
+		for _, condition := range conditions {
+			if condition.Status == "Unknown" && condition.Reason == preferred {
+				return preferred
+			}
+		}
+	}
+	return "ObserverUnavailable"
+}
+
+func sourceFor(condition string) string {
+	switch condition {
+	case "InfrastructureReady", "ControlPlaneAvailable":
+		return "CAPICluster"
+	case "NetworkReady":
+		return "BoundedNetworkEvaluator"
+	case "PlatformReady":
+		return "BoundedPlatformEvaluator"
+	default:
+		return ""
+	}
+}
+
+func isCAPISource(condition string) bool {
+	return condition == "InfrastructureReady" || condition == "ControlPlaneAvailable"
+}
+
+func validDigest(value string) bool {
+	return regexp.MustCompile(`^sha256:[0-9a-f]{64}$`).MatchString(value)
+}
+
+func validUID(value string) bool {
+	return regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$`).MatchString(value)
+}
+
+func canonicalDigest(value any) (string, error) {
+	raw, err := json.Marshal(value)
+	if err != nil {
+		return "", err
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	var generic any
+	if err := decoder.Decode(&generic); err != nil {
+		return "", err
+	}
+	canonical, err := contract.JCS(generic)
+	if err != nil {
+		return "", err
+	}
+	return digest.SHA256(canonical), nil
+}

--- a/internal/observation/evaluator_test.go
+++ b/internal/observation/evaluator_test.go
@@ -1,0 +1,138 @@
+package observation
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/openkubes/ok-cluster/internal/contract"
+)
+
+func TestPolicyFromContractAndAllTrue(t *testing.T) {
+	policy := testPolicy(t)
+	if policy.IntentRevision != testContract(t).NormalizedDigest || len(policy.Required) != 4 {
+		t.Fatalf("unexpected policy: %#v", policy)
+	}
+	result, err := Evaluate(policy, completeBundle(policy))
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := result.Receipt()
+	if err != nil || receipt.Ready != "True" || receipt.Reason != "AllRequiredConditionsSatisfied" {
+		t.Fatalf("unexpected aggregate: %#v %v", receipt, err)
+	}
+	if evidenceDigest, err := result.EvidenceDigest(); err != nil || !validDigest(evidenceDigest) {
+		t.Fatalf("invalid result digest: %q %v", evidenceDigest, err)
+	}
+}
+
+func TestEvaluateFailsClosedForMissingStaleForeignRevisionAndConflict(t *testing.T) {
+	for name, mutate := range map[string]func(*Policy, *Bundle){
+		"missing": func(_ *Policy, bundle *Bundle) {
+			bundle.Evidence = bundle.Evidence[:3]
+		},
+		"stale generation": func(_ *Policy, bundle *Bundle) {
+			bundle.Evidence[0].ObservedGeneration = 1
+			bundle.Evidence[0].Generation = 2
+		},
+		"foreign Cluster UID": func(_ *Policy, bundle *Bundle) {
+			bundle.Evidence[0].SourceUID = "foreign-cluster-uid"
+		},
+		"wrong enablement revision": func(_ *Policy, bundle *Bundle) {
+			bundle.Evidence[2].ObservedRevision = "sha256:" + strings.Repeat("9", 64)
+		},
+		"conflicting authority": func(_ *Policy, bundle *Bundle) {
+			bundle.Evidence = append(bundle.Evidence, bundle.Evidence[1])
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			policy := testPolicy(t)
+			bundle := completeBundle(policy)
+			mutate(&policy, &bundle)
+			result, err := Evaluate(policy, bundle)
+			if err != nil {
+				t.Fatal(err)
+			}
+			receipt, err := result.Receipt()
+			if err != nil || receipt.Ready == "True" {
+				t.Fatalf("unsafe aggregate: %#v %v", receipt, err)
+			}
+		})
+	}
+}
+
+func TestEvaluateCurrentFailurePrecedesUnknown(t *testing.T) {
+	policy := testPolicy(t)
+	bundle := completeBundle(policy)
+	bundle.Evidence[0].Status = "False"
+	bundle.Evidence[0].Reason = "InfrastructureNotReady"
+	bundle.Evidence = bundle.Evidence[:3]
+	result, err := Evaluate(policy, bundle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, _ := result.Receipt()
+	if receipt.Ready != "False" || receipt.Reason != "RequiredConditionFailed" {
+		t.Fatalf("False did not precede Unknown: %#v", receipt)
+	}
+}
+
+func TestEvaluateRejectsInventedGenerationAndMalformedEvidence(t *testing.T) {
+	for name, mutate := range map[string]func(*Bundle){
+		"invented generation": func(bundle *Bundle) { bundle.Evidence[2].Generation = 1 },
+		"invalid digest":      func(bundle *Bundle) { bundle.Evidence[0].EvidenceDigest = "sha256:no" },
+		"unsupported source":  func(bundle *Bundle) { bundle.Evidence[0].Source = "OpenKubesOperator" },
+	} {
+		t.Run(name, func(t *testing.T) {
+			policy := testPolicy(t)
+			bundle := completeBundle(policy)
+			mutate(&bundle)
+			if _, err := Evaluate(policy, bundle); err == nil {
+				t.Fatal("malformed evidence accepted")
+			}
+		})
+	}
+}
+
+func testContract(t *testing.T) contract.Result {
+	t.Helper()
+	raw, err := os.ReadFile("../contract/testdata/ok141-contract-v5.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	schema, err := os.ReadFile("../contract/testdata/ok141-contract-v3.schema.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := contract.Canonicalize(raw, schema)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return result
+}
+
+func testPolicy(t *testing.T) Policy {
+	t.Helper()
+	policy, err := PolicyFromContract(testContract(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	policy, err = BindTarget(policy, "capi-cluster-uid-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return policy
+}
+
+func completeBundle(policy Policy) Bundle {
+	digest := "sha256:" + strings.Repeat("a", 64)
+	return Bundle{
+		Format: BundleFormat, IntentRevision: policy.IntentRevision, EvaluatedAt: "2026-08-16T10:00:01Z",
+		Evidence: []Evidence{
+			{Type: "InfrastructureReady", Source: "CAPICluster", SourceUID: policy.TargetClusterUID, TargetClusterUID: policy.TargetClusterUID, Status: "True", Reason: "InfrastructureReady", DesiredRevision: policy.IntentRevision, ObservedRevision: policy.IntentRevision, Generation: 2, ObservedGeneration: 2, EvidenceDigest: digest},
+			{Type: "ControlPlaneAvailable", Source: "CAPICluster", SourceUID: policy.TargetClusterUID, TargetClusterUID: policy.TargetClusterUID, Status: "True", Reason: "ControlPlaneAvailable", DesiredRevision: policy.IntentRevision, ObservedRevision: policy.IntentRevision, Generation: 2, ObservedGeneration: 2, EvidenceDigest: digest},
+			{Type: "NetworkReady", Source: "BoundedNetworkEvaluator", SourceUID: "network-evidence-1", TargetClusterUID: policy.TargetClusterUID, Status: "True", Reason: "NetworkReady", DesiredRevision: policy.EnablementRevision, ObservedRevision: policy.EnablementRevision, EvidenceDigest: digest},
+			{Type: "PlatformReady", Source: "BoundedPlatformEvaluator", SourceUID: "platform-evidence-1", TargetClusterUID: policy.TargetClusterUID, Status: "True", Reason: "PlatformReady", DesiredRevision: policy.PlatformRevision, ObservedRevision: policy.PlatformRevision, EvidenceDigest: digest},
+		},
+	}
+}

--- a/internal/projection/projection.go
+++ b/internal/projection/projection.go
@@ -198,6 +198,75 @@ func Verify(manifestPath, root, expectedRevision string, expectedIdentity contra
 	}, nil
 }
 
+// ReverifyAtUse reconstructs the non-serialized resource inventories from the
+// digest-bound authority map immediately before submission. This prevents an
+// in-memory Resource list change from becoming a second, unsigned authority.
+func ReverifyAtUse(root string, binding Binding) (Binding, error) {
+	if binding.Format != BindingFormat || root == "" {
+		return Binding{}, errors.New("verified projection binding and root are required")
+	}
+	abs, err := filepath.Abs(root)
+	if err != nil {
+		return Binding{}, fmt.Errorf("resolve projection root: %w", err)
+	}
+	artifactDigests := make(map[string]string, len(binding.Artifacts))
+	for _, artifact := range binding.Artifacts {
+		if err := validateArtifactName(artifact.Name); err != nil {
+			return Binding{}, err
+		}
+		if _, duplicate := artifactDigests[artifact.Name]; duplicate {
+			return Binding{}, fmt.Errorf("verified projection repeats artifact %s", artifact.Name)
+		}
+		artifactDigests[artifact.Name] = artifact.Digest
+	}
+	for _, required := range []string{"authority-map.json", "ok-infra-prerequisites.yaml", "ok-mgmt-lifecycle.yaml"} {
+		if _, ok := artifactDigests[required]; !ok {
+			return Binding{}, fmt.Errorf("verified projection does not bind %s", required)
+		}
+	}
+	var authorityRaw []byte
+	for name, expected := range artifactDigests {
+		raw, err := os.ReadFile(filepath.Join(abs, name))
+		if err != nil {
+			return Binding{}, fmt.Errorf("read projection artifact %s: %w", name, err)
+		}
+		if actual := digest.SHA256(raw); actual != expected {
+			return Binding{}, fmt.Errorf("projection artifact %s changed after verification", name)
+		}
+		if name == "authority-map.json" {
+			authorityRaw = raw
+		}
+	}
+	if digest.SHA256(authorityRaw) != binding.AuthorityMapDigest {
+		return Binding{}, errors.New("authority map digest differs from verified binding")
+	}
+	var authority authorityMap
+	if err := jsonstrict.Decode(authorityRaw, &authority); err != nil {
+		return Binding{}, fmt.Errorf("decode authority map: %w", err)
+	}
+	if authority.IntentRevision != binding.IntentRevision || authority.ContractIdentity != binding.ContractIdentity {
+		return Binding{}, errors.New("authority map intent or Contract identity differs from verified binding")
+	}
+	if authority.Format != binding.SourceFormat {
+		return Binding{}, errors.New("authority map format differs from verified binding")
+	}
+	if err := validatePlane(authority.InfrastructurePlane, "provider-runtime-and-golden-image-prerequisites"); err != nil {
+		return Binding{}, fmt.Errorf("infrastructure plane: %w", err)
+	}
+	if err := validatePlane(authority.ManagementPlane, "single-lifecycle-writer"); err != nil {
+		return Binding{}, fmt.Errorf("management plane: %w", err)
+	}
+	if authority.InfrastructurePlane.Identity != binding.InfrastructurePlane.Identity || authority.InfrastructurePlane.Role != binding.InfrastructurePlane.Role || len(authority.InfrastructurePlane.Resources) != binding.InfrastructurePlane.ResourceCount {
+		return Binding{}, errors.New("infrastructure authority differs from verified binding")
+	}
+	if authority.ManagementPlane.Identity != binding.ManagementPlane.Identity || authority.ManagementPlane.Role != binding.ManagementPlane.Role || len(authority.ManagementPlane.Resources) != binding.ManagementPlane.ResourceCount {
+		return Binding{}, errors.New("management authority differs from verified binding")
+	}
+	binding.InfrastructurePlane.Resources = exportResources(authority.InfrastructurePlane.Resources)
+	binding.ManagementPlane.Resources = exportResources(authority.ManagementPlane.Resources)
+	return binding, nil
+}
+
 func exportResources(resources []resource) []ResourceIdentity {
 	result := make([]ResourceIdentity, 0, len(resources))
 	for _, object := range resources {

--- a/internal/submission/executor.go
+++ b/internal/submission/executor.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 )
 
+const RunReceiptFormat = "ok147-bounded-submission-run-receipt/v2"
+
 // Executor preserves the projection's authority order: provider prerequisites
 // first, then management-plane lifecycle objects. It has no retry or rollback
 // capability.
@@ -20,6 +22,7 @@ type Receipt struct {
 	Format         string        `json:"format"`
 	IntentRevision string        `json:"intentRevision"`
 	State          string        `json:"state"`
+	MutationState  string        `json:"mutationState"`
 	Infrastructure *PlaneReceipt `json:"infrastructure,omitempty"`
 	Management     *PlaneReceipt `json:"management,omitempty"`
 }
@@ -29,9 +32,10 @@ type Receipt struct {
 // and Ready remain separate observation responsibilities.
 func (executor Executor) Execute(ctx context.Context, plan Plan) (Receipt, error) {
 	receipt := Receipt{
-		Format:         "ok147-bounded-submission-run-receipt/v1",
+		Format:         RunReceiptFormat,
 		IntentRevision: plan.IntentRevision,
 		State:          "IN_PROGRESS",
+		MutationState:  "NOT_ATTEMPTED",
 	}
 	if plan.Format != PlanFormat {
 		return receipt, errors.New("submission plan format is not supported")
@@ -41,16 +45,25 @@ func (executor Executor) Execute(ctx context.Context, plan Plan) (Receipt, error
 	}
 	infrastructure, err := executor.Infrastructure.Submit(ctx, plan.Infrastructure)
 	receipt.Infrastructure = &infrastructure
+	receipt.MutationState = combinedMutationState(receipt.MutationState, infrastructure.MutationState)
 	if err != nil {
 		receipt.State = "STOPPED_PARTIAL_OR_UNKNOWN"
 		return receipt, fmt.Errorf("infrastructure authority submission: %w", err)
 	}
 	management, err := executor.Management.Submit(ctx, plan.Management)
 	receipt.Management = &management
+	receipt.MutationState = combinedMutationState(receipt.MutationState, management.MutationState)
 	if err != nil {
 		receipt.State = "STOPPED_PARTIAL_OR_UNKNOWN"
 		return receipt, fmt.Errorf("management authority submission: %w", err)
 	}
 	receipt.State = "SUBMITTED_OBSERVATION_PENDING"
 	return receipt, nil
+}
+
+func combinedMutationState(current, next string) string {
+	if current == "ATTEMPTED" || next == "ATTEMPTED" {
+		return "ATTEMPTED"
+	}
+	return "NOT_ATTEMPTED"
 }

--- a/internal/submission/kubernetes.go
+++ b/internal/submission/kubernetes.go
@@ -14,7 +14,10 @@ import (
 	"time"
 )
 
-const maximumAPIResponseBytes = 4 * 1024 * 1024
+const (
+	maximumAPIResponseBytes = 4 * 1024 * 1024
+	PlaneReceiptFormat      = "ok147-bounded-submission-receipt/v2"
+)
 
 // KubernetesClientConfig binds one client to one authority plane. Credentials
 // are supplied by an execution-environment adapter and are never retained in a
@@ -36,24 +39,26 @@ type KubernetesClient struct {
 
 // ObjectResult records only redacted, immutable submission identity.
 type ObjectResult struct {
-	Identity projectionIdentity `json:"identity"`
-	Digest   string             `json:"digest"`
-	State    string             `json:"state"`
+	Identity ObjectIdentity `json:"identity"`
+	Digest   string         `json:"digest"`
+	UID      string         `json:"uid"`
+	State    string         `json:"state"`
 }
 
 // PlaneReceipt is useful even on failure: Results contains the exact prefix
 // completed before STOP-PRESERVE-NO-RETRY.
 type PlaneReceipt struct {
-	Format    string         `json:"format"`
-	Authority string         `json:"authority"`
-	Role      string         `json:"role"`
-	State     string         `json:"state"`
-	Results   []ObjectResult `json:"results"`
+	Format        string         `json:"format"`
+	Authority     string         `json:"authority"`
+	Role          string         `json:"role"`
+	State         string         `json:"state"`
+	MutationState string         `json:"mutationState"`
+	Results       []ObjectResult `json:"results"`
 }
 
-// projectionIdentity mirrors only the public, non-secret resource identity in
-// receipts while avoiding an import cycle through JSON helpers.
-type projectionIdentity struct {
+// ObjectIdentity is the public, non-secret runtime identity used to correlate
+// later observation with the exact submission response.
+type ObjectIdentity struct {
 	APIVersion string `json:"apiVersion"`
 	Kind       string `json:"kind"`
 	Name       string `json:"name"`
@@ -106,11 +111,12 @@ func NewKubernetesClient(config KubernetesClientConfig) (*KubernetesClient, erro
 // retries. A conflict after an absence observation is indeterminate and stops.
 func (client *KubernetesClient) Submit(ctx context.Context, plane Plane) (PlaneReceipt, error) {
 	receipt := PlaneReceipt{
-		Format:    "ok147-bounded-submission-receipt/v1",
-		Authority: plane.Identity,
-		Role:      plane.Role,
-		State:     "IN_PROGRESS",
-		Results:   make([]ObjectResult, 0, len(plane.Objects)),
+		Format:        PlaneReceiptFormat,
+		Authority:     plane.Identity,
+		Role:          plane.Role,
+		State:         "IN_PROGRESS",
+		MutationState: "NOT_ATTEMPTED",
+		Results:       make([]ObjectResult, 0, len(plane.Objects)),
 	}
 	if plane.Identity != client.authority {
 		return stopped(receipt, errors.New("submission client authority differs from projection plane"))
@@ -119,13 +125,17 @@ func (client *KubernetesClient) Submit(ctx context.Context, plane Plane) (PlaneR
 		return stopped(receipt, errors.New("submission plane has no objects"))
 	}
 	for _, object := range plane.Objects {
-		state, err := client.submitObject(ctx, object)
+		state, uid, mutationAttempted, err := client.submitObject(ctx, object)
+		if mutationAttempted {
+			receipt.MutationState = "ATTEMPTED"
+		}
 		if err != nil {
 			return stopped(receipt, err)
 		}
 		receipt.Results = append(receipt.Results, ObjectResult{
-			Identity: projectionIdentity{APIVersion: object.Identity.APIVersion, Kind: object.Identity.Kind, Name: object.Identity.Name, Namespace: object.Identity.Namespace},
+			Identity: ObjectIdentity{APIVersion: object.Identity.APIVersion, Kind: object.Identity.Kind, Name: object.Identity.Name, Namespace: object.Identity.Namespace},
 			Digest:   object.Digest,
+			UID:      uid,
 			State:    state,
 		})
 	}
@@ -138,37 +148,39 @@ func stopped(receipt PlaneReceipt, cause error) (PlaneReceipt, error) {
 	return receipt, &SubmissionError{Receipt: receipt, Cause: cause}
 }
 
-func (client *KubernetesClient) submitObject(ctx context.Context, object Object) (string, error) {
+func (client *KubernetesClient) submitObject(ctx context.Context, object Object) (string, string, bool, error) {
 	response, status, err := client.request(ctx, http.MethodGet, object.ObjectPath, nil)
 	if err != nil {
-		return "", err
+		return "", "", false, err
 	}
 	switch status {
 	case http.StatusOK:
-		if err := verifyObservedObject(response, object); err != nil {
-			return "", fmt.Errorf("existing %s/%s differs from projection: %w", object.Identity.Kind, object.Identity.Name, err)
+		uid, err := verifyObservedObject(response, object)
+		if err != nil {
+			return "", "", false, fmt.Errorf("existing %s/%s differs from projection: %w", object.Identity.Kind, object.Identity.Name, err)
 		}
-		return "UNCHANGED", nil
+		return "UNCHANGED", uid, false, nil
 	case http.StatusNotFound:
 		// Continue to the one authorized create attempt.
 	default:
-		return "", apiStatusError(http.MethodGet, status, response)
+		return "", "", false, apiStatusError(http.MethodGet, status, response)
 	}
 
 	response, status, err = client.request(ctx, http.MethodPost, object.CollectionPath, object.Raw)
 	if err != nil {
-		return "", err
+		return "", "", true, err
 	}
 	if status == http.StatusConflict {
-		return "", errors.New("Kubernetes create conflicted after exact absence observation")
+		return "", "", true, errors.New("Kubernetes create conflicted after exact absence observation")
 	}
 	if status != http.StatusCreated {
-		return "", apiStatusError(http.MethodPost, status, response)
+		return "", "", true, apiStatusError(http.MethodPost, status, response)
 	}
-	if err := verifyObservedObject(response, object); err != nil {
-		return "", fmt.Errorf("created %s/%s response differs from projection: %w", object.Identity.Kind, object.Identity.Name, err)
+	uid, err := verifyObservedObject(response, object)
+	if err != nil {
+		return "", "", true, fmt.Errorf("created %s/%s response differs from projection: %w", object.Identity.Kind, object.Identity.Name, err)
 	}
-	return "CREATED", nil
+	return "CREATED", uid, true, nil
 }
 
 func (client *KubernetesClient) request(ctx context.Context, method, path string, body []byte) ([]byte, int, error) {
@@ -195,23 +207,24 @@ func (client *KubernetesClient) request(ctx context.Context, method, path string
 	return raw, response.StatusCode, nil
 }
 
-func verifyObservedObject(raw []byte, desired Object) error {
+func verifyObservedObject(raw []byte, desired Object) (string, error) {
 	observed, err := decodeJSONObject(raw)
 	if err != nil {
-		return errors.New("Kubernetes API returned invalid object JSON")
+		return "", errors.New("Kubernetes API returned invalid object JSON")
 	}
 	expected, err := decodeJSONObject(desired.Raw)
 	if err != nil {
-		return errors.New("verified projection object is invalid JSON")
+		return "", errors.New("verified projection object is invalid JSON")
 	}
 	if !isSubset(expected, observed) {
-		return errors.New("observed object does not contain the exact projected fields")
+		return "", errors.New("observed object does not contain the exact projected fields")
 	}
 	metadata, _ := observed["metadata"].(map[string]any)
-	if text(metadata["uid"]) == "" || text(metadata["resourceVersion"]) == "" {
-		return errors.New("Kubernetes API response lacks UID or resourceVersion")
+	uid := text(metadata["uid"])
+	if uid == "" || text(metadata["resourceVersion"]) == "" {
+		return "", errors.New("Kubernetes API response lacks UID or resourceVersion")
 	}
-	return nil
+	return uid, nil
 }
 
 func decodeJSONObject(raw []byte) (map[string]any, error) {

--- a/internal/submission/kubernetes_test.go
+++ b/internal/submission/kubernetes_test.go
@@ -21,11 +21,11 @@ func TestKubernetesSubmitIsExactCreateOnlyAndIdempotent(t *testing.T) {
 	client := newSubmissionClient(t, "ok-infra", api.client())
 
 	first, err := client.Submit(context.Background(), plan.Infrastructure)
-	if err != nil || first.State != "SUBMITTED" || len(first.Results) != 1 || first.Results[0].State != "CREATED" {
+	if err != nil || first.State != "SUBMITTED" || first.MutationState != "ATTEMPTED" || len(first.Results) != 1 || first.Results[0].State != "CREATED" {
 		t.Fatalf("first submission: %#v %v", first, err)
 	}
 	second, err := client.Submit(context.Background(), plan.Infrastructure)
-	if err != nil || second.Results[0].State != "UNCHANGED" {
+	if err != nil || second.MutationState != "NOT_ATTEMPTED" || second.Results[0].State != "UNCHANGED" {
 		t.Fatalf("second submission: %#v %v", second, err)
 	}
 	if api.posts != 1 {
@@ -75,7 +75,7 @@ func TestKubernetesSubmitFailsClosedForDriftConflictAndAuthority(t *testing.T) {
 		api.conflict = true
 		client := newSubmissionClient(t, "ok-infra", api.client())
 		receipt, err := client.Submit(context.Background(), plan.Infrastructure)
-		if err == nil || receipt.State != "STOPPED_PARTIAL_OR_UNKNOWN" || !strings.Contains(err.Error(), "conflicted") {
+		if err == nil || receipt.State != "STOPPED_PARTIAL_OR_UNKNOWN" || receipt.MutationState != "ATTEMPTED" || !strings.Contains(err.Error(), "conflicted") {
 			t.Fatalf("conflict accepted: %#v %v", receipt, err)
 		}
 	})
@@ -109,7 +109,7 @@ func TestExecutorPreservesAuthorityOrderAndPartialReceipt(t *testing.T) {
 	if err == nil || receipt.State != "STOPPED_PARTIAL_OR_UNKNOWN" || receipt.Infrastructure == nil || receipt.Management == nil {
 		t.Fatalf("partial execution receipt: %#v %v", receipt, err)
 	}
-	if receipt.Infrastructure.State != "SUBMITTED" || receipt.Management.State != "STOPPED_PARTIAL_OR_UNKNOWN" || infraAPI.posts != 1 || mgmtAPI.posts != 0 {
+	if receipt.MutationState != "ATTEMPTED" || receipt.Infrastructure.State != "SUBMITTED" || receipt.Management.State != "STOPPED_PARTIAL_OR_UNKNOWN" || infraAPI.posts != 1 || mgmtAPI.posts != 0 {
 		t.Fatalf("authority order/stop differs: %#v infraPosts=%d mgmtPosts=%d", receipt, infraAPI.posts, mgmtAPI.posts)
 	}
 }

--- a/internal/submission/plan.go
+++ b/internal/submission/plan.go
@@ -67,6 +67,10 @@ func Load(root string, binding projection.Binding) (Plan, error) {
 	if binding.InfrastructurePlane.Identity == binding.ManagementPlane.Identity {
 		return Plan{}, errors.New("submission authority identities must differ")
 	}
+	binding, err = projection.ReverifyAtUse(abs, binding)
+	if err != nil {
+		return Plan{}, fmt.Errorf("reverify projection at use: %w", err)
+	}
 	infrastructure, err := loadPlane(abs, "ok-infra-prerequisites.yaml", binding.InfrastructurePlane, binding, binding.IntentRevision)
 	if err != nil {
 		return Plan{}, fmt.Errorf("infrastructure submission plane: %w", err)

--- a/internal/submission/plan_test.go
+++ b/internal/submission/plan_test.go
@@ -1,6 +1,7 @@
 package submission
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -42,14 +43,19 @@ func TestLoadReverifiesArtifactAtUseTime(t *testing.T) {
 func TestLoadFailsClosedForIdentityAndYAMLGaps(t *testing.T) {
 	for name, mutate := range map[string]func(string, *projection.Binding){
 		"authority identity mismatch": func(_ string, binding *projection.Binding) {
-			binding.ManagementPlane.Resources[0].Name = "different"
+			binding.ManagementPlane.Identity = "different"
 		},
-		"unsupported kind": func(_ string, binding *projection.Binding) {
-			binding.ManagementPlane.Resources[0].APIVersion = "apps/v1"
-			binding.ManagementPlane.Resources[0].Kind = "Deployment"
+		"projection object differs from authority map": func(root string, binding *projection.Binding) {
+			path := filepath.Join(root, "ok-mgmt-lifecycle.yaml")
+			raw, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			raw = []byte(strings.Replace(string(raw), "apiVersion: cluster.x-k8s.io/v1beta2\nkind: Cluster", "apiVersion: apps/v1\nkind: Deployment", 1))
+			writeBoundArtifact(t, root, "ok-mgmt-lifecycle.yaml", raw, binding)
 		},
 		"incomplete resource inventory": func(_ string, binding *projection.Binding) {
-			binding.ManagementPlane.Resources = nil
+			binding.ManagementPlane.ResourceCount = 0
 		},
 		"alias in YAML": func(root string, binding *projection.Binding) {
 			raw := []byte("apiVersion: v1\nkind: Namespace\nmetadata: &meta\n  name: disposable-ok141\n  annotations:\n    openkubes.io/contract-name: disposable-ok141\n    openkubes.io/contract-namespace: disposable-ok141\n    openkubes.io/intent-revision: " + binding.IntentRevision + "\n")
@@ -63,6 +69,18 @@ func TestLoadFailsClosedForIdentityAndYAMLGaps(t *testing.T) {
 				t.Fatal("unsafe projection accepted")
 			}
 		})
+	}
+}
+
+func TestLoadReconstructsUnsignedInMemoryResourceInventory(t *testing.T) {
+	root, binding := validProjection(t)
+	binding.ManagementPlane.Resources[0].Name = "tampered-in-memory"
+	plan, err := Load(root, binding)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plan.Management.Objects[0].Identity.Name != "disposable-ok141" {
+		t.Fatalf("unsigned in-memory identity became authoritative: %#v", plan.Management.Objects[0].Identity)
 	}
 }
 
@@ -101,9 +119,28 @@ func validProjection(t *testing.T) (string, projection.Binding) {
 	if err := os.WriteFile(filepath.Join(root, "ok-mgmt-lifecycle.yaml"), mgmt, 0o600); err != nil {
 		t.Fatal(err)
 	}
+	authority, err := json.Marshal(map[string]any{
+		"format":           "ok141-contract-to-capi-projection/v2",
+		"contractIdentity": identity,
+		"intentRevision":   revision,
+		"infrastructurePlane": map[string]any{
+			"identity": "ok-infra", "role": "provider-runtime-and-golden-image-prerequisites",
+			"resources": []map[string]any{{"apiVersion": "v1", "kind": "Namespace", "name": "disposable-ok141"}},
+		},
+		"managementPlane": map[string]any{
+			"identity": "ok-mgmt", "role": "single-lifecycle-writer",
+			"resources": []map[string]any{{"apiVersion": "cluster.x-k8s.io/v1beta2", "kind": "Cluster", "name": "disposable-ok141", "namespace": "disposable-ok141"}},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "authority-map.json"), authority, 0o600); err != nil {
+		t.Fatal(err)
+	}
 	binding := projection.Binding{
-		Format: projection.BindingFormat, IntentRevision: revision, ContractIdentity: identity,
-		AuthorityMapDigest: "sha256:" + strings.Repeat("2", 64),
+		Format: projection.BindingFormat, SourceFormat: "ok141-contract-to-capi-projection/v2", IntentRevision: revision, ContractIdentity: identity,
+		AuthorityMapDigest: digest.SHA256(authority),
 		InfrastructurePlane: projection.Plane{Identity: "ok-infra", Role: "provider-runtime-and-golden-image-prerequisites", ResourceCount: 1, Resources: []projection.ResourceIdentity{
 			{APIVersion: "v1", Kind: "Namespace", Name: "disposable-ok141"},
 		}},
@@ -111,6 +148,7 @@ func validProjection(t *testing.T) (string, projection.Binding) {
 			{APIVersion: "cluster.x-k8s.io/v1beta2", Kind: "Cluster", Name: "disposable-ok141", Namespace: "disposable-ok141"},
 		}},
 		Artifacts: []projection.Artifact{
+			{Name: "authority-map.json", Digest: digest.SHA256(authority)},
 			{Name: "ok-infra-prerequisites.yaml", Digest: digest.SHA256(infra)},
 			{Name: "ok-mgmt-lifecycle.yaml", Digest: digest.SHA256(mgmt)},
 		},


### PR DESCRIPTION
## What changed

- compose verified authorization, durable single-use claim, exact-create submission and bounded observation into one fail-closed operation
- add a deterministic aggregate evaluator for the OK-141 required Conditions and exact R/E/P correlation
- bind observation to the CAPI Cluster UID returned by the exact submission response
- reconstruct resource inventories from the digest-bound authority map immediately before use
- version submission receipts as v2 with object UID and write-attempt evidence
- recheck the authorization time window at actual claim consumption

## Why

The previous checkpoint proved exact submission but intentionally did not connect it to grant consumption or lifecycle outcome. This checkpoint proves the crash boundary: all safe checks happen before the claim; after the claim, unexpected observer or persistence failure becomes `CLAIMED_INDETERMINATE_STOP` and cannot authorize retry.

Lifecycle success now requires a real write attempt plus current, complete `Ready=True` evidence for the exact runtime policy. Stale generations, foreign Cluster UIDs, wrong R/E/P, missing evidence, conflicting authority and historical success all fail closed.

## Impact

There is no live or infrastructure impact. The composition is internal and offline. It is not wired to the CLI, Job, published image or a Kubernetes observer adapter, and therefore cannot contact or mutate a cluster.

## Validation

- `CGO_ENABLED=0 go test ./...`
- `CGO_ENABLED=0 go vet ./...`
- `CGO_ENABLED=0 go test -race ./internal/execution ./internal/observation ./internal/submission ./internal/projection ./internal/ledger`
- `python3 -m unittest tests.ok147_runner_image_test tests.ok147_runner_publication_test` (11 tests)
- `git diff --check`

## Review question

Does the composition preserve single-use and split-authority safety while requiring generation- and revision-correct evidence before lifecycle success, without activating a runner or creating a new lifecycle controller?
