### PR TITLE
Bind per-stage authorization (OK-147)

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -769,6 +769,25 @@ execution operation is still limited to its initial lifecycle submission and
 must not be activated as a complete happy-run command until separately
 authorized stage operations and receipts consume this plan.
 
+## Content-bound authorization per mutating stage
+
+Every mutating stage now has a distinct signed authorization envelope. A grant
+binds the canonical staged-plan digest, Contract identity, `R`, `E`, `P`,
+`FixtureDigest`, exact stage order and digest, operation name, authority role,
+single-use declaration and a maximum 30-minute validity window. Verification
+accepts only Ed25519 signatures from the explicitly supplied trust key.
+
+This means, for example, that `CreateCluster` authority cannot be reused for
+`CreateEnablement`, `IssueTargetCredential`, target registration or Platform
+Application submission. Read-only observation and evaluation stages reject
+mutation grants altogether. Reordering a stage or changing any immutable input
+changes its stage and plan identity and invalidates the signature.
+
+Successful verification produces only a redaction-safe receipt and a typed
+consumption binding. It does not consume the grant or execute the stage yet;
+durable single-use claims and per-stage execution receipts remain the next
+runner boundary.
+
 ## Typed first-run Platform capability boundary
 
 First-run capability production now has a separate lazy resolver from the

