### PR TITLE
Wire workload capability transport (OK-147)

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -815,6 +815,26 @@ The implementation has so far been exercised only against an in-memory HTTP
 transport. Opening credentials and invoking it against a live workload cluster
 remain later integration steps.
 
+## Workload-bound observability transport
+
+The fixture client is now composed with the fixed five-check interface behind
+one workload-bound transport. Its opener reads the bounded token and CA files,
+verifies the actual CA digest against the runtime authority binding and rejects
+any authority identity other than the submitted CAPI Cluster UID. Opening the
+transport performs no API request.
+
+Preparation retains its complete private create receipt, including a known
+partial prefix. Each capability check receives an isolated clone of the same
+fixture and can run only in the contract-defined order. Direct out-of-order
+calls fail before reaching the check adapter. Cleanup cannot accept caller
+identities: it uses only the internally retained receipt. A known created
+prefix is cleaned through the guarded client, zero-write preflight failure is a
+no-op, and an unknown POST outcome fails closed instead of guessing which
+object to delete.
+
+The concrete service checks are still injected typed implementations in this
+checkpoint; no live Kubernetes request or capability mutation was performed.
+
 ## OK-141 compatibility evidence
 
 The verifier was run offline against the preserved Phase-R v5 projection. It

--- a/internal/runner/kubernetes.go
+++ b/internal/runner/kubernetes.go
@@ -73,6 +73,13 @@ type KubernetesPlatformObserverConfig struct {
 	Clock                 func() time.Time
 }
 
