### PR TITLE
Bind first-run platform capability (OK-147)

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -730,6 +730,24 @@ the workload credential, run the capability test, poll convergence, contact a
 cluster or mutate infrastructure. Producing those current single-run inputs
 remains an explicit subsequent runner boundary.
 
+## Typed first-run Platform capability boundary
+
+First-run capability production now has a separate lazy resolver from the
+resume file loader. Resolution binds only the post-submission target Cluster
+UID, R, P, execution fixture, capability contract digest and executable
+digest. It performs no probe. The resulting source is single-use and invokes
+the typed probe only when the Platform collector has already opened its
+capability gate.
+
+The probe request deliberately contains no command, argv, environment, file
+path, endpoint, credential, raw payload or arbitrary extension field. A probe
+returns only `Passed`; the runner supplies the observation time, constructs
+the complete capability assertion and computes its semantic evidence digest.
+Probe errors are redacted and consume the source, so neither caller code nor a
+transient failure can create an implicit retry. This boundary does not yet
+implement the concrete Kubernetes observability capability test, polling or
+target mutation.
+
 ## OK-141 compatibility evidence
 
 The verifier was run offline against the preserved Phase-R v5 projection. It

--- a/internal/runner/platform_probe.go
+++ b/internal/runner/platform_probe.go
@@ -1,0 +1,120 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/observation"
+)
+
+const PlatformCapabilityProbeRequestFormat = "ok147-platform-capability-probe-request/v1"
+
+// PlatformCapabilityProbeRequest is the complete typed input a first-run
+// capability implementation may receive. It intentionally has no command,
+// argv, environment, path, endpoint, credential or arbitrary payload field.
+type PlatformCapabilityProbeRequest struct {
+	Format           string
+	TargetClusterUID string
+	IntentRevision   string
+	PlatformRevision string
+	ExecutionFixture string
+	ContractDigest   string
+	ExecutableDigest string
+}
+
+// PlatformCapabilityProbeResult exposes only the contract outcome. Raw probe
+// output remains inside the concrete adapter and cannot enter runner evidence.
+type PlatformCapabilityProbeResult struct {
+	Passed bool
+}
+
+// PlatformCapabilityProbe implements one exact capability contract. It is not
+// a general command runner.
+type PlatformCapabilityProbe interface {
+	Probe(context.Context, PlatformCapabilityProbeRequest) (PlatformCapabilityProbeResult, error)
+}
+
+// FirstRunPlatformCapabilityResolver creates a single-use capability source
+// only after the runtime target UID and immutable Platform profile are bound.
+type FirstRunPlatformCapabilityResolver struct {
+	probe PlatformCapabilityProbe
+	clock func() time.Time
+}
+
+func NewFirstRunPlatformCapabilityResolver(probe PlatformCapabilityProbe, clock func() time.Time) (*FirstRunPlatformCapabilityResolver, error) {
+	if probe == nil || clock == nil {
+		return nil, errors.New("first-run Platform capability probe and clock are required")
+	}
+	return &FirstRunPlatformCapabilityResolver{probe: probe, clock: clock}, nil
+}
+
+func (resolver *FirstRunPlatformCapabilityResolver) ResolvePlatformCapability(ctx context.Context, policy observation.Policy, profile observation.PlatformProfile) (observation.PlatformCapabilitySource, error) {
+	if resolver == nil || resolver.probe == nil || resolver.clock == nil {
+		return nil, errors.New("first-run Platform capability resolver is required")
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, errors.New("first-run Platform capability resolution cancelled")
+	}
+	if _, err := observation.PolicyDigest(policy); err != nil {
+		return nil, errors.New("runtime-bound observation policy is invalid")
+	}
+	if _, err := observation.PlatformProfileDigest(profile); err != nil || profile.IntentRevision != policy.IntentRevision || profile.PlatformRevision != policy.PlatformRevision {
+		return nil, errors.New("Platform profile differs from runtime-bound observation policy")
+	}
+	request := PlatformCapabilityProbeRequest{
+		Format: PlatformCapabilityProbeRequestFormat, TargetClusterUID: policy.TargetClusterUID,
+		IntentRevision: policy.IntentRevision, PlatformRevision: policy.PlatformRevision,
+		ExecutionFixture: profile.ExecutionFixture, ContractDigest: profile.CapabilityContractDigest,
+		ExecutableDigest: profile.CapabilityExecutableDigest,
+	}
+	return &singleUsePlatformCapabilityProbe{probe: resolver.probe, clock: resolver.clock, request: request}, nil
+}
+
+type singleUsePlatformCapabilityProbe struct {
+	mu       sync.Mutex
+	consumed bool
+	probe    PlatformCapabilityProbe
+	clock    func() time.Time
+	request  PlatformCapabilityProbeRequest
+}
+
+func (source *singleUsePlatformCapabilityProbe) Capability(ctx context.Context) (observation.PlatformCapabilityState, error) {
+	if source == nil || source.probe == nil || source.clock == nil {
+		return observation.PlatformCapabilityState{}, errors.New("first-run Platform capability source is required")
+	}
+	source.mu.Lock()
+	if source.consumed {
+		source.mu.Unlock()
+		return observation.PlatformCapabilityState{}, errors.New("first-run Platform capability source was already consumed")
+	}
+	source.consumed = true
+	source.mu.Unlock()
+	if err := ctx.Err(); err != nil {
+		return observation.PlatformCapabilityState{}, errors.New("first-run Platform capability execution cancelled")
+	}
+	result, err := source.probe.Probe(ctx, source.request)
+	if err != nil {
+		return observation.PlatformCapabilityState{}, errors.New("bounded Platform capability probe failed")
+	}
+	state := observation.PlatformCapabilityState{
+		Format: observation.PlatformCapabilityFormat, ObservedAt: source.clock().UTC().Format(time.RFC3339Nano),
+		TargetClusterUID: source.request.TargetClusterUID, IntentRevision: source.request.IntentRevision,
+		PlatformRevision: source.request.PlatformRevision, ExecutionFixture: source.request.ExecutionFixture,
+		ContractDigest: source.request.ContractDigest, ExecutableDigest: source.request.ExecutableDigest,
+		Passed: result.Passed,
+	}
+	digest, err := observation.PlatformCapabilityDigest(state)
+	if err != nil {
+		return observation.PlatformCapabilityState{}, errors.New("digest bounded Platform capability result")
+	}
+	state.EvidenceDigest = digest
+	if err := observation.ValidatePlatformCapabilityState(state); err != nil {
+		return observation.PlatformCapabilityState{}, errors.New("normalize bounded Platform capability result")
+	}
+	return state, nil
+}
+
+var _ PlatformCapabilityResolver = (*FirstRunPlatformCapabilityResolver)(nil)
+var _ observation.PlatformCapabilitySource = (*singleUsePlatformCapabilityProbe)(nil)

