### PR TITLE
Orchestrate observability capability (OK-147)

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -748,6 +748,29 @@ transient failure can create an implicit retry. This boundary does not yet
 implement the concrete Kubernetes observability capability test, polling or
 target mutation.
 
+## Fixed observability capability orchestration
+
+The typed first-run probe now has a closed orchestration layer for the five
+Observability Capability Contract guarantees. It accepts exactly these
+semantic operations: prepare the synthetic metrics fixture; verify metrics,
+dashboards, logs, alert delivery and autonomy; and clean up only the owned
+synthetic resources. There is no generic request, manifest, command, exec,
+HTTP, Kubernetes or extension method on this boundary.
+
+Each run receives a deterministic `ok147-...` identity derived from the exact
+runtime-bound probe request. The configured namespace, contract digest and
+executable digest must match before any transport method is called. The checks
+run once in fixed order under one bounded timeout and stop at the first false
+guarantee or operational error. Synthetic cleanup is attempted after every
+prepare attempt, including partial preparation, false capability and cancelled
+execution, under its own bounded timeout. Cleanup failure fails the probe
+closed and transport details are never returned.
+
+This is still an offline semantic checkpoint. The concrete Kubernetes
+transport, fixed synthetic objects, bounded service access and credential
+materialization remain separate follow-ups. In particular, the existing Bash
+contract test is not embedded or executed by the runner.
+
 ## OK-141 compatibility evidence
 
 The verifier was run offline against the preserved Phase-R v5 projection. It

