### PR TITLE
Add exact capability fixture client (OK-147)

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -793,6 +793,28 @@ This checkpoint still performs no Kubernetes request. Exact absence/create,
 UID/resourceVersion observation, service-proxy checks and guarded cleanup will
 consume this generated fixture in later transport checkpoints.
 
+## Exact synthetic fixture create and cleanup client
+
+The generated fixture now feeds a dedicated workload-cluster client frozen to
+one runtime Cluster UID. The client accepts no manifests, names or paths at
+execution time. Before its first mutation it performs exact object GETs for
+the complete four-object fixture; any existing object or uncertain response
+stops with zero writes. Only after all four are absent does it issue the four
+fixed collection POSTs in fixture order. A redacted receipt preserves the
+exact successfully created prefix if a later create fails.
+
+Synthetic cleanup accepts only a receipt for the same fixture digest and
+created prefix. It processes that prefix in reverse order, re-reads each exact
+object, verifies the original UID and complete desired subset, and uses the
+current resourceVersion plus UID as Kubernetes DeleteOptions preconditions.
+Deletion is Foreground and any first error stops without retry. Redirects are
+denied, responses are bounded JSON, credentials are never included in errors,
+and no list, watch, discovery, apply, update, patch or force-delete path exists.
+
+The implementation has so far been exercised only against an in-memory HTTP
+transport. Opening credentials and invoking it against a live workload cluster
+remain later integration steps.
+
 ## OK-141 compatibility evidence
 
 The verifier was run offline against the preserved Phase-R v5 projection. It

