### PR TITLE
Bind observability fixture (OK-147)

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -771,6 +771,28 @@ transport, fixed synthetic objects, bounded service access and credential
 materialization remain separate follow-ups. In particular, the existing Bash
 contract test is not embedded or executed by the runner.
 
+## Deterministic observability synthetic fixture
+
+The first concrete Kubernetes-facing input is now generated internally from
+the bound capability run. It contains exactly four namespaced objects in fixed
+order: a Pushgateway Deployment, its Service, a ServiceMonitor and a one-shot
+log-emitter Pod. Callers cannot supply raw manifests, API versions, kinds,
+names, labels, commands or REST paths. The only external content inputs are the
+two container images, and both must be complete OCI references pinned by a
+SHA-256 digest.
+
+Every object carries R, P, execution-fixture, capability-contract and
+capability-executable annotations plus the deterministic run label. Object
+JSON, object digests, exact collection/object paths and membership are folded
+into a separate synthetic-fixture digest. The Pod executes only
+`/bin/echo <derived-marker>`; neither fixture contains a shell or service
+account token. Pod/container security contexts, resource bounds and the
+Prometheus release selector are fixed by the implementation.
+
+This checkpoint still performs no Kubernetes request. Exact absence/create,
+UID/resourceVersion observation, service-proxy checks and guarded cleanup will
+consume this generated fixture in later transport checkpoints.
+
 ## OK-141 compatibility evidence
 
 The verifier was run offline against the preserved Phase-R v5 projection. It

