### PR TITLE
OK-147: Bind resumable observation inputs

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -692,6 +692,35 @@ This checkpoint is library wiring only. It remains disconnected from the CLI
 and Job, performs no polling, retry, mutation or status publication, and made
 no live cluster contact.
 
+## Digest-bound resume observation inputs
+
+Two concrete file resolvers now implement the lazy runtime boundaries without
+pretending to produce first-run evidence.
+
+The workload resolver reads one maximum-64-KiB, non-symlink, strict-JSON
+private binding only after the observation policy carries the submitted CAPI
+Cluster UID. Its
+canonical digest binds R, the exact target UID, the
+`capi-cluster-uid/v1` identity scheme, the HTTPS workload endpoint and the API
+CA digest. The bearer token and CA paths remain separate execution inputs and
+are never part of the semantic record. The resolver verifies the actual CA
+bytes, and the Network adapter verifies them again when opening its client, so
+a changed CA cannot retain the runtime authority binding. The private endpoint
+means this binding is not public evidence.
+
+The Platform resolver loads one already produced, strict capability assertion
+only after runtime correlation. An independently supplied evidence digest is
+required, and the existing loader then binds the assertion to the current
+target UID, R, P, execution fixture, capability contract and executable. A
+capability file from another cluster incarnation or executable fails closed.
+
+Both constructors are side-effect free: files are read only when the required
+domain is observed. They enable a later executor invocation to resume bounded
+observation from durable correlation inputs. They deliberately do not create
+the workload credential, run the capability test, poll convergence, contact a
+cluster or mutate infrastructure. Producing those current single-run inputs
+remains an explicit subsequent runner boundary.
+
 ## OK-141 compatibility evidence
 
 The verifier was run offline against the preserved Phase-R v5 projection. It

--- a/internal/runner/kubernetes.go
+++ b/internal/runner/kubernetes.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/openkubes/ok-cluster/internal/authorization"
+	"github.com/openkubes/ok-cluster/internal/digest"
 	"github.com/openkubes/ok-cluster/internal/ledger"
 	"github.com/openkubes/ok-cluster/internal/observation"
 	"github.com/openkubes/ok-cluster/internal/submission"
@@ -43,6 +44,7 @@ type KubernetesAuthorityConfig struct {
 	AuthorityIdentity string
 	TokenFile         string
 	CAFile            string
+	CABundleDigest    string
 }
 
 // KubernetesNetworkObserverConfig binds distinct management and workload