--- a/internal/runner/observability_fixture_client.go
+++ b/internal/runner/observability_fixture_client.go
@@ -1,0 +1,293 @@
+package runner
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"net/url"
+	"reflect"
+	"strings"
+	"time"
+)
+
+const (
+	CapabilityFixtureReceiptFormat = "ok147-capability-fixture-receipt/v1"
+	maximumCapabilityAPIBytes      = 4 * 1024 * 1024
+)
+
+type KubernetesCapabilityFixtureClientConfig struct {
+	Endpoint          string
+	BearerToken       string
+	AuthorityIdentity string
+	Client            *http.Client
+}
+
+type CapabilityFixtureObjectResult struct {
+	Identity CapabilityObjectIdentity `json:"identity"`
+	Digest   string                   `json:"digest"`
+	UID      string                   `json:"uid"`
+	State    string                   `json:"state"`
+}
+
+type CapabilityFixtureReceipt struct {
+	Format        string                          `json:"format"`
+	FixtureDigest string                          `json:"fixtureDigest"`
+	State         string                          `json:"state"`
+	MutationState string                          `json:"mutationState"`
+	Results       []CapabilityFixtureObjectResult `json:"results"`
+}
+
+// KubernetesCapabilityFixtureClient freezes one generated fixture and one
+// workload authority. Create and cleanup accept no manifests, names or paths.
+type KubernetesCapabilityFixtureClient struct {
+	endpoint *url.URL
+	token    string
+	client   *http.Client
+	fixture  ObservabilitySyntheticFixture
+}
+
+func NewKubernetesCapabilityFixtureClient(config KubernetesCapabilityFixtureClientConfig, run ObservabilityCapabilityRun, fixtureConfig ObservabilitySyntheticFixtureConfig) (*KubernetesCapabilityFixtureClient, error) {
+	if config.AuthorityIdentity != run.TargetClusterUID {
+		return nil, errors.New("capability fixture authority differs from runtime-bound target")
+	}
+	endpoint, err := url.Parse(config.Endpoint)
+	if err != nil || endpoint.Host == "" || endpoint.User != nil || endpoint.RawQuery != "" || endpoint.Fragment != "" || endpoint.Path != "" && endpoint.Path != "/" {
+		return nil, errors.New("capability fixture Kubernetes endpoint is invalid")
+	}
+	host := endpoint.Hostname()
+	if endpoint.Scheme != "https" && !(endpoint.Scheme == "http" && (host == "127.0.0.1" || host == "::1" || host == "localhost")) {
+		return nil, errors.New("capability fixture Kubernetes endpoint must use HTTPS")
+	}
+	if config.BearerToken == "" || strings.TrimSpace(config.BearerToken) != config.BearerToken || strings.ContainsAny(config.BearerToken, "\r\n") || config.Client == nil {
+		return nil, errors.New("capability fixture Kubernetes credential or client is invalid")
+	}
+	fixture, err := BuildObservabilitySyntheticFixture(run, fixtureConfig)
+	if err != nil {
+		return nil, errors.New("build bound observability synthetic fixture")
+	}
+	client := *config.Client
+	client.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+	if client.Timeout == 0 {
+		client.Timeout = 15 * time.Second
+	}
+	endpoint.Path, endpoint.RawPath = "", ""
+	return &KubernetesCapabilityFixtureClient{endpoint: endpoint, token: config.BearerToken, client: &client, fixture: cloneSyntheticFixture(fixture)}, nil
+}
+
+func (client *KubernetesCapabilityFixtureClient) FixtureDigest() string {
+	if client == nil {
+		return ""
+	}
+	return client.fixture.FixtureDigest
+}
+
+// Create performs all exact absence GETs before the first collection POST.
+// Existing state therefore causes a zero-write stop rather than adoption.
+func (client *KubernetesCapabilityFixtureClient) Create(ctx context.Context) (CapabilityFixtureReceipt, error) {
+	receipt := client.newReceipt("PREFLIGHT", "NOT_ATTEMPTED")
+	if client == nil || client.client == nil {
+		return receipt, errors.New("capability fixture client is required")
+	}
+	for _, object := range client.fixture.Objects {
+		_, status, err := client.request(ctx, http.MethodGet, object.ObjectPath, nil)
+		if err != nil {
+			return stoppedCapabilityFixture(receipt, err)
+		}
+		if status != http.StatusNotFound {
+			if status == http.StatusOK {
+				return stoppedCapabilityFixture(receipt, errors.New("synthetic capability object already exists; zero-write preflight stopped"))
+			}
+			return stoppedCapabilityFixture(receipt, capabilityStatusError(http.MethodGet, status))
+		}
+	}
+	receipt.State = "CREATING"
+	for _, object := range client.fixture.Objects {
+		receipt.MutationState = "ATTEMPTED"
+		raw, status, err := client.request(ctx, http.MethodPost, object.CollectionPath, object.Raw)
+		if err != nil {
+			return stoppedCapabilityFixture(receipt, err)
+		}
+		if status != http.StatusCreated {
+			return stoppedCapabilityFixture(receipt, capabilityStatusError(http.MethodPost, status))
+		}
+		uid, _, err := verifyCapabilityObject(raw, object)
+		if err != nil {
+			return stoppedCapabilityFixture(receipt, errors.New("created synthetic capability object differs from fixture"))
+		}
+		receipt.Results = append(receipt.Results, CapabilityFixtureObjectResult{Identity: object.Identity, Digest: object.Digest, UID: uid, State: "CREATED"})
+	}
+	receipt.State = "CREATED"
+	return receipt, nil
+}
+
+// Cleanup removes only the successfully created receipt prefix, in reverse
+// order. Each DELETE is bound to the observed UID and current resourceVersion.
+func (client *KubernetesCapabilityFixtureClient) Cleanup(ctx context.Context, created CapabilityFixtureReceipt) (CapabilityFixtureReceipt, error) {
+	receipt := client.newReceipt("CLEANING", "NOT_ATTEMPTED")
+	validCreatedState := created.State == "CREATED" || created.State == "STOPPED_PARTIAL_OR_UNKNOWN"
+	if client == nil || client.client == nil || created.Format != CapabilityFixtureReceiptFormat || created.FixtureDigest != client.fixture.FixtureDigest || !validCreatedState || created.MutationState != "ATTEMPTED" || len(created.Results) == 0 || len(created.Results) > len(client.fixture.Objects) {
+		return receipt, errors.New("capability fixture cleanup receipt is invalid")
+	}
+	for index := range created.Results {
+		expected := client.fixture.Objects[index]
+		result := created.Results[index]
+		if result.Identity != expected.Identity || result.Digest != expected.Digest || result.State != "CREATED" || !runtimeInputUIDPattern.MatchString(result.UID) {
+			return stoppedCapabilityFixture(receipt, errors.New("capability fixture cleanup identity differs from created prefix"))
+		}
+	}
+	for index := len(created.Results) - 1; index >= 0; index-- {
+		object := client.fixture.Objects[index]
+		createdResult := created.Results[index]
+		raw, status, err := client.request(ctx, http.MethodGet, object.ObjectPath, nil)
+		if err != nil {
+			return stoppedCapabilityFixture(receipt, err)
+		}
+		if status != http.StatusOK {
+			return stoppedCapabilityFixture(receipt, capabilityStatusError(http.MethodGet, status))
+		}
+		uid, resourceVersion, err := verifyCapabilityObject(raw, object)
+		if err != nil || uid != createdResult.UID {
+			return stoppedCapabilityFixture(receipt, errors.New("synthetic capability cleanup target identity changed"))
+		}
+		deleteOptions, err := json.Marshal(map[string]any{
+			"apiVersion": "v1", "kind": "DeleteOptions", "propagationPolicy": "Foreground",
+			"preconditions": map[string]any{"uid": uid, "resourceVersion": resourceVersion},
+		})
+		if err != nil {
+			return stoppedCapabilityFixture(receipt, errors.New("encode capability fixture delete preconditions"))
+		}
+		receipt.MutationState = "ATTEMPTED"
+		_, status, err = client.request(ctx, http.MethodDelete, object.ObjectPath, deleteOptions)
+		if err != nil {
+			return stoppedCapabilityFixture(receipt, err)
+		}
+		if status != http.StatusOK && status != http.StatusAccepted {
+			return stoppedCapabilityFixture(receipt, capabilityStatusError(http.MethodDelete, status))
+		}
+		receipt.Results = append(receipt.Results, CapabilityFixtureObjectResult{Identity: object.Identity, Digest: object.Digest, UID: uid, State: "DELETE_ACCEPTED"})
+	}
+	receipt.State = "CLEANUP_ACCEPTED"
+	return receipt, nil
+}
+
+func (client *KubernetesCapabilityFixtureClient) newReceipt(state, mutation string) CapabilityFixtureReceipt {
+	digestValue := ""
+	if client != nil {
+		digestValue = client.fixture.FixtureDigest
+	}
+	return CapabilityFixtureReceipt{Format: CapabilityFixtureReceiptFormat, FixtureDigest: digestValue, State: state, MutationState: mutation, Results: []CapabilityFixtureObjectResult{}}
+}
+
+func stoppedCapabilityFixture(receipt CapabilityFixtureReceipt, err error) (CapabilityFixtureReceipt, error) {
+	receipt.State = "STOPPED_PARTIAL_OR_UNKNOWN"
+	return receipt, err
+}
+
+func (client *KubernetesCapabilityFixtureClient) request(ctx context.Context, method, path string, body []byte) ([]byte, int, error) {
+	endpoint := *client.endpoint
+	endpoint.Path = path
+	request, err := http.NewRequestWithContext(ctx, method, endpoint.String(), bytes.NewReader(body))
+	if err != nil {
+		return nil, 0, errors.New("construct bounded capability fixture request")
+	}
+	request.Header.Set("Accept", "application/json")
+	request.Header.Set("Authorization", "Bearer "+client.token)
+	if body != nil {
+		request.Header.Set("Content-Type", "application/json")
+	}
+	response, err := client.client.Do(request)
+	if err != nil {
+		return nil, 0, fmt.Errorf("bounded capability fixture %s request failed", method)
+	}
+	defer response.Body.Close()
+	raw, readErr := io.ReadAll(io.LimitReader(response.Body, maximumCapabilityAPIBytes+1))
+	if readErr != nil || len(raw) > maximumCapabilityAPIBytes {
+		return nil, 0, errors.New("bounded capability fixture response exceeds accepted size")
+	}
+	if len(raw) > 0 {
+		mediaType, _, err := mime.ParseMediaType(response.Header.Get("Content-Type"))
+		if err != nil || mediaType != "application/json" {
+			return nil, 0, errors.New("bounded capability fixture response is not JSON")
+		}
+	}
+	return raw, response.StatusCode, nil
+}
+
+func verifyCapabilityObject(raw []byte, expected CapabilityObject) (string, string, error) {
+	observed, err := decodeCapabilityJSONObject(raw)
+	if err != nil {
+		return "", "", err
+	}
+	desired, err := decodeCapabilityJSONObject(expected.Raw)
+	if err != nil || !capabilitySubset(desired, observed) {
+		return "", "", errors.New("observed object does not contain exact fixture fields")
+	}
+	metadata, _ := observed["metadata"].(map[string]any)
+	uid, _ := metadata["uid"].(string)
+	resourceVersion, _ := metadata["resourceVersion"].(string)
+	if !runtimeInputUIDPattern.MatchString(uid) || resourceVersion == "" {
+		return "", "", errors.New("observed object lacks runtime identity")
+	}
+	return uid, resourceVersion, nil
+}
+
+func decodeCapabilityJSONObject(raw []byte) (map[string]any, error) {
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	var value map[string]any
+	if err := decoder.Decode(&value); err != nil {
+		return nil, err
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		return nil, errors.New("trailing JSON")
+	}
+	return value, nil
+}
+
+func capabilitySubset(expected, observed any) bool {
+	switch expectedValue := expected.(type) {
+	case map[string]any:
+		observedValue, ok := observed.(map[string]any)
+		if !ok {
+			return false
+		}
+		for key, expectedChild := range expectedValue {
+			observedChild, exists := observedValue[key]
+			if !exists || !capabilitySubset(expectedChild, observedChild) {
+				return false
+			}
+		}
+		return true
+	case []any:
+		observedValue, ok := observed.([]any)
+		if !ok || len(expectedValue) != len(observedValue) {
+			return false
+		}
+		for index := range expectedValue {
+			if !capabilitySubset(expectedValue[index], observedValue[index]) {
+				return false
+			}
+		}
+		return true
+	default:
+		return reflect.DeepEqual(expected, observed)
+	}
+}
+
+func capabilityStatusError(method string, status int) error {
+	return fmt.Errorf("bounded capability fixture %s returned HTTP %d", method, status)
+}
+
+func cloneSyntheticFixture(fixture ObservabilitySyntheticFixture) ObservabilitySyntheticFixture {
+	fixture.Objects = append([]CapabilityObject(nil), fixture.Objects...)
+	for index := range fixture.Objects {
+		fixture.Objects[index].Raw = append(json.RawMessage(nil), fixture.Objects[index].Raw...)
+	}
+	return fixture
+}