--- a/internal/runner/platform_probe_test.go
+++ b/internal/runner/platform_probe_test.go
@@ -1,0 +1,111 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/observation"
+)
+
+func TestFirstRunPlatformCapabilityResolverBindsAndConsumesExactProbeOnce(t *testing.T) {
+	profile := runnerPlatformProfile()
+	policy := observation.Policy{
+		Format: observation.PolicyFormat, IntentRevision: profile.IntentRevision,
+		EnablementRevision: digestOf("e"), PlatformRevision: profile.PlatformRevision,
+		TargetClusterUID: "cluster-uid-disposable-ok147", Required: []string{"PlatformReady"},
+	}
+	probe := &recordingPlatformCapabilityProbe{result: PlatformCapabilityProbeResult{Passed: true}}
+	clock := func() time.Time { return time.Date(2026, 8, 16, 12, 0, 0, 0, time.UTC) }
+	resolver, err := NewFirstRunPlatformCapabilityResolver(probe, clock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	source, err := resolver.ResolvePlatformCapability(context.Background(), policy, profile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if probe.calls != 0 {
+		t.Fatal("first-run probe executed during lazy resolution")
+	}
+	state, err := source.Capability(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedRequest := PlatformCapabilityProbeRequest{
+		Format: PlatformCapabilityProbeRequestFormat, TargetClusterUID: policy.TargetClusterUID,
+		IntentRevision: policy.IntentRevision, PlatformRevision: policy.PlatformRevision,
+		ExecutionFixture: profile.ExecutionFixture, ContractDigest: profile.CapabilityContractDigest,
+		ExecutableDigest: profile.CapabilityExecutableDigest,
+	}
+	if probe.calls != 1 || probe.request != expectedRequest {
+		t.Fatalf("probe did not receive the exact typed binding: calls=%d request=%#v", probe.calls, probe.request)
+	}
+	if state.TargetClusterUID != policy.TargetClusterUID || state.IntentRevision != policy.IntentRevision || state.PlatformRevision != policy.PlatformRevision || state.ExecutionFixture != profile.ExecutionFixture || state.ContractDigest != profile.CapabilityContractDigest || state.ExecutableDigest != profile.CapabilityExecutableDigest || !state.Passed {
+		t.Fatalf("capability assertion differs from probe binding: %#v", state)
+	}
+	if err := observation.ValidatePlatformCapabilityState(state); err != nil {
+		t.Fatalf("probe result is not canonical capability evidence: %v", err)
+	}
+	if _, err := source.Capability(context.Background()); err == nil || probe.calls != 1 {
+		t.Fatalf("single-use capability source permitted retry: err=%v calls=%d", err, probe.calls)
+	}
+}
+
+func TestFirstRunPlatformCapabilityResolverFailsClosedAndRedactsProbeErrors(t *testing.T) {
+	profile := runnerPlatformProfile()
+	policy := observation.Policy{
+		Format: observation.PolicyFormat, IntentRevision: profile.IntentRevision,
+		EnablementRevision: digestOf("e"), PlatformRevision: profile.PlatformRevision,
+		TargetClusterUID: "cluster-uid-disposable-ok147", Required: []string{"PlatformReady"},
+	}
+	probe := &recordingPlatformCapabilityProbe{err: errors.New("secret target response")}
+	resolver, err := NewFirstRunPlatformCapabilityResolver(probe, time.Now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	foreign := policy
+	foreign.PlatformRevision = digestOf("9")
+	if _, err := resolver.ResolvePlatformCapability(context.Background(), foreign, profile); err == nil || probe.calls != 0 {
+		t.Fatalf("foreign policy reached probe: err=%v calls=%d", err, probe.calls)
+	}
+	source, err := resolver.ResolvePlatformCapability(context.Background(), policy, profile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := source.Capability(context.Background()); err == nil || strings.Contains(err.Error(), "secret target") {
+		t.Fatalf("probe error was accepted or leaked: %v", err)
+	}
+	if _, err := source.Capability(context.Background()); err == nil || probe.calls != 1 {
+		t.Fatalf("failed probe was retried: err=%v calls=%d", err, probe.calls)
+	}
+}
+
+func TestPlatformCapabilityProbeRequestHasNoCommandSurface(t *testing.T) {
+	typeOfRequest := reflect.TypeOf(PlatformCapabilityProbeRequest{})
+	expected := []string{"Format", "TargetClusterUID", "IntentRevision", "PlatformRevision", "ExecutionFixture", "ContractDigest", "ExecutableDigest"}
+	if typeOfRequest.NumField() != len(expected) {
+		t.Fatalf("probe request gained an unreviewed field: %#v", typeOfRequest)
+	}
+	for index, name := range expected {
+		if typeOfRequest.Field(index).Name != name || typeOfRequest.Field(index).Type.Kind() != reflect.String {
+			t.Fatalf("unexpected probe request field %d: %#v", index, typeOfRequest.Field(index))
+		}
+	}
+}
+
+type recordingPlatformCapabilityProbe struct {
+	result  PlatformCapabilityProbeResult
+	err     error
+	request PlatformCapabilityProbeRequest
+	calls   int
+}
+
+func (probe *recordingPlatformCapabilityProbe) Probe(_ context.Context, request PlatformCapabilityProbeRequest) (PlatformCapabilityProbeResult, error) {
+	probe.calls++
+	probe.request = request
+	return probe.result, probe.err
+}


### PR DESCRIPTION
## What changed

- add a lazy first-run Platform capability resolver distinct from resume evidence loading
- bind the probe request to the runtime Cluster UID, R, P, fixture, contract and executable digests
- expose only a typed boolean probe result and construct canonical capability evidence inside the runner
- make the capability source single-use and redact probe failures
- add negative controls for foreign revisions, error leakage, retry and command-surface growth

## Why

The runner needs to produce current capability evidence during a first run without becoming a shell runner or accepting arbitrary commands. This boundary gives a later Kubernetes adapter the minimum typed contract while preserving the already merged Argo convergence gate.

## Scope

This does not implement the concrete Kubernetes observability probe, polling, CLI/Job wiring, cluster contact or mutation.

## Validation

- `go test ./...`
- `go vet ./...`
- `go test -race -ldflags=-linkmode=external ./internal/observation ./internal/runner`
- `python3 -m unittest tests/ok141_kubevirt_infra_secret_ref_test.py tests/ok147_runner_image_test.py tests/ok147_runner_publication_test.py`
- `git diff --check`
