### PR TITLE
fix(runner): bind Platform target after submission (OK-147)

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -626,7 +626,8 @@ strict-JSON loaders now materialize:
 
 ```text
 Platform profile
-  ↔ expected canonical profile digest + R + P + FixtureDigest + target UID
+  ↔ expected canonical profile digest + R + P + FixtureDigest
+     + target identity scheme capi-cluster-uid/v1
 
 Capability assertion
   ↔ expected evidence digest + R + P + FixtureDigest + target UID
@@ -644,6 +645,15 @@ cannot alter the loaded assertion.
 These loaders execute no capability code and contact no Kubernetes API. The
 independent expected values still have to come from verified execution inputs;
 successful file parsing is neither provenance authority nor a GO decision.
+
+The concrete target Cluster UID is deliberately absent from the Platform
+profile and therefore from P: it does not exist until the exact CAPI Cluster
+submission response is available. The profile binds the
+`capi-cluster-uid/v1` resolution scheme and the Argo registration name. At
+observation time, the Platform collector receives the post-submission UID from
+the execution policy, rejects any different configured target before an Argo
+request, and requires the capability assertion to carry that same UID. This
+keeps pre-runtime Platform semantics separate from runtime correlation.
 
 ## OK-141 compatibility evidence
 

--- a/internal/observation/platform_collector.go
+++ b/internal/observation/platform_collector.go
@@ -24,8 +24,9 @@ type PlatformCapabilitySource interface {
 }
 
 type PlatformCollectorConfig struct {
-	Profile PlatformProfile
-	Clock   func() time.Time
+	Profile          PlatformProfile
+	TargetClusterUID string
+	Clock            func() time.Time
 }
 
 type PlatformSourceCollector struct {
@@ -38,7 +39,7 @@ func NewPlatformSourceCollector(argo PlatformRawGetter, capability PlatformCapab
 	if argo == nil || capability == nil || config.Clock == nil {
 		return nil, errors.New("platform collector sources and clock are required")
 	}
-	if err := ValidatePlatformProfile(config.Profile); err != nil {
+	if err := ValidatePlatformProfile(config.Profile); err != nil || !validUID(config.TargetClusterUID) {
 		return nil, errors.New("platform collector profile is invalid")
 	}
 	return &PlatformSourceCollector{argo: argo, capability: capability, config: config}, nil
@@ -62,6 +63,9 @@ func (collector *PlatformSourceCollector) Collect(ctx context.Context, policy Po
 	if err := validatePlatformProfile(policy, collector.config.Profile); err != nil {
 		return PlatformSnapshot{}, err
 	}
+	if collector.config.TargetClusterUID != policy.TargetClusterUID {
+		return PlatformSnapshot{}, errors.New("platform collector target differs from the runtime-bound Cluster")
+	}
 	applications := make([]PlatformApplicationState, 0, len(collector.config.Profile.RequiredApplications))
 	for _, expected := range collector.config.Profile.RequiredApplications {
 		path := platformApplicationPath(collector.config.Profile.ArgoNamespace, expected.Name)
@@ -82,7 +86,7 @@ func (collector *PlatformSourceCollector) Collect(ctx context.Context, policy Po
 	}
 	return PlatformSnapshot{
 		Format: PlatformSnapshotFormat, ObservedAt: collector.config.Clock().UTC().Format(time.RFC3339Nano),
-		TargetClusterUID: collector.config.Profile.TargetClusterUID,
+		TargetClusterUID: collector.config.TargetClusterUID,
 		Applications:     applications, Capability: capability,
 	}, nil
 }

--- a/internal/observation/platform_collector_test.go
+++ b/internal/observation/platform_collector_test.go
@@ -13,7 +13,7 @@ func TestPlatformCollectorReadsExactApplicationsAndComposes(t *testing.T) {
 	policy, profile, capability, getter := platformCollectorFixture(t)
 	source := &fakePlatformCapabilitySource{capability: capability}
 	collector, err := NewPlatformSourceCollector(getter, source, PlatformCollectorConfig{
-		Profile: profile, Clock: func() time.Time { return time.Date(2026, 8, 16, 10, 0, 0, 0, time.UTC) },
+		Profile: profile, TargetClusterUID: policy.TargetClusterUID, Clock: func() time.Time { return time.Date(2026, 8, 16, 10, 0, 0, 0, time.UTC) },
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -51,7 +51,7 @@ func TestPlatformCollectorRejectsRawIdentityAndMutableSource(t *testing.T) {
 			}
 			mutate(object)
 			localGetter.responses[first], _ = json.Marshal(object)
-			collector, err := NewPlatformSourceCollector(localGetter, &fakePlatformCapabilitySource{capability: localCapability}, PlatformCollectorConfig{Profile: localProfile, Clock: time.Now})
+			collector, err := NewPlatformSourceCollector(localGetter, &fakePlatformCapabilitySource{capability: localCapability}, PlatformCollectorConfig{Profile: localProfile, TargetClusterUID: policy.TargetClusterUID, Clock: time.Now})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -68,7 +68,7 @@ func TestPlatformCollectorRedactsSourceErrorsAndDoesNotRunCapabilityEarly(t *tes
 	policy, profile, capability, getter := platformCollectorFixture(t)
 	getter.err = errors.New("secret endpoint detail")
 	source := &fakePlatformCapabilitySource{capability: capability}
-	collector, err := NewPlatformSourceCollector(getter, source, PlatformCollectorConfig{Profile: profile, Clock: time.Now})
+	collector, err := NewPlatformSourceCollector(getter, source, PlatformCollectorConfig{Profile: profile, TargetClusterUID: policy.TargetClusterUID, Clock: time.Now})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -77,6 +77,23 @@ func TestPlatformCollectorRedactsSourceErrorsAndDoesNotRunCapabilityEarly(t *tes
 	}
 	if source.calls != 0 {
 		t.Fatal("capability source ran after Application collection failed")
+	}
+}
+
+func TestPlatformCollectorBindsRuntimeTargetAfterSubmission(t *testing.T) {
+	policy, profile, capability, getter := platformCollectorFixture(t)
+	if _, err := NewPlatformSourceCollector(getter, &fakePlatformCapabilitySource{capability: capability}, PlatformCollectorConfig{Profile: profile, Clock: time.Now}); err == nil {
+		t.Fatal("platform collector accepted no runtime target")
+	}
+	collector, err := NewPlatformSourceCollector(getter, &fakePlatformCapabilitySource{capability: capability}, PlatformCollectorConfig{Profile: profile, TargetClusterUID: "different-cluster-uid", Clock: time.Now})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := collector.Collect(context.Background(), policy); err == nil {
+		t.Fatal("platform collector accepted a target different from the post-submission policy")
+	}
+	if len(getter.paths) != 0 {
+		t.Fatal("platform collector contacted Argo before rejecting runtime target mismatch")
 	}
 }
 

--- a/internal/observation/platform_evaluator.go
+++ b/internal/observation/platform_evaluator.go
@@ -21,7 +21,7 @@ type PlatformProfile struct {
 	IntentRevision              string                           `json:"intentRevision"`
 	PlatformRevision            string                           `json:"platformRevision"`
 	ExecutionFixture            string                           `json:"executionFixture"`
-	TargetClusterUID            string                           `json:"targetClusterUid"`
+	TargetIdentityScheme        string                           `json:"targetIdentityScheme"`
 	ArgoNamespace               string                           `json:"argoNamespace"`
 	RegistrationName            string                           `json:"registrationName"`
 	RequiredApplications        []PlatformApplicationExpectation `json:"requiredApplications"`
@@ -118,7 +118,7 @@ func EvaluatePlatformSnapshot(policy Policy, profile PlatformProfile, snapshot P
 }
 
 func ValidatePlatformProfile(profile PlatformProfile) error {
-	if profile.Format != PlatformProfileFormat || !validDigest(profile.IntentRevision) || !validDigest(profile.PlatformRevision) || !validDigest(profile.ExecutionFixture) || !validUID(profile.TargetClusterUID) {
+	if profile.Format != PlatformProfileFormat || !validDigest(profile.IntentRevision) || !validDigest(profile.PlatformRevision) || !validDigest(profile.ExecutionFixture) || profile.TargetIdentityScheme != "capi-cluster-uid/v1" {
 		return errors.New("platform profile format or revision identity is invalid")
 	}
 	if !validDNSLabel(profile.ArgoNamespace) || !validDNSLabel(profile.RegistrationName) || len(profile.RequiredApplications) == 0 || len(profile.RequiredApplications) > 20 {
@@ -156,7 +156,7 @@ func validatePlatformProfile(policy Policy, profile PlatformProfile) error {
 	if err := ValidatePlatformProfile(profile); err != nil {
 		return err
 	}
-	if profile.IntentRevision != policy.IntentRevision || profile.PlatformRevision != policy.PlatformRevision || profile.TargetClusterUID != policy.TargetClusterUID {
+	if profile.IntentRevision != policy.IntentRevision || profile.PlatformRevision != policy.PlatformRevision {
 		return errors.New("platform profile identity differs from observation policy")
 	}
 	return nil

--- a/internal/observation/platform_evaluator_test.go
+++ b/internal/observation/platform_evaluator_test.go
@@ -158,6 +158,7 @@ func TestValidatePlatformProfileRejectsMutableOrAmbiguousInputs(t *testing.T) {
 		"invalid spec digest":      func(value *PlatformProfile) { value.RequiredApplications[0].SpecDigest = "sha256:no" },
 		"unbounded capability age": func(value *PlatformProfile) { value.MaximumCapabilityAgeSeconds = 86401 },
 		"missing fixture":          func(value *PlatformProfile) { value.ExecutionFixture = "" },
+		"wrong target scheme":      func(value *PlatformProfile) { value.TargetIdentityScheme = "name/v1" },
 	} {
 		t.Run(name, func(t *testing.T) {
 			candidate := profile
@@ -181,7 +182,7 @@ func validPlatformFixture(t *testing.T) (Policy, PlatformProfile, PlatformSnapsh
 	fixture := "sha256:" + strings.Repeat("d", 64)
 	profile := PlatformProfile{
 		Format: PlatformProfileFormat, IntentRevision: policy.IntentRevision, PlatformRevision: policy.PlatformRevision,
-		ExecutionFixture: fixture, TargetClusterUID: policy.TargetClusterUID, ArgoNamespace: "argocd", RegistrationName: "disposable-ok141",
+		ExecutionFixture: fixture, TargetIdentityScheme: "capi-cluster-uid/v1", ArgoNamespace: "argocd", RegistrationName: "disposable-ok141",
 		RequiredApplications: []PlatformApplicationExpectation{
 			{Name: "disposable-ok141-observability-core", SpecDigest: "sha256:" + strings.Repeat("1", 64)},
 			{Name: "disposable-ok141-observability-alerting", SpecDigest: "sha256:" + strings.Repeat("2", 64)},

--- a/internal/runner/kubernetes.go
+++ b/internal/runner/kubernetes.go
@@ -67,6 +67,7 @@ type KubernetesPlatformObserverConfig struct {
 	ExpectedArgoAuthority string
 	Profile               observation.PlatformProfile
 	Capability            observation.PlatformCapabilitySource
+	TargetClusterUID      string
 	Clock                 func() time.Time
 }
 
@@ -203,7 +204,7 @@ func OpenKubernetesPlatformSourceCollector(config KubernetesPlatformObserverConf
 		return nil, err
 	}
 	return observation.NewPlatformSourceCollector(reader, config.Capability, observation.PlatformCollectorConfig{
-		Profile: config.Profile, Clock: config.Clock,
+		Profile: config.Profile, TargetClusterUID: config.TargetClusterUID, Clock: config.Clock,
 	})
 }
 

--- a/internal/runner/kubernetes_test.go
+++ b/internal/runner/kubernetes_test.go
@@ -191,7 +191,7 @@ func TestOpenKubernetesPlatformSourceCollectorBindsGitOpsAuthority(t *testing.T)
 	digest := func(character string) string { return "sha256:" + strings.Repeat(character, 64) }
 	profile := observation.PlatformProfile{
 		Format: observation.PlatformProfileFormat, IntentRevision: digest("a"), PlatformRevision: digest("b"), ExecutionFixture: digest("c"),
-		TargetClusterUID: "cluster-uid-disposable-ok141", ArgoNamespace: "argocd", RegistrationName: "disposable-ok141",
+		TargetIdentityScheme: "capi-cluster-uid/v1", ArgoNamespace: "argocd", RegistrationName: "disposable-ok141",
 		RequiredApplications:     []observation.PlatformApplicationExpectation{{Name: "disposable-ok141-observability-core", SpecDigest: digest("d")}},
 		CapabilityContractDigest: digest("e"), CapabilityExecutableDigest: digest("f"), MaximumCapabilityAgeSeconds: 3600,
 	}
@@ -199,7 +199,7 @@ func TestOpenKubernetesPlatformSourceCollectorBindsGitOpsAuthority(t *testing.T)
 		Argo: KubernetesAuthorityConfig{
 			Endpoint: "https://10.43.0.1:443", AuthorityIdentity: "ok-shared", TokenFile: tokenPath, CAFile: caPath,
 		},
-		ExpectedArgoAuthority: "ok-shared", Profile: profile, Capability: inertPlatformCapabilitySource{}, Clock: time.Now,
+		ExpectedArgoAuthority: "ok-shared", Profile: profile, Capability: inertPlatformCapabilitySource{}, TargetClusterUID: "cluster-uid-disposable-ok141", Clock: time.Now,
 	}
 	if _, err := OpenKubernetesPlatformSourceCollector(config); err != nil {
 		t.Fatal(err)

--- a/internal/runner/platform_inputs.go
+++ b/internal/runner/platform_inputs.go
@@ -24,7 +24,6 @@ type PlatformProfileFileConfig struct {
 	ExpectedIntentRevision   string
 	ExpectedPlatformRevision string
 	ExpectedExecutionFixture string
-	ExpectedTargetClusterUID string
 }
 
 type LoadedPlatformProfile struct {
@@ -35,7 +34,7 @@ type LoadedPlatformProfile struct {
 // LoadPlatformProfileFile reads one bounded regular strict-JSON document and
 // rejects any semantic or canonical-identity difference from its bindings.
 func LoadPlatformProfileFile(config PlatformProfileFileConfig) (LoadedPlatformProfile, error) {
-	if config.Path == "" || !platformInputDigestPattern.MatchString(config.ExpectedProfileDigest) || !platformInputDigestPattern.MatchString(config.ExpectedIntentRevision) || !platformInputDigestPattern.MatchString(config.ExpectedPlatformRevision) || !platformInputDigestPattern.MatchString(config.ExpectedExecutionFixture) || config.ExpectedTargetClusterUID == "" {
+	if config.Path == "" || !platformInputDigestPattern.MatchString(config.ExpectedProfileDigest) || !platformInputDigestPattern.MatchString(config.ExpectedIntentRevision) || !platformInputDigestPattern.MatchString(config.ExpectedPlatformRevision) || !platformInputDigestPattern.MatchString(config.ExpectedExecutionFixture) {
 		return LoadedPlatformProfile{}, errors.New("platform profile file binding is invalid")
 	}
 	raw, err := readBoundedRegular(config.Path, maximumPlatformProfileBytes)
@@ -46,7 +45,7 @@ func LoadPlatformProfileFile(config PlatformProfileFileConfig) (LoadedPlatformPr
 	if err := jsonstrict.Decode(raw, &profile); err != nil {
 		return LoadedPlatformProfile{}, errors.New("decode strict platform profile")
 	}
-	if profile.IntentRevision != config.ExpectedIntentRevision || profile.PlatformRevision != config.ExpectedPlatformRevision || profile.ExecutionFixture != config.ExpectedExecutionFixture || profile.TargetClusterUID != config.ExpectedTargetClusterUID {
+	if profile.IntentRevision != config.ExpectedIntentRevision || profile.PlatformRevision != config.ExpectedPlatformRevision || profile.ExecutionFixture != config.ExpectedExecutionFixture {
 		return LoadedPlatformProfile{}, errors.New("platform profile identity differs from verified execution input")
 	}
 	digest, err := observation.PlatformProfileDigest(profile)

--- a/internal/runner/platform_inputs_test.go
+++ b/internal/runner/platform_inputs_test.go
@@ -23,13 +23,12 @@ func TestLoadPlatformProfileFileBindsCanonicalMembership(t *testing.T) {
 	config := PlatformProfileFileConfig{
 		Path: path, ExpectedProfileDigest: digest, ExpectedIntentRevision: profile.IntentRevision,
 		ExpectedPlatformRevision: profile.PlatformRevision, ExpectedExecutionFixture: profile.ExecutionFixture,
-		ExpectedTargetClusterUID: profile.TargetClusterUID,
 	}
 	loaded, err := LoadPlatformProfileFile(config)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if loaded.Digest != digest || loaded.Profile.TargetClusterUID != profile.TargetClusterUID {
+	if loaded.Digest != digest || loaded.Profile.TargetIdentityScheme != "capi-cluster-uid/v1" {
 		t.Fatalf("loaded Platform profile differs: %#v", loaded)
 	}
 	profile.RequiredApplications[0], profile.RequiredApplications[2] = profile.RequiredApplications[2], profile.RequiredApplications[0]
@@ -48,7 +47,6 @@ func TestLoadPlatformProfileFileRejectsMalformedOrUnboundInput(t *testing.T) {
 	base := PlatformProfileFileConfig{
 		ExpectedProfileDigest: digest, ExpectedIntentRevision: profile.IntentRevision,
 		ExpectedPlatformRevision: profile.PlatformRevision, ExpectedExecutionFixture: profile.ExecutionFixture,
-		ExpectedTargetClusterUID: profile.TargetClusterUID,
 	}
 	for name, raw := range map[string][]byte{
 		"unknown field":   append(validRaw[:len(validRaw)-1], []byte(`,"extra":true}`)...),
@@ -76,7 +74,6 @@ func TestLoadPlatformProfileFileRejectsMalformedOrUnboundInput(t *testing.T) {
 		"wrong R":       func(config *PlatformProfileFileConfig) { config.ExpectedIntentRevision = digestOf("9") },
 		"wrong P":       func(config *PlatformProfileFileConfig) { config.ExpectedPlatformRevision = digestOf("9") },
 		"wrong fixture": func(config *PlatformProfileFileConfig) { config.ExpectedExecutionFixture = digestOf("9") },
-		"wrong target":  func(config *PlatformProfileFileConfig) { config.ExpectedTargetClusterUID = "other-cluster-uid" },
 	} {
 		t.Run(name, func(t *testing.T) {
 			config := base
@@ -85,6 +82,11 @@ func TestLoadPlatformProfileFileRejectsMalformedOrUnboundInput(t *testing.T) {
 				t.Fatalf("unbound Platform profile accepted or disclosed path: %v", err)
 			}
 		})
+	}
+	profile.TargetIdentityScheme = "name/v1"
+	writePlatformJSON(t, path, profile)
+	if _, err := LoadPlatformProfileFile(base); err == nil {
+		t.Fatal("invalid target identity scheme retained the old profile binding")
 	}
 }
 
@@ -185,7 +187,7 @@ func TestLoadPlatformCapabilityFileRejectsMalformedInput(t *testing.T) {
 func runnerPlatformProfile() observation.PlatformProfile {
 	return observation.PlatformProfile{
 		Format: observation.PlatformProfileFormat, IntentRevision: digestOf("a"), PlatformRevision: digestOf("b"), ExecutionFixture: digestOf("c"),
-		TargetClusterUID: "cluster-uid-disposable-ok141", ArgoNamespace: "argocd", RegistrationName: "disposable-ok141",
+		TargetIdentityScheme: "capi-cluster-uid/v1", ArgoNamespace: "argocd", RegistrationName: "disposable-ok141",
 		RequiredApplications: []observation.PlatformApplicationExpectation{
 			{Name: "disposable-ok141-observability-core", SpecDigest: digestOf("1")},
 			{Name: "disposable-ok141-observability-alerting", SpecDigest: digestOf("2")},
@@ -199,7 +201,7 @@ func runnerPlatformCapability(t *testing.T) observation.PlatformCapabilityState 
 	t.Helper()
 	profile := runnerPlatformProfile()
 	state := observation.PlatformCapabilityState{
-		Format: observation.PlatformCapabilityFormat, ObservedAt: "2026-08-16T09:55:00Z", TargetClusterUID: profile.TargetClusterUID,
+		Format: observation.PlatformCapabilityFormat, ObservedAt: "2026-08-16T09:55:00Z", TargetClusterUID: "cluster-uid-disposable-ok141",
 		IntentRevision: profile.IntentRevision, PlatformRevision: profile.PlatformRevision, ExecutionFixture: profile.ExecutionFixture,
 		ContractDigest: profile.CapabilityContractDigest, ExecutableDigest: profile.CapabilityExecutableDigest, Passed: true,
 	}


### PR DESCRIPTION
## What changed

- remove the concrete runtime Cluster UID from the pre-submission Platform profile
- bind the profile to the explicit `capi-cluster-uid/v1` resolution scheme instead
- pass the actual target UID separately to the Platform collector after submission
- reject a collector/policy UID mismatch before the first Argo request
- retain exact target UID binding in capability evidence
- update profile loading, runner construction, tests and documentation

## Root cause

The concrete CAPI Cluster UID does not exist until the exact submission response is available. Requiring it inside the pre-runtime Platform profile made later `Operation.Run` wiring impossible and incorrectly mixed P semantics with runtime correlation.

## Impact

P and its profile remain reproducible before cluster creation. Runtime target correlation is established only after submission and still fails closed. This checkpoint performs no Kubernetes request and makes no infrastructure mutation.

## Validation

- `go test ./...`
- `go vet ./...`
- `go test -race -ldflags=-linkmode=external ./internal/observation ./internal/runner`
- `python3 -m unittest tests/ok141_kubevirt_infra_secret_ref_test.py tests/ok147_runner_image_test.py tests/ok147_runner_publication_test.py`
- `git diff --check`
