### PR TITLE
Persist immutable stage receipts (OK-147)

### DIFF
--- a/deploy/contract-executor-ledger.yaml
+++ b/deploy/contract-executor-ledger.yaml
@@ -87,8 +87,8 @@ spec:
         'system:serviceaccount:openkubes-execution-system:ok147-contract-executor'
       message: only the bounded contract executor may create ledger ConfigMaps
     - expression: >-
-        object.metadata.name.matches('^ok147-(claim|outcome)-[0-9a-f]{48}$')
-      message: ledger ConfigMap name must bind an exact claim or outcome key
+        object.metadata.name.matches('^ok147-(claim|outcome|receipt)-[0-9a-f]{48}$')
+      message: ledger ConfigMap name must bind an exact claim, outcome or stage-receipt key
     - expression: has(object.immutable) && object.immutable == true
       message: ledger ConfigMaps must be immutable
     - expression: >-
@@ -100,13 +100,15 @@ spec:
         has(object.metadata.labels) && size(object.metadata.labels) == 2 &&
         object.metadata.labels['app.kubernetes.io/managed-by'] ==
         'ok-cluster-contract-executor' &&
-        object.metadata.labels['openkubes.io/ledger-record'] in ['claim', 'outcome']
+        object.metadata.labels['openkubes.io/ledger-record'] in ['claim', 'outcome', 'stage-receipt']
       message: ledger ConfigMap labels are invalid
     - expression: >-
         (object.metadata.name.startsWith('ok147-claim-') &&
         object.metadata.labels['openkubes.io/ledger-record'] == 'claim') ||
         (object.metadata.name.startsWith('ok147-outcome-') &&
-        object.metadata.labels['openkubes.io/ledger-record'] == 'outcome')
+        object.metadata.labels['openkubes.io/ledger-record'] == 'outcome') ||
+        (object.metadata.name.startsWith('ok147-receipt-') &&
+        object.metadata.labels['openkubes.io/ledger-record'] == 'stage-receipt')
       message: ledger record label must match its name
     - expression: >-
         has(object.metadata.annotations) && size(object.metadata.annotations) == 2 &&

--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -840,6 +840,32 @@ predecessor values. The receipt is immutable evidence, not authority: it does
 not consume a grant, execute a stage, retry work or authorize a Kubernetes
 write.
 
+## Durable immutable stage-receipt slots
+
+The receipt chain can now survive process or Job replacement through the same
+create-only ledger boundary used for authorization claims. Each verified plan
+and stage maps to exactly one deterministic receipt slot:
+
+```text
+SHA-256(canonical planDigest + stageId slot identity)
+                         |
+                         v
+       immutable ok147-receipt-<key> ConfigMap
+```
+
+The local ledger uses a private `stage-receipts` directory with exclusive
+`0600` files. The Kubernetes store uses exact-name `GET` and collection
+`POST` only; admission binds the shortened object-name prefix to the distinct
+`stage-receipt` label. Both stores treat an exact create replay as idempotent
+and reject different content for an occupied plan/stage slot. This prevents a
+failed or stopped result from being replaced later by a fabricated success.
+
+Resume still requires the expected receipt digest from an independent binding
+and the complete verified direct-predecessor set. Merely finding a ConfigMap is
+not sufficient. This checkpoint only persists evidence: it does not execute a
+stage, consume a grant, select a retry, contact a cluster during construction,
+or activate the CLI/Job path.
+
 ## Typed first-run Platform capability boundary
 
 First-run capability production now has a separate lazy resolver from the

--- a/internal/ledger/deployment_test.go
+++ b/internal/ledger/deployment_test.go
@@ -85,14 +85,21 @@ func TestKubernetesLedgerDeploymentBoundary(t *testing.T) {
 		t.Fatalf("admission has %d validations, want at least 7", len(validations))
 	}
 	serviceAccountBound := false
+	stageReceiptsBound := false
 	for _, validation := range validations {
 		expression, _ := validation.(map[string]any)["expression"].(string)
 		if bytes.Contains([]byte(expression), []byte("ok147-contract-executor")) {
 			serviceAccountBound = true
 		}
+		if bytes.Contains([]byte(expression), []byte("stage-receipt")) && bytes.Contains([]byte(expression), []byte("ok147-receipt-")) {
+			stageReceiptsBound = true
+		}
 	}
 	if !serviceAccountBound {
 		t.Fatal("admission validations do not bind the exact ServiceAccount")
+	}
+	if !stageReceiptsBound {
+		t.Fatal("admission validations do not bind stage-receipt names and labels")
 	}
 }
 

