### PR TITLE
Gate platform capability execution (OK-147)

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -612,6 +612,15 @@ that assertion or run its executable. Missing, stale or revision-mismatched
 proof therefore remains `Unknown`, while current health, identity or
 capability failures remain `False`.
 
+Capability execution is additionally fail-closed behind a separately hashed
+Application gate. The collector first reads and normalizes every exact
+Application. It does not invoke the capability source unless all required
+Applications have the expected spec identity, current R/P/fixture correlation,
+the exact applied source revision, `Synced`, and `Healthy`. Pending, unhealthy,
+foreign, missing, or stale Application state therefore produces bounded
+`PlatformReady` evidence without starting capability code. The same gate also
+protects direct full-snapshot collection, so callers cannot bypass it.
+
 The runner-side opener binds the reader to one explicitly named GitOps
 authority (for the OK-141 topology, `ok-shared`) and a short-lived projected
 credential. The adapter is still not wired to the CLI or Job, no built-in

--- a/internal/observation/platform_collector.go
+++ b/internal/observation/platform_collector.go
@@ -46,7 +46,18 @@ func NewPlatformSourceCollector(argo PlatformRawGetter, capability PlatformCapab
 }
 
 func (collector *PlatformSourceCollector) Observe(ctx context.Context, policy Policy) (Evidence, error) {
-	snapshot, err := collector.Collect(ctx, policy)
+	applicationSnapshot, err := collector.collectApplications(ctx, policy)
+	if err != nil {
+		return Evidence{}, err
+	}
+	gate, err := EvaluatePlatformApplications(policy, collector.config.Profile, applicationSnapshot)
+	if err != nil {
+		return Evidence{}, err
+	}
+	if gate.Status != "True" {
+		return gate, nil
+	}
+	snapshot, err := collector.collectCapability(ctx, applicationSnapshot)
 	if err != nil {
 		return Evidence{}, err
 	}
@@ -57,37 +68,59 @@ func (collector *PlatformSourceCollector) Observe(ctx context.Context, policy Po
 // capability-source read. It has no list, discovery, watch, mutation, sync,
 // retry, repair, target-cluster access or arbitrary-command path.
 func (collector *PlatformSourceCollector) Collect(ctx context.Context, policy Policy) (PlatformSnapshot, error) {
-	if err := validatePolicy(policy, true); err != nil {
+	applicationSnapshot, err := collector.collectApplications(ctx, policy)
+	if err != nil {
 		return PlatformSnapshot{}, err
+	}
+	gate, err := EvaluatePlatformApplications(policy, collector.config.Profile, applicationSnapshot)
+	if err != nil {
+		return PlatformSnapshot{}, err
+	}
+	if gate.Status != "True" {
+		return PlatformSnapshot{}, errors.New("platform Applications are not current; capability execution is closed")
+	}
+	return collector.collectCapability(ctx, applicationSnapshot)
+}
+
+func (collector *PlatformSourceCollector) collectApplications(ctx context.Context, policy Policy) (PlatformApplicationSnapshot, error) {
+	if err := validatePolicy(policy, true); err != nil {
+		return PlatformApplicationSnapshot{}, err
 	}
 	if err := validatePlatformProfile(policy, collector.config.Profile); err != nil {
-		return PlatformSnapshot{}, err
+		return PlatformApplicationSnapshot{}, err
 	}
 	if collector.config.TargetClusterUID != policy.TargetClusterUID {
-		return PlatformSnapshot{}, errors.New("platform collector target differs from the runtime-bound Cluster")
+		return PlatformApplicationSnapshot{}, errors.New("platform collector target differs from the runtime-bound Cluster")
 	}
 	applications := make([]PlatformApplicationState, 0, len(collector.config.Profile.RequiredApplications))
 	for _, expected := range collector.config.Profile.RequiredApplications {
 		path := platformApplicationPath(collector.config.Profile.ArgoNamespace, expected.Name)
 		object, err := getPlatformObject(ctx, collector.argo, path)
 		if err != nil {
-			return PlatformSnapshot{}, fmt.Errorf("collect exact Argo Application: %w", err)
+			return PlatformApplicationSnapshot{}, fmt.Errorf("collect exact Argo Application: %w", err)
 		}
 		application, err := normalizePlatformApplication(object, collector.config.Profile, expected)
 		if err != nil {
-			return PlatformSnapshot{}, err
+			return PlatformApplicationSnapshot{}, err
 		}
 		applications = append(applications, application)
 	}
 	sortPlatformApplications(applications)
+	return PlatformApplicationSnapshot{
+		Format: PlatformApplicationSnapshotFormat, ObservedAt: collector.config.Clock().UTC().Format(time.RFC3339Nano),
+		TargetClusterUID: collector.config.TargetClusterUID, Applications: applications,
+	}, nil
+}
+
+func (collector *PlatformSourceCollector) collectCapability(ctx context.Context, applicationSnapshot PlatformApplicationSnapshot) (PlatformSnapshot, error) {
 	capability, err := collector.capability.Capability(ctx)
 	if err != nil {
 		return PlatformSnapshot{}, errors.New("collect bounded platform capability evidence")
 	}
 	return PlatformSnapshot{
 		Format: PlatformSnapshotFormat, ObservedAt: collector.config.Clock().UTC().Format(time.RFC3339Nano),
-		TargetClusterUID: collector.config.TargetClusterUID,
-		Applications:     applications, Capability: capability,
+		TargetClusterUID: applicationSnapshot.TargetClusterUID,
+		Applications:     applicationSnapshot.Applications, Capability: capability,
 	}, nil
 }
 

--- a/internal/observation/platform_collector_test.go
+++ b/internal/observation/platform_collector_test.go
@@ -80,6 +80,51 @@ func TestPlatformCollectorRedactsSourceErrorsAndDoesNotRunCapabilityEarly(t *tes
 	}
 }
 
+func TestPlatformCollectorDoesNotRunCapabilityUntilApplicationsAreCurrent(t *testing.T) {
+	for name, mutate := range map[string]func(map[string]any){
+		"wrong revision": func(object map[string]any) {
+			object["status"].(map[string]any)["sync"].(map[string]any)["revision"] = strings.Repeat("7", 40)
+		},
+		"out of sync": func(object map[string]any) {
+			object["status"].(map[string]any)["sync"].(map[string]any)["status"] = "OutOfSync"
+		},
+		"unhealthy": func(object map[string]any) {
+			object["status"].(map[string]any)["health"].(map[string]any)["status"] = "Degraded"
+		},
+		"wrong correlation": func(object map[string]any) {
+			object["metadata"].(map[string]any)["annotations"].(map[string]any)["openkubes.io/platform-revision"] = "sha256:" + strings.Repeat("9", 64)
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			policy, profile, capability, getter := platformCollectorFixture(t)
+			path := platformApplicationPath(profile.ArgoNamespace, profile.RequiredApplications[0].Name)
+			var object map[string]any
+			if err := json.Unmarshal(getter.responses[path], &object); err != nil {
+				t.Fatal(err)
+			}
+			mutate(object)
+			getter.responses[path], _ = json.Marshal(object)
+			source := &fakePlatformCapabilitySource{capability: capability}
+			collector, err := NewPlatformSourceCollector(getter, source, PlatformCollectorConfig{
+				Profile: profile, TargetClusterUID: policy.TargetClusterUID, Clock: func() time.Time { return time.Date(2026, 8, 16, 10, 0, 0, 0, time.UTC) },
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			evidence, err := collector.Observe(context.Background(), policy)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if evidence.Status == "True" || source.calls != 0 {
+				t.Fatalf("capability gate opened before Applications were current: evidence=%#v calls=%d", evidence, source.calls)
+			}
+			if _, err := collector.Collect(context.Background(), policy); err == nil || source.calls != 0 {
+				t.Fatalf("full collection bypassed capability gate: err=%v calls=%d", err, source.calls)
+			}
+		})
+	}
+}
+
 func TestPlatformCollectorBindsRuntimeTargetAfterSubmission(t *testing.T) {
 	policy, profile, capability, getter := platformCollectorFixture(t)
 	if _, err := NewPlatformSourceCollector(getter, &fakePlatformCapabilitySource{capability: capability}, PlatformCollectorConfig{Profile: profile, Clock: time.Now}); err == nil {

--- a/internal/observation/platform_evaluator.go
+++ b/internal/observation/platform_evaluator.go
@@ -8,9 +8,10 @@ import (
 )
 
 const (
-	PlatformProfileFormat    = "ok147-platform-profile/v1"
-	PlatformSnapshotFormat   = "ok147-platform-snapshot/v1"
-	PlatformCapabilityFormat = "ok147-platform-capability/v1"
+	PlatformProfileFormat             = "ok147-platform-profile/v1"
+	PlatformApplicationSnapshotFormat = "ok147-platform-application-snapshot/v1"
+	PlatformSnapshotFormat            = "ok147-platform-snapshot/v1"
+	PlatformCapabilityFormat          = "ok147-platform-capability/v1"
 )
 
 // PlatformProfile is the immutable, reviewed meaning of P consumed by the
@@ -58,6 +59,16 @@ type PlatformApplicationState struct {
 	AppliedSourceRevision string `json:"appliedSourceRevision"`
 	SyncStatus            string `json:"syncStatus"`
 	HealthStatus          string `json:"healthStatus"`
+}
+
+// PlatformApplicationSnapshot is the capability-execution gate. It contains
+// only exact, normalized Argo Application observations and deliberately no
+// capability assertion.
+type PlatformApplicationSnapshot struct {
+	Format           string                     `json:"format"`
+	ObservedAt       string                     `json:"observedAt"`
+	TargetClusterUID string                     `json:"targetClusterUid"`
+	Applications     []PlatformApplicationState `json:"applications"`
 }
 
 // PlatformCapabilityState is produced by a separately bounded capability
@@ -117,6 +128,49 @@ func EvaluatePlatformSnapshot(policy Policy, profile PlatformProfile, snapshot P
 	return evidence, nil
 }
 
+// EvaluatePlatformApplications determines whether capability execution may
+// begin. A True result is only possible when every exact Application is bound
+// to the current R/P/fixture and its desired revision is Synced and Healthy.
+func EvaluatePlatformApplications(policy Policy, profile PlatformProfile, snapshot PlatformApplicationSnapshot) (Evidence, error) {
+	if err := validatePolicy(policy, true); err != nil {
+		return Evidence{}, err
+	}
+	if err := validatePlatformProfile(policy, profile); err != nil {
+		return Evidence{}, err
+	}
+	if err := validatePlatformApplicationSnapshotShape(snapshot); err != nil {
+		return Evidence{}, err
+	}
+	profileDigest, err := PlatformProfileDigest(profile)
+	if err != nil {
+		return Evidence{}, err
+	}
+	snapshotDigest, err := canonicalDigest(snapshot)
+	if err != nil {
+		return Evidence{}, err
+	}
+	evidenceDigest, err := canonicalDigest(struct {
+		Format         string `json:"format"`
+		ProfileDigest  string `json:"profileDigest"`
+		SnapshotDigest string `json:"snapshotDigest"`
+	}{Format: "ok147-platform-application-gate-binding/v1", ProfileDigest: profileDigest, SnapshotDigest: snapshotDigest})
+	if err != nil {
+		return Evidence{}, err
+	}
+	status, reason, observedRevision := evaluatePlatformApplications(policy, profile, snapshot.TargetClusterUID, snapshot.Applications)
+	evidence := Evidence{
+		Type: "PlatformReady", Source: "BoundedPlatformEvaluator",
+		SourceUID:        "platform-gate-" + evidenceDigest[len("sha256:"):len("sha256:")+32],
+		TargetClusterUID: policy.TargetClusterUID, Status: status, Reason: reason,
+		DesiredRevision: policy.PlatformRevision, ObservedRevision: observedRevision,
+		EvidenceDigest: evidenceDigest,
+	}
+	if err := validateEvidenceShape(evidence); err != nil {
+		return Evidence{}, fmt.Errorf("normalize platform Application gate evidence: %w", err)
+	}
+	return evidence, nil
+}
+
 func ValidatePlatformProfile(profile PlatformProfile) error {
 	if profile.Format != PlatformProfileFormat || !validDigest(profile.IntentRevision) || !validDigest(profile.PlatformRevision) || !validDigest(profile.ExecutionFixture) || profile.TargetIdentityScheme != "capi-cluster-uid/v1" {
 		return errors.New("platform profile format or revision identity is invalid")
@@ -169,7 +223,24 @@ func validatePlatformSnapshotShape(snapshot PlatformSnapshot) error {
 	if _, err := time.Parse(time.RFC3339Nano, snapshot.ObservedAt); err != nil {
 		return errors.New("platform snapshot observation time is invalid")
 	}
-	for _, application := range snapshot.Applications {
+	if err := validatePlatformApplications(snapshot.Applications); err != nil {
+		return err
+	}
+	return ValidatePlatformCapabilityState(snapshot.Capability)
+}
+
+func validatePlatformApplicationSnapshotShape(snapshot PlatformApplicationSnapshot) error {
+	if snapshot.Format != PlatformApplicationSnapshotFormat || snapshot.ObservedAt == "" || !validUID(snapshot.TargetClusterUID) || len(snapshot.Applications) > 20 {
+		return errors.New("platform Application snapshot identity or size is invalid")
+	}
+	if _, err := time.Parse(time.RFC3339Nano, snapshot.ObservedAt); err != nil {
+		return errors.New("platform Application snapshot observation time is invalid")
+	}
+	return validatePlatformApplications(snapshot.Applications)
+}
+
+func validatePlatformApplications(applications []PlatformApplicationState) error {
+	for _, application := range applications {
 		if !validDNSLabel(application.Name) || !validUID(application.UID) || application.ResourceVersion == "" || !validDigest(application.SpecDigest) {
 			return errors.New("platform snapshot Application identity is invalid")
 		}
@@ -182,7 +253,7 @@ func validatePlatformSnapshotShape(snapshot PlatformSnapshot) error {
 			return errors.New("platform snapshot Application state is oversized")
 		}
 	}
-	return ValidatePlatformCapabilityState(snapshot.Capability)
+	return nil
 }
 
 // ValidatePlatformCapabilityState checks the complete redaction-safe assertion
@@ -217,7 +288,28 @@ func PlatformCapabilityDigest(capability PlatformCapabilityState) (string, error
 }
 
 func evaluatePlatformState(policy Policy, profile PlatformProfile, snapshot PlatformSnapshot) (string, string, string) {
-	if snapshot.TargetClusterUID != policy.TargetClusterUID {
+	status, reason, observedRevision := evaluatePlatformApplications(policy, profile, snapshot.TargetClusterUID, snapshot.Applications)
+	if status != "True" {
+		return status, reason, observedRevision
+	}
+	capability := snapshot.Capability
+	if capability.TargetClusterUID != policy.TargetClusterUID || capability.IntentRevision != policy.IntentRevision || capability.PlatformRevision != policy.PlatformRevision || capability.ExecutionFixture != profile.ExecutionFixture || capability.ContractDigest != profile.CapabilityContractDigest || capability.ExecutableDigest != profile.CapabilityExecutableDigest {
+		return "Unknown", "RevisionCorrelationUnproven", ""
+	}
+	observedAt, _ := time.Parse(time.RFC3339Nano, snapshot.ObservedAt)
+	capabilityAt, _ := time.Parse(time.RFC3339Nano, capability.ObservedAt)
+	age := observedAt.Sub(capabilityAt)
+	if age < 0 || age > time.Duration(profile.MaximumCapabilityAgeSeconds)*time.Second {
+		return "Unknown", "PlatformCapabilityStale", policy.PlatformRevision
+	}
+	if !capability.Passed {
+		return "False", "PlatformCapabilityFailed", policy.PlatformRevision
+	}
+	return "True", "PlatformReady", policy.PlatformRevision
+}
+
+func evaluatePlatformApplications(policy Policy, profile PlatformProfile, targetClusterUID string, applications []PlatformApplicationState) (string, string, string) {
+	if targetClusterUID != policy.TargetClusterUID {
 		return "Unknown", "RevisionCorrelationUnproven", ""
 	}
 	expected := make(map[string]string, len(profile.RequiredApplications))
@@ -225,7 +317,7 @@ func evaluatePlatformState(policy Policy, profile PlatformProfile, snapshot Plat
 		expected[application.Name] = application.SpecDigest
 	}
 	seen := map[string]struct{}{}
-	for _, application := range snapshot.Applications {
+	for _, application := range applications {
 		specDigest, exists := expected[application.Name]
 		if !exists || application.SpecDigest != specDigest {
 			return "False", "PlatformApplicationIdentityMismatch", ""
@@ -250,20 +342,7 @@ func evaluatePlatformState(policy Policy, profile PlatformProfile, snapshot Plat
 	if len(seen) != len(expected) {
 		return "Unknown", "PlatformApplicationMissing", ""
 	}
-	capability := snapshot.Capability
-	if capability.TargetClusterUID != policy.TargetClusterUID || capability.IntentRevision != policy.IntentRevision || capability.PlatformRevision != policy.PlatformRevision || capability.ExecutionFixture != profile.ExecutionFixture || capability.ContractDigest != profile.CapabilityContractDigest || capability.ExecutableDigest != profile.CapabilityExecutableDigest {
-		return "Unknown", "RevisionCorrelationUnproven", ""
-	}
-	observedAt, _ := time.Parse(time.RFC3339Nano, snapshot.ObservedAt)
-	capabilityAt, _ := time.Parse(time.RFC3339Nano, capability.ObservedAt)
-	age := observedAt.Sub(capabilityAt)
-	if age < 0 || age > time.Duration(profile.MaximumCapabilityAgeSeconds)*time.Second {
-		return "Unknown", "PlatformCapabilityStale", policy.PlatformRevision
-	}
-	if !capability.Passed {
-		return "False", "PlatformCapabilityFailed", policy.PlatformRevision
-	}
-	return "True", "PlatformReady", policy.PlatformRevision
+	return "True", "PlatformApplicationsReady", policy.PlatformRevision
 }
 
 func sortPlatformApplications(applications []PlatformApplicationState) {

--- a/internal/observation/platform_evaluator_test.go
+++ b/internal/observation/platform_evaluator_test.go
@@ -26,6 +26,29 @@ func TestEvaluatePlatformSnapshotProducesCurrentEvidence(t *testing.T) {
 	}
 }
 
+func TestEvaluatePlatformApplicationsProducesTamperEvidentCapabilityGate(t *testing.T) {
+	policy, profile, snapshot := validPlatformFixture(t)
+	applicationSnapshot := PlatformApplicationSnapshot{
+		Format: PlatformApplicationSnapshotFormat, ObservedAt: snapshot.ObservedAt,
+		TargetClusterUID: snapshot.TargetClusterUID, Applications: snapshot.Applications,
+	}
+	first, err := EvaluatePlatformApplications(policy, profile, applicationSnapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.Status != "True" || first.Reason != "PlatformApplicationsReady" || first.ObservedRevision != policy.PlatformRevision {
+		t.Fatalf("unexpected capability gate: %#v", first)
+	}
+	applicationSnapshot.Applications[0].SyncStatus = "OutOfSync"
+	second, err := EvaluatePlatformApplications(policy, profile, applicationSnapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if second.Status != "Unknown" || second.Reason != "PlatformConvergencePending" || second.EvidenceDigest == first.EvidenceDigest || second.SourceUID == first.SourceUID {
+		t.Fatalf("Application drift was not fail-closed and digest-bound: first=%#v second=%#v", first, second)
+	}
+}
+
 func TestEvaluatePlatformSnapshotBindsProfileAndCapabilityIdentity(t *testing.T) {
 	policy, profile, snapshot := validPlatformFixture(t)
 	first, err := EvaluatePlatformSnapshot(policy, profile, snapshot)


### PR DESCRIPTION
## What changed

- add a canonical, digest-bound Argo Application gate before platform capability execution
- return fail-closed `PlatformReady` evidence while exact Applications are pending, unhealthy, foreign, missing, or stale
- protect both normal observation and direct full-snapshot collection from bypassing the gate
- add negative controls for revision, sync, health, and correlation drift

## Why

The collector previously invoked the capability source after successful Application reads even when Argo had not converged. A first-run capability probe may contain bounded synthetic mutations, so it must never execute before every bound Application is on the exact expected revision and is `Synced` and `Healthy`.

## Scope

This checkpoint adds only the execution gate. It does not implement the capability probe, polling, cluster contact, or infrastructure mutation.

## Validation

- `go test ./...`
- `go vet ./...`
- `go test -race -ldflags=-linkmode=external ./internal/observation ./internal/runner`
- `python3 -m unittest tests/ok141_kubevirt_infra_secret_ref_test.py tests/ok147_runner_image_test.py tests/ok147_runner_publication_test.py`
- `git diff --check`
