### PR TITLE
OK-147: Bind immutable NetworkReady profile

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -555,9 +555,38 @@ deterministic outcome.
 The composer performs exactly one pass in CAPI, Network, Platform order and
 then evaluates one ordered bundle at the injected clock time. It has no polling,
 retry, watch, mutation, repair, durable status publication or default source.
-The concrete GitOps/Platform source and the immutable Network-profile loader
-remain separate checkpoints. Consequently this composition is not yet wired to
-the CLI or Job and made no cluster contact.
+The concrete GitOps/Platform source remains a separate checkpoint. The
+immutable Network-profile loader is described next. Consequently this
+composition is not yet wired to the CLI or Job and made no cluster contact.
+
+## Digest-bound Network profile loading
+
+NetworkReady expectations are no longer available only as freely constructed
+Go values. The runner can load exactly one maximum-64-KiB strict-JSON
+`ok147-network-profile/v1` document and requires three independent bindings:
+
+```text
+expected canonical profile digest
+expected Contract revision R
+expected Enablement revision E
+```
+
+The expected values must come from already verified execution inputs. Unknown
+fields, duplicate JSON keys, trailing values, malformed or mutable image
+identities, invalid HCP/HRP spec digests, unsafe node counts, and unbounded
+probe timing fail closed. The loader retains neither the source path nor raw
+document. Canonical JSON gives semantically equivalent key ordering and
+whitespace the same profile digest, while any semantic field change requires a
+new binding.
+
+NetworkReady evidence now hashes a versioned pair of the canonical profile
+digest and normalized runtime-snapshot digest. Therefore an unchanged runtime
+snapshot evaluated under different profile semantics cannot produce the same
+source identity or evidence digest. This closes the evaluator-provenance gap
+without making the profile a Kubernetes resource or introducing a reconciler.
+
+The loader is not yet wired to the CLI or Job, contains no built-in OK-141
+profile default, and performs no Kubernetes access or mutation.
 
 ## OK-141 compatibility evidence
 

--- a/internal/observation/network_evaluator.go
+++ b/internal/observation/network_evaluator.go
@@ -13,9 +13,9 @@ const (
 	NetworkSnapshotFormat = "ok147-network-snapshot/v1"
 )
 