--- a/internal/authorization/stage.go
+++ b/internal/authorization/stage.go
@@ -1,0 +1,200 @@
+package authorization
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"regexp"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/contract"
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/jsonstrict"
+	"github.com/openkubes/ok-cluster/internal/stageplan"
+)
+
+const (
+	StageFormat   = "ok147-stage-authorization/v1"
+	StageAudience = "ok-cluster-staged-executor"
+)
+
+var stageGrantIDPattern = regexp.MustCompile(`^[a-z0-9][a-z0-9.-]{2,127}$`)
+
+// StagePayload is a single-use decision for exactly one mutating stage. It
+// cannot authorize another stage, plan, Contract incarnation or authority.
+type StagePayload struct {
+	Audience           string            `json:"audience"`
+	GrantID            string            `json:"grantId"`
+	Decision           string            `json:"decision"`
+	PlanDigest         string            `json:"planDigest"`
+	ContractIdentity   contract.Identity `json:"contractIdentity"`
+	ContractRevision   string            `json:"contractRevision"`
+	EnablementRevision string            `json:"enablementRevision"`
+	PlatformRevision   string            `json:"platformRevision"`
+	ExecutionFixture   string            `json:"executionFixture"`
+	StageID            string            `json:"stageId"`
+	StageOrder         int               `json:"stageOrder"`
+	StageDigest        string            `json:"stageDigest"`
+	Operation          string            `json:"operation"`
+	Authority          string            `json:"authority"`
+	NotBefore          string            `json:"notBefore"`
+	NotAfter           string            `json:"notAfter"`
+	MaxUses            int               `json:"maxUses"`
+}
+
+type stageEnvelope struct {
+	Format    string       `json:"format"`
+	Payload   StagePayload `json:"payload"`
+	Signature signature    `json:"signature"`
+}
+
+type StageReceipt struct {
+	Format              string `json:"format"`
+	State               string `json:"state"`
+	AuthorizationDigest string `json:"authorizationDigest"`
+	GrantID             string `json:"grantId"`
+	KeyID               string `json:"keyId"`
+	PlanDigest          string `json:"planDigest"`
+	StageID             string `json:"stageId"`
+	StageDigest         string `json:"stageDigest"`
+	Operation           string `json:"operation"`
+	Authority           string `json:"authority"`
+	NotAfter            string `json:"notAfter"`
+	MaxUses             int    `json:"maxUses"`
+}
+
+type StageConsumptionBinding struct {
+	AuthorizationDigest string
+	GrantID             string
+	KeyID               string
+	PlanDigest          string
+	StageID             string
+	StageDigest         string
+	Operation           string
+	Authority           string
+	ContractRevision    string
+	NotBefore           string
+	NotAfter            string
+}
+
+type VerifiedStageGrant struct {
+	receipt  StageReceipt
+	binding  StageConsumptionBinding
+	verified bool
+}
+
+func (grant VerifiedStageGrant) Receipt() StageReceipt { return grant.receipt }
+
+func (grant VerifiedStageGrant) ConsumptionBinding() (StageConsumptionBinding, error) {
+	if !grant.verified {
+		return StageConsumptionBinding{}, errors.New("stage authorization was not produced by verification")
+	}
+	return grant.binding, nil
+}
+
+// VerifyStage verifies a signature and binds it to one exact mutating stage
+// from an already verified staged execution plan.
+func VerifyStage(raw, publicKeyRaw []byte, plan stageplan.Binding, expectedStageID string, at time.Time) (VerifiedStageGrant, error) {
+	stage, stageDigest, err := plan.Stage(expectedStageID)
+	if err != nil {
+		return VerifiedStageGrant{}, err
+	}
+	if !stageplan.IsMutating(stage) {
+		return VerifiedStageGrant{}, errors.New("read-only stages do not accept mutation grants")
+	}
+	var document stageEnvelope
+	if err := jsonstrict.Decode(raw, &document); err != nil {
+		return VerifiedStageGrant{}, fmt.Errorf("decode stage authorization: %w", err)
+	}
+	if document.Format != StageFormat {
+		return VerifiedStageGrant{}, fmt.Errorf("stage authorization format %q is not supported", document.Format)
+	}
+	publicKey, keyID, err := parsePublicKey(publicKeyRaw)
+	if err != nil {
+		return VerifiedStageGrant{}, err
+	}
+	if document.Signature.Algorithm != "Ed25519" || document.Signature.KeyID != keyID {
+		return VerifiedStageGrant{}, errors.New("stage authorization signature metadata is not accepted")
+	}
+	signatureBytes, err := base64.StdEncoding.Strict().DecodeString(document.Signature.Value)
+	if err != nil {
+		return VerifiedStageGrant{}, fmt.Errorf("decode stage authorization signature: %w", err)
+	}
+	signed, err := StageSigningBytes(document.Payload)
+	if err != nil {
+		return VerifiedStageGrant{}, err
+	}
+	if !ed25519.Verify(publicKey, signed, signatureBytes) {
+		return VerifiedStageGrant{}, errors.New("stage authorization signature verification failed")
+	}
+	if err := verifyStagePayload(document.Payload, plan, stage, stageDigest, at); err != nil {
+		return VerifiedStageGrant{}, err
+	}
+	receipt := StageReceipt{
+		Format: "ok147-stage-authorization-receipt/v1", State: "VERIFIED",
+		AuthorizationDigest: digest.SHA256(raw), GrantID: document.Payload.GrantID, KeyID: keyID,
+		PlanDigest: plan.PlanDigest, StageID: stage.ID, StageDigest: stageDigest,
+		Operation: stage.GrantOperation, Authority: stage.Authority,
+		NotAfter: document.Payload.NotAfter, MaxUses: document.Payload.MaxUses,
+	}
+	return VerifiedStageGrant{
+		receipt: receipt,
+		binding: StageConsumptionBinding{
+			AuthorizationDigest: receipt.AuthorizationDigest, GrantID: receipt.GrantID, KeyID: keyID,
+			PlanDigest: plan.PlanDigest, StageID: stage.ID, StageDigest: stageDigest,
+			Operation: stage.GrantOperation, Authority: stage.Authority,
+			ContractRevision: plan.IntentRevision, NotBefore: document.Payload.NotBefore, NotAfter: document.Payload.NotAfter,
+		},
+		verified: true,
+	}, nil
+}
+
+func StageSigningBytes(payload StagePayload) ([]byte, error) {
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	var value any
+	if err := decoder.Decode(&value); err != nil {
+		return nil, err
+	}
+	return contract.JCS(value)
+}
+
+func verifyStagePayload(payload StagePayload, plan stageplan.Binding, stage stageplan.Stage, stageDigest string, at time.Time) error {
+	if payload.Audience != StageAudience || payload.Decision != "ALLOW" {
+		return errors.New("stage authorization audience or decision is not accepted")
+	}
+	if !stageGrantIDPattern.MatchString(payload.GrantID) {
+		return errors.New("stage authorization grantId is invalid")
+	}
+	if payload.PlanDigest != plan.PlanDigest || payload.ContractIdentity != plan.ContractIdentity || payload.ContractRevision != plan.IntentRevision || payload.EnablementRevision != plan.EnablementRevision || payload.PlatformRevision != plan.PlatformRevision || payload.ExecutionFixture != plan.ExecutionFixture {
+		return errors.New("stage authorization plan or Contract bindings differ")
+	}
+	if payload.StageID != stage.ID || payload.StageOrder != stage.Order || payload.StageDigest != stageDigest || payload.Operation != stage.GrantOperation || payload.Authority != stage.Authority {
+		return errors.New("stage authorization does not bind the exact stage")
+	}
+	if payload.MaxUses != 1 {
+		return errors.New("stage authorization must declare exactly one use")
+	}
+	notBefore, err := time.Parse(time.RFC3339, payload.NotBefore)
+	if err != nil {
+		return fmt.Errorf("stage authorization notBefore: %w", err)
+	}
+	notAfter, err := time.Parse(time.RFC3339, payload.NotAfter)
+	if err != nil {
+		return fmt.Errorf("stage authorization notAfter: %w", err)
+	}
+	if !notAfter.After(notBefore) || notAfter.Sub(notBefore) > MaximumWindow {
+		return errors.New("stage authorization time window is invalid")
+	}
+	if at.Before(notBefore) || !at.Before(notAfter) {
+		return errors.New("stage authorization is not active at the evaluation time")
+	}
+	return nil
+}

