### PR TITLE
Bind staged execution plan (OK-147)

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -730,6 +730,45 @@ the workload credential, run the capability test, poll convergence, contact a
 cluster or mutate infrastructure. Producing those current single-run inputs
 remains an explicit subsequent runner boundary.
 
+## Digest-bound staged execution plan
+
+The first live OK-141 run proved that cluster creation is not one undivided
+submission followed by one observation. The desired state crosses explicit
+authority and evidence boundaries:
+
+```text
+provider prerequisites (ok-infra)
+  -> CAPI lifecycle (ok-mgmt)
+  -> lifecycle observation
+  -> Enablement submission (ok-mgmt)
+  -> NetworkReady observation (workload)
+  -> runtime binding
+  -> target access + short-lived credential (workload)
+  -> target registration + Applications (GitOps authority)
+  -> PlatformReady observation
+  -> aggregate evidence
+```
+
+The runner therefore verifies a strict twelve-stage
+`ok147-staged-execution-plan/v1` document before any future orchestration can
+use it. The plan binds `R`, `E`, `P`, `FixtureDigest`, the distinct
+infrastructure, management and GitOps authorities, exact stage dependencies,
+one immutable input set per stage and a separate operation name for every
+mutating stage. Its canonical digest identifies the complete experiment.
+
+The plan must remain `authorizationState: NO-GO`; it is never a grant. It
+contains no manifest content, credentials, endpoints, commands or rendering
+logic. Stage input digests can point only to artifacts produced by the
+authoritative Contract projection, Enablement, registration and Platform
+mechanisms. Consequently this boundary can detect a missing, reordered,
+foreign-authority or silently changed stage without becoming another
+Contract-to-CAPI/CAAPH/Argo compiler.
+
+This checkpoint verifies only the orchestration shape. The current bounded
+execution operation is still limited to its initial lifecycle submission and
+must not be activated as a complete happy-run command until separately
+authorized stage operations and receipts consume this plan.
+
 ## Typed first-run Platform capability boundary
 
 First-run capability production now has a separate lazy resolver from the