--- a/internal/runner/observability_probe.go
+++ b/internal/runner/observability_probe.go
@@ -1,0 +1,147 @@
+package runner
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"regexp"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+const ObservabilityCapabilityRunFormat = "ok147-observability-capability-run/v1"
+
+var capabilityNamespacePattern = regexp.MustCompile(`^[a-z0-9](?:[-a-z0-9]{0,61}[a-z0-9])?$`)
+
+// ObservabilityCapabilityRun is the immutable identity supplied to every
+// fixed observability-contract operation. It contains no credentials,
+// endpoints, commands, manifests or arbitrary parameters.
+type ObservabilityCapabilityRun struct {
+	Format           string
+	RunID            string
+	Namespace        string
+	TargetClusterUID string
+	IntentRevision   string
+	PlatformRevision string
+	ExecutionFixture string
+	ContractDigest   string
+	ExecutableDigest string
+}
+
+// ObservabilityCapabilityTransport is deliberately a closed semantic surface
+// for the five contract guarantees and their owned synthetic lifecycle. A
+// concrete adapter cannot be used as a general Kubernetes or command client.
+type ObservabilityCapabilityTransport interface {
+	PrepareSyntheticMetrics(context.Context, ObservabilityCapabilityRun) error
+	VerifyMetrics(context.Context, ObservabilityCapabilityRun) (bool, error)
+	VerifyDashboards(context.Context, ObservabilityCapabilityRun) (bool, error)
+	VerifyLogs(context.Context, ObservabilityCapabilityRun) (bool, error)
+	VerifyAlertDelivery(context.Context, ObservabilityCapabilityRun) (bool, error)
+	VerifyAutonomy(context.Context, ObservabilityCapabilityRun) (bool, error)
+	CleanupSyntheticResources(context.Context, ObservabilityCapabilityRun) error
+}
+
+type ObservabilityCapabilityProbeConfig struct {
+	Namespace                string
+	ExpectedContractDigest   string
+	ExpectedExecutableDigest string
+	Timeout                  time.Duration
+	CleanupTimeout           time.Duration
+}
+
+// ObservabilityCapabilityProbe executes the fixed contract sequence once per
+// invocation. Retry authority remains outside this type.
+type ObservabilityCapabilityProbe struct {
+	transport ObservabilityCapabilityTransport
+	config    ObservabilityCapabilityProbeConfig
+}
+
+func NewObservabilityCapabilityProbe(transport ObservabilityCapabilityTransport, config ObservabilityCapabilityProbeConfig) (*ObservabilityCapabilityProbe, error) {
+	if transport == nil || !capabilityNamespacePattern.MatchString(config.Namespace) || len(config.Namespace) > 63 || !platformInputDigestPattern.MatchString(config.ExpectedContractDigest) || !platformInputDigestPattern.MatchString(config.ExpectedExecutableDigest) {
+		return nil, errors.New("observability capability probe binding is invalid")
+	}
+	if config.Timeout < time.Minute || config.Timeout > 30*time.Minute || config.CleanupTimeout < 10*time.Second || config.CleanupTimeout > 2*time.Minute {
+		return nil, errors.New("observability capability probe timeout is invalid")
+	}
+	return &ObservabilityCapabilityProbe{transport: transport, config: config}, nil
+}
+
+func (probe *ObservabilityCapabilityProbe) Probe(ctx context.Context, request PlatformCapabilityProbeRequest) (result PlatformCapabilityProbeResult, resultErr error) {
+	if probe == nil || probe.transport == nil {
+		return result, errors.New("observability capability probe is required")
+	}
+	if err := validatePlatformCapabilityProbeRequest(request); err != nil || request.ContractDigest != probe.config.ExpectedContractDigest || request.ExecutableDigest != probe.config.ExpectedExecutableDigest {
+		return result, errors.New("observability capability request differs from the bound contract")
+	}
+	run, err := observabilityCapabilityRun(request, probe.config.Namespace)
+	if err != nil {
+		return result, errors.New("construct deterministic observability capability run")
+	}
+	bounded, cancel := context.WithTimeout(ctx, probe.config.Timeout)
+	defer cancel()
+	prepared := false
+	defer func() {
+		if !prepared {
+			return
+		}
+		cleanup, cleanupCancel := context.WithTimeout(context.WithoutCancel(ctx), probe.config.CleanupTimeout)
+		defer cleanupCancel()
+		if err := probe.transport.CleanupSyntheticResources(cleanup, run); err != nil {
+			result = PlatformCapabilityProbeResult{}
+			resultErr = errors.New("bounded observability capability cleanup failed")
+		}
+	}()
+
+	// Prepare may have produced a partial prefix before returning an error, so
+	// cleanup authority begins before the first transport call.
+	prepared = true
+	if err := probe.transport.PrepareSyntheticMetrics(bounded, run); err != nil {
+		return result, errors.New("bounded observability capability preparation failed")
+	}
+	checks := []func(context.Context, ObservabilityCapabilityRun) (bool, error){
+		probe.transport.VerifyMetrics,
+		probe.transport.VerifyDashboards,
+		probe.transport.VerifyLogs,
+		probe.transport.VerifyAlertDelivery,
+		probe.transport.VerifyAutonomy,
+	}
+	for _, check := range checks {
+		passed, err := check(bounded, run)
+		if err != nil {
+			return result, errors.New("bounded observability capability check failed")
+		}
+		if !passed {
+			return PlatformCapabilityProbeResult{Passed: false}, nil
+		}
+	}
+	return PlatformCapabilityProbeResult{Passed: true}, nil
+}
+
+func validatePlatformCapabilityProbeRequest(request PlatformCapabilityProbeRequest) error {
+	if request.Format != PlatformCapabilityProbeRequestFormat || !runtimeInputUIDPattern.MatchString(request.TargetClusterUID) {
+		return errors.New("Platform capability probe request identity is invalid")
+	}
+	for _, value := range []string{request.IntentRevision, request.PlatformRevision, request.ExecutionFixture, request.ContractDigest, request.ExecutableDigest} {
+		if !platformInputDigestPattern.MatchString(value) {
+			return errors.New("Platform capability probe request revision is invalid")
+		}
+	}
+	return nil
+}
+
+func observabilityCapabilityRun(request PlatformCapabilityProbeRequest, namespace string) (ObservabilityCapabilityRun, error) {
+	raw, err := json.Marshal(request)
+	if err != nil {
+		return ObservabilityCapabilityRun{}, err
+	}
+	requestDigest := digest.SHA256(raw)
+	return ObservabilityCapabilityRun{
+		Format: ObservabilityCapabilityRunFormat, RunID: "ok147-" + requestDigest[len("sha256:"):len("sha256:")+24], Namespace: namespace,
+		TargetClusterUID: request.TargetClusterUID, IntentRevision: request.IntentRevision,
+		PlatformRevision: request.PlatformRevision, ExecutionFixture: request.ExecutionFixture,
+		ContractDigest: request.ContractDigest, ExecutableDigest: request.ExecutableDigest,
+	}, nil
+}
+
+var _ PlatformCapabilityProbe = (*ObservabilityCapabilityProbe)(nil)

