### PR TITLE
Select fail-closed stage resume cursor (OK-147)

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -892,6 +892,28 @@ claimed stage without a durable outcome remains indeterminate. Finalization is
 evidence bookkeeping only; it cannot invoke a stage implementation, create an
 authorization, retry a mutation or turn a failed/stopped receipt into success.
 
+## Fail-closed stage resume cursor
+
+The runner can now evaluate an explicit, gap-free prefix of verified receipts
+and select exactly one result: the next stage, completed plan, or permanently
+stopped plan. Every prefix item is reverified from its canonical bytes and
+independently retained digest against the same plan and direct predecessor.
+Receipt completion times must also be monotonic across the chain.
+
+```text
+no receipts                 -> NEXT provider-prerequisites
+successful prefix           -> NEXT exact following stage
+all twelve successful       -> COMPLETED
+FAILED or STOPPED receipt   -> STOPPED, no next stage
+gap / reorder / foreign R   -> verification error
+```
+
+For a `NEXT` result the cursor exposes only the exact stage identity,
+authority, operation, authorization requirement and direct predecessor receipt
+set. It contains no dispatcher, implementation registry, credential, endpoint
+or retry policy. Therefore it can guide a later local or Job runner without
+becoming a second desired-state source or allowing a terminal plan to resume.
+
 ## Typed first-run Platform capability boundary
 
 First-run capability production now has a separate lazy resolver from the

