### PR TITLE
Execute one bounded mutating stage (OK-147)

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -927,6 +927,32 @@ The ledger still owns the final claim-time validity-window and single-use
 checks. This checkpoint adds no stage implementation, dispatcher, mutation,
 credential handling, cluster contact or CLI/Job activation.
 
+## One bounded mutating-stage operation
+
+The offline runner core can now compose the cursor and grant boundaries into
+one typed mutating-stage operation:
+
+```text
+verified cursor + exact verified grant + preconstructed typed mutator
+        -> immutable single-use claim
+        -> at most one mutator call
+        -> immutable outcome
+        -> immutable common stage receipt
+```
+
+The mutator is prebound to the exact plan, stage, operation, authority and
+Contract revision. It receives only verified identities; implementation input
+and credentials remain inside that preconstructed capability. It cannot choose
+another operation dynamically. A completed ledger outcome is finalized without
+calling the mutator again, while a claim without an outcome remains
+`CLAIMED_INDETERMINATE_STOP` and cannot be retried.
+
+Non-success results are persisted and close the receipt chain fail-closed. Raw
+mutator errors never enter the redaction-safe orchestration result. This core is
+tested with fake mutators only: no concrete Kubernetes stage implementation,
+credential resolver, dispatcher, cluster contact or CLI/Job activation exists
+at this checkpoint.
+
 ## Typed first-run Platform capability boundary
 
 First-run capability production now has a separate lazy resolver from the

