### PR TITLE
OK-147: Wire runtime-bound observation sources

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -555,9 +555,9 @@ deterministic outcome.
 The composer performs exactly one pass in CAPI, Network, Platform order and
 then evaluates one ordered bundle at the injected clock time. It has no polling,
 retry, watch, mutation, repair, durable status publication or default source.
-The concrete GitOps/Platform source remains a separate checkpoint. The
-immutable Network-profile loader is described next. Consequently this
-composition is not yet wired to the CLI or Job and made no cluster contact.
+The concrete Kubernetes adapters and immutable profile loaders are described
+next. This composition is not yet wired to the CLI or Job and made no cluster
+contact.
 
 ## Digest-bound Network profile loading
 
@@ -654,6 +654,43 @@ observation time, the Platform collector receives the post-submission UID from
 the execution policy, rejects any different configured target before an Argo
 request, and requires the capability assertion to carry that same UID. This
 keeps pre-runtime Platform semantics separate from runtime correlation.
+
+## Post-submission aggregate observer wiring
+
+The runner now exposes one concrete `execution.Observer` boundary that lazily
+composes the CAPI, Network and Platform adapters. Construction validates and
+freezes the immutable Network and Platform profiles but reads no credential
+file and contacts no API. `Observe` first requires the policy to carry the
+concrete CAPI Cluster UID returned by the exact-create submission receipt and
+to match R, E and P from both profiles.
+
+Only then can two explicit runtime resolvers run:
+
+```text
+submitted CAPI Cluster UID
+        |
+        +--> workload-authority resolver --> Network source
+        |
+        +--> capability-evidence resolver -> Platform source
+```
+
+The workload resolver must return an authority identity exactly equal to the
+runtime Cluster UID. The capability resolver receives the same bound policy
+and an isolated copy of the immutable Platform profile. Resolver failures are
+redacted, and a foreign workload identity, missing capability source or
+profile/revision mismatch fails before the affected source is opened.
+
+Domains absent from the Contract-derived required-condition policy are not
+opened and their runtime resolvers are not invoked. Required domains still run
+in the fixed CAPI, Network, Platform observation order and are immediately
+evaluated by the bounded aggregate evaluator. The wiring adds no resolver
+implementation that could silently reuse historical capability evidence: the
+single-run workload binding and capability execution remain explicit later
+runner boundaries.
+
+This checkpoint is library wiring only. It remains disconnected from the CLI
+and Job, performs no polling, retry, mutation or status publication, and made
+no live cluster contact.
 
 ## OK-141 compatibility evidence
 