+type KubernetesObservabilityTransportConfig struct {
+	Workload KubernetesAuthorityConfig
+	Run      ObservabilityCapabilityRun
+	Fixture  ObservabilitySyntheticFixtureConfig
+	Checks   ObservabilityCapabilityChecks
+}
+
 // InspectKubernetesLedger performs a read-only restart decision. It does not
 // claim the grant and therefore cannot authorize a later mutation by itself.
 func InspectKubernetesLedger(ctx context.Context, grant authorization.VerifiedGrant, config KubernetesLedgerConfig) (ledger.Inspection, error) {
@@ -211,6 +218,29 @@ func OpenKubernetesPlatformSourceCollector(config KubernetesPlatformObserverConf
 	return observation.NewPlatformSourceCollector(reader, config.Capability, observation.PlatformCollectorConfig{
 		Profile: config.Profile, TargetClusterUID: config.TargetClusterUID, Clock: config.Clock,
 	})
+}
+
+// OpenKubernetesObservabilityTransport binds the fixed capability lifecycle to
+// one runtime workload authority. It reads credential files but performs no
+// Kubernetes request until the capability probe opens its execution gate.
+func OpenKubernetesObservabilityTransport(config KubernetesObservabilityTransportConfig) (*KubernetesObservabilityTransport, error) {
+	if config.Workload.AuthorityIdentity != config.Run.TargetClusterUID || !platformInputDigestPattern.MatchString(config.Workload.CABundleDigest) {
+		return nil, errors.New("observability transport workload authority differs from runtime target")
+	}
+	token, ca, client, err := openBoundedKubernetesMaterial(config.Workload.TokenFile, config.Workload.CAFile)
+	if err != nil {
+		return nil, errors.New("open bounded observability transport credential")
+	}
+	if digest.SHA256(ca) != config.Workload.CABundleDigest {
+		return nil, errors.New("observability transport CA differs from runtime-bound authority")
+	}
+	fixtureClient, err := NewKubernetesCapabilityFixtureClient(KubernetesCapabilityFixtureClientConfig{
+		Endpoint: config.Workload.Endpoint, BearerToken: token, AuthorityIdentity: config.Workload.AuthorityIdentity, Client: client,
+	}, config.Run, config.Fixture)
+	if err != nil {
+		return nil, errors.New("open bounded observability fixture client")
+	}
+	return newKubernetesObservabilityTransport(fixtureClient, config.Run, config.Checks)
 }
 
 func openBoundedKubernetesHTTP(tokenFile, caFile string) (string, *http.Client, error) {

--- a/internal/runner/observability_fixture_client.go
+++ b/internal/runner/observability_fixture_client.go
@@ -107,18 +107,20 @@ func (client *KubernetesCapabilityFixtureClient) Create(ctx context.Context) (Ca
 	}
 	receipt.State = "CREATING"
 	for _, object := range client.fixture.Objects {
-		receipt.MutationState = "ATTEMPTED"
+		receipt.MutationState = "ATTEMPTED_UNKNOWN"
 		raw, status, err := client.request(ctx, http.MethodPost, object.CollectionPath, object.Raw)
 		if err != nil {
 			return stoppedCapabilityFixture(receipt, err)
 		}
 		if status != http.StatusCreated {
+			receipt.MutationState = "ATTEMPTED"
 			return stoppedCapabilityFixture(receipt, capabilityStatusError(http.MethodPost, status))
 		}
 		uid, _, err := verifyCapabilityObject(raw, object)
 		if err != nil {
 			return stoppedCapabilityFixture(receipt, errors.New("created synthetic capability object differs from fixture"))
 		}
+		receipt.MutationState = "ATTEMPTED"
 		receipt.Results = append(receipt.Results, CapabilityFixtureObjectResult{Identity: object.Identity, Digest: object.Digest, UID: uid, State: "CREATED"})
 	}
 	receipt.State = "CREATED"

--- a/internal/runner/observability_transport.go
+++ b/internal/runner/observability_transport.go
@@ -1,0 +1,119 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"sync"
+)
+
+// ObservabilityCapabilityChecks is the fixed, read-oriented half of the live
+// capability adapter. Synthetic object lifecycle remains owned by the fixture
+// client and cannot be influenced by a check implementation.
+type ObservabilityCapabilityChecks interface {
+	Metrics(context.Context, ObservabilityCapabilityRun, ObservabilitySyntheticFixture) (bool, error)
+	Dashboards(context.Context, ObservabilityCapabilityRun, ObservabilitySyntheticFixture) (bool, error)
+	Logs(context.Context, ObservabilityCapabilityRun, ObservabilitySyntheticFixture) (bool, error)
+	AlertDelivery(context.Context, ObservabilityCapabilityRun, ObservabilitySyntheticFixture) (bool, error)
+	Autonomy(context.Context, ObservabilityCapabilityRun, ObservabilitySyntheticFixture) (bool, error)
+}
+
+// KubernetesObservabilityTransport combines one frozen synthetic fixture
+// client with five fixed checks. It retains the private partial create receipt
+// so cleanup cannot be redirected by its caller.
+type KubernetesObservabilityTransport struct {
+	mu        sync.Mutex
+	run       ObservabilityCapabilityRun
+	fixture   ObservabilitySyntheticFixture
+	client    *KubernetesCapabilityFixtureClient
+	checks    ObservabilityCapabilityChecks
+	created   *CapabilityFixtureReceipt
+	prepared  bool
+	cleaned   bool
+	nextCheck int
+}
+
+func newKubernetesObservabilityTransport(client *KubernetesCapabilityFixtureClient, run ObservabilityCapabilityRun, checks ObservabilityCapabilityChecks) (*KubernetesObservabilityTransport, error) {
+	if client == nil || checks == nil || validateObservabilityCapabilityRun(run) != nil || client.fixture.RunID != run.RunID || client.fixture.Namespace != run.Namespace {
+		return nil, errors.New("Kubernetes observability transport binding is invalid")
+	}
+	return &KubernetesObservabilityTransport{run: run, fixture: cloneSyntheticFixture(client.fixture), client: client, checks: checks}, nil
+}
+
+func (transport *KubernetesObservabilityTransport) PrepareSyntheticMetrics(ctx context.Context, run ObservabilityCapabilityRun) error {
+	transport.mu.Lock()
+	if transport.prepared || transport.cleaned || run != transport.run {
+		transport.mu.Unlock()
+		return errors.New("Kubernetes observability preparation state is invalid")
+	}
+	transport.prepared = true
+	transport.mu.Unlock()
+	receipt, err := transport.client.Create(ctx)
+	transport.mu.Lock()
+	transport.created = &receipt
+	transport.mu.Unlock()
+	if err != nil {
+		return errors.New("create bounded observability synthetic fixture")
+	}
+	return nil
+}
+
+func (transport *KubernetesObservabilityTransport) VerifyMetrics(ctx context.Context, run ObservabilityCapabilityRun) (bool, error) {
+	return transport.check(ctx, run, 0, transport.checks.Metrics)
+}
+
+func (transport *KubernetesObservabilityTransport) VerifyDashboards(ctx context.Context, run ObservabilityCapabilityRun) (bool, error) {
+	return transport.check(ctx, run, 1, transport.checks.Dashboards)
+}
+
+func (transport *KubernetesObservabilityTransport) VerifyLogs(ctx context.Context, run ObservabilityCapabilityRun) (bool, error) {
+	return transport.check(ctx, run, 2, transport.checks.Logs)
+}
+
+func (transport *KubernetesObservabilityTransport) VerifyAlertDelivery(ctx context.Context, run ObservabilityCapabilityRun) (bool, error) {
+	return transport.check(ctx, run, 3, transport.checks.AlertDelivery)
+}
+
+func (transport *KubernetesObservabilityTransport) VerifyAutonomy(ctx context.Context, run ObservabilityCapabilityRun) (bool, error) {
+	return transport.check(ctx, run, 4, transport.checks.Autonomy)
+}
+
+func (transport *KubernetesObservabilityTransport) check(ctx context.Context, run ObservabilityCapabilityRun, expectedIndex int, check func(context.Context, ObservabilityCapabilityRun, ObservabilitySyntheticFixture) (bool, error)) (bool, error) {
+	transport.mu.Lock()
+	valid := transport.prepared && !transport.cleaned && transport.created != nil && transport.created.State == "CREATED" && run == transport.run && transport.nextCheck == expectedIndex
+	fixture := cloneSyntheticFixture(transport.fixture)
+	if valid {
+		transport.nextCheck++
+	}
+	transport.mu.Unlock()
+	if !valid {
+		return false, errors.New("Kubernetes observability check state is invalid")
+	}
+	passed, err := check(ctx, run, fixture)
+	if err != nil {
+		return false, errors.New("bounded Kubernetes observability check failed")
+	}
+	return passed, nil
+}
+
+func (transport *KubernetesObservabilityTransport) CleanupSyntheticResources(ctx context.Context, run ObservabilityCapabilityRun) error {
+	transport.mu.Lock()
+	if !transport.prepared || transport.cleaned || run != transport.run || transport.created == nil {
+		transport.mu.Unlock()
+		return errors.New("Kubernetes observability cleanup state is invalid")
+	}
+	transport.cleaned = true
+	created := *transport.created
+	transport.mu.Unlock()
+	if created.MutationState == "NOT_ATTEMPTED" && len(created.Results) == 0 {
+		return nil
+	}
+	if created.MutationState == "ATTEMPTED_UNKNOWN" || len(created.Results) == 0 {
+		return errors.New("Kubernetes observability partial state cannot be safely cleaned")
+	}
+	if _, err := transport.client.Cleanup(ctx, created); err != nil {
+		return errors.New("clean bounded observability synthetic fixture")
+	}
+	return nil
+}
+
+var _ ObservabilityCapabilityTransport = (*KubernetesObservabilityTransport)(nil)

--- a/internal/runner/observability_transport_test.go
+++ b/internal/runner/observability_transport_test.go
@@ -1,0 +1,163 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+func TestKubernetesObservabilityTransportOwnsCreateChecksAndCleanup(t *testing.T) {
+	api := newCapabilityFixtureAPI(t)
+	client := newCapabilityFixtureClient(t, api.client())
+	run, _ := observabilityCapabilityRun(observabilityProbeRequest(), "ok-observability")
+	checks := &recordingCapabilityChecks{}
+	transport, err := newKubernetesObservabilityTransport(client, run, checks)
+	if err != nil {
+		t.Fatal(err)
+	}
+	probe, err := NewObservabilityCapabilityProbe(transport, ObservabilityCapabilityProbeConfig{
+		Namespace: run.Namespace, ExpectedContractDigest: run.ContractDigest, ExpectedExecutableDigest: run.ExecutableDigest,
+		Timeout: time.Minute, CleanupTimeout: 10 * time.Second,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := probe.Probe(context.Background(), observabilityProbeRequest())
+	if err != nil || !result.Passed {
+		t.Fatalf("composed Kubernetes transport failed: %#v %v", result, err)
+	}
+	expected := []string{"metrics", "dashboards", "logs", "alert-delivery", "autonomy"}
+	if !reflect.DeepEqual(checks.calls, expected) || len(api.objects) != 0 {
+		t.Fatalf("fixed checks or owned cleanup differ: checks=%v remaining=%d", checks.calls, len(api.objects))
+	}
+	for _, fixture := range checks.fixtures {
+		if fixture.FixtureDigest != client.FixtureDigest() || fixture.RunID != run.RunID {
+			t.Fatalf("check received foreign fixture: %#v", fixture)
+		}
+	}
+}
+
+func TestKubernetesObservabilityTransportCleansKnownPartialPrefix(t *testing.T) {
+	api := newCapabilityFixtureAPI(t)
+	api.failPost = 3
+	client := newCapabilityFixtureClient(t, api.client())
+	run, _ := observabilityCapabilityRun(observabilityProbeRequest(), "ok-observability")
+	transport, err := newKubernetesObservabilityTransport(client, run, &recordingCapabilityChecks{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := transport.PrepareSyntheticMetrics(context.Background(), run); err == nil {
+		t.Fatal("partial fixture creation was accepted")
+	}
+	if len(api.objects) != 2 {
+		t.Fatalf("fake partial prefix differs: %d", len(api.objects))
+	}
+	if err := transport.CleanupSyntheticResources(context.Background(), run); err != nil || len(api.objects) != 0 {
+		t.Fatalf("known partial prefix was not safely cleaned: remaining=%d err=%v", len(api.objects), err)
+	}
+}
+
+func TestKubernetesObservabilityTransportRejectsOutOfOrderCheck(t *testing.T) {
+	api := newCapabilityFixtureAPI(t)
+	client := newCapabilityFixtureClient(t, api.client())
+	run, _ := observabilityCapabilityRun(observabilityProbeRequest(), "ok-observability")
+	checks := &recordingCapabilityChecks{}
+	transport, err := newKubernetesObservabilityTransport(client, run, checks)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := transport.PrepareSyntheticMetrics(context.Background(), run); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := transport.VerifyLogs(context.Background(), run); err == nil || len(checks.calls) != 0 {
+		t.Fatalf("out-of-order check reached adapter: err=%v calls=%v", err, checks.calls)
+	}
+	if err := transport.CleanupSyntheticResources(context.Background(), run); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestKubernetesObservabilityTransportRejectsUnknownPartialState(t *testing.T) {
+	run, _ := observabilityCapabilityRun(observabilityProbeRequest(), "ok-observability")
+	calls := 0
+	httpClient := &http.Client{Transport: capabilityRoundTripFunc(func(request *http.Request) (*http.Response, error) {
+		calls++
+		if request.Method == http.MethodGet {
+			return capabilityJSONResponse(http.StatusNotFound, map[string]any{"reason": "NotFound"}, nil), nil
+		}
+		return nil, errors.New("secret transport failure")
+	})}
+	client := newCapabilityFixtureClient(t, httpClient)
+	transport, err := newKubernetesObservabilityTransport(client, run, &recordingCapabilityChecks{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := transport.PrepareSyntheticMetrics(context.Background(), run); err == nil || calls != 5 {
+		t.Fatalf("unknown POST outcome was accepted: calls=%d err=%v", calls, err)
+	}
+	if err := transport.CleanupSyntheticResources(context.Background(), run); err == nil || strings.Contains(err.Error(), "secret transport") {
+		t.Fatalf("unknown partial state was cleaned or leaked: %v", err)
+	}
+}
+
+func TestOpenKubernetesObservabilityTransportBindsCredentialAndCA(t *testing.T) {
+	root := t.TempDir()
+	tokenPath, caPath := filepath.Join(root, "token"), filepath.Join(root, "ca.crt")
+	ca := testCA(t)
+	if err := os.WriteFile(tokenPath, []byte("short-lived-workload-token"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(caPath, ca, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	run, _ := observabilityCapabilityRun(observabilityProbeRequest(), "ok-observability")
+	config := KubernetesObservabilityTransportConfig{
+		Workload: KubernetesAuthorityConfig{
+			Endpoint: "https://192.168.100.213:6443", AuthorityIdentity: run.TargetClusterUID,
+			TokenFile: tokenPath, CAFile: caPath, CABundleDigest: digest.SHA256(ca),
+		},
+		Run: run, Fixture: capabilityFixtureConfig(), Checks: &recordingCapabilityChecks{},
+	}
+	if _, err := OpenKubernetesObservabilityTransport(config); err != nil {
+		t.Fatal(err)
+	}
+	config.Workload.CABundleDigest = digestOf("9")
+	if _, err := OpenKubernetesObservabilityTransport(config); err == nil || strings.Contains(err.Error(), root) {
+		t.Fatalf("foreign CA accepted or path leaked: %v", err)
+	}
+}
+
+type recordingCapabilityChecks struct {
+	calls    []string
+	fixtures []ObservabilitySyntheticFixture
+}
+
+func (checks *recordingCapabilityChecks) record(name string, fixture ObservabilitySyntheticFixture) (bool, error) {
+	checks.calls = append(checks.calls, name)
+	checks.fixtures = append(checks.fixtures, fixture)
+	return true, nil
+}
+
+func (checks *recordingCapabilityChecks) Metrics(_ context.Context, _ ObservabilityCapabilityRun, fixture ObservabilitySyntheticFixture) (bool, error) {
+	return checks.record("metrics", fixture)
+}
+func (checks *recordingCapabilityChecks) Dashboards(_ context.Context, _ ObservabilityCapabilityRun, fixture ObservabilitySyntheticFixture) (bool, error) {
+	return checks.record("dashboards", fixture)
+}
+func (checks *recordingCapabilityChecks) Logs(_ context.Context, _ ObservabilityCapabilityRun, fixture ObservabilitySyntheticFixture) (bool, error) {
+	return checks.record("logs", fixture)
+}
+func (checks *recordingCapabilityChecks) AlertDelivery(_ context.Context, _ ObservabilityCapabilityRun, fixture ObservabilitySyntheticFixture) (bool, error) {
+	return checks.record("alert-delivery", fixture)
+}
+func (checks *recordingCapabilityChecks) Autonomy(_ context.Context, _ ObservabilityCapabilityRun, fixture ObservabilitySyntheticFixture) (bool, error) {
+	return checks.record("autonomy", fixture)
+}


### PR DESCRIPTION
## What changed

- bind the synthetic fixture client to the post-submission workload authority and verified CA digest
- retain private full/partial create receipts inside the transport
- expose exactly five typed capability checks over cloned immutable fixture data
- enforce contract check order even for direct transport calls
- clean known created prefixes from retained evidence and fail closed for unknown POST outcomes
- distinguish definite rejected writes from indeterminate transport outcomes

## Why

The capability orchestration needs a concrete workload-bound lifecycle without allowing callers to redirect cleanup or substitute manifests. This checkpoint safely composes credentials, exact creates, fixed checks and guarded cleanup while preserving partial-state semantics.

## Scope

No concrete service check implementation and no live Kubernetes execution. Tests use bounded local transports and temporary credential files only.

## Validation

- `go test ./...`
- `go vet ./...`
- `go test -race -ldflags=-linkmode=external ./internal/runner`
- `python3 -m unittest tests/ok141_kubevirt_infra_secret_ref_test.py tests/ok147_runner_image_test.py tests/ok147_runner_publication_test.py`
- `git diff --check`