--- a/internal/stageplan/plan.go
+++ b/internal/stageplan/plan.go
@@ -1,0 +1,291 @@
+// Package stageplan verifies the complete bounded execution sequence without
+// rendering manifests, opening credentials, contacting Kubernetes, or granting
+// authority. It binds each stage to independently produced immutable inputs.
+package stageplan
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/openkubes/ok-cluster/internal/contract"
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/jsonstrict"
+)
+
+const (
+	Format           = "ok147-staged-execution-plan/v1"
+	BindingFormat    = "ok147-verified-staged-execution-plan/v1"
+	maximumPlanBytes = 128 * 1024
+)
+
+var (
+	digestPattern = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
+	namePattern   = regexp.MustCompile(`^[a-z0-9][a-z0-9.-]{1,127}$`)
+)
+
+// Expected is supplied from already verified Contract, fixture and topology
+// inputs. It prevents a plan file from selecting different authority planes.
+type Expected struct {
+	ContractIdentity        contract.Identity
+	IntentRevision          string
+	EnablementRevision      string
+	PlatformRevision        string
+	ExecutionFixture        string
+	InfrastructureAuthority string
+	ManagementAuthority     string
+	GitOpsAuthority         string
+}
+
+type Authorities struct {
+	Infrastructure       string `json:"infrastructure"`
+	Management           string `json:"management"`
+	GitOps               string `json:"gitOps"`
+	WorkloadIdentityMode string `json:"workloadIdentityMode"`
+	RunnerIdentityMode   string `json:"runnerIdentityMode"`
+}
+
+// Input binds a stage to an immutable, externally produced artifact. The
+// runner may consume it, but this package never interprets or creates it.
+type Input struct {
+	Name   string `json:"name"`
+	Digest string `json:"digest"`
+}
+
+type Stage struct {
+	ID             string   `json:"id"`
+	Order          int      `json:"order"`
+	Kind           string   `json:"kind"`
+	Authority      string   `json:"authority"`
+	GrantOperation string   `json:"grantOperation,omitempty"`
+	Requires       []string `json:"requires"`
+	Inputs         []Input  `json:"inputs"`
+}
+
+type document struct {
+	Format             string            `json:"format"`
+	ContractIdentity   contract.Identity `json:"contractIdentity"`
+	IntentRevision     string            `json:"intentRevision"`
+	EnablementRevision string            `json:"enablementRevision"`
+	PlatformRevision   string            `json:"platformRevision"`
+	ExecutionFixture   string            `json:"executionFixture"`
+	AuthorizationState string            `json:"authorizationState"`
+	Authorities        Authorities       `json:"authorities"`
+	Stages             []Stage           `json:"stages"`
+}
+
+// Binding is the immutable, redaction-safe result of successful verification.
+// It carries no source path, raw manifests, credentials or authorization.
+type Binding struct {
+	Format             string            `json:"format"`
+	PlanDigest         string            `json:"planDigest"`
+	ContractIdentity   contract.Identity `json:"contractIdentity"`
+	IntentRevision     string            `json:"intentRevision"`
+	EnablementRevision string            `json:"enablementRevision"`
+	PlatformRevision   string            `json:"platformRevision"`
+	ExecutionFixture   string            `json:"executionFixture"`
+	Authorities        Authorities       `json:"authorities"`
+	Stages             []Stage           `json:"stages"`
+}
+
+type stageRule struct {
+	id             string
+	kind           string
+	authority      string
+	grantOperation string
+	requires       []string
+}
+
+var requiredSequence = []stageRule{
+	{id: "provider-prerequisites", kind: "Submission", authority: "infrastructure", grantOperation: "CreateProviderPrerequisites"},
+	{id: "cluster-lifecycle", kind: "Submission", authority: "management", grantOperation: "CreateCluster", requires: []string{"provider-prerequisites"}},
+	{id: "lifecycle-observation", kind: "Observation", authority: "management", requires: []string{"cluster-lifecycle"}},
+	{id: "enablement", kind: "Submission", authority: "management", grantOperation: "CreateEnablement", requires: []string{"lifecycle-observation"}},
+	{id: "network-observation", kind: "Observation", authority: "workload", requires: []string{"enablement"}},
+	{id: "runtime-binding", kind: "Binding", authority: "runner", requires: []string{"network-observation"}},
+	{id: "target-access", kind: "Submission", authority: "workload", grantOperation: "CreateTargetAccess", requires: []string{"runtime-binding"}},
+	{id: "target-credential", kind: "Credential", authority: "workload", grantOperation: "IssueTargetCredential", requires: []string{"target-access"}},
+	{id: "target-registration", kind: "Submission", authority: "gitops", grantOperation: "RegisterTarget", requires: []string{"target-credential"}},
+	{id: "platform-applications", kind: "Submission", authority: "gitops", grantOperation: "CreatePlatformApplications", requires: []string{"target-registration"}},
+	{id: "platform-observation", kind: "Observation", authority: "gitops", requires: []string{"platform-applications"}},
+	{id: "aggregate-evidence", kind: "Evaluation", authority: "runner", requires: []string{"platform-observation"}},
+}
+
+// Load reads and verifies one bounded strict-JSON plan.
+func Load(path string, expected Expected) (Binding, error) {
+	if path == "" {
+		return Binding{}, errors.New("staged execution plan path is required")
+	}
+	info, err := os.Lstat(path)
+	if err != nil {
+		return Binding{}, fmt.Errorf("inspect staged execution plan: %w", err)
+	}
+	if !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 || info.Size() <= 0 || info.Size() > maximumPlanBytes {
+		return Binding{}, errors.New("staged execution plan metadata is invalid")
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return Binding{}, fmt.Errorf("open staged execution plan: %w", err)
+	}
+	defer file.Close()
+	raw, err := io.ReadAll(io.LimitReader(file, maximumPlanBytes+1))
+	if err != nil || len(raw) > maximumPlanBytes {
+		return Binding{}, errors.New("read bounded staged execution plan")
+	}
+	return Verify(raw, expected)
+}
+
+// Verify validates plan content already held in memory. It is exported so a
+// caller can verify a plan delivered by a bounded non-filesystem transport.
+func Verify(raw []byte, expected Expected) (Binding, error) {
+	if err := validateExpected(expected); err != nil {
+		return Binding{}, err
+	}
+	var source document
+	if err := jsonstrict.Decode(raw, &source); err != nil {
+		return Binding{}, fmt.Errorf("decode staged execution plan: %w", err)
+	}
+	if source.Format != Format {
+		return Binding{}, fmt.Errorf("staged execution plan format %q is not supported", source.Format)
+	}
+	if source.AuthorizationState != "NO-GO" {
+		return Binding{}, errors.New("staged execution plan must remain non-authorizing (authorizationState NO-GO)")
+	}
+	if source.IntentRevision != expected.IntentRevision || source.EnablementRevision != expected.EnablementRevision || source.PlatformRevision != expected.PlatformRevision || source.ExecutionFixture != expected.ExecutionFixture {
+		return Binding{}, errors.New("staged execution plan revisions or fixture differ from verified inputs")
+	}
+	if source.ContractIdentity != expected.ContractIdentity {
+		return Binding{}, errors.New("staged execution plan Contract identity differs from verified input")
+	}
+	if source.Authorities.Infrastructure != expected.InfrastructureAuthority || source.Authorities.Management != expected.ManagementAuthority || source.Authorities.GitOps != expected.GitOpsAuthority {
+		return Binding{}, errors.New("staged execution plan authority identities differ from verified topology")
+	}
+	if source.Authorities.WorkloadIdentityMode != "capi-cluster-uid/v1" || source.Authorities.RunnerIdentityMode != "bounded-job/v1" {
+		return Binding{}, errors.New("staged execution plan uses an unsupported dynamic authority mode")
+	}
+	if err := validateStages(source.Stages); err != nil {
+		return Binding{}, err
+	}
+	planDigest, err := canonicalDigest(source)
+	if err != nil {
+		return Binding{}, err
+	}
+	return Binding{
+		Format: BindingFormat, PlanDigest: planDigest,
+		ContractIdentity: source.ContractIdentity,
+		IntentRevision:   source.IntentRevision, EnablementRevision: source.EnablementRevision,
+		PlatformRevision: source.PlatformRevision, ExecutionFixture: source.ExecutionFixture,
+		Authorities: source.Authorities, Stages: cloneStages(source.Stages),
+	}, nil
+}
+
+func validateExpected(expected Expected) error {
+	if expected.ContractIdentity.Name == "" || expected.ContractIdentity.Namespace == "" {
+		return errors.New("expected Contract identity is incomplete")
+	}
+	for label, value := range map[string]string{
+		"intent revision": expected.IntentRevision, "enablement revision": expected.EnablementRevision,
+		"platform revision": expected.PlatformRevision, "execution fixture": expected.ExecutionFixture,
+	} {
+		if !digestPattern.MatchString(value) {
+			return fmt.Errorf("expected %s is invalid", label)
+		}
+	}
+	for label, value := range map[string]string{
+		"infrastructure authority": expected.InfrastructureAuthority,
+		"management authority":     expected.ManagementAuthority, "GitOps authority": expected.GitOpsAuthority,
+	} {
+		if !namePattern.MatchString(value) {
+			return fmt.Errorf("expected %s is invalid", label)
+		}
+	}
+	if expected.InfrastructureAuthority == expected.ManagementAuthority || expected.InfrastructureAuthority == expected.GitOpsAuthority || expected.ManagementAuthority == expected.GitOpsAuthority {
+		return errors.New("infrastructure, management, and GitOps authorities must be distinct")
+	}
+	return nil
+}
+
+func validateStages(stages []Stage) error {
+	if len(stages) != len(requiredSequence) {
+		return fmt.Errorf("staged execution plan has %d stages, expected %d", len(stages), len(requiredSequence))
+	}
+	for index, rule := range requiredSequence {
+		stage := stages[index]
+		if stage.Order != index+1 || stage.ID != rule.id || stage.Kind != rule.kind || stage.Authority != rule.authority || stage.GrantOperation != rule.grantOperation || !equalStrings(stage.Requires, rule.requires) {
+			return fmt.Errorf("stage %d does not match the required bounded sequence", index+1)
+		}
+		if len(stage.Inputs) == 0 {
+			return fmt.Errorf("stage %s has no immutable input bindings", stage.ID)
+		}
+		previous := ""
+		for _, input := range stage.Inputs {
+			if !namePattern.MatchString(input.Name) || !digestPattern.MatchString(input.Digest) {
+				return fmt.Errorf("stage %s has an invalid input binding", stage.ID)
+			}
+			if previous != "" && input.Name <= previous {
+				return fmt.Errorf("stage %s input bindings are not uniquely sorted", stage.ID)
+			}
+			previous = input.Name
+		}
+	}
+	return nil
+}
+
+func equalStrings(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for index := range left {
+		if left[index] != right[index] {
+			return false
+		}
+	}
+	return true
+}
+
+func cloneStages(stages []Stage) []Stage {
+	result := make([]Stage, len(stages))
+	for index, stage := range stages {
+		result[index] = stage
+		result[index].Requires = append([]string(nil), stage.Requires...)
+		result[index].Inputs = append([]Input(nil), stage.Inputs...)
+	}
+	return result
+}
+
+func canonicalDigest(value any) (string, error) {
+	raw, err := json.Marshal(value)
+	if err != nil {
+		return "", err
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	var generic any
+	if err := decoder.Decode(&generic); err != nil {
+		return "", err
+	}
+	canonical, err := contract.JCS(generic)
+	if err != nil {
+		return "", err
+	}
+	return digest.SHA256(canonical), nil
+}
+
+// InputNames returns a stable copy useful for redacted plan evidence.
+func InputNames(stage Stage) []string {
+	names := make([]string, 0, len(stage.Inputs))
+	for _, input := range stage.Inputs {
+		names = append(names, input.Name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// IsMutating reports whether a stage needs its own content-bound grant.
+func IsMutating(stage Stage) bool { return strings.TrimSpace(stage.GrantOperation) != "" }

--- a/internal/stageplan/plan_test.go
+++ b/internal/stageplan/plan_test.go
@@ -1,0 +1,158 @@
+package stageplan
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/openkubes/ok-cluster/internal/contract"
+)
+
+func TestVerifyAcceptsExactBoundedSequence(t *testing.T) {
+	raw := planJSON(t, validDocument())
+	binding, err := Verify(raw, expected())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if binding.Format != BindingFormat || binding.PlanDigest == "" || len(binding.Stages) != 12 {
+		t.Fatalf("unexpected binding: %#v", binding)
+	}
+	if !IsMutating(binding.Stages[0]) || IsMutating(binding.Stages[2]) {
+		t.Fatal("mutation classification differs from grant operations")
+	}
+	if names := InputNames(binding.Stages[0]); len(names) != 1 || names[0] != "projection.provider-prerequisites" {
+		t.Fatalf("unexpected redacted input names: %v", names)
+	}
+}
+
+func TestVerifyRejectsSequenceAuthorityAndGrantChanges(t *testing.T) {
+	tests := map[string]func(*document){
+		"missing stage":       func(plan *document) { plan.Stages = plan.Stages[:11] },
+		"reordered stage":     func(plan *document) { plan.Stages[0], plan.Stages[1] = plan.Stages[1], plan.Stages[0] },
+		"wrong dependency":    func(plan *document) { plan.Stages[4].Requires = []string{"cluster-lifecycle"} },
+		"authority drift":     func(plan *document) { plan.Stages[3].Authority = "runner" },
+		"grant removed":       func(plan *document) { plan.Stages[3].GrantOperation = "" },
+		"grant added to read": func(plan *document) { plan.Stages[4].GrantOperation = "ObserveNetwork" },
+		"missing input":       func(plan *document) { plan.Stages[9].Inputs = nil },
+		"duplicate input":     func(plan *document) { plan.Stages[9].Inputs = append(plan.Stages[9].Inputs, plan.Stages[9].Inputs[0]) },
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			plan := validDocument()
+			mutate(&plan)
+			if _, err := Verify(planJSON(t, plan), expected()); err == nil {
+				t.Fatal("changed staged plan was accepted")
+			}
+		})
+	}
+}
+
+func TestVerifyRejectsAuthorizationAndRevisionDrift(t *testing.T) {
+	tests := map[string]func(*document){
+		"authorizing document":   func(plan *document) { plan.AuthorizationState = "GO" },
+		"wrong identity":         func(plan *document) { plan.ContractIdentity.Name = "another-cluster" },
+		"wrong R":                func(plan *document) { plan.IntentRevision = sha("9") },
+		"wrong E":                func(plan *document) { plan.EnablementRevision = sha("8") },
+		"wrong P":                func(plan *document) { plan.PlatformRevision = sha("7") },
+		"wrong fixture":          func(plan *document) { plan.ExecutionFixture = sha("6") },
+		"wrong GitOps authority": func(plan *document) { plan.Authorities.GitOps = "other-shared" },
+		"wrong workload mode":    func(plan *document) { plan.Authorities.WorkloadIdentityMode = "endpoint-name/v1" },
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			plan := validDocument()
+			mutate(&plan)
+			if _, err := Verify(planJSON(t, plan), expected()); err == nil {
+				t.Fatal("foreign execution identity was accepted")
+			}
+		})
+	}
+}
+
+func TestVerifyIsCanonicalAndStrict(t *testing.T) {
+	first := planJSON(t, validDocument())
+	var generic map[string]any
+	if err := json.Unmarshal(first, &generic); err != nil {
+		t.Fatal(err)
+	}
+	second, err := json.MarshalIndent(generic, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	one, err := Verify(first, expected())
+	if err != nil {
+		t.Fatal(err)
+	}
+	two, err := Verify(second, expected())
+	if err != nil || one.PlanDigest != two.PlanDigest {
+		t.Fatalf("canonical plan identity differs: %s %s %v", one.PlanDigest, two.PlanDigest, err)
+	}
+	duplicate := strings.Replace(string(first), `"format":"`+Format+`"`, `"format":"`+Format+`","format":"`+Format+`"`, 1)
+	if _, err := Verify([]byte(duplicate), expected()); err == nil {
+		t.Fatal("duplicate JSON key was accepted")
+	}
+	unknown := strings.Replace(string(first), `"format":"`+Format+`"`, `"format":"`+Format+`","unknown":true`, 1)
+	if _, err := Verify([]byte(unknown), expected()); err == nil {
+		t.Fatal("unknown JSON field was accepted")
+	}
+}
+
+func TestLoadRejectsSymlink(t *testing.T) {
+	root := t.TempDir()
+	actual := filepath.Join(root, "plan.json")
+	if err := os.WriteFile(actual, planJSON(t, validDocument()), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(root, "plan-link.json")
+	if err := os.Symlink(actual, link); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Load(link, expected()); err == nil {
+		t.Fatal("symlinked plan was accepted")
+	}
+}
+
+func validDocument() document {
+	stages := make([]Stage, 0, len(requiredSequence))
+	for index, rule := range requiredSequence {
+		stages = append(stages, Stage{
+			ID: rule.id, Order: index + 1, Kind: rule.kind, Authority: rule.authority,
+			GrantOperation: rule.grantOperation, Requires: append([]string(nil), rule.requires...),
+			Inputs: []Input{{Name: inputName(rule.id), Digest: sha(string("abcdef012345"[index]))}},
+		})
+	}
+	return document{
+		Format: Format, ContractIdentity: contractIdentity(), IntentRevision: sha("1"), EnablementRevision: sha("2"),
+		PlatformRevision: sha("3"), ExecutionFixture: sha("4"), AuthorizationState: "NO-GO",
+		Authorities: Authorities{Infrastructure: "ok-infra", Management: "ok-mgmt", GitOps: "ok-shared", WorkloadIdentityMode: "capi-cluster-uid/v1", RunnerIdentityMode: "bounded-job/v1"},
+		Stages:      stages,
+	}
+}
+
+func expected() Expected {
+	return Expected{ContractIdentity: contractIdentity(), IntentRevision: sha("1"), EnablementRevision: sha("2"), PlatformRevision: sha("3"), ExecutionFixture: sha("4"), InfrastructureAuthority: "ok-infra", ManagementAuthority: "ok-mgmt", GitOpsAuthority: "ok-shared"}
+}
+
+func contractIdentity() contract.Identity {
+	return contract.Identity{Namespace: "disposable-ok147", Name: "disposable-ok147"}
+}
+
+func inputName(stage string) string {
+	if stage == "provider-prerequisites" {
+		return "projection.provider-prerequisites"
+	}
+	return "stage." + stage
+}
+
+func planJSON(t *testing.T, value document) []byte {
+	t.Helper()
+	raw, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return raw
+}
+
+func sha(value string) string { return "sha256:" + strings.Repeat(value, 64) }


### PR DESCRIPTION
## Outcome
- add a strict, canonical 12-stage execution-plan verifier
- bind Contract identity, R/E/P, FixtureDigest and distinct authority planes
- require one immutable input set per stage and separate grant operations for every mutating boundary
- keep the plan explicitly NO-GO and free of manifests, credentials, commands and rendering logic
- document why the current single-submission operation must not yet be activated as the complete happy run

## Safety
- offline only; no cluster contact or infrastructure mutation
- no second Contract-to-CAPI/CAAPH/Argo renderer
- missing, reordered, foreign-authority and changed-input plans fail closed

## Validation
- go test -ldflags=-linkmode=external ./...
- go vet ./...
- go test -race -ldflags=-linkmode=external ./internal/stageplan ./internal/execution ./internal/runner ./internal/submission
- python3 -m unittest tests/ok141_kubevirt_infra_secret_ref_test.py tests/ok147_runner_image_test.py tests/ok147_runner_publication_test.py
- git diff --check