### PR TITLE
OK-147: Add deterministic NetworkReady evaluator

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -429,6 +429,52 @@ not contact a cluster. A later composition adapter must combine this exact CAPI
 evidence with separately verified Network and Platform evidence before the
 aggregate evaluator can produce lifecycle success.
 
+## Deterministic NetworkReady source evaluation
+
+The next offline source boundary translates the NetworkReady semantics proven
+by OK-141 into typed Go inputs. It does not reduce NetworkReady to Helm success
+or DaemonSet availability. `NetworkReady=True` requires one current evaluation
+that correlates all of the following to the exact target Cluster UID and `E`:
+
+```text
+current HCP + exactly one owned current HRP
+        |
+        v
+exact reviewed HCP/HRP semantic digests
+        |
+        v
+all expected Nodes Ready with CiliumIsUp
+        |
+        v
+current Cilium, Envoy and operator rollouts at pinned image digests
+        |
+        v
+one ready Cilium agent Pod per Node
+        |
+        v
+complete host + health-endpoint HTTP/ICMP probe matrix
+```
+
+The functional status rule retains the Cilium v1.19.6 finding: an omitted or
+empty path status is a success candidate, while any non-empty status fails.
+Freshness uses the observed probe interval plus the bounded cache-exposure
+window instead of the disproven fixed 120-second assumption. The evaluated
+snapshot retains only normalized identities, counters, timestamps and status
+categories; no Secret, kubeconfig, token, certificate, endpoint, IP address,
+raw API object, log, or raw probe output is part of the type.
+
+Revision or convergence gaps evaluate to `Unknown`. Current invariant
+violations such as image mismatch, duplicate identity, incomplete functional
+coverage, failed paths, or stale probe evidence evaluate to `False`. The
+result is one `BoundedNetworkEvaluator` source statement carrying exact `E`
+and a deterministic snapshot digest.
+
+This checkpoint contains only the deterministic source evaluator. A later
+Kubernetes collector must obtain these inputs through separately bounded
+management/workload clients and must derive the reviewed network profile from
+a digest-bound input. No command execution, Secret read, cluster contact,
+polling, CLI/Job wiring, or mutation is introduced here.
+
 ## OK-141 compatibility evidence
 
 The verifier was run offline against the preserved Phase-R v5 projection. It