--- a/internal/runner/observability_probe_test.go
+++ b/internal/runner/observability_probe_test.go
@@ -1,0 +1,147 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestObservabilityCapabilityProbeRunsFixedSequenceAndCleanup(t *testing.T) {
+	request := observabilityProbeRequest()
+	transport := &recordingObservabilityTransport{}
+	probe, err := NewObservabilityCapabilityProbe(transport, ObservabilityCapabilityProbeConfig{
+		Namespace: "ok-observability", ExpectedContractDigest: request.ContractDigest,
+		ExpectedExecutableDigest: request.ExecutableDigest, Timeout: 5 * time.Minute, CleanupTimeout: 30 * time.Second,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := probe.Probe(context.Background(), request)
+	if err != nil || !result.Passed {
+		t.Fatalf("fixed observability probe failed: %#v %v", result, err)
+	}
+	expected := []string{"prepare", "metrics", "dashboards", "logs", "alert-delivery", "autonomy", "cleanup"}
+	if !reflect.DeepEqual(transport.calls, expected) {
+		t.Fatalf("unexpected capability sequence: %v", transport.calls)
+	}
+	if transport.run.Format != ObservabilityCapabilityRunFormat || !strings.HasPrefix(transport.run.RunID, "ok147-") || len(transport.run.RunID) != 30 || transport.run.Namespace != "ok-observability" || transport.run.TargetClusterUID != request.TargetClusterUID || transport.run.ContractDigest != request.ContractDigest || transport.run.ExecutableDigest != request.ExecutableDigest {
+		t.Fatalf("capability run is not deterministically bound: %#v", transport.run)
+	}
+	second, _ := observabilityCapabilityRun(request, "ok-observability")
+	if second != transport.run {
+		t.Fatal("equivalent capability request produced another run identity")
+	}
+}
+
+func TestObservabilityCapabilityProbeFailsClosedAndAlwaysCleansPartialState(t *testing.T) {
+	request := observabilityProbeRequest()
+	for name, configure := range map[string]func(*recordingObservabilityTransport){
+		"prepare error":   func(transport *recordingObservabilityTransport) { transport.failAt = "prepare" },
+		"false guarantee": func(transport *recordingObservabilityTransport) { transport.falseAt = "logs" },
+		"check error":     func(transport *recordingObservabilityTransport) { transport.failAt = "dashboards" },
+		"cleanup error":   func(transport *recordingObservabilityTransport) { transport.failAt = "cleanup" },
+	} {
+		t.Run(name, func(t *testing.T) {
+			transport := &recordingObservabilityTransport{}
+			configure(transport)
+			probe, err := NewObservabilityCapabilityProbe(transport, ObservabilityCapabilityProbeConfig{
+				Namespace: "ok-observability", ExpectedContractDigest: request.ContractDigest,
+				ExpectedExecutableDigest: request.ExecutableDigest, Timeout: time.Minute, CleanupTimeout: 10 * time.Second,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			result, err := probe.Probe(context.Background(), request)
+			if transport.calls[len(transport.calls)-1] != "cleanup" {
+				t.Fatalf("synthetic cleanup was not last: %v", transport.calls)
+			}
+			if name == "false guarantee" {
+				if err != nil || result.Passed {
+					t.Fatalf("false guarantee was not represented as a capability failure: %#v %v", result, err)
+				}
+			} else if err == nil || result.Passed || strings.Contains(err.Error(), "transport secret") {
+				t.Fatalf("operational failure was accepted or leaked: %#v %v", result, err)
+			}
+		})
+	}
+}
+
+func TestObservabilityCapabilityProbeRejectsForeignContractBeforeTransport(t *testing.T) {
+	request := observabilityProbeRequest()
+	transport := &recordingObservabilityTransport{}
+	probe, err := NewObservabilityCapabilityProbe(transport, ObservabilityCapabilityProbeConfig{
+		Namespace: "ok-observability", ExpectedContractDigest: request.ContractDigest,
+		ExpectedExecutableDigest: request.ExecutableDigest, Timeout: time.Minute, CleanupTimeout: 10 * time.Second,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.ExecutableDigest = digestOf("9")
+	if _, err := probe.Probe(context.Background(), request); err == nil || len(transport.calls) != 0 {
+		t.Fatalf("foreign executable reached capability transport: err=%v calls=%v", err, transport.calls)
+	}
+}
+
+func TestObservabilityCapabilityTransportHasOnlyContractOperations(t *testing.T) {
+	typeOfTransport := reflect.TypeOf((*ObservabilityCapabilityTransport)(nil)).Elem()
+	expected := []string{"CleanupSyntheticResources", "PrepareSyntheticMetrics", "VerifyAlertDelivery", "VerifyAutonomy", "VerifyDashboards", "VerifyLogs", "VerifyMetrics"}
+	if typeOfTransport.NumMethod() != len(expected) {
+		t.Fatalf("capability transport gained an unreviewed operation: %#v", typeOfTransport)
+	}
+	for index, name := range expected {
+		if typeOfTransport.Method(index).Name != name {
+			t.Fatalf("unexpected capability transport operation %d: %s", index, typeOfTransport.Method(index).Name)
+		}
+	}
+}
+
+func observabilityProbeRequest() PlatformCapabilityProbeRequest {
+	return PlatformCapabilityProbeRequest{
+		Format: PlatformCapabilityProbeRequestFormat, TargetClusterUID: "cluster-uid-disposable-ok147",
+		IntentRevision: digestOf("a"), PlatformRevision: digestOf("b"), ExecutionFixture: digestOf("c"),
+		ContractDigest: digestOf("4"), ExecutableDigest: digestOf("5"),
+	}
+}
+
+type recordingObservabilityTransport struct {
+	calls   []string
+	run     ObservabilityCapabilityRun
+	failAt  string
+	falseAt string
+}
+
+func (transport *recordingObservabilityTransport) record(name string, run ObservabilityCapabilityRun) (bool, error) {
+	transport.calls = append(transport.calls, name)
+	transport.run = run
+	if transport.failAt == name {
+		return false, errors.New("transport secret detail")
+	}
+	return transport.falseAt != name, nil
+}
+
+func (transport *recordingObservabilityTransport) PrepareSyntheticMetrics(_ context.Context, run ObservabilityCapabilityRun) error {
+	_, err := transport.record("prepare", run)
+	return err
+}
+func (transport *recordingObservabilityTransport) VerifyMetrics(_ context.Context, run ObservabilityCapabilityRun) (bool, error) {
+	return transport.record("metrics", run)
+}
+func (transport *recordingObservabilityTransport) VerifyDashboards(_ context.Context, run ObservabilityCapabilityRun) (bool, error) {
+	return transport.record("dashboards", run)
+}
+func (transport *recordingObservabilityTransport) VerifyLogs(_ context.Context, run ObservabilityCapabilityRun) (bool, error) {
+	return transport.record("logs", run)
+}
+func (transport *recordingObservabilityTransport) VerifyAlertDelivery(_ context.Context, run ObservabilityCapabilityRun) (bool, error) {
+	return transport.record("alert-delivery", run)
+}
+func (transport *recordingObservabilityTransport) VerifyAutonomy(_ context.Context, run ObservabilityCapabilityRun) (bool, error) {
+	return transport.record("autonomy", run)
+}
+func (transport *recordingObservabilityTransport) CleanupSyntheticResources(_ context.Context, run ObservabilityCapabilityRun) error {
+	_, err := transport.record("cleanup", run)
+	return err
+}


### PR DESCRIPTION
## What changed

- add a closed orchestration surface for all five Observability Capability Contract guarantees
- derive a deterministic run identity from the runtime-bound capability request
- enforce exact namespace, contract digest, executable digest and bounded execution time
- run metrics, dashboards, logs, alert-delivery and autonomy checks in a fixed order
- attempt exact synthetic cleanup after every prepare attempt, including partial failure and cancellation
- reject generic commands, manifests, Kubernetes calls and extension payloads at this boundary

## Why

The existing Bash contract test mixes contract semantics with shell, kubectl, port-forwarding, credentials and cleanup. Embedding it would turn the runner into an arbitrary tool executor. This checkpoint extracts the fixed state machine while keeping the concrete Kubernetes transport separate.

## Scope

Offline orchestration only. It does not execute the Bash test, open credentials, contact Kubernetes or mutate infrastructure.

## Validation

- `go test ./...`
- `go vet ./...`
- `go test -race -ldflags=-linkmode=external ./internal/runner`
- `python3 -m unittest tests/ok141_kubevirt_infra_secret_ref_test.py tests/ok147_runner_image_test.py tests/ok147_runner_publication_test.py`
- `git diff --check`
