### PR TITLE
Stage observation authority gates (OK-147)

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -856,6 +856,31 @@ Platform collector's separately hashed Application gate invokes capability
 code only after Argo is current, ordinary pre-convergence polling also does not
 consume the single-use first-run capability source.
 
+## Staged authority observation gates
+
+Each polling pass now opens source authorities in dependency order rather than
+materializing every runtime credential up front:
+
+```text
+CAPI lifecycle current
+        ↓
+resolve workload authority and evaluate NetworkReady
+        ↓
+resolve GitOps capability and evaluate PlatformReady
+```
+
+If a required CAPI condition is `False`, `Unknown`, missing, stale, foreign or
+conflicting, the workload resolver and Platform source remain unopened. If
+NetworkReady is not `True`, the Platform resolver remains unopened. The partial
+authoritative bundle is still evaluated normally, so `False` remains terminal
+and unresolved downstream conditions remain `Unknown`; no success is inferred.
+Malformed source evidence remains an operational error.
+
+This staging is required for a real first create: the workload authority cannot
+exist before CAPI has produced the target, and capability execution must not
+start before NetworkReady. The gate adds no retry, credential creation,
+mutation, repair or persistent state.
+
 ## Bounded Kubernetes execution composition
 
 The runtime package now composes the durable ledger, the two exact-create

--- a/internal/observation/aggregate_observer.go
+++ b/internal/observation/aggregate_observer.go
@@ -72,6 +72,13 @@ func (observer *AggregateObserver) Observe(ctx context.Context, policy Policy) (
 				evidenceByType[item.Type] = append(evidenceByType[item.Type], item)
 			}
 		}
