### PR TITLE
OK-147: Compose bounded observation sources

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -425,9 +425,9 @@ projection plan. Network and Platform evidence remain separate bounded source
 domains; this CAPI adapter does not infer either one.
 
 This checkpoint still does not wire the observer into the CLI or Job and does
-not contact a cluster. A later composition adapter must combine this exact CAPI
-evidence with separately verified Network and Platform evidence before the
-aggregate evaluator can produce lifecycle success.
+not contact a cluster. The later single-pass composition described below
+combines this exact CAPI evidence with separately verified Network and Platform
+evidence before the aggregate evaluator can produce lifecycle success.
 
 ## Deterministic NetworkReady source evaluation
 
@@ -522,8 +522,42 @@ races and bounded output failures.
 This checkpoint still introduces no shell, `kubectl`, arbitrary command
 arguments, mutation, polling, retry, CLI/Job wiring, status publication, or live
 cluster contact. The executor is constructed as part of the bounded Kubernetes
-Network source collector but remains unused until a later composition path
-explicitly invokes that collector.
+Network source collector and can be invoked only through the single-pass
+composition described next; no production command activates that path yet.
+
+## Single-pass aggregate source composition
+
+The next offline checkpoint implements the exact `Observer` shape required by
+the crash-safe execution operation. It composes three ownership domains without
+introducing a controller or persistent status surface:
+
+```text
+CAPI Cluster source                → InfrastructureReady + ControlPlaneAvailable
+bounded Network source + profile   → NetworkReady
+bounded Platform source            → PlatformReady
+                                      |
+                                      v
+                       deterministic aggregate evaluator
+                                      |
+                                      v
+                         one verified observation result
+```
+
+Only domains named by the Contract-derived required-condition policy are
+called. CAPI may emit only its two lifecycle statements, while the Network and
+Platform sources may each emit only their own statement. Cross-domain evidence
+is rejected before evaluation; duplicate CAPI authority is retained and becomes
+`Unknown/ConflictingAuthority` rather than being silently selected. Source
+failures are redacted and stop the already claimed execution path
+indeterminately, while valid `False` or `Unknown` evidence remains an explicit
+deterministic outcome.
+
+The composer performs exactly one pass in CAPI, Network, Platform order and
+then evaluates one ordered bundle at the injected clock time. It has no polling,
+retry, watch, mutation, repair, durable status publication or default source.
+The concrete GitOps/Platform source and the immutable Network-profile loader
+remain separate checkpoints. Consequently this composition is not yet wired to
+the CLI or Job and made no cluster contact.
 
 ## OK-141 compatibility evidence
 

--- a/internal/execution/execution_test.go
+++ b/internal/execution/execution_test.go
@@ -23,6 +23,8 @@ import (
 	"github.com/openkubes/ok-cluster/internal/submission"
 )
 
