### PR TITLE
feat(runner): add bounded PlatformReady adapter (OK-147)

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -588,6 +588,36 @@ without making the profile a Kubernetes resource or introducing a reconciler.
 The loader is not yet wired to the CLI or Job, contains no built-in OK-141
 profile default, and performs no Kubernetes access or mutation.
 
+## Bounded Argo PlatformReady adapter
+
+The concrete Platform source now reads only the exact Argo CD Applications
+named by an immutable `ok147-platform-profile/v1`. Its Kubernetes transport is
+TLS-only, denies redirects, accepts no arbitrary path and derives an allowlist
+containing one namespaced GET per required Application. It has no discovery,
+list, watch, sync, mutation, retry, target-cluster or command-execution path.
+
+Each Application observation binds its UID, resource version, R, P, execution
+fixture, normalized semantic spec, immutable desired Git commit, applied
+revision, sync state and health state. The normalized spec includes source,
+project, destination and sync policy, while target registration is also checked
+against the profile. Membership is exact and canonicalized as a set, so input
+ordering does not create a different profile identity.
+
+Argo `Synced` and `Healthy` is intentionally not sufficient for
+`PlatformReady=True`. A separately verified, redaction-safe capability
+assertion must bind the same target UID, R, P, capability contract and
+executable identities; its self-independent evidence digest and bounded age
+are checked by the evaluator. The Argo adapter cannot manufacture that
+assertion or run its executable. Missing, stale or revision-mismatched proof
+therefore remains `Unknown`, while current health, identity or capability
+failures remain `False`.
+
+The runner-side opener binds the reader to one explicitly named GitOps
+authority (for the OK-141 topology, `ok-shared`) and a short-lived projected
+credential. The adapter is still not wired to the CLI or Job, no built-in
+OK-141 profile is selected, and this offline checkpoint made no cluster
+contact or infrastructure mutation.
+
 ## OK-141 compatibility evidence
 
 The verifier was run offline against the preserved Phase-R v5 projection. It