@@ -157,6 +159,9 @@ func OpenKubernetesNetworkSourceCollector(config KubernetesNetworkObserverConfig
 	if err != nil {
 		return nil, errors.New("open bounded workload network credential")
 	}
+	if !platformInputDigestPattern.MatchString(config.Workload.CABundleDigest) || digest.SHA256(workloadCA) != config.Workload.CABundleDigest {
+		return nil, errors.New("workload network CA differs from the runtime-bound authority")
+	}
 	if len(managementToken) == len(workloadToken) && subtle.ConstantTimeCompare([]byte(managementToken), []byte(workloadToken)) == 1 {
 		return nil, errors.New("network observer management and workload credentials must be distinct")
 	}
@@ -246,6 +251,13 @@ func openBoundedKubernetesMaterial(tokenFile, caFile string) (string, []byte, *h
 }
 
 func readBoundedRegular(path string, maximum int64) ([]byte, error) {
+	pathInfo, err := os.Lstat(path)
+	if err != nil {
+		return nil, err
+	}
+	if pathInfo.Mode()&os.ModeSymlink != 0 || !pathInfo.Mode().IsRegular() || pathInfo.Size() <= 0 || pathInfo.Size() > maximum {
+		return nil, errors.New("projected file metadata is invalid")
+	}
 	file, err := os.Open(path)
 	if err != nil {
 		return nil, err
@@ -255,7 +267,7 @@ func readBoundedRegular(path string, maximum int64) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	if !info.Mode().IsRegular() || info.Size() <= 0 || info.Size() > maximum {
+	if !os.SameFile(pathInfo, info) || !info.Mode().IsRegular() || info.Size() <= 0 || info.Size() > maximum {
 		return nil, fmt.Errorf("projected file metadata is invalid")
 	}
 	raw, err := io.ReadAll(io.LimitReader(file, maximum+1))

--- a/internal/runner/kubernetes_test.go
+++ b/internal/runner/kubernetes_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/openkubes/ok-cluster/internal/digest"
 	"github.com/openkubes/ok-cluster/internal/observation"
 )
 
@@ -129,10 +130,11 @@ func TestOpenKubernetesNetworkSourceCollectorBindsDistinctAuthorities(t *testing
 	managementToken := filepath.Join(root, "management-token")
 	workloadToken := filepath.Join(root, "workload-token")
 	caPath := filepath.Join(root, "ca.crt")
+	ca := testCA(t)
 	for path, value := range map[string][]byte{
 		managementToken: []byte("short-lived-management-token"),
 		workloadToken:   []byte("short-lived-workload-token"),
-		caPath:          testCA(t),
+		caPath:          ca,
 	} {
 		if err := os.WriteFile(path, value, 0o600); err != nil {
 			t.Fatal(err)
@@ -144,7 +146,7 @@ func TestOpenKubernetesNetworkSourceCollectorBindsDistinctAuthorities(t *testing
 			Endpoint: "https://10.43.0.1:443", AuthorityIdentity: "ok-mgmt", TokenFile: managementToken, CAFile: caPath,
 		},
 		Workload: KubernetesAuthorityConfig{
-			Endpoint: "https://192.168.100.213:6443", AuthorityIdentity: targetUID, TokenFile: workloadToken, CAFile: caPath,
+			Endpoint: "https://192.168.100.213:6443", AuthorityIdentity: targetUID, TokenFile: workloadToken, CAFile: caPath, CABundleDigest: digest.SHA256(ca),
 		},
 		ExpectedManagementAuthority: "ok-mgmt", TargetClusterUID: targetUID,
 		Namespace: "disposable-ok141", Name: "disposable-ok141", HCPName: "disposable-ok141-cilium",
@@ -166,6 +168,12 @@ func TestOpenKubernetesNetworkSourceCollectorBindsDistinctAuthorities(t *testing
 		},
 		"shared credential": func(config *KubernetesNetworkObserverConfig) {
 			config.Workload.TokenFile = config.Management.TokenFile
+		},
+		"missing workload CA binding": func(config *KubernetesNetworkObserverConfig) {
+			config.Workload.CABundleDigest = ""
+		},
+		"different workload CA binding": func(config *KubernetesNetworkObserverConfig) {
+			config.Workload.CABundleDigest = "sha256:" + strings.Repeat("9", 64)
 		},
 	} {
 		t.Run(name, func(t *testing.T) {

--- a/internal/runner/runtime_resolvers.go
+++ b/internal/runner/runtime_resolvers.go
@@ -1,0 +1,186 @@
+package runner
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/url"
+	"regexp"
+	"strconv"
+
+	"github.com/openkubes/ok-cluster/internal/contract"
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/jsonstrict"
+	"github.com/openkubes/ok-cluster/internal/observation"
+)
+
+const (
+	WorkloadAuthorityBindingFormat = "ok147-workload-authority-binding/v1"
+	maximumWorkloadBindingBytes    = 64 * 1024
+)
+
+var runtimeInputUIDPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$`)
+
+// WorkloadAuthorityBinding is private durable correlation data for a later
+// observation invocation. Credential bytes and local file paths are not part
+// of this semantic record; its API endpoint still prevents public retention.
+type WorkloadAuthorityBinding struct {
+	Format               string `json:"format"`
+	IntentRevision       string `json:"intentRevision"`
+	TargetClusterUID     string `json:"targetClusterUid"`
+	TargetIdentityScheme string `json:"targetIdentityScheme"`
+	Endpoint             string `json:"endpoint"`
+	CABundleDigest       string `json:"caBundleDigest"`
+}
+
+// WorkloadAuthorityFileResolverConfig binds the semantic record to separately
+// mounted short-lived credential material. Paths are execution inputs and are
+// deliberately excluded from the binding digest.
+type WorkloadAuthorityFileResolverConfig struct {
+	Path                  string
+	ExpectedBindingDigest string
+	TokenFile             string
+	CAFile                string
+}
+
+// WorkloadAuthorityFileResolver reads and verifies the runtime binding only
+// after submission has supplied a concrete target Cluster UID.
+type WorkloadAuthorityFileResolver struct {
+	config WorkloadAuthorityFileResolverConfig
+}
+
+// OpenWorkloadAuthorityFileResolver validates only the static configuration;
+// it performs no file read and no API request.
+func OpenWorkloadAuthorityFileResolver(config WorkloadAuthorityFileResolverConfig) (*WorkloadAuthorityFileResolver, error) {
+	if config.Path == "" || config.TokenFile == "" || config.CAFile == "" || !platformInputDigestPattern.MatchString(config.ExpectedBindingDigest) {
+		return nil, errors.New("workload authority file resolver binding is invalid")
+	}
+	return &WorkloadAuthorityFileResolver{config: config}, nil
+}
+
+func (resolver *WorkloadAuthorityFileResolver) ResolveWorkloadAuthority(ctx context.Context, policy observation.Policy) (KubernetesAuthorityConfig, error) {
+	if resolver == nil {
+		return KubernetesAuthorityConfig{}, errors.New("workload authority file resolver is required")
+	}
+	if err := ctx.Err(); err != nil {
+		return KubernetesAuthorityConfig{}, errors.New("workload authority resolution cancelled")
+	}
+	if _, err := observation.PolicyDigest(policy); err != nil {
+		return KubernetesAuthorityConfig{}, errors.New("runtime-bound observation policy is invalid")
+	}
+	raw, err := readBoundedRegular(resolver.config.Path, maximumWorkloadBindingBytes)
+	if err != nil {
+		return KubernetesAuthorityConfig{}, errors.New("read bounded workload authority binding")
+	}
+	var binding WorkloadAuthorityBinding
+	if err := jsonstrict.Decode(raw, &binding); err != nil {
+		return KubernetesAuthorityConfig{}, errors.New("decode strict workload authority binding")
+	}
+	bindingDigest, err := WorkloadAuthorityBindingDigest(binding)
+	if err != nil {
+		return KubernetesAuthorityConfig{}, errors.New("validate workload authority binding")
+	}
+	if bindingDigest != resolver.config.ExpectedBindingDigest || binding.IntentRevision != policy.IntentRevision || binding.TargetClusterUID != policy.TargetClusterUID {
+		return KubernetesAuthorityConfig{}, errors.New("workload authority binding differs from runtime-bound observation policy")
+	}
+	ca, err := readBoundedRegular(resolver.config.CAFile, maximumCABytes)
+	if err != nil {
+		return KubernetesAuthorityConfig{}, errors.New("read bounded workload API CA")
+	}
+	if digest.SHA256(ca) != binding.CABundleDigest {
+		return KubernetesAuthorityConfig{}, errors.New("workload API CA differs from runtime binding")
+	}
+	return KubernetesAuthorityConfig{
+		Endpoint: binding.Endpoint, AuthorityIdentity: policy.TargetClusterUID,
+		TokenFile: resolver.config.TokenFile, CAFile: resolver.config.CAFile,
+		CABundleDigest: binding.CABundleDigest,
+	}, nil
+}
+
+// WorkloadAuthorityBindingDigest identifies the canonical, secret-free
+// runtime correlation record.
+func WorkloadAuthorityBindingDigest(binding WorkloadAuthorityBinding) (string, error) {
+	if err := validateWorkloadAuthorityBinding(binding); err != nil {
+		return "", err
+	}
+	raw, err := json.Marshal(binding)
+	if err != nil {
+		return "", err
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	var value any
+	if err := decoder.Decode(&value); err != nil {
+		return "", err
+	}
+	canonical, err := contract.JCS(value)
+	if err != nil {
+		return "", err
+	}
+	return digest.SHA256(canonical), nil
+}
+
+func validateWorkloadAuthorityBinding(binding WorkloadAuthorityBinding) error {
+	if binding.Format != WorkloadAuthorityBindingFormat || !platformInputDigestPattern.MatchString(binding.IntentRevision) || !runtimeInputUIDPattern.MatchString(binding.TargetClusterUID) || binding.TargetIdentityScheme != "capi-cluster-uid/v1" || !platformInputDigestPattern.MatchString(binding.CABundleDigest) {
+		return errors.New("workload authority binding identity is invalid")
+	}
+	endpoint, err := url.Parse(binding.Endpoint)
+	if err != nil || endpoint.Scheme != "https" || endpoint.Hostname() == "" || endpoint.Port() == "" || endpoint.User != nil || endpoint.Path != "" || endpoint.RawQuery != "" || endpoint.Fragment != "" {
+		return errors.New("workload authority endpoint is invalid")
+	}
+	port, err := strconv.Atoi(endpoint.Port())
+	if err != nil || port < 1 || port > 65535 {
+		return errors.New("workload authority endpoint port is invalid")
+	}
+	return nil
+}
+
+// PlatformCapabilityFileResolverConfig binds one already produced capability
+// assertion for resumable observation. The assertion digest must come from
+// durable execution correlation data, not from the file itself.
+type PlatformCapabilityFileResolverConfig struct {
+	Path                   string
+	ExpectedEvidenceDigest string
+}
+
+type PlatformCapabilityFileResolver struct {
+	config PlatformCapabilityFileResolverConfig
+}
+
+// OpenPlatformCapabilityFileResolver performs no file read. The file is read
+// only after the runtime policy and Platform profile have been correlated.
+func OpenPlatformCapabilityFileResolver(config PlatformCapabilityFileResolverConfig) (*PlatformCapabilityFileResolver, error) {
+	if config.Path == "" || !platformInputDigestPattern.MatchString(config.ExpectedEvidenceDigest) {
+		return nil, errors.New("Platform capability file resolver binding is invalid")
+	}
+	return &PlatformCapabilityFileResolver{config: config}, nil
+}
+
+func (resolver *PlatformCapabilityFileResolver) ResolvePlatformCapability(ctx context.Context, policy observation.Policy, profile observation.PlatformProfile) (observation.PlatformCapabilitySource, error) {
+	if resolver == nil {
+		return nil, errors.New("Platform capability file resolver is required")
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, errors.New("Platform capability resolution cancelled")
+	}
+	if _, err := observation.PolicyDigest(policy); err != nil {
+		return nil, errors.New("runtime-bound observation policy is invalid")
+	}
+	if _, err := observation.PlatformProfileDigest(profile); err != nil || profile.IntentRevision != policy.IntentRevision || profile.PlatformRevision != policy.PlatformRevision {
+		return nil, errors.New("Platform profile differs from runtime-bound observation policy")
+	}
+	loaded, err := LoadPlatformCapabilityFile(PlatformCapabilityFileConfig{
+		Path: resolver.config.Path, ExpectedEvidenceDigest: resolver.config.ExpectedEvidenceDigest,
+		ExpectedIntentRevision: policy.IntentRevision, ExpectedPlatformRevision: policy.PlatformRevision,
+		ExpectedExecutionFixture: profile.ExecutionFixture, ExpectedTargetClusterUID: policy.TargetClusterUID,
+		ExpectedContractDigest: profile.CapabilityContractDigest, ExpectedExecutableDigest: profile.CapabilityExecutableDigest,
+	})
+	if err != nil {
+		return nil, errors.New("load runtime-bound Platform capability evidence")
+	}
+	return loaded, nil
+}
+
+var _ WorkloadAuthorityResolver = (*WorkloadAuthorityFileResolver)(nil)
+var _ PlatformCapabilityResolver = (*PlatformCapabilityFileResolver)(nil)

--- a/internal/runner/runtime_resolvers_test.go
+++ b/internal/runner/runtime_resolvers_test.go
@@ -1,0 +1,206 @@
+package runner
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/observation"
+)
+
+func TestWorkloadAuthorityFileResolverBindsRuntimeIdentityAndCA(t *testing.T) {
+	root := t.TempDir()
+	policy, binding, ca := runtimeWorkloadBindingFixture(t)
+	bindingPath := filepath.Join(root, "binding.json")
+	tokenPath := filepath.Join(root, "token")
+	caPath := filepath.Join(root, "ca.crt")
+	writePlatformJSON(t, bindingPath, binding)
+	if err := os.WriteFile(tokenPath, []byte("short-lived-workload-token"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(caPath, ca, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	bindingDigest, _ := WorkloadAuthorityBindingDigest(binding)
+	resolver, err := OpenWorkloadAuthorityFileResolver(WorkloadAuthorityFileResolverConfig{
+		Path: bindingPath, ExpectedBindingDigest: bindingDigest, TokenFile: tokenPath, CAFile: caPath,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	authority, err := resolver.ResolveWorkloadAuthority(context.Background(), policy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if authority.Endpoint != binding.Endpoint || authority.AuthorityIdentity != policy.TargetClusterUID || authority.CABundleDigest != binding.CABundleDigest || authority.TokenFile != tokenPath || authority.CAFile != caPath {
+		t.Fatalf("resolved workload authority differs from binding: %#v", authority)
+	}
+}
+
+func TestWorkloadAuthorityFileResolverFailsClosedOnTampering(t *testing.T) {
+	root := t.TempDir()
+	policy, binding, ca := runtimeWorkloadBindingFixture(t)
+	bindingPath := filepath.Join(root, "binding.json")
+	tokenPath := filepath.Join(root, "token")
+	caPath := filepath.Join(root, "ca.crt")
+	writePlatformJSON(t, bindingPath, binding)
+	if err := os.WriteFile(tokenPath, []byte("short-lived-workload-token"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(caPath, ca, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	bindingDigest, _ := WorkloadAuthorityBindingDigest(binding)
+	open := func() *WorkloadAuthorityFileResolver {
+		resolver, err := OpenWorkloadAuthorityFileResolver(WorkloadAuthorityFileResolverConfig{
+			Path: bindingPath, ExpectedBindingDigest: bindingDigest, TokenFile: tokenPath, CAFile: caPath,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return resolver
+	}
+
+	t.Run("foreign runtime target", func(t *testing.T) {
+		foreign := policy
+		foreign.TargetClusterUID = "other-cluster-uid"
+		if _, err := open().ResolveWorkloadAuthority(context.Background(), foreign); err == nil {
+			t.Fatal("foreign target accepted")
+		}
+	})
+	t.Run("changed CA", func(t *testing.T) {
+		if err := os.WriteFile(caPath, testCA(t), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		_, err := open().ResolveWorkloadAuthority(context.Background(), policy)
+		if err == nil || strings.Contains(err.Error(), root) || strings.Contains(err.Error(), binding.Endpoint) {
+			t.Fatalf("changed CA accepted or disclosed runtime data: %v", err)
+		}
+		if err := os.WriteFile(caPath, ca, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	})
+	t.Run("changed binding", func(t *testing.T) {
+		changed := binding
+		changed.Endpoint = "https://192.0.2.20:6443"
+		writePlatformJSON(t, bindingPath, changed)
+		_, err := open().ResolveWorkloadAuthority(context.Background(), policy)
+		if err == nil || strings.Contains(err.Error(), changed.Endpoint) {
+			t.Fatalf("changed binding accepted or disclosed endpoint: %v", err)
+		}
+		writePlatformJSON(t, bindingPath, binding)
+	})
+	t.Run("unknown field", func(t *testing.T) {
+		raw, _ := json.Marshal(binding)
+		raw = append(raw[:len(raw)-1], []byte(`,"unexpected":true}`)...)
+		if err := os.WriteFile(bindingPath, raw, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := open().ResolveWorkloadAuthority(context.Background(), policy); err == nil {
+			t.Fatal("unknown workload binding field accepted")
+		}
+	})
+	t.Run("symlink input", func(t *testing.T) {
+		writePlatformJSON(t, bindingPath, binding)
+		link := filepath.Join(root, "binding-link.json")
+		if err := os.Symlink(bindingPath, link); err != nil {
+			t.Fatal(err)
+		}
+		resolver, err := OpenWorkloadAuthorityFileResolver(WorkloadAuthorityFileResolverConfig{
+			Path: link, ExpectedBindingDigest: bindingDigest, TokenFile: tokenPath, CAFile: caPath,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := resolver.ResolveWorkloadAuthority(context.Background(), policy); err == nil || strings.Contains(err.Error(), root) {
+			t.Fatalf("symlink binding accepted or disclosed path: %v", err)
+		}
+	})
+}
+
+func TestWorkloadAuthorityBindingCanonicalIdentity(t *testing.T) {
+	_, binding, _ := runtimeWorkloadBindingFixture(t)
+	first, err := WorkloadAuthorityBindingDigest(binding)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw := []byte(`{"targetClusterUid":"` + binding.TargetClusterUID + `","endpoint":"` + binding.Endpoint + `","format":"` + binding.Format + `","caBundleDigest":"` + binding.CABundleDigest + `","targetIdentityScheme":"capi-cluster-uid/v1","intentRevision":"` + binding.IntentRevision + `"}`)
+	var reordered WorkloadAuthorityBinding
+	if err := json.Unmarshal(raw, &reordered); err != nil {
+		t.Fatal(err)
+	}
+	second, err := WorkloadAuthorityBindingDigest(reordered)
+	if err != nil || first != second {
+		t.Fatalf("equivalent workload binding changed identity: %s %s %v", first, second, err)
+	}
+	reordered.Endpoint = "https://192.0.2.20:6443"
+	third, _ := WorkloadAuthorityBindingDigest(reordered)
+	if third == first {
+		t.Fatal("semantic endpoint change retained workload binding identity")
+	}
+}
+
+func TestPlatformCapabilityFileResolverBindsResumeEvidenceAtRuntime(t *testing.T) {
+	root := t.TempDir()
+	profile := runnerPlatformProfile()
+	state := runnerPlatformCapability(t)
+	path := filepath.Join(root, "capability.json")
+	writePlatformJSON(t, path, state)
+	resolver, err := OpenPlatformCapabilityFileResolver(PlatformCapabilityFileResolverConfig{Path: path, ExpectedEvidenceDigest: state.EvidenceDigest})
+	if err != nil {
+		t.Fatal(err)
+	}
+	policy := observation.Policy{
+		Format: observation.PolicyFormat, IntentRevision: state.IntentRevision, EnablementRevision: digestOf("e"), PlatformRevision: state.PlatformRevision,
+		TargetClusterUID: state.TargetClusterUID, Required: []string{"PlatformReady"},
+	}
+	source, err := resolver.ResolvePlatformCapability(context.Background(), policy, profile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	observed, err := source.Capability(context.Background())
+	if err != nil || observed != state {
+		t.Fatalf("resume capability differs: %#v %v", observed, err)
+	}
+
+	foreign := policy
+	foreign.TargetClusterUID = "other-cluster-uid"
+	if _, err := resolver.ResolvePlatformCapability(context.Background(), foreign, profile); err == nil || strings.Contains(err.Error(), path) {
+		t.Fatalf("foreign capability accepted or disclosed path: %v", err)
+	}
+	profile.CapabilityExecutableDigest = digestOf("9")
+	if _, err := resolver.ResolvePlatformCapability(context.Background(), policy, profile); err == nil {
+		t.Fatal("capability from a different executable was accepted")
+	}
+}
+
+func TestRuntimeFileResolversDoNotReadDuringConstruction(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "not-created")
+	if _, err := OpenWorkloadAuthorityFileResolver(WorkloadAuthorityFileResolverConfig{
+		Path: missing, ExpectedBindingDigest: digestOf("a"), TokenFile: missing + "-token", CAFile: missing + "-ca",
+	}); err != nil {
+		t.Fatalf("workload resolver performed eager input validation: %v", err)
+	}
+	if _, err := OpenPlatformCapabilityFileResolver(PlatformCapabilityFileResolverConfig{Path: missing, ExpectedEvidenceDigest: digestOf("b")}); err != nil {
+		t.Fatalf("Platform resolver performed eager input validation: %v", err)
+	}
+}
+
+func runtimeWorkloadBindingFixture(t *testing.T) (observation.Policy, WorkloadAuthorityBinding, []byte) {
+	t.Helper()
+	ca := testCA(t)
+	policy := observation.Policy{
+		Format: observation.PolicyFormat, IntentRevision: digestOf("a"), EnablementRevision: digestOf("b"), PlatformRevision: digestOf("c"),
+		TargetClusterUID: "cluster-uid-disposable-ok147", Required: []string{"NetworkReady"},
+	}
+	binding := WorkloadAuthorityBinding{
+		Format: WorkloadAuthorityBindingFormat, IntentRevision: policy.IntentRevision,
+		TargetClusterUID: policy.TargetClusterUID, TargetIdentityScheme: "capi-cluster-uid/v1",
+		Endpoint: "https://192.0.2.10:6443", CABundleDigest: digest.SHA256(ca),
+	}
+	return policy, binding, ca
+}


### PR DESCRIPTION
## What changed

- add a canonical, digest-bound private workload-authority binding for resumable observation
- add a lazy file resolver that binds workload endpoint and CA to the post-submission CAPI Cluster UID and R
- require the Network adapter to reverify the bound CA bytes when opening its workload client
- add a lazy resume resolver for previously produced Platform capability evidence bound to target UID, R, P, fixture, contract and executable
- reject symlinks and path replacement in the shared bounded-file reader
- document that these inputs support resume observation and do not manufacture first-run evidence

## Why

OK-147 requires a later executor invocation to resume observation without reusing the consumed submission authority or treating runner-local state as desired state. The runtime target does not exist before submission, so workload authority and capability evidence must be correlated lazily to the concrete CAPI Cluster UID.

This checkpoint deliberately does not create credentials or execute the capability test. It introduces no CLI/Job activation, API contact, mutation, polling, retry, status publication or controller loop.

## Validation

- `CGO_ENABLED=0 go test ./...`
- `CGO_ENABLED=0 go vet ./...`
- `go test -race -ldflags=-linkmode=external ./internal/runner`
- `python3 -m unittest tests/ok141_kubevirt_infra_secret_ref_test.py tests/ok147_runner_image_test.py tests/ok147_runner_publication_test.py`
- `git diff --check`
