### PR TITLE
Finalize durable stage outcomes (OK-147)

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -866,6 +866,32 @@ not sufficient. This checkpoint only persists evidence: it does not execute a
 stage, consume a grant, select a retry, contact a cluster during construction,
 or activate the CLI/Job path.
 
+## Durable mutating-stage outcome finalization
+
+A completed mutating-stage ledger outcome can now be transformed into the
+common stage receipt without re-running the operation. Finalization rechecks
+the verified grant against the same staged plan, requires the ledger claim and
+outcome to be complete, and requires the supplied predecessor-receipt set to
+have the exact digest signed into that grant. It then binds the immutable
+ledger outcome digest as `operationOutcomeDigest` and persists the resulting
+stage receipt in its deterministic slot.
+
+This split is intentionally crash-safe:
+
+```text
+claim -> one bounded mutation -> durable outcome
+                                  |
+                    process may disappear here
+                                  |
+                                  v
+                   idempotent receipt finalization
+```
+
+An outcome cannot be finalized against a different predecessor chain, and a
+claimed stage without a durable outcome remains indeterminate. Finalization is
+evidence bookkeeping only; it cannot invoke a stage implementation, create an
+authorization, retry a mutation or turn a failed/stopped receipt into success.
+
 ## Typed first-run Platform capability boundary
 
 First-run capability production now has a separate lazy resolver from the

--- a/internal/ledger/stage_finalize.go
+++ b/internal/ledger/stage_finalize.go
@@ -1,0 +1,83 @@
+package ledger
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/authorization"
+	"github.com/openkubes/ok-cluster/internal/stageplan"
+	"github.com/openkubes/ok-cluster/internal/stagereceipt"
+)
+
+// FinalizeStageReceipt derives and persists the common stage receipt from an
+// already durable mutating-stage outcome. It performs no stage work itself.
+func (ledger *Ledger) FinalizeStageReceipt(ctx context.Context, plan stageplan.Binding, grant authorization.VerifiedStageGrant, predecessors []stagereceipt.Verified) (stagereceipt.Verified, error) {
+	binding, err := grant.ConsumptionBinding()
+	if err != nil {
+		return stagereceipt.Verified{}, err
+	}
+	stage, stageDigest, err := plan.Stage(binding.StageID)
+	if err != nil {
+		return stagereceipt.Verified{}, err
+	}
+	if !stageplan.IsMutating(stage) || binding.PlanDigest != plan.PlanDigest || binding.StageDigest != stageDigest || binding.Operation != stage.GrantOperation || binding.Authority != stage.Authority || binding.ContractRevision != plan.IntentRevision {
+		return stagereceipt.Verified{}, errors.New("stage grant does not bind the mutating stage plan")
+	}
+	predecessorDigest, err := finalizedPredecessorDigest(predecessors)
+	if err != nil {
+		return stagereceipt.Verified{}, err
+	}
+	if predecessorDigest != binding.PredecessorDigest {
+		return stagereceipt.Verified{}, errors.New("stage finalization predecessor receipts differ from authorization")
+	}
+	inspection, err := ledger.InspectStage(ctx, grant)
+	if err != nil {
+		return stagereceipt.Verified{}, err
+	}
+	if inspection.State != "COMPLETED" || inspection.Outcome == nil || inspection.OutcomeDigest == "" {
+		return stagereceipt.Verified{}, errors.New("mutating stage has no durable completed outcome")
+	}
+	completedAt, err := time.Parse(time.RFC3339Nano, inspection.Outcome.CompletedAt)
+	if err != nil {
+		return stagereceipt.Verified{}, errors.New("mutating stage completion time is invalid")
+	}
+	verified, err := stagereceipt.New(
+		plan,
+		stage.ID,
+		predecessors,
+		inspection.Outcome.Outcome,
+		inspection.Outcome.MutationState,
+		inspection.OutcomeDigest,
+		inspection.Outcome.EvidenceDigest,
+		completedAt,
+	)
+	if err != nil {
+		return stagereceipt.Verified{}, fmt.Errorf("derive stage receipt from durable outcome: %w", err)
+	}
+	if _, err := ledger.StoreStageReceipt(ctx, plan, verified, predecessors); err != nil {
+		return stagereceipt.Verified{}, err
+	}
+	return verified, nil
+}
+
+func finalizedPredecessorDigest(predecessors []stagereceipt.Verified) (string, error) {
+	if predecessors == nil {
+		return "", errors.New("stage finalization predecessor set must be explicit")
+	}
+	bindings := make([]authorization.StagePredecessor, len(predecessors))
+	for index, predecessor := range predecessors {
+		receipt, err := predecessor.Receipt()
+		if err != nil {
+			return "", err
+		}
+		receiptDigest, err := predecessor.Digest()
+		if err != nil {
+			return "", err
+		}
+		bindings[index] = authorization.StagePredecessor{StageID: receipt.StageID, OutcomeDigest: receiptDigest}
+	}
+	_, predecessorDigest, err := canonicalRecord(bindings)
+	return predecessorDigest, err
+}

