### PR TITLE
Add bounded convergence polling (OK-147)

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -835,6 +835,27 @@ object to delete.
 The concrete service checks are still injected typed implementations in this
 checkpoint; no live Kubernetes request or capability mutation was performed.
 
+## Bounded convergence observation polling
+
+The aggregate observer can now be wrapped by a bounded polling observer before
+it is supplied to `execution.Operation`. This closes the immediate-observation
+gap: CAPI, Network and Platform sources may remain `Unknown` while their
+existing owners converge after submission without causing the executor to
+pretend the run is complete.
+
+Only `Ready=Unknown` permits another read-oriented observation. `Ready=True`
+and `Ready=False` return immediately. An operational source error, invalid or
+unverified result, cancellation or wait failure also stops immediately and is
+never retried. Interval and total duration have hard constructor bounds; the
+final delay is shortened to the exact deadline. If the deadline is reached
+while state remains Unknown, the latest verified fail-closed result is returned
+so the execution outcome remains STOPPED rather than fabricated success.
+
+This wrapper never repeats submission or another mutation. Because the
+Platform collector's separately hashed Application gate invokes capability
+code only after Argo is current, ordinary pre-convergence polling also does not
+consume the single-use first-run capability source.
+
 ## OK-141 compatibility evidence
 
 The verifier was run offline against the preserved Phase-R v5 projection. It

