### PR TITLE
OK-147: Add bounded NetworkReady source collector

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -469,11 +469,24 @@ coverage, failed paths, or stale probe evidence evaluate to `False`. The
 result is one `BoundedNetworkEvaluator` source statement carrying exact `E`
 and a deterministic snapshot digest.
 
-This checkpoint contains only the deterministic source evaluator. A later
-Kubernetes collector must obtain these inputs through separately bounded
-management/workload clients and must derive the reviewed network profile from
-a digest-bound input. No command execution, Secret read, cluster contact,
-polling, CLI/Job wiring, or mutation is introduced here.
+The following offline checkpoint adds the bounded source collector behind that
+evaluator. Its interfaces permit at most two exact management reads (the bound
+HCP and its label-selected HRP set), five workload reads (Nodes, the exact
+Cilium and Envoy DaemonSets, the exact Cilium operator Deployment, and the
+label-selected Cilium agent Pods), and one fixed functional probe. The probe
+interface accepts only the selected Pod name and UID; it has no arbitrary
+command or argument surface. The collector sorts runtime collections before
+digesting them, rejects malformed or ambiguous list members, verifies exact
+object/owner/target selection, and discards raw transport errors and probe
+output after normalization.
+
+This remains an offline boundary: fake clients exercise the complete collector
+and evaluator path, while credential materialization, TLS/token HTTP adapters,
+Secret reads, cluster contact, polling, CLI/Job wiring, and mutation remain out
+of scope. A later adapter must bind the management reader to the management
+authority and the workload reader/probe to the already verified immutable
+target Cluster UID. The collector does not infer that authority from reusable
+names or API endpoints.
 
 ## OK-141 compatibility evidence
 