--- a/internal/ledger/kubernetes.go
+++ b/internal/ledger/kubernetes.go
@@ -217,10 +217,16 @@ func kubernetesRecordIdentity(category, key string) (string, string, error) {
 		recordType = "claim"
 	case "outcomes":
 		recordType = "outcome"
+	case "stage-receipts":
+		recordType = "stage-receipt"
 	default:
 		return "", "", fmt.Errorf("Kubernetes ledger record category %q is invalid", category)
 	}
-	return "ok147-" + recordType + "-" + key[:48], recordType, nil
+	prefix := recordType
+	if recordType == "stage-receipt" {
+		prefix = "receipt"
+	}
+	return "ok147-" + prefix + "-" + key[:48], recordType, nil
 }
 
 func validateCanonicalReceipt(raw []byte) error {

--- a/internal/ledger/ledger.go
+++ b/internal/ledger/ledger.go
@@ -95,11 +95,18 @@ func Open(root string) (*Ledger, error) {
 	if err := secureDirectory(abs); err != nil {
 		return nil, err
 	}
-	store := &fileStore{claims: filepath.Join(abs, "claims"), outcomes: filepath.Join(abs, "outcomes")}
+	store := &fileStore{
+		claims:        filepath.Join(abs, "claims"),
+		outcomes:      filepath.Join(abs, "outcomes"),
+		stageReceipts: filepath.Join(abs, "stage-receipts"),
+	}
 	if err := secureDirectory(store.claims); err != nil {
 		return nil, err
 	}
 	if err := secureDirectory(store.outcomes); err != nil {
+		return nil, err
+	}
+	if err := secureDirectory(store.stageReceipts); err != nil {
 		return nil, err
 	}
 	return New(store)
@@ -328,8 +335,9 @@ func secureDirectory(path string) error {
 }
 
 type fileStore struct {
-	claims   string
-	outcomes string
+	claims        string
+	outcomes      string
+	stageReceipts string
 }
 
 func (store *fileStore) Create(ctx context.Context, category, key string, raw []byte) error {
@@ -374,6 +382,8 @@ func (store *fileStore) path(category, key string) (string, string, error) {
 		directory = store.claims
 	case "outcomes":
 		directory = store.outcomes
+	case "stage-receipts":
+		directory = store.stageReceipts
 	default:
 		return "", "", fmt.Errorf("ledger record category %q is invalid", category)
 	}

--- a/internal/ledger/stage_receipt.go
+++ b/internal/ledger/stage_receipt.go
@@ -1,0 +1,95 @@
+package ledger
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/openkubes/ok-cluster/internal/stageplan"
+	"github.com/openkubes/ok-cluster/internal/stagereceipt"
+)
+
+const stageReceiptSlotFormat = "ok147-stage-receipt-slot/v1"
+
+var ErrStageReceiptConflict = errors.New("a different stage receipt already occupies the immutable slot")
+
+// StoreStageReceipt persists one verified receipt in the deterministic slot
+// for its plan and stage. An exact replay is idempotent; different content for
+// the same slot fails closed.
+func (ledger *Ledger) StoreStageReceipt(ctx context.Context, plan stageplan.Binding, verified stagereceipt.Verified, predecessors []stagereceipt.Verified) (string, error) {
+	receipt, err := verified.Receipt()
+	if err != nil {
+		return "", err
+	}
+	raw, err := verified.Bytes()
+	if err != nil {
+		return "", err
+	}
+	receiptDigest, err := verified.Digest()
+	if err != nil {
+		return "", err
+	}
+	if _, err := stagereceipt.Verify(raw, receiptDigest, plan, predecessors); err != nil {
+		return "", fmt.Errorf("verify stage receipt before persistence: %w", err)
+	}
+	key, err := stageReceiptKey(plan, receipt.StageID)
+	if err != nil {
+		return "", err
+	}
+	if err := ledger.store.Create(ctx, "stage-receipts", key, raw); err == nil {
+		return receiptDigest, nil
+	} else if !errors.Is(err, ErrRecordExists) {
+		return "", fmt.Errorf("write immutable stage receipt: %w", err)
+	}
+	existing, err := ledger.store.Get(ctx, "stage-receipts", key)
+	if err != nil {
+		return "", fmt.Errorf("read existing stage receipt: %w", err)
+	}
+	if !bytes.Equal(existing, raw) {
+		return "", ErrStageReceiptConflict
+	}
+	if _, err := stagereceipt.Verify(existing, receiptDigest, plan, predecessors); err != nil {
+		return "", fmt.Errorf("verify existing stage receipt: %w", err)
+	}
+	return receiptDigest, nil
+}
+
+// LoadStageReceipt reads one deterministic slot and requires the receipt
+// identity to be supplied independently by the caller.
+func (ledger *Ledger) LoadStageReceipt(ctx context.Context, plan stageplan.Binding, stageID, expectedDigest string, predecessors []stagereceipt.Verified) (stagereceipt.Verified, error) {
+	key, err := stageReceiptKey(plan, stageID)
+	if err != nil {
+		return stagereceipt.Verified{}, err
+	}
+	raw, err := ledger.store.Get(ctx, "stage-receipts", key)
+	if err != nil {
+		return stagereceipt.Verified{}, err
+	}
+	verified, err := stagereceipt.Verify(raw, expectedDigest, plan, predecessors)
+	if err != nil {
+		return stagereceipt.Verified{}, fmt.Errorf("verify persisted stage receipt: %w", err)
+	}
+	receipt, err := verified.Receipt()
+	if err != nil || receipt.StageID != stageID {
+		return stagereceipt.Verified{}, errors.New("persisted stage receipt occupies a different stage")
+	}
+	return verified, nil
+}
+
+func stageReceiptKey(plan stageplan.Binding, stageID string) (string, error) {
+	if _, _, err := plan.Stage(stageID); err != nil {
+		return "", err
+	}
+	identity := struct {
+		Format     string `json:"format"`
+		PlanDigest string `json:"planDigest"`
+		StageID    string `json:"stageId"`
+	}{Format: stageReceiptSlotFormat, PlanDigest: plan.PlanDigest, StageID: stageID}
+	_, identityDigest, err := canonicalRecord(identity)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimPrefix(identityDigest, "sha256:"), nil
+}

--- a/internal/ledger/stage_receipt_test.go
+++ b/internal/ledger/stage_receipt_test.go
@@ -1,0 +1,118 @@
+package ledger
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/stagereceipt"
+)
+
+func TestStageReceiptSurvivesLedgerRecreation(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "ledger")
+	first, err := Open(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan := verifiedStagePlan(t)
+	at := time.Date(2026, 8, 16, 17, 0, 0, 0, time.UTC)
+	receipt, err := stagereceipt.New(plan, "provider-prerequisites", []stagereceipt.Verified{}, "SUCCEEDED", "ATTEMPTED", stageSHA("1"), stageSHA("e"), at)
+	if err != nil {
+		t.Fatal(err)
+	}
+	digest, err := first.StoreStageReceipt(context.Background(), plan, receipt, []stagereceipt.Verified{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if replay, err := first.StoreStageReceipt(context.Background(), plan, receipt, []stagereceipt.Verified{}); err != nil || replay != digest {
+		t.Fatalf("exact receipt replay is not idempotent: %s %v", replay, err)
+	}
+
+	replacement, err := Open(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := replacement.LoadStageReceipt(context.Background(), plan, "provider-prerequisites", digest, []stagereceipt.Verified{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loadedDigest, _ := loaded.Digest(); loadedDigest != digest {
+		t.Fatalf("loaded digest = %s, want %s", loadedDigest, digest)
+	}
+	if _, err := replacement.LoadStageReceipt(context.Background(), plan, "provider-prerequisites", stageSHA("f"), []stagereceipt.Verified{}); err == nil {
+		t.Fatal("receipt loaded under a different independently supplied digest")
+	}
+	lifecycle, err := stagereceipt.New(plan, "cluster-lifecycle", []stagereceipt.Verified{loaded}, "SUCCEEDED", "ATTEMPTED", stageSHA("2"), stageSHA("d"), at.Add(time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	lifecycleDigest, err := replacement.StoreStageReceipt(context.Background(), plan, lifecycle, []stagereceipt.Verified{loaded})
+	if err != nil {
+		t.Fatal(err)
+	}
+	lifecycle, err = replacement.LoadStageReceipt(context.Background(), plan, "cluster-lifecycle", lifecycleDigest, []stagereceipt.Verified{loaded})
+	if err != nil {
+		t.Fatal(err)
+	}
+	observation, err := stagereceipt.New(plan, "lifecycle-observation", []stagereceipt.Verified{lifecycle}, "SUCCEEDED", "NOT_APPLICABLE", "", stageSHA("c"), at.Add(2*time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	observationDigest, err := replacement.StoreStageReceipt(context.Background(), plan, observation, []stagereceipt.Verified{lifecycle})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := replacement.LoadStageReceipt(context.Background(), plan, "lifecycle-observation", observationDigest, []stagereceipt.Verified{lifecycle}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestStageReceiptSlotRejectsConflictingOutcome(t *testing.T) {
+	store, err := Open(filepath.Join(t.TempDir(), "ledger"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan := verifiedStagePlan(t)
+	at := time.Date(2026, 8, 16, 17, 0, 0, 0, time.UTC)
+	first, _ := stagereceipt.New(plan, "provider-prerequisites", []stagereceipt.Verified{}, "SUCCEEDED", "ATTEMPTED", stageSHA("1"), stageSHA("e"), at)
+	conflict, _ := stagereceipt.New(plan, "provider-prerequisites", []stagereceipt.Verified{}, "FAILED", "ATTEMPTED", stageSHA("2"), stageSHA("f"), at.Add(time.Second))
+	if _, err := store.StoreStageReceipt(context.Background(), plan, first, []stagereceipt.Verified{}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.StoreStageReceipt(context.Background(), plan, conflict, []stagereceipt.Verified{}); !errors.Is(err, ErrStageReceiptConflict) {
+		t.Fatalf("conflicting receipt = %v, want ErrStageReceiptConflict", err)
+	}
+}
+
+func TestKubernetesStorePersistsStageReceiptByExactSlot(t *testing.T) {
+	api := newFakeConfigMapAPI(t)
+	ledger, err := New(newTestKubernetesStore(t, api.client()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan := verifiedStagePlan(t)
+	receipt, _ := stagereceipt.New(plan, "provider-prerequisites", []stagereceipt.Verified{}, "SUCCEEDED", "ATTEMPTED", stageSHA("1"), stageSHA("e"), time.Date(2026, 8, 16, 17, 0, 0, 0, time.UTC))
+	digest, err := ledger.StoreStageReceipt(context.Background(), plan, receipt, []stagereceipt.Verified{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ledger.LoadStageReceipt(context.Background(), plan, "provider-prerequisites", digest, []stagereceipt.Verified{}); err != nil {
+		t.Fatal(err)
+	}
+	if api.nonExactRequests.Load() != 0 {
+		t.Fatalf("store issued %d non-exact requests", api.nonExactRequests.Load())
+	}
+	key, err := stageReceiptKey(plan, "provider-prerequisites")
+	if err != nil {
+		t.Fatal(err)
+	}
+	name, recordType, err := kubernetesRecordIdentity("stage-receipts", key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(name) > 63 || recordType != "stage-receipt" {
+		t.Fatalf("stage receipt identity = %s/%s", name, recordType)
+	}
+}

--- a/internal/ledger/stage_test.go
+++ b/internal/ledger/stage_test.go
@@ -101,6 +101,35 @@ func TestStageCompletionIsBoundImmutableAndIdempotent(t *testing.T) {
 
 func verifiedStageGrant(t *testing.T, at time.Time) authorization.VerifiedStageGrant {
 	t.Helper()
+	plan := verifiedStagePlan(t)
+	identity := plan.ContractIdentity
+	stage, stageDigest, err := plan.Stage("provider-prerequisites")
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload := authorization.StagePayload{
+		Audience: authorization.StageAudience, GrantID: "ok147-stage-ledger-20260816-01", Decision: "ALLOW",
+		PlanDigest: plan.PlanDigest, ContractIdentity: identity, ContractRevision: plan.IntentRevision,
+		EnablementRevision: plan.EnablementRevision, PlatformRevision: plan.PlatformRevision, ExecutionFixture: plan.ExecutionFixture,
+		StageID: stage.ID, StageOrder: stage.Order, StageDigest: stageDigest, Operation: stage.GrantOperation, Authority: stage.Authority,
+		Predecessors: []authorization.StagePredecessor{},
+		NotBefore:    at.Add(-time.Minute).Format(time.RFC3339), NotAfter: at.Add(20 * time.Minute).Format(time.RFC3339), MaxUses: 1,
+	}
+	publicKey, privateKey, _ := ed25519.GenerateKey(rand.Reader)
+	signed, _ := authorization.StageSigningBytes(payload)
+	document, _ := json.Marshal(map[string]any{
+		"format": authorization.StageFormat, "payload": payload,
+		"signature": map[string]any{"algorithm": "Ed25519", "keyId": digest.SHA256(publicKey), "value": base64.StdEncoding.EncodeToString(ed25519.Sign(privateKey, signed))},
+	})
+	grant, err := authorization.VerifyStage(document, []byte(base64.StdEncoding.EncodeToString(publicKey)), plan, stage.ID, []stagereceipt.Verified{}, at)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return grant
+}
+
+func verifiedStagePlan(t *testing.T) stageplan.Binding {
+	t.Helper()
 	identity := contract.Identity{Namespace: "disposable-ok147", Name: "disposable-ok147"}
 	ids := []string{"provider-prerequisites", "cluster-lifecycle", "lifecycle-observation", "enablement", "network-observation", "runtime-binding", "target-access", "target-credential", "target-registration", "platform-applications", "platform-observation", "aggregate-evidence"}
 	kinds := []string{"Submission", "Submission", "Observation", "Submission", "Observation", "Binding", "Submission", "Credential", "Submission", "Submission", "Observation", "Evaluation"}
@@ -134,29 +163,7 @@ func verifiedStageGrant(t *testing.T, at time.Time) authorization.VerifiedStageG
 	if err != nil {
 		t.Fatal(err)
 	}
-	stage, stageDigest, err := plan.Stage("provider-prerequisites")
-	if err != nil {
-		t.Fatal(err)
-	}
-	payload := authorization.StagePayload{
-		Audience: authorization.StageAudience, GrantID: "ok147-stage-ledger-20260816-01", Decision: "ALLOW",
-		PlanDigest: plan.PlanDigest, ContractIdentity: identity, ContractRevision: plan.IntentRevision,
-		EnablementRevision: plan.EnablementRevision, PlatformRevision: plan.PlatformRevision, ExecutionFixture: plan.ExecutionFixture,
-		StageID: stage.ID, StageOrder: stage.Order, StageDigest: stageDigest, Operation: stage.GrantOperation, Authority: stage.Authority,
-		Predecessors: []authorization.StagePredecessor{},
-		NotBefore:    at.Add(-time.Minute).Format(time.RFC3339), NotAfter: at.Add(20 * time.Minute).Format(time.RFC3339), MaxUses: 1,
-	}
-	publicKey, privateKey, _ := ed25519.GenerateKey(rand.Reader)
-	signed, _ := authorization.StageSigningBytes(payload)
-	document, _ := json.Marshal(map[string]any{
-		"format": authorization.StageFormat, "payload": payload,
-		"signature": map[string]any{"algorithm": "Ed25519", "keyId": digest.SHA256(publicKey), "value": base64.StdEncoding.EncodeToString(ed25519.Sign(privateKey, signed))},
-	})
-	grant, err := authorization.VerifyStage(document, []byte(base64.StdEncoding.EncodeToString(publicKey)), plan, stage.ID, []stagereceipt.Verified{}, at)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return grant
+	return plan
 }
 
 func stageSHA(value string) string { return "sha256:" + strings.Repeat(value, 64) }


### PR DESCRIPTION
Persists the verified twelve-stage receipt chain in deterministic create-only plan/stage slots.\n\n- adds private local stage-receipt storage\n- extends the exact-name Kubernetes ConfigMap ledger and admission candidate\n- makes exact replay idempotent and conflicting outcomes fail closed\n- requires an independently supplied receipt digest and verified predecessor chain on resume\n- covers mutating and read-only receipts across process replacement\n\nValidation:\n- go test ./...\n- go vet ./...\n- race tests for staged and execution packages\n- 11 Python repository tests\n\nNo deployment, CLI/Job activation, credential access or cluster contact.