### PR TITLE
Persist single-use stage claims (OK-147)

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -788,6 +788,24 @@ consumption binding. It does not consume the grant or execute the stage yet;
 durable single-use claims and per-stage execution receipts remain the next
 runner boundary.
 
+## Durable single-use stage claims
+
+Verified mutation grants can now be consumed through the same atomic ledger
+namespace as the original CreateCluster grant. The ledger writes an immutable
+claim before any future stage write and binds the authorization, staged plan,
+stage, operation, authority and Contract revision. Concurrent claim attempts
+produce exactly one winner.
+
+If the process disappears after that claim, inspection returns
+`CLAIMED_INDETERMINATE_STOP`; it never makes the stage available again. A
+separate immutable outcome record binds the evidence digest and mutation state,
+and exact completion replay is idempotent while conflicting completion fails
+closed. A successful mutating stage must report `ATTEMPTED`.
+
+This checkpoint still invokes no stage implementation. It provides the durable
+crash boundary needed before separately bounded HCP, target-access,
+TokenRequest, registration and Application submitters can be composed.
+
 ## Typed first-run Platform capability boundary
 
 First-run capability production now has a separate lazy resolver from the

--- a/internal/ledger/stage.go
+++ b/internal/ledger/stage.go
@@ -1,0 +1,253 @@
+package ledger
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/authorization"
+	"github.com/openkubes/ok-cluster/internal/jsonstrict"
+)
+
+const (
+	StageClaimFormat   = "ok147-stage-grant-claim/v1"
+	StageOutcomeFormat = "ok147-stage-operation-receipt/v1"
+)
+
+type StageClaimReceipt struct {
+	Format              string `json:"format"`
+	State               string `json:"state"`
+	AuthorizationDigest string `json:"authorizationDigest"`
+	GrantID             string `json:"grantId"`
+	KeyID               string `json:"keyId"`
+	PlanDigest          string `json:"planDigest"`
+	StageID             string `json:"stageId"`
+	StageDigest         string `json:"stageDigest"`
+	Operation           string `json:"operation"`
+	Authority           string `json:"authority"`
+	ContractRevision    string `json:"contractRevision"`
+	ClaimedAt           string `json:"claimedAt"`
+}
+
+type StageOutcomeReceipt struct {
+	Format         string `json:"format"`
+	State          string `json:"state"`
+	GrantID        string `json:"grantId"`
+	PlanDigest     string `json:"planDigest"`
+	StageID        string `json:"stageId"`
+	StageDigest    string `json:"stageDigest"`
+	Operation      string `json:"operation"`
+	ClaimDigest    string `json:"claimDigest"`
+	Outcome        string `json:"outcome"`
+	MutationState  string `json:"mutationState"`
+	EvidenceDigest string `json:"evidenceDigest"`
+	CompletedAt    string `json:"completedAt"`
+}
+
+type StageInspection struct {
+	State         string               `json:"state"`
+	ClaimAllowed  bool                 `json:"claimAllowed"`
+	ClaimDigest   string               `json:"claimDigest,omitempty"`
+	OutcomeDigest string               `json:"outcomeDigest,omitempty"`
+	Outcome       *StageOutcomeReceipt `json:"outcome,omitempty"`
+}
+
+// ClaimStage atomically consumes one verified stage grant in the same global
+// grant-ID namespace as CreateCluster grants.
+func (ledger *Ledger) ClaimStage(ctx context.Context, grant authorization.VerifiedStageGrant, at time.Time) (StageClaimReceipt, error) {
+	binding, err := grant.ConsumptionBinding()
+	if err != nil {
+		return StageClaimReceipt{}, err
+	}
+	starts, err := time.Parse(time.RFC3339, binding.NotBefore)
+	if err != nil {
+		return StageClaimReceipt{}, fmt.Errorf("stage grant start: %w", err)
+	}
+	expires, err := time.Parse(time.RFC3339, binding.NotAfter)
+	if err != nil {
+		return StageClaimReceipt{}, fmt.Errorf("stage grant expiration: %w", err)
+	}
+	if at.Before(starts) || !at.Before(expires) {
+		return StageClaimReceipt{}, errors.New("stage grant is not active at consumption time")
+	}
+	receipt := StageClaimReceipt{
+		Format: StageClaimFormat, State: "CLAIMED", AuthorizationDigest: binding.AuthorizationDigest,
+		GrantID: binding.GrantID, KeyID: binding.KeyID, PlanDigest: binding.PlanDigest,
+		StageID: binding.StageID, StageDigest: binding.StageDigest, Operation: binding.Operation,
+		Authority: binding.Authority, ContractRevision: binding.ContractRevision,
+		ClaimedAt: at.UTC().Format(time.RFC3339Nano),
+	}
+	raw, _, err := canonicalRecord(receipt)
+	if err != nil {
+		return StageClaimReceipt{}, err
+	}
+	if err := ledger.store.Create(ctx, "claims", recordKey(binding.GrantID), raw); err != nil {
+		if errors.Is(err, ErrRecordExists) {
+			return StageClaimReceipt{}, ErrGrantConsumed
+		}
+		return StageClaimReceipt{}, fmt.Errorf("write stage grant claim: %w", err)
+	}
+	return receipt, nil
+}
+
+// CompleteStage records one immutable result. An exact repeat is idempotent;
+// a successful mutating stage must have attempted its mutation.
+func (ledger *Ledger) CompleteStage(ctx context.Context, claim StageClaimReceipt, outcome, mutationState, evidenceDigest string, at time.Time) (StageOutcomeReceipt, error) {
+	if !allowed(outcome, "SUCCEEDED", "FAILED", "STOPPED") || !allowed(mutationState, "NOT_ATTEMPTED", "ATTEMPTED", "UNKNOWN") {
+		return StageOutcomeReceipt{}, errors.New("stage completion state is invalid")
+	}
+	if outcome == "SUCCEEDED" && mutationState != "ATTEMPTED" {
+		return StageOutcomeReceipt{}, errors.New("successful mutating stage requires mutationState ATTEMPTED")
+	}
+	if !validDigest(evidenceDigest) {
+		return StageOutcomeReceipt{}, errors.New("stage evidence digest is invalid")
+	}
+	stored, claimDigest, err := ledger.readStageClaim(ctx, claim.GrantID)
+	if err != nil {
+		return StageOutcomeReceipt{}, err
+	}
+	_, providedDigest, err := canonicalRecord(claim)
+	if err != nil || claimDigest != providedDigest || stored != claim {
+		return StageOutcomeReceipt{}, errors.New("provided stage claim differs from immutable ledger claim")
+	}
+	claimedAt, err := time.Parse(time.RFC3339Nano, claim.ClaimedAt)
+	if err != nil || at.Before(claimedAt) {
+		return StageOutcomeReceipt{}, errors.New("stage completion time precedes claim")
+	}
+	receipt := StageOutcomeReceipt{
+		Format: StageOutcomeFormat, State: "COMPLETED", GrantID: claim.GrantID,
+		PlanDigest: claim.PlanDigest, StageID: claim.StageID, StageDigest: claim.StageDigest,
+		Operation: claim.Operation, ClaimDigest: claimDigest, Outcome: outcome,
+		MutationState: mutationState, EvidenceDigest: evidenceDigest,
+		CompletedAt: at.UTC().Format(time.RFC3339Nano),
+	}
+	raw, expectedDigest, err := canonicalRecord(receipt)
+	if err != nil {
+		return StageOutcomeReceipt{}, err
+	}
+	if err := ledger.store.Create(ctx, "outcomes", recordKey(claim.GrantID), raw); err != nil {
+		if !errors.Is(err, ErrRecordExists) {
+			return StageOutcomeReceipt{}, fmt.Errorf("write stage outcome: %w", err)
+		}
+		existing, existingDigest, readErr := ledger.readStageOutcome(ctx, claim.GrantID)
+		if readErr != nil {
+			return StageOutcomeReceipt{}, readErr
+		}
+		if existingDigest == expectedDigest && existing == receipt {
+			return existing, nil
+		}
+		return StageOutcomeReceipt{}, errors.New("conflicting stage outcome already exists")
+	}
+	return receipt, nil
+}
+
+func (ledger *Ledger) InspectStage(ctx context.Context, grant authorization.VerifiedStageGrant) (StageInspection, error) {
+	binding, err := grant.ConsumptionBinding()
+	if err != nil {
+		return StageInspection{}, err
+	}
+	claim, claimDigest, err := ledger.readStageClaim(ctx, binding.GrantID)
+	if errors.Is(err, ErrRecordNotFound) {
+		return StageInspection{State: "AVAILABLE", ClaimAllowed: true}, nil
+	}
+	if err != nil {
+		return StageInspection{}, err
+	}
+	if err := matchStageBinding(claim, binding); err != nil {
+		return StageInspection{}, err
+	}
+	outcome, outcomeDigest, err := ledger.readStageOutcome(ctx, binding.GrantID)
+	if errors.Is(err, ErrRecordNotFound) {
+		return StageInspection{State: "CLAIMED_INDETERMINATE_STOP", ClaimAllowed: false, ClaimDigest: claimDigest}, nil
+	}
+	if err != nil {
+		return StageInspection{}, err
+	}
+	if outcome.ClaimDigest != claimDigest || outcome.GrantID != claim.GrantID || outcome.PlanDigest != claim.PlanDigest || outcome.StageDigest != claim.StageDigest || outcome.Operation != claim.Operation {
+		return StageInspection{}, errors.New("stage outcome does not match immutable claim")
+	}
+	return StageInspection{State: "COMPLETED", ClaimAllowed: false, ClaimDigest: claimDigest, OutcomeDigest: outcomeDigest, Outcome: &outcome}, nil
+}
+
+func (ledger *Ledger) readStageClaim(ctx context.Context, grantID string) (StageClaimReceipt, string, error) {
+	var value StageClaimReceipt
+	raw, err := ledger.store.Get(ctx, "claims", recordKey(grantID))
+	if err != nil {
+		return value, "", err
+	}
+	if err := jsonstrict.Decode(raw, &value); err != nil {
+		return value, "", fmt.Errorf("decode stage grant claim: %w", err)
+	}
+	canonical, identity, err := canonicalRecord(value)
+	if err != nil {
+		return value, "", err
+	}
+	if !bytes.Equal(raw, canonical) {
+		return value, "", errors.New("stage grant claim is not canonical or was modified")
+	}
+	return value, identity, validateStageClaim(value)
+}
+
+func (ledger *Ledger) readStageOutcome(ctx context.Context, grantID string) (StageOutcomeReceipt, string, error) {
+	var value StageOutcomeReceipt
+	raw, err := ledger.store.Get(ctx, "outcomes", recordKey(grantID))
+	if err != nil {
+		return value, "", err
+	}
+	if err := jsonstrict.Decode(raw, &value); err != nil {
+		return value, "", fmt.Errorf("decode stage outcome: %w", err)
+	}
+	canonical, identity, err := canonicalRecord(value)
+	if err != nil {
+		return value, "", err
+	}
+	if !bytes.Equal(raw, canonical) {
+		return value, "", errors.New("stage outcome is not canonical or was modified")
+	}
+	return value, identity, validateStageOutcome(value)
+}
+
+func validateStageClaim(value StageClaimReceipt) error {
+	if value.Format != StageClaimFormat || value.State != "CLAIMED" || value.GrantID == "" || value.StageID == "" || value.Operation == "" || value.Authority == "" {
+		return errors.New("stage grant claim is incomplete")
+	}
+	for _, identity := range []string{value.AuthorizationDigest, value.KeyID, value.PlanDigest, value.StageDigest, value.ContractRevision} {
+		if !validDigest(identity) {
+			return errors.New("stage grant claim contains an invalid digest")
+		}
+	}
+	if _, err := time.Parse(time.RFC3339Nano, value.ClaimedAt); err != nil {
+		return errors.New("stage grant claim has an invalid timestamp")
+	}
+	return nil
+}
+
+func validateStageOutcome(value StageOutcomeReceipt) error {
+	if value.Format != StageOutcomeFormat || value.State != "COMPLETED" || value.GrantID == "" || value.StageID == "" || value.Operation == "" {
+		return errors.New("stage outcome is incomplete")
+	}
+	if !allowed(value.Outcome, "SUCCEEDED", "FAILED", "STOPPED") || !allowed(value.MutationState, "NOT_ATTEMPTED", "ATTEMPTED", "UNKNOWN") {
+		return errors.New("stage outcome contains an invalid state")
+	}
+	for _, identity := range []string{value.PlanDigest, value.StageDigest, value.ClaimDigest, value.EvidenceDigest} {
+		if !validDigest(identity) {
+			return errors.New("stage outcome contains an invalid digest")
+		}
+	}
+	if _, err := time.Parse(time.RFC3339Nano, value.CompletedAt); err != nil {
+		return errors.New("stage outcome has an invalid timestamp")
+	}
+	if value.Outcome == "SUCCEEDED" && value.MutationState != "ATTEMPTED" {
+		return errors.New("successful stage outcome lacks attempted mutation state")
+	}
+	return nil
+}
+
+func matchStageBinding(claim StageClaimReceipt, binding authorization.StageConsumptionBinding) error {
+	if claim.AuthorizationDigest != binding.AuthorizationDigest || claim.GrantID != binding.GrantID || claim.KeyID != binding.KeyID || claim.PlanDigest != binding.PlanDigest || claim.StageID != binding.StageID || claim.StageDigest != binding.StageDigest || claim.Operation != binding.Operation || claim.Authority != binding.Authority || claim.ContractRevision != binding.ContractRevision {
+		return errors.New("stored stage claim differs from verified authorization")
+	}
+	return nil
+}

