### PR TITLE
OK-147: Bind NetworkReady Kubernetes adapters

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -480,13 +480,33 @@ digesting them, rejects malformed or ambiguous list members, verifies exact
 object/owner/target selection, and discards raw transport errors and probe
 output after normalization.
 
-This remains an offline boundary: fake clients exercise the complete collector
-and evaluator path, while credential materialization, TLS/token HTTP adapters,
-Secret reads, cluster contact, polling, CLI/Job wiring, and mutation remain out
-of scope. A later adapter must bind the management reader to the management
-authority and the workload reader/probe to the already verified immutable
-target Cluster UID. The collector does not infer that authority from reusable
-names or API endpoints.
+At that checkpoint, fake clients exercised the complete collector and evaluator
+path, while credential materialization, TLS/token HTTP adapters, Secret reads,
+cluster contact, polling, CLI/Job wiring, and mutation remained out of scope.
+The collector itself does not infer authority from reusable names or API
+endpoints.
+
+The next adapter checkpoint establishes that authority boundary without making
+a live request. It materializes separate TLS-only, redirect-denying clients
+from distinct projected management and workload tokens. The management client
+accepts only the two HCP/HRP paths; the workload client accepts only the five
+runtime paths above. Equal endpoints, equal token contents, a management-plane
+identity mismatch, a runtime Cluster UID mismatch, and every non-allowlisted
+path fail before source data can be accepted. Raw transport failures are never
+returned to the evidence layer.
+
+The functional probe is also bound at the type boundary to exactly:
+
+```text
+cilium-health status --probe --output json
+```
+
+It carries the selected Pod name and UID plus the fixed `kube-system` namespace
+and `cilium-agent` container to a narrow Pod-exec transport. The concrete
+WebSocket/SPDY transport must still verify the Pod UID immediately before exec;
+that transport and any live cluster contact remain a later checkpoint. No
+shell, `kubectl`, arbitrary command arguments, mutation, polling, CLI/Job
+wiring, or status publication is introduced here.
 
 ## OK-141 compatibility evidence
 

--- a/internal/observation/network_collector.go
+++ b/internal/observation/network_collector.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net/url"
 	"sort"
 	"time"
 )
@@ -27,10 +26,11 @@ type FixedCiliumProbe interface {
 }
 
 type NetworkCollectorConfig struct {
-	Namespace string
-	Name      string
-	HCPName   string
-	Clock     func() time.Time
+	Namespace        string
+	Name             string
+	HCPName          string
+	TargetClusterUID string
+	Clock            func() time.Time
 }
 
 // NetworkSourceCollector performs one bounded source collection. It has no
@@ -49,6 +49,9 @@ func NewNetworkSourceCollector(management, workload NetworkRawGetter, probe Fixe
 	}
 	if !validDNSLabel(config.Namespace) || !validDNSLabel(config.Name) || !validDNSLabel(config.HCPName) {
 		return nil, errors.New("network collector object identity is invalid")
+	}
+	if !validUID(config.TargetClusterUID) {
+		return nil, errors.New("network collector target Cluster UID is invalid")
 	}
 	return &NetworkSourceCollector{management: management, workload: workload, probe: probe, config: config}, nil
 }