--- a/internal/stagecursor/cursor.go
+++ b/internal/stagecursor/cursor.go
@@ -1,0 +1,148 @@
+// Package stagecursor verifies a durable receipt prefix and selects exactly
+// one next stage. It does not execute, authorize or persist stage work.
+package stagecursor
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/openkubes/ok-cluster/internal/stageplan"
+	"github.com/openkubes/ok-cluster/internal/stagereceipt"
+)
+
+const DecisionFormat = "ok147-stage-cursor-decision/v1"
+
+type Predecessor struct {
+	StageID       string `json:"stageId"`
+	ReceiptDigest string `json:"receiptDigest"`
+}
+
+// Decision is a redaction-safe description of NEXT, COMPLETED or STOPPED.
+type Decision struct {
+	Format                string        `json:"format"`
+	State                 string        `json:"state"`
+	PlanDigest            string        `json:"planDigest"`
+	CompletedStages       int           `json:"completedStages"`
+	StageID               string        `json:"stageId,omitempty"`
+	StageOrder            int           `json:"stageOrder,omitempty"`
+	StageDigest           string        `json:"stageDigest,omitempty"`
+	Kind                  string        `json:"kind,omitempty"`
+	Authority             string        `json:"authority,omitempty"`
+	Operation             string        `json:"operation,omitempty"`
+	RequiresAuthorization bool          `json:"requiresAuthorization"`
+	Predecessors          []Predecessor `json:"predecessors"`
+	TerminalOutcome       string        `json:"terminalOutcome,omitempty"`
+	TerminalReceiptDigest string        `json:"terminalReceiptDigest,omitempty"`
+}
+
+// Cursor can only be produced by evaluating verified canonical receipts.
+type Cursor struct {
+	decision     Decision
+	predecessors []stagereceipt.Verified
+	verified     bool
+}
+
+func (cursor Cursor) Decision() (Decision, error) {
+	if !cursor.verified {
+		return Decision{}, errors.New("stage cursor was not produced by verification")
+	}
+	decision := cursor.decision
+	decision.Predecessors = append([]Predecessor{}, cursor.decision.Predecessors...)
+	return decision, nil
+}
+
+func (cursor Cursor) Predecessors() ([]stagereceipt.Verified, error) {
+	if !cursor.verified {
+		return nil, errors.New("stage cursor was not produced by verification")
+	}
+	return append([]stagereceipt.Verified{}, cursor.predecessors...), nil
+}
+
+// Evaluate verifies an explicit, gap-free receipt prefix and returns the only
+// safe next decision. Any terminal receipt closes the sequence permanently.
+func Evaluate(plan stageplan.Binding, prefix []stagereceipt.Verified) (Cursor, error) {
+	if prefix == nil {
+		return Cursor{}, errors.New("stage receipt prefix must be explicit")
+	}
+	if len(prefix) > len(plan.Stages) {
+		return Cursor{}, errors.New("stage receipt prefix exceeds the staged plan")
+	}
+	previous := []stagereceipt.Verified{}
+	for index, verified := range prefix {
+		expected := plan.Stages[index]
+		raw, err := verified.Bytes()
+		if err != nil {
+			return Cursor{}, err
+		}
+		receiptDigest, err := verified.Digest()
+		if err != nil {
+			return Cursor{}, err
+		}
+		rechecked, err := stagereceipt.Verify(raw, receiptDigest, plan, previous)
+		if err != nil {
+			return Cursor{}, fmt.Errorf("verify stage receipt prefix item %d: %w", index+1, err)
+		}
+		receipt, err := rechecked.Receipt()
+		if err != nil {
+			return Cursor{}, err
+		}
+		if receipt.StageID != expected.ID || receipt.StageOrder != expected.Order {
+			return Cursor{}, errors.New("stage receipt prefix is reordered or contains a gap")
+		}
+		if receipt.State != "SUCCEEDED" {
+			if index != len(prefix)-1 {
+				return Cursor{}, errors.New("stage receipt prefix continues after a terminal outcome")
+			}
+			return verifiedCursor(Decision{
+				Format: DecisionFormat, State: "STOPPED", PlanDigest: plan.PlanDigest,
+				CompletedStages: index, StageID: receipt.StageID, StageOrder: receipt.StageOrder,
+				StageDigest: receipt.StageDigest, Kind: receipt.Kind, Authority: receipt.Authority,
+				Operation: receipt.Operation, RequiresAuthorization: false,
+				Predecessors: explicitPredecessors(receipt.Predecessors), TerminalOutcome: receipt.State,
+				TerminalReceiptDigest: receiptDigest,
+			}, nil), nil
+		}
+		previous = []stagereceipt.Verified{rechecked}
+	}
+	if len(prefix) == len(plan.Stages) {
+		return verifiedCursor(Decision{
+			Format: DecisionFormat, State: "COMPLETED", PlanDigest: plan.PlanDigest,
+			CompletedStages: len(prefix), RequiresAuthorization: false, Predecessors: []Predecessor{},
+		}, nil), nil
+	}
+	next, nextDigest, err := plan.Stage(plan.Stages[len(prefix)].ID)
+	if err != nil {
+		return Cursor{}, err
+	}
+	predecessors := make([]Predecessor, len(previous))
+	for index, verified := range previous {
+		receipt, err := verified.Receipt()
+		if err != nil {
+			return Cursor{}, err
+		}
+		receiptDigest, err := verified.Digest()
+		if err != nil {
+			return Cursor{}, err
+		}
+		predecessors[index] = Predecessor{StageID: receipt.StageID, ReceiptDigest: receiptDigest}
+	}
+	return verifiedCursor(Decision{
+		Format: DecisionFormat, State: "NEXT", PlanDigest: plan.PlanDigest,
+		CompletedStages: len(prefix), StageID: next.ID, StageOrder: next.Order,
+		StageDigest: nextDigest, Kind: next.Kind, Authority: next.Authority,
+		Operation: next.GrantOperation, RequiresAuthorization: stageplan.IsMutating(next),
+		Predecessors: predecessors,
+	}, previous), nil
+}
+
+func verifiedCursor(decision Decision, predecessors []stagereceipt.Verified) Cursor {
+	return Cursor{decision: decision, predecessors: append([]stagereceipt.Verified{}, predecessors...), verified: true}
+}
+
+func explicitPredecessors(source []stagereceipt.Predecessor) []Predecessor {
+	result := make([]Predecessor, len(source))
+	for index, predecessor := range source {
+		result[index] = Predecessor{StageID: predecessor.StageID, ReceiptDigest: predecessor.ReceiptDigest}
+	}
+	return result
+}