-// NetworkProfile contains the reviewed, immutable semantics behind E. A later
-// Kubernetes adapter must derive it from a digest-bound profile; this evaluator
-// deliberately has no API client or command-execution path.
+// NetworkProfile contains the reviewed, immutable semantics behind E. The
+// runner adapter loads it from a separately digest-bound strict-JSON document;
+// this evaluator deliberately has no API client or command-execution path.
 type NetworkProfile struct {
 	Format                       string        `json:"format"`
 	IntentRevision               string        `json:"intentRevision"`
@@ -133,6 +133,18 @@ func EvaluateNetworkSnapshot(policy Policy, profile NetworkProfile, snapshot Net
 	if err != nil {
 		return Evidence{}, err
 	}
+	profileDigest, err := NetworkProfileDigest(profile)
+	if err != nil {
+		return Evidence{}, err
+	}
+	evidenceDigest, err := canonicalDigest(struct {
+		Format         string `json:"format"`
+		ProfileDigest  string `json:"profileDigest"`
+		SnapshotDigest string `json:"snapshotDigest"`
+	}{Format: "ok147-network-evidence-binding/v1", ProfileDigest: profileDigest, SnapshotDigest: snapshotDigest})
+	if err != nil {
+		return Evidence{}, err
+	}
 	observedRevision := snapshot.EnablementRevision
 	if !validDigest(observedRevision) {
 		observedRevision = ""
@@ -140,10 +152,10 @@ func EvaluateNetworkSnapshot(policy Policy, profile NetworkProfile, snapshot Net
 	status, reason := evaluateNetworkState(policy, profile, snapshot)
 	evidence := Evidence{
 		Type: "NetworkReady", Source: "BoundedNetworkEvaluator",
-		SourceUID:        "network-evidence-" + snapshotDigest[len("sha256:"):len("sha256:")+32],
+		SourceUID:        "network-evidence-" + evidenceDigest[len("sha256:"):len("sha256:")+32],
 		TargetClusterUID: policy.TargetClusterUID, Status: status, Reason: reason,
 		DesiredRevision: policy.EnablementRevision, ObservedRevision: observedRevision,
-		EvidenceDigest: snapshotDigest,
+		EvidenceDigest: evidenceDigest,
 	}
 	if err := validateEvidenceShape(evidence); err != nil {
 		return Evidence{}, fmt.Errorf("normalize NetworkReady evidence: %w", err)
@@ -154,6 +166,15 @@ func EvaluateNetworkSnapshot(policy Policy, profile NetworkProfile, snapshot Net
 func validateNetworkProfile(policy Policy, profile NetworkProfile) error {
 	if profile.Format != NetworkProfileFormat || profile.IntentRevision != policy.IntentRevision || profile.EnablementRevision != policy.EnablementRevision {
 		return errors.New("network profile identity differs from observation policy")
+	}
+	return ValidateNetworkProfile(profile)
+}
+
+// ValidateNetworkProfile checks the complete intrinsic profile shape without
+// inferring its R or E identity from a runtime source.
+func ValidateNetworkProfile(profile NetworkProfile) error {
+	if profile.Format != NetworkProfileFormat || !validDigest(profile.IntentRevision) || !validDigest(profile.EnablementRevision) {
+		return errors.New("network profile format or revision identity is invalid")
 	}
 	if profile.ExpectedNodeCount < 1 || profile.ExpectedNodeCount > 100 || !validDigest(profile.ExpectedHCPSpecDigest) || !validDigest(profile.ExpectedHRPSpecDigest) {
 		return errors.New("network profile object expectations are invalid")
@@ -167,6 +188,15 @@ func validateNetworkProfile(policy Policy, profile NetworkProfile) error {
 		return errors.New("network profile probe freshness boundary is invalid")
 	}
 	return nil
+}
+
+// NetworkProfileDigest identifies the canonical semantic profile consumed by
+// NetworkReady evaluation. Whitespace and JSON object ordering are irrelevant.
+func NetworkProfileDigest(profile NetworkProfile) (string, error) {
+	if err := ValidateNetworkProfile(profile); err != nil {
+		return "", err
+	}
+	return canonicalDigest(profile)
 }
 
 func validateNetworkSnapshotShape(snapshot NetworkSnapshot) error {

--- a/internal/observation/network_evaluator_test.go
+++ b/internal/observation/network_evaluator_test.go
@@ -27,6 +27,22 @@ func TestEvaluateNetworkSnapshotProducesCurrentEVIDENCE(t *testing.T) {
 	}
 }
 
+func TestEvaluateNetworkSnapshotBindsSemanticProfileIdentity(t *testing.T) {
+	policy, profile, snapshot := validNetworkFixture(t)
+	first, err := EvaluateNetworkSnapshot(policy, profile, snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	profile.MinimumProbeFreshnessSeconds++
+	second, err := EvaluateNetworkSnapshot(policy, profile, snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.Status != "True" || second.Status != "True" || first.EvidenceDigest == second.EvidenceDigest || first.SourceUID == second.SourceUID {
+		t.Fatalf("semantic profile change was not bound into evidence: first=%#v second=%#v", first, second)
+	}
+}
+
 func TestEvaluateNetworkSnapshotFailsClosed(t *testing.T) {
 	tests := map[string]struct {
 		mutate func(*NetworkSnapshot)

--- a/internal/runner/network_profile.go
+++ b/internal/runner/network_profile.go
@@ -1,0 +1,56 @@
+package runner
+
+import (
+	"errors"
+	"regexp"
+
+	"github.com/openkubes/ok-cluster/internal/jsonstrict"
+	"github.com/openkubes/ok-cluster/internal/observation"
+)
+
+const maximumNetworkProfileBytes = 64 * 1024
+
+var networkProfileDigestPattern = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
+
+// NetworkProfileFileConfig binds one local semantic profile to an independently
+// supplied digest plus the Contract-derived R and E identities.
+type NetworkProfileFileConfig struct {
+	Path                       string
+	ExpectedProfileDigest      string
+	ExpectedIntentRevision     string
+	ExpectedEnablementRevision string
+}
+
+// LoadedNetworkProfile retains the verified profile identity used by the
+// NetworkReady evaluator. It contains no source path or raw document.
+type LoadedNetworkProfile struct {
+	Profile observation.NetworkProfile
+	Digest  string
+}
+
+// LoadNetworkProfileFile reads one bounded strict-JSON profile. The caller must
+// obtain all expected identities from already verified execution inputs.
+func LoadNetworkProfileFile(config NetworkProfileFileConfig) (LoadedNetworkProfile, error) {
+	if config.Path == "" || !networkProfileDigestPattern.MatchString(config.ExpectedProfileDigest) || !networkProfileDigestPattern.MatchString(config.ExpectedIntentRevision) || !networkProfileDigestPattern.MatchString(config.ExpectedEnablementRevision) {
+		return LoadedNetworkProfile{}, errors.New("network profile file binding is invalid")
+	}
+	raw, err := readBoundedRegular(config.Path, maximumNetworkProfileBytes)
+	if err != nil {
+		return LoadedNetworkProfile{}, errors.New("read bounded network profile")
+	}
+	var profile observation.NetworkProfile
+	if err := jsonstrict.Decode(raw, &profile); err != nil {
+		return LoadedNetworkProfile{}, errors.New("decode strict network profile")
+	}
+	if profile.IntentRevision != config.ExpectedIntentRevision || profile.EnablementRevision != config.ExpectedEnablementRevision {
+		return LoadedNetworkProfile{}, errors.New("network profile revision differs from verified execution input")
+	}
+	digest, err := observation.NetworkProfileDigest(profile)
+	if err != nil {
+		return LoadedNetworkProfile{}, errors.New("validate semantic network profile")
+	}
+	if digest != config.ExpectedProfileDigest {
+		return LoadedNetworkProfile{}, errors.New("network profile digest differs from verified execution input")
+	}
+	return LoadedNetworkProfile{Profile: profile, Digest: digest}, nil
+}

--- a/internal/runner/network_profile_test.go
+++ b/internal/runner/network_profile_test.go
@@ -1,0 +1,144 @@
+package runner
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/openkubes/ok-cluster/internal/observation"
+)
+
+func TestLoadNetworkProfileFileBindsCanonicalIdentity(t *testing.T) {
+	root := t.TempDir()
+	profile := runnerNetworkProfile()
+	digest, err := observation.NetworkProfileDigest(profile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := json.MarshalIndent(profile, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(root, "network-profile.json")
+	if err := os.WriteFile(path, raw, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	config := NetworkProfileFileConfig{
+		Path: path, ExpectedProfileDigest: digest,
+		ExpectedIntentRevision: profile.IntentRevision, ExpectedEnablementRevision: profile.EnablementRevision,
+	}
+	loaded, err := LoadNetworkProfileFile(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.Profile != profile || loaded.Digest != digest {
+		t.Fatalf("loaded profile differs: %#v", loaded)
+	}
+
+	var reordered map[string]any
+	if err := json.Unmarshal(raw, &reordered); err != nil {
+		t.Fatal(err)
+	}
+	reorderedRaw, err := json.Marshal(reordered)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, reorderedRaw, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	semanticallySame, err := LoadNetworkProfileFile(config)
+	if err != nil || semanticallySame.Digest != digest {
+		t.Fatalf("semantically identical JSON changed identity: %#v %v", semanticallySame, err)
+	}
+}
+
+func TestLoadNetworkProfileFileRejectsUnboundOrMalformedInput(t *testing.T) {
+	root := t.TempDir()
+	profile := runnerNetworkProfile()
+	digest, _ := observation.NetworkProfileDigest(profile)
+	validRaw, _ := json.Marshal(profile)
+	base := NetworkProfileFileConfig{
+		ExpectedProfileDigest: digest, ExpectedIntentRevision: profile.IntentRevision,
+		ExpectedEnablementRevision: profile.EnablementRevision,
+	}
+	tests := map[string][]byte{
+		"unknown field":   append(validRaw[:len(validRaw)-1], []byte(`,"extra":true}`)...),
+		"duplicate field": []byte(strings.Replace(string(validRaw), `"format":"`+observation.NetworkProfileFormat+`"`, `"format":"`+observation.NetworkProfileFormat+`","format":"`+observation.NetworkProfileFormat+`"`, 1)),
+		"trailing value":  append(append([]byte(nil), validRaw...), []byte(` {}`)...),
+		"oversized":       []byte(`{"format":"` + strings.Repeat("x", maximumNetworkProfileBytes) + `"}`),
+	}
+	for name, raw := range tests {
+		t.Run(name, func(t *testing.T) {
+			path := filepath.Join(root, strings.ReplaceAll(name, " ", "-")+".json")
+			if err := os.WriteFile(path, raw, 0o644); err != nil {
+				t.Fatal(err)
+			}
+			config := base
+			config.Path = path
+			if _, err := LoadNetworkProfileFile(config); err == nil || strings.Contains(err.Error(), root) {
+				t.Fatalf("unsafe profile accepted or disclosed path: %v", err)
+			}
+		})
+	}
+}
+
+func TestLoadNetworkProfileFileRejectsIdentityOrSemanticChanges(t *testing.T) {
+	root := t.TempDir()
+	profile := runnerNetworkProfile()
+	digest, _ := observation.NetworkProfileDigest(profile)
+	path := filepath.Join(root, "network-profile.json")
+	write := func(value observation.NetworkProfile) {
+		raw, _ := json.Marshal(value)
+		if err := os.WriteFile(path, raw, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write(profile)
+	base := NetworkProfileFileConfig{
+		Path: path, ExpectedProfileDigest: digest, ExpectedIntentRevision: profile.IntentRevision,
+		ExpectedEnablementRevision: profile.EnablementRevision,
+	}
+	for name, mutate := range map[string]func(*NetworkProfileFileConfig){
+		"malformed digest": func(config *NetworkProfileFileConfig) { config.ExpectedProfileDigest = "sha256:no" },
+		"wrong digest": func(config *NetworkProfileFileConfig) {
+			config.ExpectedProfileDigest = "sha256:" + strings.Repeat("9", 64)
+		},
+		"wrong R": func(config *NetworkProfileFileConfig) {
+			config.ExpectedIntentRevision = "sha256:" + strings.Repeat("9", 64)
+		},
+		"wrong E": func(config *NetworkProfileFileConfig) {
+			config.ExpectedEnablementRevision = "sha256:" + strings.Repeat("9", 64)
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			config := base
+			mutate(&config)
+			if _, err := LoadNetworkProfileFile(config); err == nil || strings.Contains(err.Error(), root) {
+				t.Fatalf("unbound profile accepted or disclosed path: %v", err)
+			}
+		})
+	}
+
+	changed := profile
+	changed.CacheExposureSeconds++
+	write(changed)
+	if _, err := LoadNetworkProfileFile(base); err == nil {
+		t.Fatal("semantic profile change retained the old binding")
+	}
+}
+
+func runnerNetworkProfile() observation.NetworkProfile {
+	return observation.NetworkProfile{
+		Format:         observation.NetworkProfileFormat,
+		IntentRevision: "sha256:" + strings.Repeat("a", 64), EnablementRevision: "sha256:" + strings.Repeat("b", 64),
+		ExpectedNodeCount: 2, ExpectedHCPSpecDigest: "sha256:" + strings.Repeat("c", 64), ExpectedHRPSpecDigest: "sha256:" + strings.Repeat("d", 64),
+		ExpectedImages: observation.NetworkImages{
+			CiliumAgent:    "registry.example/cilium@sha256:" + strings.Repeat("1", 64),
+			CiliumEnvoy:    "registry.example/envoy@sha256:" + strings.Repeat("2", 64),
+			CiliumOperator: "registry.example/operator@sha256:" + strings.Repeat("3", 64),
+		},
+		MinimumProbeFreshnessSeconds: 120, MaximumProbeIntervalSeconds: 60, CacheExposureSeconds: 30,
+	}
+}


### PR DESCRIPTION
## What changed

- add a bounded strict-JSON loader for `ok147-network-profile/v1`
- require independent bindings for the canonical profile digest, Contract revision R, and Enablement revision E
- validate all intrinsic NetworkReady expectations before use
- reject unknown or duplicate fields, trailing JSON, oversized input, mutable images, and identity mismatches
- bind both the canonical profile digest and runtime snapshot digest into NetworkReady evidence
- document the profile and evidence-provenance boundary

## Why

The NetworkReady evaluator previously accepted a Go profile value without a concrete immutable loading boundary. That left the expected HCP/HRP semantics, images, node count, and probe timing outside the file/digest verification path. This checkpoint makes those expectations reproducible and ensures that changing evaluation semantics changes the resulting evidence identity.

## Boundaries

- maximum 64 KiB strict JSON
- canonical semantic digest; whitespace and key order are not semantic
- no built-in OK-141 profile default
- no Runtime flags can override individual profile fields
- no Kubernetes API access
- no CLI/Job activation
- no mutation, reconciliation, or status publication

## Validation

- `go test ./...`
- `go test -race -ldflags=-linkmode=external ./internal/observation ./internal/runner ./internal/execution`
- `go vet ./...`
- 11 existing Python regression tests
- `git diff --check`
