### PR TITLE
OK-147: Add bounded CAPI lifecycle observer

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -398,6 +398,37 @@ an internal offline primitive: there is still no mutating CLI flag, observer
 HTTP adapter, Job wiring, deployment or infrastructure contact in this
 checkpoint.
 
+## Bounded CAPI lifecycle observation
+
+The first concrete source adapter observes only the management-plane CAPI
+`Cluster` used by the verified projection. It performs one exact GET on the
+bound namespace and name and emits normalized evidence only for:
+
+```text
+InfrastructureReady
+ControlPlaneAvailable
+```
+
+The adapter binds the actual Cluster UID, resource version, object generation,
+the `openkubes.io/intent-revision` carrier, and each Condition's
+`observedGeneration` into a redacted evidence digest. Kubernetes-added fields
+and Condition messages are not copied into the normalized evidence. A missing
+revision carrier is represented as unproven correlation; a foreign UID or
+stale generation therefore evaluates to `Unknown`, never `True`. Duplicate
+authoritative Conditions, malformed runtime identity, invalid status, a
+non-200 response, or an ambiguous object stop fail-closed.
+
+The client has no discovery, list, watch, mutation, retry, repair, or status
+publication path. Its projected TLS and token adapter independently verifies
+that the credential authority matches the management authority from the
+projection plan. Network and Platform evidence remain separate bounded source
+domains; this CAPI adapter does not infer either one.
+
+This checkpoint still does not wire the observer into the CLI or Job and does
+not contact a cluster. A later composition adapter must combine this exact CAPI
+evidence with separately verified Network and Platform evidence before the
+aggregate evaluator can produce lifecycle success.
+
 ## OK-141 compatibility evidence
 
 The verifier was run offline against the preserved Phase-R v5 projection. It