--- a/internal/runner/polling_observer.go
+++ b/internal/runner/polling_observer.go
@@ -1,0 +1,90 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/observation"
+)
+
+type ObservationSource interface {
+	Observe(context.Context, observation.Policy) (observation.VerifiedResult, error)
+}
+
+type ObservationWaiter func(context.Context, time.Duration) error
+
+type BoundedPollingObserverConfig struct {
+	Source   ObservationSource
+	Interval time.Duration
+	Timeout  time.Duration
+	Clock    func() time.Time
+	Wait     ObservationWaiter
+}
+
+// BoundedPollingObserver repeats only read-oriented aggregate observation.
+// It never repeats submission, capability execution after a terminal result,
+// mutation or an operationally failed observation.
+type BoundedPollingObserver struct {
+	config BoundedPollingObserverConfig
+}
+
+func NewBoundedPollingObserver(config BoundedPollingObserverConfig) (*BoundedPollingObserver, error) {
+	if config.Source == nil || config.Clock == nil || config.Wait == nil || config.Interval < time.Second || config.Interval > 5*time.Minute || config.Timeout < config.Interval || config.Timeout > 6*time.Hour {
+		return nil, errors.New("bounded polling observer configuration is invalid")
+	}
+	return &BoundedPollingObserver{config: config}, nil
+}
+
+func (observer *BoundedPollingObserver) Observe(ctx context.Context, policy observation.Policy) (observation.VerifiedResult, error) {
+	if observer == nil || observer.config.Source == nil {
+		return observation.VerifiedResult{}, errors.New("bounded polling observer is required")
+	}
+	if err := ctx.Err(); err != nil {
+		return observation.VerifiedResult{}, errors.New("bounded observation polling cancelled")
+	}
+	started := observer.config.Clock()
+	deadline := started.Add(observer.config.Timeout)
+	var last observation.VerifiedResult
+	for {
+		result, err := observer.config.Source.Observe(ctx, policy)
+		if err != nil {
+			return observation.VerifiedResult{}, errors.New("bounded aggregate observation failed")
+		}
+		receipt, err := result.Receipt()
+		if err != nil {
+			return observation.VerifiedResult{}, errors.New("aggregate observer returned an unverified result")
+		}
+		last = result
+		if receipt.Ready == "True" || receipt.Ready == "False" {
+			return result, nil
+		}
+		if receipt.Ready != "Unknown" {
+			return observation.VerifiedResult{}, errors.New("aggregate observer returned an invalid readiness state")
+		}
+		now := observer.config.Clock()
+		if !now.Before(deadline) {
+			return last, nil
+		}
+		wait := observer.config.Interval
+		if remaining := deadline.Sub(now); remaining < wait {
+			wait = remaining
+		}
+		if err := observer.config.Wait(ctx, wait); err != nil {
+			return observation.VerifiedResult{}, errors.New("bounded observation polling interrupted")
+		}
+	}
+}
+
+func WaitWithTimer(ctx context.Context, duration time.Duration) error {
+	timer := time.NewTimer(duration)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+var _ ObservationSource = (*KubernetesAggregateObserver)(nil)

--- a/internal/runner/polling_observer_test.go
+++ b/internal/runner/polling_observer_test.go
@@ -1,0 +1,135 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/observation"
+)
+
+func TestBoundedPollingObserverStopsAtFirstTerminalResult(t *testing.T) {
+	policy, _ := aggregateRunnerFixture()
+	unknown := pollingResult(t, policy, "Unknown")
+	ready := pollingResult(t, policy, "True")
+	current := time.Date(2026, 8, 16, 12, 0, 0, 0, time.UTC)
+	source := &sequenceObservationSource{results: []observation.VerifiedResult{unknown, unknown, ready}}
+	waits := 0
+	observer, err := NewBoundedPollingObserver(BoundedPollingObserverConfig{
+		Source: source, Interval: 10 * time.Second, Timeout: time.Minute, Clock: func() time.Time { return current },
+		Wait: func(_ context.Context, duration time.Duration) error {
+			waits++
+			current = current.Add(duration)
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := observer.Observe(context.Background(), policy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, _ := result.Receipt()
+	if receipt.Ready != "True" || source.calls != 3 || waits != 2 {
+		t.Fatalf("poller did not stop at first terminal result: receipt=%#v calls=%d waits=%d", receipt, source.calls, waits)
+	}
+}
+
+func TestBoundedPollingObserverReturnsLastUnknownAtDeadline(t *testing.T) {
+	policy, _ := aggregateRunnerFixture()
+	unknown := pollingResult(t, policy, "Unknown")
+	current := time.Date(2026, 8, 16, 12, 0, 0, 0, time.UTC)
+	source := &sequenceObservationSource{fallback: unknown}
+	observer, err := NewBoundedPollingObserver(BoundedPollingObserverConfig{
+		Source: source, Interval: 10 * time.Second, Timeout: 25 * time.Second, Clock: func() time.Time { return current },
+		Wait: func(_ context.Context, duration time.Duration) error { current = current.Add(duration); return nil },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := observer.Observe(context.Background(), policy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, _ := result.Receipt()
+	if receipt.Ready != "Unknown" || source.calls != 4 || !current.Equal(time.Date(2026, 8, 16, 12, 0, 25, 0, time.UTC)) {
+		t.Fatalf("deadline did not return last fail-closed evidence: receipt=%#v calls=%d now=%s", receipt, source.calls, current)
+	}
+}
+
+func TestBoundedPollingObserverDoesNotRetryFalseOrOperationalError(t *testing.T) {
+	policy, _ := aggregateRunnerFixture()
+	falseResult := pollingResult(t, policy, "False")
+	for name, source := range map[string]*sequenceObservationSource{
+		"terminal false": {results: []observation.VerifiedResult{falseResult}},
+		"source error":   {err: errors.New("secret API detail")},
+	} {
+		t.Run(name, func(t *testing.T) {
+			waits := 0
+			observer, err := NewBoundedPollingObserver(BoundedPollingObserverConfig{
+				Source: source, Interval: time.Second, Timeout: time.Minute, Clock: time.Now,
+				Wait: func(context.Context, time.Duration) error { waits++; return nil },
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			result, err := observer.Observe(context.Background(), policy)
+			if name == "terminal false" {
+				receipt, receiptErr := result.Receipt()
+				if err != nil || receiptErr != nil || receipt.Ready != "False" {
+					t.Fatalf("terminal False was not returned: %#v %v %v", receipt, err, receiptErr)
+				}
+			} else if err == nil || strings.Contains(err.Error(), "secret API") {
+				t.Fatalf("operational error retried or leaked: %v", err)
+			}
+			if source.calls != 1 || waits != 0 {
+				t.Fatalf("terminal observation was retried: calls=%d waits=%d", source.calls, waits)
+			}
+		})
+	}
+}
+
+func pollingResult(t *testing.T, policy observation.Policy, readiness string) observation.VerifiedResult {
+	t.Helper()
+	evidence := []observation.Evidence{}
+	if readiness == "True" || readiness == "False" {
+		for _, condition := range policy.Required {
+			item := aggregateRunnerEvidence(policy, condition)
+			if readiness == "False" && condition == "PlatformReady" {
+				item.Status, item.Reason = "False", "PlatformCapabilityFailed"
+			}
+			evidence = append(evidence, item)
+		}
+	}
+	result, err := observation.Evaluate(policy, observation.Bundle{
+		Format: observation.BundleFormat, IntentRevision: policy.IntentRevision,
+		EvaluatedAt: "2026-08-16T12:00:00Z", Evidence: evidence,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return result
+}
+
+type sequenceObservationSource struct {
+	results  []observation.VerifiedResult
+	fallback observation.VerifiedResult
+	err      error
+	calls    int
+}
+
+func (source *sequenceObservationSource) Observe(context.Context, observation.Policy) (observation.VerifiedResult, error) {
+	source.calls++
+	if source.err != nil {
+		return observation.VerifiedResult{}, source.err
+	}
+	if len(source.results) > 0 {
+		result := source.results[0]
+		source.results = source.results[1:]
+		return result, nil
+	}
+	return source.fallback, nil
+}


### PR DESCRIPTION
## What changed

- add a bounded wrapper around aggregate observation
- poll only while verified aggregate readiness is `Unknown`
- stop immediately on `True`, `False`, operational error, invalid result or cancellation
- cap interval and total duration and shorten the final wait to the exact deadline
- return the latest verified Unknown result at timeout

## Why

The execution operation observes immediately after create. Existing controllers need time to converge, so a single observation cannot support a real happy run. Polling must repeat only read-oriented observation, never submission or mutation.

## Scope

Library wiring only. No CLI/Job integration, credential read, cluster contact or mutation.

## Validation

- `go test ./...`
- `go vet ./...`
- `go test -race -ldflags=-linkmode=external ./internal/runner ./internal/execution`
- `python3 -m unittest tests/ok141_kubevirt_infra_secret_ref_test.py tests/ok147_runner_image_test.py tests/ok147_runner_publication_test.py`
- `git diff --check`