--- a/internal/ledger/stage_test.go
+++ b/internal/ledger/stage_test.go
@@ -1,0 +1,160 @@
+package ledger
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/authorization"
+	"github.com/openkubes/ok-cluster/internal/contract"
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/stageplan"
+)
+
+func TestStageClaimIsAtomicAndCrashStopsRetry(t *testing.T) {
+	store, err := Open(filepath.Join(t.TempDir(), "ledger"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	at := time.Date(2026, 8, 16, 15, 0, 0, 0, time.UTC)
+	grant := verifiedStageGrant(t, at)
+	available, err := store.InspectStage(context.Background(), grant)
+	if err != nil || available.State != "AVAILABLE" || !available.ClaimAllowed {
+		t.Fatalf("stage grant is not available: %#v %v", available, err)
+	}
+	var acquired atomic.Int32
+	var consumed atomic.Int32
+	var wait sync.WaitGroup
+	for index := 0; index < 24; index++ {
+		wait.Add(1)
+		go func() {
+			defer wait.Done()
+			if _, err := store.ClaimStage(context.Background(), grant, at); err == nil {
+				acquired.Add(1)
+			} else if errors.Is(err, ErrGrantConsumed) {
+				consumed.Add(1)
+			} else {
+				t.Errorf("claim stage: %v", err)
+			}
+		}()
+	}
+	wait.Wait()
+	if acquired.Load() != 1 || consumed.Load() != 23 {
+		t.Fatalf("acquired=%d consumed=%d", acquired.Load(), consumed.Load())
+	}
+	inspection, err := store.InspectStage(context.Background(), grant)
+	if err != nil || inspection.State != "CLAIMED_INDETERMINATE_STOP" || inspection.ClaimAllowed {
+		t.Fatalf("unsafe stage restart decision: %#v %v", inspection, err)
+	}
+}
+
+func TestStageClaimRechecksWindowAtConsumption(t *testing.T) {
+	store, _ := Open(filepath.Join(t.TempDir(), "ledger"))
+	at := time.Date(2026, 8, 16, 15, 0, 0, 0, time.UTC)
+	grant := verifiedStageGrant(t, at)
+	if _, err := store.ClaimStage(context.Background(), grant, at.Add(30*time.Minute)); err == nil {
+		t.Fatal("expired stage grant was consumed")
+	}
+	if _, err := store.ClaimStage(context.Background(), grant, at); err != nil {
+		t.Fatalf("rejected attempt consumed stage grant: %v", err)
+	}
+}
+
+func TestStageCompletionIsBoundImmutableAndIdempotent(t *testing.T) {
+	store, _ := Open(filepath.Join(t.TempDir(), "ledger"))
+	at := time.Date(2026, 8, 16, 15, 0, 0, 0, time.UTC)
+	grant := verifiedStageGrant(t, at)
+	claim, err := store.ClaimStage(context.Background(), grant, at)
+	if err != nil {
+		t.Fatal(err)
+	}
+	evidence := stageSHA("e")
+	if _, err := store.CompleteStage(context.Background(), claim, "SUCCEEDED", "NOT_ATTEMPTED", evidence, at.Add(time.Second)); err == nil {
+		t.Fatal("successful stage without attempted mutation was accepted")
+	}
+	first, err := store.CompleteStage(context.Background(), claim, "SUCCEEDED", "ATTEMPTED", evidence, at.Add(time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := store.CompleteStage(context.Background(), claim, "SUCCEEDED", "ATTEMPTED", evidence, at.Add(time.Second))
+	if err != nil || second != first {
+		t.Fatalf("identical stage completion is not idempotent: %#v %v", second, err)
+	}
+	if _, err := store.CompleteStage(context.Background(), claim, "FAILED", "UNKNOWN", evidence, at.Add(2*time.Second)); err == nil {
+		t.Fatal("conflicting stage completion was accepted")
+	}
+	inspection, err := store.InspectStage(context.Background(), grant)
+	if err != nil || inspection.State != "COMPLETED" || inspection.Outcome == nil || inspection.Outcome.Outcome != "SUCCEEDED" {
+		t.Fatalf("unexpected completed stage inspection: %#v %v", inspection, err)
+	}
+}
+
+func verifiedStageGrant(t *testing.T, at time.Time) authorization.VerifiedStageGrant {
+	t.Helper()
+	identity := contract.Identity{Namespace: "disposable-ok147", Name: "disposable-ok147"}
+	ids := []string{"provider-prerequisites", "cluster-lifecycle", "lifecycle-observation", "enablement", "network-observation", "runtime-binding", "target-access", "target-credential", "target-registration", "platform-applications", "platform-observation", "aggregate-evidence"}
+	kinds := []string{"Submission", "Submission", "Observation", "Submission", "Observation", "Binding", "Submission", "Credential", "Submission", "Submission", "Observation", "Evaluation"}
+	authorities := []string{"infrastructure", "management", "management", "management", "workload", "runner", "workload", "workload", "gitops", "gitops", "gitops", "runner"}
+	operations := []string{"CreateProviderPrerequisites", "CreateCluster", "", "CreateEnablement", "", "", "CreateTargetAccess", "IssueTargetCredential", "RegisterTarget", "CreatePlatformApplications", "", ""}
+	stages := make([]map[string]any, len(ids))
+	for index := range ids {
+		requires := []string{}
+		if index > 0 {
+			requires = []string{ids[index-1]}
+		}
+		stages[index] = map[string]any{
+			"id": ids[index], "order": index + 1, "kind": kinds[index], "authority": authorities[index], "requires": requires,
+			"inputs": []map[string]any{{"name": "stage." + ids[index], "digest": stageSHA(string("abcdef012345"[index]))}},
+		}
+		if operations[index] != "" {
+			stages[index]["grantOperation"] = operations[index]
+		}
+	}
+	planRaw, _ := json.Marshal(map[string]any{
+		"format": stageplan.Format, "contractIdentity": identity,
+		"intentRevision": stageSHA("a"), "enablementRevision": stageSHA("b"), "platformRevision": stageSHA("c"), "executionFixture": stageSHA("d"),
+		"authorizationState": "NO-GO",
+		"authorities":        map[string]any{"infrastructure": "ok-infra", "management": "ok-mgmt", "gitOps": "ok-shared", "workloadIdentityMode": "capi-cluster-uid/v1", "runnerIdentityMode": "bounded-job/v1"},
+		"stages":             stages,
+	})
+	plan, err := stageplan.Verify(planRaw, stageplan.Expected{
+		ContractIdentity: identity, IntentRevision: stageSHA("a"), EnablementRevision: stageSHA("b"), PlatformRevision: stageSHA("c"), ExecutionFixture: stageSHA("d"),
+		InfrastructureAuthority: "ok-infra", ManagementAuthority: "ok-mgmt", GitOpsAuthority: "ok-shared",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	stage, stageDigest, err := plan.Stage("provider-prerequisites")
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload := authorization.StagePayload{
+		Audience: authorization.StageAudience, GrantID: "ok147-stage-ledger-20260816-01", Decision: "ALLOW",
+		PlanDigest: plan.PlanDigest, ContractIdentity: identity, ContractRevision: plan.IntentRevision,
+		EnablementRevision: plan.EnablementRevision, PlatformRevision: plan.PlatformRevision, ExecutionFixture: plan.ExecutionFixture,
+		StageID: stage.ID, StageOrder: stage.Order, StageDigest: stageDigest, Operation: stage.GrantOperation, Authority: stage.Authority,
+		NotBefore: at.Add(-time.Minute).Format(time.RFC3339), NotAfter: at.Add(20 * time.Minute).Format(time.RFC3339), MaxUses: 1,
+	}
+	publicKey, privateKey, _ := ed25519.GenerateKey(rand.Reader)
+	signed, _ := authorization.StageSigningBytes(payload)
+	document, _ := json.Marshal(map[string]any{
+		"format": authorization.StageFormat, "payload": payload,
+		"signature": map[string]any{"algorithm": "Ed25519", "keyId": digest.SHA256(publicKey), "value": base64.StdEncoding.EncodeToString(ed25519.Sign(privateKey, signed))},
+	})
+	grant, err := authorization.VerifyStage(document, []byte(base64.StdEncoding.EncodeToString(publicKey)), plan, stage.ID, at)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return grant
+}
+
+func stageSHA(value string) string { return "sha256:" + strings.Repeat(value, 64) }

--- a/internal/stageplan/plan.go
+++ b/internal/stageplan/plan.go
@@ -270,8 +270,12 @@ func cloneStages(stages []Stage) []Stage {
 	result := make([]Stage, len(stages))
 	for index, stage := range stages {
 		result[index] = stage
-		result[index].Requires = append([]string(nil), stage.Requires...)
-		result[index].Inputs = append([]Input(nil), stage.Inputs...)
+		if stage.Requires != nil {
+			result[index].Requires = append([]string{}, stage.Requires...)
+		}
+		if stage.Inputs != nil {
+			result[index].Inputs = append([]Input{}, stage.Inputs...)
+		}
 	}
 	return result
 }
@@ -314,7 +318,7 @@ func (binding Binding) Stage(id string) (Stage, string, error) {
 		return Stage{}, "", errors.New("verified staged execution binding is required")
 	}
 	if binding.ContractIdentity != binding.verifiedIdentity || [4]string{binding.IntentRevision, binding.EnablementRevision, binding.PlatformRevision, binding.ExecutionFixture} != binding.verifiedRevisions || binding.Authorities != binding.verifiedAuthorities {
-		return Stage{}, "", errors.New("staged execution binding changed after verification")
+		return Stage{}, "", errors.New("staged execution top-level binding changed after verification")
 	}
 	if err := validateStages(binding.Stages); err != nil {
 		return Stage{}, "", fmt.Errorf("revalidate staged execution binding: %w", err)
@@ -323,7 +327,7 @@ func (binding Binding) Stage(id string) (Stage, string, error) {
 		if stage.ID == id {
 			stageDigest, err := canonicalDigest(stage)
 			if err != nil || stageDigest != binding.stageDigests[id] {
-				return Stage{}, "", errors.New("staged execution binding changed after verification")
+				return Stage{}, "", errors.New("staged execution stage binding changed after verification")
 			}
 			return cloneStages([]Stage{stage})[0], stageDigest, nil
 		}


### PR DESCRIPTION
## Outcome
- atomically consume verified mutation-stage grants in the global grant-ID namespace
- persist plan, stage, operation, authority and Contract bindings before any future write
- expose fail-closed AVAILABLE / CLAIMED_INDETERMINATE_STOP / COMPLETED inspection
- make exact stage completion idempotent and conflicting completion impossible
- require attempted mutation for a successful mutating stage

## Safety
- offline only; no stage implementation or Kubernetes contact
- crashes never reopen an already claimed stage grant
- no retry, rollback, renderer, manifest or credential capability is introduced

## Validation
- go test -ldflags=-linkmode=external ./...
- go vet ./...
- go test -race -ldflags=-linkmode=external ./internal/stageplan ./internal/authorization ./internal/ledger ./internal/execution ./internal/runner ./internal/submission
- python3 -m unittest tests/ok141_kubevirt_infra_secret_ref_test.py tests/ok147_runner_image_test.py tests/ok147_runner_publication_test.py
- git diff --check