### PR TITLE
Bind cursor to verified stage grant (OK-147)

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -914,6 +914,19 @@ set. It contains no dispatcher, implementation registry, credential, endpoint
 or retry policy. Therefore it can guide a later local or Job runner without
 becoming a second desired-state source or allowing a terminal plan to resume.
 
+## Cursor-to-grant binding
+
+Selecting a next stage is not claim authority. Before a later runner may claim
+a mutating ledger slot, the verified single-use grant can now be rebound to the
+cursor's exact plan digest, stage identity and digest, operation, authority,
+Contract revision and verified direct-predecessor receipt digest. A read-only
+stage can never accept such a grant, and a grant verified for another stage or
+another predecessor outcome fails closed.
+
+The ledger still owns the final claim-time validity-window and single-use
+checks. This checkpoint adds no stage implementation, dispatcher, mutation,
+credential handling, cluster contact or CLI/Job activation.
+
 ## Typed first-run Platform capability boundary
 
 First-run capability production now has a separate lazy resolver from the

--- a/internal/authorization/stage.go
+++ b/internal/authorization/stage.go
@@ -107,6 +107,30 @@ func (grant VerifiedStageGrant) ConsumptionBinding() (StageConsumptionBinding, e
 	return grant.binding, nil
 }
 
+// BindStageGrant rechecks a verified grant against the exact next mutating
+// stage and its verified direct predecessor receipts before ledger claim.
+func BindStageGrant(grant VerifiedStageGrant, plan stageplan.Binding, expectedStageID string, expectedPredecessors []stagereceipt.Verified) (StageConsumptionBinding, error) {
+	binding, err := grant.ConsumptionBinding()
+	if err != nil {
+		return StageConsumptionBinding{}, err
+	}
+	stage, stageDigest, err := plan.Stage(expectedStageID)
+	if err != nil {
+		return StageConsumptionBinding{}, err
+	}
+	if !stageplan.IsMutating(stage) {
+		return StageConsumptionBinding{}, errors.New("read-only stage cannot bind a mutation grant")
+	}
+	_, predecessorDigest, err := verifiedStagePredecessors(expectedPredecessors, stage.Requires, plan.PlanDigest)
+	if err != nil {
+		return StageConsumptionBinding{}, err
+	}
+	if binding.PlanDigest != plan.PlanDigest || binding.StageID != stage.ID || binding.StageDigest != stageDigest || binding.Operation != stage.GrantOperation || binding.Authority != stage.Authority || binding.PredecessorDigest != predecessorDigest || binding.ContractRevision != plan.IntentRevision {
+		return StageConsumptionBinding{}, errors.New("verified stage grant differs from the selected stage cursor")
+	}
+	return binding, nil
+}
+
 // VerifyStage verifies a signature and binds it to one exact mutating stage
 // from an already verified staged execution plan.
 func VerifyStage(raw, publicKeyRaw []byte, plan stageplan.Binding, expectedStageID string, expectedPredecessors []stagereceipt.Verified, at time.Time) (VerifiedStageGrant, error) {
@@ -222,34 +246,50 @@ func verifyStagePredecessors(payload []StagePredecessor, expected []stagereceipt
 	if payload == nil || expected == nil || len(payload) != len(required) || len(expected) != len(required) {
 		return "", errors.New("stage authorization predecessor set is incomplete")
 	}
+	bindings, predecessorDigest, err := verifiedStagePredecessors(expected, required, planDigest)
+	if err != nil {
+		return "", err
+	}
+	for index := range bindings {
+		if payload[index] != bindings[index] || !stageDigestPattern.MatchString(payload[index].OutcomeDigest) {
+			return "", errors.New("stage authorization predecessor evidence differs")
+		}
+	}
+	return predecessorDigest, nil
+}
+
+func verifiedStagePredecessors(expected []stagereceipt.Verified, required []string, planDigest string) ([]StagePredecessor, string, error) {
+	if expected == nil || len(expected) != len(required) {
+		return nil, "", errors.New("stage authorization predecessor set is incomplete")
+	}
 	bindings := make([]StagePredecessor, len(expected))
 	for index, stageID := range required {
 		receipt, err := expected[index].Receipt()
 		if err != nil {
-			return "", err
+			return nil, "", err
 		}
 		receiptDigest, err := expected[index].Digest()
 		if err != nil {
-			return "", err
+			return nil, "", err
 		}
 		bindings[index] = StagePredecessor{StageID: receipt.StageID, OutcomeDigest: receiptDigest}
-		if receipt.PlanDigest != planDigest || receipt.State != "SUCCEEDED" || bindings[index].StageID != stageID || payload[index] != bindings[index] || !stageDigestPattern.MatchString(payload[index].OutcomeDigest) {
-			return "", errors.New("stage authorization predecessor evidence differs")
+		if receipt.PlanDigest != planDigest || receipt.State != "SUCCEEDED" || bindings[index].StageID != stageID || !stageDigestPattern.MatchString(receiptDigest) {
+			return nil, "", errors.New("stage authorization predecessor evidence differs")
 		}
 	}
 	raw, err := json.Marshal(bindings)
 	if err != nil {
-		return "", err
+		return nil, "", err
 	}
 	decoder := json.NewDecoder(bytes.NewReader(raw))
 	decoder.UseNumber()
 	var value any
 	if err := decoder.Decode(&value); err != nil {
-		return "", err
+		return nil, "", err
 	}
 	canonical, err := contract.JCS(value)
 	if err != nil {
-		return "", err
+		return nil, "", err
 	}
-	return digest.SHA256(canonical), nil
+	return bindings, digest.SHA256(canonical), nil
 }

--- a/internal/authorization/stage_test.go
+++ b/internal/authorization/stage_test.go
@@ -120,6 +120,86 @@ func TestVerifyStageRejectsTamperingAndNonStrictEnvelope(t *testing.T) {
 	}
 }
 
+func TestBindStageGrantAcceptsExactCursorStage(t *testing.T) {
+	plan := stagePlanFixture(t)
+	at := time.Date(2026, 8, 16, 14, 0, 0, 0, time.UTC)
+	publicKey, privateKey, _ := ed25519.GenerateKey(rand.Reader)
+	predecessors := stagePredecessorReceipts(t, plan, "enablement", at)
+	payload := stagePayloadFixture(t, plan, "enablement", at)
+	grant, err := VerifyStage(
+		signStage(t, payload, publicKey, privateKey),
+		[]byte(base64.StdEncoding.EncodeToString(publicKey)),
+		plan,
+		"enablement",
+		predecessors,
+		at,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	binding, err := BindStageGrant(grant, plan, "enablement", predecessors)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if binding.StageID != "enablement" || binding.PlanDigest != plan.PlanDigest || binding.PredecessorDigest != grant.Receipt().PredecessorDigest {
+		t.Fatalf("unexpected cursor binding: %#v", binding)
+	}
+}
+
+func TestBindStageGrantRejectsCrossStageAndSubstitutedPredecessor(t *testing.T) {
+	plan := stagePlanFixture(t)
+	at := time.Date(2026, 8, 16, 14, 0, 0, 0, time.UTC)
+	publicKey, privateKey, _ := ed25519.GenerateKey(rand.Reader)
+	predecessors := stagePredecessorReceipts(t, plan, "enablement", at)
+	payload := stagePayloadFixture(t, plan, "enablement", at)
+	grant, err := VerifyStage(
+		signStage(t, payload, publicKey, privateKey),
+		[]byte(base64.StdEncoding.EncodeToString(publicKey)),
+		plan,
+		"enablement",
+		predecessors,
+		at,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := BindStageGrant(grant, plan, "platform-applications", stagePredecessorReceipts(t, plan, "platform-applications", at)); err == nil {
+		t.Fatal("enablement grant was rebound to the Platform cursor stage")
+	}
+	lifecyclePredecessors := stagePredecessorReceipts(t, plan, "lifecycle-observation", at)
+	alternative, err := stagereceipt.New(plan, "lifecycle-observation", lifecyclePredecessors, "SUCCEEDED", "NOT_APPLICABLE", "", authSHA("d"), at.Add(3*time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := BindStageGrant(grant, plan, "enablement", []stagereceipt.Verified{alternative}); err == nil {
+		t.Fatal("grant was rebound to a substituted predecessor receipt")
+	}
+}
+
+func TestBindStageGrantRejectsUnverifiedGrantAndReadOnlyStage(t *testing.T) {
+	plan := stagePlanFixture(t)
+	at := time.Date(2026, 8, 16, 14, 0, 0, 0, time.UTC)
+	if _, err := BindStageGrant(VerifiedStageGrant{}, plan, "enablement", stagePredecessorReceipts(t, plan, "enablement", at)); err == nil {
+		t.Fatal("unverified stage grant was accepted")
+	}
+	publicKey, privateKey, _ := ed25519.GenerateKey(rand.Reader)
+	predecessors := stagePredecessorReceipts(t, plan, "enablement", at)
+	grant, err := VerifyStage(
+		signStage(t, stagePayloadFixture(t, plan, "enablement", at), publicKey, privateKey),
+		[]byte(base64.StdEncoding.EncodeToString(publicKey)),
+		plan,
+		"enablement",
+		predecessors,
+		at,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := BindStageGrant(grant, plan, "lifecycle-observation", stagePredecessorReceipts(t, plan, "lifecycle-observation", at)); err == nil {
+		t.Fatal("read-only cursor stage accepted a mutation grant")
+	}
+}
+
 func stagePayloadFixture(t *testing.T, plan stageplan.Binding, stageID string, at time.Time) StagePayload {
 	t.Helper()
 	stage, stageDigest, err := plan.Stage(stageID)


### PR DESCRIPTION
## What changed

- rebind a verified single-use stage grant to the exact stage selected by the fail-closed resume cursor
- verify plan, stage digest, operation, authority, Contract revision and direct predecessor receipt digest before ledger claim
- reject read-only stages, cross-stage reuse and substituted predecessor evidence
- document that cursor selection is not mutation authority

## Why

The resume cursor and stage authorization were independently verified, but the hand-off between them was not yet represented by one explicit fail-closed operation. This checkpoint closes that boundary before any typed mutating-stage executor is introduced.

## Impact

This is an offline safety primitive only. It adds no dispatcher, mutation, credential handling, cluster contact or CLI/Job activation.

## Validation

- `go test -ldflags=-linkmode=external ./...`
- `go vet ./...`
- `go test -race -ldflags=-linkmode=external ./internal/stageplan ./internal/stagereceipt ./internal/stagecursor ./internal/authorization ./internal/ledger ./internal/execution ./internal/runner ./internal/submission`
- 11 Python regression tests
- `git diff --check`