--- a/internal/runner/observability_fixture.go
+++ b/internal/runner/observability_fixture.go
@@ -1,0 +1,211 @@
+package runner
+
+import (
+	"encoding/json"
+	"errors"
+	"regexp"
+	"strings"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+const ObservabilitySyntheticFixtureFormat = "ok147-observability-synthetic-fixture/v1"
+
+var capabilityImageDigestPattern = regexp.MustCompile(`^[a-z0-9][a-z0-9./:_-]*@sha256:[0-9a-f]{64}$`)
+
+type ObservabilitySyntheticFixtureConfig struct {
+	PushgatewayImage string
+	LogEmitterImage  string
+}
+
+type CapabilityObjectIdentity struct {
+	APIVersion string `json:"apiVersion"`
+	Kind       string `json:"kind"`
+	Namespace  string `json:"namespace"`
+	Name       string `json:"name"`
+}
+
+// CapabilityObject is one exact generated object. No caller-supplied raw
+// manifest or REST path enters this type.
+type CapabilityObject struct {
+	Identity       CapabilityObjectIdentity `json:"identity"`
+	Digest         string                   `json:"digest"`
+	CollectionPath string                   `json:"collectionPath"`
+	ObjectPath     string                   `json:"objectPath"`
+	Raw            json.RawMessage          `json:"-"`
+}
+
+type ObservabilitySyntheticFixture struct {
+	Format             string             `json:"format"`
+	RunID              string             `json:"runId"`
+	Namespace          string             `json:"namespace"`
+	MetricsWorkload    string             `json:"metricsWorkload"`
+	LogEmitter         string             `json:"logEmitter"`
+	MetricName         string             `json:"metricName"`
+	AlertTriggerMetric string             `json:"alertTriggerMetric"`
+	LogMarker          string             `json:"logMarker"`
+	Objects            []CapabilityObject `json:"objects"`
+	FixtureDigest      string             `json:"fixtureDigest"`
+}
+
+// BuildObservabilitySyntheticFixture is the only manifest constructor for the
+// capability transport. It produces exactly Deployment, Service,
+// ServiceMonitor and log-emitter Pod objects in fixed order.
+func BuildObservabilitySyntheticFixture(run ObservabilityCapabilityRun, config ObservabilitySyntheticFixtureConfig) (ObservabilitySyntheticFixture, error) {
+	if err := validateObservabilityCapabilityRun(run); err != nil {
+		return ObservabilitySyntheticFixture{}, err
+	}
+	if !capabilityImageDigestPattern.MatchString(config.PushgatewayImage) || !capabilityImageDigestPattern.MatchString(config.LogEmitterImage) {
+		return ObservabilitySyntheticFixture{}, errors.New("observability synthetic image is not immutable")
+	}
+	suffix := strings.TrimPrefix(run.RunID, "ok147-")
+	fixture := ObservabilitySyntheticFixture{
+		Format: ObservabilitySyntheticFixtureFormat, RunID: run.RunID, Namespace: run.Namespace,
+		MetricsWorkload: "ok147-metrics-" + suffix, LogEmitter: "ok147-log-" + suffix,
+		MetricName:         "ok_observability_contract_metric_" + suffix,
+		AlertTriggerMetric: "ok_observability_synthetic_alert_trigger",
+		LogMarker:          "OK147_OBSERVABILITY_LOG_" + suffix,
+	}
+	metadata := func(name string) map[string]any {
+		return map[string]any{
+			"name": name, "namespace": run.Namespace,
+			"labels": map[string]any{
+				"app.kubernetes.io/managed-by": "ok147-runner", "openkubes.io/run-id": run.RunID,
+			},
+			"annotations": map[string]any{
+				"openkubes.io/intent-revision": run.IntentRevision, "openkubes.io/platform-revision": run.PlatformRevision,
+				"openkubes.io/execution-fixture": run.ExecutionFixture, "openkubes.io/capability-contract": run.ContractDigest,
+				"openkubes.io/capability-executable": run.ExecutableDigest,
+			},
+		}
+	}
+	podSecurityContext := map[string]any{"runAsNonRoot": true, "seccompProfile": map[string]any{"type": "RuntimeDefault"}}
+	containerSecurityContext := map[string]any{"allowPrivilegeEscalation": false, "capabilities": map[string]any{"drop": []any{"ALL"}}, "readOnlyRootFilesystem": true}
+	selectorLabels := map[string]any{"app": fixture.MetricsWorkload, "openkubes.io/run-id": run.RunID}
+
+	deploymentMetadata := metadata(fixture.MetricsWorkload)
+	deploymentMetadata["labels"].(map[string]any)["app"] = fixture.MetricsWorkload
+	serviceMetadata := metadata(fixture.MetricsWorkload)
+	serviceMetadata["labels"].(map[string]any)["app"] = fixture.MetricsWorkload
+	monitorMetadata := metadata(fixture.MetricsWorkload)
+	monitorMetadata["labels"].(map[string]any)["release"] = "ok-observability"
+	objects := []map[string]any{
+		{
+			"apiVersion": "apps/v1", "kind": "Deployment", "metadata": deploymentMetadata,
+			"spec": map[string]any{
+				"replicas": 1, "selector": map[string]any{"matchLabels": selectorLabels},
+				"template": map[string]any{
+					"metadata": map[string]any{"labels": selectorLabels},
+					"spec": map[string]any{
+						"automountServiceAccountToken": false, "enableServiceLinks": false, "securityContext": podSecurityContext,
+						"containers": []any{map[string]any{
+							"name": "pushgateway", "image": config.PushgatewayImage, "imagePullPolicy": "IfNotPresent",
+							"ports":           []any{map[string]any{"name": "http", "containerPort": 9091}},
+							"securityContext": containerSecurityContext,
+							"resources":       map[string]any{"requests": map[string]any{"cpu": "10m", "memory": "32Mi"}, "limits": map[string]any{"cpu": "250m", "memory": "128Mi"}},
+						}},
+					},
+				},
+			},
+		},
+		{
+			"apiVersion": "v1", "kind": "Service", "metadata": serviceMetadata,
+			"spec": map[string]any{"selector": selectorLabels, "ports": []any{map[string]any{"name": "http", "port": 9091, "targetPort": 9091}}},
+		},
+		{
+			"apiVersion": "monitoring.coreos.com/v1", "kind": "ServiceMonitor", "metadata": monitorMetadata,
+			"spec": map[string]any{"selector": map[string]any{"matchLabels": map[string]any{"app": fixture.MetricsWorkload}}, "endpoints": []any{map[string]any{"port": "http", "interval": "10s"}}},
+		},
+		{
+			"apiVersion": "v1", "kind": "Pod", "metadata": metadata(fixture.LogEmitter),
+			"spec": map[string]any{
+				"automountServiceAccountToken": false, "enableServiceLinks": false, "restartPolicy": "Never", "securityContext": podSecurityContext,
+				"containers": []any{map[string]any{
+					"name": "log-emitter", "image": config.LogEmitterImage, "imagePullPolicy": "IfNotPresent",
+					"command": []any{"/bin/echo", fixture.LogMarker}, "securityContext": containerSecurityContext,
+					"resources": map[string]any{"requests": map[string]any{"cpu": "1m", "memory": "4Mi"}, "limits": map[string]any{"cpu": "50m", "memory": "16Mi"}},
+				}},
+			},
+		},
+	}
+	fixture.Objects = make([]CapabilityObject, 0, len(objects))
+	for _, object := range objects {
+		capabilityObject, err := encodeCapabilityObject(object)
+		if err != nil {
+			return ObservabilitySyntheticFixture{}, err
+		}
+		fixture.Objects = append(fixture.Objects, capabilityObject)
+	}
+	fixtureDigest, err := ObservabilitySyntheticFixtureDigest(fixture)
+	if err != nil {
+		return ObservabilitySyntheticFixture{}, err
+	}
+	fixture.FixtureDigest = fixtureDigest
+	return fixture, nil
+}
+
+func ObservabilitySyntheticFixtureDigest(fixture ObservabilitySyntheticFixture) (string, error) {
+	normalized := fixture
+	normalized.FixtureDigest = ""
+	raw, err := json.Marshal(normalized)
+	if err != nil {
+		return "", err
+	}
+	return digest.SHA256(raw), nil
+}
+
+func encodeCapabilityObject(object map[string]any) (CapabilityObject, error) {
+	apiVersion, _ := object["apiVersion"].(string)
+	kind, _ := object["kind"].(string)
+	metadata, _ := object["metadata"].(map[string]any)
+	name, _ := metadata["name"].(string)
+	namespace, _ := metadata["namespace"].(string)
+	if apiVersion == "" || kind == "" || !capabilityNamespacePattern.MatchString(name) || !capabilityNamespacePattern.MatchString(namespace) || len(name) > 63 || len(namespace) > 63 {
+		return CapabilityObject{}, errors.New("synthetic capability object identity is invalid")
+	}
+	resource, err := capabilityResource(apiVersion, kind)
+	if err != nil {
+		return CapabilityObject{}, err
+	}
+	prefix := "/api/v1"
+	if apiVersion != "v1" {
+		parts := strings.Split(apiVersion, "/")
+		prefix = "/apis/" + parts[0] + "/" + parts[1]
+	}
+	collection := prefix + "/namespaces/" + namespace + "/" + resource
+	raw, err := json.Marshal(object)
+	if err != nil {
+		return CapabilityObject{}, errors.New("encode synthetic capability object")
+	}
+	return CapabilityObject{
+		Identity: CapabilityObjectIdentity{APIVersion: apiVersion, Kind: kind, Namespace: namespace, Name: name},
+		Digest:   digest.SHA256(raw), CollectionPath: collection, ObjectPath: collection + "/" + name, Raw: raw,
+	}, nil
+}
+
+func capabilityResource(apiVersion, kind string) (string, error) {
+	switch apiVersion + "/" + kind {
+	case "apps/v1/Deployment":
+		return "deployments", nil
+	case "v1/Service":
+		return "services", nil
+	case "monitoring.coreos.com/v1/ServiceMonitor":
+		return "servicemonitors", nil
+	case "v1/Pod":
+		return "pods", nil
+	default:
+		return "", errors.New("synthetic capability object kind is not permitted")
+	}
+}
+
+func validateObservabilityCapabilityRun(run ObservabilityCapabilityRun) error {
+	if run.Format != ObservabilityCapabilityRunFormat || !capabilityNamespacePattern.MatchString(run.RunID) || len(run.RunID) != 30 || !strings.HasPrefix(run.RunID, "ok147-") || !capabilityNamespacePattern.MatchString(run.Namespace) || len(run.Namespace) > 63 || !runtimeInputUIDPattern.MatchString(run.TargetClusterUID) {
+		return errors.New("observability capability run identity is invalid")
+	}
+	for _, value := range []string{run.IntentRevision, run.PlatformRevision, run.ExecutionFixture, run.ContractDigest, run.ExecutableDigest} {
+		if !platformInputDigestPattern.MatchString(value) {
+			return errors.New("observability capability run revision is invalid")
+		}
+	}
+	return nil
+}

--- a/internal/runner/observability_fixture_test.go
+++ b/internal/runner/observability_fixture_test.go
@@ -1,0 +1,94 @@
+package runner
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+func TestBuildObservabilitySyntheticFixtureProducesExactImmutableObjects(t *testing.T) {
+	run, err := observabilityCapabilityRun(observabilityProbeRequest(), "ok-observability")
+	if err != nil {
+		t.Fatal(err)
+	}
+	config := ObservabilitySyntheticFixtureConfig{
+		PushgatewayImage: "registry.example.test/prom/pushgateway@sha256:" + strings.Repeat("1", 64),
+		LogEmitterImage:  "registry.example.test/library/busybox@sha256:" + strings.Repeat("2", 64),
+	}
+	fixture, err := BuildObservabilitySyntheticFixture(run, config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fixture.Format != ObservabilitySyntheticFixtureFormat || fixture.RunID != run.RunID || fixture.Namespace != run.Namespace || len(fixture.Objects) != 4 || !platformInputDigestPattern.MatchString(fixture.FixtureDigest) {
+		t.Fatalf("unexpected synthetic fixture: %#v", fixture)
+	}
+	expectedKinds := []string{"Deployment", "Service", "ServiceMonitor", "Pod"}
+	expectedResources := []string{"deployments", "services", "servicemonitors", "pods"}
+	for index, object := range fixture.Objects {
+		if object.Identity.Kind != expectedKinds[index] || !strings.Contains(object.CollectionPath, "/namespaces/"+run.Namespace+"/"+expectedResources[index]) || object.ObjectPath != object.CollectionPath+"/"+object.Identity.Name || !platformInputDigestPattern.MatchString(object.Digest) {
+			t.Fatalf("object %d is outside the fixed identity: %#v", index, object)
+		}
+		if object.Digest != digest.SHA256(object.Raw) {
+			t.Fatalf("object %d raw content differs from its digest", index)
+		}
+		var decoded map[string]any
+		if err := json.Unmarshal(object.Raw, &decoded); err != nil {
+			t.Fatal(err)
+		}
+		metadata := decoded["metadata"].(map[string]any)
+		annotations := metadata["annotations"].(map[string]any)
+		if annotations["openkubes.io/intent-revision"] != run.IntentRevision || annotations["openkubes.io/platform-revision"] != run.PlatformRevision || annotations["openkubes.io/execution-fixture"] != run.ExecutionFixture || annotations["openkubes.io/capability-contract"] != run.ContractDigest || annotations["openkubes.io/capability-executable"] != run.ExecutableDigest {
+			t.Fatalf("object %d lost runtime correlation: %#v", index, annotations)
+		}
+	}
+	second, err := BuildObservabilitySyntheticFixture(run, config)
+	if err != nil || !reflect.DeepEqual(fixture, second) {
+		t.Fatalf("equivalent run changed synthetic projection: %v", err)
+	}
+}
+
+func TestBuildObservabilitySyntheticFixtureRejectsMutableImages(t *testing.T) {
+	run, err := observabilityCapabilityRun(observabilityProbeRequest(), "ok-observability")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for name, config := range map[string]ObservabilitySyntheticFixtureConfig{
+		"mutable pushgateway": {PushgatewayImage: "prom/pushgateway:v1.9.0", LogEmitterImage: "busybox@sha256:" + strings.Repeat("2", 64)},
+		"mutable logger":      {PushgatewayImage: "prom/pushgateway@sha256:" + strings.Repeat("1", 64), LogEmitterImage: "busybox:latest"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := BuildObservabilitySyntheticFixture(run, config); err == nil {
+				t.Fatal("mutable image was accepted")
+			}
+		})
+	}
+}
+
+func TestObservabilitySyntheticFixtureBindsEverySemanticChange(t *testing.T) {
+	run, err := observabilityCapabilityRun(observabilityProbeRequest(), "ok-observability")
+	if err != nil {
+		t.Fatal(err)
+	}
+	config := ObservabilitySyntheticFixtureConfig{
+		PushgatewayImage: "prom/pushgateway@sha256:" + strings.Repeat("1", 64),
+		LogEmitterImage:  "busybox@sha256:" + strings.Repeat("2", 64),
+	}
+	first, err := BuildObservabilitySyntheticFixture(run, config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	config.LogEmitterImage = "busybox@sha256:" + strings.Repeat("3", 64)
+	second, err := BuildObservabilitySyntheticFixture(run, config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.FixtureDigest == second.FixtureDigest || first.Objects[3].Digest == second.Objects[3].Digest {
+		t.Fatal("image semantic change retained fixture or Pod identity")
+	}
+	if first.Objects[0].Digest != second.Objects[0].Digest || first.Objects[1].Digest != second.Objects[1].Digest || first.Objects[2].Digest != second.Objects[2].Digest {
+		t.Fatal("log image change modified unrelated metrics objects")
+	}
+}


### PR DESCRIPTION
## What changed

- generate an exact four-object Kubernetes synthetic fixture from the bound capability run
- bind Deployment, Service, ServiceMonitor and log-emitter Pod to R, P, fixture, contract and executable identities
- require immutable SHA-256 image references
- derive exact object names, labels, markers, REST routes and per-object digests internally
- bind membership and object identities into a separate fixture digest

## Why

The concrete capability transport needs synthetic Kubernetes resources, but accepting raw manifests would create an arbitrary mutation surface. This checkpoint makes the fixture deterministic and closed before any API client is added.

## Scope

Offline projection only. No Kubernetes request, credential read, cluster contact or mutation occurs.

## Validation

- `go test ./...`
- `go vet ./...`
- `go test -race -ldflags=-linkmode=external ./internal/runner`
- `python3 -m unittest tests/ok141_kubevirt_infra_secret_ref_test.py tests/ok147_runner_image_test.py tests/ok147_runner_publication_test.py`
- `git diff --check`