--- a/internal/ledger/stage_finalize_test.go
+++ b/internal/ledger/stage_finalize_test.go
@@ -1,0 +1,90 @@
+package ledger
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/stagereceipt"
+)
+
+func TestFinalizeStageReceiptBridgesDurableOutcome(t *testing.T) {
+	store, err := Open(filepath.Join(t.TempDir(), "ledger"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan := verifiedStagePlan(t)
+	at := time.Date(2026, 8, 16, 18, 0, 0, 0, time.UTC)
+	grant := verifiedStageGrantFor(t, plan, "provider-prerequisites", []stagereceipt.Verified{}, at)
+	claim, err := store.ClaimStage(context.Background(), grant, at)
+	if err != nil {
+		t.Fatal(err)
+	}
+	outcome, err := store.CompleteStage(context.Background(), claim, "SUCCEEDED", "ATTEMPTED", stageSHA("e"), at.Add(time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	inspection, err := store.InspectStage(context.Background(), grant)
+	if err != nil {
+		t.Fatal(err)
+	}
+	verified, err := store.FinalizeStageReceipt(context.Background(), plan, grant, []stagereceipt.Verified{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := verified.Receipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if receipt.State != outcome.Outcome || receipt.MutationState != outcome.MutationState || receipt.OperationOutcomeDigest != inspection.OutcomeDigest || receipt.EvidenceDigest != outcome.EvidenceDigest || receipt.CompletedAt != outcome.CompletedAt {
+		t.Fatalf("final receipt does not bind durable outcome: %#v", receipt)
+	}
+	digest, _ := verified.Digest()
+	if _, err := store.LoadStageReceipt(context.Background(), plan, "provider-prerequisites", digest, []stagereceipt.Verified{}); err != nil {
+		t.Fatal(err)
+	}
+	if replay, err := store.FinalizeStageReceipt(context.Background(), plan, grant, []stagereceipt.Verified{}); err != nil {
+		t.Fatal(err)
+	} else if replayDigest, _ := replay.Digest(); replayDigest != digest {
+		t.Fatal("idempotent finalization changed receipt identity")
+	}
+}
+
+func TestFinalizeStageReceiptRequiresCompletedOutcome(t *testing.T) {
+	store, _ := Open(filepath.Join(t.TempDir(), "ledger"))
+	plan := verifiedStagePlan(t)
+	at := time.Date(2026, 8, 16, 18, 0, 0, 0, time.UTC)
+	grant := verifiedStageGrantFor(t, plan, "provider-prerequisites", []stagereceipt.Verified{}, at)
+	if _, err := store.ClaimStage(context.Background(), grant, at); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.FinalizeStageReceipt(context.Background(), plan, grant, []stagereceipt.Verified{}); err == nil {
+		t.Fatal("claimed but incomplete stage produced a final receipt")
+	}
+}
+
+func TestFinalizeStageReceiptRejectsDifferentPredecessorChain(t *testing.T) {
+	store, _ := Open(filepath.Join(t.TempDir(), "ledger"))
+	plan := verifiedStagePlan(t)
+	at := time.Date(2026, 8, 16, 18, 0, 0, 0, time.UTC)
+	bound, err := stagereceipt.New(plan, "provider-prerequisites", []stagereceipt.Verified{}, "SUCCEEDED", "ATTEMPTED", stageSHA("1"), stageSHA("a"), at)
+	if err != nil {
+		t.Fatal(err)
+	}
+	other, err := stagereceipt.New(plan, "provider-prerequisites", []stagereceipt.Verified{}, "SUCCEEDED", "ATTEMPTED", stageSHA("2"), stageSHA("b"), at.Add(time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	grant := verifiedStageGrantFor(t, plan, "cluster-lifecycle", []stagereceipt.Verified{bound}, at.Add(2*time.Second))
+	claim, err := store.ClaimStage(context.Background(), grant, at.Add(2*time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.CompleteStage(context.Background(), claim, "SUCCEEDED", "ATTEMPTED", stageSHA("e"), at.Add(3*time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.FinalizeStageReceipt(context.Background(), plan, grant, []stagereceipt.Verified{other}); err == nil {
+		t.Fatal("stage outcome was finalized against a different predecessor receipt")
+	}
+}

--- a/internal/ledger/stage_test.go
+++ b/internal/ledger/stage_test.go
@@ -102,17 +102,33 @@ func TestStageCompletionIsBoundImmutableAndIdempotent(t *testing.T) {
 func verifiedStageGrant(t *testing.T, at time.Time) authorization.VerifiedStageGrant {
 	t.Helper()
 	plan := verifiedStagePlan(t)
-	identity := plan.ContractIdentity
-	stage, stageDigest, err := plan.Stage("provider-prerequisites")
+	return verifiedStageGrantFor(t, plan, "provider-prerequisites", []stagereceipt.Verified{}, at)
+}
+
+func verifiedStageGrantFor(t *testing.T, plan stageplan.Binding, stageID string, predecessors []stagereceipt.Verified, at time.Time) authorization.VerifiedStageGrant {
+	t.Helper()
+	stage, stageDigest, err := plan.Stage(stageID)
 	if err != nil {
 		t.Fatal(err)
 	}
+	signedPredecessors := make([]authorization.StagePredecessor, len(predecessors))
+	for index, predecessor := range predecessors {
+		receipt, err := predecessor.Receipt()
+		if err != nil {
+			t.Fatal(err)
+		}
+		receiptDigest, err := predecessor.Digest()
+		if err != nil {
+			t.Fatal(err)
+		}
+		signedPredecessors[index] = authorization.StagePredecessor{StageID: receipt.StageID, OutcomeDigest: receiptDigest}
+	}
 	payload := authorization.StagePayload{
 		Audience: authorization.StageAudience, GrantID: "ok147-stage-ledger-20260816-01", Decision: "ALLOW",
-		PlanDigest: plan.PlanDigest, ContractIdentity: identity, ContractRevision: plan.IntentRevision,
+		PlanDigest: plan.PlanDigest, ContractIdentity: plan.ContractIdentity, ContractRevision: plan.IntentRevision,
 		EnablementRevision: plan.EnablementRevision, PlatformRevision: plan.PlatformRevision, ExecutionFixture: plan.ExecutionFixture,
 		StageID: stage.ID, StageOrder: stage.Order, StageDigest: stageDigest, Operation: stage.GrantOperation, Authority: stage.Authority,
-		Predecessors: []authorization.StagePredecessor{},
+		Predecessors: signedPredecessors,
 		NotBefore:    at.Add(-time.Minute).Format(time.RFC3339), NotAfter: at.Add(20 * time.Minute).Format(time.RFC3339), MaxUses: 1,
 	}
 	publicKey, privateKey, _ := ed25519.GenerateKey(rand.Reader)
@@ -121,7 +137,7 @@ func verifiedStageGrant(t *testing.T, at time.Time) authorization.VerifiedStageG
 		"format": authorization.StageFormat, "payload": payload,
 		"signature": map[string]any{"algorithm": "Ed25519", "keyId": digest.SHA256(publicKey), "value": base64.StdEncoding.EncodeToString(ed25519.Sign(privateKey, signed))},
 	})
-	grant, err := authorization.VerifyStage(document, []byte(base64.StdEncoding.EncodeToString(publicKey)), plan, stage.ID, []stagereceipt.Verified{}, at)
+	grant, err := authorization.VerifyStage(document, []byte(base64.StdEncoding.EncodeToString(publicKey)), plan, stage.ID, predecessors, at)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Bridges an already durable mutating-stage outcome into the common immutable stage receipt.\n\n- rechecks grant, plan, stage, operation and authority\n- requires the exact predecessor receipt set signed into the grant\n- binds the immutable ledger outcome digest into the stage receipt\n- supports idempotent finalization after process replacement\n- rejects claimed-but-incomplete stages and predecessor substitution\n\nValidation: full Go tests, vet, focused race tests and 11 Python repository tests all pass.\n\nNo stage execution, retry, CLI/Job activation, credential use or cluster contact.