### PR TITLE
Bind stage predecessor outcomes (OK-147)

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -774,8 +774,10 @@ authorized stage operations and receipts consume this plan.
 Every mutating stage now has a distinct signed authorization envelope. A grant
 binds the canonical staged-plan digest, Contract identity, `R`, `E`, `P`,
 `FixtureDigest`, exact stage order and digest, operation name, authority role,
-single-use declaration and a maximum 30-minute validity window. Verification
-accepts only Ed25519 signatures from the explicitly supplied trust key.
+the exact immutable outcome digest of every required predecessor, single-use
+declaration and a maximum 30-minute validity window. Verification accepts only
+Ed25519 signatures from the explicitly supplied trust key. Even the first
+stage must carry an explicit empty predecessor set rather than omit the field.
 
 This means, for example, that `CreateCluster` authority cannot be reused for
 `CreateEnablement`, `IssueTargetCredential`, target registration or Platform
@@ -794,7 +796,8 @@ Verified mutation grants can now be consumed through the same atomic ledger
 namespace as the original CreateCluster grant. The ledger writes an immutable
 claim before any future stage write and binds the authorization, staged plan,
 stage, operation, authority and Contract revision. Concurrent claim attempts
-produce exactly one winner.
+produce exactly one winner. The claim also persists the canonical predecessor
+set digest, so a stage cannot be resumed against different prior evidence.
 
 If the process disappears after that claim, inspection returns
 `CLAIMED_INDETERMINATE_STOP`; it never makes the stage available again. A

--- a/internal/authorization/stage.go
+++ b/internal/authorization/stage.go
@@ -21,28 +21,37 @@ const (
 	StageAudience = "ok-cluster-staged-executor"
 )
 
