### PR TITLE
Chain verified stage receipts (OK-147)

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -774,7 +774,7 @@ authorized stage operations and receipts consume this plan.
 Every mutating stage now has a distinct signed authorization envelope. A grant
 binds the canonical staged-plan digest, Contract identity, `R`, `E`, `P`,
 `FixtureDigest`, exact stage order and digest, operation name, authority role,
-the exact immutable outcome digest of every required predecessor, single-use
+the exact immutable receipt digest of every required predecessor, single-use
 declaration and a maximum 30-minute validity window. Verification accepts only
 Ed25519 signatures from the explicitly supplied trust key. Even the first
 stage must carry an explicit empty predecessor set rather than omit the field.
@@ -808,6 +808,37 @@ closed. A successful mutating stage must report `ATTEMPTED`.
 This checkpoint still invokes no stage implementation. It provides the durable
 crash boundary needed before separately bounded HCP, target-access,
 TokenRequest, registration and Application submitters can be composed.
+
+## Immutable stage receipt chain
+
+Every one of the twelve stages now produces the same canonical
+`ok147-stage-receipt/v1` evidence shape. A receipt binds the staged-plan and
+Contract identities, exact stage metadata, completion state, evidence digest
+and the receipt digest of each direct predecessor:
+
+```text
+verified successful predecessor receipt(s)
+                  |
+                  v
+       current canonical stage receipt
+                  |
+                  v
+      independently retained receipt digest
+```
+
+Mutating stages additionally bind whether mutation was attempted and the exact
+operation-outcome digest. Read-only stages must declare
+`mutationState: NOT_APPLICABLE` and cannot carry an operation outcome. Only a
+`SUCCEEDED` receipt may open a dependent stage. Failed, stopped, foreign-plan,
+wrong-order or wrong-stage receipts fail closed.
+
+Loading a receipt during resume requires both its canonical bytes and an
+independently supplied expected digest; otherwise a semantically valid rewrite
+could silently acquire a new identity. A per-stage signed authorization must
+likewise match verified successful receipts rather than caller-asserted
+predecessor values. The receipt is immutable evidence, not authority: it does
+not consume a grant, execute a stage, retry work or authorize a Kubernetes
+write.
 
 ## Typed first-run Platform capability boundary
 

--- a/internal/authorization/stage.go
+++ b/internal/authorization/stage.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openkubes/ok-cluster/internal/digest"
 	"github.com/openkubes/ok-cluster/internal/jsonstrict"
 	"github.com/openkubes/ok-cluster/internal/stageplan"