+var _ Observer = (*observation.AggregateObserver)(nil)
+
 func TestRunCompletesOnlyAfterCurrentReadyObservation(t *testing.T) {
 	fixture := executionFixture(t)
 	store, err := ledger.Open(filepath.Join(t.TempDir(), "ledger"))

--- a/internal/observation/aggregate_observer.go
+++ b/internal/observation/aggregate_observer.go
@@ -1,0 +1,115 @@
+package observation
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+// CAPIEvidenceSource owns only the two CAPI lifecycle statements.
+type CAPIEvidenceSource interface {
+	Collect(context.Context, Policy) ([]Evidence, error)
+}
+
+// NetworkEvidenceSource owns only the bounded NetworkReady statement.
+type NetworkEvidenceSource interface {
+	Observe(context.Context, Policy, NetworkProfile) (Evidence, error)
+}
+
+// PlatformEvidenceSource owns only the bounded PlatformReady statement. Its
+// concrete GitOps adapter remains a separate mechanism checkpoint.
+type PlatformEvidenceSource interface {
+	Observe(context.Context, Policy) (Evidence, error)
+}
+
+// AggregateObserverConfig contains the complete set of authoritative source
+// adapters. There is no permissive default or persistent status surface.
+type AggregateObserverConfig struct {
+	CAPI           CAPIEvidenceSource
+	Network        NetworkEvidenceSource
+	Platform       PlatformEvidenceSource
+	NetworkProfile NetworkProfile
+	Clock          func() time.Time
+}
+
+// AggregateObserver performs one bounded source pass and immediately applies
+// the deterministic aggregate evaluator. It does not poll, retry, publish
+// status, or repair any source resource.
+type AggregateObserver struct {
+	config AggregateObserverConfig
+}
+
+func NewAggregateObserver(config AggregateObserverConfig) (*AggregateObserver, error) {
+	if config.CAPI == nil || config.Network == nil || config.Platform == nil || config.Clock == nil {
+		return nil, errors.New("aggregate observer sources and clock are required")
+	}
+	return &AggregateObserver{config: config}, nil
+}
+
+func (observer *AggregateObserver) Observe(ctx context.Context, policy Policy) (VerifiedResult, error) {
+	if err := validatePolicy(policy, true); err != nil {
+		return VerifiedResult{}, err
+	}
+	required := make(map[string]struct{}, len(policy.Required))
+	for _, condition := range policy.Required {
+		required[condition] = struct{}{}
+	}
+	evidenceByType := make(map[string][]Evidence, len(policy.Required))
+
+	if requiresAny(required, "InfrastructureReady", "ControlPlaneAvailable") {
+		items, err := observer.config.CAPI.Collect(ctx, policy)
+		if err != nil {
+			return VerifiedResult{}, errors.New("collect bounded CAPI evidence")
+		}
+		if len(items) > 2 {
+			return VerifiedResult{}, errors.New("CAPI source exceeded its evidence boundary")
+		}
+		for _, item := range items {
+			if item.Type != "InfrastructureReady" && item.Type != "ControlPlaneAvailable" {
+				return VerifiedResult{}, errors.New("CAPI source returned evidence outside its ownership domain")
+			}
+			if _, wanted := required[item.Type]; wanted {
+				evidenceByType[item.Type] = append(evidenceByType[item.Type], item)
+			}
+		}
+	}
+	if _, wanted := required["NetworkReady"]; wanted {
+		item, err := observer.config.Network.Observe(ctx, policy, observer.config.NetworkProfile)
+		if err != nil {
+			return VerifiedResult{}, errors.New("collect bounded NetworkReady evidence")
+		}
+		if item.Type != "NetworkReady" {
+			return VerifiedResult{}, errors.New("Network source returned evidence outside its ownership domain")
+		}
+		evidenceByType[item.Type] = append(evidenceByType[item.Type], item)
+	}
+	if _, wanted := required["PlatformReady"]; wanted {
+		item, err := observer.config.Platform.Observe(ctx, policy)
+		if err != nil {
+			return VerifiedResult{}, errors.New("collect bounded PlatformReady evidence")
+		}
+		if item.Type != "PlatformReady" {
+			return VerifiedResult{}, errors.New("Platform source returned evidence outside its ownership domain")
+		}
+		evidenceByType[item.Type] = append(evidenceByType[item.Type], item)
+	}
+
+	evidence := make([]Evidence, 0, len(policy.Required))
+	for _, condition := range policy.Required {
+		evidence = append(evidence, evidenceByType[condition]...)
+	}
+	bundle := Bundle{
+		Format: BundleFormat, IntentRevision: policy.IntentRevision,
+		EvaluatedAt: observer.config.Clock().UTC().Format(time.RFC3339Nano), Evidence: evidence,
+	}
+	return Evaluate(policy, bundle)
+}
+
+func requiresAny(required map[string]struct{}, conditions ...string) bool {
+	for _, condition := range conditions {
+		if _, exists := required[condition]; exists {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/observation/aggregate_observer_test.go
+++ b/internal/observation/aggregate_observer_test.go
@@ -1,0 +1,229 @@
+package observation
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestAggregateObserverComposesAuthoritativeSourcesOnce(t *testing.T) {
+	policy, profile := aggregateFixture()
+	order := []string{}
+	capi := &fakeCAPIEvidenceSource{evidence: []Evidence{
+		aggregateEvidence(policy, "InfrastructureReady"),
+		aggregateEvidence(policy, "ControlPlaneAvailable"),
+	}, order: &order}
+	network := &fakeNetworkEvidenceSource{evidence: aggregateEvidence(policy, "NetworkReady"), order: &order}
+	platform := &fakePlatformEvidenceSource{evidence: aggregateEvidence(policy, "PlatformReady"), order: &order}
+	clock := time.Date(2026, 8, 16, 12, 30, 0, 0, time.UTC)
+	observer, err := NewAggregateObserver(AggregateObserverConfig{
+		CAPI: capi, Network: network, Platform: platform, NetworkProfile: profile,
+		Clock: func() time.Time { return clock },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := observer.Observe(context.Background(), policy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := result.Receipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if receipt.Ready != "True" || receipt.Reason != "AllRequiredConditionsSatisfied" || receipt.EvaluatedAt != clock.Format(time.RFC3339Nano) || len(receipt.Conditions) != 4 {
+		t.Fatalf("unexpected aggregate receipt: %#v", receipt)
+	}
+	if capi.calls != 1 || network.calls != 1 || platform.calls != 1 || network.profile != profile || strings.Join(order, ",") != "CAPI,Network,Platform" {
+		t.Fatalf("source composition differs: capi=%d network=%d platform=%d profile=%#v", capi.calls, network.calls, platform.calls, network.profile)
+	}
+}
+
+func TestAggregateObserverCallsOnlyRequiredDomains(t *testing.T) {
+	policy, profile := aggregateFixture()
+	policy.Required = []string{"InfrastructureReady"}
+	capi := &fakeCAPIEvidenceSource{evidence: []Evidence{
+		aggregateEvidence(policy, "InfrastructureReady"),
+		aggregateEvidence(policy, "ControlPlaneAvailable"),
+	}}
+	network := &fakeNetworkEvidenceSource{err: errors.New("must not be called")}
+	platform := &fakePlatformEvidenceSource{err: errors.New("must not be called")}
+	observer, err := NewAggregateObserver(AggregateObserverConfig{
+		CAPI: capi, Network: network, Platform: platform, NetworkProfile: profile,
+		Clock: func() time.Time { return time.Date(2026, 8, 16, 12, 30, 0, 0, time.UTC) },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := observer.Observe(context.Background(), policy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, _ := result.Receipt()
+	if receipt.Ready != "True" || len(receipt.Conditions) != 1 || capi.calls != 1 || network.calls != 0 || platform.calls != 0 {
+		t.Fatalf("unrequired source was called or retained: %#v calls=%d/%d/%d", receipt, capi.calls, network.calls, platform.calls)
+	}
+}
+
+func TestAggregateObserverPreservesConflictingAuthority(t *testing.T) {
+	policy, profile := aggregateFixture()
+	policy.Required = []string{"InfrastructureReady"}
+	item := aggregateEvidence(policy, "InfrastructureReady")
+	capi := &fakeCAPIEvidenceSource{evidence: []Evidence{item, item}}
+	observer, err := NewAggregateObserver(AggregateObserverConfig{
+		CAPI: capi, Network: &fakeNetworkEvidenceSource{}, Platform: &fakePlatformEvidenceSource{},
+		NetworkProfile: profile, Clock: func() time.Time { return time.Date(2026, 8, 16, 12, 30, 0, 0, time.UTC) },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := observer.Observe(context.Background(), policy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, _ := result.Receipt()
+	if receipt.Ready != "Unknown" || receipt.Reason != "ConflictingAuthority" {
+		t.Fatalf("duplicate source authority was not retained fail-closed: %#v", receipt)
+	}
+}
+
+func TestAggregateObserverFailsClosedAndRedactsSources(t *testing.T) {
+	policy, profile := aggregateFixture()
+	tests := map[string]AggregateObserverConfig{
+		"CAPI error": {
+			CAPI: &fakeCAPIEvidenceSource{err: errors.New("sensitive CAPI detail")}, Network: &fakeNetworkEvidenceSource{}, Platform: &fakePlatformEvidenceSource{},
+		},
+		"CAPI foreign domain": {
+			CAPI: &fakeCAPIEvidenceSource{evidence: []Evidence{aggregateEvidence(policy, "PlatformReady")}}, Network: &fakeNetworkEvidenceSource{}, Platform: &fakePlatformEvidenceSource{},
+		},
+		"network error": {
+			CAPI: &fakeCAPIEvidenceSource{evidence: []Evidence{aggregateEvidence(policy, "InfrastructureReady"), aggregateEvidence(policy, "ControlPlaneAvailable")}}, Network: &fakeNetworkEvidenceSource{err: errors.New("sensitive network detail")}, Platform: &fakePlatformEvidenceSource{},
+		},
+		"network foreign domain": {
+			CAPI: &fakeCAPIEvidenceSource{evidence: []Evidence{aggregateEvidence(policy, "InfrastructureReady"), aggregateEvidence(policy, "ControlPlaneAvailable")}}, Network: &fakeNetworkEvidenceSource{evidence: aggregateEvidence(policy, "PlatformReady")}, Platform: &fakePlatformEvidenceSource{},
+		},
+		"platform error": {
+			CAPI: &fakeCAPIEvidenceSource{evidence: []Evidence{aggregateEvidence(policy, "InfrastructureReady"), aggregateEvidence(policy, "ControlPlaneAvailable")}}, Network: &fakeNetworkEvidenceSource{evidence: aggregateEvidence(policy, "NetworkReady")}, Platform: &fakePlatformEvidenceSource{err: errors.New("sensitive platform detail")},
+		},
+		"platform foreign domain": {
+			CAPI: &fakeCAPIEvidenceSource{evidence: []Evidence{aggregateEvidence(policy, "InfrastructureReady"), aggregateEvidence(policy, "ControlPlaneAvailable")}}, Network: &fakeNetworkEvidenceSource{evidence: aggregateEvidence(policy, "NetworkReady")}, Platform: &fakePlatformEvidenceSource{evidence: aggregateEvidence(policy, "NetworkReady")},
+		},
+	}
+	for name, config := range tests {
+		t.Run(name, func(t *testing.T) {
+			config.NetworkProfile = profile
+			config.Clock = func() time.Time { return time.Date(2026, 8, 16, 12, 30, 0, 0, time.UTC) }
+			observer, err := NewAggregateObserver(config)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := observer.Observe(context.Background(), policy); err == nil {
+				t.Fatal("invalid or failed source was accepted")
+			} else if strings.Contains(err.Error(), "sensitive") {
+				t.Fatalf("raw source detail leaked: %v", err)
+			}
+		})
+	}
+}
+
+func TestNewAggregateObserverRequiresAllSources(t *testing.T) {
+	valid := AggregateObserverConfig{
+		CAPI: &fakeCAPIEvidenceSource{}, Network: &fakeNetworkEvidenceSource{}, Platform: &fakePlatformEvidenceSource{},
+		Clock: func() time.Time { return time.Now() },
+	}
+	for name, mutate := range map[string]func(*AggregateObserverConfig){
+		"CAPI":     func(config *AggregateObserverConfig) { config.CAPI = nil },
+		"network":  func(config *AggregateObserverConfig) { config.Network = nil },
+		"platform": func(config *AggregateObserverConfig) { config.Platform = nil },
+		"clock":    func(config *AggregateObserverConfig) { config.Clock = nil },
+	} {
+		t.Run(name, func(t *testing.T) {
+			config := valid
+			mutate(&config)
+			if _, err := NewAggregateObserver(config); err == nil {
+				t.Fatal("incomplete aggregate observer accepted")
+			}
+		})
+	}
+}
+
+func aggregateFixture() (Policy, NetworkProfile) {
+	digestA := "sha256:" + strings.Repeat("a", 64)
+	digestB := "sha256:" + strings.Repeat("b", 64)
+	digestC := "sha256:" + strings.Repeat("c", 64)
+	policy := Policy{
+		Format: PolicyFormat, IntentRevision: digestA, EnablementRevision: digestB, PlatformRevision: digestC,
+		TargetClusterUID: "cluster-uid-1", Required: []string{"InfrastructureReady", "ControlPlaneAvailable", "NetworkReady", "PlatformReady"},
+	}
+	return policy, NetworkProfile{Format: NetworkProfileFormat, IntentRevision: digestA, EnablementRevision: digestB}
+}
+
+func aggregateEvidence(policy Policy, condition string) Evidence {
+	evidence := Evidence{
+		Type: condition, TargetClusterUID: policy.TargetClusterUID, Status: "True", Reason: condition,
+		SourceUID: "source-uid-" + strings.ToLower(condition), EvidenceDigest: "sha256:" + strings.Repeat("d", 64),
+	}
+	switch condition {
+	case "InfrastructureReady", "ControlPlaneAvailable":
+		evidence.Source = "CAPICluster"
+		evidence.SourceUID = policy.TargetClusterUID
+		evidence.DesiredRevision, evidence.ObservedRevision = policy.IntentRevision, policy.IntentRevision
+		evidence.Generation, evidence.ObservedGeneration = 7, 7
+	case "NetworkReady":
+		evidence.Source = "BoundedNetworkEvaluator"
+		evidence.DesiredRevision, evidence.ObservedRevision = policy.EnablementRevision, policy.EnablementRevision
+	case "PlatformReady":
+		evidence.Source = "BoundedPlatformEvaluator"
+		evidence.DesiredRevision, evidence.ObservedRevision = policy.PlatformRevision, policy.PlatformRevision
+	}
+	return evidence
+}
+
+type fakeCAPIEvidenceSource struct {
+	evidence []Evidence
+	err      error
+	calls    int
+	order    *[]string
+}
+
+func (source *fakeCAPIEvidenceSource) Collect(context.Context, Policy) ([]Evidence, error) {
+	source.calls++
+	if source.order != nil {
+		*source.order = append(*source.order, "CAPI")
+	}
+	return source.evidence, source.err
+}
+
+type fakeNetworkEvidenceSource struct {
+	evidence Evidence
+	err      error
+	profile  NetworkProfile
+	calls    int
+	order    *[]string
+}
+
+func (source *fakeNetworkEvidenceSource) Observe(_ context.Context, _ Policy, profile NetworkProfile) (Evidence, error) {
+	source.calls++
+	if source.order != nil {
+		*source.order = append(*source.order, "Network")
+	}
+	source.profile = profile
+	return source.evidence, source.err
+}
+
+type fakePlatformEvidenceSource struct {
+	evidence Evidence
+	err      error
+	calls    int
+	order    *[]string
+}
+
+func (source *fakePlatformEvidenceSource) Observe(context.Context, Policy) (Evidence, error) {
+	source.calls++
+	if source.order != nil {
+		*source.order = append(*source.order, "Platform")
+	}
+	return source.evidence, source.err
+}


### PR DESCRIPTION
## What changed

- add a single-pass `AggregateObserver` implementing the existing crash-safe execution `Observer` boundary
- compose CAPI, NetworkReady, and PlatformReady source domains in deterministic order
- call only the source domains required by the Contract-derived policy
- reject cross-domain evidence before aggregate evaluation
- preserve duplicate CAPI evidence as `Unknown/ConflictingAuthority`
- redact operational source errors
- document the composition and remaining adapter boundaries

## Why

The executor already requires one verified aggregate observation, while CAPI and NetworkReady existed only as separate source adapters. This checkpoint connects those source contracts to the existing deterministic evaluator without introducing a controller, persistent status surface, or duplicated lifecycle ownership.

## Boundaries

- exactly one source pass; no polling or retry
- no watch, mutation, repair, or status publication
- no default or inferred authority
- concrete PlatformReady adapter remains a separate checkpoint
- immutable Network-profile loading remains a separate checkpoint
- no CLI/Job activation
- no live cluster contact or infrastructure mutation

## Validation

- `go test ./...`
- `go test -race -ldflags=-linkmode=external ./internal/observation ./internal/execution ./internal/runner`
- `go vet ./...`
- 11 existing Python regression tests
- `git diff --check`