--- a/internal/observation/network_collector.go
+++ b/internal/observation/network_collector.go
@@ -1,0 +1,532 @@
+package observation
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/url"
+	"sort"
+	"time"
+)
+
+const maximumNetworkSourceBytes = 4 * 1024 * 1024
+
+// NetworkRawGetter deliberately exposes only GET. Concrete management and
+// workload adapters must each bind their own credential and API endpoint.
+type NetworkRawGetter interface {
+	Get(context.Context, string) ([]byte, error)
+}
+
+// FixedCiliumProbe exposes no command argument. A concrete adapter may execute
+// only `cilium-health status --probe --output json` in the selected Pod/UID.
+type FixedCiliumProbe interface {
+	Probe(context.Context, string, string) ([]byte, error)
+}
+
+type NetworkCollectorConfig struct {
+	Namespace string
+	Name      string
+	HCPName   string
+	Clock     func() time.Time
+}
+
+// NetworkSourceCollector performs one bounded source collection. It has no
+// mutation, discovery, watch, retry, repair, arbitrary query, or arbitrary
+// command path.
+type NetworkSourceCollector struct {
+	management NetworkRawGetter
+	workload   NetworkRawGetter
+	probe      FixedCiliumProbe
+	config     NetworkCollectorConfig
+}
+
+func NewNetworkSourceCollector(management, workload NetworkRawGetter, probe FixedCiliumProbe, config NetworkCollectorConfig) (*NetworkSourceCollector, error) {
+	if management == nil || workload == nil || probe == nil || config.Clock == nil {
+		return nil, errors.New("network collector sources and clock are required")
+	}
+	if !validDNSLabel(config.Namespace) || !validDNSLabel(config.Name) || !validDNSLabel(config.HCPName) {
+		return nil, errors.New("network collector object identity is invalid")
+	}
+	return &NetworkSourceCollector{management: management, workload: workload, probe: probe, config: config}, nil
+}
+
+// Observe collects and immediately evaluates one current normalized snapshot.
+func (collector *NetworkSourceCollector) Observe(ctx context.Context, policy Policy, profile NetworkProfile) (Evidence, error) {
+	snapshot, err := collector.Collect(ctx, policy)
+	if err != nil {
+		return Evidence{}, err
+	}
+	return EvaluateNetworkSnapshot(policy, profile, snapshot)
+}
+
+// Collect performs at most two management reads, five workload reads and one
+// fixed Cilium probe. Every collection is size-bounded and normalized before
+// raw payloads leave the call frame.
+func (collector *NetworkSourceCollector) Collect(ctx context.Context, policy Policy) (NetworkSnapshot, error) {
+	if err := validatePolicy(policy, true); err != nil {
+		return NetworkSnapshot{}, err
+	}
+	namespace, name, hcpName := collector.config.Namespace, collector.config.Name, collector.config.HCPName
+	hcpPath := "/apis/addons.cluster.x-k8s.io/v1alpha1/namespaces/" + namespace + "/helmchartproxies/" + hcpName
+	selector := "cluster.x-k8s.io/cluster-name=" + name + ",helmreleaseproxy.addons.cluster.x-k8s.io/helmchartproxy-name=" + hcpName
+	hrpPath := "/apis/addons.cluster.x-k8s.io/v1alpha1/namespaces/" + namespace + "/helmreleaseproxies?labelSelector=" + url.QueryEscape(selector)
+
+	hcpObject, err := getNetworkObject(ctx, collector.management, hcpPath)
+	if err != nil {
+		return NetworkSnapshot{}, fmt.Errorf("collect exact HCP: %w", err)
+	}
+	hrpList, err := getNetworkObject(ctx, collector.management, hrpPath)
+	if err != nil {
+		return NetworkSnapshot{}, fmt.Errorf("collect bounded HRP set: %w", err)
+	}
+	hcp, err := normalizeHCP(hcpObject, namespace, hcpName, name, policy)
+	if err != nil {
+		return NetworkSnapshot{}, err
+	}
+	hrpCount, hrp, err := normalizeHRPList(hrpList, namespace, name, hcpName, hcp.UID, policy)
+	if err != nil {
+		return NetworkSnapshot{}, err
+	}
+
+	nodesObject, err := getNetworkObject(ctx, collector.workload, "/api/v1/nodes")
+	if err != nil {
+		return NetworkSnapshot{}, fmt.Errorf("collect bounded Node set: %w", err)
+	}
+	nodes, nodeNames, err := normalizeNodes(nodesObject)
+	if err != nil {
+		return NetworkSnapshot{}, err
+	}
+	components := make([]NetworkComponent, 0, 3)
+	for _, source := range []struct {
+		path          string
+		kind          string
+		name          string
+		id            string
+		containerName string
+	}{
+		{"/apis/apps/v1/namespaces/kube-system/daemonsets/cilium", "DaemonSet", "cilium", "cilium-agent", "cilium-agent"},
+		{"/apis/apps/v1/namespaces/kube-system/daemonsets/cilium-envoy", "DaemonSet", "cilium-envoy", "cilium-envoy", "cilium-envoy"},
+		{"/apis/apps/v1/namespaces/kube-system/deployments/cilium-operator", "Deployment", "cilium-operator", "cilium-operator", "cilium-operator"},
+	} {
+		object, getErr := getNetworkObject(ctx, collector.workload, source.path)
+		if getErr != nil {
+			return NetworkSnapshot{}, fmt.Errorf("collect exact %s: %w", source.id, getErr)
+		}
+		component, normalizeErr := normalizeComponent(object, source.kind, source.name, source.id, source.containerName)
+		if normalizeErr != nil {
+			return NetworkSnapshot{}, normalizeErr
+		}
+		components = append(components, component)
+	}
+	podsObject, err := getNetworkObject(ctx, collector.workload, "/api/v1/namespaces/kube-system/pods?labelSelector=k8s-app%3Dcilium")
+	if err != nil {
+		return NetworkSnapshot{}, fmt.Errorf("collect bounded Cilium Pod set: %w", err)
+	}
+	pods, selectedName, selectedUID, err := normalizeAgentPods(podsObject, nodeNames)
+	if err != nil {
+		return NetworkSnapshot{}, err
+	}
+	probeRaw, err := collector.probe.Probe(ctx, selectedName, selectedUID)
+	if err != nil {
+		return NetworkSnapshot{}, errors.New("fixed Cilium functional probe failed")
+	}
+	probe, err := normalizeNetworkProbe(probeRaw, nodeNames)
+	if err != nil {
+		return NetworkSnapshot{}, err
+	}
+	return NetworkSnapshot{
+		Format: NetworkSnapshotFormat, ObservedAt: collector.config.Clock().UTC().Format(time.RFC3339Nano),
+		TargetClusterUID: policy.TargetClusterUID, IntentRevision: policy.IntentRevision,
+		EnablementRevision: hcp.EnablementRevision, HCP: hcp, HRPCount: hrpCount, HRP: hrp,
+		Nodes: nodes, Components: components, AgentPods: pods, Probe: probe,
+	}, nil
+}
+
+func getNetworkObject(ctx context.Context, source NetworkRawGetter, path string) (map[string]any, error) {
+	raw, err := source.Get(ctx, path)
+	if err != nil {
+		return nil, errors.New("bounded network source GET failed")
+	}
+	if len(raw) == 0 || len(raw) > maximumNetworkSourceBytes {
+		return nil, errors.New("network source response size is invalid")
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	var value map[string]any
+	if err := decoder.Decode(&value); err != nil {
+		return nil, errors.New("network source returned invalid JSON object")
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		return nil, errors.New("network source returned trailing JSON")
+	}
+	return value, nil
+}
+
+func normalizeHCP(object map[string]any, namespace, hcpName, clusterName string, policy Policy) (NetworkAddonSource, error) {
+	if text(object["apiVersion"]) != "addons.cluster.x-k8s.io/v1alpha1" || text(object["kind"]) != "HelmChartProxy" {
+		return NetworkAddonSource{}, errors.New("HCP API identity is invalid")
+	}
+	metadata, err := objectMap(object, "metadata")
+	if err != nil || text(metadata["namespace"]) != namespace || text(metadata["name"]) != hcpName {
+		return NetworkAddonSource{}, errors.New("HCP object identity differs from exact target")
+	}
+	spec, err := objectMap(object, "spec")
+	if err != nil {
+		return NetworkAddonSource{}, errors.New("HCP spec is missing")
+	}
+	specDigest, err := addonSpecDigest(spec, false)
+	if err != nil {
+		return NetworkAddonSource{}, err
+	}
+	status, _ := objectMap(object, "status")
+	matching, err := requiredObjectSlice(status, "matchingClusters", 10)
+	if err != nil {
+		return NetworkAddonSource{}, errors.New("HCP target selection is invalid")
+	}
+	selected := len(matching) == 1 && textMap(matching[0], "namespace") == namespace && textMap(matching[0], "name") == clusterName
+	annotations, _ := objectMap(metadata, "annotations")
+	conditions, err := normalizeSourceConditions(status)
+	if err != nil {
+		return NetworkAddonSource{}, err
+	}
+	return NetworkAddonSource{
+		UID: text(metadata["uid"]), Generation: integer(metadata["generation"]),
+		StatusObservedGeneration: integer(status["observedGeneration"]), SpecDigest: specDigest,
+		IntentRevision: text(annotations["openkubes.io/intent-revision"]), EnablementRevision: text(annotations["openkubes.io/enablement-revision"]),
+		TargetClusterUID: policy.TargetClusterUID, TargetSelected: selected,
+		Conditions: conditions,
+	}, nil
+}
+
+func normalizeHRPList(list map[string]any, namespace, clusterName, hcpName, hcpUID string, policy Policy) (int, NetworkAddonSource, error) {
+	if text(list["apiVersion"]) != "addons.cluster.x-k8s.io/v1alpha1" || text(list["kind"]) != "HelmReleaseProxyList" {
+		return 0, NetworkAddonSource{}, errors.New("HRP collection identity is invalid")
+	}
+	items, err := requiredObjectSlice(list, "items", 10)
+	if err != nil {
+		return 0, NetworkAddonSource{}, errors.New("HRP collection is invalid or exceeds bounded size")
+	}
+	if len(items) != 1 {
+		return len(items), NetworkAddonSource{}, nil
+	}
+	object := items[0]
+	metadata, err := objectMap(object, "metadata")
+	if err != nil || text(object["apiVersion"]) != "addons.cluster.x-k8s.io/v1alpha1" || text(object["kind"]) != "HelmReleaseProxy" || text(metadata["namespace"]) != namespace {
+		return 0, NetworkAddonSource{}, errors.New("HRP object identity is invalid")
+	}
+	spec, err := objectMap(object, "spec")
+	if err != nil {
+		return 0, NetworkAddonSource{}, errors.New("HRP spec is missing")
+	}
+	clusterRef, _ := objectMap(spec, "clusterRef")
+	selected := text(clusterRef["apiVersion"]) == "cluster.x-k8s.io/v1beta2" && text(clusterRef["kind"]) == "Cluster" && text(clusterRef["namespace"]) == namespace && text(clusterRef["name"]) == clusterName
+	ownerUID, err := controllerOwnerUID(metadata, "HelmChartProxy", hcpName)
+	if err != nil {
+		return 0, NetworkAddonSource{}, err
+	}
+	specDigest, err := addonSpecDigest(spec, true)
+	if err != nil {
+		return 0, NetworkAddonSource{}, err
+	}
+	status, _ := objectMap(object, "status")
+	conditions, err := normalizeSourceConditions(status)
+	if err != nil {
+		return 0, NetworkAddonSource{}, err
+	}
+	return 1, NetworkAddonSource{
+		UID: text(metadata["uid"]), Generation: integer(metadata["generation"]),
+		StatusObservedGeneration: integer(status["observedGeneration"]), SpecDigest: specDigest,
+		IntentRevision: policy.IntentRevision, EnablementRevision: policy.EnablementRevision,
+		OwnerUID: ownerUID, TargetClusterUID: policy.TargetClusterUID, TargetSelected: selected && ownerUID == hcpUID,
+		ReleaseStatus: text(status["status"]), ReleaseRevision: integer(status["revision"]),
+		Conditions: conditions,
+	}, nil
+}
+
+func addonSpecDigest(spec map[string]any, includeClusterRef bool) (string, error) {
+	keys := []string{"chartName", "repoURL", "version", "releaseName", "namespace", "reconcileStrategy", "valuesTemplate", "options"}
+	if includeClusterRef {
+		keys = []string{"chartName", "repoURL", "version", "releaseName", "namespace", "reconcileStrategy", "values", "clusterRef"}
+	}
+	semantic := make(map[string]any, len(keys))
+	for _, key := range keys {
+		semantic[key] = spec[key]
+	}
+	return canonicalDigest(semantic)
+}
+
+func normalizeNodes(list map[string]any) ([]NetworkNode, map[string]string, error) {
+	if text(list["apiVersion"]) != "v1" || text(list["kind"]) != "NodeList" {
+		return nil, nil, errors.New("Node collection identity is invalid")
+	}
+	items, err := requiredObjectSlice(list, "items", 100)
+	if err != nil {
+		return nil, nil, errors.New("Node collection is invalid or exceeds bounded size")
+	}
+	nodes := make([]NetworkNode, 0, len(items))
+	names := make(map[string]string, len(items))
+	for _, object := range items {
+		metadata, _ := objectMap(object, "metadata")
+		spec, _ := objectMap(object, "spec")
+		status, _ := objectMap(object, "status")
+		name, uid := text(metadata["name"]), text(metadata["uid"])
+		if !validDNSLabel(name) || uid == "" {
+			return nil, nil, errors.New("Node runtime identity is invalid")
+		}
+		if _, duplicate := names[name]; duplicate {
+			return nil, nil, errors.New("Node name is duplicated")
+		}
+		ready, network, err := exactNodeConditions(status)
+		if err != nil {
+			return nil, nil, err
+		}
+		names[name] = uid
+		nodes = append(nodes, NetworkNode{UID: uid, ProviderID: text(spec["providerID"]), Ready: text(ready["status"]), NetworkUnavailable: text(network["status"]), NetworkUnavailableReason: text(network["reason"])})
+	}
+	sort.Slice(nodes, func(left, right int) bool { return nodes[left].UID < nodes[right].UID })
+	return nodes, names, nil
+}
+
+func normalizeComponent(object map[string]any, kind, name, id, containerName string) (NetworkComponent, error) {
+	if text(object["apiVersion"]) != "apps/v1" || text(object["kind"]) != kind {
+		return NetworkComponent{}, fmt.Errorf("%s API identity is invalid", id)
+	}
+	metadata, _ := objectMap(object, "metadata")
+	if text(metadata["namespace"]) != "kube-system" || text(metadata["name"]) != name {
+		return NetworkComponent{}, fmt.Errorf("%s object identity differs from exact target", id)
+	}
+	spec, _ := objectMap(object, "spec")
+	template, _ := objectMap(spec, "template")
+	podSpec, _ := objectMap(template, "spec")
+	containers, err := requiredObjectSlice(podSpec, "containers", 20)
+	if err != nil {
+		return NetworkComponent{}, fmt.Errorf("%s Pod template containers are invalid", id)
+	}
+	image := containerImage(containers, containerName)
+	status, _ := objectMap(object, "status")
+	desired := integer(status["desiredNumberScheduled"])
+	updated := integer(status["updatedNumberScheduled"])
+	available := integer(status["numberAvailable"])
+	ready := integer(status["numberReady"])
+	if kind == "Deployment" {
+		desired = integer(spec["replicas"])
+		if desired == 0 {
+			desired = 1
+		}
+		updated, available, ready = integer(status["updatedReplicas"]), integer(status["availableReplicas"]), integer(status["readyReplicas"])
+	}
+	return NetworkComponent{ID: id, UID: text(metadata["uid"]), Generation: integer(metadata["generation"]), ObservedGeneration: integer(status["observedGeneration"]), Desired: desired, Updated: updated, Available: available, Ready: ready, Image: image}, nil
+}
+
+func normalizeAgentPods(list map[string]any, nodeNames map[string]string) ([]NetworkAgentPod, string, string, error) {
+	if text(list["apiVersion"]) != "v1" || text(list["kind"]) != "PodList" {
+		return nil, "", "", errors.New("Cilium Pod collection identity is invalid")
+	}
+	items, err := requiredObjectSlice(list, "items", 100)
+	if err != nil || len(items) == 0 {
+		return nil, "", "", errors.New("Cilium Pod collection size is invalid")
+	}
+	type namedPod struct {
+		name string
+		pod  NetworkAgentPod
+	}
+	normalized := make([]namedPod, 0, len(items))
+	for _, object := range items {
+		metadata, _ := objectMap(object, "metadata")
+		spec, _ := objectMap(object, "spec")
+		status, _ := objectMap(object, "status")
+		name, uid, nodeName := text(metadata["name"]), text(metadata["uid"]), text(spec["nodeName"])
+		nodeUID := nodeNames[nodeName]
+		if !validDNSLabel(name) || uid == "" || nodeUID == "" {
+			return nil, "", "", errors.New("Cilium Pod runtime identity is invalid")
+		}
+		ready := false
+		containerStatuses, statusErr := requiredObjectSlice(status, "containerStatuses", 20)
+		if statusErr != nil {
+			return nil, "", "", errors.New("Cilium Pod container status is invalid")
+		}
+		for _, item := range containerStatuses {
+			if text(item["name"]) == "cilium-agent" {
+				ready, _ = item["ready"].(bool)
+			}
+		}
+		normalized = append(normalized, namedPod{name: name, pod: NetworkAgentPod{UID: uid, NodeUID: nodeUID, Phase: text(status["phase"]), Ready: ready}})
+	}
+	sort.Slice(normalized, func(left, right int) bool { return normalized[left].name < normalized[right].name })
+	pods := make([]NetworkAgentPod, 0, len(normalized))
+	for _, item := range normalized {
+		pods = append(pods, item.pod)
+	}
+	return pods, normalized[0].name, normalized[0].pod.UID, nil
+}
+
+func normalizeNetworkProbe(raw []byte, nodeNames map[string]string) (NetworkProbe, error) {
+	if len(raw) == 0 || len(raw) > maximumNetworkSourceBytes {
+		return NetworkProbe{}, errors.New("functional probe response size is invalid")
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	var value map[string]any
+	if err := decoder.Decode(&value); err != nil {
+		return NetworkProbe{}, errors.New("functional probe returned invalid JSON")
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		return NetworkProbe{}, errors.New("functional probe returned trailing JSON")
+	}
+	interval, err := time.ParseDuration(text(value["probeInterval"]))
+	if err != nil || interval <= 0 {
+		return NetworkProbe{}, errors.New("functional probe interval is invalid")
+	}
+	paths := make([]NetworkProbePath, 0, len(nodeNames)*4)
+	probeNodes, err := requiredObjectSlice(value, "nodes", 100)
+	if err != nil {
+		return NetworkProbe{}, errors.New("functional probe Node collection is invalid")
+	}
+	for _, node := range probeNodes {
+		uid := nodeNames[text(node["name"])]
+		if uid == "" {
+			return NetworkProbe{}, errors.New("functional probe contains a foreign Node")
+		}
+		for _, scope := range []string{"host", "health-endpoint"} {
+			scopeObject, _ := objectMap(node, scope)
+			address, _ := objectMap(scopeObject, "primary-address")
+			for _, protocol := range []string{"http", "icmp"} {
+				path, ok := address[protocol].(map[string]any)
+				if !ok {
+					return NetworkProbe{}, errors.New("functional probe path is missing")
+				}
+				statusRaw, present := path["status"]
+				status := ""
+				if present {
+					var valid bool
+					status, valid = statusRaw.(string)
+					if !valid {
+						return NetworkProbe{}, errors.New("functional probe status representation is invalid")
+					}
+				}
+				paths = append(paths, NetworkProbePath{NodeUID: uid, Scope: scope, Protocol: protocol, StatusPresent: present, Status: status, LastProbed: text(path["lastProbed"])})
+			}
+		}
+	}
+	sort.Slice(paths, func(left, right int) bool {
+		leftKey := paths[left].NodeUID + paths[left].Scope + paths[left].Protocol
+		rightKey := paths[right].NodeUID + paths[right].Scope + paths[right].Protocol
+		return leftKey < rightKey
+	})
+	return NetworkProbe{ResponseTimestamp: text(value["timestamp"]), ProbeIntervalMilliseconds: interval.Milliseconds(), Paths: paths}, nil
+}
+
+func normalizeSourceConditions(status map[string]any) ([]NetworkSourceCondition, error) {
+	items, err := requiredObjectSlice(status, "conditions", 16)
+	if err != nil {
+		return nil, errors.New("add-on source Conditions are invalid")
+	}
+	result := make([]NetworkSourceCondition, 0, len(items))
+	for _, item := range items {
+		result = append(result, NetworkSourceCondition{Type: text(item["type"]), Status: text(item["status"]), ObservedGeneration: integer(item["observedGeneration"])})
+	}
+	sort.Slice(result, func(left, right int) bool { return result[left].Type < result[right].Type })
+	return result, nil
+}
+
+func exactNodeConditions(status map[string]any) (map[string]any, map[string]any, error) {
+	var ready, network map[string]any
+	items, err := requiredObjectSlice(status, "conditions", 64)
+	if err != nil {
+		return nil, nil, errors.New("Node Conditions are invalid")
+	}
+	for _, item := range items {
+		switch text(item["type"]) {
+		case "Ready":
+			if ready != nil {
+				return nil, nil, errors.New("Node Ready Condition is duplicated")
+			}
+			ready = item
+		case "NetworkUnavailable":
+			if network != nil {
+				return nil, nil, errors.New("Node NetworkUnavailable Condition is duplicated")
+			}
+			network = item
+		}
+	}
+	if ready == nil || network == nil {
+		return nil, nil, errors.New("Node network Conditions are incomplete")
+	}
+	return ready, network, nil
+}
+
+func controllerOwnerUID(metadata map[string]any, kind, name string) (string, error) {
+	owners, err := requiredObjectSlice(metadata, "ownerReferences", 16)
+	if err != nil {
+		return "", errors.New("HRP owner references are invalid")
+	}
+	var uid string
+	for _, owner := range owners {
+		controller, _ := owner["controller"].(bool)
+		if controller && text(owner["kind"]) == kind && text(owner["name"]) == name {
+			if uid != "" {
+				return "", errors.New("HRP controller owner is ambiguous")
+			}
+			uid = text(owner["uid"])
+		}
+	}
+	return uid, nil
+}
+
+func containerImage(containers []map[string]any, name string) string {
+	var image string
+	for _, container := range containers {
+		if text(container["name"]) == name {
+			if image != "" {
+				return ""
+			}
+			image = text(container["image"])
+		}
+	}
+	return image
+}
+
+func objectMap(parent map[string]any, key string) (map[string]any, error) {
+	value, ok := parent[key].(map[string]any)
+	if !ok {
+		return map[string]any{}, fmt.Errorf("%s is not an object", key)
+	}
+	return value, nil
+}
+
+func requiredObjectSlice(parent map[string]any, key string, maximum int) ([]map[string]any, error) {
+	raw, ok := parent[key].([]any)
+	if !ok || len(raw) > maximum {
+		return nil, fmt.Errorf("%s is not a bounded array", key)
+	}
+	result := make([]map[string]any, 0, len(raw))
+	for _, item := range raw {
+		object, ok := item.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("%s contains a non-object item", key)
+		}
+		result = append(result, object)
+	}
+	return result, nil
+}
+
+func textMap(parent map[string]any, key string) string { return text(parent[key]) }
+
+func text(value any) string {
+	result, _ := value.(string)
+	return result
+}
+
+func integer(value any) int64 {
+	number, ok := value.(json.Number)
+	if !ok {
+		return 0
+	}
+	result, _ := number.Int64()
+	return result
+}

--- a/internal/observation/network_collector_test.go
+++ b/internal/observation/network_collector_test.go
@@ -1,0 +1,281 @@
+package observation
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNetworkSourceCollectorUsesOnlyBoundedSources(t *testing.T) {
+	policy, profile, management, workload, probe := collectorFixture(t)
+	collector, err := NewNetworkSourceCollector(management, workload, probe, NetworkCollectorConfig{
+		Namespace: "disposable-ok141", Name: "disposable-ok141", HCPName: "disposable-ok141-cilium",
+		Clock: func() time.Time { return time.Date(2026, 8, 16, 10, 0, 0, 0, time.UTC) },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	evidence, err := collector.Observe(context.Background(), policy, profile)
+	if err != nil || evidence.Status != "True" || evidence.Reason != "NetworkReady" {
+		t.Fatalf("unexpected collected evidence: %#v %v", evidence, err)
+	}
+	wantManagement := []string{
+		"/apis/addons.cluster.x-k8s.io/v1alpha1/namespaces/disposable-ok141/helmchartproxies/disposable-ok141-cilium",
+		"/apis/addons.cluster.x-k8s.io/v1alpha1/namespaces/disposable-ok141/helmreleaseproxies?labelSelector=cluster.x-k8s.io%2Fcluster-name%3Ddisposable-ok141%2Chelmreleaseproxy.addons.cluster.x-k8s.io%2Fhelmchartproxy-name%3Ddisposable-ok141-cilium",
+	}
+	wantWorkload := []string{
+		"/api/v1/nodes",
+		"/apis/apps/v1/namespaces/kube-system/daemonsets/cilium",
+		"/apis/apps/v1/namespaces/kube-system/daemonsets/cilium-envoy",
+		"/apis/apps/v1/namespaces/kube-system/deployments/cilium-operator",
+		"/api/v1/namespaces/kube-system/pods?labelSelector=k8s-app%3Dcilium",
+	}
+	if !reflect.DeepEqual(management.requests, wantManagement) || !reflect.DeepEqual(workload.requests, wantWorkload) {
+		t.Fatalf("collector query boundary differs:\nmanagement=%#v\nworkload=%#v", management.requests, workload.requests)
+	}
+	if probe.calls != 1 || probe.podName != "cilium-a" || probe.podUID != "pod-uid-1" {
+		t.Fatalf("fixed probe boundary differs: %#v", probe)
+	}
+}
+
+func TestNetworkSourceCollectorNormalizesOrderDeterministically(t *testing.T) {
+	policy, profile, management, workload, probe := collectorFixture(t)
+	collector := mustNetworkCollector(t, management, workload, probe)
+	first, err := collector.Observe(context.Background(), policy, profile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	reverseList(t, workload.responses["/api/v1/nodes"])
+	reverseList(t, workload.responses["/api/v1/namespaces/kube-system/pods?labelSelector=k8s-app%3Dcilium"])
+	reverseList(t, probe.response)
+	second, err := collector.Observe(context.Background(), policy, profile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.EvidenceDigest != second.EvidenceDigest || first.SourceUID != second.SourceUID {
+		t.Fatalf("source ordering changed evidence identity: %#v %#v", first, second)
+	}
+}
+
+func TestNetworkSourceCollectorFailsClosed(t *testing.T) {
+	for name, mutate := range map[string]func(*fakeNetworkGetter, *fakeNetworkGetter, *fakeFixedProbe){
+		"foreign HCP": func(management, _ *fakeNetworkGetter, _ *fakeFixedProbe) {
+			management.responses[managementPathHCP] = mutateJSON(t, management.responses[managementPathHCP], func(value map[string]any) {
+				value["metadata"].(map[string]any)["name"] = "other"
+			})
+		},
+		"malformed Node condition": func(_ *fakeNetworkGetter, workload *fakeNetworkGetter, _ *fakeFixedProbe) {
+			workload.responses["/api/v1/nodes"] = mutateJSON(t, workload.responses["/api/v1/nodes"], func(value map[string]any) {
+				node := value["items"].([]any)[0].(map[string]any)
+				conditions := node["status"].(map[string]any)["conditions"].([]any)
+				node["status"].(map[string]any)["conditions"] = conditions[:1]
+			})
+		},
+		"foreign probe Node": func(_ *fakeNetworkGetter, _ *fakeNetworkGetter, probe *fakeFixedProbe) {
+			probe.response = mutateJSON(t, probe.response, func(value map[string]any) {
+				value["nodes"].([]any)[0].(map[string]any)["name"] = "foreign"
+			})
+		},
+		"invalid probe status representation": func(_ *fakeNetworkGetter, _ *fakeNetworkGetter, probe *fakeFixedProbe) {
+			probe.response = mutateJSON(t, probe.response, func(value map[string]any) {
+				node := value["nodes"].([]any)[0].(map[string]any)
+				path := node["host"].(map[string]any)["primary-address"].(map[string]any)["http"].(map[string]any)
+				path["status"] = nil
+			})
+		},
+		"ambiguous HRP collection": func(management, _ *fakeNetworkGetter, _ *fakeFixedProbe) {
+			path := "/apis/addons.cluster.x-k8s.io/v1alpha1/namespaces/disposable-ok141/helmreleaseproxies?labelSelector=cluster.x-k8s.io%2Fcluster-name%3Ddisposable-ok141%2Chelmreleaseproxy.addons.cluster.x-k8s.io%2Fhelmchartproxy-name%3Ddisposable-ok141-cilium"
+			management.responses[path] = mutateJSON(t, management.responses[path], func(value map[string]any) {
+				value["items"] = append(value["items"].([]any), "malformed")
+			})
+		},
+		"trailing probe JSON": func(_ *fakeNetworkGetter, _ *fakeNetworkGetter, probe *fakeFixedProbe) {
+			probe.response = append(probe.response, []byte(` {"unexpected":true}`)...)
+		},
+		"source transport error": func(management, _ *fakeNetworkGetter, _ *fakeFixedProbe) {
+			management.errors = map[string]error{managementPathHCP: errors.New("https://sensitive-endpoint:6443/token")}
+		},
+		"probe execution error": func(_ *fakeNetworkGetter, _ *fakeNetworkGetter, probe *fakeFixedProbe) {
+			probe.err = errors.New("sensitive raw failure")
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			policy, profile, management, workload, probe := collectorFixture(t)
+			mutate(management, workload, probe)
+			collector := mustNetworkCollector(t, management, workload, probe)
+			if _, err := collector.Observe(context.Background(), policy, profile); err == nil {
+				t.Fatal("malformed or foreign network source accepted")
+			} else if (name == "probe execution error" || name == "source transport error") && strings.Contains(err.Error(), "sensitive") {
+				t.Fatalf("raw source error leaked: %v", err)
+			}
+		})
+	}
+}
+
+const managementPathHCP = "/apis/addons.cluster.x-k8s.io/v1alpha1/namespaces/disposable-ok141/helmchartproxies/disposable-ok141-cilium"
+
+type fakeNetworkGetter struct {
+	responses map[string][]byte
+	errors    map[string]error
+	requests  []string
+}
+
+func (getter *fakeNetworkGetter) Get(_ context.Context, path string) ([]byte, error) {
+	getter.requests = append(getter.requests, path)
+	if err := getter.errors[path]; err != nil {
+		return nil, err
+	}
+	raw, ok := getter.responses[path]
+	if !ok {
+		return nil, errors.New("unexpected bounded GET")
+	}
+	return append([]byte(nil), raw...), nil
+}
+
+type fakeFixedProbe struct {
+	response []byte
+	err      error
+	calls    int
+	podName  string
+	podUID   string
+}
+
+func (probe *fakeFixedProbe) Probe(_ context.Context, name, uid string) ([]byte, error) {
+	probe.calls++
+	probe.podName, probe.podUID = name, uid
+	return append([]byte(nil), probe.response...), probe.err
+}
+
+func collectorFixture(t *testing.T) (Policy, NetworkProfile, *fakeNetworkGetter, *fakeNetworkGetter, *fakeFixedProbe) {
+	t.Helper()
+	policy, profile, _ := validNetworkFixture(t)
+	namespace, cluster, hcpName := "disposable-ok141", "disposable-ok141", "disposable-ok141-cilium"
+	hcpSpec := map[string]any{
+		"chartName": "cilium", "repoURL": "oci://quay.io/cilium/charts", "version": "1.19.6",
+		"releaseName": "cilium", "namespace": "kube-system", "reconcileStrategy": "Continuous",
+		"valuesTemplate": "pinned-values", "options": map[string]any{"wait": true},
+	}
+	hrpSpec := map[string]any{
+		"chartName": "cilium", "repoURL": "oci://quay.io/cilium/charts", "version": "1.19.6",
+		"releaseName": "cilium", "namespace": "kube-system", "reconcileStrategy": "Continuous", "values": "pinned-values",
+		"clusterRef": map[string]any{"apiVersion": "cluster.x-k8s.io/v1beta2", "kind": "Cluster", "namespace": namespace, "name": cluster},
+	}
+	profile.ExpectedHCPSpecDigest, _ = addonSpecDigest(hcpSpec, false)
+	profile.ExpectedHRPSpecDigest, _ = addonSpecDigest(hrpSpec, true)
+	condition := func(kind string) map[string]any {
+		return map[string]any{"type": kind, "status": "True", "observedGeneration": 4}
+	}
+	hcp := map[string]any{
+		"apiVersion": "addons.cluster.x-k8s.io/v1alpha1", "kind": "HelmChartProxy",
+		"metadata": map[string]any{"name": hcpName, "namespace": namespace, "uid": "hcp-uid-1", "generation": 4,
+			"annotations": map[string]any{"openkubes.io/intent-revision": policy.IntentRevision, "openkubes.io/enablement-revision": policy.EnablementRevision}},
+		"spec": hcpSpec,
+		"status": map[string]any{"observedGeneration": 4, "matchingClusters": []any{map[string]any{"namespace": namespace, "name": cluster}},
+			"conditions": []any{condition("Ready"), condition("HelmReleaseProxySpecsUpToDate"), condition("HelmReleaseProxiesReady")}},
+	}
+	hrp := map[string]any{
+		"apiVersion": "addons.cluster.x-k8s.io/v1alpha1", "kind": "HelmReleaseProxy",
+		"metadata": map[string]any{"name": "cilium-disposable-ok141-a", "namespace": namespace, "uid": "hrp-uid-1", "generation": 4,
+			"ownerReferences": []any{map[string]any{"kind": "HelmChartProxy", "name": hcpName, "uid": "hcp-uid-1", "controller": true}}},
+		"spec": hrpSpec,
+		"status": map[string]any{"observedGeneration": 4, "status": "deployed", "revision": 1,
+			"conditions": []any{condition("Ready"), condition("HelmReleaseReady")}},
+	}
+	node := func(name, uid string) map[string]any {
+		return map[string]any{"apiVersion": "v1", "kind": "Node", "metadata": map[string]any{"name": name, "uid": uid},
+			"spec": map[string]any{"providerID": "provider://" + name}, "status": map[string]any{"conditions": []any{
+				map[string]any{"type": "Ready", "status": "True"}, map[string]any{"type": "NetworkUnavailable", "status": "False", "reason": "CiliumIsUp"},
+			}}}
+	}
+	component := func(kind, name, uid, container, image string, desired int) map[string]any {
+		status := map[string]any{"observedGeneration": 3, "desiredNumberScheduled": desired, "updatedNumberScheduled": desired, "numberAvailable": desired, "numberReady": desired}
+		spec := map[string]any{"template": map[string]any{"spec": map[string]any{"containers": []any{map[string]any{"name": container, "image": image}}}}}
+		if kind == "Deployment" {
+			spec["replicas"] = desired
+			status = map[string]any{"observedGeneration": 3, "updatedReplicas": desired, "availableReplicas": desired, "readyReplicas": desired}
+		}
+		return map[string]any{"apiVersion": "apps/v1", "kind": kind, "metadata": map[string]any{"name": name, "namespace": "kube-system", "uid": uid, "generation": 3}, "spec": spec, "status": status}
+	}
+	pod := func(name, uid, nodeName string) map[string]any {
+		return map[string]any{"apiVersion": "v1", "kind": "Pod", "metadata": map[string]any{"name": name, "namespace": "kube-system", "uid": uid},
+			"spec": map[string]any{"nodeName": nodeName}, "status": map[string]any{"phase": "Running", "containerStatuses": []any{map[string]any{"name": "cilium-agent", "ready": true}}}}
+	}
+	management := &fakeNetworkGetter{responses: map[string][]byte{
+		managementPathHCP: jsonBytes(t, hcp),
+		"/apis/addons.cluster.x-k8s.io/v1alpha1/namespaces/disposable-ok141/helmreleaseproxies?labelSelector=cluster.x-k8s.io%2Fcluster-name%3Ddisposable-ok141%2Chelmreleaseproxy.addons.cluster.x-k8s.io%2Fhelmchartproxy-name%3Ddisposable-ok141-cilium": jsonBytes(t, map[string]any{"apiVersion": "addons.cluster.x-k8s.io/v1alpha1", "kind": "HelmReleaseProxyList", "items": []any{hrp}}),
+	}}
+	workload := &fakeNetworkGetter{responses: map[string][]byte{
+		"/api/v1/nodes": jsonBytes(t, map[string]any{"apiVersion": "v1", "kind": "NodeList", "items": []any{node("node-b", "node-uid-2"), node("node-a", "node-uid-1")}}),
+		"/apis/apps/v1/namespaces/kube-system/daemonsets/cilium":             jsonBytes(t, component("DaemonSet", "cilium", "component-uid-1", "cilium-agent", profile.ExpectedImages.CiliumAgent, 2)),
+		"/apis/apps/v1/namespaces/kube-system/daemonsets/cilium-envoy":       jsonBytes(t, component("DaemonSet", "cilium-envoy", "component-uid-2", "cilium-envoy", profile.ExpectedImages.CiliumEnvoy, 2)),
+		"/apis/apps/v1/namespaces/kube-system/deployments/cilium-operator":   jsonBytes(t, component("Deployment", "cilium-operator", "component-uid-3", "cilium-operator", profile.ExpectedImages.CiliumOperator, 1)),
+		"/api/v1/namespaces/kube-system/pods?labelSelector=k8s-app%3Dcilium": jsonBytes(t, map[string]any{"apiVersion": "v1", "kind": "PodList", "items": []any{pod("cilium-b", "pod-uid-2", "node-b"), pod("cilium-a", "pod-uid-1", "node-a")}}),
+	}}
+	path := func() map[string]any { return map[string]any{"lastProbed": "2026-08-16T09:57:00Z"} }
+	probeNode := func(name string) map[string]any {
+		return map[string]any{"name": name,
+			"host":            map[string]any{"primary-address": map[string]any{"http": path(), "icmp": path()}},
+			"health-endpoint": map[string]any{"primary-address": map[string]any{"http": path(), "icmp": path()}},
+		}
+	}
+	probe := &fakeFixedProbe{response: jsonBytes(t, map[string]any{"timestamp": "2026-08-16T09:59:00Z", "probeInterval": "1m36.566s", "nodes": []any{probeNode("node-b"), probeNode("node-a")}})}
+	return policy, profile, management, workload, probe
+}
+
+func mustNetworkCollector(t *testing.T, management, workload NetworkRawGetter, probe FixedCiliumProbe) *NetworkSourceCollector {
+	t.Helper()
+	collector, err := NewNetworkSourceCollector(management, workload, probe, NetworkCollectorConfig{
+		Namespace: "disposable-ok141", Name: "disposable-ok141", HCPName: "disposable-ok141-cilium",
+		Clock: func() time.Time { return time.Date(2026, 8, 16, 10, 0, 0, 0, time.UTC) },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return collector
+}
+
+func jsonBytes(t *testing.T, value any) []byte {
+	t.Helper()
+	raw, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return raw
+}
+
+func mutateJSON(t *testing.T, raw []byte, mutate func(map[string]any)) []byte {
+	t.Helper()
+	var value map[string]any
+	if err := json.Unmarshal(raw, &value); err != nil {
+		t.Fatal(err)
+	}
+	mutate(value)
+	return jsonBytes(t, value)
+}
+
+func reverseList(t *testing.T, raw []byte) {
+	t.Helper()
+	var value map[string]any
+	if err := json.Unmarshal(raw, &value); err != nil {
+		t.Fatal(err)
+	}
+	items := value["items"]
+	key := "items"
+	if items == nil {
+		items, key = value["nodes"], "nodes"
+	}
+	list := items.([]any)
+	for left, right := 0, len(list)-1; left < right; left, right = left+1, right-1 {
+		list[left], list[right] = list[right], list[left]
+	}
+	value[key] = list
+	updated := jsonBytes(t, value)
+	copy(raw, updated)
+	if len(updated) != len(raw) {
+		t.Fatalf("reordered fixture changed length: %d != %d", len(updated), len(raw))
+	}
+}

--- a/internal/observation/network_evaluator.go
+++ b/internal/observation/network_evaluator.go
@@ -62,6 +62,7 @@ type NetworkAddonSource struct {
 	EnablementRevision       string                   `json:"enablementRevision"`
 	OwnerUID                 string                   `json:"ownerUid,omitempty"`
 	TargetClusterUID         string                   `json:"targetClusterUid"`
+	TargetSelected           bool                     `json:"targetSelected"`
 	ReleaseStatus            string                   `json:"releaseStatus,omitempty"`
 	ReleaseRevision          int64                    `json:"releaseRevision,omitempty"`
 	Conditions               []NetworkSourceCondition `json:"conditions"`
@@ -259,7 +260,7 @@ func evaluateNetworkState(policy Policy, profile NetworkProfile, snapshot Networ
 }
 
 func evaluateAddonSource(source NetworkAddonSource, targetUID, ownerUID, specDigest string, policy Policy, required []string, reasonPrefix string) (string, string) {
-	if !validUID(source.UID) || source.SpecDigest != specDigest || source.IntentRevision != policy.IntentRevision || source.EnablementRevision != policy.EnablementRevision || source.TargetClusterUID != targetUID || source.OwnerUID != ownerUID {
+	if !validUID(source.UID) || source.SpecDigest != specDigest || source.IntentRevision != policy.IntentRevision || source.EnablementRevision != policy.EnablementRevision || source.TargetClusterUID != targetUID || !source.TargetSelected || source.OwnerUID != ownerUID {
 		return "False", reasonPrefix + "IdentityMismatch"
 	}
 	if source.Generation <= 0 || source.StatusObservedGeneration != source.Generation {

--- a/internal/observation/network_evaluator_test.go
+++ b/internal/observation/network_evaluator_test.go
@@ -45,6 +45,10 @@ func TestEvaluateNetworkSnapshotFailsClosed(t *testing.T) {
 			mutate: func(snapshot *NetworkSnapshot) { snapshot.HCP.SpecDigest = "sha256:" + strings.Repeat("f", 64) },
 			status: "False", reason: "EnablementOwnerIdentityMismatch",
 		},
+		"HCP target not selected": {
+			mutate: func(snapshot *NetworkSnapshot) { snapshot.HCP.TargetSelected = false },
+			status: "False", reason: "EnablementOwnerIdentityMismatch",
+		},
 		"multiple HRPs": {
 			mutate: func(snapshot *NetworkSnapshot) { snapshot.HRPCount = 2 },
 			status: "Unknown", reason: "EnablementReleaseNotReady",
@@ -167,13 +171,13 @@ func validNetworkFixture(t *testing.T) (Policy, NetworkProfile, NetworkSnapshot)
 	hcp := NetworkAddonSource{
 		UID: "hcp-uid-1", Generation: 4, StatusObservedGeneration: 4, SpecDigest: digestA,
 		IntentRevision: policy.IntentRevision, EnablementRevision: policy.EnablementRevision,
-		TargetClusterUID: policy.TargetClusterUID,
-		Conditions:       conditions("Ready", "HelmReleaseProxySpecsUpToDate", "HelmReleaseProxiesReady"),
+		TargetClusterUID: policy.TargetClusterUID, TargetSelected: true,
+		Conditions: conditions("Ready", "HelmReleaseProxySpecsUpToDate", "HelmReleaseProxiesReady"),
 	}
 	hrp := NetworkAddonSource{
 		UID: "hrp-uid-1", Generation: 4, StatusObservedGeneration: 4, SpecDigest: digestB,
 		IntentRevision: policy.IntentRevision, EnablementRevision: policy.EnablementRevision,
-		OwnerUID: hcp.UID, TargetClusterUID: policy.TargetClusterUID,
+		OwnerUID: hcp.UID, TargetClusterUID: policy.TargetClusterUID, TargetSelected: true,
 		ReleaseStatus: "deployed", ReleaseRevision: 1,
 		Conditions: conditions("Ready", "HelmReleaseReady"),
 	}


### PR DESCRIPTION
## What changed

- add a bounded management/workload source collector for the merged `NetworkReady` evaluator
- normalize exact HCP/HRP, Node, Cilium rollout, agent Pod, and fixed functional-probe sources
- bind explicit target-selection evidence and reject malformed or ambiguous list members
- sort collection inputs before digesting and redact raw transport/probe failures
- document the collector's exact query and command boundary

## Why

OK-147 needs an executable path from authoritative Kubernetes sources to deterministic `NetworkReady` evidence without introducing a lifecycle controller or an arbitrary client/command surface.

## Boundary

This is an offline checkpoint only. It adds no credential materialization, TLS/token adapter, Secret read, live cluster contact, polling, CLI/Job wiring, mutation, retry, repair, or status publication.

## Validation

- `go test ./...`
- `go test -race -ldflags=-linkmode=external ./internal/observation ./internal/execution`
- `go vet ./...`
- OK-141 infra secret-reference test: PASS
- OK-147 runner image tests: 6 PASS
- OK-147 runner publication tests: 5 PASS
- `git diff --check`