--- a/internal/runner/aggregate_observer.go
+++ b/internal/runner/aggregate_observer.go
@@ -1,0 +1,214 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/observation"
+)
+
+// WorkloadAuthorityResolver materializes the bounded workload API authority
+// only after submission has bound the immutable CAPI Cluster UID. It must not
+// return a reusable multi-cluster administrator identity.
+type WorkloadAuthorityResolver interface {
+	ResolveWorkloadAuthority(context.Context, observation.Policy) (KubernetesAuthorityConfig, error)
+}
+
+// PlatformCapabilityResolver returns capability evidence for the exact
+// runtime-bound execution. A pre-existing assertion from another target or
+// revision is rejected by the Platform evaluator.
+type PlatformCapabilityResolver interface {
+	ResolvePlatformCapability(context.Context, observation.Policy, observation.PlatformProfile) (observation.PlatformCapabilitySource, error)
+}
+
+// WorkloadAuthorityResolverFunc adapts a bounded function to a resolver.
+type WorkloadAuthorityResolverFunc func(context.Context, observation.Policy) (KubernetesAuthorityConfig, error)
+
+func (resolve WorkloadAuthorityResolverFunc) ResolveWorkloadAuthority(ctx context.Context, policy observation.Policy) (KubernetesAuthorityConfig, error) {
+	return resolve(ctx, policy)
+}
+
+// PlatformCapabilityResolverFunc adapts a bounded function to a resolver.
+type PlatformCapabilityResolverFunc func(context.Context, observation.Policy, observation.PlatformProfile) (observation.PlatformCapabilitySource, error)
+
+func (resolve PlatformCapabilityResolverFunc) ResolvePlatformCapability(ctx context.Context, policy observation.Policy, profile observation.PlatformProfile) (observation.PlatformCapabilitySource, error) {
+	return resolve(ctx, policy, profile)
+}
+
+// KubernetesAggregateObserverConfig binds the three observation authorities
+// and immutable Network/Platform semantics. Workload authority and capability
+// proof are deliberately lazy because their concrete target UID does not exist
+// before the CAPI submission response.
+type KubernetesAggregateObserverConfig struct {
+	Management                  KubernetesAuthorityConfig
+	ExpectedManagementAuthority string
+	Argo                        KubernetesAuthorityConfig
+	ExpectedArgoAuthority       string
+	Namespace                   string
+	Name                        string
+	HCPName                     string
+	NetworkProfile              observation.NetworkProfile
+	PlatformProfile             observation.PlatformProfile
+	WorkloadAuthority           WorkloadAuthorityResolver
+	PlatformCapability          PlatformCapabilityResolver
+	Clock                       func() time.Time
+}
+
+// KubernetesAggregateObserver lazily materializes only the source domains
+// required by the runtime-bound observation policy. It has no polling, retry,
+// mutation, status publication, or persistent controller loop.
+type KubernetesAggregateObserver struct {
+	config  KubernetesAggregateObserverConfig
+	openers kubernetesAggregateSourceOpeners
+}
+
+type kubernetesAggregateSourceOpeners struct {
+	capi     func(KubernetesAuthorityConfig, string, string, string) (observation.CAPIEvidenceSource, error)
+	network  func(KubernetesNetworkObserverConfig) (observation.NetworkEvidenceSource, error)
+	platform func(KubernetesPlatformObserverConfig) (observation.PlatformEvidenceSource, error)
+}
+
+// OpenKubernetesAggregateObserver validates and freezes the pre-runtime
+// inputs. It performs no file read and no Kubernetes request.
+func OpenKubernetesAggregateObserver(config KubernetesAggregateObserverConfig) (*KubernetesAggregateObserver, error) {
+	if config.ExpectedManagementAuthority == "" || config.ExpectedArgoAuthority == "" || config.Namespace == "" || config.Name == "" || config.HCPName == "" || config.WorkloadAuthority == nil || config.PlatformCapability == nil || config.Clock == nil {
+		return nil, errors.New("aggregate Kubernetes observer binding is incomplete")
+	}
+	if _, err := observation.NetworkProfileDigest(config.NetworkProfile); err != nil {
+		return nil, errors.New("aggregate Kubernetes observer Network profile is invalid")
+	}
+	if _, err := observation.PlatformProfileDigest(config.PlatformProfile); err != nil {
+		return nil, errors.New("aggregate Kubernetes observer Platform profile is invalid")
+	}
+	config.PlatformProfile = clonePlatformProfile(config.PlatformProfile)
+	return &KubernetesAggregateObserver{
+		config: config,
+		openers: kubernetesAggregateSourceOpeners{
+			capi: func(authority KubernetesAuthorityConfig, expected, namespace, name string) (observation.CAPIEvidenceSource, error) {
+				return OpenKubernetesCAPILifecycleObserver(authority, expected, namespace, name)
+			},
+			network: func(config KubernetesNetworkObserverConfig) (observation.NetworkEvidenceSource, error) {
+				return OpenKubernetesNetworkSourceCollector(config)
+			},
+			platform: func(config KubernetesPlatformObserverConfig) (observation.PlatformEvidenceSource, error) {
+				return OpenKubernetesPlatformSourceCollector(config)
+			},
+		},
+	}, nil
+}
+
+// Observe receives only a post-submission policy. Resolver and credential
+// materialization cannot occur until that policy carries the concrete target
+// Cluster UID and matches both immutable profiles.
+func (observer *KubernetesAggregateObserver) Observe(ctx context.Context, policy observation.Policy) (observation.VerifiedResult, error) {
+	if observer == nil {
+		return observation.VerifiedResult{}, errors.New("aggregate Kubernetes observer is required")
+	}
+	if err := ctx.Err(); err != nil {
+		return observation.VerifiedResult{}, errors.New("aggregate Kubernetes observation cancelled")
+	}
+	if _, err := observation.PolicyDigest(policy); err != nil {
+		return observation.VerifiedResult{}, errors.New("runtime-bound observation policy is invalid")
+	}
+	if observer.config.NetworkProfile.IntentRevision != policy.IntentRevision || observer.config.NetworkProfile.EnablementRevision != policy.EnablementRevision {
+		return observation.VerifiedResult{}, errors.New("Network profile differs from runtime-bound observation policy")
+	}
+	if observer.config.PlatformProfile.IntentRevision != policy.IntentRevision || observer.config.PlatformProfile.PlatformRevision != policy.PlatformRevision {
+		return observation.VerifiedResult{}, errors.New("Platform profile differs from runtime-bound observation policy")
+	}
+
+	required := requiredObservationDomains(policy.Required)
+	capiSource := observation.CAPIEvidenceSource(unusedCAPISource{})
+	networkSource := observation.NetworkEvidenceSource(unusedNetworkSource{})
+	platformSource := observation.PlatformEvidenceSource(unusedPlatformSource{})
+
+	if required.capi {
+		var err error
+		capiSource, err = observer.openers.capi(observer.config.Management, observer.config.ExpectedManagementAuthority, observer.config.Namespace, observer.config.Name)
+		if err != nil {
+			return observation.VerifiedResult{}, errors.New("open bounded CAPI observation source")
+		}
+	}
+	if required.network {
+		workload, err := observer.config.WorkloadAuthority.ResolveWorkloadAuthority(ctx, policy)
+		if err != nil {
+			return observation.VerifiedResult{}, errors.New("resolve bounded workload observation authority")
+		}
+		if workload.AuthorityIdentity != policy.TargetClusterUID {
+			return observation.VerifiedResult{}, errors.New("workload observation authority differs from runtime-bound target Cluster")
+		}
+		networkSource, err = observer.openers.network(KubernetesNetworkObserverConfig{
+			Management: observer.config.Management, Workload: workload,
+			ExpectedManagementAuthority: observer.config.ExpectedManagementAuthority,
+			TargetClusterUID:            policy.TargetClusterUID, Namespace: observer.config.Namespace,
+			Name: observer.config.Name, HCPName: observer.config.HCPName, Clock: observer.config.Clock,
+		})
+		if err != nil {
+			return observation.VerifiedResult{}, errors.New("open bounded NetworkReady observation source")
+		}
+	}
+	if required.platform {
+		capability, err := observer.config.PlatformCapability.ResolvePlatformCapability(ctx, policy, clonePlatformProfile(observer.config.PlatformProfile))
+		if err != nil || capability == nil {
+			return observation.VerifiedResult{}, errors.New("resolve bounded Platform capability evidence")
+		}
+		platformSource, err = observer.openers.platform(KubernetesPlatformObserverConfig{
+			Argo: observer.config.Argo, ExpectedArgoAuthority: observer.config.ExpectedArgoAuthority,
+			Profile: clonePlatformProfile(observer.config.PlatformProfile), Capability: capability,
+			TargetClusterUID: policy.TargetClusterUID, Clock: observer.config.Clock,
+		})
+		if err != nil {
+			return observation.VerifiedResult{}, errors.New("open bounded PlatformReady observation source")
+		}
+	}
+
+	aggregate, err := observation.NewAggregateObserver(observation.AggregateObserverConfig{
+		CAPI: capiSource, Network: networkSource, Platform: platformSource,
+		NetworkProfile: observer.config.NetworkProfile, Clock: observer.config.Clock,
+	})
+	if err != nil {
+		return observation.VerifiedResult{}, errors.New("compose bounded aggregate observation")
+	}
+	return aggregate.Observe(ctx, policy)
+}
+
+func clonePlatformProfile(profile observation.PlatformProfile) observation.PlatformProfile {
+	profile.RequiredApplications = append([]observation.PlatformApplicationExpectation(nil), profile.RequiredApplications...)
+	return profile
+}
+
+type observationDomains struct{ capi, network, platform bool }
+
+func requiredObservationDomains(conditions []string) observationDomains {
+	var domains observationDomains
+	for _, condition := range conditions {
+		switch condition {
+		case "InfrastructureReady", "ControlPlaneAvailable":
+			domains.capi = true
+		case "NetworkReady":
+			domains.network = true
+		case "PlatformReady":
+			domains.platform = true
+		}
+	}
+	return domains
+}
+
+type unusedCAPISource struct{}
+
+func (unusedCAPISource) Collect(context.Context, observation.Policy) ([]observation.Evidence, error) {
+	return nil, errors.New("unused CAPI source was called")
+}
+
+type unusedNetworkSource struct{}
+
+func (unusedNetworkSource) Observe(context.Context, observation.Policy, observation.NetworkProfile) (observation.Evidence, error) {
+	return observation.Evidence{}, errors.New("unused Network source was called")
+}
+
+type unusedPlatformSource struct{}
+
+func (unusedPlatformSource) Observe(context.Context, observation.Policy) (observation.Evidence, error) {
+	return observation.Evidence{}, errors.New("unused Platform source was called")
+}

