### PR TITLE
Wire bounded execution operation (OK-147)

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -856,6 +856,23 @@ Platform collector's separately hashed Application gate invokes capability
 code only after Argo is current, ordinary pre-convergence polling also does not
 consume the single-use first-run capability source.
 
+## Bounded Kubernetes execution composition
+
+The runtime package now composes the durable ledger, the two exact-create
+authorities, the runtime-bound aggregate observer and bounded polling into the
+single `execution.Operation` boundary. Construction reads bounded credential
+files for the ledger and submission authorities but performs no Kubernetes
+request. Observer credentials remain lazy. Infrastructure and management must
+have different endpoints, identities and actual bearer-token values; the
+management observer must use exactly the same authority binding as management
+submission, and the GitOps observer must name its authority explicitly.
+
+The same injected clock drives source evidence, polling and durable execution
+completion. The resulting operation still has no renderer, policy decision,
+retry, rollback, status writer or controller loop. This is library wiring only:
+the dry-run CLI and Job do not activate it, and this checkpoint made no cluster
+contact or mutation.
+
 ## OK-141 compatibility evidence
 
 The verifier was run offline against the preserved Phase-R v5 projection. It

--- a/internal/runner/execution_operation.go
+++ b/internal/runner/execution_operation.go
@@ -1,0 +1,75 @@
+package runner
+
+import (
+	"crypto/subtle"
+	"errors"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/execution"
+	"github.com/openkubes/ok-cluster/internal/submission"
+)
+
+// KubernetesExecutionOperationConfig is the complete runtime composition for
+// one bounded create execution. It contains no implicit authority, retry,
+// rollback, renderer or status publisher.
+type KubernetesExecutionOperationConfig struct {
+	Ledger         KubernetesLedgerConfig
+	Infrastructure KubernetesAuthorityConfig
+	Management     KubernetesAuthorityConfig
+	Observer       KubernetesAggregateObserverConfig
+	PollInterval   time.Duration
+	PollTimeout    time.Duration
+	Clock          func() time.Time
+	Wait           ObservationWaiter
+}
+
+// OpenKubernetesExecutionOperation materializes the four bounded runtime
+// capabilities without contacting a Kubernetes API. Credential files are read
+// once during construction, and infra/mgmt write credentials must be distinct.
+func OpenKubernetesExecutionOperation(config KubernetesExecutionOperationConfig) (execution.Operation, error) {
+	if config.Clock == nil || config.Wait == nil {
+		return execution.Operation{}, errors.New("execution clock and bounded waiter are required")
+	}
+	if config.Infrastructure.AuthorityIdentity == config.Management.AuthorityIdentity || config.Infrastructure.Endpoint == config.Management.Endpoint {
+		return execution.Operation{}, errors.New("infrastructure and management write authorities must be distinct")
+	}
+	if config.Observer.Management != config.Management || config.Observer.ExpectedManagementAuthority != config.Management.AuthorityIdentity {
+		return execution.Operation{}, errors.New("observation management authority differs from submission authority")
+	}
+	if config.Observer.Argo.AuthorityIdentity == "" || config.Observer.ExpectedArgoAuthority != config.Observer.Argo.AuthorityIdentity {
+		return execution.Operation{}, errors.New("GitOps observation authority is not explicitly bound")
+	}
+
+	store, err := OpenKubernetesLedger(config.Ledger)
+	if err != nil {
+		return execution.Operation{}, errors.New("open bounded execution ledger")
+	}
+	infrastructure, infrastructureToken, err := openKubernetesSubmissionClient(config.Infrastructure)
+	if err != nil {
+		return execution.Operation{}, errors.New("open infrastructure submission authority")
+	}
+	management, managementToken, err := openKubernetesSubmissionClient(config.Management)
+	if err != nil {
+		return execution.Operation{}, errors.New("open management submission authority")
+	}
+	if len(infrastructureToken) == len(managementToken) && subtle.ConstantTimeCompare([]byte(infrastructureToken), []byte(managementToken)) == 1 {
+		return execution.Operation{}, errors.New("infrastructure and management write credentials must be distinct")
+	}
+
+	observerConfig := config.Observer
+	observerConfig.Clock = config.Clock
+	aggregate, err := OpenKubernetesAggregateObserver(observerConfig)
+	if err != nil {
+		return execution.Operation{}, errors.New("open bounded aggregate observer")
+	}
+	polling, err := NewBoundedPollingObserver(BoundedPollingObserverConfig{
+		Source: aggregate, Interval: config.PollInterval, Timeout: config.PollTimeout,
+		Clock: config.Clock, Wait: config.Wait,
+	})
+	if err != nil {
+		return execution.Operation{}, errors.New("open bounded convergence observer")
+	}
+
+	submitter := submission.Executor{Infrastructure: infrastructure, Management: management}
+	return execution.Operation{Ledger: store, Submitter: submitter, Observer: polling, Clock: config.Clock}, nil
+}