--- a/internal/authorization/stage_test.go
+++ b/internal/authorization/stage_test.go
@@ -1,0 +1,193 @@
+package authorization
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/contract"
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/stageplan"
+)
+
+func TestVerifyStageAcceptsExactMutatingStage(t *testing.T) {
+	plan := stagePlanFixture(t)
+	at := time.Date(2026, 8, 16, 14, 0, 0, 0, time.UTC)
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload := stagePayloadFixture(t, plan, "enablement", at)
+	raw := signStage(t, payload, publicKey, privateKey)
+	grant, err := VerifyStage(raw, []byte(base64.StdEncoding.EncodeToString(publicKey)), plan, "enablement", at)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt := grant.Receipt()
+	if receipt.State != "VERIFIED" || receipt.StageID != "enablement" || receipt.Operation != "CreateEnablement" || receipt.PlanDigest != plan.PlanDigest {
+		t.Fatalf("unexpected stage receipt: %#v", receipt)
+	}
+	binding, err := grant.ConsumptionBinding()
+	if err != nil || binding.StageDigest != receipt.StageDigest || binding.GrantID != payload.GrantID {
+		t.Fatalf("unexpected consumption binding: %#v %v", binding, err)
+	}
+}
+
+func TestVerifyStageRejectsReadOnlyStageAndCrossStageReuse(t *testing.T) {
+	plan := stagePlanFixture(t)
+	at := time.Date(2026, 8, 16, 14, 0, 0, 0, time.UTC)
+	publicKey, privateKey, _ := ed25519.GenerateKey(rand.Reader)
+	payload := stagePayloadFixture(t, plan, "enablement", at)
+	raw := signStage(t, payload, publicKey, privateKey)
+	key := []byte(base64.StdEncoding.EncodeToString(publicKey))
+	if _, err := VerifyStage(raw, key, plan, "platform-applications", at); err == nil {
+		t.Fatal("enablement grant was reused for Platform submission")
+	}
+	readPayload := stagePayloadFixture(t, plan, "lifecycle-observation", at)
+	if _, err := VerifyStage(signStage(t, readPayload, publicKey, privateKey), key, plan, "lifecycle-observation", at); err == nil {
+		t.Fatal("mutation grant was accepted for a read-only stage")
+	}
+}
+
+func TestVerifyStageRejectsEveryChangedBinding(t *testing.T) {
+	plan := stagePlanFixture(t)
+	at := time.Date(2026, 8, 16, 14, 0, 0, 0, time.UTC)
+	publicKey, privateKey, _ := ed25519.GenerateKey(rand.Reader)
+	key := []byte(base64.StdEncoding.EncodeToString(publicKey))
+	tests := map[string]func(*StagePayload){
+		"decision":       func(payload *StagePayload) { payload.Decision = "DENY" },
+		"plan":           func(payload *StagePayload) { payload.PlanDigest = authSHA("0") },
+		"identity":       func(payload *StagePayload) { payload.ContractIdentity.Name = "another" },
+		"R":              func(payload *StagePayload) { payload.ContractRevision = authSHA("1") },
+		"E":              func(payload *StagePayload) { payload.EnablementRevision = authSHA("2") },
+		"P":              func(payload *StagePayload) { payload.PlatformRevision = authSHA("3") },
+		"fixture":        func(payload *StagePayload) { payload.ExecutionFixture = authSHA("4") },
+		"stage":          func(payload *StagePayload) { payload.StageID = "cluster-lifecycle" },
+		"order":          func(payload *StagePayload) { payload.StageOrder++ },
+		"stage digest":   func(payload *StagePayload) { payload.StageDigest = authSHA("5") },
+		"operation":      func(payload *StagePayload) { payload.Operation = "CreateCluster" },
+		"authority":      func(payload *StagePayload) { payload.Authority = "gitops" },
+		"uses":           func(payload *StagePayload) { payload.MaxUses = 2 },
+		"expired":        func(payload *StagePayload) { payload.NotAfter = at.Format(time.RFC3339) },
+		"oversized time": func(payload *StagePayload) { payload.NotAfter = at.Add(31 * time.Minute).Format(time.RFC3339) },
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			payload := stagePayloadFixture(t, plan, "enablement", at)
+			mutate(&payload)
+			if _, err := VerifyStage(signStage(t, payload, publicKey, privateKey), key, plan, "enablement", at); err == nil {
+				t.Fatal("changed stage authorization was accepted")
+			}
+		})
+	}
+}
+
+func TestVerifyStageRejectsTamperingAndNonStrictEnvelope(t *testing.T) {
+	plan := stagePlanFixture(t)
+	at := time.Date(2026, 8, 16, 14, 0, 0, 0, time.UTC)
+	publicKey, privateKey, _ := ed25519.GenerateKey(rand.Reader)
+	raw := signStage(t, stagePayloadFixture(t, plan, "enablement", at), publicKey, privateKey)
+	key := []byte(base64.StdEncoding.EncodeToString(publicKey))
+	tampered := strings.Replace(string(raw), `"operation":"CreateEnablement"`, `"operation":"CreateCluster"`, 1)
+	if _, err := VerifyStage([]byte(tampered), key, plan, "enablement", at); err == nil {
+		t.Fatal("tampered stage authorization was accepted")
+	}
+	unknown := strings.Replace(string(raw), `"format":"`+StageFormat+`"`, `"format":"`+StageFormat+`","unknown":true`, 1)
+	if _, err := VerifyStage([]byte(unknown), key, plan, "enablement", at); err == nil {
+		t.Fatal("unknown stage authorization field was accepted")
+	}
+}
+
+func stagePayloadFixture(t *testing.T, plan stageplan.Binding, stageID string, at time.Time) StagePayload {
+	t.Helper()
+	stage, stageDigest, err := plan.Stage(stageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return StagePayload{
+		Audience: StageAudience, GrantID: "ok147-stage-20260816-01", Decision: "ALLOW",
+		PlanDigest: plan.PlanDigest, ContractIdentity: plan.ContractIdentity, ContractRevision: plan.IntentRevision,
+		EnablementRevision: plan.EnablementRevision, PlatformRevision: plan.PlatformRevision,
+		ExecutionFixture: plan.ExecutionFixture, StageID: stage.ID, StageOrder: stage.Order,
+		StageDigest: stageDigest, Operation: stage.GrantOperation, Authority: stage.Authority,
+		NotBefore: at.Add(-time.Minute).Format(time.RFC3339), NotAfter: at.Add(20 * time.Minute).Format(time.RFC3339), MaxUses: 1,
+	}
+}
+
+func signStage(t *testing.T, payload StagePayload, publicKey ed25519.PublicKey, privateKey ed25519.PrivateKey) []byte {
+	t.Helper()
+	signed, err := StageSigningBytes(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := json.Marshal(stageEnvelope{
+		Format: StageFormat, Payload: payload,
+		Signature: signature{Algorithm: "Ed25519", KeyID: digest.SHA256(publicKey), Value: base64.StdEncoding.EncodeToString(ed25519.Sign(privateKey, signed))},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return raw
+}
+
+func stagePlanFixture(t *testing.T) stageplan.Binding {
+	t.Helper()
+	identity := contract.Identity{Namespace: "disposable-ok147", Name: "disposable-ok147"}
+	type stage struct {
+		id, kind, authority, operation string
+		requires                       []string
+	}
+	sequence := []stage{
+		{id: "provider-prerequisites", kind: "Submission", authority: "infrastructure", operation: "CreateProviderPrerequisites"},
+		{id: "cluster-lifecycle", kind: "Submission", authority: "management", operation: "CreateCluster", requires: []string{"provider-prerequisites"}},
+		{id: "lifecycle-observation", kind: "Observation", authority: "management", requires: []string{"cluster-lifecycle"}},
+		{id: "enablement", kind: "Submission", authority: "management", operation: "CreateEnablement", requires: []string{"lifecycle-observation"}},
+		{id: "network-observation", kind: "Observation", authority: "workload", requires: []string{"enablement"}},
+		{id: "runtime-binding", kind: "Binding", authority: "runner", requires: []string{"network-observation"}},
+		{id: "target-access", kind: "Submission", authority: "workload", operation: "CreateTargetAccess", requires: []string{"runtime-binding"}},
+		{id: "target-credential", kind: "Credential", authority: "workload", operation: "IssueTargetCredential", requires: []string{"target-access"}},
+		{id: "target-registration", kind: "Submission", authority: "gitops", operation: "RegisterTarget", requires: []string{"target-credential"}},
+		{id: "platform-applications", kind: "Submission", authority: "gitops", operation: "CreatePlatformApplications", requires: []string{"target-registration"}},
+		{id: "platform-observation", kind: "Observation", authority: "gitops", requires: []string{"platform-applications"}},
+		{id: "aggregate-evidence", kind: "Evaluation", authority: "runner", requires: []string{"platform-observation"}},
+	}
+	stages := make([]map[string]any, 0, len(sequence))
+	for index, item := range sequence {
+		value := map[string]any{
+			"id": item.id, "order": index + 1, "kind": item.kind, "authority": item.authority,
+			"requires": item.requires, "inputs": []map[string]any{{"name": "stage." + item.id, "digest": authSHA(string("abcdef012345"[index]))}},
+		}
+		if item.requires == nil {
+			value["requires"] = []string{}
+		}
+		if item.operation != "" {
+			value["grantOperation"] = item.operation
+		}
+		stages = append(stages, value)
+	}
+	document := map[string]any{
+		"format": stageplan.Format, "contractIdentity": identity,
+		"intentRevision": authSHA("a"), "enablementRevision": authSHA("b"), "platformRevision": authSHA("c"), "executionFixture": authSHA("d"),
+		"authorizationState": "NO-GO",
+		"authorities":        map[string]any{"infrastructure": "ok-infra", "management": "ok-mgmt", "gitOps": "ok-shared", "workloadIdentityMode": "capi-cluster-uid/v1", "runnerIdentityMode": "bounded-job/v1"},
+		"stages":             stages,
+	}
+	raw, err := json.Marshal(document)
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan, err := stageplan.Verify(raw, stageplan.Expected{
+		ContractIdentity: identity, IntentRevision: authSHA("a"), EnablementRevision: authSHA("b"), PlatformRevision: authSHA("c"), ExecutionFixture: authSHA("d"),
+		InfrastructureAuthority: "ok-infra", ManagementAuthority: "ok-mgmt", GitOpsAuthority: "ok-shared",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return plan
+}
+
+func authSHA(value string) string { return "sha256:" + strings.Repeat(value, 64) }

--- a/internal/stageplan/plan.go
+++ b/internal/stageplan/plan.go
@@ -83,15 +83,21 @@ type document struct {
 // Binding is the immutable, redaction-safe result of successful verification.
 // It carries no source path, raw manifests, credentials or authorization.
 type Binding struct {
-	Format             string            `json:"format"`
-	PlanDigest         string            `json:"planDigest"`
-	ContractIdentity   contract.Identity `json:"contractIdentity"`
-	IntentRevision     string            `json:"intentRevision"`
-	EnablementRevision string            `json:"enablementRevision"`
-	PlatformRevision   string            `json:"platformRevision"`
-	ExecutionFixture   string            `json:"executionFixture"`
-	Authorities        Authorities       `json:"authorities"`
-	Stages             []Stage           `json:"stages"`
+	Format              string            `json:"format"`
+	PlanDigest          string            `json:"planDigest"`
+	ContractIdentity    contract.Identity `json:"contractIdentity"`
+	IntentRevision      string            `json:"intentRevision"`
+	EnablementRevision  string            `json:"enablementRevision"`
+	PlatformRevision    string            `json:"platformRevision"`
+	ExecutionFixture    string            `json:"executionFixture"`
+	Authorities         Authorities       `json:"authorities"`
+	Stages              []Stage           `json:"stages"`
+	verified            bool
+	verifiedDigest      string
+	verifiedIdentity    contract.Identity
+	verifiedRevisions   [4]string
+	verifiedAuthorities Authorities
+	stageDigests        map[string]string
 }
 
 type stageRule struct {
@@ -176,12 +182,23 @@ func Verify(raw []byte, expected Expected) (Binding, error) {
 	if err != nil {
 		return Binding{}, err
 	}
+	stageDigests := make(map[string]string, len(source.Stages))
+	for _, stage := range source.Stages {
+		stageDigest, err := canonicalDigest(stage)
+		if err != nil {
+			return Binding{}, err
+		}
+		stageDigests[stage.ID] = stageDigest
+	}
 	return Binding{
 		Format: BindingFormat, PlanDigest: planDigest,
 		ContractIdentity: source.ContractIdentity,
 		IntentRevision:   source.IntentRevision, EnablementRevision: source.EnablementRevision,
 		PlatformRevision: source.PlatformRevision, ExecutionFixture: source.ExecutionFixture,
 		Authorities: source.Authorities, Stages: cloneStages(source.Stages),
+		verified: true, verifiedDigest: planDigest, verifiedIdentity: source.ContractIdentity,
+		verifiedRevisions:   [4]string{source.IntentRevision, source.EnablementRevision, source.PlatformRevision, source.ExecutionFixture},
+		verifiedAuthorities: source.Authorities, stageDigests: stageDigests,
 	}, nil
 }
 
@@ -289,3 +306,27 @@ func InputNames(stage Stage) []string {
 
 // IsMutating reports whether a stage needs its own content-bound grant.
 func IsMutating(stage Stage) bool { return strings.TrimSpace(stage.GrantOperation) != "" }
+
+// Stage returns one stage and its canonical semantic digest after rechecking
+// that the in-memory binding still represents the originally verified plan.
+func (binding Binding) Stage(id string) (Stage, string, error) {
+	if !binding.verified || binding.Format != BindingFormat || binding.PlanDigest != binding.verifiedDigest || !digestPattern.MatchString(binding.PlanDigest) {
+		return Stage{}, "", errors.New("verified staged execution binding is required")
+	}
+	if binding.ContractIdentity != binding.verifiedIdentity || [4]string{binding.IntentRevision, binding.EnablementRevision, binding.PlatformRevision, binding.ExecutionFixture} != binding.verifiedRevisions || binding.Authorities != binding.verifiedAuthorities {
+		return Stage{}, "", errors.New("staged execution binding changed after verification")
+	}
+	if err := validateStages(binding.Stages); err != nil {
+		return Stage{}, "", fmt.Errorf("revalidate staged execution binding: %w", err)
+	}
+	for _, stage := range binding.Stages {
+		if stage.ID == id {
+			stageDigest, err := canonicalDigest(stage)
+			if err != nil || stageDigest != binding.stageDigests[id] {
+				return Stage{}, "", errors.New("staged execution binding changed after verification")
+			}
+			return cloneStages([]Stage{stage})[0], stageDigest, nil
+		}
+	}
+	return Stage{}, "", fmt.Errorf("stage %q is not part of the verified execution plan", id)
+}

--- a/internal/stageplan/plan_test.go
+++ b/internal/stageplan/plan_test.go
@@ -114,6 +114,21 @@ func TestLoadRejectsSymlink(t *testing.T) {
 	}
 }
 
+func TestStageRechecksInMemoryBinding(t *testing.T) {
+	binding, err := Verify(planJSON(t, validDocument()), expected())
+	if err != nil {
+		t.Fatal(err)
+	}
+	stage, stageDigest, err := binding.Stage("enablement")
+	if err != nil || stage.ID != "enablement" || !strings.HasPrefix(stageDigest, "sha256:") {
+		t.Fatalf("unexpected stage binding: %#v %s %v", stage, stageDigest, err)
+	}
+	binding.Stages[3].Inputs[0].Digest = sha("0")
+	if _, _, err := binding.Stage("enablement"); err == nil {
+		t.Fatal("changed in-memory stage binding was accepted")
+	}
+}
+
 func validDocument() document {
 	stages := make([]Stage, 0, len(requiredSequence))
 	for index, rule := range requiredSequence {


### PR DESCRIPTION
## Outcome
- add signed, content-bound authorization for each mutating execution stage
- bind the complete plan digest, Contract identity, R/E/P, FixtureDigest, stage order/digest, operation and authority
- enforce one use, Ed25519 trust and a maximum 30-minute window
- reject mutation grants for read-only stages and cross-stage grant reuse
- recheck verified stage-plan bindings against in-memory changes

## Safety
- offline only; no grant consumption, Kubernetes access or mutation
- a plan remains NO-GO and each future mutation still needs its own durable claim
- no manifests, credentials, endpoints, commands or rendering logic are added

## Validation
- go test -ldflags=-linkmode=external ./...
- go vet ./...
- go test -race -ldflags=-linkmode=external ./internal/stageplan ./internal/authorization ./internal/execution ./internal/runner ./internal/submission
- python3 -m unittest tests/ok141_kubevirt_infra_secret_ref_test.py tests/ok147_runner_image_test.py tests/ok147_runner_publication_test.py
- git diff --check