--- a/internal/stagecursor/cursor_test.go
+++ b/internal/stagecursor/cursor_test.go
@@ -1,0 +1,159 @@
+package stagecursor
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/contract"
+	"github.com/openkubes/ok-cluster/internal/stageplan"
+	"github.com/openkubes/ok-cluster/internal/stagereceipt"
+)
+
+func TestCursorSelectsEveryExactNextStageAndCompletes(t *testing.T) {
+	plan := cursorPlan(t, "e")
+	chain := successfulReceiptChain(t, plan)
+	for completed := 0; completed <= len(chain); completed++ {
+		cursor, err := Evaluate(plan, append([]stagereceipt.Verified{}, chain[:completed]...))
+		if err != nil {
+			t.Fatalf("completed=%d: %v", completed, err)
+		}
+		decision, err := cursor.Decision()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if decision.CompletedStages != completed || decision.PlanDigest != plan.PlanDigest {
+			t.Fatalf("completed=%d decision=%#v", completed, decision)
+		}
+		if completed == len(chain) {
+			if decision.State != "COMPLETED" || decision.StageID != "" || decision.RequiresAuthorization || decision.Predecessors == nil {
+				t.Fatalf("unexpected final decision: %#v", decision)
+			}
+			continue
+		}
+		expected := plan.Stages[completed]
+		if decision.State != "NEXT" || decision.StageID != expected.ID || decision.StageOrder != expected.Order || decision.RequiresAuthorization != stageplan.IsMutating(expected) {
+			t.Fatalf("unexpected next decision: %#v", decision)
+		}
+		predecessors, err := cursor.Predecessors()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if completed == 0 && (predecessors == nil || len(predecessors) != 0) {
+			t.Fatal("first stage lacks an explicit empty predecessor set")
+		}
+		if completed > 0 {
+			digest, _ := chain[completed-1].Digest()
+			if len(predecessors) != 1 || len(decision.Predecessors) != 1 || decision.Predecessors[0].ReceiptDigest != digest {
+				t.Fatalf("next stage does not bind direct predecessor: %#v", decision)
+			}
+		}
+	}
+}
+
+func TestCursorStopsPermanentlyAtTerminalReceipt(t *testing.T) {
+	plan := cursorPlan(t, "e")
+	at := time.Date(2026, 8, 16, 19, 0, 0, 0, time.UTC)
+	failed, err := stagereceipt.New(plan, "provider-prerequisites", []stagereceipt.Verified{}, "FAILED", "ATTEMPTED", cursorSHA("1"), cursorSHA("a"), at)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cursor, err := Evaluate(plan, []stagereceipt.Verified{failed})
+	if err != nil {
+		t.Fatal(err)
+	}
+	decision, _ := cursor.Decision()
+	failedDigest, _ := failed.Digest()
+	if decision.State != "STOPPED" || decision.TerminalOutcome != "FAILED" || decision.TerminalReceiptDigest != failedDigest || decision.CompletedStages != 0 {
+		t.Fatalf("unexpected terminal decision: %#v", decision)
+	}
+	success := successfulReceiptChain(t, plan)
+	if _, err := Evaluate(plan, []stagereceipt.Verified{failed, success[1]}); err == nil {
+		t.Fatal("receipt prefix continued after terminal outcome")
+	}
+}
+
+func TestCursorRejectsNilGapAndForeignPlan(t *testing.T) {
+	plan := cursorPlan(t, "e")
+	chain := successfulReceiptChain(t, plan)
+	if _, err := Evaluate(plan, nil); err == nil {
+		t.Fatal("nil receipt prefix was accepted")
+	}
+	if _, err := Evaluate(plan, []stagereceipt.Verified{chain[0], chain[2]}); err == nil {
+		t.Fatal("gapped receipt prefix was accepted")
+	}
+	foreign := cursorPlan(t, "f")
+	if _, err := Evaluate(foreign, []stagereceipt.Verified{chain[0]}); err == nil {
+		t.Fatal("receipt from a different plan was accepted")
+	}
+	if _, err := (Cursor{}).Decision(); err == nil {
+		t.Fatal("unverified zero-value cursor exposed a decision")
+	}
+}
+
+func successfulReceiptChain(t *testing.T, plan stageplan.Binding) []stagereceipt.Verified {
+	t.Helper()
+	at := time.Date(2026, 8, 16, 19, 0, 0, 0, time.UTC)
+	result := make([]stagereceipt.Verified, 0, len(plan.Stages))
+	predecessors := []stagereceipt.Verified{}
+	for index, stage := range plan.Stages {
+		mutationState := "NOT_APPLICABLE"
+		operationOutcome := ""
+		if stageplan.IsMutating(stage) {
+			mutationState = "ATTEMPTED"
+			operationOutcome = cursorSHA(string("123456789abc"[index]))
+		}
+		receipt, err := stagereceipt.New(plan, stage.ID, predecessors, "SUCCEEDED", mutationState, operationOutcome, cursorSHA(string("abcdef012345"[index])), at.Add(time.Duration(index)*time.Second))
+		if err != nil {
+			t.Fatal(err)
+		}
+		result = append(result, receipt)
+		predecessors = []stagereceipt.Verified{receipt}
+	}
+	return result
+}
+
+func cursorPlan(t *testing.T, firstInput string) stageplan.Binding {
+	t.Helper()
+	identity := contract.Identity{Namespace: "disposable-ok147", Name: "disposable-ok147"}
+	ids := []string{"provider-prerequisites", "cluster-lifecycle", "lifecycle-observation", "enablement", "network-observation", "runtime-binding", "target-access", "target-credential", "target-registration", "platform-applications", "platform-observation", "aggregate-evidence"}
+	kinds := []string{"Submission", "Submission", "Observation", "Submission", "Observation", "Binding", "Submission", "Credential", "Submission", "Submission", "Observation", "Evaluation"}
+	authorities := []string{"infrastructure", "management", "management", "management", "workload", "runner", "workload", "workload", "gitops", "gitops", "gitops", "runner"}
+	operations := []string{"CreateProviderPrerequisites", "CreateCluster", "", "CreateEnablement", "", "", "CreateTargetAccess", "IssueTargetCredential", "RegisterTarget", "CreatePlatformApplications", "", ""}
+	stages := make([]map[string]any, len(ids))
+	for index := range ids {
+		requires := []string{}
+		if index > 0 {
+			requires = []string{ids[index-1]}
+		}
+		inputDigest := cursorSHA(string("abcdef012345"[index]))
+		if index == 0 {
+			inputDigest = cursorSHA(firstInput)
+		}
+		stages[index] = map[string]any{
+			"id": ids[index], "order": index + 1, "kind": kinds[index], "authority": authorities[index], "requires": requires,
+			"inputs": []map[string]any{{"name": "stage." + ids[index], "digest": inputDigest}},
+		}
+		if operations[index] != "" {
+			stages[index]["grantOperation"] = operations[index]
+		}
+	}
+	raw, _ := json.Marshal(map[string]any{
+		"format": stageplan.Format, "contractIdentity": identity,
+		"intentRevision": cursorSHA("a"), "enablementRevision": cursorSHA("b"), "platformRevision": cursorSHA("c"), "executionFixture": cursorSHA("d"),
+		"authorizationState": "NO-GO",
+		"authorities":        map[string]any{"infrastructure": "ok-infra", "management": "ok-mgmt", "gitOps": "ok-shared", "workloadIdentityMode": "capi-cluster-uid/v1", "runnerIdentityMode": "bounded-job/v1"},
+		"stages":             stages,
+	})
+	plan, err := stageplan.Verify(raw, stageplan.Expected{
+		ContractIdentity: identity, IntentRevision: cursorSHA("a"), EnablementRevision: cursorSHA("b"), PlatformRevision: cursorSHA("c"), ExecutionFixture: cursorSHA("d"),
+		InfrastructureAuthority: "ok-infra", ManagementAuthority: "ok-mgmt", GitOpsAuthority: "ok-shared",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return plan
+}
+
+func cursorSHA(value string) string { return "sha256:" + strings.Repeat(value, 64) }

--- a/internal/stagereceipt/receipt.go
+++ b/internal/stagereceipt/receipt.go
@@ -69,7 +69,7 @@ func New(plan stageplan.Binding, stageID string, predecessors []Verified, state,
 	if err != nil {
 		return Verified{}, err
 	}
-	links, err := verifiedLinks(plan, stage, predecessors)
+	links, err := verifiedLinks(plan, stage, predecessors, completedAt)
 	if err != nil {
 		return Verified{}, err
 	}
@@ -166,7 +166,11 @@ func verifyReceipt(receipt Receipt, plan stageplan.Binding, predecessors []Verif
 	if receipt.StageOrder != stage.Order || receipt.StageDigest != stageDigest || receipt.Kind != stage.Kind || receipt.Authority != stage.Authority || receipt.Operation != stage.GrantOperation {
 		return Verified{}, errors.New("stage receipt does not bind the exact stage")
 	}
-	expectedLinks, err := verifiedLinks(plan, stage, predecessors)
+	completedAt, err := time.Parse(time.RFC3339Nano, receipt.CompletedAt)
+	if err != nil {
+		return Verified{}, errors.New("stage receipt completion time is invalid")
+	}
+	expectedLinks, err := verifiedLinks(plan, stage, predecessors, completedAt)
 	if err != nil {
 		return Verified{}, err
 	}
@@ -186,9 +190,6 @@ func verifyReceipt(receipt Receipt, plan stageplan.Binding, predecessors []Verif
 	} else if receipt.MutationState != "NOT_APPLICABLE" || receipt.OperationOutcomeDigest != "" {
 		return Verified{}, errors.New("read-only stage receipt contains mutation state")
 	}
-	if _, err := time.Parse(time.RFC3339Nano, receipt.CompletedAt); err != nil {
-		return Verified{}, errors.New("stage receipt completion time is invalid")
-	}
 	raw, receiptDigest, err := canonicalReceipt(receipt)
 	if err != nil {
 		return Verified{}, err
@@ -196,7 +197,7 @@ func verifyReceipt(receipt Receipt, plan stageplan.Binding, predecessors []Verif
 	return Verified{receipt: receipt, digest: receiptDigest, raw: raw, verified: true}, nil
 }
 
-func verifiedLinks(plan stageplan.Binding, stage stageplan.Stage, predecessors []Verified) ([]Predecessor, error) {
+func verifiedLinks(plan stageplan.Binding, stage stageplan.Stage, predecessors []Verified, completedAt time.Time) ([]Predecessor, error) {
 	if predecessors == nil || len(predecessors) != len(stage.Requires) {
 		return nil, errors.New("stage receipt predecessor set is incomplete")
 	}
@@ -212,6 +213,10 @@ func verifiedLinks(plan stageplan.Binding, stage stageplan.Stage, predecessors [
 		}
 		if receipt.PlanDigest != plan.PlanDigest || receipt.StageID != stage.Requires[index] || receipt.State != "SUCCEEDED" || receipt.StageOrder >= stage.Order {
 			return nil, errors.New("stage receipt predecessor is foreign, unsuccessful or out of order")
+		}
+		predecessorCompletedAt, err := time.Parse(time.RFC3339Nano, receipt.CompletedAt)
+		if err != nil || completedAt.Before(predecessorCompletedAt) {
+			return nil, errors.New("stage receipt completion precedes its predecessor")
 		}
 		links[index] = Predecessor{StageID: receipt.StageID, ReceiptDigest: predecessorDigest}
 	}

--- a/internal/stagereceipt/receipt_test.go
+++ b/internal/stagereceipt/receipt_test.go
@@ -75,6 +75,18 @@ func TestReceiptEnforcesMutationBoundary(t *testing.T) {
 	}
 }
 
+func TestReceiptRejectsCompletionBeforePredecessor(t *testing.T) {
+	plan := receiptPlan(t)
+	at := time.Date(2026, 8, 16, 16, 0, 0, 0, time.UTC)
+	provider, err := New(plan, "provider-prerequisites", []Verified{}, "SUCCEEDED", "ATTEMPTED", receiptSHA("1"), receiptSHA("a"), at)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := New(plan, "cluster-lifecycle", []Verified{provider}, "SUCCEEDED", "ATTEMPTED", receiptSHA("2"), receiptSHA("b"), at.Add(-time.Nanosecond)); err == nil {
+		t.Fatal("stage receipt completed before its predecessor was accepted")
+	}
+}
+
 func TestReceiptVerificationFailsClosedOnTamperingAndSymlink(t *testing.T) {
 	plan := receiptPlan(t)
 	at := time.Date(2026, 8, 16, 16, 0, 0, 0, time.UTC)


### PR DESCRIPTION
Adds a verified resume cursor over the durable twelve-stage receipt chain.\n\n- selects exactly NEXT, COMPLETED or STOPPED\n- rejects nil, gapped, reordered and foreign-plan receipt prefixes\n- permanently closes a plan after FAILED or STOPPED\n- exposes only the exact next stage and direct predecessor set\n- enforces monotonic receipt completion time\n\nValidation: full Go tests, vet, focused race tests and 11 Python repository tests pass.\n\nNo dispatcher, retry policy, credentials, CLI/Job activation or cluster contact.