--- a/internal/observation/capi_kubernetes.go
+++ b/internal/observation/capi_kubernetes.go
@@ -1,0 +1,227 @@
+package observation
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+	"time"
+)
+
+const (
+	capiClusterAPIVersion = "cluster.x-k8s.io/v1beta2"
+	capiClusterKind       = "Cluster"
+	intentRevisionKey     = "openkubes.io/intent-revision"
+	maximumCAPIResponse   = 4 * 1024 * 1024
+)
+
+// CAPILifecycleObserverConfig binds the observer to exactly one CAPI Cluster.
+// The client must already contain the trust roots for the management API.
+type CAPILifecycleObserverConfig struct {
+	Endpoint    string
+	BearerToken string
+	Namespace   string
+	Name        string
+	Client      *http.Client
+}
+
+// CAPILifecycleObserver performs one exact GET. It has no discovery, list,
+// watch, mutation, retry, or status-publication path.
+type CAPILifecycleObserver struct {
+	endpoint  *url.URL
+	token     string
+	namespace string
+	name      string
+	client    *http.Client
+}
+
+// NewCAPILifecycleObserver constructs a bounded CAPI source observer.
+func NewCAPILifecycleObserver(config CAPILifecycleObserverConfig) (*CAPILifecycleObserver, error) {
+	endpoint, err := url.Parse(config.Endpoint)
+	if err != nil || endpoint.Host == "" || endpoint.User != nil || endpoint.RawQuery != "" || endpoint.Fragment != "" {
+		return nil, errors.New("CAPI observer Kubernetes endpoint is invalid")
+	}
+	if endpoint.Path != "" && endpoint.Path != "/" {
+		return nil, errors.New("CAPI observer Kubernetes endpoint must not contain a path")
+	}
+	host := endpoint.Hostname()
+	if endpoint.Scheme != "https" && !(endpoint.Scheme == "http" && (host == "127.0.0.1" || host == "::1" || host == "localhost")) {
+		return nil, errors.New("CAPI observer Kubernetes endpoint must use HTTPS")
+	}
+	if config.BearerToken == "" || strings.TrimSpace(config.BearerToken) != config.BearerToken || strings.ContainsAny(config.BearerToken, "\r\n") {
+		return nil, errors.New("CAPI observer bearer token is invalid")
+	}
+	if !validDNSLabel(config.Namespace) || !validDNSLabel(config.Name) {
+		return nil, errors.New("CAPI observer Cluster identity is invalid")
+	}
+	if config.Client == nil {
+		return nil, errors.New("CAPI observer requires an explicitly configured HTTP client")
+	}
+	client := *config.Client
+	client.CheckRedirect = func(_ *http.Request, _ []*http.Request) error { return http.ErrUseLastResponse }
+	if client.Timeout == 0 {
+		client.Timeout = 15 * time.Second
+	}
+	endpoint.Path = ""
+	return &CAPILifecycleObserver{
+		endpoint: endpoint, token: config.BearerToken, namespace: config.Namespace,
+		name: config.Name, client: &client,
+	}, nil
+}
+
+// Collect returns normalized authoritative evidence for the two CAPI-owned
+// lifecycle facts. Revision mismatch and stale generation remain explicit
+// inputs for the aggregate evaluator and cannot become Ready=True.
+func (observer *CAPILifecycleObserver) Collect(ctx context.Context, policy Policy) ([]Evidence, error) {
+	if err := validatePolicy(policy, true); err != nil {
+		return nil, err
+	}
+	endpoint := *observer.endpoint
+	endpoint.Path = "/apis/cluster.x-k8s.io/v1beta2/namespaces/" + observer.namespace + "/clusters/" + observer.name
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint.String(), nil)
+	if err != nil {
+		return nil, errors.New("construct bounded CAPI observation request")
+	}
+	request.Header.Set("Accept", "application/json")
+	request.Header.Set("Authorization", "Bearer "+observer.token)
+	response, err := observer.client.Do(request)
+	if err != nil {
+		return nil, errors.New("bounded CAPI observation request failed")
+	}
+	defer response.Body.Close()
+	raw, err := io.ReadAll(io.LimitReader(response.Body, maximumCAPIResponse+1))
+	if err != nil || len(raw) > maximumCAPIResponse {
+		return nil, errors.New("bounded CAPI observation response exceeds accepted size")
+	}
+	if response.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("bounded CAPI observation returned HTTP %d", response.StatusCode)
+	}
+	cluster, err := decodeCAPICluster(raw)
+	if err != nil {
+		return nil, err
+	}
+	if cluster.APIVersion != capiClusterAPIVersion || cluster.Kind != capiClusterKind || cluster.Metadata.Namespace != observer.namespace || cluster.Metadata.Name != observer.name {
+		return nil, errors.New("CAPI observation object identity differs from the exact target")
+	}
+	if !validUID(cluster.Metadata.UID) || cluster.Metadata.ResourceVersion == "" || cluster.Metadata.Generation <= 0 {
+		return nil, errors.New("CAPI observation object lacks runtime identity")
+	}
+	observedRevision := cluster.Metadata.Annotations[intentRevisionKey]
+	if !validDigest(observedRevision) {
+		observedRevision = ""
+	}
+
+	conditions := make(map[string]capiCondition, 2)
+	for _, item := range cluster.Status.Conditions {
+		if item.Type != "InfrastructureReady" && item.Type != "ControlPlaneAvailable" {
+			continue
+		}
+		if _, duplicate := conditions[item.Type]; duplicate {
+			return nil, fmt.Errorf("CAPI Cluster contains duplicate %s Conditions", item.Type)
+		}
+		conditions[item.Type] = item
+	}
+
+	evidence := make([]Evidence, 0, 2)
+	for _, conditionType := range []string{"InfrastructureReady", "ControlPlaneAvailable"} {
+		item, present := conditions[conditionType]
+		if !present {
+			continue
+		}
+		if item.Status != "True" && item.Status != "False" && item.Status != "Unknown" {
+			return nil, fmt.Errorf("CAPI %s status is invalid", conditionType)
+		}
+		reason := item.Reason
+		if !validReason(reason) {
+			reason = "SourceReasonUnavailable"
+		}
+		snapshot := capiEvidenceSnapshot{
+			APIVersion: cluster.APIVersion, Kind: cluster.Kind, Namespace: cluster.Metadata.Namespace,
+			Name: cluster.Metadata.Name, UID: cluster.Metadata.UID,
+			ResourceVersion: cluster.Metadata.ResourceVersion, Generation: cluster.Metadata.Generation,
+			IntentRevision: observedRevision, Type: conditionType, Status: item.Status,
+			Reason: reason, ObservedGeneration: item.ObservedGeneration,
+		}
+		evidenceDigest, err := canonicalDigest(snapshot)
+		if err != nil {
+			return nil, fmt.Errorf("digest CAPI %s evidence: %w", conditionType, err)
+		}
+		itemEvidence := Evidence{
+			Type: conditionType, Source: "CAPICluster", SourceUID: cluster.Metadata.UID,
+			TargetClusterUID: policy.TargetClusterUID, Status: item.Status, Reason: reason,
+			DesiredRevision: policy.IntentRevision, ObservedRevision: observedRevision,
+			Generation: cluster.Metadata.Generation, ObservedGeneration: item.ObservedGeneration,
+			EvidenceDigest: evidenceDigest,
+		}
+		if err := validateEvidenceShape(itemEvidence); err != nil {
+			return nil, fmt.Errorf("normalize CAPI %s evidence: %w", conditionType, err)
+		}
+		evidence = append(evidence, itemEvidence)
+	}
+	return evidence, nil
+}
+
+type capiCluster struct {
+	APIVersion string `json:"apiVersion"`
+	Kind       string `json:"kind"`
+	Metadata   struct {
+		Name            string            `json:"name"`
+		Namespace       string            `json:"namespace"`
+		UID             string            `json:"uid"`
+		ResourceVersion string            `json:"resourceVersion"`
+		Generation      int64             `json:"generation"`
+		Annotations     map[string]string `json:"annotations"`
+	} `json:"metadata"`
+	Status struct {
+		Conditions []capiCondition `json:"conditions"`
+	} `json:"status"`
+}
+
+type capiCondition struct {
+	Type               string `json:"type"`
+	Status             string `json:"status"`
+	Reason             string `json:"reason"`
+	ObservedGeneration int64  `json:"observedGeneration"`
+}
+
+type capiEvidenceSnapshot struct {
+	APIVersion         string `json:"apiVersion"`
+	Kind               string `json:"kind"`
+	Namespace          string `json:"namespace"`
+	Name               string `json:"name"`
+	UID                string `json:"uid"`
+	ResourceVersion    string `json:"resourceVersion"`
+	Generation         int64  `json:"generation"`
+	IntentRevision     string `json:"intentRevision,omitempty"`
+	Type               string `json:"type"`
+	Status             string `json:"status"`
+	Reason             string `json:"reason"`
+	ObservedGeneration int64  `json:"observedGeneration"`
+}
+
+func decodeCAPICluster(raw []byte) (capiCluster, error) {
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	var value capiCluster
+	if err := decoder.Decode(&value); err != nil {
+		return capiCluster{}, errors.New("Kubernetes API returned invalid CAPI Cluster JSON")
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		return capiCluster{}, errors.New("Kubernetes API returned trailing CAPI Cluster JSON")
+	}
+	return value, nil
+}
+
+func validDNSLabel(value string) bool {
+	return len(value) > 0 && len(value) <= 63 && regexp.MustCompile(`^[a-z0-9](?:[-a-z0-9]*[a-z0-9])?$`).MatchString(value)
+}
+
+func validReason(value string) bool {
+	return regexp.MustCompile(`^[A-Za-z][A-Za-z0-9]{0,127}$`).MatchString(value)
+}