--- a/internal/observation/network_evaluator.go
+++ b/internal/observation/network_evaluator.go
@@ -1,0 +1,368 @@
+package observation
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"sort"
+	"time"
+)
+
+const (
+	NetworkProfileFormat  = "ok147-network-profile/v1"
+	NetworkSnapshotFormat = "ok147-network-snapshot/v1"
+)
+
+// NetworkProfile contains the reviewed, immutable semantics behind E. A later
+// Kubernetes adapter must derive it from a digest-bound profile; this evaluator
+// deliberately has no API client or command-execution path.
+type NetworkProfile struct {
+	Format                       string        `json:"format"`
+	IntentRevision               string        `json:"intentRevision"`
+	EnablementRevision           string        `json:"enablementRevision"`
+	ExpectedNodeCount            int           `json:"expectedNodeCount"`
+	ExpectedHCPSpecDigest        string        `json:"expectedHcpSpecDigest"`
+	ExpectedHRPSpecDigest        string        `json:"expectedHrpSpecDigest"`
+	ExpectedImages               NetworkImages `json:"expectedImages"`
+	MinimumProbeFreshnessSeconds int64         `json:"minimumProbeFreshnessSeconds"`
+	MaximumProbeIntervalSeconds  int64         `json:"maximumProbeIntervalSeconds"`
+	CacheExposureSeconds         int64         `json:"cacheExposureSeconds"`
+}
+
+type NetworkImages struct {
+	CiliumAgent    string `json:"ciliumAgent"`
+	CiliumEnvoy    string `json:"ciliumEnvoy"`
+	CiliumOperator string `json:"ciliumOperator"`
+}
+
+// NetworkSnapshot is a redaction-safe normalized input. It contains no Secret,
+// kubeconfig, token, certificate, endpoint, IP address, raw API object, log, or
+// raw probe output.
+type NetworkSnapshot struct {
+	Format             string             `json:"format"`
+	ObservedAt         string             `json:"observedAt"`
+	TargetClusterUID   string             `json:"targetClusterUid"`
+	IntentRevision     string             `json:"intentRevision"`
+	EnablementRevision string             `json:"enablementRevision"`
+	HCP                NetworkAddonSource `json:"hcp"`
+	HRPCount           int                `json:"hrpCount"`
+	HRP                NetworkAddonSource `json:"hrp"`
+	Nodes              []NetworkNode      `json:"nodes"`
+	Components         []NetworkComponent `json:"components"`
+	AgentPods          []NetworkAgentPod  `json:"agentPods"`
+	Probe              NetworkProbe       `json:"probe"`
+}
+
+type NetworkAddonSource struct {
+	UID                      string                   `json:"uid"`
+	Generation               int64                    `json:"generation"`
+	StatusObservedGeneration int64                    `json:"statusObservedGeneration"`
+	SpecDigest               string                   `json:"specDigest"`
+	IntentRevision           string                   `json:"intentRevision"`
+	EnablementRevision       string                   `json:"enablementRevision"`
+	OwnerUID                 string                   `json:"ownerUid,omitempty"`
+	TargetClusterUID         string                   `json:"targetClusterUid"`
+	ReleaseStatus            string                   `json:"releaseStatus,omitempty"`
+	ReleaseRevision          int64                    `json:"releaseRevision,omitempty"`
+	Conditions               []NetworkSourceCondition `json:"conditions"`
+}
+
+type NetworkSourceCondition struct {
+	Type               string `json:"type"`
+	Status             string `json:"status"`
+	ObservedGeneration int64  `json:"observedGeneration"`
+}
+
+type NetworkNode struct {
+	UID                      string `json:"uid"`
+	ProviderID               string `json:"providerId"`
+	Ready                    string `json:"ready"`
+	NetworkUnavailable       string `json:"networkUnavailable"`
+	NetworkUnavailableReason string `json:"networkUnavailableReason"`
+}
+
+type NetworkComponent struct {
+	ID                 string `json:"id"`
+	UID                string `json:"uid"`
+	Generation         int64  `json:"generation"`
+	ObservedGeneration int64  `json:"observedGeneration"`
+	Desired            int64  `json:"desired"`
+	Updated            int64  `json:"updated"`
+	Available          int64  `json:"available"`
+	Ready              int64  `json:"ready"`
+	Image              string `json:"image"`
+}
+
+type NetworkAgentPod struct {
+	UID     string `json:"uid"`
+	NodeUID string `json:"nodeUid"`
+	Phase   string `json:"phase"`
+	Ready   bool   `json:"ready"`
+}
+
+type NetworkProbe struct {
+	ResponseTimestamp         string             `json:"responseTimestamp"`
+	ProbeIntervalMilliseconds int64              `json:"probeIntervalMilliseconds"`
+	Paths                     []NetworkProbePath `json:"paths"`
+}
+
+type NetworkProbePath struct {
+	NodeUID       string `json:"nodeUid"`
+	Scope         string `json:"scope"`
+	Protocol      string `json:"protocol"`
+	StatusPresent bool   `json:"statusPresent"`
+	Status        string `json:"status,omitempty"`
+	LastProbed    string `json:"lastProbed"`
+}
+
+// EvaluateNetworkSnapshot translates the proven OK-141 network semantics into
+// one normalized source statement. Convergence gaps are Unknown; current
+// invariant violations are False. Neither can become aggregate Ready=True.
+func EvaluateNetworkSnapshot(policy Policy, profile NetworkProfile, snapshot NetworkSnapshot) (Evidence, error) {
+	if err := validatePolicy(policy, true); err != nil {
+		return Evidence{}, err
+	}
+	if err := validateNetworkProfile(policy, profile); err != nil {
+		return Evidence{}, err
+	}
+	if err := validateNetworkSnapshotShape(snapshot); err != nil {
+		return Evidence{}, err
+	}
+	snapshotDigest, err := canonicalDigest(snapshot)
+	if err != nil {
+		return Evidence{}, err
+	}
+	observedRevision := snapshot.EnablementRevision
+	if !validDigest(observedRevision) {
+		observedRevision = ""
+	}
+	status, reason := evaluateNetworkState(policy, profile, snapshot)
+	evidence := Evidence{
+		Type: "NetworkReady", Source: "BoundedNetworkEvaluator",
+		SourceUID:        "network-evidence-" + snapshotDigest[len("sha256:"):len("sha256:")+32],
+		TargetClusterUID: policy.TargetClusterUID, Status: status, Reason: reason,
+		DesiredRevision: policy.EnablementRevision, ObservedRevision: observedRevision,
+		EvidenceDigest: snapshotDigest,
+	}
+	if err := validateEvidenceShape(evidence); err != nil {
+		return Evidence{}, fmt.Errorf("normalize NetworkReady evidence: %w", err)
+	}
+	return evidence, nil
+}
+
+func validateNetworkProfile(policy Policy, profile NetworkProfile) error {
+	if profile.Format != NetworkProfileFormat || profile.IntentRevision != policy.IntentRevision || profile.EnablementRevision != policy.EnablementRevision {
+		return errors.New("network profile identity differs from observation policy")
+	}
+	if profile.ExpectedNodeCount < 1 || profile.ExpectedNodeCount > 100 || !validDigest(profile.ExpectedHCPSpecDigest) || !validDigest(profile.ExpectedHRPSpecDigest) {
+		return errors.New("network profile object expectations are invalid")
+	}
+	for _, image := range []string{profile.ExpectedImages.CiliumAgent, profile.ExpectedImages.CiliumEnvoy, profile.ExpectedImages.CiliumOperator} {
+		if !validPinnedImage(image) {
+			return errors.New("network profile contains a mutable or invalid image")
+		}
+	}
+	if profile.MinimumProbeFreshnessSeconds < 30 || profile.MinimumProbeFreshnessSeconds > 600 || profile.MaximumProbeIntervalSeconds < 30 || profile.MaximumProbeIntervalSeconds > 600 || profile.CacheExposureSeconds < 0 || profile.CacheExposureSeconds > 300 {
+		return errors.New("network profile probe freshness boundary is invalid")
+	}
+	return nil
+}
+
+func validateNetworkSnapshotShape(snapshot NetworkSnapshot) error {
+	if snapshot.Format != NetworkSnapshotFormat || !validUID(snapshot.TargetClusterUID) || snapshot.ObservedAt == "" {
+		return errors.New("network snapshot identity is invalid")
+	}
+	if _, err := time.Parse(time.RFC3339Nano, snapshot.ObservedAt); err != nil {
+		return errors.New("network snapshot observation time is invalid")
+	}
+	if (snapshot.IntentRevision != "" && !validDigest(snapshot.IntentRevision)) || (snapshot.EnablementRevision != "" && !validDigest(snapshot.EnablementRevision)) {
+		return errors.New("network snapshot revision is malformed")
+	}
+	if snapshot.HRPCount < 0 || snapshot.HRPCount > 10 || len(snapshot.Nodes) > 100 || len(snapshot.Components) > 10 || len(snapshot.AgentPods) > 100 || len(snapshot.Probe.Paths) > 400 {
+		return errors.New("network snapshot exceeds bounded collection limits")
+	}
+	if len(snapshot.HCP.Conditions) > 16 || len(snapshot.HRP.Conditions) > 16 {
+		return errors.New("network snapshot exceeds bounded Condition limits")
+	}
+	for _, node := range snapshot.Nodes {
+		if len(node.ProviderID) > 512 {
+			return errors.New("network snapshot contains an oversized provider identity")
+		}
+	}
+	for _, component := range snapshot.Components {
+		if len(component.ID) > 64 || len(component.Image) > 1024 {
+			return errors.New("network snapshot contains oversized component identity")
+		}
+	}
+	return nil
+}
+
+func evaluateNetworkState(policy Policy, profile NetworkProfile, snapshot NetworkSnapshot) (string, string) {
+	if snapshot.TargetClusterUID != policy.TargetClusterUID || snapshot.IntentRevision != policy.IntentRevision || snapshot.EnablementRevision != policy.EnablementRevision {
+		return "Unknown", "RevisionCorrelationUnproven"
+	}
+	if status, reason := evaluateAddonSource(snapshot.HCP, snapshot.TargetClusterUID, "", profile.ExpectedHCPSpecDigest, policy, []string{"Ready", "HelmReleaseProxySpecsUpToDate", "HelmReleaseProxiesReady"}, "EnablementOwner"); status != "True" {
+		return status, reason
+	}
+	if snapshot.HRPCount != 1 {
+		return "Unknown", "EnablementReleaseNotReady"
+	}
+	if status, reason := evaluateAddonSource(snapshot.HRP, snapshot.TargetClusterUID, snapshot.HCP.UID, profile.ExpectedHRPSpecDigest, policy, []string{"Ready", "HelmReleaseReady"}, "EnablementRelease"); status != "True" {
+		return status, reason
+	}
+	if snapshot.HRP.ReleaseStatus != "deployed" || snapshot.HRP.ReleaseRevision < 1 {
+		return "Unknown", "EnablementReleaseNotReady"
+	}
+	if len(snapshot.Nodes) != profile.ExpectedNodeCount {
+		return "Unknown", "NodeInventoryNotReady"
+	}
+	nodeUIDs := make(map[string]struct{}, len(snapshot.Nodes))
+	providerIDs := make(map[string]struct{}, len(snapshot.Nodes))
+	for _, node := range snapshot.Nodes {
+		if !validUID(node.UID) || node.ProviderID == "" {
+			return "False", "NodeIdentityInvalid"
+		}
+		if _, duplicate := nodeUIDs[node.UID]; duplicate {
+			return "False", "NodeIdentityInvalid"
+		}
+		if _, duplicate := providerIDs[node.ProviderID]; duplicate {
+			return "False", "NodeIdentityInvalid"
+		}
+		nodeUIDs[node.UID], providerIDs[node.ProviderID] = struct{}{}, struct{}{}
+		if node.Ready != "True" || node.NetworkUnavailable != "False" || node.NetworkUnavailableReason != "CiliumIsUp" {
+			return "Unknown", "NodeNetworkNotReady"
+		}
+	}
+	if status, reason := evaluateNetworkComponents(profile, snapshot.Components); status != "True" {
+		return status, reason
+	}
+	if len(snapshot.AgentPods) != profile.ExpectedNodeCount {
+		return "Unknown", "CiliumAgentPodsNotReady"
+	}
+	podNodes := make(map[string]struct{}, len(snapshot.AgentPods))
+	for _, pod := range snapshot.AgentPods {
+		if !validUID(pod.UID) || pod.Phase != "Running" || !pod.Ready {
+			return "Unknown", "CiliumAgentPodsNotReady"
+		}
+		if _, exists := nodeUIDs[pod.NodeUID]; !exists {
+			return "False", "CiliumNodeCoverageInvalid"
+		}
+		if _, duplicate := podNodes[pod.NodeUID]; duplicate {
+			return "False", "CiliumNodeCoverageInvalid"
+		}
+		podNodes[pod.NodeUID] = struct{}{}
+	}
+	if len(podNodes) != len(nodeUIDs) {
+		return "False", "CiliumNodeCoverageInvalid"
+	}
+	return evaluateNetworkProbe(profile, snapshot, nodeUIDs)
+}
+
+func evaluateAddonSource(source NetworkAddonSource, targetUID, ownerUID, specDigest string, policy Policy, required []string, reasonPrefix string) (string, string) {
+	if !validUID(source.UID) || source.SpecDigest != specDigest || source.IntentRevision != policy.IntentRevision || source.EnablementRevision != policy.EnablementRevision || source.TargetClusterUID != targetUID || source.OwnerUID != ownerUID {
+		return "False", reasonPrefix + "IdentityMismatch"
+	}
+	if source.Generation <= 0 || source.StatusObservedGeneration != source.Generation {
+		return "Unknown", reasonPrefix + "NotReady"
+	}
+	conditions := make(map[string]NetworkSourceCondition, len(source.Conditions))
+	for _, condition := range source.Conditions {
+		if _, duplicate := conditions[condition.Type]; duplicate {
+			return "False", reasonPrefix + "IdentityMismatch"
+		}
+		conditions[condition.Type] = condition
+	}
+	for _, name := range required {
+		condition, exists := conditions[name]
+		if !exists || condition.Status != "True" || condition.ObservedGeneration != source.Generation {
+			return "Unknown", reasonPrefix + "NotReady"
+		}
+	}
+	return "True", reasonPrefix + "Ready"
+}
+
+func evaluateNetworkComponents(profile NetworkProfile, components []NetworkComponent) (string, string) {
+	expected := map[string]struct {
+		desired int64
+		image   string
+	}{
+		"cilium-agent":    {int64(profile.ExpectedNodeCount), profile.ExpectedImages.CiliumAgent},
+		"cilium-envoy":    {int64(profile.ExpectedNodeCount), profile.ExpectedImages.CiliumEnvoy},
+		"cilium-operator": {1, profile.ExpectedImages.CiliumOperator},
+	}
+	if len(components) != len(expected) {
+		return "Unknown", "CiliumRolloutNotReady"
+	}
+	seen := map[string]struct{}{}
+	for _, component := range components {
+		want, exists := expected[component.ID]
+		if !exists {
+			return "False", "CiliumComponentIdentityInvalid"
+		}
+		if _, duplicate := seen[component.ID]; duplicate {
+			return "False", "CiliumComponentIdentityInvalid"
+		}
+		seen[component.ID] = struct{}{}
+		if !validUID(component.UID) || component.Generation <= 0 || component.ObservedGeneration != component.Generation || component.Desired != want.desired || component.Updated != want.desired || component.Available != want.desired || component.Ready != want.desired {
+			return "Unknown", "CiliumRolloutNotReady"
+		}
+		if component.Image != want.image {
+			return "False", "CiliumImageMismatch"
+		}
+	}
+	return "True", "CiliumRolloutReady"
+}
+
+func evaluateNetworkProbe(profile NetworkProfile, snapshot NetworkSnapshot, nodeUIDs map[string]struct{}) (string, string) {
+	observedAt, _ := time.Parse(time.RFC3339Nano, snapshot.ObservedAt)
+	responseAt, err := time.Parse(time.RFC3339Nano, snapshot.Probe.ResponseTimestamp)
+	if err != nil || snapshot.Probe.ProbeIntervalMilliseconds <= 0 || snapshot.Probe.ProbeIntervalMilliseconds > profile.MaximumProbeIntervalSeconds*1000 {
+		return "False", "FunctionalProbeInvalid"
+	}
+	probeIntervalSeconds := float64(snapshot.Probe.ProbeIntervalMilliseconds) / 1000
+	maximumAge := math.Max(float64(profile.MinimumProbeFreshnessSeconds), 2*probeIntervalSeconds+float64(profile.CacheExposureSeconds))
+	if age := observedAt.Sub(responseAt).Seconds(); age < -5 || age > maximumAge {
+		return "False", "FunctionalProbeStale"
+	}
+	expectedPathCount := len(nodeUIDs) * 4
+	if len(snapshot.Probe.Paths) != expectedPathCount {
+		return "False", "FunctionalProbeCoverageInvalid"
+	}
+	seen := make([]string, 0, len(snapshot.Probe.Paths))
+	for _, path := range snapshot.Probe.Paths {
+		if _, exists := nodeUIDs[path.NodeUID]; !exists || path.Scope != "host" && path.Scope != "health-endpoint" || path.Protocol != "http" && path.Protocol != "icmp" {
+			return "False", "FunctionalProbeCoverageInvalid"
+		}
+		key := path.NodeUID + "/" + path.Scope + "/" + path.Protocol
+		seen = append(seen, key)
+		if !path.StatusPresent && path.Status != "" {
+			return "False", "FunctionalProbeInvalid"
+		}
+		if path.StatusPresent && path.Status != "" {
+			return "False", "FunctionalProbeFailed"
+		}
+		lastProbed, err := time.Parse(time.RFC3339Nano, path.LastProbed)
+		if err != nil {
+			return "False", "FunctionalProbeInvalid"
+		}
+		if age := observedAt.Sub(lastProbed).Seconds(); age < -5 || age > maximumAge {
+			return "False", "FunctionalProbeStale"
+		}
+	}
+	sort.Strings(seen)
+	for index := 1; index < len(seen); index++ {
+		if seen[index] == seen[index-1] {
+			return "False", "FunctionalProbeCoverageInvalid"
+		}
+	}
+	return "True", "NetworkReady"
+}
+
+func validPinnedImage(value string) bool {
+	const separator = "@sha256:"
+	index := len(value) - 64 - len(separator)
+	if index <= 0 || value[index:index+len(separator)] != separator {
+		return false
+	}
+	return validDigest("sha256:" + value[index+len(separator):])
+}

