### PR TITLE
feat(runner): bind PlatformReady inputs (OK-147)

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -605,18 +605,45 @@ ordering does not create a different profile identity.
 
 Argo `Synced` and `Healthy` is intentionally not sufficient for
 `PlatformReady=True`. A separately verified, redaction-safe capability
-assertion must bind the same target UID, R, P, capability contract and
-executable identities; its self-independent evidence digest and bounded age
-are checked by the evaluator. The Argo adapter cannot manufacture that
-assertion or run its executable. Missing, stale or revision-mismatched proof
-therefore remains `Unknown`, while current health, identity or capability
-failures remain `False`.
+assertion must bind the same target UID, R, P, execution fixture, capability
+contract and executable identities; its self-independent evidence digest and
+bounded age are checked by the evaluator. The Argo adapter cannot manufacture
+that assertion or run its executable. Missing, stale or revision-mismatched
+proof therefore remains `Unknown`, while current health, identity or
+capability failures remain `False`.
 
 The runner-side opener binds the reader to one explicitly named GitOps
 authority (for the OK-141 topology, `ok-shared`) and a short-lived projected
 credential. The adapter is still not wired to the CLI or Job, no built-in
 OK-141 profile is selected, and this offline checkpoint made no cluster
 contact or infrastructure mutation.
+
+## Digest-bound Platform input loading
+
+The Platform adapter no longer depends on freely constructed profile and
+capability values at its runner boundary. Two separate maximum-64-KiB,
+strict-JSON loaders now materialize:
+
+```text
+Platform profile
+  ↔ expected canonical profile digest + R + P + FixtureDigest + target UID
+
+Capability assertion
+  ↔ expected evidence digest + R + P + FixtureDigest + target UID
+     + capability contract digest + executable digest
+```
+
+Both inputs must be bounded regular files and reject duplicate keys, unknown
+fields, trailing values, malformed identities and semantic changes. Required
+Application membership is canonicalized as a set, so ordering alone does not
+change the profile digest. Capability content is verified against its
+self-independent digest before becoming an immutable in-memory
+`PlatformCapabilitySource`; subsequent changes to or removal of the source file
+cannot alter the loaded assertion.
+
+These loaders execute no capability code and contact no Kubernetes API. The
+independent expected values still have to come from verified execution inputs;
+successful file parsing is neither provenance authority nor a GO decision.
 
 ## OK-141 compatibility evidence
 

--- a/internal/observation/platform_evaluator.go
+++ b/internal/observation/platform_evaluator.go
@@ -68,6 +68,7 @@ type PlatformCapabilityState struct {
 	TargetClusterUID string `json:"targetClusterUid"`
 	IntentRevision   string `json:"intentRevision"`
 	PlatformRevision string `json:"platformRevision"`
+	ExecutionFixture string `json:"executionFixture"`
 	ContractDigest   string `json:"contractDigest"`
 	ExecutableDigest string `json:"executableDigest"`
 	Passed           bool   `json:"passed"`
@@ -181,14 +182,21 @@ func validatePlatformSnapshotShape(snapshot PlatformSnapshot) error {
 			return errors.New("platform snapshot Application state is oversized")
 		}
 	}