--- a/internal/observation/capi_kubernetes_test.go
+++ b/internal/observation/capi_kubernetes_test.go
@@ -1,0 +1,200 @@
+package observation
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+)
+
+func TestCAPILifecycleObserverCollectsCurrentExactEvidence(t *testing.T) {
+	policy := testPolicy(t)
+	requests := 0
+	client := &http.Client{Transport: capiRoundTripFunc(func(request *http.Request) (*http.Response, error) {
+		requests++
+		if request.Method != http.MethodGet || request.URL.Path != "/apis/cluster.x-k8s.io/v1beta2/namespaces/disposable-ok141/clusters/disposable-ok141" || request.URL.RawQuery != "" {
+			t.Errorf("unbounded request: %s %s", request.Method, request.URL.String())
+		}
+		if request.Header.Get("Authorization") != "Bearer observer-token" {
+			t.Error("missing bounded observer credential")
+		}
+		return capiJSONResponse(t, http.StatusOK, capiFixture(policy, policy.TargetClusterUID, policy.IntentRevision, 7, 7)), nil
+	})}
+
+	observer := newTestCAPIObserver(t, client)
+	evidence, err := observer.Collect(context.Background(), policy)
+	if err != nil || requests != 1 || len(evidence) != 2 {
+		t.Fatalf("collect evidence: count=%d requests=%d err=%v", len(evidence), requests, err)
+	}
+	for _, item := range evidence {
+		if item.Source != "CAPICluster" || item.SourceUID != policy.TargetClusterUID || item.TargetClusterUID != policy.TargetClusterUID || item.Generation != 7 || item.ObservedGeneration != 7 || !validDigest(item.EvidenceDigest) {
+			t.Fatalf("unexpected CAPI evidence: %#v", item)
+		}
+	}
+
+	bundle := completeBundle(policy)
+	bundle.Evidence[0], bundle.Evidence[1] = evidence[0], evidence[1]
+	result, err := Evaluate(policy, bundle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, _ := result.Receipt()
+	if receipt.Ready != "True" {
+		t.Fatalf("current authoritative evidence did not converge: %#v", receipt)
+	}
+}
+
+func TestCAPILifecycleObserverPreservesFailClosedCorrelation(t *testing.T) {
+	for name, testCase := range map[string]struct {
+		mutate func(Policy) map[string]any
+		reason string
+	}{
+		"missing revision": {
+			mutate: func(policy Policy) map[string]any { return capiFixture(policy, policy.TargetClusterUID, "", 7, 7) },
+			reason: "RevisionCorrelationUnproven",
+		},
+		"foreign uid": {
+			mutate: func(policy Policy) map[string]any {
+				return capiFixture(policy, "foreign-cluster-uid", policy.IntentRevision, 7, 7)
+			},
+			reason: "RevisionCorrelationUnproven",
+		},
+		"stale generation": {
+			mutate: func(policy Policy) map[string]any {
+				return capiFixture(policy, policy.TargetClusterUID, policy.IntentRevision, 8, 7)
+			},
+			reason: "SourceObservationStale",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			policy := testPolicy(t)
+			client := &http.Client{Transport: capiRoundTripFunc(func(_ *http.Request) (*http.Response, error) {
+				return capiJSONResponse(t, http.StatusOK, testCase.mutate(policy)), nil
+			})}
+			observer := newTestCAPIObserver(t, client)
+			evidence, err := observer.Collect(context.Background(), policy)
+			if err != nil {
+				t.Fatal(err)
+			}
+			bundle := completeBundle(policy)
+			bundle.Evidence[0], bundle.Evidence[1] = evidence[0], evidence[1]
+			result, err := Evaluate(policy, bundle)
+			if err != nil {
+				t.Fatal(err)
+			}
+			receipt, _ := result.Receipt()
+			if receipt.Ready != "Unknown" || receipt.Reason != testCase.reason {
+				t.Fatalf("unsafe correlation result: %#v", receipt)
+			}
+		})
+	}
+}
+
+func TestCAPILifecycleObserverRejectsAmbiguousOrForeignObjects(t *testing.T) {
+	for name, mutate := range map[string]func(map[string]any){
+		"duplicate condition": func(cluster map[string]any) {
+			status := cluster["status"].(map[string]any)
+			conditions := status["conditions"].([]map[string]any)
+			status["conditions"] = append(conditions, conditions[0])
+		},
+		"wrong name": func(cluster map[string]any) {
+			cluster["metadata"].(map[string]any)["name"] = "other"
+		},
+		"missing runtime identity": func(cluster map[string]any) {
+			cluster["metadata"].(map[string]any)["resourceVersion"] = ""
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			policy := testPolicy(t)
+			cluster := capiFixture(policy, policy.TargetClusterUID, policy.IntentRevision, 7, 7)
+			mutate(cluster)
+			client := &http.Client{Transport: capiRoundTripFunc(func(_ *http.Request) (*http.Response, error) {
+				return capiJSONResponse(t, http.StatusOK, cluster), nil
+			})}
+			observer := newTestCAPIObserver(t, client)
+			if _, err := observer.Collect(context.Background(), policy); err == nil {
+				t.Fatal("ambiguous or foreign CAPI object accepted")
+			}
+		})
+	}
+}
+
+func TestCAPILifecycleObserverNormalizesInvalidReasonAndMissingCondition(t *testing.T) {
+	policy := testPolicy(t)
+	cluster := capiFixture(policy, policy.TargetClusterUID, policy.IntentRevision, 7, 7)
+	status := cluster["status"].(map[string]any)
+	conditions := status["conditions"].([]map[string]any)
+	conditions[0]["reason"] = "invalid reason with spaces"
+	status["conditions"] = conditions[:1]
+	client := &http.Client{Transport: capiRoundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		return capiJSONResponse(t, http.StatusOK, cluster), nil
+	})}
+
+	evidence, err := newTestCAPIObserver(t, client).Collect(context.Background(), policy)
+	if err != nil || len(evidence) != 1 || evidence[0].Reason != "SourceReasonUnavailable" {
+		t.Fatalf("unexpected normalized evidence: %#v %v", evidence, err)
+	}
+	bundle := completeBundle(policy)
+	bundle.Evidence = append(evidence, bundle.Evidence[2:]...)
+	result, err := Evaluate(policy, bundle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, _ := result.Receipt()
+	if receipt.Ready != "Unknown" || receipt.Reason != "RequiredEvidenceMissing" {
+		t.Fatalf("missing condition did not fail closed: %#v", receipt)
+	}
+}
+
+func newTestCAPIObserver(t *testing.T, client *http.Client) *CAPILifecycleObserver {
+	t.Helper()
+	observer, err := NewCAPILifecycleObserver(CAPILifecycleObserverConfig{
+		Endpoint: "http://127.0.0.1:12345", BearerToken: "observer-token", Namespace: "disposable-ok141",
+		Name: "disposable-ok141", Client: client,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return observer
+}
+
+func capiFixture(policy Policy, uid, revision string, generation, observedGeneration int64) map[string]any {
+	annotations := map[string]string{}
+	if revision != "" {
+		annotations[intentRevisionKey] = revision
+	}
+	return map[string]any{
+		"apiVersion": capiClusterAPIVersion,
+		"kind":       capiClusterKind,
+		"metadata": map[string]any{
+			"name": "disposable-ok141", "namespace": "disposable-ok141", "uid": uid,
+			"resourceVersion": "41", "generation": generation, "annotations": annotations,
+		},
+		"spec": map[string]any{"paused": false},
+		"status": map[string]any{"conditions": []map[string]any{
+			{"type": "InfrastructureReady", "status": "True", "reason": "InfrastructureReady", "message": "redacted by observer", "observedGeneration": observedGeneration},
+			{"type": "ControlPlaneAvailable", "status": "True", "reason": "ControlPlaneAvailable", "observedGeneration": observedGeneration},
+		}},
+	}
+}
+
+type capiRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (function capiRoundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return function(request)
+}
+
+func capiJSONResponse(t *testing.T, status int, cluster map[string]any) *http.Response {
+	t.Helper()
+	var buffer bytes.Buffer
+	if err := json.NewEncoder(&buffer).Encode(cluster); err != nil {
+		t.Fatal(err)
+	}
+	return &http.Response{
+		StatusCode: status,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(bytes.NewReader(buffer.Bytes())),
+	}
+}

--- a/internal/observation/evaluator.go
+++ b/internal/observation/evaluator.go
@@ -273,7 +273,7 @@ func validatePolicy(policy Policy, requireTarget bool) error {
 }
 
 func validateEvidenceShape(value Evidence) error {
-	if !validUID(value.SourceUID) || !validUID(value.TargetClusterUID) || !regexp.MustCompile(`^[A-Za-z][A-Za-z0-9]{0,127}$`).MatchString(value.Reason) || !validDigest(value.DesiredRevision) || !validDigest(value.ObservedRevision) || !validDigest(value.EvidenceDigest) {
+	if !validUID(value.SourceUID) || !validUID(value.TargetClusterUID) || !regexp.MustCompile(`^[A-Za-z][A-Za-z0-9]{0,127}$`).MatchString(value.Reason) || !validDigest(value.DesiredRevision) || (value.ObservedRevision != "" && !validDigest(value.ObservedRevision)) || !validDigest(value.EvidenceDigest) {
 		return errors.New("identity, revision, reason, or evidence digest is invalid")
 	}
 	if value.Status != "True" && value.Status != "False" && value.Status != "Unknown" {

--- a/internal/observation/evaluator_test.go
+++ b/internal/observation/evaluator_test.go
@@ -79,9 +79,10 @@ func TestEvaluateCurrentFailurePrecedesUnknown(t *testing.T) {
 
 func TestEvaluateRejectsInventedGenerationAndMalformedEvidence(t *testing.T) {
 	for name, mutate := range map[string]func(*Bundle){
-		"invented generation": func(bundle *Bundle) { bundle.Evidence[2].Generation = 1 },
-		"invalid digest":      func(bundle *Bundle) { bundle.Evidence[0].EvidenceDigest = "sha256:no" },
-		"unsupported source":  func(bundle *Bundle) { bundle.Evidence[0].Source = "OpenKubesOperator" },
+		"invented generation":       func(bundle *Bundle) { bundle.Evidence[2].Generation = 1 },
+		"invalid digest":            func(bundle *Bundle) { bundle.Evidence[0].EvidenceDigest = "sha256:no" },
+		"invalid observed revision": func(bundle *Bundle) { bundle.Evidence[0].ObservedRevision = "sha256:no" },
+		"unsupported source":        func(bundle *Bundle) { bundle.Evidence[0].Source = "OpenKubesOperator" },
 	} {
 		t.Run(name, func(t *testing.T) {
 			policy := testPolicy(t)

--- a/internal/runner/kubernetes.go
+++ b/internal/runner/kubernetes.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/openkubes/ok-cluster/internal/authorization"
 	"github.com/openkubes/ok-cluster/internal/ledger"
+	"github.com/openkubes/ok-cluster/internal/observation"
 	"github.com/openkubes/ok-cluster/internal/submission"
 )
 
@@ -86,6 +87,25 @@ func OpenKubernetesSubmissionClient(config KubernetesAuthorityConfig) (*submissi
 	}
 	return submission.NewKubernetesClient(submission.KubernetesClientConfig{
 		Endpoint: config.Endpoint, AuthorityIdentity: config.AuthorityIdentity, BearerToken: token, Client: client,
+	})
+}
+
+// OpenKubernetesCAPILifecycleObserver materializes a bounded management-plane
+// observer for one exact CAPI Cluster. The independently supplied expected
+// authority must match the credential identity bound by the projection plan.
+func OpenKubernetesCAPILifecycleObserver(config KubernetesAuthorityConfig, expectedAuthority, namespace, name string) (*observation.CAPILifecycleObserver, error) {
+	if config.Endpoint == "" || config.AuthorityIdentity == "" || config.TokenFile == "" || config.CAFile == "" {
+		return nil, errors.New("Kubernetes CAPI observer endpoint, identity, token file, and CA file are required")
+	}
+	if expectedAuthority == "" || config.AuthorityIdentity != expectedAuthority {
+		return nil, errors.New("Kubernetes CAPI observer authority differs from the verified management plane")
+	}
+	token, client, err := openBoundedKubernetesHTTP(config.TokenFile, config.CAFile)
+	if err != nil {
+		return nil, err
+	}
+	return observation.NewCAPILifecycleObserver(observation.CAPILifecycleObserverConfig{
+		Endpoint: config.Endpoint, BearerToken: token, Namespace: namespace, Name: name, Client: client,
 	})
 }
 

--- a/internal/runner/kubernetes_test.go
+++ b/internal/runner/kubernetes_test.go
@@ -97,6 +97,30 @@ func TestOpenKubernetesSubmissionClientBindsOneAuthority(t *testing.T) {
 	}
 }
 
+func TestOpenKubernetesCAPILifecycleObserverBindsManagementAuthority(t *testing.T) {
+	root := t.TempDir()
+	tokenPath := filepath.Join(root, "token")
+	caPath := filepath.Join(root, "ca.crt")
+	if err := os.WriteFile(tokenPath, []byte("short-lived-token"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(caPath, testCA(t), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	config := KubernetesAuthorityConfig{
+		Endpoint: "https://10.43.0.1:443", AuthorityIdentity: "ok-mgmt", TokenFile: tokenPath, CAFile: caPath,
+	}
+	if _, err := OpenKubernetesCAPILifecycleObserver(config, "ok-mgmt", "disposable-ok141", "disposable-ok141"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := OpenKubernetesCAPILifecycleObserver(config, "different", "disposable-ok141", "disposable-ok141"); err == nil {
+		t.Fatal("mismatched management authority accepted")
+	}
+	if _, err := OpenKubernetesCAPILifecycleObserver(config, "ok-mgmt", "INVALID", "disposable-ok141"); err == nil || strings.Contains(err.Error(), root) {
+		t.Fatalf("unsafe target identity accepted or disclosed a path: %v", err)
+	}
+}
+
 func testCA(t *testing.T) []byte {
 	t.Helper()
 	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)


### PR DESCRIPTION
## What changed

- add a bounded Kubernetes observer for the exact management-plane CAPI `Cluster`
- derive only `InfrastructureReady` and `ControlPlaneAvailable` source evidence
- bind actual Cluster UID, intent revision, generation, observed generation, and a redacted evidence digest
- add the projected TLS/token runner adapter with explicit management-authority matching
- allow an absent observed revision to represent unproven correlation while continuing to reject malformed revisions
- document the observer boundary and keep Network/Platform evidence separate

## Why

The crash-safe execution composition merged in the previous checkpoint could consume verified aggregate evidence, but had no concrete Kubernetes source adapter. This checkpoint supplies the first source-specific observer without introducing discovery, list, watch, mutation, retry, repair, or status publication.

Foreign UIDs, missing revision carriers, stale generations, missing Conditions, duplicate Conditions, and malformed runtime identity all fail closed and cannot produce `Ready=True`.

## Scope

This remains an offline checkpoint. It does not wire a mutating CLI command or Job, contact a cluster, submit resources, infer Network/Platform readiness, or authorize execution.

## Validation

- `CGO_ENABLED=0 go test ./...`
- `CGO_ENABLED=0 go test -race ./internal/observation ./internal/runner ./internal/execution`
- `CGO_ENABLED=0 go vet ./...`
- `python3 -m unittest tests.ok147_runner_image_test tests.ok147_runner_publication_test`
- `git diff --check`