--- a/internal/runner/execution_operation_test.go
+++ b/internal/runner/execution_operation_test.go
@@ -1,0 +1,112 @@
+package runner
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/observation"
+)
+
+func TestOpenKubernetesExecutionOperationComposesBoundedRuntime(t *testing.T) {
+	config := executionOperationFixture(t)
+	operation, err := OpenKubernetesExecutionOperation(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if operation.Ledger == nil || operation.Submitter == nil || operation.Observer == nil || operation.Clock == nil {
+		t.Fatalf("execution operation is incomplete: %#v", operation)
+	}
+	if _, ok := operation.Observer.(*BoundedPollingObserver); !ok {
+		t.Fatalf("execution observer is not bounded polling: %T", operation.Observer)
+	}
+}
+
+func TestOpenKubernetesExecutionOperationRejectsAuthorityAliasing(t *testing.T) {
+	for name, mutate := range map[string]func(*KubernetesExecutionOperationConfig){
+		"same endpoint": func(config *KubernetesExecutionOperationConfig) {
+			config.Infrastructure.Endpoint = config.Management.Endpoint
+		},
+		"same identity": func(config *KubernetesExecutionOperationConfig) {
+			config.Infrastructure.AuthorityIdentity = config.Management.AuthorityIdentity
+		},
+		"same credential": func(config *KubernetesExecutionOperationConfig) {
+			config.Infrastructure.TokenFile = config.Management.TokenFile
+		},
+		"different observation authority": func(config *KubernetesExecutionOperationConfig) {
+			config.Observer.ExpectedManagementAuthority = "other-management"
+		},
+		"unbound GitOps authority": func(config *KubernetesExecutionOperationConfig) {
+			config.Observer.ExpectedArgoAuthority = "other-gitops"
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			config := executionOperationFixture(t)
+			mutate(&config)
+			if _, err := OpenKubernetesExecutionOperation(config); err == nil {
+				t.Fatal("unsafe authority composition accepted")
+			}
+		})
+	}
+}
+
+func TestOpenKubernetesExecutionOperationRedactsCredentialFailures(t *testing.T) {
+	config := executionOperationFixture(t)
+	secretPath := filepath.Join(t.TempDir(), "private-infrastructure-token")
+	config.Infrastructure.TokenFile = secretPath
+	_, err := OpenKubernetesExecutionOperation(config)
+	if err == nil || strings.Contains(err.Error(), secretPath) {
+		t.Fatalf("credential failure was accepted or disclosed a path: %v", err)
+	}
+}
+
+func TestOpenKubernetesExecutionOperationRejectsUnboundedPolling(t *testing.T) {
+	config := executionOperationFixture(t)
+	config.PollTimeout = 7 * time.Hour
+	if _, err := OpenKubernetesExecutionOperation(config); err == nil {
+		t.Fatal("unbounded polling accepted")
+	}
+}
+
+func executionOperationFixture(t *testing.T) KubernetesExecutionOperationConfig {
+	t.Helper()
+	root := t.TempDir()
+	caPath := filepath.Join(root, "ca.crt")
+	if err := os.WriteFile(caPath, testCA(t), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	authority := func(name, endpoint, token string) KubernetesAuthorityConfig {
+		path := filepath.Join(root, token)
+		if err := os.WriteFile(path, []byte("short-lived-"+token), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		return KubernetesAuthorityConfig{Endpoint: endpoint, AuthorityIdentity: name, TokenFile: path, CAFile: caPath}
+	}
+	ledgerToken := filepath.Join(root, "ledger-token")
+	if err := os.WriteFile(ledgerToken, []byte("short-lived-ledger-token"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, observer := aggregateRunnerFixture()
+	management := authority("ok-mgmt", "https://10.0.0.2:443", "management-token")
+	observer.Management = management
+	observer.ExpectedManagementAuthority = management.AuthorityIdentity
+	observer.Argo = authority("ok-shared", "https://10.0.0.3:443", "gitops-token")
+	observer.ExpectedArgoAuthority = observer.Argo.AuthorityIdentity
+	observer.WorkloadAuthority = WorkloadAuthorityResolverFunc(func(context.Context, observation.Policy) (KubernetesAuthorityConfig, error) {
+		return KubernetesAuthorityConfig{}, nil
+	})
+	observer.PlatformCapability = PlatformCapabilityResolverFunc(func(context.Context, observation.Policy, observation.PlatformProfile) (observation.PlatformCapabilitySource, error) {
+		return inertPlatformCapabilitySource{}, nil
+	})
+	clock := func() time.Time { return time.Date(2026, 8, 16, 12, 0, 0, 0, time.UTC) }
+	return KubernetesExecutionOperationConfig{
+		Ledger:         KubernetesLedgerConfig{Endpoint: "https://10.0.0.3:443", Namespace: "openkubes-execution-system", TokenFile: ledgerToken, CAFile: caPath},
+		Infrastructure: authority("ok-infra", "https://10.0.0.1:443", "infrastructure-token"),
+		Management:     management, Observer: observer, PollInterval: 15 * time.Second,
+		PollTimeout: 2 * time.Hour, Clock: clock,
+		Wait: func(context.Context, time.Duration) error { return nil },
+	}
+}

--- a/internal/runner/kubernetes.go
+++ b/internal/runner/kubernetes.go
@@ -114,16 +114,28 @@ func OpenKubernetesLedger(config KubernetesLedgerConfig) (*ledger.Ledger, error)
 // for one exact authority plane. Paths and credential contents are never
 // returned in errors or receipts.
 func OpenKubernetesSubmissionClient(config KubernetesAuthorityConfig) (*submission.KubernetesClient, error) {
+	client, _, err := openKubernetesSubmissionClient(config)
+	return client, err
+}
+
+// openKubernetesSubmissionClient also returns the bounded token so operation
+// composition can prove that the two write authorities do not share one
+// credential. The token never leaves this package or enters an error/receipt.
+func openKubernetesSubmissionClient(config KubernetesAuthorityConfig) (*submission.KubernetesClient, string, error) {
 	if config.Endpoint == "" || config.AuthorityIdentity == "" || config.TokenFile == "" || config.CAFile == "" {
-		return nil, errors.New("Kubernetes authority endpoint, identity, token file, and CA file are required")
+		return nil, "", errors.New("Kubernetes authority endpoint, identity, token file, and CA file are required")
 	}
 	token, client, err := openBoundedKubernetesHTTP(config.TokenFile, config.CAFile)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
-	return submission.NewKubernetesClient(submission.KubernetesClientConfig{
+	submitter, err := submission.NewKubernetesClient(submission.KubernetesClientConfig{
 		Endpoint: config.Endpoint, AuthorityIdentity: config.AuthorityIdentity, BearerToken: token, Client: client,
 	})
+	if err != nil {
+		return nil, "", err
+	}
+	return submitter, token, nil
 }
 
 // OpenKubernetesCAPILifecycleObserver materializes a bounded management-plane


### PR DESCRIPTION
## What changed

- compose the durable ledger, exact infra/mgmt submission clients, aggregate observer and bounded polling into one `execution.Operation`
- require distinct infra/mgmt endpoints, identities and actual bearer-token values
- bind management observation to the exact management submission authority
- require an explicitly named GitOps observation authority
- use one injected clock across observation, polling and completion

## Scope

Library wiring only. The dry-run CLI and Job remain unchanged. Construction performs no Kubernetes request and this checkpoint made no infrastructure mutation.

## Validation

- `go test -ldflags=-linkmode=external ./...`
- `go vet ./...`
- `go test -race -ldflags=-linkmode=external ./internal/runner ./internal/execution ./internal/submission`
- `python3 -m unittest tests/ok141_kubevirt_infra_secret_ref_test.py tests/ok147_runner_image_test.py tests/ok147_runner_publication_test.py`
- `git diff --check`