--- a/internal/runner/observability_fixture_client_test.go
+++ b/internal/runner/observability_fixture_client_test.go
@@ -1,0 +1,227 @@
+package runner
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestKubernetesCapabilityFixtureClientPreflightsCreatesAndCleansExactObjects(t *testing.T) {
+	api := newCapabilityFixtureAPI(t)
+	client := newCapabilityFixtureClient(t, api.client())
+	created, err := client.Create(context.Background())
+	if err != nil || created.State != "CREATED" || created.MutationState != "ATTEMPTED" || len(created.Results) != 4 {
+		t.Fatalf("fixture create failed: %#v %v", created, err)
+	}
+	if len(api.requests) != 8 {
+		t.Fatalf("expected four preflight GETs and four POSTs, got %v", api.requests)
+	}
+	for index := 0; index < 4; index++ {
+		if api.requests[index].method != http.MethodGet || api.requests[index+4].method != http.MethodPost {
+			t.Fatalf("zero-write preflight/order differs: %v", api.requests)
+		}
+	}
+	api.requests = nil
+	cleaned, err := client.Cleanup(context.Background(), created)
+	if err != nil || cleaned.State != "CLEANUP_ACCEPTED" || len(cleaned.Results) != 4 {
+		t.Fatalf("fixture cleanup failed: %#v %v", cleaned, err)
+	}
+	if len(api.requests) != 8 {
+		t.Fatalf("expected four identity GETs and four DELETEs, got %v", api.requests)
+	}
+	for index := 0; index < 4; index++ {
+		getRequest := api.requests[index*2]
+		deleteRequest := api.requests[index*2+1]
+		expectedObject := client.fixture.Objects[3-index]
+		if getRequest.method != http.MethodGet || getRequest.path != expectedObject.ObjectPath || deleteRequest.method != http.MethodDelete || deleteRequest.path != expectedObject.ObjectPath {
+			t.Fatalf("cleanup was not exact reverse order: %v", api.requests)
+		}
+		var options map[string]any
+		if err := json.Unmarshal(deleteRequest.body, &options); err != nil {
+			t.Fatal(err)
+		}
+		preconditions := options["preconditions"].(map[string]any)
+		if preconditions["uid"] != created.Results[3-index].UID || preconditions["resourceVersion"] == "" || options["propagationPolicy"] != "Foreground" {
+			t.Fatalf("cleanup preconditions differ: %#v", options)
+		}
+	}
+}
+
+func TestKubernetesCapabilityFixtureClientStopsZeroWriteWhenAnyObjectExists(t *testing.T) {
+	api := newCapabilityFixtureAPI(t)
+	client := newCapabilityFixtureClient(t, api.client())
+	existing := client.fixture.Objects[2]
+	api.objects[existing.ObjectPath] = api.runtimeObject(existing, "existing-uid", "7")
+	receipt, err := client.Create(context.Background())
+	if err == nil || receipt.MutationState != "NOT_ATTEMPTED" || api.posts != 0 || len(receipt.Results) != 0 {
+		t.Fatalf("existing object did not stop before first write: %#v posts=%d err=%v", receipt, api.posts, err)
+	}
+	for _, request := range api.requests {
+		if request.method != http.MethodGet {
+			t.Fatalf("mutation occurred during failed preflight: %#v", request)
+		}
+	}
+}
+
+func TestKubernetesCapabilityFixtureClientPreservesPartialCreatePrefix(t *testing.T) {
+	api := newCapabilityFixtureAPI(t)
+	api.failPost = 3
+	client := newCapabilityFixtureClient(t, api.client())
+	receipt, err := client.Create(context.Background())
+	if err == nil || receipt.State != "STOPPED_PARTIAL_OR_UNKNOWN" || receipt.MutationState != "ATTEMPTED" || len(receipt.Results) != 2 {
+		t.Fatalf("partial create prefix was not preserved: %#v %v", receipt, err)
+	}
+	if receipt.Results[0].Identity != client.fixture.Objects[0].Identity || receipt.Results[1].Identity != client.fixture.Objects[1].Identity {
+		t.Fatalf("partial receipt does not describe exact created prefix: %#v", receipt)
+	}
+}
+
+func TestKubernetesCapabilityFixtureClientRejectsForeignAuthorityAndRedirect(t *testing.T) {
+	run, _ := observabilityCapabilityRun(observabilityProbeRequest(), "ok-observability")
+	fixtureConfig := capabilityFixtureConfig()
+	if _, err := NewKubernetesCapabilityFixtureClient(KubernetesCapabilityFixtureClientConfig{
+		Endpoint: "https://192.0.2.10:6443", BearerToken: "token", AuthorityIdentity: "foreign", Client: &http.Client{},
+	}, run, fixtureConfig); err == nil {
+		t.Fatal("foreign workload authority accepted")
+	}
+	calls := 0
+	client, err := NewKubernetesCapabilityFixtureClient(KubernetesCapabilityFixtureClientConfig{
+		Endpoint: "http://127.0.0.1:12345", BearerToken: "short-lived-test-token", AuthorityIdentity: run.TargetClusterUID,
+		Client: &http.Client{Transport: capabilityRoundTripFunc(func(*http.Request) (*http.Response, error) {
+			calls++
+			return capabilityJSONResponse(http.StatusTemporaryRedirect, nil, map[string]string{"Location": "http://127.0.0.1:12346/foreign"}), nil
+		})},
+	}, run, fixtureConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.Create(context.Background()); err == nil || calls != 1 {
+		t.Fatalf("redirect followed or accepted: calls=%d err=%v", calls, err)
+	}
+}
+
+type capabilityRecordedRequest struct {
+	method string
+	path   string
+	body   []byte
+}
+
+type capabilityFixtureAPI struct {
+	t        *testing.T
+	mu       sync.Mutex
+	objects  map[string]map[string]any
+	requests []capabilityRecordedRequest
+	posts    int
+	failPost int
+}
+
+func newCapabilityFixtureAPI(t *testing.T) *capabilityFixtureAPI {
+	return &capabilityFixtureAPI{t: t, objects: map[string]map[string]any{}}
+}
+
+func (api *capabilityFixtureAPI) client() *http.Client {
+	return &http.Client{Transport: capabilityRoundTripFunc(api.roundTrip)}
+}
+
+func (api *capabilityFixtureAPI) roundTrip(request *http.Request) (*http.Response, error) {
+	api.mu.Lock()
+	defer api.mu.Unlock()
+	body, _ := io.ReadAll(request.Body)
+	api.requests = append(api.requests, capabilityRecordedRequest{method: request.Method, path: request.URL.Path, body: body})
+	if request.Header.Get("Authorization") != "Bearer short-lived-test-token" {
+		return capabilityJSONResponse(http.StatusUnauthorized, nil, nil), nil
+	}
+	switch request.Method {
+	case http.MethodGet:
+		object, ok := api.objects[request.URL.Path]
+		if !ok {
+			return capabilityJSONResponse(http.StatusNotFound, map[string]any{"reason": "NotFound"}, nil), nil
+		}
+		// Simulate controller/status updates between create and cleanup.
+		object["metadata"].(map[string]any)["resourceVersion"] = "current-9"
+		return capabilityJSONResponse(http.StatusOK, object, nil), nil
+	case http.MethodPost:
+		api.posts++
+		if api.failPost == api.posts {
+			return capabilityJSONResponse(http.StatusForbidden, map[string]any{"reason": "Denied"}, nil), nil
+		}
+		var object map[string]any
+		decoder := json.NewDecoder(bytes.NewReader(body))
+		decoder.UseNumber()
+		if err := decoder.Decode(&object); err != nil {
+			api.t.Fatal(err)
+		}
+		metadata := object["metadata"].(map[string]any)
+		uid := "created-uid-" + string(rune('a'+api.posts-1))
+		metadata["uid"], metadata["resourceVersion"] = uid, "1"
+		path := request.URL.Path + "/" + metadata["name"].(string)
+		api.objects[path] = object
+		return capabilityJSONResponse(http.StatusCreated, object, nil), nil
+	case http.MethodDelete:
+		if _, ok := api.objects[request.URL.Path]; !ok {
+			return capabilityJSONResponse(http.StatusNotFound, map[string]any{"reason": "NotFound"}, nil), nil
+		}
+		delete(api.objects, request.URL.Path)
+		return capabilityJSONResponse(http.StatusOK, map[string]any{"kind": "Status", "status": "Success"}, nil), nil
+	default:
+		return capabilityJSONResponse(http.StatusMethodNotAllowed, nil, nil), nil
+	}
+}
+
+func (api *capabilityFixtureAPI) runtimeObject(object CapabilityObject, uid, resourceVersion string) map[string]any {
+	var value map[string]any
+	decoder := json.NewDecoder(bytes.NewReader(object.Raw))
+	decoder.UseNumber()
+	if err := decoder.Decode(&value); err != nil {
+		api.t.Fatal(err)
+	}
+	metadata := value["metadata"].(map[string]any)
+	metadata["uid"], metadata["resourceVersion"] = uid, resourceVersion
+	return value
+}
+
+func newCapabilityFixtureClient(t *testing.T, httpClient *http.Client) *KubernetesCapabilityFixtureClient {
+	t.Helper()
+	run, err := observabilityCapabilityRun(observabilityProbeRequest(), "ok-observability")
+	if err != nil {
+		t.Fatal(err)
+	}
+	client, err := NewKubernetesCapabilityFixtureClient(KubernetesCapabilityFixtureClientConfig{
+		Endpoint: "http://127.0.0.1:12345", BearerToken: "short-lived-test-token", AuthorityIdentity: run.TargetClusterUID, Client: httpClient,
+	}, run, capabilityFixtureConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return client
+}
+
+func capabilityFixtureConfig() ObservabilitySyntheticFixtureConfig {
+	return ObservabilitySyntheticFixtureConfig{
+		PushgatewayImage: "prom/pushgateway@sha256:" + strings.Repeat("1", 64),
+		LogEmitterImage:  "busybox@sha256:" + strings.Repeat("2", 64),
+	}
+}
+
+type capabilityRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (function capabilityRoundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return function(request)
+}
+
+func capabilityJSONResponse(status int, value any, headers map[string]string) *http.Response {
+	var raw []byte
+	if value != nil {
+		raw, _ = json.Marshal(value)
+	}
+	header := make(http.Header)
+	header.Set("Content-Type", "application/json")
+	for key, value := range headers {
+		header.Set(key, value)
+	}
+	return &http.Response{StatusCode: status, Header: header, Body: io.NopCloser(bytes.NewReader(raw))}
+}


### PR DESCRIPTION
## What changed

- add a workload-authority client frozen to one generated capability fixture
- perform a complete exact-name absence preflight before the first write
- create only the four internally generated objects in fixed order
- preserve a redacted exact created prefix on partial failure
- clean only that prefix in reverse order with UID/current-resourceVersion DeleteOptions preconditions
- deny redirects and expose no list, watch, discovery, apply, update, patch or force-delete operation

## Why

The capability runner needs synthetic Kubernetes resources without accepting arbitrary manifests or adopting existing objects. This client turns the deterministic fixture into a zero-write-preflight/create-only transaction with explicit partial-state evidence and guarded synthetic cleanup.

## Scope

The client is tested only with an in-memory HTTP transport. It is not wired to credentials, the orchestrator, CLI/Job or a live cluster.

## Validation

- `go test ./...`
- `go vet ./...`
- `go test -race -ldflags=-linkmode=external ./internal/runner`
- `python3 -m unittest tests/ok141_kubevirt_infra_secret_ref_test.py tests/ok147_runner_image_test.py tests/ok147_runner_publication_test.py`
- `git diff --check`