+		ready, err := stageConditionsTrue(policy, required, evidenceByType, "InfrastructureReady", "ControlPlaneAvailable")
+		if err != nil {
+			return VerifiedResult{}, errors.New("validate bounded CAPI evidence")
+		}
+		if !ready {
+			return observer.evaluate(policy, evidenceByType)
+		}
 	}
 	if _, wanted := required["NetworkReady"]; wanted {
 		item, err := observer.config.Network.Observe(ctx, policy, observer.config.NetworkProfile)
@@ -82,6 +89,13 @@ func (observer *AggregateObserver) Observe(ctx context.Context, policy Policy) (
 			return VerifiedResult{}, errors.New("Network source returned evidence outside its ownership domain")
 		}
 		evidenceByType[item.Type] = append(evidenceByType[item.Type], item)
+		ready, err := stageConditionsTrue(policy, required, evidenceByType, "NetworkReady")
+		if err != nil {
+			return VerifiedResult{}, errors.New("validate bounded NetworkReady evidence")
+		}
+		if !ready {
+			return observer.evaluate(policy, evidenceByType)
+		}
 	}
 	if _, wanted := required["PlatformReady"]; wanted {
 		item, err := observer.config.Platform.Observe(ctx, policy)
@@ -94,6 +108,10 @@ func (observer *AggregateObserver) Observe(ctx context.Context, policy Policy) (
 		evidenceByType[item.Type] = append(evidenceByType[item.Type], item)
 	}
 
+	return observer.evaluate(policy, evidenceByType)
+}
+
+func (observer *AggregateObserver) evaluate(policy Policy, evidenceByType map[string][]Evidence) (VerifiedResult, error) {
 	evidence := make([]Evidence, 0, len(policy.Required))
 	for _, condition := range policy.Required {
 		evidence = append(evidence, evidenceByType[condition]...)
@@ -103,6 +121,28 @@ func (observer *AggregateObserver) Observe(ctx context.Context, policy Policy) (
 		EvaluatedAt: observer.config.Clock().UTC().Format(time.RFC3339Nano), Evidence: evidence,
 	}
 	return Evaluate(policy, bundle)
+}
+
+// stageConditionsTrue decides only whether a downstream authority may be
+// opened. False, Unknown, missing, conflicting, stale or foreign evidence all
+// keep the next stage closed; malformed evidence remains an operational error.
+func stageConditionsTrue(policy Policy, required map[string]struct{}, evidenceByType map[string][]Evidence, conditions ...string) (bool, error) {
+	for _, condition := range conditions {
+		if _, wanted := required[condition]; !wanted {
+			continue
+		}
+		items := evidenceByType[condition]
+		if len(items) != 1 {
+			return false, nil
+		}
+		if err := validateEvidenceShape(items[0]); err != nil {
+			return false, err
+		}
+		if evaluateEvidence(policy, items[0]).Status != "True" {
+			return false, nil
+		}
+	}
+	return true, nil
 }
 
 func requiresAny(required map[string]struct{}, conditions ...string) bool {

--- a/internal/observation/aggregate_observer_test.go
+++ b/internal/observation/aggregate_observer_test.go
@@ -67,6 +67,58 @@ func TestAggregateObserverCallsOnlyRequiredDomains(t *testing.T) {
 	}
 }
 
+func TestAggregateObserverKeepsDownstreamAuthoritiesClosedUntilPriorStageReady(t *testing.T) {
+	policy, profile := aggregateFixture()
+
+	t.Run("CAPI pending keeps Network and Platform closed", func(t *testing.T) {
+		infrastructure := aggregateEvidence(policy, "InfrastructureReady")
+		infrastructure.Status = "Unknown"
+		infrastructure.Reason = "Provisioning"
+		capi := &fakeCAPIEvidenceSource{evidence: []Evidence{infrastructure, aggregateEvidence(policy, "ControlPlaneAvailable")}}
+		network := &fakeNetworkEvidenceSource{err: errors.New("must not be called")}
+		platform := &fakePlatformEvidenceSource{err: errors.New("must not be called")}
+		observer, err := NewAggregateObserver(AggregateObserverConfig{
+			CAPI: capi, Network: network, Platform: platform, NetworkProfile: profile,
+			Clock: func() time.Time { return time.Date(2026, 8, 16, 12, 30, 0, 0, time.UTC) },
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		result, err := observer.Observe(context.Background(), policy)
+		if err != nil {
+			t.Fatal(err)
+		}
+		receipt, _ := result.Receipt()
+		if receipt.Ready != "Unknown" || network.calls != 0 || platform.calls != 0 {
+			t.Fatalf("downstream source opened before CAPI convergence: receipt=%#v calls=%d/%d", receipt, network.calls, platform.calls)
+		}
+	})
+
+	t.Run("Network pending keeps Platform closed", func(t *testing.T) {
+		networkEvidence := aggregateEvidence(policy, "NetworkReady")
+		networkEvidence.Status = "Unknown"
+		networkEvidence.Reason = "ProbePending"
+		capi := &fakeCAPIEvidenceSource{evidence: []Evidence{aggregateEvidence(policy, "InfrastructureReady"), aggregateEvidence(policy, "ControlPlaneAvailable")}}
+		network := &fakeNetworkEvidenceSource{evidence: networkEvidence}
+		platform := &fakePlatformEvidenceSource{err: errors.New("must not be called")}
+		observer, err := NewAggregateObserver(AggregateObserverConfig{
+			CAPI: capi, Network: network, Platform: platform, NetworkProfile: profile,
+			Clock: func() time.Time { return time.Date(2026, 8, 16, 12, 30, 0, 0, time.UTC) },
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		result, err := observer.Observe(context.Background(), policy)
+		if err != nil {
+			t.Fatal(err)
+		}
+		receipt, _ := result.Receipt()
+		if receipt.Ready != "Unknown" || network.calls != 1 || platform.calls != 0 {
+			t.Fatalf("Platform source opened before Network convergence: receipt=%#v calls=%d/%d", receipt, network.calls, platform.calls)
+		}
+	})
+}
+
 func TestAggregateObserverPreservesConflictingAuthority(t *testing.T) {
 	policy, profile := aggregateFixture()
 	policy.Required = []string{"InfrastructureReady"}

--- a/internal/runner/aggregate_observer.go
+++ b/internal/runner/aggregate_observer.go
@@ -56,8 +56,9 @@ type KubernetesAggregateObserverConfig struct {
 }
 
 // KubernetesAggregateObserver lazily materializes only the source domains
-// required by the runtime-bound observation policy. It has no polling, retry,
-// mutation, status publication, or persistent controller loop.
+// required by the runtime-bound observation policy and only after the prior
+// authority stage is current. It has no polling, retry, mutation, status
+// publication, or persistent controller loop.
 type KubernetesAggregateObserver struct {
 	config  KubernetesAggregateObserverConfig
 	openers kubernetesAggregateSourceOpeners
@@ -131,36 +132,42 @@ func (observer *KubernetesAggregateObserver) Observe(ctx context.Context, policy
 		}
 	}
 	if required.network {
-		workload, err := observer.config.WorkloadAuthority.ResolveWorkloadAuthority(ctx, policy)
-		if err != nil {
-			return observation.VerifiedResult{}, errors.New("resolve bounded workload observation authority")
-		}
-		if workload.AuthorityIdentity != policy.TargetClusterUID {
-			return observation.VerifiedResult{}, errors.New("workload observation authority differs from runtime-bound target Cluster")
-		}
-		networkSource, err = observer.openers.network(KubernetesNetworkObserverConfig{
-			Management: observer.config.Management, Workload: workload,
-			ExpectedManagementAuthority: observer.config.ExpectedManagementAuthority,
-			TargetClusterUID:            policy.TargetClusterUID, Namespace: observer.config.Namespace,
-			Name: observer.config.Name, HCPName: observer.config.HCPName, Clock: observer.config.Clock,
-		})
-		if err != nil {
-			return observation.VerifiedResult{}, errors.New("open bounded NetworkReady observation source")
-		}
+		networkSource = lazyNetworkEvidenceSource{open: func(stageCtx context.Context) (observation.NetworkEvidenceSource, error) {
+			workload, err := observer.config.WorkloadAuthority.ResolveWorkloadAuthority(stageCtx, policy)
+			if err != nil {
+				return nil, errors.New("resolve bounded workload observation authority")
+			}
+			if workload.AuthorityIdentity != policy.TargetClusterUID {
+				return nil, errors.New("workload observation authority differs from runtime-bound target Cluster")
+			}
+			source, err := observer.openers.network(KubernetesNetworkObserverConfig{
+				Management: observer.config.Management, Workload: workload,
+				ExpectedManagementAuthority: observer.config.ExpectedManagementAuthority,
+				TargetClusterUID:            policy.TargetClusterUID, Namespace: observer.config.Namespace,
+				Name: observer.config.Name, HCPName: observer.config.HCPName, Clock: observer.config.Clock,
+			})
+			if err != nil || source == nil {
+				return nil, errors.New("open bounded NetworkReady observation source")
+			}
+			return source, nil
+		}}
 	}
 	if required.platform {
-		capability, err := observer.config.PlatformCapability.ResolvePlatformCapability(ctx, policy, clonePlatformProfile(observer.config.PlatformProfile))
-		if err != nil || capability == nil {
-			return observation.VerifiedResult{}, errors.New("resolve bounded Platform capability evidence")
-		}
-		platformSource, err = observer.openers.platform(KubernetesPlatformObserverConfig{
-			Argo: observer.config.Argo, ExpectedArgoAuthority: observer.config.ExpectedArgoAuthority,
-			Profile: clonePlatformProfile(observer.config.PlatformProfile), Capability: capability,
-			TargetClusterUID: policy.TargetClusterUID, Clock: observer.config.Clock,
-		})
-		if err != nil {
-			return observation.VerifiedResult{}, errors.New("open bounded PlatformReady observation source")
-		}
+		platformSource = lazyPlatformEvidenceSource{open: func(stageCtx context.Context) (observation.PlatformEvidenceSource, error) {
+			capability, err := observer.config.PlatformCapability.ResolvePlatformCapability(stageCtx, policy, clonePlatformProfile(observer.config.PlatformProfile))
+			if err != nil || capability == nil {
+				return nil, errors.New("resolve bounded Platform capability evidence")
+			}
+			source, err := observer.openers.platform(KubernetesPlatformObserverConfig{
+				Argo: observer.config.Argo, ExpectedArgoAuthority: observer.config.ExpectedArgoAuthority,
+				Profile: clonePlatformProfile(observer.config.PlatformProfile), Capability: capability,
+				TargetClusterUID: policy.TargetClusterUID, Clock: observer.config.Clock,
+			})
+			if err != nil || source == nil {
+				return nil, errors.New("open bounded PlatformReady observation source")
+			}
+			return source, nil
+		}}
 	}
 
 	aggregate, err := observation.NewAggregateObserver(observation.AggregateObserverConfig{
@@ -211,4 +218,28 @@ type unusedPlatformSource struct{}
 
 func (unusedPlatformSource) Observe(context.Context, observation.Policy) (observation.Evidence, error) {
 	return observation.Evidence{}, errors.New("unused Platform source was called")
+}
+
+type lazyNetworkEvidenceSource struct {
+	open func(context.Context) (observation.NetworkEvidenceSource, error)
+}
+
+func (source lazyNetworkEvidenceSource) Observe(ctx context.Context, policy observation.Policy, profile observation.NetworkProfile) (observation.Evidence, error) {
+	opened, err := source.open(ctx)
+	if err != nil {
+		return observation.Evidence{}, errors.New("materialize bounded NetworkReady source")
+	}
+	return opened.Observe(ctx, policy, profile)
+}
+
+type lazyPlatformEvidenceSource struct {
+	open func(context.Context) (observation.PlatformEvidenceSource, error)
+}
+
+func (source lazyPlatformEvidenceSource) Observe(ctx context.Context, policy observation.Policy) (observation.Evidence, error) {
+	opened, err := source.open(ctx)
+	if err != nil {
+		return observation.Evidence{}, errors.New("materialize bounded PlatformReady source")
+	}
+	return opened.Observe(ctx, policy)
 }

--- a/internal/runner/aggregate_observer_test.go
+++ b/internal/runner/aggregate_observer_test.go
@@ -67,9 +67,74 @@ func TestKubernetesAggregateObserverBindsRuntimeTargetBeforeOpeningSources(t *te
 	if err != nil || receipt.Ready != "True" {
 		t.Fatalf("unexpected aggregate result: receipt=%#v err=%v", receipt, err)
 	}
-	expected := []string{"open-capi", "resolve-workload", "open-network", "resolve-capability", "open-platform", "collect-capi", "observe-network", "observe-platform"}
+	expected := []string{"open-capi", "collect-capi", "resolve-workload", "open-network", "observe-network", "resolve-capability", "open-platform", "observe-platform"}
 	if strings.Join(order, ",") != strings.Join(expected, ",") {
 		t.Fatalf("unexpected lazy source order: %v", order)
+	}
+}
+
+func TestKubernetesAggregateObserverDefersRuntimeResolversUntilTheirStage(t *testing.T) {
+	policy, config := aggregateRunnerFixture()
+	workloadCalls, capabilityCalls := 0, 0
+	config.WorkloadAuthority = WorkloadAuthorityResolverFunc(func(context.Context, observation.Policy) (KubernetesAuthorityConfig, error) {
+		workloadCalls++
+		return KubernetesAuthorityConfig{}, errors.New("must remain closed")
+	})
+	config.PlatformCapability = PlatformCapabilityResolverFunc(func(context.Context, observation.Policy, observation.PlatformProfile) (observation.PlatformCapabilitySource, error) {
+		capabilityCalls++
+		return nil, errors.New("must remain closed")
+	})
+	observer, err := OpenKubernetesAggregateObserver(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pending := aggregateRunnerEvidence(policy, "InfrastructureReady")
+	pending.Status = "Unknown"
+	pending.Reason = "Provisioning"
+	observer.openers.capi = func(KubernetesAuthorityConfig, string, string, string) (observation.CAPIEvidenceSource, error) {
+		return &aggregateRunnerCAPISource{policy: policy, evidence: []observation.Evidence{pending, aggregateRunnerEvidence(policy, "ControlPlaneAvailable")}}, nil
+	}
+	result, err := observer.Observe(context.Background(), policy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, _ := result.Receipt()
+	if receipt.Ready != "Unknown" || workloadCalls != 0 || capabilityCalls != 0 {
+		t.Fatalf("runtime authority opened before CAPI convergence: receipt=%#v calls=%d/%d", receipt, workloadCalls, capabilityCalls)
+	}
+}
+
+func TestKubernetesAggregateObserverDefersPlatformResolverUntilNetworkReady(t *testing.T) {
+	policy, config := aggregateRunnerFixture()
+	workloadCalls, capabilityCalls := 0, 0
+	config.WorkloadAuthority = WorkloadAuthorityResolverFunc(func(_ context.Context, received observation.Policy) (KubernetesAuthorityConfig, error) {
+		workloadCalls++
+		return KubernetesAuthorityConfig{AuthorityIdentity: received.TargetClusterUID}, nil
+	})
+	config.PlatformCapability = PlatformCapabilityResolverFunc(func(context.Context, observation.Policy, observation.PlatformProfile) (observation.PlatformCapabilitySource, error) {
+		capabilityCalls++
+		return nil, errors.New("must remain closed")
+	})
+	observer, err := OpenKubernetesAggregateObserver(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	observer.openers.capi = func(KubernetesAuthorityConfig, string, string, string) (observation.CAPIEvidenceSource, error) {
+		return &aggregateRunnerCAPISource{policy: policy}, nil
+	}
+	observer.openers.network = func(KubernetesNetworkObserverConfig) (observation.NetworkEvidenceSource, error) {
+		pending := aggregateRunnerEvidence(policy, "NetworkReady")
+		pending.Status = "Unknown"
+		pending.Reason = "ProbePending"
+		return &aggregateRunnerNetworkSource{policy: policy, evidence: &pending}, nil
+	}
+	result, err := observer.Observe(context.Background(), policy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, _ := result.Receipt()
+	if receipt.Ready != "Unknown" || workloadCalls != 1 || capabilityCalls != 0 {
+		t.Fatalf("Platform authority opened before NetworkReady: receipt=%#v calls=%d/%d", receipt, workloadCalls, capabilityCalls)
 	}
 }
 
@@ -220,25 +285,33 @@ func aggregateRunnerFixture() (observation.Policy, KubernetesAggregateObserverCo
 }
 
 type aggregateRunnerCAPISource struct {
-	policy observation.Policy
-	order  *[]string
+	policy   observation.Policy
+	order    *[]string
+	evidence []observation.Evidence
 }
 
 func (source *aggregateRunnerCAPISource) Collect(context.Context, observation.Policy) ([]observation.Evidence, error) {
 	if source.order != nil {
 		*source.order = append(*source.order, "collect-capi")
 	}
+	if source.evidence != nil {
+		return source.evidence, nil
+	}
 	return []observation.Evidence{aggregateRunnerEvidence(source.policy, "InfrastructureReady"), aggregateRunnerEvidence(source.policy, "ControlPlaneAvailable")}, nil
 }
 
 type aggregateRunnerNetworkSource struct {
-	policy observation.Policy
-	order  *[]string
+	policy   observation.Policy
+	order    *[]string
+	evidence *observation.Evidence
 }
 
 func (source *aggregateRunnerNetworkSource) Observe(context.Context, observation.Policy, observation.NetworkProfile) (observation.Evidence, error) {
 	if source.order != nil {
 		*source.order = append(*source.order, "observe-network")
+	}
+	if source.evidence != nil {
+		return *source.evidence, nil
 	}
 	return aggregateRunnerEvidence(source.policy, "NetworkReady"), nil
 }


### PR DESCRIPTION
## What changed

- gate observation in dependency order: CAPI lifecycle → NetworkReady → PlatformReady
- keep workload and Platform authority resolvers unopened until the prior stage is `True`
- return a verified partial aggregate result for pending, false, missing, stale, foreign or conflicting prior-stage evidence
- retain malformed source evidence as an operational fail-closed error
- verify both semantic source gating and concrete runtime credential deferral

## Why

A fresh target workload authority cannot exist before CAPI creates the cluster, and Platform capability execution must not begin before NetworkReady. Eagerly opening all required sources would stop a normal first create before existing controllers had time to converge.

## Scope

Observation behavior only. No CLI/Job activation, credential creation, cluster contact or infrastructure mutation.

## Validation

- `go test -ldflags=-linkmode=external ./...`
- `go vet ./...`
- `go test -race -ldflags=-linkmode=external ./internal/observation ./internal/runner ./internal/execution`
- `python3 -m unittest tests/ok141_kubevirt_infra_secret_ref_test.py tests/ok147_runner_image_test.py tests/ok147_runner_publication_test.py`
- `git diff --check`