--- a/internal/execution/staged.go
+++ b/internal/execution/staged.go
@@ -1,0 +1,189 @@
+package execution
+
+import (
+	"context"
+	"errors"
+	"regexp"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/authorization"
+	"github.com/openkubes/ok-cluster/internal/contract"
+	"github.com/openkubes/ok-cluster/internal/ledger"
+	"github.com/openkubes/ok-cluster/internal/stagecursor"
+	"github.com/openkubes/ok-cluster/internal/stageplan"
+	"github.com/openkubes/ok-cluster/internal/stagereceipt"
+)
+
+const StagedReceiptFormat = "ok147-staged-operation-run-receipt/v1"
+
+var stagedDigestPattern = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
+
+// StageMutationBinding makes one preconstructed mutator specific to one
+// verified plan stage. The mutator is not a dynamic operation dispatcher.
+type StageMutationBinding struct {
+	PlanDigest       string
+	StageID          string
+	StageDigest      string
+	Operation        string
+	Authority        string
+	ContractRevision string
+}
+
+// StageMutationRequest contains only verified identities. Implementation
+// inputs and credentials remain inside the preconstructed mutator.
+type StageMutationRequest struct {
+	StageMutationBinding
+	ContractIdentity  contract.Identity
+	GrantID           string
+	PredecessorDigest string
+}
+
+// StageMutationResult is the complete redaction-safe result of one call.
+type StageMutationResult struct {
+	Outcome        string
+	MutationState  string
+	EvidenceDigest string
+}
+
+// StageMutator is a single, preconstructed mutation capability.
+type StageMutator interface {
+	Binding() StageMutationBinding
+	Mutate(context.Context, StageMutationRequest) (StageMutationResult, error)
+}
+
+// StagedOperation composes cursor verification, authorization binding,
+// single-use claim, one mutator call, durable outcome and receipt finalization.
+type StagedOperation struct {
+	Ledger  *ledger.Ledger
+	Mutator StageMutator
+	Clock   func() time.Time
+}
+
+// StagedOperationReceipt is redaction-safe orchestration evidence. The
+// immutable stage receipt remains authoritative for chain continuation.
+type StagedOperationReceipt struct {
+	Format             string                      `json:"format"`
+	State              string                      `json:"state"`
+	PlanDigest         string                      `json:"planDigest,omitempty"`
+	StageID            string                      `json:"stageId,omitempty"`
+	Claim              *ledger.StageClaimReceipt   `json:"claim,omitempty"`
+	Outcome            *ledger.StageOutcomeReceipt `json:"outcome,omitempty"`
+	StageReceiptDigest string                      `json:"stageReceiptDigest,omitempty"`
+}
+
+// StageResultError means the operation reached a durable non-success outcome.
+// It never exposes a mutator's raw error.
+type StageResultError struct{ State string }
+
+func (err *StageResultError) Error() string { return "staged operation completed with " + err.State }
+
+// Run invokes at most one mutator. A pre-existing claim without outcome is an
+// indeterminate terminal stop; a durable outcome is finalized without replay.
+func (operation StagedOperation) Run(ctx context.Context, plan stageplan.Binding, cursor stagecursor.Cursor, grant authorization.VerifiedStageGrant) (StagedOperationReceipt, error) {
+	receipt := StagedOperationReceipt{Format: StagedReceiptFormat, State: "PRECLAIM"}
+	if operation.Ledger == nil || operation.Mutator == nil || operation.Clock == nil {
+		return receipt, errors.New("staged operation ledger, mutator, and clock are required")
+	}
+	decision, err := cursor.Decision()
+	if err != nil {
+		return receipt, err
+	}
+	if decision.State != "NEXT" || !decision.RequiresAuthorization || decision.Operation == "" {
+		return receipt, errors.New("stage cursor does not select an authorized mutating stage")
+	}
+	predecessors, err := cursor.Predecessors()
+	if err != nil {
+		return receipt, err
+	}
+	binding, err := authorization.BindStageGrant(grant, plan, decision.StageID, predecessors)
+	if err != nil {
+		return receipt, err
+	}
+	receipt.PlanDigest = binding.PlanDigest
+	receipt.StageID = binding.StageID
+	wantMutation := StageMutationBinding{
+		PlanDigest: binding.PlanDigest, StageID: binding.StageID, StageDigest: binding.StageDigest,
+		Operation: binding.Operation, Authority: binding.Authority, ContractRevision: binding.ContractRevision,
+	}
+	if operation.Mutator.Binding() != wantMutation {
+		return receipt, errors.New("preconstructed mutator differs from the selected authorized stage")
+	}
+	inspection, err := operation.Ledger.InspectStage(ctx, grant)
+	if err != nil {
+		return receipt, err
+	}
+	switch inspection.State {
+	case "COMPLETED":
+		return operation.finalize(ctx, receipt, plan, grant, predecessors, inspection.Outcome)
+	case "AVAILABLE":
+		if !inspection.ClaimAllowed {
+			return receipt, errors.New("available stage grant is not claimable")
+		}
+	case "CLAIMED_INDETERMINATE_STOP":
+		receipt.State = "CLAIMED_INDETERMINATE_STOP"
+		return receipt, errors.New("mutating stage was claimed without a durable outcome")
+	default:
+		return receipt, errors.New("stage ledger returned an unsupported inspection state")
+	}
+	claim, err := operation.Ledger.ClaimStage(ctx, grant, operation.Clock())
+	if err != nil {
+		return receipt, err
+	}
+	receipt.Claim = &claim
+	receipt.State = "CLAIMED_INDETERMINATE_STOP"
+	result, mutationErr := operation.Mutator.Mutate(ctx, StageMutationRequest{
+		StageMutationBinding: wantMutation,
+		ContractIdentity:     plan.ContractIdentity,
+		GrantID:              binding.GrantID,
+		PredecessorDigest:    binding.PredecessorDigest,
+	})
+	if err := validateStageMutationResult(result, mutationErr); err != nil {
+		return receipt, err
+	}
+	outcome, err := operation.Ledger.CompleteStage(ctx, claim, result.Outcome, result.MutationState, result.EvidenceDigest, operation.Clock())
+	if err != nil {
+		return receipt, err
+	}
+	receipt.Outcome = &outcome
+	return operation.finalize(ctx, receipt, plan, grant, predecessors, &outcome)
+}
+
+func (operation StagedOperation) finalize(ctx context.Context, receipt StagedOperationReceipt, plan stageplan.Binding, grant authorization.VerifiedStageGrant, predecessors []stagereceipt.Verified, outcome *ledger.StageOutcomeReceipt) (StagedOperationReceipt, error) {
+	if outcome == nil {
+		return receipt, errors.New("completed stage inspection has no durable outcome")
+	}
+	verified, err := operation.Ledger.FinalizeStageReceipt(ctx, plan, grant, predecessors)
+	if err != nil {
+		return receipt, err
+	}
+	receiptDigest, err := verified.Digest()
+	if err != nil {
+		return receipt, err
+	}
+	receipt.Outcome = outcome
+	receipt.StageReceiptDigest = receiptDigest
+	receipt.State = "COMPLETED_" + outcome.Outcome
+	if outcome.Outcome != "SUCCEEDED" {
+		return receipt, &StageResultError{State: receipt.State}
+	}
+	return receipt, nil
+}
+
+func validateStageMutationResult(result StageMutationResult, mutationErr error) error {
+	if !oneOf(result.Outcome, "SUCCEEDED", "FAILED", "STOPPED") || !oneOf(result.MutationState, "NOT_ATTEMPTED", "ATTEMPTED", "UNKNOWN") || !stagedDigestPattern.MatchString(result.EvidenceDigest) {
+		return errors.New("stage mutator returned an invalid redaction-safe result")
+	}
+	if result.Outcome == "SUCCEEDED" && (result.MutationState != "ATTEMPTED" || mutationErr != nil) {
+		return errors.New("stage mutator reported an inconsistent successful result")
+	}
+	return nil
+}
+
+func oneOf(value string, allowed ...string) bool {
+	for _, candidate := range allowed {
+		if value == candidate {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/execution/staged_test.go
+++ b/internal/execution/staged_test.go
@@ -1,0 +1,256 @@
+package execution
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/authorization"
+	"github.com/openkubes/ok-cluster/internal/contract"
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/ledger"
+	"github.com/openkubes/ok-cluster/internal/stagecursor"
+	"github.com/openkubes/ok-cluster/internal/stageplan"
+	"github.com/openkubes/ok-cluster/internal/stagereceipt"
+)
+
+func TestStagedOperationRunsOneBoundMutationAndResumesFromOutcome(t *testing.T) {
+	plan := stagedPlan(t)
+	at := time.Date(2026, 8, 16, 18, 0, 0, 0, time.UTC)
+	cursor, err := stagecursor.Evaluate(plan, []stagereceipt.Verified{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	grant := stagedGrant(t, plan, "provider-prerequisites", []stagereceipt.Verified{}, at)
+	store, _ := ledger.Open(filepath.Join(t.TempDir(), "ledger"))
+	mutator := &fakeStageMutator{
+		binding: stagedMutationBinding(t, plan, "provider-prerequisites"),
+		result:  StageMutationResult{Outcome: "SUCCEEDED", MutationState: "ATTEMPTED", EvidenceDigest: stagedSHA("e")},
+	}
+	operation := StagedOperation{Ledger: store, Mutator: mutator, Clock: stagedClock(at)}
+	receipt, err := operation.Run(context.Background(), plan, cursor, grant)
+	if err != nil || receipt.State != "COMPLETED_SUCCEEDED" || receipt.StageReceiptDigest == "" || mutator.calls != 1 {
+		t.Fatalf("unexpected staged run: %#v calls=%d err=%v", receipt, mutator.calls, err)
+	}
+	if mutator.request.StageID != "provider-prerequisites" || mutator.request.ContractIdentity != plan.ContractIdentity || mutator.request.GrantID == "" {
+		t.Fatalf("mutator received a different binding: %#v", mutator.request)
+	}
+	verified, err := store.LoadStageReceipt(context.Background(), plan, "provider-prerequisites", receipt.StageReceiptDigest, []stagereceipt.Verified{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	next, err := stagecursor.Evaluate(plan, []stagereceipt.Verified{verified})
+	if err != nil {
+		t.Fatal(err)
+	}
+	decision, _ := next.Decision()
+	if decision.State != "NEXT" || decision.StageID != "cluster-lifecycle" {
+		t.Fatalf("durable receipt did not advance cursor: %#v", decision)
+	}
+	replayed, err := operation.Run(context.Background(), plan, cursor, grant)
+	if err != nil || replayed.StageReceiptDigest != receipt.StageReceiptDigest || mutator.calls != 1 {
+		t.Fatalf("completed outcome replayed mutation: %#v calls=%d err=%v", replayed, mutator.calls, err)
+	}
+}
+
+func TestStagedOperationPersistsRedactedNonSuccessWithoutRetry(t *testing.T) {
+	plan := stagedPlan(t)
+	at := time.Date(2026, 8, 16, 18, 0, 0, 0, time.UTC)
+	cursor, _ := stagecursor.Evaluate(plan, []stagereceipt.Verified{})
+	grant := stagedGrant(t, plan, "provider-prerequisites", []stagereceipt.Verified{}, at)
+	store, _ := ledger.Open(filepath.Join(t.TempDir(), "ledger"))
+	mutator := &fakeStageMutator{
+		binding: stagedMutationBinding(t, plan, "provider-prerequisites"),
+		result:  StageMutationResult{Outcome: "STOPPED", MutationState: "UNKNOWN", EvidenceDigest: stagedSHA("f")},
+		err:     errors.New("secret endpoint detail"),
+	}
+	receipt, err := (StagedOperation{Ledger: store, Mutator: mutator, Clock: stagedClock(at)}).Run(context.Background(), plan, cursor, grant)
+	var resultErr *StageResultError
+	if !errors.As(err, &resultErr) || strings.Contains(err.Error(), "secret") || receipt.State != "COMPLETED_STOPPED" || mutator.calls != 1 {
+		t.Fatalf("non-success was not durably redacted: %#v calls=%d err=%v", receipt, mutator.calls, err)
+	}
+	verified, loadErr := store.LoadStageReceipt(context.Background(), plan, "provider-prerequisites", receipt.StageReceiptDigest, []stagereceipt.Verified{})
+	if loadErr != nil {
+		t.Fatal(loadErr)
+	}
+	terminal, _ := stagecursor.Evaluate(plan, []stagereceipt.Verified{verified})
+	decision, _ := terminal.Decision()
+	if decision.State != "STOPPED" || decision.TerminalOutcome != "STOPPED" {
+		t.Fatalf("non-success receipt did not close the plan: %#v", decision)
+	}
+}
+
+func TestStagedOperationInvalidMutatorResultLeavesIndeterminateClaim(t *testing.T) {
+	plan := stagedPlan(t)
+	at := time.Date(2026, 8, 16, 18, 0, 0, 0, time.UTC)
+	cursor, _ := stagecursor.Evaluate(plan, []stagereceipt.Verified{})
+	grant := stagedGrant(t, plan, "provider-prerequisites", []stagereceipt.Verified{}, at)
+	store, _ := ledger.Open(filepath.Join(t.TempDir(), "ledger"))
+	mutator := &fakeStageMutator{
+		binding: stagedMutationBinding(t, plan, "provider-prerequisites"),
+		result:  StageMutationResult{Outcome: "SUCCEEDED", MutationState: "ATTEMPTED", EvidenceDigest: stagedSHA("e")},
+		err:     errors.New("write result uncertain with sensitive detail"),
+	}
+	operation := StagedOperation{Ledger: store, Mutator: mutator, Clock: stagedClock(at)}
+	receipt, err := operation.Run(context.Background(), plan, cursor, grant)
+	if err == nil || strings.Contains(err.Error(), "sensitive") || receipt.State != "CLAIMED_INDETERMINATE_STOP" || mutator.calls != 1 {
+		t.Fatalf("inconsistent mutator result did not fail closed: %#v calls=%d err=%v", receipt, mutator.calls, err)
+	}
+	inspection, err := store.InspectStage(context.Background(), grant)
+	if err != nil || inspection.State != "CLAIMED_INDETERMINATE_STOP" {
+		t.Fatalf("claim is not durably indeterminate: %#v %v", inspection, err)
+	}
+	if _, err := operation.Run(context.Background(), plan, cursor, grant); err == nil || mutator.calls != 1 {
+		t.Fatalf("indeterminate claim retried mutation: calls=%d err=%v", mutator.calls, err)
+	}
+}
+
+func TestStagedOperationRejectsWrongMutatorBeforeClaim(t *testing.T) {
+	plan := stagedPlan(t)
+	at := time.Date(2026, 8, 16, 18, 0, 0, 0, time.UTC)
+	cursor, _ := stagecursor.Evaluate(plan, []stagereceipt.Verified{})
+	grant := stagedGrant(t, plan, "provider-prerequisites", []stagereceipt.Verified{}, at)
+	store, _ := ledger.Open(filepath.Join(t.TempDir(), "ledger"))
+	mutator := &fakeStageMutator{binding: stagedMutationBinding(t, plan, "provider-prerequisites")}
+	mutator.binding.Operation = "CreateCluster"
+	if _, err := (StagedOperation{Ledger: store, Mutator: mutator, Clock: stagedClock(at)}).Run(context.Background(), plan, cursor, grant); err == nil {
+		t.Fatal("wrong preconstructed mutator was accepted")
+	}
+	inspection, err := store.InspectStage(context.Background(), grant)
+	if err != nil || inspection.State != "AVAILABLE" || mutator.calls != 0 {
+		t.Fatalf("preclaim mismatch consumed grant: %#v calls=%d err=%v", inspection, mutator.calls, err)
+	}
+}
+
+func TestStagedOperationRejectsReadOnlyCursor(t *testing.T) {
+	plan := stagedPlan(t)
+	at := time.Date(2026, 8, 16, 18, 0, 0, 0, time.UTC)
+	first, _ := stagereceipt.New(plan, "provider-prerequisites", []stagereceipt.Verified{}, "SUCCEEDED", "ATTEMPTED", stagedSHA("1"), stagedSHA("e"), at)
+	second, _ := stagereceipt.New(plan, "cluster-lifecycle", []stagereceipt.Verified{first}, "SUCCEEDED", "ATTEMPTED", stagedSHA("2"), stagedSHA("e"), at.Add(time.Second))
+	cursor, err := stagecursor.Evaluate(plan, []stagereceipt.Verified{first, second})
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, _ := ledger.Open(filepath.Join(t.TempDir(), "ledger"))
+	mutator := &fakeStageMutator{}
+	if _, err := (StagedOperation{Ledger: store, Mutator: mutator, Clock: stagedClock(at)}).Run(context.Background(), plan, cursor, authorization.VerifiedStageGrant{}); err == nil || mutator.calls != 0 {
+		t.Fatalf("read-only cursor reached mutator: calls=%d err=%v", mutator.calls, err)
+	}
+}
+
+type fakeStageMutator struct {
+	binding StageMutationBinding
+	result  StageMutationResult
+	err     error
+	calls   int
+	request StageMutationRequest
+}
+
+func (mutator *fakeStageMutator) Binding() StageMutationBinding { return mutator.binding }
+
+func (mutator *fakeStageMutator) Mutate(_ context.Context, request StageMutationRequest) (StageMutationResult, error) {
+	mutator.calls++
+	mutator.request = request
+	return mutator.result, mutator.err
+}
+
+func stagedMutationBinding(t *testing.T, plan stageplan.Binding, stageID string) StageMutationBinding {
+	t.Helper()
+	stage, stageDigest, err := plan.Stage(stageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return StageMutationBinding{
+		PlanDigest: plan.PlanDigest, StageID: stage.ID, StageDigest: stageDigest,
+		Operation: stage.GrantOperation, Authority: stage.Authority, ContractRevision: plan.IntentRevision,
+	}
+}
+
+func stagedGrant(t *testing.T, plan stageplan.Binding, stageID string, predecessors []stagereceipt.Verified, at time.Time) authorization.VerifiedStageGrant {
+	t.Helper()
+	stage, stageDigest, err := plan.Stage(stageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	signedPredecessors := make([]authorization.StagePredecessor, len(predecessors))
+	for index, predecessor := range predecessors {
+		receipt, _ := predecessor.Receipt()
+		receiptDigest, _ := predecessor.Digest()
+		signedPredecessors[index] = authorization.StagePredecessor{StageID: receipt.StageID, OutcomeDigest: receiptDigest}
+	}
+	payload := authorization.StagePayload{
+		Audience: authorization.StageAudience, GrantID: "ok147-staged-operation-20260816-01", Decision: "ALLOW",
+		PlanDigest: plan.PlanDigest, ContractIdentity: plan.ContractIdentity, ContractRevision: plan.IntentRevision,
+		EnablementRevision: plan.EnablementRevision, PlatformRevision: plan.PlatformRevision, ExecutionFixture: plan.ExecutionFixture,
+		StageID: stage.ID, StageOrder: stage.Order, StageDigest: stageDigest, Operation: stage.GrantOperation, Authority: stage.Authority,
+		Predecessors: signedPredecessors,
+		NotBefore:    at.Add(-time.Minute).Format(time.RFC3339), NotAfter: at.Add(20 * time.Minute).Format(time.RFC3339), MaxUses: 1,
+	}
+	publicKey, privateKey, _ := ed25519.GenerateKey(rand.Reader)
+	signed, _ := authorization.StageSigningBytes(payload)
+	raw, _ := json.Marshal(map[string]any{
+		"format": authorization.StageFormat, "payload": payload,
+		"signature": map[string]any{"algorithm": "Ed25519", "keyId": digest.SHA256(publicKey), "value": base64.StdEncoding.EncodeToString(ed25519.Sign(privateKey, signed))},
+	})
+	grant, err := authorization.VerifyStage(raw, []byte(base64.StdEncoding.EncodeToString(publicKey)), plan, stageID, predecessors, at)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return grant
+}
+
+func stagedPlan(t *testing.T) stageplan.Binding {
+	t.Helper()
+	identity := contract.Identity{Namespace: "disposable-ok147", Name: "disposable-ok147"}
+	ids := []string{"provider-prerequisites", "cluster-lifecycle", "lifecycle-observation", "enablement", "network-observation", "runtime-binding", "target-access", "target-credential", "target-registration", "platform-applications", "platform-observation", "aggregate-evidence"}
+	kinds := []string{"Submission", "Submission", "Observation", "Submission", "Observation", "Binding", "Submission", "Credential", "Submission", "Submission", "Observation", "Evaluation"}
+	authorities := []string{"infrastructure", "management", "management", "management", "workload", "runner", "workload", "workload", "gitops", "gitops", "gitops", "runner"}
+	operations := []string{"CreateProviderPrerequisites", "CreateCluster", "", "CreateEnablement", "", "", "CreateTargetAccess", "IssueTargetCredential", "RegisterTarget", "CreatePlatformApplications", "", ""}
+	stages := make([]map[string]any, len(ids))
+	for index := range ids {
+		requires := []string{}
+		if index > 0 {
+			requires = []string{ids[index-1]}
+		}
+		stages[index] = map[string]any{
+			"id": ids[index], "order": index + 1, "kind": kinds[index], "authority": authorities[index], "requires": requires,
+			"inputs": []map[string]any{{"name": "stage." + ids[index], "digest": stagedSHA(string("abcdef012345"[index]))}},
+		}
+		if operations[index] != "" {
+			stages[index]["grantOperation"] = operations[index]
+		}
+	}
+	raw, _ := json.Marshal(map[string]any{
+		"format": stageplan.Format, "contractIdentity": identity,
+		"intentRevision": stagedSHA("a"), "enablementRevision": stagedSHA("b"), "platformRevision": stagedSHA("c"), "executionFixture": stagedSHA("d"),
+		"authorizationState": "NO-GO",
+		"authorities":        map[string]any{"infrastructure": "ok-infra", "management": "ok-mgmt", "gitOps": "ok-shared", "workloadIdentityMode": "capi-cluster-uid/v1", "runnerIdentityMode": "bounded-job/v1"},
+		"stages":             stages,
+	})
+	plan, err := stageplan.Verify(raw, stageplan.Expected{
+		ContractIdentity: identity, IntentRevision: stagedSHA("a"), EnablementRevision: stagedSHA("b"), PlatformRevision: stagedSHA("c"), ExecutionFixture: stagedSHA("d"),
+		InfrastructureAuthority: "ok-infra", ManagementAuthority: "ok-mgmt", GitOpsAuthority: "ok-shared",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return plan
+}
+
+func stagedClock(start time.Time) func() time.Time {
+	next := start
+	return func() time.Time {
+		current := next
+		next = next.Add(time.Second)
+		return current
+	}
+}
+
+func stagedSHA(value string) string { return "sha256:" + strings.Repeat(value, 64) }


### PR DESCRIPTION
## What changed

- add a typed staged operation that composes verified cursor, exact grant, immutable ledger claim, one preconstructed mutator call, durable outcome and common stage receipt
- bind every mutator to one plan, stage, digest, operation, authority and Contract revision
- finalize an already durable outcome without replaying mutation
- stop permanently on a claim without an outcome and persist redacted non-success results

## Why

OK-147 had independently verified primitives for stage selection, per-stage authorization, single-use claims, durable outcomes and stage receipts. This checkpoint connects those primitives while preserving the rule that a process restart must never repeat an indeterminate write.

## Impact

The implementation uses fake mutators only. It adds no concrete Kubernetes mutation, credential resolver, dispatcher, cluster contact or CLI/Job activation.

## Validation

- `go test -ldflags=-linkmode=external ./...`
- `go vet ./...`
- race tests across stage plan, receipts, cursor, authorization, ledger, execution, runner and submission
- 11 Python regression tests
- `git diff --check`