+	"github.com/openkubes/ok-cluster/internal/stagereceipt"
 )
 
 const (
@@ -108,7 +109,7 @@ func (grant VerifiedStageGrant) ConsumptionBinding() (StageConsumptionBinding, e
 
 // VerifyStage verifies a signature and binds it to one exact mutating stage
 // from an already verified staged execution plan.
-func VerifyStage(raw, publicKeyRaw []byte, plan stageplan.Binding, expectedStageID string, expectedPredecessors []StagePredecessor, at time.Time) (VerifiedStageGrant, error) {
+func VerifyStage(raw, publicKeyRaw []byte, plan stageplan.Binding, expectedStageID string, expectedPredecessors []stagereceipt.Verified, at time.Time) (VerifiedStageGrant, error) {
 	stage, stageDigest, err := plan.Stage(expectedStageID)
 	if err != nil {
 		return VerifiedStageGrant{}, err
@@ -180,7 +181,7 @@ func StageSigningBytes(payload StagePayload) ([]byte, error) {
 	return contract.JCS(value)
 }
 
-func verifyStagePayload(payload StagePayload, plan stageplan.Binding, stage stageplan.Stage, stageDigest string, expectedPredecessors []StagePredecessor, at time.Time) (string, error) {
+func verifyStagePayload(payload StagePayload, plan stageplan.Binding, stage stageplan.Stage, stageDigest string, expectedPredecessors []stagereceipt.Verified, at time.Time) (string, error) {
 	if payload.Audience != StageAudience || payload.Decision != "ALLOW" {
 		return "", errors.New("stage authorization audience or decision is not accepted")
 	}
@@ -193,7 +194,7 @@ func verifyStagePayload(payload StagePayload, plan stageplan.Binding, stage stag
 	if payload.StageID != stage.ID || payload.StageOrder != stage.Order || payload.StageDigest != stageDigest || payload.Operation != stage.GrantOperation || payload.Authority != stage.Authority {
 		return "", errors.New("stage authorization does not bind the exact stage")
 	}
-	predecessorDigest, err := verifyStagePredecessors(payload.Predecessors, expectedPredecessors, stage.Requires)
+	predecessorDigest, err := verifyStagePredecessors(payload.Predecessors, expectedPredecessors, stage.Requires, plan.PlanDigest)
 	if err != nil {
 		return "", err
 	}
@@ -217,16 +218,26 @@ func verifyStagePayload(payload StagePayload, plan stageplan.Binding, stage stag
 	return predecessorDigest, nil
 }
 
-func verifyStagePredecessors(payload, expected []StagePredecessor, required []string) (string, error) {
+func verifyStagePredecessors(payload []StagePredecessor, expected []stagereceipt.Verified, required []string, planDigest string) (string, error) {
 	if payload == nil || expected == nil || len(payload) != len(required) || len(expected) != len(required) {
 		return "", errors.New("stage authorization predecessor set is incomplete")
 	}
+	bindings := make([]StagePredecessor, len(expected))
 	for index, stageID := range required {
-		if payload[index].StageID != stageID || expected[index].StageID != stageID || payload[index] != expected[index] || !stageDigestPattern.MatchString(payload[index].OutcomeDigest) {
+		receipt, err := expected[index].Receipt()
+		if err != nil {
+			return "", err
+		}
+		receiptDigest, err := expected[index].Digest()
+		if err != nil {
+			return "", err
+		}
+		bindings[index] = StagePredecessor{StageID: receipt.StageID, OutcomeDigest: receiptDigest}
+		if receipt.PlanDigest != planDigest || receipt.State != "SUCCEEDED" || bindings[index].StageID != stageID || payload[index] != bindings[index] || !stageDigestPattern.MatchString(payload[index].OutcomeDigest) {
 			return "", errors.New("stage authorization predecessor evidence differs")
 		}
 	}
-	raw, err := json.Marshal(payload)
+	raw, err := json.Marshal(bindings)
 	if err != nil {
 		return "", err
 	}

--- a/internal/authorization/stage_test.go
+++ b/internal/authorization/stage_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/openkubes/ok-cluster/internal/contract"
 	"github.com/openkubes/ok-cluster/internal/digest"
 	"github.com/openkubes/ok-cluster/internal/stageplan"
+	"github.com/openkubes/ok-cluster/internal/stagereceipt"
 )
 
 func TestVerifyStageAcceptsExactMutatingStage(t *testing.T) {
@@ -23,7 +24,7 @@ func TestVerifyStageAcceptsExactMutatingStage(t *testing.T) {
 	}
 	payload := stagePayloadFixture(t, plan, "enablement", at)
 	raw := signStage(t, payload, publicKey, privateKey)
-	grant, err := VerifyStage(raw, []byte(base64.StdEncoding.EncodeToString(publicKey)), plan, "enablement", payload.Predecessors, at)
+	grant, err := VerifyStage(raw, []byte(base64.StdEncoding.EncodeToString(publicKey)), plan, "enablement", stagePredecessorReceipts(t, plan, "enablement", at), at)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -44,12 +45,12 @@ func TestVerifyStageRejectsReadOnlyStageAndCrossStageReuse(t *testing.T) {
 	payload := stagePayloadFixture(t, plan, "enablement", at)
 	raw := signStage(t, payload, publicKey, privateKey)
 	key := []byte(base64.StdEncoding.EncodeToString(publicKey))
-	platformPredecessors := stagePayloadFixture(t, plan, "platform-applications", at).Predecessors
+	platformPredecessors := stagePredecessorReceipts(t, plan, "platform-applications", at)
 	if _, err := VerifyStage(raw, key, plan, "platform-applications", platformPredecessors, at); err == nil {
 		t.Fatal("enablement grant was reused for Platform submission")
 	}
 	readPayload := stagePayloadFixture(t, plan, "lifecycle-observation", at)
-	if _, err := VerifyStage(signStage(t, readPayload, publicKey, privateKey), key, plan, "lifecycle-observation", readPayload.Predecessors, at); err == nil {
+	if _, err := VerifyStage(signStage(t, readPayload, publicKey, privateKey), key, plan, "lifecycle-observation", stagePredecessorReceipts(t, plan, "lifecycle-observation", at), at); err == nil {
 		t.Fatal("mutation grant was accepted for a read-only stage")
 	}
 }
@@ -61,7 +62,7 @@ func TestVerifyStageRequiresExplicitPredecessorReceipts(t *testing.T) {
 	key := []byte(base64.StdEncoding.EncodeToString(publicKey))
 	payload := stagePayloadFixture(t, plan, "provider-prerequisites", at)
 	payload.Predecessors = nil
-	if _, err := VerifyStage(signStage(t, payload, publicKey, privateKey), key, plan, "provider-prerequisites", []StagePredecessor{}, at); err == nil {
+	if _, err := VerifyStage(signStage(t, payload, publicKey, privateKey), key, plan, "provider-prerequisites", []stagereceipt.Verified{}, at); err == nil {
 		t.Fatal("omitted empty predecessor set was accepted for the first stage")
 	}
 }
@@ -94,7 +95,7 @@ func TestVerifyStageRejectsEveryChangedBinding(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			payload := stagePayloadFixture(t, plan, "enablement", at)
 			mutate(&payload)
-			expectedPredecessors := stagePayloadFixture(t, plan, "enablement", at).Predecessors
+			expectedPredecessors := stagePredecessorReceipts(t, plan, "enablement", at)
 			if _, err := VerifyStage(signStage(t, payload, publicKey, privateKey), key, plan, "enablement", expectedPredecessors, at); err == nil {
 				t.Fatal("changed stage authorization was accepted")
 			}
@@ -109,7 +110,7 @@ func TestVerifyStageRejectsTamperingAndNonStrictEnvelope(t *testing.T) {
 	raw := signStage(t, stagePayloadFixture(t, plan, "enablement", at), publicKey, privateKey)
 	key := []byte(base64.StdEncoding.EncodeToString(publicKey))
 	tampered := strings.Replace(string(raw), `"operation":"CreateEnablement"`, `"operation":"CreateCluster"`, 1)
-	predecessors := stagePayloadFixture(t, plan, "enablement", at).Predecessors
+	predecessors := stagePredecessorReceipts(t, plan, "enablement", at)
 	if _, err := VerifyStage([]byte(tampered), key, plan, "enablement", predecessors, at); err == nil {
 		t.Fatal("tampered stage authorization was accepted")
 	}
@@ -125,9 +126,18 @@ func stagePayloadFixture(t *testing.T, plan stageplan.Binding, stageID string, a
 	if err != nil {
 		t.Fatal(err)
 	}
-	predecessors := make([]StagePredecessor, len(stage.Requires))
-	for index, predecessor := range stage.Requires {
-		predecessors[index] = StagePredecessor{StageID: predecessor, OutcomeDigest: authSHA("e")}
+	predecessorReceipts := stagePredecessorReceipts(t, plan, stageID, at)
+	predecessors := make([]StagePredecessor, len(predecessorReceipts))
+	for index, predecessor := range predecessorReceipts {
+		receipt, err := predecessor.Receipt()
+		if err != nil {
+			t.Fatal(err)
+		}
+		receiptDigest, err := predecessor.Digest()
+		if err != nil {
+			t.Fatal(err)
+		}
+		predecessors[index] = StagePredecessor{StageID: receipt.StageID, OutcomeDigest: receiptDigest}
 	}
 	return StagePayload{
 		Audience: StageAudience, GrantID: "ok147-stage-20260816-01", Decision: "ALLOW",
@@ -138,6 +148,29 @@ func stagePayloadFixture(t *testing.T, plan stageplan.Binding, stageID string, a
 		Predecessors: predecessors,
 		NotBefore:    at.Add(-time.Minute).Format(time.RFC3339), NotAfter: at.Add(20 * time.Minute).Format(time.RFC3339), MaxUses: 1,
 	}
+}
+
+func stagePredecessorReceipts(t *testing.T, plan stageplan.Binding, stageID string, at time.Time) []stagereceipt.Verified {
+	t.Helper()
+	predecessors := []stagereceipt.Verified{}
+	for _, stage := range plan.Stages {
+		if stage.ID == stageID {
+			return predecessors
+		}
+		mutationState := "NOT_APPLICABLE"
+		operationOutcome := ""
+		if stageplan.IsMutating(stage) {
+			mutationState = "ATTEMPTED"
+			operationOutcome = authSHA("f")
+		}
+		receipt, err := stagereceipt.New(plan, stage.ID, predecessors, "SUCCEEDED", mutationState, operationOutcome, authSHA("e"), at.Add(time.Duration(stage.Order)*time.Second))
+		if err != nil {
+			t.Fatal(err)
+		}
+		predecessors = []stagereceipt.Verified{receipt}
+	}
+	t.Fatalf("stage %s is not in plan", stageID)
+	return nil
 }
 
 func signStage(t *testing.T, payload StagePayload, publicKey ed25519.PublicKey, privateKey ed25519.PrivateKey) []byte {

--- a/internal/ledger/stage_test.go
+++ b/internal/ledger/stage_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/openkubes/ok-cluster/internal/contract"
 	"github.com/openkubes/ok-cluster/internal/digest"
 	"github.com/openkubes/ok-cluster/internal/stageplan"
+	"github.com/openkubes/ok-cluster/internal/stagereceipt"
 )
 
 func TestStageClaimIsAtomicAndCrashStopsRetry(t *testing.T) {
@@ -151,7 +152,7 @@ func verifiedStageGrant(t *testing.T, at time.Time) authorization.VerifiedStageG
 		"format": authorization.StageFormat, "payload": payload,
 		"signature": map[string]any{"algorithm": "Ed25519", "keyId": digest.SHA256(publicKey), "value": base64.StdEncoding.EncodeToString(ed25519.Sign(privateKey, signed))},
 	})
-	grant, err := authorization.VerifyStage(document, []byte(base64.StdEncoding.EncodeToString(publicKey)), plan, stage.ID, payload.Predecessors, at)
+	grant, err := authorization.VerifyStage(document, []byte(base64.StdEncoding.EncodeToString(publicKey)), plan, stage.ID, []stagereceipt.Verified{}, at)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/stagereceipt/receipt.go
+++ b/internal/stagereceipt/receipt.go
@@ -1,0 +1,258 @@
+// Package stagereceipt creates and verifies the immutable evidence chain shared
+// by mutating and read-only stages. It performs no stage work itself.
+package stagereceipt
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"regexp"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/contract"
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/jsonstrict"
+	"github.com/openkubes/ok-cluster/internal/stageplan"
+)
+
+const (
+	Format              = "ok147-stage-receipt/v1"
+	maximumReceiptBytes = 128 * 1024
+)
+
+var receiptDigestPattern = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
+
+type Predecessor struct {
+	StageID       string `json:"stageId"`
+	ReceiptDigest string `json:"receiptDigest"`
+}
+
+// Receipt contains only redaction-safe identities and evidence digests.
+type Receipt struct {
+	Format                 string            `json:"format"`
+	PlanDigest             string            `json:"planDigest"`
+	ContractIdentity       contract.Identity `json:"contractIdentity"`
+	ContractRevision       string            `json:"contractRevision"`
+	EnablementRevision     string            `json:"enablementRevision"`
+	PlatformRevision       string            `json:"platformRevision"`
+	ExecutionFixture       string            `json:"executionFixture"`
+	StageID                string            `json:"stageId"`
+	StageOrder             int               `json:"stageOrder"`
+	StageDigest            string            `json:"stageDigest"`
+	Kind                   string            `json:"kind"`
+	Authority              string            `json:"authority"`
+	Operation              string            `json:"operation,omitempty"`
+	Predecessors           []Predecessor     `json:"predecessors"`
+	State                  string            `json:"state"`
+	MutationState          string            `json:"mutationState"`
+	OperationOutcomeDigest string            `json:"operationOutcomeDigest,omitempty"`
+	EvidenceDigest         string            `json:"evidenceDigest"`
+	CompletedAt            string            `json:"completedAt"`
+}
+
+// Verified can only be produced by New, Verify or Load. It retains canonical
+// bytes so later links cannot observe caller mutation of a Receipt copy.
+type Verified struct {
+	receipt  Receipt
+	digest   string
+	raw      []byte
+	verified bool
+}
+
+// New builds a receipt only after all direct predecessor receipts have been
+// verified, completed successfully and matched to the same staged plan.
+func New(plan stageplan.Binding, stageID string, predecessors []Verified, state, mutationState, operationOutcomeDigest, evidenceDigest string, completedAt time.Time) (Verified, error) {
+	stage, stageDigest, err := plan.Stage(stageID)
+	if err != nil {
+		return Verified{}, err
+	}
+	links, err := verifiedLinks(plan, stage, predecessors)
+	if err != nil {
+		return Verified{}, err
+	}
+	receipt := Receipt{
+		Format: Format, PlanDigest: plan.PlanDigest, ContractIdentity: plan.ContractIdentity,
+		ContractRevision: plan.IntentRevision, EnablementRevision: plan.EnablementRevision,
+		PlatformRevision: plan.PlatformRevision, ExecutionFixture: plan.ExecutionFixture,
+		StageID: stage.ID, StageOrder: stage.Order, StageDigest: stageDigest, Kind: stage.Kind,
+		Authority: stage.Authority, Operation: stage.GrantOperation, Predecessors: links,
+		State: state, MutationState: mutationState, OperationOutcomeDigest: operationOutcomeDigest,
+		EvidenceDigest: evidenceDigest, CompletedAt: completedAt.UTC().Format(time.RFC3339Nano),
+	}
+	return verifyReceipt(receipt, plan, predecessors)
+}
+
+// Verify accepts only canonical receipt bytes with an independently supplied
+// expected digest and rechecks the complete direct predecessor chain.
+func Verify(raw []byte, expectedDigest string, plan stageplan.Binding, predecessors []Verified) (Verified, error) {
+	if !receiptDigestPattern.MatchString(expectedDigest) {
+		return Verified{}, errors.New("expected stage receipt digest is invalid")
+	}
+	var receipt Receipt
+	if err := jsonstrict.Decode(raw, &receipt); err != nil {
+		return Verified{}, fmt.Errorf("decode stage receipt: %w", err)
+	}
+	verified, err := verifyReceipt(receipt, plan, predecessors)
+	if err != nil {
+		return Verified{}, err
+	}
+	if !bytes.Equal(raw, verified.raw) {
+		return Verified{}, errors.New("stage receipt is not canonical or was modified")
+	}
+	if verified.digest != expectedDigest {
+		return Verified{}, errors.New("stage receipt digest differs from expected identity")
+	}
+	return verified, nil
+}
+
+// Load reads one bounded, non-symlink receipt before verifying it.
+func Load(path, expectedDigest string, plan stageplan.Binding, predecessors []Verified) (Verified, error) {
+	if path == "" {
+		return Verified{}, errors.New("stage receipt path is required")
+	}
+	info, err := os.Lstat(path)
+	if err != nil {
+		return Verified{}, fmt.Errorf("inspect stage receipt: %w", err)
+	}
+	if !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 || info.Size() <= 0 || info.Size() > maximumReceiptBytes {
+		return Verified{}, errors.New("stage receipt metadata is invalid")
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return Verified{}, fmt.Errorf("open stage receipt: %w", err)
+	}
+	defer file.Close()
+	raw, err := io.ReadAll(io.LimitReader(file, maximumReceiptBytes+1))
+	if err != nil || len(raw) > maximumReceiptBytes {
+		return Verified{}, errors.New("read bounded stage receipt")
+	}
+	return Verify(raw, expectedDigest, plan, predecessors)
+}
+
+func (verified Verified) Receipt() (Receipt, error) {
+	if !verified.verified {
+		return Receipt{}, errors.New("stage receipt was not produced by verification")
+	}
+	receipt := verified.receipt
+	receipt.Predecessors = append([]Predecessor{}, verified.receipt.Predecessors...)
+	return receipt, nil
+}
+
+func (verified Verified) Digest() (string, error) {
+	if !verified.verified || !receiptDigestPattern.MatchString(verified.digest) {
+		return "", errors.New("stage receipt was not produced by verification")
+	}
+	return verified.digest, nil
+}
+
+func (verified Verified) Bytes() ([]byte, error) {
+	if !verified.verified || len(verified.raw) == 0 {
+		return nil, errors.New("stage receipt was not produced by verification")
+	}
+	return append([]byte(nil), verified.raw...), nil
+}
+
+func verifyReceipt(receipt Receipt, plan stageplan.Binding, predecessors []Verified) (Verified, error) {
+	stage, stageDigest, err := plan.Stage(receipt.StageID)
+	if err != nil {
+		return Verified{}, err
+	}
+	if receipt.Format != Format || receipt.PlanDigest != plan.PlanDigest || receipt.ContractIdentity != plan.ContractIdentity || receipt.ContractRevision != plan.IntentRevision || receipt.EnablementRevision != plan.EnablementRevision || receipt.PlatformRevision != plan.PlatformRevision || receipt.ExecutionFixture != plan.ExecutionFixture {
+		return Verified{}, errors.New("stage receipt plan or Contract identity differs")
+	}
+	if receipt.StageOrder != stage.Order || receipt.StageDigest != stageDigest || receipt.Kind != stage.Kind || receipt.Authority != stage.Authority || receipt.Operation != stage.GrantOperation {
+		return Verified{}, errors.New("stage receipt does not bind the exact stage")
+	}
+	expectedLinks, err := verifiedLinks(plan, stage, predecessors)
+	if err != nil {
+		return Verified{}, err
+	}
+	if !equalLinks(receipt.Predecessors, expectedLinks) {
+		return Verified{}, errors.New("stage receipt predecessor chain differs")
+	}
+	if !allowed(receipt.State, "SUCCEEDED", "FAILED", "STOPPED") || !receiptDigestPattern.MatchString(receipt.EvidenceDigest) {
+		return Verified{}, errors.New("stage receipt outcome or evidence digest is invalid")
+	}
+	if stageplan.IsMutating(stage) {
+		if !allowed(receipt.MutationState, "NOT_ATTEMPTED", "ATTEMPTED", "UNKNOWN") || !receiptDigestPattern.MatchString(receipt.OperationOutcomeDigest) {
+			return Verified{}, errors.New("mutating stage receipt lacks a valid operation outcome")
+		}
+		if receipt.State == "SUCCEEDED" && receipt.MutationState != "ATTEMPTED" {
+			return Verified{}, errors.New("successful mutating stage did not attempt mutation")
+		}
+	} else if receipt.MutationState != "NOT_APPLICABLE" || receipt.OperationOutcomeDigest != "" {
+		return Verified{}, errors.New("read-only stage receipt contains mutation state")
+	}
+	if _, err := time.Parse(time.RFC3339Nano, receipt.CompletedAt); err != nil {
+		return Verified{}, errors.New("stage receipt completion time is invalid")
+	}
+	raw, receiptDigest, err := canonicalReceipt(receipt)
+	if err != nil {
+		return Verified{}, err
+	}
+	return Verified{receipt: receipt, digest: receiptDigest, raw: raw, verified: true}, nil
+}
+
+func verifiedLinks(plan stageplan.Binding, stage stageplan.Stage, predecessors []Verified) ([]Predecessor, error) {
+	if predecessors == nil || len(predecessors) != len(stage.Requires) {
+		return nil, errors.New("stage receipt predecessor set is incomplete")
+	}
+	links := make([]Predecessor, len(predecessors))
+	for index, predecessor := range predecessors {
+		receipt, err := predecessor.Receipt()
+		if err != nil {
+			return nil, err
+		}
+		predecessorDigest, err := predecessor.Digest()
+		if err != nil {
+			return nil, err
+		}
+		if receipt.PlanDigest != plan.PlanDigest || receipt.StageID != stage.Requires[index] || receipt.State != "SUCCEEDED" || receipt.StageOrder >= stage.Order {
+			return nil, errors.New("stage receipt predecessor is foreign, unsuccessful or out of order")
+		}
+		links[index] = Predecessor{StageID: receipt.StageID, ReceiptDigest: predecessorDigest}
+	}
+	return links, nil
+}
+
+func canonicalReceipt(receipt Receipt) ([]byte, string, error) {
+	raw, err := json.Marshal(receipt)
+	if err != nil {
+		return nil, "", err
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	var value any
+	if err := decoder.Decode(&value); err != nil {
+		return nil, "", err
+	}
+	canonical, err := contract.JCS(value)
+	if err != nil {
+		return nil, "", err
+	}
+	return canonical, digest.SHA256(canonical), nil
+}
+
+func equalLinks(left, right []Predecessor) bool {
+	if left == nil || right == nil || len(left) != len(right) {
+		return false
+	}
+	for index := range left {
+		if left[index] != right[index] {
+			return false
+		}
+	}
+	return true
+}
+
+func allowed(value string, choices ...string) bool {
+	for _, choice := range choices {
+		if value == choice {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/stagereceipt/receipt_test.go
+++ b/internal/stagereceipt/receipt_test.go
@@ -1,0 +1,148 @@
+package stagereceipt
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/contract"
+	"github.com/openkubes/ok-cluster/internal/stageplan"
+)
+
+func TestReceiptChainIncludesMutatingAndReadOnlyStages(t *testing.T) {
+	plan := receiptPlan(t)
+	at := time.Date(2026, 8, 16, 16, 0, 0, 0, time.UTC)
+	provider, err := New(plan, "provider-prerequisites", []Verified{}, "SUCCEEDED", "ATTEMPTED", receiptSHA("1"), receiptSHA("a"), at)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lifecycle, err := New(plan, "cluster-lifecycle", []Verified{provider}, "SUCCEEDED", "ATTEMPTED", receiptSHA("2"), receiptSHA("b"), at.Add(time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	observation, err := New(plan, "lifecycle-observation", []Verified{lifecycle}, "SUCCEEDED", "NOT_APPLICABLE", "", receiptSHA("c"), at.Add(2*time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := observation.Receipt()
+	if err != nil || receipt.StageID != "lifecycle-observation" || receipt.MutationState != "NOT_APPLICABLE" || len(receipt.Predecessors) != 1 {
+		t.Fatalf("unexpected observation receipt: %#v %v", receipt, err)
+	}
+	lifecycleDigest, _ := lifecycle.Digest()
+	if receipt.Predecessors[0].ReceiptDigest != lifecycleDigest {
+		t.Fatal("observation does not bind the exact lifecycle receipt")
+	}
+	raw, _ := observation.Bytes()
+	observationDigest, _ := observation.Digest()
+	reloaded, err := Verify(raw, observationDigest, plan, []Verified{lifecycle})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reloadedDigest, _ := reloaded.Digest(); reloadedDigest == "" {
+		t.Fatal("verified receipt has no digest")
+	}
+}
+
+func TestReceiptRejectsMissingForeignAndFailedPredecessors(t *testing.T) {
+	plan := receiptPlan(t)
+	at := time.Date(2026, 8, 16, 16, 0, 0, 0, time.UTC)
+	if _, err := New(plan, "provider-prerequisites", nil, "SUCCEEDED", "ATTEMPTED", receiptSHA("1"), receiptSHA("a"), at); err == nil {
+		t.Fatal("omitted empty predecessor set was accepted")
+	}
+	provider, _ := New(plan, "provider-prerequisites", []Verified{}, "SUCCEEDED", "ATTEMPTED", receiptSHA("1"), receiptSHA("a"), at)
+	if _, err := New(plan, "lifecycle-observation", []Verified{provider}, "SUCCEEDED", "NOT_APPLICABLE", "", receiptSHA("b"), at); err == nil {
+		t.Fatal("wrong predecessor stage was accepted")
+	}
+	failedProvider, _ := New(plan, "provider-prerequisites", []Verified{}, "FAILED", "ATTEMPTED", receiptSHA("1"), receiptSHA("a"), at)
+	if _, err := New(plan, "cluster-lifecycle", []Verified{failedProvider}, "SUCCEEDED", "ATTEMPTED", receiptSHA("2"), receiptSHA("b"), at); err == nil {
+		t.Fatal("failed predecessor opened the next stage")
+	}
+}
+
+func TestReceiptEnforcesMutationBoundary(t *testing.T) {
+	plan := receiptPlan(t)
+	at := time.Date(2026, 8, 16, 16, 0, 0, 0, time.UTC)
+	if _, err := New(plan, "provider-prerequisites", []Verified{}, "SUCCEEDED", "NOT_ATTEMPTED", receiptSHA("1"), receiptSHA("a"), at); err == nil {
+		t.Fatal("successful mutation without attempt was accepted")
+	}
+	provider, _ := New(plan, "provider-prerequisites", []Verified{}, "SUCCEEDED", "ATTEMPTED", receiptSHA("1"), receiptSHA("a"), at)
+	lifecycle, _ := New(plan, "cluster-lifecycle", []Verified{provider}, "SUCCEEDED", "ATTEMPTED", receiptSHA("2"), receiptSHA("b"), at)
+	if _, err := New(plan, "lifecycle-observation", []Verified{lifecycle}, "SUCCEEDED", "ATTEMPTED", receiptSHA("3"), receiptSHA("c"), at); err == nil {
+		t.Fatal("read-only stage with mutation state was accepted")
+	}
+}
+
+func TestReceiptVerificationFailsClosedOnTamperingAndSymlink(t *testing.T) {
+	plan := receiptPlan(t)
+	at := time.Date(2026, 8, 16, 16, 0, 0, 0, time.UTC)
+	provider, _ := New(plan, "provider-prerequisites", []Verified{}, "SUCCEEDED", "ATTEMPTED", receiptSHA("1"), receiptSHA("a"), at)
+	raw, _ := provider.Bytes()
+	providerDigest, _ := provider.Digest()
+	tampered := strings.Replace(string(raw), `"state":"SUCCEEDED"`, `"state":"FAILED"`, 1)
+	if _, err := Verify([]byte(tampered), providerDigest, plan, []Verified{}); err == nil {
+		t.Fatal("tampered receipt was accepted")
+	}
+	pretty := map[string]any{}
+	if err := json.Unmarshal(raw, &pretty); err != nil {
+		t.Fatal(err)
+	}
+	nonCanonical, _ := json.MarshalIndent(pretty, "", "  ")
+	if _, err := Verify(nonCanonical, providerDigest, plan, []Verified{}); err == nil {
+		t.Fatal("non-canonical receipt was accepted")
+	}
+	root := t.TempDir()
+	path := filepath.Join(root, "receipt.json")
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(root, "receipt-link.json")
+	if err := os.Symlink(path, link); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Load(link, providerDigest, plan, []Verified{}); err == nil {
+		t.Fatal("symlinked receipt was accepted")
+	}
+}
+
+func receiptPlan(t *testing.T) stageplan.Binding {
+	t.Helper()
+	identity := contract.Identity{Namespace: "disposable-ok147", Name: "disposable-ok147"}
+	ids := []string{"provider-prerequisites", "cluster-lifecycle", "lifecycle-observation", "enablement", "network-observation", "runtime-binding", "target-access", "target-credential", "target-registration", "platform-applications", "platform-observation", "aggregate-evidence"}
+	kinds := []string{"Submission", "Submission", "Observation", "Submission", "Observation", "Binding", "Submission", "Credential", "Submission", "Submission", "Observation", "Evaluation"}
+	authorities := []string{"infrastructure", "management", "management", "management", "workload", "runner", "workload", "workload", "gitops", "gitops", "gitops", "runner"}
+	operations := []string{"CreateProviderPrerequisites", "CreateCluster", "", "CreateEnablement", "", "", "CreateTargetAccess", "IssueTargetCredential", "RegisterTarget", "CreatePlatformApplications", "", ""}
+	stages := make([]map[string]any, len(ids))
+	for index := range ids {
+		requires := []string{}
+		if index > 0 {
+			requires = []string{ids[index-1]}
+		}
+		stages[index] = map[string]any{
+			"id": ids[index], "order": index + 1, "kind": kinds[index], "authority": authorities[index], "requires": requires,
+			"inputs": []map[string]any{{"name": "stage." + ids[index], "digest": receiptSHA(string("abcdef012345"[index]))}},
+		}
+		if operations[index] != "" {
+			stages[index]["grantOperation"] = operations[index]
+		}
+	}
+	raw, _ := json.Marshal(map[string]any{
+		"format": stageplan.Format, "contractIdentity": identity,
+		"intentRevision": receiptSHA("a"), "enablementRevision": receiptSHA("b"), "platformRevision": receiptSHA("c"), "executionFixture": receiptSHA("d"),
+		"authorizationState": "NO-GO",
+		"authorities":        map[string]any{"infrastructure": "ok-infra", "management": "ok-mgmt", "gitOps": "ok-shared", "workloadIdentityMode": "capi-cluster-uid/v1", "runnerIdentityMode": "bounded-job/v1"},
+		"stages":             stages,
+	})
+	plan, err := stageplan.Verify(raw, stageplan.Expected{
+		ContractIdentity: identity, IntentRevision: receiptSHA("a"), EnablementRevision: receiptSHA("b"), PlatformRevision: receiptSHA("c"), ExecutionFixture: receiptSHA("d"),
+		InfrastructureAuthority: "ok-infra", ManagementAuthority: "ok-mgmt", GitOpsAuthority: "ok-shared",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return plan
+}
+
+func receiptSHA(value string) string { return "sha256:" + strings.Repeat(value, 64) }


### PR DESCRIPTION
Adds one canonical receipt chain across all twelve bounded stages.\n\n- binds R/E/P, FixtureDigest, plan and exact stage metadata\n- separates mutating operation outcomes from read-only evidence\n- permits only verified successful direct predecessor receipts\n- requires an independently retained digest for resume verification\n- strengthens per-stage authorization so caller-asserted predecessor digests are insufficient\n\nValidation:\n- go test ./...\n- go vet ./...\n- race tests for stageplan, stagereceipt, authorization, ledger, execution, runner and submission\n- 11 Python repository tests\n\nNo CLI/Job wiring, Kubernetes contact, credential use or infrastructure mutation.