@@ -69,10 +72,11 @@ func (collector *NetworkSourceCollector) Collect(ctx context.Context, policy Pol
 	if err := validatePolicy(policy, true); err != nil {
 		return NetworkSnapshot{}, err
 	}
+	if policy.TargetClusterUID != collector.config.TargetClusterUID {
+		return NetworkSnapshot{}, errors.New("network collector authority differs from the runtime-bound target Cluster")
+	}
 	namespace, name, hcpName := collector.config.Namespace, collector.config.Name, collector.config.HCPName
-	hcpPath := "/apis/addons.cluster.x-k8s.io/v1alpha1/namespaces/" + namespace + "/helmchartproxies/" + hcpName
-	selector := "cluster.x-k8s.io/cluster-name=" + name + ",helmreleaseproxy.addons.cluster.x-k8s.io/helmchartproxy-name=" + hcpName
-	hrpPath := "/apis/addons.cluster.x-k8s.io/v1alpha1/namespaces/" + namespace + "/helmreleaseproxies?labelSelector=" + url.QueryEscape(selector)
+	hcpPath, hrpPath := managementNetworkPaths(namespace, name, hcpName)
 
 	hcpObject, err := getNetworkObject(ctx, collector.management, hcpPath)
 	if err != nil {

--- a/internal/observation/network_collector_test.go
+++ b/internal/observation/network_collector_test.go
@@ -13,7 +13,7 @@ import (
 func TestNetworkSourceCollectorUsesOnlyBoundedSources(t *testing.T) {
 	policy, profile, management, workload, probe := collectorFixture(t)
 	collector, err := NewNetworkSourceCollector(management, workload, probe, NetworkCollectorConfig{
-		Namespace: "disposable-ok141", Name: "disposable-ok141", HCPName: "disposable-ok141-cilium",
+		Namespace: "disposable-ok141", Name: "disposable-ok141", HCPName: "disposable-ok141-cilium", TargetClusterUID: policy.TargetClusterUID,
 		Clock: func() time.Time { return time.Date(2026, 8, 16, 10, 0, 0, 0, time.UTC) },
 	})
 	if err != nil {
@@ -44,7 +44,7 @@ func TestNetworkSourceCollectorUsesOnlyBoundedSources(t *testing.T) {
 
 func TestNetworkSourceCollectorNormalizesOrderDeterministically(t *testing.T) {
 	policy, profile, management, workload, probe := collectorFixture(t)
-	collector := mustNetworkCollector(t, management, workload, probe)
+	collector := mustNetworkCollector(t, policy, management, workload, probe)
 	first, err := collector.Observe(context.Background(), policy, profile)
 	if err != nil {
 		t.Fatal(err)
@@ -58,6 +58,18 @@ func TestNetworkSourceCollectorNormalizesOrderDeterministically(t *testing.T) {
 	}
 	if first.EvidenceDigest != second.EvidenceDigest || first.SourceUID != second.SourceUID {
 		t.Fatalf("source ordering changed evidence identity: %#v %#v", first, second)
+	}
+}
+
+func TestNetworkSourceCollectorRejectsDifferentRuntimeAuthorityBeforeReads(t *testing.T) {
+	policy, _, management, workload, probe := collectorFixture(t)
+	collector := mustNetworkCollector(t, policy, management, workload, probe)
+	policy.TargetClusterUID = "different-runtime-cluster-uid"
+	if _, err := collector.Collect(context.Background(), policy); err == nil {
+		t.Fatal("collector accepted a policy for a different runtime authority")
+	}
+	if len(management.requests) != 0 || len(workload.requests) != 0 || probe.calls != 0 {
+		t.Fatal("authority mismatch reached a network source")
 	}
 }
 
@@ -106,7 +118,7 @@ func TestNetworkSourceCollectorFailsClosed(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			policy, profile, management, workload, probe := collectorFixture(t)
 			mutate(management, workload, probe)
-			collector := mustNetworkCollector(t, management, workload, probe)
+			collector := mustNetworkCollector(t, policy, management, workload, probe)
 			if _, err := collector.Observe(context.Background(), policy, profile); err == nil {
 				t.Fatal("malformed or foreign network source accepted")
 			} else if (name == "probe execution error" || name == "source transport error") && strings.Contains(err.Error(), "sensitive") {
@@ -226,10 +238,10 @@ func collectorFixture(t *testing.T) (Policy, NetworkProfile, *fakeNetworkGetter,
 	return policy, profile, management, workload, probe
 }
 
-func mustNetworkCollector(t *testing.T, management, workload NetworkRawGetter, probe FixedCiliumProbe) *NetworkSourceCollector {
+func mustNetworkCollector(t *testing.T, policy Policy, management, workload NetworkRawGetter, probe FixedCiliumProbe) *NetworkSourceCollector {
 	t.Helper()
 	collector, err := NewNetworkSourceCollector(management, workload, probe, NetworkCollectorConfig{
-		Namespace: "disposable-ok141", Name: "disposable-ok141", HCPName: "disposable-ok141-cilium",
+		Namespace: "disposable-ok141", Name: "disposable-ok141", HCPName: "disposable-ok141-cilium", TargetClusterUID: policy.TargetClusterUID,
 		Clock: func() time.Time { return time.Date(2026, 8, 16, 10, 0, 0, 0, time.UTC) },
 	})
 	if err != nil {

--- a/internal/observation/network_kubernetes.go
+++ b/internal/observation/network_kubernetes.go
@@ -1,0 +1,174 @@
+package observation
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// KubernetesNetworkReaderConfig binds one bearer credential and one explicitly
+// configured TLS client to one Kubernetes API endpoint. The plane-specific
+// constructors derive their request allowlists internally.
+type KubernetesNetworkReaderConfig struct {
+	Endpoint    string
+	BearerToken string
+	Client      *http.Client
+}
+
+// KubernetesNetworkReader implements NetworkRawGetter without exposing
+// discovery, arbitrary list paths, watch, mutation, retry, or redirects.
+type KubernetesNetworkReader struct {
+	endpoint *url.URL
+	token    string
+	client   *http.Client
+	allowed  map[string]struct{}
+}
+
+func NewKubernetesManagementNetworkReader(config KubernetesNetworkReaderConfig, namespace, name, hcpName string) (*KubernetesNetworkReader, error) {
+	if !validDNSLabel(namespace) || !validDNSLabel(name) || !validDNSLabel(hcpName) {
+		return nil, errors.New("management network reader object identity is invalid")
+	}
+	hcpPath, hrpPath := managementNetworkPaths(namespace, name, hcpName)
+	return newKubernetesNetworkReader(config, []string{hcpPath, hrpPath})
+}
+
+func NewKubernetesWorkloadNetworkReader(config KubernetesNetworkReaderConfig) (*KubernetesNetworkReader, error) {
+	return newKubernetesNetworkReader(config, workloadNetworkPaths())
+}
+
+func newKubernetesNetworkReader(config KubernetesNetworkReaderConfig, allowed []string) (*KubernetesNetworkReader, error) {
+	endpoint, err := url.Parse(config.Endpoint)
+	if err != nil || endpoint.Host == "" || endpoint.User != nil || endpoint.RawQuery != "" || endpoint.Fragment != "" {
+		return nil, errors.New("network reader Kubernetes endpoint is invalid")
+	}
+	if endpoint.Path != "" && endpoint.Path != "/" {
+		return nil, errors.New("network reader Kubernetes endpoint must not contain a path")
+	}
+	host := endpoint.Hostname()
+	if endpoint.Scheme != "https" && !(endpoint.Scheme == "http" && (host == "127.0.0.1" || host == "::1" || host == "localhost")) {
+		return nil, errors.New("network reader Kubernetes endpoint must use HTTPS")
+	}
+	if config.BearerToken == "" || strings.TrimSpace(config.BearerToken) != config.BearerToken || strings.ContainsAny(config.BearerToken, "\r\n") {
+		return nil, errors.New("network reader Kubernetes bearer token is invalid")
+	}
+	if config.Client == nil {
+		return nil, errors.New("network reader requires an explicitly configured HTTP client")
+	}
+	paths := make(map[string]struct{}, len(allowed))
+	for _, path := range allowed {
+		if _, duplicate := paths[path]; duplicate {
+			return nil, errors.New("network reader allowlist contains a duplicate path")
+		}
+		paths[path] = struct{}{}
+	}
+	client := *config.Client
+	client.CheckRedirect = func(_ *http.Request, _ []*http.Request) error { return http.ErrUseLastResponse }
+	if client.Timeout == 0 {
+		client.Timeout = 15 * time.Second
+	}
+	endpoint.Path, endpoint.RawPath = "", ""
+	return &KubernetesNetworkReader{endpoint: endpoint, token: config.BearerToken, client: &client, allowed: paths}, nil
+}
+
+func (reader *KubernetesNetworkReader) Get(ctx context.Context, path string) ([]byte, error) {
+	if _, allowed := reader.allowed[path]; !allowed {
+		return nil, errors.New("network reader path is outside the fixed allowlist")
+	}
+	reference, err := url.ParseRequestURI(path)
+	if err != nil || reference.IsAbs() || reference.Host != "" || !strings.HasPrefix(reference.Path, "/") {
+		return nil, errors.New("network reader allowlisted path is invalid")
+	}
+	endpoint := *reader.endpoint
+	endpoint.Path, endpoint.RawPath, endpoint.RawQuery = reference.Path, reference.RawPath, reference.RawQuery
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint.String(), nil)
+	if err != nil {
+		return nil, errors.New("construct bounded network source request")
+	}
+	request.Header.Set("Accept", "application/json")
+	request.Header.Set("Authorization", "Bearer "+reader.token)
+	response, err := reader.client.Do(request)
+	if err != nil {
+		return nil, errors.New("bounded network source request failed")
+	}
+	defer response.Body.Close()
+	raw, readErr := io.ReadAll(io.LimitReader(response.Body, maximumNetworkSourceBytes+1))
+	if readErr != nil || len(raw) > maximumNetworkSourceBytes {
+		return nil, errors.New("bounded network source response exceeds accepted size")
+	}
+	if response.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("bounded network source request returned HTTP %d", response.StatusCode)
+	}
+	mediaType, _, err := mime.ParseMediaType(response.Header.Get("Content-Type"))
+	if err != nil || mediaType != "application/json" {
+		return nil, errors.New("bounded network source response is not JSON")
+	}
+	return raw, nil
+}
+
+// CiliumProbeExecRequest is the complete immutable request accepted by the
+// low-level Kubernetes Pod-exec transport. The high-level probe constructs it;
+// callers cannot supply a command through FixedCiliumProbe.
+type CiliumProbeExecRequest struct {
+	Namespace string
+	PodName   string
+	PodUID    string
+	Container string
+	Command   [5]string
+}
+
+type CiliumProbePodExecutor interface {
+	Exec(context.Context, CiliumProbeExecRequest) ([]byte, error)
+}
+
+// KubernetesFixedCiliumProbe binds the only permitted command. The low-level
+// transport must verify the Pod UID immediately before opening its exec stream.
+type KubernetesFixedCiliumProbe struct {
+	executor CiliumProbePodExecutor
+}
+
+func NewKubernetesFixedCiliumProbe(executor CiliumProbePodExecutor) (*KubernetesFixedCiliumProbe, error) {
+	if executor == nil {
+		return nil, errors.New("fixed Cilium probe requires a Pod executor")
+	}
+	return &KubernetesFixedCiliumProbe{executor: executor}, nil
+}
+
+func (probe *KubernetesFixedCiliumProbe) Probe(ctx context.Context, podName, podUID string) ([]byte, error) {
+	if !validDNSLabel(podName) || !validUID(podUID) {
+		return nil, errors.New("fixed Cilium probe Pod identity is invalid")
+	}
+	raw, err := probe.executor.Exec(ctx, CiliumProbeExecRequest{
+		Namespace: "kube-system", PodName: podName, PodUID: podUID, Container: "cilium-agent",
+		Command: [5]string{"cilium-health", "status", "--probe", "--output", "json"},
+	})
+	if err != nil {
+		return nil, errors.New("fixed Cilium Pod exec failed")
+	}
+	if len(raw) == 0 || len(raw) > maximumNetworkSourceBytes {
+		return nil, errors.New("fixed Cilium Pod exec response size is invalid")
+	}
+	return append([]byte(nil), raw...), nil
+}
+
+func managementNetworkPaths(namespace, name, hcpName string) (string, string) {
+	hcpPath := "/apis/addons.cluster.x-k8s.io/v1alpha1/namespaces/" + namespace + "/helmchartproxies/" + hcpName
+	selector := "cluster.x-k8s.io/cluster-name=" + name + ",helmreleaseproxy.addons.cluster.x-k8s.io/helmchartproxy-name=" + hcpName
+	hrpPath := "/apis/addons.cluster.x-k8s.io/v1alpha1/namespaces/" + namespace + "/helmreleaseproxies?labelSelector=" + url.QueryEscape(selector)
+	return hcpPath, hrpPath
+}
+
+func workloadNetworkPaths() []string {
+	return []string{
+		"/api/v1/nodes",
+		"/apis/apps/v1/namespaces/kube-system/daemonsets/cilium",
+		"/apis/apps/v1/namespaces/kube-system/daemonsets/cilium-envoy",
+		"/apis/apps/v1/namespaces/kube-system/deployments/cilium-operator",
+		"/api/v1/namespaces/kube-system/pods?labelSelector=k8s-app%3Dcilium",
+	}
+}

--- a/internal/observation/network_kubernetes_test.go
+++ b/internal/observation/network_kubernetes_test.go
@@ -1,0 +1,180 @@
+package observation
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestKubernetesManagementNetworkReaderUsesExactAllowlist(t *testing.T) {
+	wantHCP, wantHRP := managementNetworkPaths("disposable-ok141", "disposable-ok141", "disposable-ok141-cilium")
+	var requests []string
+	client := &http.Client{Transport: networkRoundTripFunc(func(request *http.Request) (*http.Response, error) {
+		requests = append(requests, request.URL.RequestURI())
+		if request.Method != http.MethodGet || request.Header.Get("Authorization") != "Bearer management-token" || request.Header.Get("Accept") != "application/json" {
+			t.Fatalf("unbounded management request: %s %#v", request.Method, request.Header)
+		}
+		return networkJSONResponse(http.StatusOK, `{}`), nil
+	})}
+	reader, err := NewKubernetesManagementNetworkReader(KubernetesNetworkReaderConfig{
+		Endpoint: "http://127.0.0.1:12345", BearerToken: "management-token", Client: client,
+	}, "disposable-ok141", "disposable-ok141", "disposable-ok141-cilium")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, path := range []string{wantHCP, wantHRP} {
+		if _, err := reader.Get(context.Background(), path); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := reader.Get(context.Background(), "/api/v1/nodes"); err == nil {
+		t.Fatal("management reader accepted a workload or arbitrary path")
+	}
+	if !reflect.DeepEqual(requests, []string{wantHCP, wantHRP}) {
+		t.Fatalf("management request boundary differs: %#v", requests)
+	}
+}
+
+func TestKubernetesWorkloadNetworkReaderUsesExactAllowlist(t *testing.T) {
+	var requests []string
+	client := &http.Client{Transport: networkRoundTripFunc(func(request *http.Request) (*http.Response, error) {
+		requests = append(requests, request.URL.RequestURI())
+		if request.Header.Get("Authorization") != "Bearer workload-token" {
+			t.Fatal("workload credential was not isolated")
+		}
+		return networkJSONResponse(http.StatusOK, `{}`), nil
+	})}
+	reader, err := NewKubernetesWorkloadNetworkReader(KubernetesNetworkReaderConfig{
+		Endpoint: "http://127.0.0.1:23456", BearerToken: "workload-token", Client: client,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := workloadNetworkPaths()
+	for _, path := range want {
+		if _, err := reader.Get(context.Background(), path); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := reader.Get(context.Background(), "/api/v1/secrets"); err == nil {
+		t.Fatal("workload reader accepted a Secret or arbitrary path")
+	}
+	if !reflect.DeepEqual(requests, want) {
+		t.Fatalf("workload request boundary differs: %#v", requests)
+	}
+}
+
+func TestKubernetesNetworkReaderFailsClosedAndRedacts(t *testing.T) {
+	for name, client := range map[string]*http.Client{
+		"transport error": {Transport: networkRoundTripFunc(func(*http.Request) (*http.Response, error) {
+			return nil, errors.New("sensitive endpoint and token")
+		})},
+		"redirect": {Transport: networkRoundTripFunc(func(*http.Request) (*http.Response, error) {
+			return networkJSONResponse(http.StatusTemporaryRedirect, `{}`), nil
+		})},
+		"non JSON": {Transport: networkRoundTripFunc(func(*http.Request) (*http.Response, error) {
+			response := networkJSONResponse(http.StatusOK, `{}`)
+			response.Header.Set("Content-Type", "text/plain")
+			return response, nil
+		})},
+		"oversized": {Transport: networkRoundTripFunc(func(*http.Request) (*http.Response, error) {
+			return networkJSONResponse(http.StatusOK, string(bytes.Repeat([]byte("x"), maximumNetworkSourceBytes+1))), nil
+		})},
+	} {
+		t.Run(name, func(t *testing.T) {
+			reader, err := NewKubernetesWorkloadNetworkReader(KubernetesNetworkReaderConfig{
+				Endpoint: "http://localhost:12345", BearerToken: "workload-token", Client: client,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := reader.Get(context.Background(), "/api/v1/nodes"); err == nil {
+				t.Fatal("unsafe network source response accepted")
+			} else if strings.Contains(err.Error(), "sensitive") {
+				t.Fatalf("raw transport error leaked: %v", err)
+			}
+		})
+	}
+
+	for name, config := range map[string]KubernetesNetworkReaderConfig{
+		"remote HTTP":    {Endpoint: "http://api.example.test", BearerToken: "token", Client: http.DefaultClient},
+		"endpoint path":  {Endpoint: "https://api.example.test/api", BearerToken: "token", Client: http.DefaultClient},
+		"token newline":  {Endpoint: "https://api.example.test", BearerToken: "token\n", Client: http.DefaultClient},
+		"missing client": {Endpoint: "https://api.example.test", BearerToken: "token"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := NewKubernetesWorkloadNetworkReader(config); err == nil {
+				t.Fatal("unsafe network reader configuration accepted")
+			}
+		})
+	}
+}
+
+func TestKubernetesFixedCiliumProbeBindsExactCommand(t *testing.T) {
+	executor := &fakeCiliumPodExecutor{response: []byte(`{"nodes":[]}`)}
+	probe, err := NewKubernetesFixedCiliumProbe(executor)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := probe.Probe(context.Background(), "cilium-abc12", "pod-uid-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := CiliumProbeExecRequest{
+		Namespace: "kube-system", PodName: "cilium-abc12", PodUID: "pod-uid-1", Container: "cilium-agent",
+		Command: [5]string{"cilium-health", "status", "--probe", "--output", "json"},
+	}
+	if executor.calls != 1 || executor.request != want || string(raw) != `{"nodes":[]}` {
+		t.Fatalf("fixed probe boundary differs: calls=%d request=%#v raw=%q", executor.calls, executor.request, raw)
+	}
+	raw[0] = 'x'
+	if executor.response[0] == 'x' {
+		t.Fatal("probe returned an alias of transport-owned memory")
+	}
+}
+
+func TestKubernetesFixedCiliumProbeFailsClosed(t *testing.T) {
+	if _, err := NewKubernetesFixedCiliumProbe(nil); err == nil {
+		t.Fatal("nil Pod executor accepted")
+	}
+	executor := &fakeCiliumPodExecutor{err: errors.New("sensitive exec details")}
+	probe, _ := NewKubernetesFixedCiliumProbe(executor)
+	if _, err := probe.Probe(context.Background(), "cilium-abc12", "pod-uid-1"); err == nil || strings.Contains(err.Error(), "sensitive") {
+		t.Fatalf("raw Pod exec error leaked or was accepted: %v", err)
+	}
+	if _, err := probe.Probe(context.Background(), "../pod", "pod-uid-1"); err == nil || executor.calls != 1 {
+		t.Fatal("invalid Pod identity reached the executor")
+	}
+}
+
+type fakeCiliumPodExecutor struct {
+	request  CiliumProbeExecRequest
+	response []byte
+	err      error
+	calls    int
+}
+
+func (executor *fakeCiliumPodExecutor) Exec(_ context.Context, request CiliumProbeExecRequest) ([]byte, error) {
+	executor.calls++
+	executor.request = request
+	return executor.response, executor.err
+}
+
+type networkRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (function networkRoundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return function(request)
+}
+
+func networkJSONResponse(status int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}

--- a/internal/runner/kubernetes.go
+++ b/internal/runner/kubernetes.go
@@ -4,6 +4,7 @@ package runner
 
 import (
 	"context"
+	"crypto/subtle"
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
@@ -42,6 +43,21 @@ type KubernetesAuthorityConfig struct {
 	AuthorityIdentity string
 	TokenFile         string
 	CAFile            string
+}
+
+// KubernetesNetworkObserverConfig binds distinct management and workload
+// credentials to one runtime Cluster UID. Pod exec remains a separately
+// supplied, fixed-command transport rather than an arbitrary shell surface.
+type KubernetesNetworkObserverConfig struct {
+	Management                  KubernetesAuthorityConfig
+	Workload                    KubernetesAuthorityConfig
+	ExpectedManagementAuthority string
+	TargetClusterUID            string
+	Namespace                   string
+	Name                        string
+	HCPName                     string
+	Clock                       func() time.Time
+	PodExecutor                 observation.CiliumProbePodExecutor
 }
 
 // InspectKubernetesLedger performs a read-only restart decision. It does not
@@ -106,6 +122,52 @@ func OpenKubernetesCAPILifecycleObserver(config KubernetesAuthorityConfig, expec
 	}
 	return observation.NewCAPILifecycleObserver(observation.CAPILifecycleObserverConfig{
 		Endpoint: config.Endpoint, BearerToken: token, Namespace: namespace, Name: name, Client: client,
+	})
+}
+
+// OpenKubernetesNetworkSourceCollector materializes two isolated TLS clients:
+// one for HCP/HRP reads on the management authority and one for runtime reads
+// on the immutable workload Cluster UID. It performs no API request itself.
+func OpenKubernetesNetworkSourceCollector(config KubernetesNetworkObserverConfig) (*observation.NetworkSourceCollector, error) {
+	if config.ExpectedManagementAuthority == "" || config.Management.AuthorityIdentity != config.ExpectedManagementAuthority {
+		return nil, errors.New("network observer management authority differs from the verified management plane")
+	}
+	if config.TargetClusterUID == "" || config.Workload.AuthorityIdentity != config.TargetClusterUID {
+		return nil, errors.New("network observer workload authority differs from the runtime-bound target Cluster")
+	}
+	if config.Management.Endpoint == config.Workload.Endpoint {
+		return nil, errors.New("network observer management and workload endpoints must be distinct")
+	}
+	managementToken, managementClient, err := openBoundedKubernetesHTTP(config.Management.TokenFile, config.Management.CAFile)
+	if err != nil {
+		return nil, errors.New("open bounded management network credential")
+	}
+	workloadToken, workloadClient, err := openBoundedKubernetesHTTP(config.Workload.TokenFile, config.Workload.CAFile)
+	if err != nil {
+		return nil, errors.New("open bounded workload network credential")
+	}
+	if len(managementToken) == len(workloadToken) && subtle.ConstantTimeCompare([]byte(managementToken), []byte(workloadToken)) == 1 {
+		return nil, errors.New("network observer management and workload credentials must be distinct")
+	}
+	management, err := observation.NewKubernetesManagementNetworkReader(observation.KubernetesNetworkReaderConfig{
+		Endpoint: config.Management.Endpoint, BearerToken: managementToken, Client: managementClient,
+	}, config.Namespace, config.Name, config.HCPName)
+	if err != nil {
+		return nil, err
+	}
+	workload, err := observation.NewKubernetesWorkloadNetworkReader(observation.KubernetesNetworkReaderConfig{
+		Endpoint: config.Workload.Endpoint, BearerToken: workloadToken, Client: workloadClient,
+	})
+	if err != nil {
+		return nil, err
+	}
+	probe, err := observation.NewKubernetesFixedCiliumProbe(config.PodExecutor)
+	if err != nil {
+		return nil, err
+	}
+	return observation.NewNetworkSourceCollector(management, workload, probe, observation.NetworkCollectorConfig{
+		Namespace: config.Namespace, Name: config.Name, HCPName: config.HCPName,
+		TargetClusterUID: config.TargetClusterUID, Clock: config.Clock,
 	})
 }
 

--- a/internal/runner/kubernetes_test.go
+++ b/internal/runner/kubernetes_test.go
@@ -1,6 +1,7 @@
 package runner
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -13,6 +14,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/openkubes/ok-cluster/internal/observation"
 )
 
 func TestOpenKubernetesLedgerValidatesProjectedInputs(t *testing.T) {
@@ -119,6 +122,70 @@ func TestOpenKubernetesCAPILifecycleObserverBindsManagementAuthority(t *testing.
 	if _, err := OpenKubernetesCAPILifecycleObserver(config, "ok-mgmt", "INVALID", "disposable-ok141"); err == nil || strings.Contains(err.Error(), root) {
 		t.Fatalf("unsafe target identity accepted or disclosed a path: %v", err)
 	}
+}
+
+func TestOpenKubernetesNetworkSourceCollectorBindsDistinctAuthorities(t *testing.T) {
+	root := t.TempDir()
+	managementToken := filepath.Join(root, "management-token")
+	workloadToken := filepath.Join(root, "workload-token")
+	caPath := filepath.Join(root, "ca.crt")
+	for path, value := range map[string][]byte{
+		managementToken: []byte("short-lived-management-token"),
+		workloadToken:   []byte("short-lived-workload-token"),
+		caPath:          testCA(t),
+	} {
+		if err := os.WriteFile(path, value, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	targetUID := "cluster-uid-disposable-ok141"
+	base := KubernetesNetworkObserverConfig{
+		Management: KubernetesAuthorityConfig{
+			Endpoint: "https://10.43.0.1:443", AuthorityIdentity: "ok-mgmt", TokenFile: managementToken, CAFile: caPath,
+		},
+		Workload: KubernetesAuthorityConfig{
+			Endpoint: "https://192.168.100.213:6443", AuthorityIdentity: targetUID, TokenFile: workloadToken, CAFile: caPath,
+		},
+		ExpectedManagementAuthority: "ok-mgmt", TargetClusterUID: targetUID,
+		Namespace: "disposable-ok141", Name: "disposable-ok141", HCPName: "disposable-ok141-cilium",
+		Clock:       func() time.Time { return time.Date(2026, 8, 16, 12, 0, 0, 0, time.UTC) },
+		PodExecutor: runnerProbeExecutor{},
+	}
+	if _, err := OpenKubernetesNetworkSourceCollector(base); err != nil {
+		t.Fatal(err)
+	}
+
+	for name, mutate := range map[string]func(*KubernetesNetworkObserverConfig){
+		"management authority": func(config *KubernetesNetworkObserverConfig) {
+			config.ExpectedManagementAuthority = "other"
+		},
+		"workload authority": func(config *KubernetesNetworkObserverConfig) {
+			config.Workload.AuthorityIdentity = "other-uid"
+		},
+		"shared endpoint": func(config *KubernetesNetworkObserverConfig) {
+			config.Workload.Endpoint = config.Management.Endpoint
+		},
+		"shared credential": func(config *KubernetesNetworkObserverConfig) {
+			config.Workload.TokenFile = config.Management.TokenFile
+		},
+		"missing executor": func(config *KubernetesNetworkObserverConfig) {
+			config.PodExecutor = nil
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			candidate := base
+			mutate(&candidate)
+			if _, err := OpenKubernetesNetworkSourceCollector(candidate); err == nil || strings.Contains(err.Error(), root) {
+				t.Fatalf("unsafe network authority configuration accepted or disclosed a path: %v", err)
+			}
+		})
+	}
+}
+
+type runnerProbeExecutor struct{}
+
+func (runnerProbeExecutor) Exec(context.Context, observation.CiliumProbeExecRequest) ([]byte, error) {
+	return []byte(`{"nodes":[]}`), nil
 }
 
 func testCA(t *testing.T) []byte {


### PR DESCRIPTION
## What changed

- add fixed-allowlist Kubernetes readers for the two HCP/HRP management sources and five workload runtime sources
- bind separate management and workload TLS/token clients to the verified management authority and runtime Cluster UID
- reject equal endpoints, equal credential contents, authority mismatches, redirects, non-JSON/oversized responses, and every non-allowlisted path
- bind the functional probe to exactly `cilium-health status --probe --output json`
- require the narrow Pod-exec transport to receive and re-verify the selected Pod UID
- make the NetworkReady collector reject a policy for any other runtime Cluster UID before source access

## Why

The merged NetworkReady collector still used fake source interfaces. This checkpoint establishes the credential, endpoint, path, target-identity, and fixed-command boundaries required before a live Kubernetes transport can safely be connected.

## Boundary

This remains offline. It adds no live cluster contact, Secret API read, WebSocket/SPDY implementation, polling, CLI/Job wiring, submission, mutation, retry, repair, or status publication. The concrete Pod-exec transport is intentionally deferred.

## Validation

- `go test ./...`
- `go test -race -ldflags=-linkmode=external ./internal/observation ./internal/runner ./internal/execution`
- `go vet ./...`
- OK-141 infra secret-reference test: PASS
- OK-147 runner image tests: 6 PASS
- OK-147 runner publication tests: 5 PASS
- `git diff --check`