--- a/internal/observation/network_evaluator_test.go
+++ b/internal/observation/network_evaluator_test.go
@@ -1,0 +1,208 @@
+package observation
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestEvaluateNetworkSnapshotProducesCurrentEVIDENCE(t *testing.T) {
+	policy, profile, snapshot := validNetworkFixture(t)
+	evidence, err := EvaluateNetworkSnapshot(policy, profile, snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if evidence.Type != "NetworkReady" || evidence.Source != "BoundedNetworkEvaluator" || evidence.Status != "True" || evidence.Reason != "NetworkReady" || evidence.TargetClusterUID != policy.TargetClusterUID || evidence.ObservedRevision != policy.EnablementRevision || !validDigest(evidence.EvidenceDigest) {
+		t.Fatalf("unexpected network evidence: %#v", evidence)
+	}
+	bundle := completeBundle(policy)
+	bundle.Evidence[2] = evidence
+	result, err := Evaluate(policy, bundle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, _ := result.Receipt()
+	if receipt.Ready != "True" {
+		t.Fatalf("network evidence did not compose: %#v", receipt)
+	}
+}
+
+func TestEvaluateNetworkSnapshotFailsClosed(t *testing.T) {
+	tests := map[string]struct {
+		mutate func(*NetworkSnapshot)
+		status string
+		reason string
+	}{
+		"missing E": {
+			mutate: func(snapshot *NetworkSnapshot) { snapshot.EnablementRevision = "" },
+			status: "Unknown", reason: "RevisionCorrelationUnproven",
+		},
+		"stale HCP": {
+			mutate: func(snapshot *NetworkSnapshot) { snapshot.HCP.StatusObservedGeneration-- },
+			status: "Unknown", reason: "EnablementOwnerNotReady",
+		},
+		"HCP spec mismatch": {
+			mutate: func(snapshot *NetworkSnapshot) { snapshot.HCP.SpecDigest = "sha256:" + strings.Repeat("f", 64) },
+			status: "False", reason: "EnablementOwnerIdentityMismatch",
+		},
+		"multiple HRPs": {
+			mutate: func(snapshot *NetworkSnapshot) { snapshot.HRPCount = 2 },
+			status: "Unknown", reason: "EnablementReleaseNotReady",
+		},
+		"node networking pending": {
+			mutate: func(snapshot *NetworkSnapshot) { snapshot.Nodes[0].NetworkUnavailable = "True" },
+			status: "Unknown", reason: "NodeNetworkNotReady",
+		},
+		"mutable image mismatch": {
+			mutate: func(snapshot *NetworkSnapshot) { snapshot.Components[0].Image = "quay.io/cilium/cilium:v1.19.6" },
+			status: "False", reason: "CiliumImageMismatch",
+		},
+		"rollout stale": {
+			mutate: func(snapshot *NetworkSnapshot) { snapshot.Components[0].ObservedGeneration-- },
+			status: "Unknown", reason: "CiliumRolloutNotReady",
+		},
+		"pod coverage differs": {
+			mutate: func(snapshot *NetworkSnapshot) { snapshot.AgentPods[1].NodeUID = snapshot.AgentPods[0].NodeUID },
+			status: "False", reason: "CiliumNodeCoverageInvalid",
+		},
+		"functional path failed": {
+			mutate: func(snapshot *NetworkSnapshot) {
+				snapshot.Probe.Paths[0].StatusPresent, snapshot.Probe.Paths[0].Status = true, "timeout"
+			},
+			status: "False", reason: "FunctionalProbeFailed",
+		},
+		"functional path stale": {
+			mutate: func(snapshot *NetworkSnapshot) { snapshot.Probe.Paths[0].LastProbed = "2026-08-16T09:55:00Z" },
+			status: "False", reason: "FunctionalProbeStale",
+		},
+		"duplicate functional path": {
+			mutate: func(snapshot *NetworkSnapshot) { snapshot.Probe.Paths[1] = snapshot.Probe.Paths[0] },
+			status: "False", reason: "FunctionalProbeCoverageInvalid",
+		},
+	}
+	for name, testCase := range tests {
+		t.Run(name, func(t *testing.T) {
+			policy, profile, snapshot := validNetworkFixture(t)
+			testCase.mutate(&snapshot)
+			evidence, err := EvaluateNetworkSnapshot(policy, profile, snapshot)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if evidence.Status != testCase.status || evidence.Reason != testCase.reason || evidence.Status == "True" {
+				t.Fatalf("unsafe network result: %#v", evidence)
+			}
+		})
+	}
+}
+
+func TestEvaluateNetworkSnapshotUsesBoundedDynamicCacheFreshness(t *testing.T) {
+	policy, profile, snapshot := validNetworkFixture(t)
+	// 2 * 96.566s probe interval + 60s cache exposure = 253.132s.
+	snapshot.Probe.ProbeIntervalMilliseconds = 96566
+	snapshot.Probe.Paths[0].LastProbed = "2026-08-16T09:56:00Z" // 240s old.
+	evidence, err := EvaluateNetworkSnapshot(policy, profile, snapshot)
+	if err != nil || evidence.Status != "True" {
+		t.Fatalf("valid cached Cilium path was rejected: %#v %v", evidence, err)
+	}
+	snapshot.Probe.Paths[0].LastProbed = "2026-08-16T09:55:30Z" // 270s old.
+	evidence, err = EvaluateNetworkSnapshot(policy, profile, snapshot)
+	if err != nil || evidence.Status != "False" || evidence.Reason != "FunctionalProbeStale" {
+		t.Fatalf("stale cached Cilium path was accepted: %#v %v", evidence, err)
+	}
+}
+
+func TestEvaluateNetworkSnapshotRejectsMalformedUnboundedInput(t *testing.T) {
+	for name, mutate := range map[string]func(*NetworkProfile, *NetworkSnapshot){
+		"mutable profile image": func(profile *NetworkProfile, _ *NetworkSnapshot) {
+			profile.ExpectedImages.CiliumAgent = "quay.io/cilium/cilium:v1.19.6"
+		},
+		"malformed revision": func(_ *NetworkProfile, snapshot *NetworkSnapshot) {
+			snapshot.EnablementRevision = "sha256:no"
+		},
+		"too many nodes": func(_ *NetworkProfile, snapshot *NetworkSnapshot) {
+			snapshot.Nodes = make([]NetworkNode, 101)
+		},
+		"unbounded probe interval": func(_ *NetworkProfile, snapshot *NetworkSnapshot) {
+			snapshot.Probe.ProbeIntervalMilliseconds = 601000
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			policy, profile, snapshot := validNetworkFixture(t)
+			mutate(&profile, &snapshot)
+			if _, err := EvaluateNetworkSnapshot(policy, profile, snapshot); err == nil && name != "unbounded probe interval" {
+				t.Fatal("malformed network input accepted")
+			} else if name == "unbounded probe interval" && err == nil {
+				evidence, _ := EvaluateNetworkSnapshot(policy, profile, snapshot)
+				if evidence.Status != "False" || evidence.Reason != "FunctionalProbeInvalid" {
+					t.Fatalf("unbounded probe interval accepted: %#v", evidence)
+				}
+			}
+		})
+	}
+}
+
+func validNetworkFixture(t *testing.T) (Policy, NetworkProfile, NetworkSnapshot) {
+	t.Helper()
+	policy := testPolicy(t)
+	digestA := "sha256:" + strings.Repeat("a", 64)
+	digestB := "sha256:" + strings.Repeat("b", 64)
+	images := NetworkImages{
+		CiliumAgent:    "quay.io/cilium/cilium:v1.19.6@sha256:" + strings.Repeat("1", 64),
+		CiliumEnvoy:    "quay.io/cilium/cilium-envoy:v1.36.9@sha256:" + strings.Repeat("2", 64),
+		CiliumOperator: "quay.io/cilium/operator-generic:v1.19.6@sha256:" + strings.Repeat("3", 64),
+	}
+	profile := NetworkProfile{
+		Format: NetworkProfileFormat, IntentRevision: policy.IntentRevision,
+		EnablementRevision: policy.EnablementRevision, ExpectedNodeCount: 2,
+		ExpectedHCPSpecDigest: digestA, ExpectedHRPSpecDigest: digestB, ExpectedImages: images,
+		MinimumProbeFreshnessSeconds: 120, MaximumProbeIntervalSeconds: 120, CacheExposureSeconds: 60,
+	}
+	conditions := func(names ...string) []NetworkSourceCondition {
+		result := make([]NetworkSourceCondition, 0, len(names))
+		for _, name := range names {
+			result = append(result, NetworkSourceCondition{Type: name, Status: "True", ObservedGeneration: 4})
+		}
+		return result
+	}
+	hcp := NetworkAddonSource{
+		UID: "hcp-uid-1", Generation: 4, StatusObservedGeneration: 4, SpecDigest: digestA,
+		IntentRevision: policy.IntentRevision, EnablementRevision: policy.EnablementRevision,
+		TargetClusterUID: policy.TargetClusterUID,
+		Conditions:       conditions("Ready", "HelmReleaseProxySpecsUpToDate", "HelmReleaseProxiesReady"),
+	}
+	hrp := NetworkAddonSource{
+		UID: "hrp-uid-1", Generation: 4, StatusObservedGeneration: 4, SpecDigest: digestB,
+		IntentRevision: policy.IntentRevision, EnablementRevision: policy.EnablementRevision,
+		OwnerUID: hcp.UID, TargetClusterUID: policy.TargetClusterUID,
+		ReleaseStatus: "deployed", ReleaseRevision: 1,
+		Conditions: conditions("Ready", "HelmReleaseReady"),
+	}
+	nodes := []NetworkNode{
+		{UID: "node-uid-1", ProviderID: "provider://node-1", Ready: "True", NetworkUnavailable: "False", NetworkUnavailableReason: "CiliumIsUp"},
+		{UID: "node-uid-2", ProviderID: "provider://node-2", Ready: "True", NetworkUnavailable: "False", NetworkUnavailableReason: "CiliumIsUp"},
+	}
+	components := []NetworkComponent{
+		{ID: "cilium-agent", UID: "component-uid-1", Generation: 3, ObservedGeneration: 3, Desired: 2, Updated: 2, Available: 2, Ready: 2, Image: images.CiliumAgent},
+		{ID: "cilium-envoy", UID: "component-uid-2", Generation: 3, ObservedGeneration: 3, Desired: 2, Updated: 2, Available: 2, Ready: 2, Image: images.CiliumEnvoy},
+		{ID: "cilium-operator", UID: "component-uid-3", Generation: 3, ObservedGeneration: 3, Desired: 1, Updated: 1, Available: 1, Ready: 1, Image: images.CiliumOperator},
+	}
+	pods := []NetworkAgentPod{
+		{UID: "pod-uid-1", NodeUID: nodes[0].UID, Phase: "Running", Ready: true},
+		{UID: "pod-uid-2", NodeUID: nodes[1].UID, Phase: "Running", Ready: true},
+	}
+	paths := make([]NetworkProbePath, 0, 8)
+	for _, node := range nodes {
+		for _, scope := range []string{"host", "health-endpoint"} {
+			for _, protocol := range []string{"http", "icmp"} {
+				paths = append(paths, NetworkProbePath{NodeUID: node.UID, Scope: scope, Protocol: protocol, LastProbed: "2026-08-16T09:57:00Z"})
+			}
+		}
+	}
+	return policy, profile, NetworkSnapshot{
+		Format: NetworkSnapshotFormat, ObservedAt: time.Date(2026, 8, 16, 10, 0, 0, 0, time.UTC).Format(time.RFC3339Nano),
+		TargetClusterUID: policy.TargetClusterUID, IntentRevision: policy.IntentRevision,
+		EnablementRevision: policy.EnablementRevision, HCP: hcp, HRPCount: 1, HRP: hrp,
+		Nodes: nodes, Components: components, AgentPods: pods,
+		Probe: NetworkProbe{ResponseTimestamp: "2026-08-16T09:59:00Z", ProbeIntervalMilliseconds: 96566, Paths: paths},
+	}
+}


### PR DESCRIPTION
## What changed

- add a deterministic Go evaluator for the OK-141 `NetworkReady` source semantics
- correlate the exact target Cluster UID, R, E, current HCP, and exactly one owned HRP
- require current Node, Cilium, Envoy, operator, and per-Node agent Pod evidence
- require exact digest-pinned component images
- evaluate the complete host/health-endpoint HTTP/ICMP matrix
- preserve the corrected Cilium v1.19.6 omitted/empty success-status semantics
- use bounded dynamic cache freshness derived from probe interval plus cache exposure
- emit one normalized `BoundedNetworkEvaluator` statement for aggregate evaluation

## Why

`NetworkReady` is not equivalent to Helm success or DaemonSet availability. The OK-141 Happy Run proved that it requires correlation across enablement ownership, workload identity, current rollout state, exact artifacts, and functional connectivity. This checkpoint moves that proven semantic evaluation into the runner without introducing a second Cilium or CAAPH reconciler.

Revision and convergence gaps evaluate to `Unknown`. Current identity, artifact, coverage, functional-path, or freshness violations evaluate to `False`; neither can become aggregate `Ready=True`.

## Scope

This remains an offline-only evaluator. It performs no Kubernetes requests, Secret reads, command execution, polling, CLI/Job wiring, status publication, or mutation. A later collector must obtain its normalized inputs with separately bounded management and workload clients and derive the profile from digest-bound input.

## Validation

- `CGO_ENABLED=0 go test ./...`
- `CGO_ENABLED=0 go test -race ./internal/observation ./internal/execution`
- `CGO_ENABLED=0 go vet ./...`
- `python3 -m unittest tests.ok147_runner_image_test tests.ok147_runner_publication_test`
- `git diff --check`