--- a/internal/observation/platform_collector.go
+++ b/internal/observation/platform_collector.go
@@ -1,0 +1,191 @@
+package observation
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"time"
+)
+
+// PlatformRawGetter exposes only the exact Application GETs selected when the
+// adapter is constructed.
+type PlatformRawGetter interface {
+	Get(context.Context, string) ([]byte, error)
+}
+
+// PlatformCapabilitySource returns one already verified, redaction-safe
+// capability assertion. It intentionally cannot accept a command or execute a
+// test from this Argo adapter.
+type PlatformCapabilitySource interface {
+	Capability(context.Context) (PlatformCapabilityState, error)
+}
+
+type PlatformCollectorConfig struct {
+	Profile PlatformProfile
+	Clock   func() time.Time
+}
+
+type PlatformSourceCollector struct {
+	argo       PlatformRawGetter
+	capability PlatformCapabilitySource
+	config     PlatformCollectorConfig
+}
+
+func NewPlatformSourceCollector(argo PlatformRawGetter, capability PlatformCapabilitySource, config PlatformCollectorConfig) (*PlatformSourceCollector, error) {
+	if argo == nil || capability == nil || config.Clock == nil {
+		return nil, errors.New("platform collector sources and clock are required")
+	}
+	if err := ValidatePlatformProfile(config.Profile); err != nil {
+		return nil, errors.New("platform collector profile is invalid")
+	}
+	return &PlatformSourceCollector{argo: argo, capability: capability, config: config}, nil
+}
+
+func (collector *PlatformSourceCollector) Observe(ctx context.Context, policy Policy) (Evidence, error) {
+	snapshot, err := collector.Collect(ctx, policy)
+	if err != nil {
+		return Evidence{}, err
+	}
+	return EvaluatePlatformSnapshot(policy, collector.config.Profile, snapshot)
+}
+
+// Collect performs exactly one GET per profiled Application plus one bounded
+// capability-source read. It has no list, discovery, watch, mutation, sync,
+// retry, repair, target-cluster access or arbitrary-command path.
+func (collector *PlatformSourceCollector) Collect(ctx context.Context, policy Policy) (PlatformSnapshot, error) {
+	if err := validatePolicy(policy, true); err != nil {
+		return PlatformSnapshot{}, err
+	}
+	if err := validatePlatformProfile(policy, collector.config.Profile); err != nil {
+		return PlatformSnapshot{}, err
+	}
+	applications := make([]PlatformApplicationState, 0, len(collector.config.Profile.RequiredApplications))
+	for _, expected := range collector.config.Profile.RequiredApplications {
+		path := platformApplicationPath(collector.config.Profile.ArgoNamespace, expected.Name)
+		object, err := getPlatformObject(ctx, collector.argo, path)
+		if err != nil {
+			return PlatformSnapshot{}, fmt.Errorf("collect exact Argo Application: %w", err)
+		}
+		application, err := normalizePlatformApplication(object, collector.config.Profile, expected)
+		if err != nil {
+			return PlatformSnapshot{}, err
+		}
+		applications = append(applications, application)
+	}
+	sortPlatformApplications(applications)
+	capability, err := collector.capability.Capability(ctx)
+	if err != nil {
+		return PlatformSnapshot{}, errors.New("collect bounded platform capability evidence")
+	}
+	return PlatformSnapshot{
+		Format: PlatformSnapshotFormat, ObservedAt: collector.config.Clock().UTC().Format(time.RFC3339Nano),
+		TargetClusterUID: collector.config.Profile.TargetClusterUID,
+		Applications:     applications, Capability: capability,
+	}, nil
+}
+
+func getPlatformObject(ctx context.Context, source PlatformRawGetter, path string) (map[string]any, error) {
+	raw, err := source.Get(ctx, path)
+	if err != nil {
+		return nil, errors.New("bounded platform source GET failed")
+	}
+	if len(raw) == 0 || len(raw) > maximumPlatformSourceBytes {
+		return nil, errors.New("platform source response size is invalid")
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	var value map[string]any
+	if err := decoder.Decode(&value); err != nil {
+		return nil, errors.New("platform source returned invalid JSON object")
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		return nil, errors.New("platform source returned trailing JSON")
+	}
+	return value, nil
+}
+
+func normalizePlatformApplication(object map[string]any, profile PlatformProfile, expected PlatformApplicationExpectation) (PlatformApplicationState, error) {
+	if text(object["apiVersion"]) != "argoproj.io/v1alpha1" || text(object["kind"]) != "Application" {
+		return PlatformApplicationState{}, errors.New("Argo Application API identity is invalid")
+	}
+	metadata, err := objectMap(object, "metadata")
+	if err != nil || text(metadata["namespace"]) != profile.ArgoNamespace || text(metadata["name"]) != expected.Name {
+		return PlatformApplicationState{}, errors.New("Argo Application object identity differs from exact target")
+	}
+	uid, resourceVersion := text(metadata["uid"]), text(metadata["resourceVersion"])
+	if !validUID(uid) || resourceVersion == "" {
+		return PlatformApplicationState{}, errors.New("Argo Application runtime identity is invalid")
+	}
+	annotations, _ := objectMap(metadata, "annotations")
+	spec, err := objectMap(object, "spec")
+	if err != nil {
+		return PlatformApplicationState{}, errors.New("Argo Application spec is missing")
+	}
+	normalizedSpec, desiredRevision, err := normalizedPlatformApplicationSpec(spec)
+	if err != nil {
+		return PlatformApplicationState{}, err
+	}
+	destination, _ := normalizedSpec["destination"].(map[string]any)
+	if text(destination["name"]) != profile.RegistrationName {
+		return PlatformApplicationState{}, errors.New("Argo Application destination differs from the bound registration")
+	}
+	specDigest, err := canonicalDigest(normalizedSpec)
+	if err != nil {
+		return PlatformApplicationState{}, errors.New("digest normalized Argo Application spec")
+	}
+	status, _ := objectMap(object, "status")
+	sync, _ := objectMap(status, "sync")
+	health, _ := objectMap(status, "health")
+	return PlatformApplicationState{
+		Name: expected.Name, UID: uid, ResourceVersion: resourceVersion,
+		IntentRevision:   text(annotations["openkubes.io/intent-revision"]),
+		PlatformRevision: text(annotations["openkubes.io/platform-revision"]),
+		ExecutionFixture: text(annotations["openkubes.io/execution-fixture"]),
+		SpecDigest:       specDigest, DesiredSourceRevision: desiredRevision,
+		AppliedSourceRevision: text(sync["revision"]), SyncStatus: text(sync["status"]), HealthStatus: text(health["status"]),
+	}, nil
+}
+
+func normalizedPlatformApplicationSpec(spec map[string]any) (map[string]any, string, error) {
+	source, err := objectMap(spec, "source")
+	if err != nil {
+		return nil, "", errors.New("Argo Application source is missing")
+	}
+	destination, err := objectMap(spec, "destination")
+	if err != nil {
+		return nil, "", errors.New("Argo Application destination is missing")
+	}
+	revision := text(source["targetRevision"])
+	if !validGitCommit(revision) || text(source["repoURL"]) == "" || text(source["path"]) == "" || text(spec["project"]) == "" || text(destination["name"]) == "" || text(destination["namespace"]) == "" {
+		return nil, "", errors.New("Argo Application semantic identity is incomplete or mutable")
+	}
+	// Keep all source and sync semantics, but only the stable target fields. The
+	// API may default unrelated destination fields; these cannot change P.
+	normalized := map[string]any{
+		"project":     spec["project"],
+		"source":      source,
+		"destination": map[string]any{"name": destination["name"], "namespace": destination["namespace"]},
+	}
+	if syncPolicy, exists := spec["syncPolicy"]; exists {
+		normalized["syncPolicy"] = syncPolicy
+	}
+	return normalized, revision, nil
+}
+
+func validGitCommit(value string) bool {
+	if len(value) != 40 {
+		return false
+	}
+	for _, character := range value {
+		if character < '0' || character > '9' {
+			if character < 'a' || character > 'f' {
+				return false
+			}
+		}
+	}
+	return true
+}

--- a/internal/observation/platform_collector_test.go
+++ b/internal/observation/platform_collector_test.go
@@ -1,0 +1,149 @@
+package observation
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestPlatformCollectorReadsExactApplicationsAndComposes(t *testing.T) {
+	policy, profile, capability, getter := platformCollectorFixture(t)
+	source := &fakePlatformCapabilitySource{capability: capability}
+	collector, err := NewPlatformSourceCollector(getter, source, PlatformCollectorConfig{
+		Profile: profile, Clock: func() time.Time { return time.Date(2026, 8, 16, 10, 0, 0, 0, time.UTC) },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	evidence, err := collector.Observe(context.Background(), policy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if evidence.Status != "True" || evidence.Reason != "PlatformReady" || source.calls != 1 || len(getter.paths) != len(profile.RequiredApplications) {
+		t.Fatalf("unexpected platform collection: evidence=%#v paths=%v capabilityCalls=%d", evidence, getter.paths, source.calls)
+	}
+	for index, application := range profile.RequiredApplications {
+		expected := platformApplicationPath(profile.ArgoNamespace, application.Name)
+		if getter.paths[index] != expected {
+			t.Fatalf("unexpected Application path %d: %q", index, getter.paths[index])
+		}
+	}
+}
+
+func TestPlatformCollectorRejectsRawIdentityAndMutableSource(t *testing.T) {
+	policy, profile, capability, getter := platformCollectorFixture(t)
+	first := platformApplicationPath(profile.ArgoNamespace, profile.RequiredApplications[0].Name)
+	for name, mutate := range map[string]func(map[string]any){
+		"foreign name": func(object map[string]any) { object["metadata"].(map[string]any)["name"] = "other" },
+		"missing uid":  func(object map[string]any) { delete(object["metadata"].(map[string]any), "uid") },
+		"mutable branch": func(object map[string]any) {
+			object["spec"].(map[string]any)["source"].(map[string]any)["targetRevision"] = "main"
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, localProfile, localCapability, localGetter := platformCollectorFixture(t)
+			var object map[string]any
+			if err := json.Unmarshal(localGetter.responses[first], &object); err != nil {
+				t.Fatal(err)
+			}
+			mutate(object)
+			localGetter.responses[first], _ = json.Marshal(object)
+			collector, err := NewPlatformSourceCollector(localGetter, &fakePlatformCapabilitySource{capability: localCapability}, PlatformCollectorConfig{Profile: localProfile, Clock: time.Now})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := collector.Observe(context.Background(), policy); err == nil {
+				t.Fatal("unsafe Argo Application accepted")
+			}
+		})
+	}
+	_ = capability
+	_ = getter
+}
+
+func TestPlatformCollectorRedactsSourceErrorsAndDoesNotRunCapabilityEarly(t *testing.T) {
+	policy, profile, capability, getter := platformCollectorFixture(t)
+	getter.err = errors.New("secret endpoint detail")
+	source := &fakePlatformCapabilitySource{capability: capability}
+	collector, err := NewPlatformSourceCollector(getter, source, PlatformCollectorConfig{Profile: profile, Clock: time.Now})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := collector.Observe(context.Background(), policy); err == nil || strings.Contains(err.Error(), "secret endpoint") {
+		t.Fatalf("raw source failure leaked or was accepted: %v", err)
+	}
+	if source.calls != 0 {
+		t.Fatal("capability source ran after Application collection failed")
+	}
+}
+
+func platformCollectorFixture(t *testing.T) (Policy, PlatformProfile, PlatformCapabilityState, *fakePlatformRawGetter) {
+	t.Helper()
+	policy, profile, snapshot := validPlatformFixture(t)
+	getter := &fakePlatformRawGetter{responses: map[string][]byte{}}
+	for index := range profile.RequiredApplications {
+		name := profile.RequiredApplications[index].Name
+		path := "profiles/ok-observability-standard"
+		if index == 1 {
+			path = "alerting"
+		} else if index == 2 {
+			path = "dashboards"
+		}
+		spec := map[string]any{
+			"project":     "openkubes-disposable",
+			"source":      map[string]any{"repoURL": "https://github.com/openkubes/ok-observability.git", "path": path, "targetRevision": strings.Repeat("6", 40)},
+			"destination": map[string]any{"name": profile.RegistrationName, "namespace": "ok-observability"},
+			"syncPolicy":  map[string]any{"automated": map[string]any{"enabled": true, "prune": true, "selfHeal": true, "allowEmpty": false}},
+		}
+		normalized, _, err := normalizedPlatformApplicationSpec(spec)
+		if err != nil {
+			t.Fatal(err)
+		}
+		profile.RequiredApplications[index].SpecDigest, err = canonicalDigest(normalized)
+		if err != nil {
+			t.Fatal(err)
+		}
+		object := map[string]any{
+			"apiVersion": "argoproj.io/v1alpha1", "kind": "Application",
+			"metadata": map[string]any{
+				"namespace": profile.ArgoNamespace, "name": name, "uid": "application-uid-" + string(rune('a'+index)), "resourceVersion": "17",
+				"annotations": map[string]any{
+					"openkubes.io/intent-revision": policy.IntentRevision, "openkubes.io/platform-revision": policy.PlatformRevision,
+					"openkubes.io/execution-fixture": profile.ExecutionFixture,
+				},
+			},
+			"spec":   spec,
+			"status": map[string]any{"sync": map[string]any{"status": "Synced", "revision": strings.Repeat("6", 40)}, "health": map[string]any{"status": "Healthy"}},
+		}
+		getter.responses[platformApplicationPath(profile.ArgoNamespace, name)], _ = json.Marshal(object)
+	}
+	return policy, profile, snapshot.Capability, getter
+}
+
+type fakePlatformRawGetter struct {
+	responses map[string][]byte
+	paths     []string
+	err       error
+}
+
+func (getter *fakePlatformRawGetter) Get(_ context.Context, path string) ([]byte, error) {
+	getter.paths = append(getter.paths, path)
+	if getter.err != nil {
+		return nil, getter.err
+	}
+	return append([]byte(nil), getter.responses[path]...), nil
+}
+
+type fakePlatformCapabilitySource struct {
+	capability PlatformCapabilityState
+	err        error
+	calls      int
+}
+
+func (source *fakePlatformCapabilitySource) Capability(context.Context) (PlatformCapabilityState, error) {
+	source.calls++
+	return source.capability, source.err
+}

--- a/internal/observation/platform_evaluator.go
+++ b/internal/observation/platform_evaluator.go
@@ -1,0 +1,263 @@
+package observation
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"time"
+)
+
+const (
+	PlatformProfileFormat    = "ok147-platform-profile/v1"
+	PlatformSnapshotFormat   = "ok147-platform-snapshot/v1"
+	PlatformCapabilityFormat = "ok147-platform-capability/v1"
+)
+
+// PlatformProfile is the immutable, reviewed meaning of P consumed by the
+// bounded evaluator. It identifies exact Argo Applications and a separate
+// capability proof; Argo health alone is deliberately insufficient.
+type PlatformProfile struct {
+	Format                      string                           `json:"format"`
+	IntentRevision              string                           `json:"intentRevision"`
+	PlatformRevision            string                           `json:"platformRevision"`
+	ExecutionFixture            string                           `json:"executionFixture"`
+	TargetClusterUID            string                           `json:"targetClusterUid"`
+	ArgoNamespace               string                           `json:"argoNamespace"`
+	RegistrationName            string                           `json:"registrationName"`
+	RequiredApplications        []PlatformApplicationExpectation `json:"requiredApplications"`
+	CapabilityContractDigest    string                           `json:"capabilityContractDigest"`
+	CapabilityExecutableDigest  string                           `json:"capabilityExecutableDigest"`
+	MaximumCapabilityAgeSeconds int64                            `json:"maximumCapabilityAgeSeconds"`
+}
+
+type PlatformApplicationExpectation struct {
+	Name       string `json:"name"`
+	SpecDigest string `json:"specDigest"`
+}
+
+// PlatformSnapshot contains only normalized, redaction-safe observations. It
+// contains no Secret, token, kubeconfig, endpoint, raw Application, message,
+// log, or capability output.
+type PlatformSnapshot struct {
+	Format           string                     `json:"format"`
+	ObservedAt       string                     `json:"observedAt"`
+	TargetClusterUID string                     `json:"targetClusterUid"`
+	Applications     []PlatformApplicationState `json:"applications"`
+	Capability       PlatformCapabilityState    `json:"capability"`
+}
+
+type PlatformApplicationState struct {
+	Name                  string `json:"name"`
+	UID                   string `json:"uid"`
+	ResourceVersion       string `json:"resourceVersion"`
+	IntentRevision        string `json:"intentRevision"`
+	PlatformRevision      string `json:"platformRevision"`
+	ExecutionFixture      string `json:"executionFixture"`
+	SpecDigest            string `json:"specDigest"`
+	DesiredSourceRevision string `json:"desiredSourceRevision"`
+	AppliedSourceRevision string `json:"appliedSourceRevision"`
+	SyncStatus            string `json:"syncStatus"`
+	HealthStatus          string `json:"healthStatus"`
+}
+
+// PlatformCapabilityState is produced by a separately bounded capability
+// mechanism. The Argo reader cannot manufacture or execute this assertion.
+type PlatformCapabilityState struct {
+	Format           string `json:"format"`
+	ObservedAt       string `json:"observedAt"`
+	TargetClusterUID string `json:"targetClusterUid"`
+	IntentRevision   string `json:"intentRevision"`
+	PlatformRevision string `json:"platformRevision"`
+	ContractDigest   string `json:"contractDigest"`
+	ExecutableDigest string `json:"executableDigest"`
+	Passed           bool   `json:"passed"`
+	EvidenceDigest   string `json:"evidenceDigest"`
+}
+
+// EvaluatePlatformSnapshot emits one PlatformReady statement. It observes and
+// correlates only; it cannot sync Argo, repair a target or run capability code.
+func EvaluatePlatformSnapshot(policy Policy, profile PlatformProfile, snapshot PlatformSnapshot) (Evidence, error) {
+	if err := validatePolicy(policy, true); err != nil {
+		return Evidence{}, err
+	}
+	if err := validatePlatformProfile(policy, profile); err != nil {
+		return Evidence{}, err
+	}
+	if err := validatePlatformSnapshotShape(snapshot); err != nil {
+		return Evidence{}, err
+	}
+	profileDigest, err := PlatformProfileDigest(profile)
+	if err != nil {
+		return Evidence{}, err
+	}
+	snapshotDigest, err := canonicalDigest(snapshot)
+	if err != nil {
+		return Evidence{}, err
+	}
+	evidenceDigest, err := canonicalDigest(struct {
+		Format         string `json:"format"`
+		ProfileDigest  string `json:"profileDigest"`
+		SnapshotDigest string `json:"snapshotDigest"`
+	}{Format: "ok147-platform-evidence-binding/v1", ProfileDigest: profileDigest, SnapshotDigest: snapshotDigest})
+	if err != nil {
+		return Evidence{}, err
+	}
+	status, reason, observedRevision := evaluatePlatformState(policy, profile, snapshot)
+	evidence := Evidence{
+		Type: "PlatformReady", Source: "BoundedPlatformEvaluator",
+		SourceUID:        "platform-evidence-" + evidenceDigest[len("sha256:"):len("sha256:")+32],
+		TargetClusterUID: policy.TargetClusterUID, Status: status, Reason: reason,
+		DesiredRevision: policy.PlatformRevision, ObservedRevision: observedRevision,
+		EvidenceDigest: evidenceDigest,
+	}
+	if err := validateEvidenceShape(evidence); err != nil {
+		return Evidence{}, fmt.Errorf("normalize PlatformReady evidence: %w", err)
+	}
+	return evidence, nil
+}
+
+func ValidatePlatformProfile(profile PlatformProfile) error {
+	if profile.Format != PlatformProfileFormat || !validDigest(profile.IntentRevision) || !validDigest(profile.PlatformRevision) || !validDigest(profile.ExecutionFixture) || !validUID(profile.TargetClusterUID) {
+		return errors.New("platform profile format or revision identity is invalid")
+	}
+	if !validDNSLabel(profile.ArgoNamespace) || !validDNSLabel(profile.RegistrationName) || len(profile.RequiredApplications) == 0 || len(profile.RequiredApplications) > 20 {
+		return errors.New("platform profile target or Application set is invalid")
+	}
+	seen := map[string]struct{}{}
+	for _, application := range profile.RequiredApplications {
+		if !validDNSLabel(application.Name) || !validDigest(application.SpecDigest) {
+			return errors.New("platform profile Application identity is invalid")
+		}
+		if _, duplicate := seen[application.Name]; duplicate {
+			return errors.New("platform profile contains a duplicate Application")
+		}
+		seen[application.Name] = struct{}{}
+	}
+	if !validDigest(profile.CapabilityContractDigest) || !validDigest(profile.CapabilityExecutableDigest) || profile.MaximumCapabilityAgeSeconds < 60 || profile.MaximumCapabilityAgeSeconds > 86400 {
+		return errors.New("platform profile capability boundary is invalid")
+	}
+	return nil
+}
+
+func PlatformProfileDigest(profile PlatformProfile) (string, error) {
+	if err := ValidatePlatformProfile(profile); err != nil {
+		return "", err
+	}
+	normalized := profile
+	normalized.RequiredApplications = append([]PlatformApplicationExpectation(nil), profile.RequiredApplications...)
+	sort.Slice(normalized.RequiredApplications, func(i, j int) bool {
+		return normalized.RequiredApplications[i].Name < normalized.RequiredApplications[j].Name
+	})
+	return canonicalDigest(normalized)
+}
+
+func validatePlatformProfile(policy Policy, profile PlatformProfile) error {
+	if err := ValidatePlatformProfile(profile); err != nil {
+		return err
+	}
+	if profile.IntentRevision != policy.IntentRevision || profile.PlatformRevision != policy.PlatformRevision || profile.TargetClusterUID != policy.TargetClusterUID {
+		return errors.New("platform profile identity differs from observation policy")
+	}
+	return nil
+}
+
+func validatePlatformSnapshotShape(snapshot PlatformSnapshot) error {
+	if snapshot.Format != PlatformSnapshotFormat || snapshot.ObservedAt == "" || !validUID(snapshot.TargetClusterUID) || len(snapshot.Applications) > 20 {
+		return errors.New("platform snapshot identity or size is invalid")
+	}
+	if _, err := time.Parse(time.RFC3339Nano, snapshot.ObservedAt); err != nil {
+		return errors.New("platform snapshot observation time is invalid")
+	}
+	for _, application := range snapshot.Applications {
+		if !validDNSLabel(application.Name) || !validUID(application.UID) || application.ResourceVersion == "" || !validDigest(application.SpecDigest) {
+			return errors.New("platform snapshot Application identity is invalid")
+		}
+		for _, revision := range []string{application.IntentRevision, application.PlatformRevision, application.ExecutionFixture} {
+			if revision != "" && !validDigest(revision) {
+				return errors.New("platform snapshot Application revision is malformed")
+			}
+		}
+		if len(application.DesiredSourceRevision) > 128 || len(application.AppliedSourceRevision) > 128 || len(application.SyncStatus) > 64 || len(application.HealthStatus) > 64 {
+			return errors.New("platform snapshot Application state is oversized")
+		}
+	}
+	capability := snapshot.Capability
+	if capability.Format != PlatformCapabilityFormat || capability.ObservedAt == "" || !validUID(capability.TargetClusterUID) {
+		return errors.New("platform capability identity is invalid")
+	}
+	if _, err := time.Parse(time.RFC3339Nano, capability.ObservedAt); err != nil {
+		return errors.New("platform capability observation time is invalid")
+	}
+	for _, revision := range []string{capability.IntentRevision, capability.PlatformRevision, capability.ContractDigest, capability.ExecutableDigest, capability.EvidenceDigest} {
+		if !validDigest(revision) {
+			return errors.New("platform capability revision or evidence identity is invalid")
+		}
+	}
+	expectedCapabilityDigest, err := PlatformCapabilityDigest(capability)
+	if err != nil || capability.EvidenceDigest != expectedCapabilityDigest {
+		return errors.New("platform capability evidence digest is invalid")
+	}
+	return nil
+}
+
+// PlatformCapabilityDigest binds the normalized capability statement without
+// making its digest self-referential.
+func PlatformCapabilityDigest(capability PlatformCapabilityState) (string, error) {
+	value := capability
+	value.EvidenceDigest = ""
+	return canonicalDigest(value)
+}
+
+func evaluatePlatformState(policy Policy, profile PlatformProfile, snapshot PlatformSnapshot) (string, string, string) {
+	if snapshot.TargetClusterUID != policy.TargetClusterUID {
+		return "Unknown", "RevisionCorrelationUnproven", ""
+	}
+	expected := make(map[string]string, len(profile.RequiredApplications))
+	for _, application := range profile.RequiredApplications {
+		expected[application.Name] = application.SpecDigest
+	}
+	seen := map[string]struct{}{}
+	for _, application := range snapshot.Applications {
+		specDigest, exists := expected[application.Name]
+		if !exists || application.SpecDigest != specDigest {
+			return "False", "PlatformApplicationIdentityMismatch", ""
+		}
+		if _, duplicate := seen[application.Name]; duplicate {
+			return "False", "PlatformApplicationIdentityMismatch", ""
+		}
+		seen[application.Name] = struct{}{}
+		if application.IntentRevision != policy.IntentRevision || application.PlatformRevision != policy.PlatformRevision || application.ExecutionFixture != profile.ExecutionFixture {
+			return "Unknown", "RevisionCorrelationUnproven", ""
+		}
+		if application.DesiredSourceRevision == "" || application.AppliedSourceRevision != application.DesiredSourceRevision {
+			return "Unknown", "PlatformConvergencePending", policy.PlatformRevision
+		}
+		if application.SyncStatus != "Synced" {
+			return "Unknown", "PlatformConvergencePending", policy.PlatformRevision
+		}
+		if application.HealthStatus != "Healthy" {
+			return "False", "PlatformHealthFailed", policy.PlatformRevision
+		}
+	}
+	if len(seen) != len(expected) {
+		return "Unknown", "PlatformApplicationMissing", ""
+	}
+	capability := snapshot.Capability
+	if capability.TargetClusterUID != policy.TargetClusterUID || capability.IntentRevision != policy.IntentRevision || capability.PlatformRevision != policy.PlatformRevision || capability.ContractDigest != profile.CapabilityContractDigest || capability.ExecutableDigest != profile.CapabilityExecutableDigest {
+		return "Unknown", "RevisionCorrelationUnproven", ""
+	}
+	observedAt, _ := time.Parse(time.RFC3339Nano, snapshot.ObservedAt)
+	capabilityAt, _ := time.Parse(time.RFC3339Nano, capability.ObservedAt)
+	age := observedAt.Sub(capabilityAt)
+	if age < 0 || age > time.Duration(profile.MaximumCapabilityAgeSeconds)*time.Second {
+		return "Unknown", "PlatformCapabilityStale", policy.PlatformRevision
+	}
+	if !capability.Passed {
+		return "False", "PlatformCapabilityFailed", policy.PlatformRevision
+	}
+	return "True", "PlatformReady", policy.PlatformRevision
+}
+
+func sortPlatformApplications(applications []PlatformApplicationState) {
+	sort.Slice(applications, func(i, j int) bool { return applications[i].Name < applications[j].Name })
+}

--- a/internal/observation/platform_evaluator_test.go
+++ b/internal/observation/platform_evaluator_test.go
@@ -1,0 +1,216 @@
+package observation
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestEvaluatePlatformSnapshotProducesCurrentEvidence(t *testing.T) {
+	policy, profile, snapshot := validPlatformFixture(t)
+	evidence, err := EvaluatePlatformSnapshot(policy, profile, snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if evidence.Type != "PlatformReady" || evidence.Source != "BoundedPlatformEvaluator" || evidence.Status != "True" || evidence.Reason != "PlatformReady" || evidence.ObservedRevision != policy.PlatformRevision || !validDigest(evidence.EvidenceDigest) {
+		t.Fatalf("unexpected platform evidence: %#v", evidence)
+	}
+	bundle := completeBundle(policy)
+	bundle.Evidence[3] = evidence
+	result, err := Evaluate(policy, bundle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, _ := result.Receipt()
+	if receipt.Ready != "True" {
+		t.Fatalf("platform evidence did not compose: %#v", receipt)
+	}
+}
+
+func TestEvaluatePlatformSnapshotBindsProfileAndCapabilityIdentity(t *testing.T) {
+	policy, profile, snapshot := validPlatformFixture(t)
+	first, err := EvaluatePlatformSnapshot(policy, profile, snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	profile.MaximumCapabilityAgeSeconds++
+	second, err := EvaluatePlatformSnapshot(policy, profile, snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.EvidenceDigest == second.EvidenceDigest || first.SourceUID == second.SourceUID {
+		t.Fatal("platform profile semantic change was not bound into evidence")
+	}
+	snapshot.Capability.Passed = false
+	if _, err := EvaluatePlatformSnapshot(policy, profile, snapshot); err == nil {
+		t.Fatal("tampered capability assertion was accepted without a matching digest")
+	}
+}
+
+func TestPlatformProfileDigestTreatsApplicationMembershipAsASet(t *testing.T) {
+	_, profile, _ := validPlatformFixture(t)
+	first, err := PlatformProfileDigest(profile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	profile.RequiredApplications[0], profile.RequiredApplications[2] = profile.RequiredApplications[2], profile.RequiredApplications[0]
+	second, err := PlatformProfileDigest(profile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first != second {
+		t.Fatalf("membership ordering changed semantic profile identity: %s != %s", first, second)
+	}
+}
+
+func TestEvaluatePlatformSnapshotFailsClosed(t *testing.T) {
+	tests := map[string]struct {
+		mutate func(*PlatformProfile, *PlatformSnapshot)
+		status string
+		reason string
+	}{
+		"foreign target": {
+			mutate: func(_ *PlatformProfile, snapshot *PlatformSnapshot) { snapshot.TargetClusterUID = "other-cluster-uid" },
+			status: "Unknown", reason: "RevisionCorrelationUnproven",
+		},
+		"wrong P carrier": {
+			mutate: func(_ *PlatformProfile, snapshot *PlatformSnapshot) {
+				snapshot.Applications[0].PlatformRevision = "sha256:" + strings.Repeat("f", 64)
+			},
+			status: "Unknown", reason: "RevisionCorrelationUnproven",
+		},
+		"wrong fixture carrier": {
+			mutate: func(_ *PlatformProfile, snapshot *PlatformSnapshot) {
+				snapshot.Applications[0].ExecutionFixture = "sha256:" + strings.Repeat("f", 64)
+			},
+			status: "Unknown", reason: "RevisionCorrelationUnproven",
+		},
+		"application spec drift": {
+			mutate: func(_ *PlatformProfile, snapshot *PlatformSnapshot) {
+				snapshot.Applications[0].SpecDigest = "sha256:" + strings.Repeat("f", 64)
+			},
+			status: "False", reason: "PlatformApplicationIdentityMismatch",
+		},
+		"applied revision pending": {
+			mutate: func(_ *PlatformProfile, snapshot *PlatformSnapshot) {
+				snapshot.Applications[0].AppliedSourceRevision = strings.Repeat("f", 40)
+			},
+			status: "Unknown", reason: "PlatformConvergencePending",
+		},
+		"out of sync": {
+			mutate: func(_ *PlatformProfile, snapshot *PlatformSnapshot) {
+				snapshot.Applications[0].SyncStatus = "OutOfSync"
+			},
+			status: "Unknown", reason: "PlatformConvergencePending",
+		},
+		"degraded": {
+			mutate: func(_ *PlatformProfile, snapshot *PlatformSnapshot) {
+				snapshot.Applications[0].HealthStatus = "Degraded"
+			},
+			status: "False", reason: "PlatformHealthFailed",
+		},
+		"application missing": {
+			mutate: func(_ *PlatformProfile, snapshot *PlatformSnapshot) {
+				snapshot.Applications = snapshot.Applications[:1]
+			},
+			status: "Unknown", reason: "PlatformApplicationMissing",
+		},
+		"capability stale": {
+			mutate: func(_ *PlatformProfile, snapshot *PlatformSnapshot) {
+				snapshot.Capability.ObservedAt = "2026-08-16T08:00:00Z"
+				rebindPlatformCapability(t, snapshot)
+			},
+			status: "Unknown", reason: "PlatformCapabilityStale",
+		},
+		"capability failed": {
+			mutate: func(_ *PlatformProfile, snapshot *PlatformSnapshot) {
+				snapshot.Capability.Passed = false
+				rebindPlatformCapability(t, snapshot)
+			},
+			status: "False", reason: "PlatformCapabilityFailed",
+		},
+	}
+	for name, testCase := range tests {
+		t.Run(name, func(t *testing.T) {
+			policy, profile, snapshot := validPlatformFixture(t)
+			testCase.mutate(&profile, &snapshot)
+			evidence, err := EvaluatePlatformSnapshot(policy, profile, snapshot)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if evidence.Status != testCase.status || evidence.Reason != testCase.reason || evidence.Status == "True" {
+				t.Fatalf("unsafe platform result: %#v", evidence)
+			}
+		})
+	}
+}
+
+func TestValidatePlatformProfileRejectsMutableOrAmbiguousInputs(t *testing.T) {
+	_, profile, _ := validPlatformFixture(t)
+	for name, mutate := range map[string]func(*PlatformProfile){
+		"duplicate application":    func(value *PlatformProfile) { value.RequiredApplications[1].Name = value.RequiredApplications[0].Name },
+		"invalid spec digest":      func(value *PlatformProfile) { value.RequiredApplications[0].SpecDigest = "sha256:no" },
+		"unbounded capability age": func(value *PlatformProfile) { value.MaximumCapabilityAgeSeconds = 86401 },
+		"missing fixture":          func(value *PlatformProfile) { value.ExecutionFixture = "" },
+	} {
+		t.Run(name, func(t *testing.T) {
+			candidate := profile
+			candidate.RequiredApplications = append([]PlatformApplicationExpectation(nil), profile.RequiredApplications...)
+			mutate(&candidate)
+			if err := ValidatePlatformProfile(candidate); err == nil {
+				t.Fatal("unsafe platform profile accepted")
+			}
+		})
+	}
+}
+
+func validPlatformFixture(t *testing.T) (Policy, PlatformProfile, PlatformSnapshot) {
+	t.Helper()
+	policy := Policy{
+		Format: PolicyFormat, IntentRevision: "sha256:" + strings.Repeat("a", 64),
+		EnablementRevision: "sha256:" + strings.Repeat("b", 64), PlatformRevision: "sha256:" + strings.Repeat("c", 64),
+		TargetClusterUID: "cluster-uid-disposable-ok141",
+		Required:         []string{"InfrastructureReady", "ControlPlaneAvailable", "NetworkReady", "PlatformReady"},
+	}
+	fixture := "sha256:" + strings.Repeat("d", 64)
+	profile := PlatformProfile{
+		Format: PlatformProfileFormat, IntentRevision: policy.IntentRevision, PlatformRevision: policy.PlatformRevision,
+		ExecutionFixture: fixture, TargetClusterUID: policy.TargetClusterUID, ArgoNamespace: "argocd", RegistrationName: "disposable-ok141",
+		RequiredApplications: []PlatformApplicationExpectation{
+			{Name: "disposable-ok141-observability-core", SpecDigest: "sha256:" + strings.Repeat("1", 64)},
+			{Name: "disposable-ok141-observability-alerting", SpecDigest: "sha256:" + strings.Repeat("2", 64)},
+			{Name: "disposable-ok141-observability-dashboards", SpecDigest: "sha256:" + strings.Repeat("3", 64)},
+		},
+		CapabilityContractDigest: "sha256:" + strings.Repeat("4", 64), CapabilityExecutableDigest: "sha256:" + strings.Repeat("5", 64),
+		MaximumCapabilityAgeSeconds: 3600,
+	}
+	commit := strings.Repeat("6", 40)
+	applications := make([]PlatformApplicationState, 0, len(profile.RequiredApplications))
+	for index, expected := range profile.RequiredApplications {
+		applications = append(applications, PlatformApplicationState{
+			Name: expected.Name, UID: "application-uid-" + string(rune('a'+index)), ResourceVersion: "17",
+			IntentRevision: policy.IntentRevision, PlatformRevision: policy.PlatformRevision, ExecutionFixture: fixture,
+			SpecDigest: expected.SpecDigest, DesiredSourceRevision: commit, AppliedSourceRevision: commit,
+			SyncStatus: "Synced", HealthStatus: "Healthy",
+		})
+	}
+	snapshot := PlatformSnapshot{
+		Format: PlatformSnapshotFormat, ObservedAt: "2026-08-16T10:00:00Z", TargetClusterUID: policy.TargetClusterUID,
+		Applications: applications,
+		Capability: PlatformCapabilityState{
+			Format: PlatformCapabilityFormat, ObservedAt: "2026-08-16T09:55:00Z", TargetClusterUID: policy.TargetClusterUID,
+			IntentRevision: policy.IntentRevision, PlatformRevision: policy.PlatformRevision,
+			ContractDigest: profile.CapabilityContractDigest, ExecutableDigest: profile.CapabilityExecutableDigest, Passed: true,
+		},
+	}
+	rebindPlatformCapability(t, &snapshot)
+	return policy, profile, snapshot
+}
+
+func rebindPlatformCapability(t *testing.T, snapshot *PlatformSnapshot) {
+	t.Helper()
+	digest, err := PlatformCapabilityDigest(snapshot.Capability)
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshot.Capability.EvidenceDigest = digest
+}

--- a/internal/observation/platform_kubernetes.go
+++ b/internal/observation/platform_kubernetes.go
@@ -1,0 +1,94 @@
+package observation
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const maximumPlatformSourceBytes = 4 * 1024 * 1024
+
+type KubernetesPlatformReaderConfig struct {
+	Endpoint    string
+	BearerToken string
+	Client      *http.Client
+}
+
+// KubernetesPlatformReader can read only the exact Applications named by the
+// immutable profile supplied at construction time.
+type KubernetesPlatformReader struct {
+	endpoint *url.URL
+	token    string
+	client   *http.Client
+	allowed  map[string]struct{}
+}
+
+func NewKubernetesPlatformReader(config KubernetesPlatformReaderConfig, profile PlatformProfile) (*KubernetesPlatformReader, error) {
+	if err := ValidatePlatformProfile(profile); err != nil {
+		return nil, errors.New("platform reader profile is invalid")
+	}
+	endpoint, err := url.Parse(config.Endpoint)
+	if err != nil || endpoint.Scheme != "https" || endpoint.Host == "" || endpoint.User != nil || endpoint.RawQuery != "" || endpoint.Fragment != "" || endpoint.Path != "" && endpoint.Path != "/" {
+		return nil, errors.New("platform reader Kubernetes endpoint is invalid")
+	}
+	if config.BearerToken == "" || strings.TrimSpace(config.BearerToken) != config.BearerToken || strings.ContainsAny(config.BearerToken, "\r\n") || config.Client == nil {
+		return nil, errors.New("platform reader credential or client is invalid")
+	}
+	allowed := make(map[string]struct{}, len(profile.RequiredApplications))
+	for _, application := range profile.RequiredApplications {
+		path := platformApplicationPath(profile.ArgoNamespace, application.Name)
+		allowed[path] = struct{}{}
+	}
+	client := *config.Client
+	client.CheckRedirect = func(_ *http.Request, _ []*http.Request) error { return http.ErrUseLastResponse }
+	if client.Timeout == 0 {
+		client.Timeout = 15 * time.Second
+	}
+	endpoint.Path, endpoint.RawPath = "", ""
+	return &KubernetesPlatformReader{endpoint: endpoint, token: config.BearerToken, client: &client, allowed: allowed}, nil
+}
+
+func (reader *KubernetesPlatformReader) Get(ctx context.Context, path string) ([]byte, error) {
+	if _, allowed := reader.allowed[path]; !allowed {
+		return nil, errors.New("platform reader path is outside the fixed allowlist")
+	}
+	reference, err := url.ParseRequestURI(path)
+	if err != nil || reference.IsAbs() || reference.Host != "" || reference.RawQuery != "" {
+		return nil, errors.New("platform reader allowlisted path is invalid")
+	}
+	endpoint := *reader.endpoint
+	endpoint.Path, endpoint.RawPath = reference.Path, reference.RawPath
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint.String(), nil)
+	if err != nil {
+		return nil, errors.New("construct exact Argo Application request")
+	}
+	request.Header.Set("Accept", "application/json")
+	request.Header.Set("Authorization", "Bearer "+reader.token)
+	response, err := reader.client.Do(request)
+	if err != nil {
+		return nil, errors.New("exact Argo Application request failed")
+	}
+	defer response.Body.Close()
+	raw, readErr := io.ReadAll(io.LimitReader(response.Body, maximumPlatformSourceBytes+1))
+	if readErr != nil || len(raw) > maximumPlatformSourceBytes {
+		return nil, errors.New("exact Argo Application response exceeds accepted size")
+	}
+	if response.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("exact Argo Application request returned HTTP %d", response.StatusCode)
+	}
+	mediaType, _, err := mime.ParseMediaType(response.Header.Get("Content-Type"))
+	if err != nil || mediaType != "application/json" {
+		return nil, errors.New("exact Argo Application response is not JSON")
+	}
+	return raw, nil
+}
+
+func platformApplicationPath(namespace, name string) string {
+	return "/apis/argoproj.io/v1alpha1/namespaces/" + namespace + "/applications/" + name
+}

--- a/internal/observation/platform_kubernetes_test.go
+++ b/internal/observation/platform_kubernetes_test.go
@@ -1,0 +1,100 @@
+package observation
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestKubernetesPlatformReaderAllowsOnlyExactApplications(t *testing.T) {
+	_, profile, _ := validPlatformFixture(t)
+	requests := []string{}
+	client := &http.Client{Transport: platformRoundTripFunc(func(request *http.Request) (*http.Response, error) {
+		requests = append(requests, request.Method+" "+request.URL.RequestURI())
+		if request.Header.Get("Authorization") != "Bearer short-lived-token" || request.Header.Get("Accept") != "application/json" {
+			t.Error("bounded platform request headers differ")
+		}
+		return platformResponse(http.StatusOK, "application/json", `{}`), nil
+	})}
+	reader, err := NewKubernetesPlatformReader(KubernetesPlatformReaderConfig{
+		Endpoint: "https://ok-shared.example.invalid", BearerToken: "short-lived-token", Client: client,
+	}, profile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, application := range profile.RequiredApplications {
+		path := platformApplicationPath(profile.ArgoNamespace, application.Name)
+		if _, err := reader.Get(context.Background(), path); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if len(requests) != len(profile.RequiredApplications) {
+		t.Fatalf("unexpected request count: %v", requests)
+	}
+	for _, path := range []string{
+		"/apis/argoproj.io/v1alpha1/namespaces/argocd/applications",
+		platformApplicationPath(profile.ArgoNamespace, profile.RequiredApplications[0].Name) + "?watch=true",
+		"/api/v1/secrets",
+	} {
+		if _, err := reader.Get(context.Background(), path); err == nil {
+			t.Fatalf("path outside exact Application allowlist accepted: %s", path)
+		}
+	}
+	if len(requests) != len(profile.RequiredApplications) {
+		t.Fatal("forbidden platform path reached the server")
+	}
+}
+
+func TestKubernetesPlatformReaderFailsClosedOnTransportShape(t *testing.T) {
+	_, profile, _ := validPlatformFixture(t)
+	path := platformApplicationPath(profile.ArgoNamespace, profile.RequiredApplications[0].Name)
+	for name, response := range map[string]*http.Response{
+		"redirect":  platformResponse(http.StatusFound, "application/json", `{}`),
+		"non json":  platformResponse(http.StatusOK, "text/plain", `{}`),
+		"oversized": platformResponse(http.StatusOK, "application/json", strings.Repeat("x", maximumPlatformSourceBytes+1)),
+	} {
+		t.Run(name, func(t *testing.T) {
+			client := &http.Client{Transport: platformRoundTripFunc(func(*http.Request) (*http.Response, error) { return response, nil })}
+			reader, err := NewKubernetesPlatformReader(KubernetesPlatformReaderConfig{Endpoint: "https://ok-shared.example.invalid", BearerToken: "token", Client: client}, profile)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := reader.Get(context.Background(), path); err == nil {
+				t.Fatal("unsafe platform transport response accepted")
+			}
+		})
+	}
+}
+
+type platformRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (function platformRoundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return function(request)
+}
+
+func platformResponse(status int, contentType, body string) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Header:     http.Header{"Content-Type": []string{contentType}},
+		Body:       io.NopCloser(strings.NewReader(body)),
+	}
+}
+
+func TestNewKubernetesPlatformReaderRejectsUnsafeConfiguration(t *testing.T) {
+	_, profile, _ := validPlatformFixture(t)
+	client := &http.Client{}
+	for name, config := range map[string]KubernetesPlatformReaderConfig{
+		"plaintext":      {Endpoint: "http://10.0.0.1:6443", BearerToken: "token", Client: client},
+		"endpoint path":  {Endpoint: "https://10.0.0.1:6443/api", BearerToken: "token", Client: client},
+		"token newline":  {Endpoint: "https://10.0.0.1:6443", BearerToken: "token\n", Client: client},
+		"missing client": {Endpoint: "https://10.0.0.1:6443", BearerToken: "token"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := NewKubernetesPlatformReader(config, profile); err == nil {
+				t.Fatal("unsafe platform reader configuration accepted")
+			}
+		})
+	}
+}

--- a/internal/runner/kubernetes.go
+++ b/internal/runner/kubernetes.go
@@ -59,6 +59,17 @@ type KubernetesNetworkObserverConfig struct {
 	Clock                       func() time.Time
 }
 
+// KubernetesPlatformObserverConfig binds the GitOps control-plane authority,
+// an immutable Platform profile and an independently verified capability
+// source. The Argo adapter itself cannot execute capability code.
+type KubernetesPlatformObserverConfig struct {
+	Argo                  KubernetesAuthorityConfig
+	ExpectedArgoAuthority string
+	Profile               observation.PlatformProfile
+	Capability            observation.PlatformCapabilitySource
+	Clock                 func() time.Time
+}
+
 // InspectKubernetesLedger performs a read-only restart decision. It does not
 // claim the grant and therefore cannot authorize a later mutation by itself.
 func InspectKubernetesLedger(ctx context.Context, grant authorization.VerifiedGrant, config KubernetesLedgerConfig) (ledger.Inspection, error) {
@@ -171,6 +182,28 @@ func OpenKubernetesNetworkSourceCollector(config KubernetesNetworkObserverConfig
 	return observation.NewNetworkSourceCollector(management, workload, probe, observation.NetworkCollectorConfig{
 		Namespace: config.Namespace, Name: config.Name, HCPName: config.HCPName,
 		TargetClusterUID: config.TargetClusterUID, Clock: config.Clock,
+	})
+}
+
+// OpenKubernetesPlatformSourceCollector materializes one TLS client restricted
+// to exact Argo Application GETs on the configured GitOps control plane. It
+// performs no API request itself and exposes no sync or mutation operation.
+func OpenKubernetesPlatformSourceCollector(config KubernetesPlatformObserverConfig) (*observation.PlatformSourceCollector, error) {
+	if config.ExpectedArgoAuthority == "" || config.Argo.AuthorityIdentity != config.ExpectedArgoAuthority {
+		return nil, errors.New("platform observer authority differs from the verified GitOps control plane")
+	}
+	token, client, err := openBoundedKubernetesHTTP(config.Argo.TokenFile, config.Argo.CAFile)
+	if err != nil {
+		return nil, errors.New("open bounded GitOps observation credential")
+	}
+	reader, err := observation.NewKubernetesPlatformReader(observation.KubernetesPlatformReaderConfig{
+		Endpoint: config.Argo.Endpoint, BearerToken: token, Client: client,
+	}, config.Profile)
+	if err != nil {
+		return nil, err
+	}
+	return observation.NewPlatformSourceCollector(reader, config.Capability, observation.PlatformCollectorConfig{
+		Profile: config.Profile, Clock: config.Clock,
 	})
 }
 

--- a/internal/runner/kubernetes_test.go
+++ b/internal/runner/kubernetes_test.go
@@ -1,6 +1,7 @@
 package runner
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -13,6 +14,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/openkubes/ok-cluster/internal/observation"
 )
 
 func TestOpenKubernetesLedgerValidatesProjectedInputs(t *testing.T) {
@@ -173,6 +176,44 @@ func TestOpenKubernetesNetworkSourceCollectorBindsDistinctAuthorities(t *testing
 			}
 		})
 	}
+}
+
+func TestOpenKubernetesPlatformSourceCollectorBindsGitOpsAuthority(t *testing.T) {
+	root := t.TempDir()
+	tokenPath := filepath.Join(root, "token")
+	caPath := filepath.Join(root, "ca.crt")
+	if err := os.WriteFile(tokenPath, []byte("short-lived-platform-token"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(caPath, testCA(t), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	digest := func(character string) string { return "sha256:" + strings.Repeat(character, 64) }
+	profile := observation.PlatformProfile{
+		Format: observation.PlatformProfileFormat, IntentRevision: digest("a"), PlatformRevision: digest("b"), ExecutionFixture: digest("c"),
+		TargetClusterUID: "cluster-uid-disposable-ok141", ArgoNamespace: "argocd", RegistrationName: "disposable-ok141",
+		RequiredApplications:     []observation.PlatformApplicationExpectation{{Name: "disposable-ok141-observability-core", SpecDigest: digest("d")}},
+		CapabilityContractDigest: digest("e"), CapabilityExecutableDigest: digest("f"), MaximumCapabilityAgeSeconds: 3600,
+	}
+	config := KubernetesPlatformObserverConfig{
+		Argo: KubernetesAuthorityConfig{
+			Endpoint: "https://10.43.0.1:443", AuthorityIdentity: "ok-shared", TokenFile: tokenPath, CAFile: caPath,
+		},
+		ExpectedArgoAuthority: "ok-shared", Profile: profile, Capability: inertPlatformCapabilitySource{}, Clock: time.Now,
+	}
+	if _, err := OpenKubernetesPlatformSourceCollector(config); err != nil {
+		t.Fatal(err)
+	}
+	config.ExpectedArgoAuthority = "other"
+	if _, err := OpenKubernetesPlatformSourceCollector(config); err == nil || strings.Contains(err.Error(), root) {
+		t.Fatalf("unsafe GitOps authority accepted or disclosed a path: %v", err)
+	}
+}
+
+type inertPlatformCapabilitySource struct{}
+
+func (inertPlatformCapabilitySource) Capability(context.Context) (observation.PlatformCapabilityState, error) {
+	return observation.PlatformCapabilityState{}, nil
 }
 
 func testCA(t *testing.T) []byte {


### PR DESCRIPTION
## What changed

- add a deterministic, revision-bound `PlatformReady` evaluator
- collect only the exact Argo CD Applications named by the immutable Platform profile
- bind Application UID, R, P, execution fixture, semantic spec, desired/applied Git revision, sync and health
- require a separate digest-bound and freshness-bounded capability assertion; Argo health alone cannot prove `PlatformReady`
- add a TLS-only Kubernetes adapter with a fixed exact-GET allowlist and an `ok-shared` authority-bound runner opener
- document the boundary and add positive, negative, transport and authority tests

## Why

OK-147 already composes a Platform source but previously had no concrete implementation. This checkpoint translates the OK-141 Platform evidence model into a bounded read-only adapter without introducing an Argo sync surface, target mutation, arbitrary command execution or an OpenKubes reconciler.

## Impact

This remains an offline implementation checkpoint. The adapter is not wired to the CLI or Job, selects no built-in OK-141 profile, performs no live cluster contact and makes no infrastructure changes.

## Validation

- `go test ./...`
- `go vet ./...`
- `go test -race -ldflags=-linkmode=external ./internal/observation ./internal/runner`
- `python3 -m unittest tests/ok141_kubevirt_infra_secret_ref_test.py tests/ok147_runner_image_test.py tests/ok147_runner_publication_test.py`
- `git diff --check`