-	capability := snapshot.Capability
+	return ValidatePlatformCapabilityState(snapshot.Capability)
+}
+
+// ValidatePlatformCapabilityState checks the complete redaction-safe assertion
+// including its self-independent semantic digest. It does not establish who
+// produced the assertion; expected identities are supplied to the runner input
+// loader from an independently verified execution boundary.
+func ValidatePlatformCapabilityState(capability PlatformCapabilityState) error {
 	if capability.Format != PlatformCapabilityFormat || capability.ObservedAt == "" || !validUID(capability.TargetClusterUID) {
 		return errors.New("platform capability identity is invalid")
 	}
 	if _, err := time.Parse(time.RFC3339Nano, capability.ObservedAt); err != nil {
 		return errors.New("platform capability observation time is invalid")
 	}
-	for _, revision := range []string{capability.IntentRevision, capability.PlatformRevision, capability.ContractDigest, capability.ExecutableDigest, capability.EvidenceDigest} {
+	for _, revision := range []string{capability.IntentRevision, capability.PlatformRevision, capability.ExecutionFixture, capability.ContractDigest, capability.ExecutableDigest, capability.EvidenceDigest} {
 		if !validDigest(revision) {
 			return errors.New("platform capability revision or evidence identity is invalid")
 		}
@@ -243,7 +251,7 @@ func evaluatePlatformState(policy Policy, profile PlatformProfile, snapshot Plat
 		return "Unknown", "PlatformApplicationMissing", ""
 	}
 	capability := snapshot.Capability
-	if capability.TargetClusterUID != policy.TargetClusterUID || capability.IntentRevision != policy.IntentRevision || capability.PlatformRevision != policy.PlatformRevision || capability.ContractDigest != profile.CapabilityContractDigest || capability.ExecutableDigest != profile.CapabilityExecutableDigest {
+	if capability.TargetClusterUID != policy.TargetClusterUID || capability.IntentRevision != policy.IntentRevision || capability.PlatformRevision != policy.PlatformRevision || capability.ExecutionFixture != profile.ExecutionFixture || capability.ContractDigest != profile.CapabilityContractDigest || capability.ExecutableDigest != profile.CapabilityExecutableDigest {
 		return "Unknown", "RevisionCorrelationUnproven", ""
 	}
 	observedAt, _ := time.Parse(time.RFC3339Nano, snapshot.ObservedAt)

--- a/internal/observation/platform_evaluator_test.go
+++ b/internal/observation/platform_evaluator_test.go
@@ -121,6 +121,13 @@ func TestEvaluatePlatformSnapshotFailsClosed(t *testing.T) {
 			},
 			status: "Unknown", reason: "PlatformCapabilityStale",
 		},
+		"capability from other fixture": {
+			mutate: func(_ *PlatformProfile, snapshot *PlatformSnapshot) {
+				snapshot.Capability.ExecutionFixture = "sha256:" + strings.Repeat("f", 64)
+				rebindPlatformCapability(t, snapshot)
+			},
+			status: "Unknown", reason: "RevisionCorrelationUnproven",
+		},
 		"capability failed": {
 			mutate: func(_ *PlatformProfile, snapshot *PlatformSnapshot) {
 				snapshot.Capability.Passed = false
@@ -198,7 +205,7 @@ func validPlatformFixture(t *testing.T) (Policy, PlatformProfile, PlatformSnapsh
 		Applications: applications,
 		Capability: PlatformCapabilityState{
 			Format: PlatformCapabilityFormat, ObservedAt: "2026-08-16T09:55:00Z", TargetClusterUID: policy.TargetClusterUID,
-			IntentRevision: policy.IntentRevision, PlatformRevision: policy.PlatformRevision,
+			IntentRevision: policy.IntentRevision, PlatformRevision: policy.PlatformRevision, ExecutionFixture: fixture,
 			ContractDigest: profile.CapabilityContractDigest, ExecutableDigest: profile.CapabilityExecutableDigest, Passed: true,
 		},
 	}

--- a/internal/runner/platform_inputs.go
+++ b/internal/runner/platform_inputs.go
@@ -1,0 +1,117 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"regexp"
+
+	"github.com/openkubes/ok-cluster/internal/jsonstrict"
+	"github.com/openkubes/ok-cluster/internal/observation"
+)
+
+const (
+	maximumPlatformProfileBytes    = 64 * 1024
+	maximumPlatformCapabilityBytes = 64 * 1024
+)
+
+var platformInputDigestPattern = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
+
+// PlatformProfileFileConfig binds a strict local profile to identities from
+// already verified execution inputs. The path itself is never retained.
+type PlatformProfileFileConfig struct {
+	Path                     string
+	ExpectedProfileDigest    string
+	ExpectedIntentRevision   string
+	ExpectedPlatformRevision string
+	ExpectedExecutionFixture string
+	ExpectedTargetClusterUID string
+}
+
+type LoadedPlatformProfile struct {
+	Profile observation.PlatformProfile
+	Digest  string
+}
+
+// LoadPlatformProfileFile reads one bounded regular strict-JSON document and
+// rejects any semantic or canonical-identity difference from its bindings.
+func LoadPlatformProfileFile(config PlatformProfileFileConfig) (LoadedPlatformProfile, error) {
+	if config.Path == "" || !platformInputDigestPattern.MatchString(config.ExpectedProfileDigest) || !platformInputDigestPattern.MatchString(config.ExpectedIntentRevision) || !platformInputDigestPattern.MatchString(config.ExpectedPlatformRevision) || !platformInputDigestPattern.MatchString(config.ExpectedExecutionFixture) || config.ExpectedTargetClusterUID == "" {
+		return LoadedPlatformProfile{}, errors.New("platform profile file binding is invalid")
+	}
+	raw, err := readBoundedRegular(config.Path, maximumPlatformProfileBytes)
+	if err != nil {
+		return LoadedPlatformProfile{}, errors.New("read bounded platform profile")
+	}
+	var profile observation.PlatformProfile
+	if err := jsonstrict.Decode(raw, &profile); err != nil {
+		return LoadedPlatformProfile{}, errors.New("decode strict platform profile")
+	}
+	if profile.IntentRevision != config.ExpectedIntentRevision || profile.PlatformRevision != config.ExpectedPlatformRevision || profile.ExecutionFixture != config.ExpectedExecutionFixture || profile.TargetClusterUID != config.ExpectedTargetClusterUID {
+		return LoadedPlatformProfile{}, errors.New("platform profile identity differs from verified execution input")
+	}
+	digest, err := observation.PlatformProfileDigest(profile)
+	if err != nil {
+		return LoadedPlatformProfile{}, errors.New("validate semantic platform profile")
+	}
+	if digest != config.ExpectedProfileDigest {
+		return LoadedPlatformProfile{}, errors.New("platform profile digest differs from verified execution input")
+	}
+	return LoadedPlatformProfile{Profile: profile, Digest: digest}, nil
+}
+
+// PlatformCapabilityFileConfig binds a redaction-safe assertion to all of the
+// identities that make it relevant to the current execution.
+type PlatformCapabilityFileConfig struct {
+	Path                     string
+	ExpectedEvidenceDigest   string
+	ExpectedIntentRevision   string
+	ExpectedPlatformRevision string
+	ExpectedExecutionFixture string
+	ExpectedTargetClusterUID string
+	ExpectedContractDigest   string
+	ExpectedExecutableDigest string
+}
+
+// LoadedPlatformCapability is an immutable in-memory capability source. Raw
+// bytes and the input path are discarded before it can be passed to the Argo
+// collector.
+type LoadedPlatformCapability struct {
+	state  observation.PlatformCapabilityState
+	digest string
+}
+
+func (loaded LoadedPlatformCapability) Capability(ctx context.Context) (observation.PlatformCapabilityState, error) {
+	if err := ctx.Err(); err != nil {
+		return observation.PlatformCapabilityState{}, err
+	}
+	return loaded.state, nil
+}
+
+func (loaded LoadedPlatformCapability) EvidenceDigest() string {
+	return loaded.digest
+}
+
+// LoadPlatformCapabilityFile verifies one previously produced capability
+// assertion. It never executes the capability test or reads cluster state.
+func LoadPlatformCapabilityFile(config PlatformCapabilityFileConfig) (LoadedPlatformCapability, error) {
+	if config.Path == "" || !platformInputDigestPattern.MatchString(config.ExpectedEvidenceDigest) || !platformInputDigestPattern.MatchString(config.ExpectedIntentRevision) || !platformInputDigestPattern.MatchString(config.ExpectedPlatformRevision) || !platformInputDigestPattern.MatchString(config.ExpectedExecutionFixture) || config.ExpectedTargetClusterUID == "" || !platformInputDigestPattern.MatchString(config.ExpectedContractDigest) || !platformInputDigestPattern.MatchString(config.ExpectedExecutableDigest) {
+		return LoadedPlatformCapability{}, errors.New("platform capability file binding is invalid")
+	}
+	raw, err := readBoundedRegular(config.Path, maximumPlatformCapabilityBytes)
+	if err != nil {
+		return LoadedPlatformCapability{}, errors.New("read bounded platform capability evidence")
+	}
+	var state observation.PlatformCapabilityState
+	if err := jsonstrict.Decode(raw, &state); err != nil {
+		return LoadedPlatformCapability{}, errors.New("decode strict platform capability evidence")
+	}
+	if err := observation.ValidatePlatformCapabilityState(state); err != nil {
+		return LoadedPlatformCapability{}, errors.New("validate platform capability evidence")
+	}
+	if state.EvidenceDigest != config.ExpectedEvidenceDigest || state.IntentRevision != config.ExpectedIntentRevision || state.PlatformRevision != config.ExpectedPlatformRevision || state.ExecutionFixture != config.ExpectedExecutionFixture || state.TargetClusterUID != config.ExpectedTargetClusterUID || state.ContractDigest != config.ExpectedContractDigest || state.ExecutableDigest != config.ExpectedExecutableDigest {
+		return LoadedPlatformCapability{}, errors.New("platform capability identity differs from verified execution input")
+	}
+	return LoadedPlatformCapability{state: state, digest: state.EvidenceDigest}, nil
+}
+
+var _ observation.PlatformCapabilitySource = LoadedPlatformCapability{}

--- a/internal/runner/platform_inputs_test.go
+++ b/internal/runner/platform_inputs_test.go
@@ -1,0 +1,227 @@
+package runner
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/openkubes/ok-cluster/internal/observation"
+)
+
+func TestLoadPlatformProfileFileBindsCanonicalMembership(t *testing.T) {
+	root := t.TempDir()
+	profile := runnerPlatformProfile()
+	digest, err := observation.PlatformProfileDigest(profile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(root, "platform-profile.json")
+	writePlatformJSON(t, path, profile)
+	config := PlatformProfileFileConfig{
+		Path: path, ExpectedProfileDigest: digest, ExpectedIntentRevision: profile.IntentRevision,
+		ExpectedPlatformRevision: profile.PlatformRevision, ExpectedExecutionFixture: profile.ExecutionFixture,
+		ExpectedTargetClusterUID: profile.TargetClusterUID,
+	}
+	loaded, err := LoadPlatformProfileFile(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.Digest != digest || loaded.Profile.TargetClusterUID != profile.TargetClusterUID {
+		t.Fatalf("loaded Platform profile differs: %#v", loaded)
+	}
+	profile.RequiredApplications[0], profile.RequiredApplications[2] = profile.RequiredApplications[2], profile.RequiredApplications[0]
+	writePlatformJSON(t, path, profile)
+	reordered, err := LoadPlatformProfileFile(config)
+	if err != nil || reordered.Digest != digest {
+		t.Fatalf("equivalent Application membership changed identity: %#v %v", reordered, err)
+	}
+}
+
+func TestLoadPlatformProfileFileRejectsMalformedOrUnboundInput(t *testing.T) {
+	root := t.TempDir()
+	profile := runnerPlatformProfile()
+	digest, _ := observation.PlatformProfileDigest(profile)
+	validRaw, _ := json.Marshal(profile)
+	base := PlatformProfileFileConfig{
+		ExpectedProfileDigest: digest, ExpectedIntentRevision: profile.IntentRevision,
+		ExpectedPlatformRevision: profile.PlatformRevision, ExpectedExecutionFixture: profile.ExecutionFixture,
+		ExpectedTargetClusterUID: profile.TargetClusterUID,
+	}
+	for name, raw := range map[string][]byte{
+		"unknown field":   append(validRaw[:len(validRaw)-1], []byte(`,"extra":true}`)...),
+		"duplicate field": []byte(strings.Replace(string(validRaw), `"format":"`+observation.PlatformProfileFormat+`"`, `"format":"`+observation.PlatformProfileFormat+`","format":"`+observation.PlatformProfileFormat+`"`, 1)),
+		"trailing value":  append(append([]byte(nil), validRaw...), []byte(` {}`)...),
+		"oversized":       []byte(`{"format":"` + strings.Repeat("x", maximumPlatformProfileBytes) + `"}`),
+	} {
+		t.Run(name, func(t *testing.T) {
+			path := filepath.Join(root, strings.ReplaceAll(name, " ", "-")+".json")
+			if err := os.WriteFile(path, raw, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			config := base
+			config.Path = path
+			if _, err := LoadPlatformProfileFile(config); err == nil || strings.Contains(err.Error(), root) {
+				t.Fatalf("unsafe Platform profile accepted or disclosed path: %v", err)
+			}
+		})
+	}
+	path := filepath.Join(root, "valid.json")
+	writePlatformJSON(t, path, profile)
+	base.Path = path
+	for name, mutate := range map[string]func(*PlatformProfileFileConfig){
+		"wrong digest":  func(config *PlatformProfileFileConfig) { config.ExpectedProfileDigest = digestOf("9") },
+		"wrong R":       func(config *PlatformProfileFileConfig) { config.ExpectedIntentRevision = digestOf("9") },
+		"wrong P":       func(config *PlatformProfileFileConfig) { config.ExpectedPlatformRevision = digestOf("9") },
+		"wrong fixture": func(config *PlatformProfileFileConfig) { config.ExpectedExecutionFixture = digestOf("9") },
+		"wrong target":  func(config *PlatformProfileFileConfig) { config.ExpectedTargetClusterUID = "other-cluster-uid" },
+	} {
+		t.Run(name, func(t *testing.T) {
+			config := base
+			mutate(&config)
+			if _, err := LoadPlatformProfileFile(config); err == nil || strings.Contains(err.Error(), root) {
+				t.Fatalf("unbound Platform profile accepted or disclosed path: %v", err)
+			}
+		})
+	}
+}
+
+func TestLoadPlatformCapabilityFileProducesImmutableSource(t *testing.T) {
+	root := t.TempDir()
+	state := runnerPlatformCapability(t)
+	path := filepath.Join(root, "platform-capability.json")
+	writePlatformJSON(t, path, state)
+	config := PlatformCapabilityFileConfig{
+		Path: path, ExpectedEvidenceDigest: state.EvidenceDigest, ExpectedIntentRevision: state.IntentRevision,
+		ExpectedPlatformRevision: state.PlatformRevision, ExpectedExecutionFixture: state.ExecutionFixture, ExpectedTargetClusterUID: state.TargetClusterUID,
+		ExpectedContractDigest: state.ContractDigest, ExpectedExecutableDigest: state.ExecutableDigest,
+	}
+	loaded, err := LoadPlatformCapabilityFile(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.EvidenceDigest() != state.EvidenceDigest {
+		t.Fatal("loaded capability digest differs")
+	}
+	if err := os.WriteFile(path, []byte(`{}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	retained, err := loaded.Capability(context.Background())
+	if err != nil || retained != state {
+		t.Fatalf("loaded capability retained path dependency: %#v %v", retained, err)
+	}
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := loaded.Capability(cancelled); err == nil {
+		t.Fatal("cancelled capability read was accepted")
+	}
+}
+
+func TestLoadPlatformCapabilityFileRejectsTamperingAndBindingChanges(t *testing.T) {
+	root := t.TempDir()
+	state := runnerPlatformCapability(t)
+	path := filepath.Join(root, "platform-capability.json")
+	writePlatformJSON(t, path, state)
+	base := PlatformCapabilityFileConfig{
+		Path: path, ExpectedEvidenceDigest: state.EvidenceDigest, ExpectedIntentRevision: state.IntentRevision,
+		ExpectedPlatformRevision: state.PlatformRevision, ExpectedExecutionFixture: state.ExecutionFixture, ExpectedTargetClusterUID: state.TargetClusterUID,
+		ExpectedContractDigest: state.ContractDigest, ExpectedExecutableDigest: state.ExecutableDigest,
+	}
+	for name, mutate := range map[string]func(*PlatformCapabilityFileConfig){
+		"wrong evidence":   func(config *PlatformCapabilityFileConfig) { config.ExpectedEvidenceDigest = digestOf("9") },
+		"wrong R":          func(config *PlatformCapabilityFileConfig) { config.ExpectedIntentRevision = digestOf("9") },
+		"wrong P":          func(config *PlatformCapabilityFileConfig) { config.ExpectedPlatformRevision = digestOf("9") },
+		"wrong fixture":    func(config *PlatformCapabilityFileConfig) { config.ExpectedExecutionFixture = digestOf("9") },
+		"wrong target":     func(config *PlatformCapabilityFileConfig) { config.ExpectedTargetClusterUID = "other-cluster-uid" },
+		"wrong contract":   func(config *PlatformCapabilityFileConfig) { config.ExpectedContractDigest = digestOf("9") },
+		"wrong executable": func(config *PlatformCapabilityFileConfig) { config.ExpectedExecutableDigest = digestOf("9") },
+	} {
+		t.Run(name, func(t *testing.T) {
+			config := base
+			mutate(&config)
+			if _, err := LoadPlatformCapabilityFile(config); err == nil || strings.Contains(err.Error(), root) {
+				t.Fatalf("unbound capability accepted or disclosed path: %v", err)
+			}
+		})
+	}
+	state.Passed = false
+	writePlatformJSON(t, path, state)
+	if _, err := LoadPlatformCapabilityFile(base); err == nil {
+		t.Fatal("tampered capability retained the old semantic digest")
+	}
+}
+
+func TestLoadPlatformCapabilityFileRejectsMalformedInput(t *testing.T) {
+	root := t.TempDir()
+	state := runnerPlatformCapability(t)
+	validRaw, _ := json.Marshal(state)
+	base := PlatformCapabilityFileConfig{
+		ExpectedEvidenceDigest: state.EvidenceDigest, ExpectedIntentRevision: state.IntentRevision,
+		ExpectedPlatformRevision: state.PlatformRevision, ExpectedExecutionFixture: state.ExecutionFixture, ExpectedTargetClusterUID: state.TargetClusterUID,
+		ExpectedContractDigest: state.ContractDigest, ExpectedExecutableDigest: state.ExecutableDigest,
+	}
+	for name, raw := range map[string][]byte{
+		"unknown field":   append(validRaw[:len(validRaw)-1], []byte(`,"extra":true}`)...),
+		"duplicate field": []byte(strings.Replace(string(validRaw), `"format":"`+observation.PlatformCapabilityFormat+`"`, `"format":"`+observation.PlatformCapabilityFormat+`","format":"`+observation.PlatformCapabilityFormat+`"`, 1)),
+		"trailing value":  append(append([]byte(nil), validRaw...), []byte(` {}`)...),
+		"oversized":       []byte(`{"format":"` + strings.Repeat("x", maximumPlatformCapabilityBytes) + `"}`),
+	} {
+		t.Run(name, func(t *testing.T) {
+			path := filepath.Join(root, strings.ReplaceAll(name, " ", "-")+".json")
+			if err := os.WriteFile(path, raw, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			config := base
+			config.Path = path
+			if _, err := LoadPlatformCapabilityFile(config); err == nil || strings.Contains(err.Error(), root) {
+				t.Fatalf("unsafe capability input accepted or disclosed path: %v", err)
+			}
+		})
+	}
+}
+
+func runnerPlatformProfile() observation.PlatformProfile {
+	return observation.PlatformProfile{
+		Format: observation.PlatformProfileFormat, IntentRevision: digestOf("a"), PlatformRevision: digestOf("b"), ExecutionFixture: digestOf("c"),
+		TargetClusterUID: "cluster-uid-disposable-ok141", ArgoNamespace: "argocd", RegistrationName: "disposable-ok141",
+		RequiredApplications: []observation.PlatformApplicationExpectation{
+			{Name: "disposable-ok141-observability-core", SpecDigest: digestOf("1")},
+			{Name: "disposable-ok141-observability-alerting", SpecDigest: digestOf("2")},
+			{Name: "disposable-ok141-observability-dashboards", SpecDigest: digestOf("3")},
+		},
+		CapabilityContractDigest: digestOf("4"), CapabilityExecutableDigest: digestOf("5"), MaximumCapabilityAgeSeconds: 3600,
+	}
+}
+
+func runnerPlatformCapability(t *testing.T) observation.PlatformCapabilityState {
+	t.Helper()
+	profile := runnerPlatformProfile()
+	state := observation.PlatformCapabilityState{
+		Format: observation.PlatformCapabilityFormat, ObservedAt: "2026-08-16T09:55:00Z", TargetClusterUID: profile.TargetClusterUID,
+		IntentRevision: profile.IntentRevision, PlatformRevision: profile.PlatformRevision, ExecutionFixture: profile.ExecutionFixture,
+		ContractDigest: profile.CapabilityContractDigest, ExecutableDigest: profile.CapabilityExecutableDigest, Passed: true,
+	}
+	digest, err := observation.PlatformCapabilityDigest(state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	state.EvidenceDigest = digest
+	return state
+}
+
+func writePlatformJSON(t *testing.T, path string, value any) {
+	t.Helper()
+	raw, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func digestOf(character string) string {
+	return "sha256:" + strings.Repeat(character, 64)
+}


### PR DESCRIPTION
## What changed

- add strict, bounded Platform profile loading bound to canonical profile digest, R, P, FixtureDigest and target Cluster UID
- add strict, bounded capability-evidence loading bound to evidence digest, R, P, FixtureDigest, target UID, capability contract and executable
- retain loaded capability evidence as an immutable in-memory `PlatformCapabilitySource`
- extend Platform capability semantics to reject evidence from a different execution fixture
- add malformed, duplicate-field, oversized, tampering, identity and post-load file-change tests
- document the input trust boundary

## Why

The new read-only Argo adapter still accepted freely constructed Go values at its runner boundary. This checkpoint makes the two Platform inputs independently and cryptographically bindable before later CLI or Job wiring, while preserving the distinction between parsing, provenance authority and execution authorization.

## Impact

This is an offline materialization checkpoint. It executes no capability code, performs no Kubernetes request, selects no built-in OK-141 profile and makes no infrastructure mutation.

## Validation

- `go test ./...`
- `go vet ./...`
- `go test -race -ldflags=-linkmode=external ./internal/observation ./internal/runner`
- `python3 -m unittest tests/ok141_kubevirt_infra_secret_ref_test.py tests/ok147_runner_image_test.py tests/ok147_runner_publication_test.py`
- `git diff --check`