-var stageGrantIDPattern = regexp.MustCompile(`^[a-z0-9][a-z0-9.-]{2,127}$`)
+var (
+	stageGrantIDPattern = regexp.MustCompile(`^[a-z0-9][a-z0-9.-]{2,127}$`)
+	stageDigestPattern  = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
+)
 
 // StagePayload is a single-use decision for exactly one mutating stage. It
 // cannot authorize another stage, plan, Contract incarnation or authority.
 type StagePayload struct {
-	Audience           string            `json:"audience"`
-	GrantID            string            `json:"grantId"`
-	Decision           string            `json:"decision"`
-	PlanDigest         string            `json:"planDigest"`
-	ContractIdentity   contract.Identity `json:"contractIdentity"`
-	ContractRevision   string            `json:"contractRevision"`
-	EnablementRevision string            `json:"enablementRevision"`
-	PlatformRevision   string            `json:"platformRevision"`
-	ExecutionFixture   string            `json:"executionFixture"`
-	StageID            string            `json:"stageId"`
-	StageOrder         int               `json:"stageOrder"`
-	StageDigest        string            `json:"stageDigest"`
-	Operation          string            `json:"operation"`
-	Authority          string            `json:"authority"`
-	NotBefore          string            `json:"notBefore"`
-	NotAfter           string            `json:"notAfter"`
-	MaxUses            int               `json:"maxUses"`
+	Audience           string             `json:"audience"`
+	GrantID            string             `json:"grantId"`
+	Decision           string             `json:"decision"`
+	PlanDigest         string             `json:"planDigest"`
+	ContractIdentity   contract.Identity  `json:"contractIdentity"`
+	ContractRevision   string             `json:"contractRevision"`
+	EnablementRevision string             `json:"enablementRevision"`
+	PlatformRevision   string             `json:"platformRevision"`
+	ExecutionFixture   string             `json:"executionFixture"`
+	StageID            string             `json:"stageId"`
+	StageOrder         int                `json:"stageOrder"`
+	StageDigest        string             `json:"stageDigest"`
+	Operation          string             `json:"operation"`
+	Authority          string             `json:"authority"`
+	Predecessors       []StagePredecessor `json:"predecessors"`
+	NotBefore          string             `json:"notBefore"`
+	NotAfter           string             `json:"notAfter"`
+	MaxUses            int                `json:"maxUses"`
+}
+
+type StagePredecessor struct {
+	StageID       string `json:"stageId"`
+	OutcomeDigest string `json:"outcomeDigest"`
 }
 
 type stageEnvelope struct {
@@ -62,6 +71,7 @@ type StageReceipt struct {
 	StageDigest         string `json:"stageDigest"`
 	Operation           string `json:"operation"`
 	Authority           string `json:"authority"`
+	PredecessorDigest   string `json:"predecessorDigest"`
 	NotAfter            string `json:"notAfter"`
 	MaxUses             int    `json:"maxUses"`
 }
@@ -75,6 +85,7 @@ type StageConsumptionBinding struct {
 	StageDigest         string
 	Operation           string
 	Authority           string
+	PredecessorDigest   string
 	ContractRevision    string
 	NotBefore           string
 	NotAfter            string
@@ -97,7 +108,7 @@ func (grant VerifiedStageGrant) ConsumptionBinding() (StageConsumptionBinding, e
 
 // VerifyStage verifies a signature and binds it to one exact mutating stage
 // from an already verified staged execution plan.
-func VerifyStage(raw, publicKeyRaw []byte, plan stageplan.Binding, expectedStageID string, at time.Time) (VerifiedStageGrant, error) {
+func VerifyStage(raw, publicKeyRaw []byte, plan stageplan.Binding, expectedStageID string, expectedPredecessors []StagePredecessor, at time.Time) (VerifiedStageGrant, error) {
 	stage, stageDigest, err := plan.Stage(expectedStageID)
 	if err != nil {
 		return VerifiedStageGrant{}, err
@@ -130,7 +141,8 @@ func VerifyStage(raw, publicKeyRaw []byte, plan stageplan.Binding, expectedStage
 	if !ed25519.Verify(publicKey, signed, signatureBytes) {
 		return VerifiedStageGrant{}, errors.New("stage authorization signature verification failed")
 	}
-	if err := verifyStagePayload(document.Payload, plan, stage, stageDigest, at); err != nil {
+	predecessorDigest, err := verifyStagePayload(document.Payload, plan, stage, stageDigest, expectedPredecessors, at)
+	if err != nil {
 		return VerifiedStageGrant{}, err
 	}
 	receipt := StageReceipt{
@@ -138,7 +150,8 @@ func VerifyStage(raw, publicKeyRaw []byte, plan stageplan.Binding, expectedStage
 		AuthorizationDigest: digest.SHA256(raw), GrantID: document.Payload.GrantID, KeyID: keyID,
 		PlanDigest: plan.PlanDigest, StageID: stage.ID, StageDigest: stageDigest,
 		Operation: stage.GrantOperation, Authority: stage.Authority,
-		NotAfter: document.Payload.NotAfter, MaxUses: document.Payload.MaxUses,
+		PredecessorDigest: predecessorDigest,
+		NotAfter:          document.Payload.NotAfter, MaxUses: document.Payload.MaxUses,
 	}
 	return VerifiedStageGrant{
 		receipt: receipt,
@@ -146,7 +159,8 @@ func VerifyStage(raw, publicKeyRaw []byte, plan stageplan.Binding, expectedStage
 			AuthorizationDigest: receipt.AuthorizationDigest, GrantID: receipt.GrantID, KeyID: keyID,
 			PlanDigest: plan.PlanDigest, StageID: stage.ID, StageDigest: stageDigest,
 			Operation: stage.GrantOperation, Authority: stage.Authority,
-			ContractRevision: plan.IntentRevision, NotBefore: document.Payload.NotBefore, NotAfter: document.Payload.NotAfter,
+			PredecessorDigest: predecessorDigest,
+			ContractRevision:  plan.IntentRevision, NotBefore: document.Payload.NotBefore, NotAfter: document.Payload.NotAfter,
 		},
 		verified: true,
 	}, nil
@@ -166,35 +180,65 @@ func StageSigningBytes(payload StagePayload) ([]byte, error) {
 	return contract.JCS(value)
 }
 
-func verifyStagePayload(payload StagePayload, plan stageplan.Binding, stage stageplan.Stage, stageDigest string, at time.Time) error {
+func verifyStagePayload(payload StagePayload, plan stageplan.Binding, stage stageplan.Stage, stageDigest string, expectedPredecessors []StagePredecessor, at time.Time) (string, error) {
 	if payload.Audience != StageAudience || payload.Decision != "ALLOW" {
-		return errors.New("stage authorization audience or decision is not accepted")
+		return "", errors.New("stage authorization audience or decision is not accepted")
 	}
 	if !stageGrantIDPattern.MatchString(payload.GrantID) {
-		return errors.New("stage authorization grantId is invalid")
+		return "", errors.New("stage authorization grantId is invalid")
 	}
 	if payload.PlanDigest != plan.PlanDigest || payload.ContractIdentity != plan.ContractIdentity || payload.ContractRevision != plan.IntentRevision || payload.EnablementRevision != plan.EnablementRevision || payload.PlatformRevision != plan.PlatformRevision || payload.ExecutionFixture != plan.ExecutionFixture {
-		return errors.New("stage authorization plan or Contract bindings differ")
+		return "", errors.New("stage authorization plan or Contract bindings differ")
 	}
 	if payload.StageID != stage.ID || payload.StageOrder != stage.Order || payload.StageDigest != stageDigest || payload.Operation != stage.GrantOperation || payload.Authority != stage.Authority {
-		return errors.New("stage authorization does not bind the exact stage")
+		return "", errors.New("stage authorization does not bind the exact stage")
+	}
+	predecessorDigest, err := verifyStagePredecessors(payload.Predecessors, expectedPredecessors, stage.Requires)
+	if err != nil {
+		return "", err
 	}
 	if payload.MaxUses != 1 {
-		return errors.New("stage authorization must declare exactly one use")
+		return "", errors.New("stage authorization must declare exactly one use")
 	}
 	notBefore, err := time.Parse(time.RFC3339, payload.NotBefore)
 	if err != nil {
-		return fmt.Errorf("stage authorization notBefore: %w", err)
+		return "", fmt.Errorf("stage authorization notBefore: %w", err)
 	}
 	notAfter, err := time.Parse(time.RFC3339, payload.NotAfter)
 	if err != nil {
-		return fmt.Errorf("stage authorization notAfter: %w", err)
+		return "", fmt.Errorf("stage authorization notAfter: %w", err)
 	}
 	if !notAfter.After(notBefore) || notAfter.Sub(notBefore) > MaximumWindow {
-		return errors.New("stage authorization time window is invalid")
+		return "", errors.New("stage authorization time window is invalid")
 	}
 	if at.Before(notBefore) || !at.Before(notAfter) {
-		return errors.New("stage authorization is not active at the evaluation time")
+		return "", errors.New("stage authorization is not active at the evaluation time")
 	}
-	return nil
+	return predecessorDigest, nil
+}
+
+func verifyStagePredecessors(payload, expected []StagePredecessor, required []string) (string, error) {
+	if payload == nil || expected == nil || len(payload) != len(required) || len(expected) != len(required) {
+		return "", errors.New("stage authorization predecessor set is incomplete")
+	}
+	for index, stageID := range required {
+		if payload[index].StageID != stageID || expected[index].StageID != stageID || payload[index] != expected[index] || !stageDigestPattern.MatchString(payload[index].OutcomeDigest) {
+			return "", errors.New("stage authorization predecessor evidence differs")
+		}
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return "", err
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	var value any
+	if err := decoder.Decode(&value); err != nil {
+		return "", err
+	}
+	canonical, err := contract.JCS(value)
+	if err != nil {
+		return "", err
+	}
+	return digest.SHA256(canonical), nil
 }

--- a/internal/authorization/stage_test.go
+++ b/internal/authorization/stage_test.go
@@ -23,7 +23,7 @@ func TestVerifyStageAcceptsExactMutatingStage(t *testing.T) {
 	}
 	payload := stagePayloadFixture(t, plan, "enablement", at)
 	raw := signStage(t, payload, publicKey, privateKey)
-	grant, err := VerifyStage(raw, []byte(base64.StdEncoding.EncodeToString(publicKey)), plan, "enablement", at)
+	grant, err := VerifyStage(raw, []byte(base64.StdEncoding.EncodeToString(publicKey)), plan, "enablement", payload.Predecessors, at)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -44,12 +44,25 @@ func TestVerifyStageRejectsReadOnlyStageAndCrossStageReuse(t *testing.T) {
 	payload := stagePayloadFixture(t, plan, "enablement", at)
 	raw := signStage(t, payload, publicKey, privateKey)
 	key := []byte(base64.StdEncoding.EncodeToString(publicKey))
-	if _, err := VerifyStage(raw, key, plan, "platform-applications", at); err == nil {
+	platformPredecessors := stagePayloadFixture(t, plan, "platform-applications", at).Predecessors
+	if _, err := VerifyStage(raw, key, plan, "platform-applications", platformPredecessors, at); err == nil {
 		t.Fatal("enablement grant was reused for Platform submission")
 	}
 	readPayload := stagePayloadFixture(t, plan, "lifecycle-observation", at)
-	if _, err := VerifyStage(signStage(t, readPayload, publicKey, privateKey), key, plan, "lifecycle-observation", at); err == nil {
+	if _, err := VerifyStage(signStage(t, readPayload, publicKey, privateKey), key, plan, "lifecycle-observation", readPayload.Predecessors, at); err == nil {
 		t.Fatal("mutation grant was accepted for a read-only stage")
+	}
+}
+
+func TestVerifyStageRequiresExplicitPredecessorReceipts(t *testing.T) {
+	plan := stagePlanFixture(t)
+	at := time.Date(2026, 8, 16, 14, 0, 0, 0, time.UTC)
+	publicKey, privateKey, _ := ed25519.GenerateKey(rand.Reader)
+	key := []byte(base64.StdEncoding.EncodeToString(publicKey))
+	payload := stagePayloadFixture(t, plan, "provider-prerequisites", at)
+	payload.Predecessors = nil
+	if _, err := VerifyStage(signStage(t, payload, publicKey, privateKey), key, plan, "provider-prerequisites", []StagePredecessor{}, at); err == nil {
+		t.Fatal("omitted empty predecessor set was accepted for the first stage")
 	}
 }
 
@@ -59,27 +72,30 @@ func TestVerifyStageRejectsEveryChangedBinding(t *testing.T) {
 	publicKey, privateKey, _ := ed25519.GenerateKey(rand.Reader)
 	key := []byte(base64.StdEncoding.EncodeToString(publicKey))
 	tests := map[string]func(*StagePayload){
-		"decision":       func(payload *StagePayload) { payload.Decision = "DENY" },
-		"plan":           func(payload *StagePayload) { payload.PlanDigest = authSHA("0") },
-		"identity":       func(payload *StagePayload) { payload.ContractIdentity.Name = "another" },
-		"R":              func(payload *StagePayload) { payload.ContractRevision = authSHA("1") },
-		"E":              func(payload *StagePayload) { payload.EnablementRevision = authSHA("2") },
-		"P":              func(payload *StagePayload) { payload.PlatformRevision = authSHA("3") },
-		"fixture":        func(payload *StagePayload) { payload.ExecutionFixture = authSHA("4") },
-		"stage":          func(payload *StagePayload) { payload.StageID = "cluster-lifecycle" },
-		"order":          func(payload *StagePayload) { payload.StageOrder++ },
-		"stage digest":   func(payload *StagePayload) { payload.StageDigest = authSHA("5") },
-		"operation":      func(payload *StagePayload) { payload.Operation = "CreateCluster" },
-		"authority":      func(payload *StagePayload) { payload.Authority = "gitops" },
-		"uses":           func(payload *StagePayload) { payload.MaxUses = 2 },
-		"expired":        func(payload *StagePayload) { payload.NotAfter = at.Format(time.RFC3339) },
-		"oversized time": func(payload *StagePayload) { payload.NotAfter = at.Add(31 * time.Minute).Format(time.RFC3339) },
+		"decision":            func(payload *StagePayload) { payload.Decision = "DENY" },
+		"plan":                func(payload *StagePayload) { payload.PlanDigest = authSHA("0") },
+		"identity":            func(payload *StagePayload) { payload.ContractIdentity.Name = "another" },
+		"R":                   func(payload *StagePayload) { payload.ContractRevision = authSHA("1") },
+		"E":                   func(payload *StagePayload) { payload.EnablementRevision = authSHA("2") },
+		"P":                   func(payload *StagePayload) { payload.PlatformRevision = authSHA("3") },
+		"fixture":             func(payload *StagePayload) { payload.ExecutionFixture = authSHA("4") },
+		"stage":               func(payload *StagePayload) { payload.StageID = "cluster-lifecycle" },
+		"order":               func(payload *StagePayload) { payload.StageOrder++ },
+		"stage digest":        func(payload *StagePayload) { payload.StageDigest = authSHA("5") },
+		"operation":           func(payload *StagePayload) { payload.Operation = "CreateCluster" },
+		"authority":           func(payload *StagePayload) { payload.Authority = "gitops" },
+		"predecessor":         func(payload *StagePayload) { payload.Predecessors[0].OutcomeDigest = authSHA("0") },
+		"missing predecessor": func(payload *StagePayload) { payload.Predecessors = nil },
+		"uses":                func(payload *StagePayload) { payload.MaxUses = 2 },
+		"expired":             func(payload *StagePayload) { payload.NotAfter = at.Format(time.RFC3339) },
+		"oversized time":      func(payload *StagePayload) { payload.NotAfter = at.Add(31 * time.Minute).Format(time.RFC3339) },
 	}
 	for name, mutate := range tests {
 		t.Run(name, func(t *testing.T) {
 			payload := stagePayloadFixture(t, plan, "enablement", at)
 			mutate(&payload)
-			if _, err := VerifyStage(signStage(t, payload, publicKey, privateKey), key, plan, "enablement", at); err == nil {
+			expectedPredecessors := stagePayloadFixture(t, plan, "enablement", at).Predecessors
+			if _, err := VerifyStage(signStage(t, payload, publicKey, privateKey), key, plan, "enablement", expectedPredecessors, at); err == nil {
 				t.Fatal("changed stage authorization was accepted")
 			}
 		})
@@ -93,11 +109,12 @@ func TestVerifyStageRejectsTamperingAndNonStrictEnvelope(t *testing.T) {
 	raw := signStage(t, stagePayloadFixture(t, plan, "enablement", at), publicKey, privateKey)
 	key := []byte(base64.StdEncoding.EncodeToString(publicKey))
 	tampered := strings.Replace(string(raw), `"operation":"CreateEnablement"`, `"operation":"CreateCluster"`, 1)
-	if _, err := VerifyStage([]byte(tampered), key, plan, "enablement", at); err == nil {
+	predecessors := stagePayloadFixture(t, plan, "enablement", at).Predecessors
+	if _, err := VerifyStage([]byte(tampered), key, plan, "enablement", predecessors, at); err == nil {
 		t.Fatal("tampered stage authorization was accepted")
 	}
 	unknown := strings.Replace(string(raw), `"format":"`+StageFormat+`"`, `"format":"`+StageFormat+`","unknown":true`, 1)
-	if _, err := VerifyStage([]byte(unknown), key, plan, "enablement", at); err == nil {
+	if _, err := VerifyStage([]byte(unknown), key, plan, "enablement", predecessors, at); err == nil {
 		t.Fatal("unknown stage authorization field was accepted")
 	}
 }
@@ -108,13 +125,18 @@ func stagePayloadFixture(t *testing.T, plan stageplan.Binding, stageID string, a
 	if err != nil {
 		t.Fatal(err)
 	}
+	predecessors := make([]StagePredecessor, len(stage.Requires))
+	for index, predecessor := range stage.Requires {
+		predecessors[index] = StagePredecessor{StageID: predecessor, OutcomeDigest: authSHA("e")}
+	}
 	return StagePayload{
 		Audience: StageAudience, GrantID: "ok147-stage-20260816-01", Decision: "ALLOW",
 		PlanDigest: plan.PlanDigest, ContractIdentity: plan.ContractIdentity, ContractRevision: plan.IntentRevision,
 		EnablementRevision: plan.EnablementRevision, PlatformRevision: plan.PlatformRevision,
 		ExecutionFixture: plan.ExecutionFixture, StageID: stage.ID, StageOrder: stage.Order,
 		StageDigest: stageDigest, Operation: stage.GrantOperation, Authority: stage.Authority,
-		NotBefore: at.Add(-time.Minute).Format(time.RFC3339), NotAfter: at.Add(20 * time.Minute).Format(time.RFC3339), MaxUses: 1,
+		Predecessors: predecessors,
+		NotBefore:    at.Add(-time.Minute).Format(time.RFC3339), NotAfter: at.Add(20 * time.Minute).Format(time.RFC3339), MaxUses: 1,
 	}
 }
 

--- a/internal/ledger/stage.go
+++ b/internal/ledger/stage.go
@@ -27,6 +27,7 @@ type StageClaimReceipt struct {
 	StageDigest         string `json:"stageDigest"`
 	Operation           string `json:"operation"`
 	Authority           string `json:"authority"`
+	PredecessorDigest   string `json:"predecessorDigest"`
 	ContractRevision    string `json:"contractRevision"`
 	ClaimedAt           string `json:"claimedAt"`
 }
@@ -76,7 +77,7 @@ func (ledger *Ledger) ClaimStage(ctx context.Context, grant authorization.Verifi
 		Format: StageClaimFormat, State: "CLAIMED", AuthorizationDigest: binding.AuthorizationDigest,
 		GrantID: binding.GrantID, KeyID: binding.KeyID, PlanDigest: binding.PlanDigest,
 		StageID: binding.StageID, StageDigest: binding.StageDigest, Operation: binding.Operation,
-		Authority: binding.Authority, ContractRevision: binding.ContractRevision,
+		Authority: binding.Authority, PredecessorDigest: binding.PredecessorDigest, ContractRevision: binding.ContractRevision,
 		ClaimedAt: at.UTC().Format(time.RFC3339Nano),
 	}
 	raw, _, err := canonicalRecord(receipt)
@@ -213,7 +214,7 @@ func validateStageClaim(value StageClaimReceipt) error {
 	if value.Format != StageClaimFormat || value.State != "CLAIMED" || value.GrantID == "" || value.StageID == "" || value.Operation == "" || value.Authority == "" {
 		return errors.New("stage grant claim is incomplete")
 	}
-	for _, identity := range []string{value.AuthorizationDigest, value.KeyID, value.PlanDigest, value.StageDigest, value.ContractRevision} {
+	for _, identity := range []string{value.AuthorizationDigest, value.KeyID, value.PlanDigest, value.StageDigest, value.PredecessorDigest, value.ContractRevision} {
 		if !validDigest(identity) {
 			return errors.New("stage grant claim contains an invalid digest")
 		}
@@ -246,7 +247,7 @@ func validateStageOutcome(value StageOutcomeReceipt) error {
 }
 
 func matchStageBinding(claim StageClaimReceipt, binding authorization.StageConsumptionBinding) error {
-	if claim.AuthorizationDigest != binding.AuthorizationDigest || claim.GrantID != binding.GrantID || claim.KeyID != binding.KeyID || claim.PlanDigest != binding.PlanDigest || claim.StageID != binding.StageID || claim.StageDigest != binding.StageDigest || claim.Operation != binding.Operation || claim.Authority != binding.Authority || claim.ContractRevision != binding.ContractRevision {
+	if claim.AuthorizationDigest != binding.AuthorizationDigest || claim.GrantID != binding.GrantID || claim.KeyID != binding.KeyID || claim.PlanDigest != binding.PlanDigest || claim.StageID != binding.StageID || claim.StageDigest != binding.StageDigest || claim.Operation != binding.Operation || claim.Authority != binding.Authority || claim.PredecessorDigest != binding.PredecessorDigest || claim.ContractRevision != binding.ContractRevision {
 		return errors.New("stored stage claim differs from verified authorization")
 	}
 	return nil

--- a/internal/ledger/stage_test.go
+++ b/internal/ledger/stage_test.go
@@ -142,7 +142,8 @@ func verifiedStageGrant(t *testing.T, at time.Time) authorization.VerifiedStageG
 		PlanDigest: plan.PlanDigest, ContractIdentity: identity, ContractRevision: plan.IntentRevision,
 		EnablementRevision: plan.EnablementRevision, PlatformRevision: plan.PlatformRevision, ExecutionFixture: plan.ExecutionFixture,
 		StageID: stage.ID, StageOrder: stage.Order, StageDigest: stageDigest, Operation: stage.GrantOperation, Authority: stage.Authority,
-		NotBefore: at.Add(-time.Minute).Format(time.RFC3339), NotAfter: at.Add(20 * time.Minute).Format(time.RFC3339), MaxUses: 1,
+		Predecessors: []authorization.StagePredecessor{},
+		NotBefore:    at.Add(-time.Minute).Format(time.RFC3339), NotAfter: at.Add(20 * time.Minute).Format(time.RFC3339), MaxUses: 1,
 	}
 	publicKey, privateKey, _ := ed25519.GenerateKey(rand.Reader)
 	signed, _ := authorization.StageSigningBytes(payload)
@@ -150,7 +151,7 @@ func verifiedStageGrant(t *testing.T, at time.Time) authorization.VerifiedStageG
 		"format": authorization.StageFormat, "payload": payload,
 		"signature": map[string]any{"algorithm": "Ed25519", "keyId": digest.SHA256(publicKey), "value": base64.StdEncoding.EncodeToString(ed25519.Sign(privateKey, signed))},
 	})
-	grant, err := authorization.VerifyStage(document, []byte(base64.StdEncoding.EncodeToString(publicKey)), plan, stage.ID, at)
+	grant, err := authorization.VerifyStage(document, []byte(base64.StdEncoding.EncodeToString(publicKey)), plan, stage.ID, payload.Predecessors, at)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Outcome
- require every signed stage grant to bind the exact immutable outcome digest of each required predecessor
- require an explicit empty predecessor set for the first stage
- persist the canonical predecessor-set digest in the atomic stage claim
- reject missing, stale, foreign or changed predecessor evidence

## Why
Stage IDs alone prove ordering intent but not which completed runtime evidence authorized a later mutation. This closes that gap before any concrete stage executor is connected.

## Safety
- offline only; no Kubernetes contact or mutation
- no retry, rollback, rendering or credential capability
- all existing staged-plan and ledger boundaries remain fail closed

## Validation
- go test -ldflags=-linkmode=external ./...
- go vet ./...
- go test -race -ldflags=-linkmode=external ./internal/stageplan ./internal/authorization ./internal/ledger ./internal/execution ./internal/runner ./internal/submission
- python3 -m unittest tests/ok141_kubevirt_infra_secret_ref_test.py tests/ok147_runner_image_test.py tests/ok147_runner_publication_test.py
- git diff --check