--- a/internal/runner/aggregate_observer_test.go
+++ b/internal/runner/aggregate_observer_test.go
@@ -1,0 +1,276 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/observation"
+)
+
+func TestKubernetesAggregateObserverBindsRuntimeTargetBeforeOpeningSources(t *testing.T) {
+	policy, config := aggregateRunnerFixture()
+	var order []string
+	config.WorkloadAuthority = WorkloadAuthorityResolverFunc(func(_ context.Context, received observation.Policy) (KubernetesAuthorityConfig, error) {
+		order = append(order, "resolve-workload")
+		if received.TargetClusterUID != policy.TargetClusterUID {
+			t.Fatal("workload resolver did not receive runtime-bound target")
+		}
+		return KubernetesAuthorityConfig{AuthorityIdentity: received.TargetClusterUID}, nil
+	})
+	config.PlatformCapability = PlatformCapabilityResolverFunc(func(_ context.Context, received observation.Policy, profile observation.PlatformProfile) (observation.PlatformCapabilitySource, error) {
+		order = append(order, "resolve-capability")
+		if received.TargetClusterUID != policy.TargetClusterUID || profile.TargetIdentityScheme != "capi-cluster-uid/v1" {
+			t.Fatal("capability resolver received an unbound runtime identity")
+		}
+		profile.RequiredApplications[0].Name = "resolver-mutation-must-not-escape"
+		return inertPlatformCapabilitySource{}, nil
+	})
+	observer, err := OpenKubernetesAggregateObserver(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	capi := &aggregateRunnerCAPISource{policy: policy, order: &order}
+	network := &aggregateRunnerNetworkSource{policy: policy, order: &order}
+	platform := &aggregateRunnerPlatformSource{policy: policy, order: &order}
+	observer.openers = kubernetesAggregateSourceOpeners{
+		capi: func(_ KubernetesAuthorityConfig, expected, namespace, name string) (observation.CAPIEvidenceSource, error) {
+			order = append(order, "open-capi")
+			if expected != "ok-mgmt" || namespace != "disposable-ok147" || name != "disposable-ok147" {
+				t.Fatal("CAPI opener received a different authority binding")
+			}
+			return capi, nil
+		},
+		network: func(received KubernetesNetworkObserverConfig) (observation.NetworkEvidenceSource, error) {
+			order = append(order, "open-network")
+			if received.TargetClusterUID != policy.TargetClusterUID || received.Workload.AuthorityIdentity != policy.TargetClusterUID {
+				t.Fatal("Network opener did not receive runtime-bound target")
+			}
+			return network, nil
+		},
+		platform: func(received KubernetesPlatformObserverConfig) (observation.PlatformEvidenceSource, error) {
+			order = append(order, "open-platform")
+			if received.TargetClusterUID != policy.TargetClusterUID || received.Profile.TargetIdentityScheme != "capi-cluster-uid/v1" || received.Profile.RequiredApplications[0].Name != "disposable-ok147-core" {
+				t.Fatal("Platform opener did not receive runtime-bound target")
+			}
+			return platform, nil
+		},
+	}
+
+	result, err := observer.Observe(context.Background(), policy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := result.Receipt()
+	if err != nil || receipt.Ready != "True" {
+		t.Fatalf("unexpected aggregate result: receipt=%#v err=%v", receipt, err)
+	}
+	expected := []string{"open-capi", "resolve-workload", "open-network", "resolve-capability", "open-platform", "collect-capi", "observe-network", "observe-platform"}
+	if strings.Join(order, ",") != strings.Join(expected, ",") {
+		t.Fatalf("unexpected lazy source order: %v", order)
+	}
+}
+
+func TestKubernetesAggregateObserverMaterializesOnlyRequiredDomains(t *testing.T) {
+	policy, config := aggregateRunnerFixture()
+	policy.Required = []string{"InfrastructureReady", "ControlPlaneAvailable"}
+	workloadCalls, capabilityCalls := 0, 0
+	config.WorkloadAuthority = WorkloadAuthorityResolverFunc(func(context.Context, observation.Policy) (KubernetesAuthorityConfig, error) {
+		workloadCalls++
+		return KubernetesAuthorityConfig{}, errors.New("must not run")
+	})
+	config.PlatformCapability = PlatformCapabilityResolverFunc(func(context.Context, observation.Policy, observation.PlatformProfile) (observation.PlatformCapabilitySource, error) {
+		capabilityCalls++
+		return nil, errors.New("must not run")
+	})
+	observer, err := OpenKubernetesAggregateObserver(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	capi := &aggregateRunnerCAPISource{policy: policy}
+	observer.openers = kubernetesAggregateSourceOpeners{
+		capi: func(KubernetesAuthorityConfig, string, string, string) (observation.CAPIEvidenceSource, error) {
+			return capi, nil
+		},
+		network: func(KubernetesNetworkObserverConfig) (observation.NetworkEvidenceSource, error) {
+			t.Fatal("Network source opened although NetworkReady was not required")
+			return nil, nil
+		},
+		platform: func(KubernetesPlatformObserverConfig) (observation.PlatformEvidenceSource, error) {
+			t.Fatal("Platform source opened although PlatformReady was not required")
+			return nil, nil
+		},
+	}
+	result, err := observer.Observe(context.Background(), policy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, _ := result.Receipt()
+	if receipt.Ready != "True" || workloadCalls != 0 || capabilityCalls != 0 {
+		t.Fatalf("unused runtime domains were materialized: receipt=%#v workload=%d capability=%d", receipt, workloadCalls, capabilityCalls)
+	}
+}
+
+func TestKubernetesAggregateObserverFailsBeforeRuntimeResolution(t *testing.T) {
+	policy, config := aggregateRunnerFixture()
+	resolverCalls := 0
+	config.WorkloadAuthority = WorkloadAuthorityResolverFunc(func(context.Context, observation.Policy) (KubernetesAuthorityConfig, error) {
+		resolverCalls++
+		return KubernetesAuthorityConfig{}, nil
+	})
+	config.PlatformCapability = PlatformCapabilityResolverFunc(func(context.Context, observation.Policy, observation.PlatformProfile) (observation.PlatformCapabilitySource, error) {
+		resolverCalls++
+		return inertPlatformCapabilitySource{}, nil
+	})
+	observer, err := OpenKubernetesAggregateObserver(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	policy.TargetClusterUID = ""
+	if _, err := observer.Observe(context.Background(), policy); err == nil || resolverCalls != 0 {
+		t.Fatalf("unbound policy reached a runtime resolver: err=%v calls=%d", err, resolverCalls)
+	}
+}
+
+func TestKubernetesAggregateObserverRedactsResolverFailure(t *testing.T) {
+	policy, config := aggregateRunnerFixture()
+	secret := "/private/tmp/secret-workload-kubeconfig"
+	config.WorkloadAuthority = WorkloadAuthorityResolverFunc(func(context.Context, observation.Policy) (KubernetesAuthorityConfig, error) {
+		return KubernetesAuthorityConfig{}, errors.New(secret)
+	})
+	observer, err := OpenKubernetesAggregateObserver(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	observer.openers.capi = func(KubernetesAuthorityConfig, string, string, string) (observation.CAPIEvidenceSource, error) {
+		return &aggregateRunnerCAPISource{policy: policy}, nil
+	}
+	_, err = observer.Observe(context.Background(), policy)
+	if err == nil || strings.Contains(err.Error(), secret) {
+		t.Fatalf("resolver failure was accepted or disclosed details: %v", err)
+	}
+}
+
+func TestKubernetesAggregateObserverRejectsForeignWorkloadAuthority(t *testing.T) {
+	policy, config := aggregateRunnerFixture()
+	config.WorkloadAuthority = WorkloadAuthorityResolverFunc(func(context.Context, observation.Policy) (KubernetesAuthorityConfig, error) {
+		return KubernetesAuthorityConfig{AuthorityIdentity: "other-cluster-uid"}, nil
+	})
+	observer, err := OpenKubernetesAggregateObserver(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	observer.openers.capi = func(KubernetesAuthorityConfig, string, string, string) (observation.CAPIEvidenceSource, error) {
+		return &aggregateRunnerCAPISource{policy: policy}, nil
+	}
+	if _, err := observer.Observe(context.Background(), policy); err == nil {
+		t.Fatal("foreign workload authority reached the Network source opener")
+	}
+}
+
+func TestOpenKubernetesAggregateObserverFreezesPlatformMembership(t *testing.T) {
+	_, config := aggregateRunnerFixture()
+	observer, err := OpenKubernetesAggregateObserver(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	config.PlatformProfile.RequiredApplications[0].Name = "mutated-after-open"
+	if observer.config.PlatformProfile.RequiredApplications[0].Name != "disposable-ok147-core" {
+		t.Fatal("aggregate observer retained mutable Platform membership")
+	}
+}
+
+func aggregateRunnerFixture() (observation.Policy, KubernetesAggregateObserverConfig) {
+	digest := func(character string) string { return "sha256:" + strings.Repeat(character, 64) }
+	policy := observation.Policy{
+		Format: observation.PolicyFormat, IntentRevision: digest("a"), EnablementRevision: digest("b"), PlatformRevision: digest("c"),
+		TargetClusterUID: "cluster-uid-disposable-ok147", Required: []string{"InfrastructureReady", "ControlPlaneAvailable", "NetworkReady", "PlatformReady"},
+	}
+	networkProfile := observation.NetworkProfile{
+		Format: observation.NetworkProfileFormat, IntentRevision: policy.IntentRevision, EnablementRevision: policy.EnablementRevision,
+		ExpectedNodeCount: 2, ExpectedHCPSpecDigest: digest("d"), ExpectedHRPSpecDigest: digest("e"),
+		ExpectedImages: observation.NetworkImages{
+			CiliumAgent:    "example.invalid/cilium@sha256:" + strings.Repeat("1", 64),
+			CiliumEnvoy:    "example.invalid/envoy@sha256:" + strings.Repeat("2", 64),
+			CiliumOperator: "example.invalid/operator@sha256:" + strings.Repeat("3", 64),
+		},
+		MinimumProbeFreshnessSeconds: 60, MaximumProbeIntervalSeconds: 60, CacheExposureSeconds: 30,
+	}
+	platformProfile := observation.PlatformProfile{
+		Format: observation.PlatformProfileFormat, IntentRevision: policy.IntentRevision, PlatformRevision: policy.PlatformRevision,
+		ExecutionFixture: digest("f"), TargetIdentityScheme: "capi-cluster-uid/v1", ArgoNamespace: "argocd", RegistrationName: "disposable-ok147",
+		RequiredApplications:     []observation.PlatformApplicationExpectation{{Name: "disposable-ok147-core", SpecDigest: digest("7")}},
+		CapabilityContractDigest: digest("8"), CapabilityExecutableDigest: digest("9"), MaximumCapabilityAgeSeconds: 3600,
+	}
+	return policy, KubernetesAggregateObserverConfig{
+		Management: KubernetesAuthorityConfig{AuthorityIdentity: "ok-mgmt"}, ExpectedManagementAuthority: "ok-mgmt",
+		Argo: KubernetesAuthorityConfig{AuthorityIdentity: "ok-shared"}, ExpectedArgoAuthority: "ok-shared",
+		Namespace: "disposable-ok147", Name: "disposable-ok147", HCPName: "disposable-ok147-cilium",
+		NetworkProfile: networkProfile, PlatformProfile: platformProfile,
+		WorkloadAuthority: WorkloadAuthorityResolverFunc(func(_ context.Context, policy observation.Policy) (KubernetesAuthorityConfig, error) {
+			return KubernetesAuthorityConfig{AuthorityIdentity: policy.TargetClusterUID}, nil
+		}),
+		PlatformCapability: PlatformCapabilityResolverFunc(func(context.Context, observation.Policy, observation.PlatformProfile) (observation.PlatformCapabilitySource, error) {
+			return inertPlatformCapabilitySource{}, nil
+		}),
+		Clock: func() time.Time { return time.Date(2026, 8, 16, 12, 0, 0, 0, time.UTC) },
+	}
+}
+
+type aggregateRunnerCAPISource struct {
+	policy observation.Policy
+	order  *[]string
+}
+
+func (source *aggregateRunnerCAPISource) Collect(context.Context, observation.Policy) ([]observation.Evidence, error) {
+	if source.order != nil {
+		*source.order = append(*source.order, "collect-capi")
+	}
+	return []observation.Evidence{aggregateRunnerEvidence(source.policy, "InfrastructureReady"), aggregateRunnerEvidence(source.policy, "ControlPlaneAvailable")}, nil
+}
+
+type aggregateRunnerNetworkSource struct {
+	policy observation.Policy
+	order  *[]string
+}
+
+func (source *aggregateRunnerNetworkSource) Observe(context.Context, observation.Policy, observation.NetworkProfile) (observation.Evidence, error) {
+	if source.order != nil {
+		*source.order = append(*source.order, "observe-network")
+	}
+	return aggregateRunnerEvidence(source.policy, "NetworkReady"), nil
+}
+
+type aggregateRunnerPlatformSource struct {
+	policy observation.Policy
+	order  *[]string
+}
+
+func (source *aggregateRunnerPlatformSource) Observe(context.Context, observation.Policy) (observation.Evidence, error) {
+	if source.order != nil {
+		*source.order = append(*source.order, "observe-platform")
+	}
+	return aggregateRunnerEvidence(source.policy, "PlatformReady"), nil
+}
+
+func aggregateRunnerEvidence(policy observation.Policy, condition string) observation.Evidence {
+	value := observation.Evidence{
+		Type: condition, SourceUID: "source-uid-" + strings.ToLower(condition), TargetClusterUID: policy.TargetClusterUID,
+		Status: "True", Reason: condition, EvidenceDigest: "sha256:" + strings.Repeat("6", 64),
+	}
+	switch condition {
+	case "InfrastructureReady", "ControlPlaneAvailable":
+		value.Source, value.SourceUID = "CAPICluster", policy.TargetClusterUID
+		value.DesiredRevision, value.ObservedRevision = policy.IntentRevision, policy.IntentRevision
+		value.Generation, value.ObservedGeneration = 3, 3
+	case "NetworkReady":
+		value.Source = "BoundedNetworkEvaluator"
+		value.DesiredRevision, value.ObservedRevision = policy.EnablementRevision, policy.EnablementRevision
+	case "PlatformReady":
+		value.Source = "BoundedPlatformEvaluator"
+		value.DesiredRevision, value.ObservedRevision = policy.PlatformRevision, policy.PlatformRevision
+	}
+	return value
+}


### PR DESCRIPTION
## What changed

- add a lazy Kubernetes aggregate observer implementing the post-submission observation boundary
- bind workload authority and Platform capability resolution to the concrete CAPI Cluster UID
- open only the CAPI, Network and Platform domains required by the verified condition policy
- freeze Platform Application membership across resolver boundaries and redact resolver failures
- document the remaining explicit workload-binding and capability-execution boundaries

## Why

The concrete target Cluster UID does not exist before exact-create submission. Network and Platform adapters therefore cannot be safely constructed as pre-runtime objects. This checkpoint materializes them only after `execution.Operation` has bound the submitted Cluster UID, without treating historical capability evidence as current.

This is library wiring only. It adds no CLI/Job activation, Kubernetes mutation, polling, retry, persistent status surface or controller loop, and it made no live cluster contact.

## Validation

- `CGO_ENABLED=0 go test ./...`
- `CGO_ENABLED=0 go vet ./...`
- `go test -race -ldflags=-linkmode=external ./internal/observation ./internal/runner`
- `python3 -m unittest tests/ok141_kubevirt_infra_secret_ref_test.py tests/ok147_runner_image_test.py tests/ok147_runner_publication_test.py`
- `git diff --check`
