### PR TITLE
Bind typed submission stages (OK-147)

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -953,6 +953,22 @@ tested with fake mutators only: no concrete Kubernetes stage implementation,
 credential resolver, dispatcher, cluster contact or CLI/Job activation exists
 at this checkpoint.
 
+## Typed Contract-to-CAPI submission stages
+
+The existing bounded exact-create submission primitive now has a typed adapter
+for the first two mutating stages only: `provider-prerequisites` selects the
+verified infrastructure plane and `cluster-lifecycle` selects the verified
+management plane. Construction binds one copied plane to its exact staged-plan
+identity and authority; the runtime request cannot switch plane or operation.
+Enablement and later writes are deliberately rejected by this adapter.
+
+A complete, validated submission receipt becomes redaction-safe stage evidence.
+A partial submission becomes durable `STOPPED` evidence, and an all-unchanged
+pass cannot claim first-run stage success because it attempted no mutation.
+Malformed or foreign receipts stop indeterminately rather than manufacturing a
+stage outcome. Tests use a fake plane submitter: Kubernetes credentials and the
+live client are not yet composed into the staged runner path.
+
 ## Typed first-run Platform capability boundary
 
 First-run capability production now has a separate lazy resolver from the

--- a/internal/execution/staged_submission.go
+++ b/internal/execution/staged_submission.go
@@ -1,0 +1,134 @@
+package execution
+
+import (
+	"context"
+	"errors"
+
+	"github.com/openkubes/ok-cluster/internal/contract"
+	"github.com/openkubes/ok-cluster/internal/stageplan"
+	"github.com/openkubes/ok-cluster/internal/submission"
+)
+
+// PlaneSubmitter is the exact-create capability already implemented by the
+// bounded Kubernetes submission client.
+type PlaneSubmitter interface {
+	Submit(context.Context, submission.Plane) (submission.PlaneReceipt, error)
+}
+
+// SubmissionPlaneMutator is preconstructed for exactly one of the two
+// Contract-to-CAPI projection planes. It cannot select another stage at run
+// time and does not combine authority domains.
+type SubmissionPlaneMutator struct {
+	binding   StageMutationBinding
+	identity  contract.Identity
+	plane     submission.Plane
+	submitter PlaneSubmitter
+}
+
+var _ StageMutator = (*SubmissionPlaneMutator)(nil)
+
+// NewSubmissionPlaneMutator accepts only the provider-prerequisites or
+// cluster-lifecycle stage. Enablement and later writes require their own typed
+// adapters rather than a generic Kubernetes dispatcher.
+func NewSubmissionPlaneMutator(plan stageplan.Binding, stageID string, projected submission.Plan, submitter PlaneSubmitter) (*SubmissionPlaneMutator, error) {
+	if submitter == nil {
+		return nil, errors.New("submission stage requires a bounded plane submitter")
+	}
+	stage, stageDigest, err := plan.Stage(stageID)
+	if err != nil {
+		return nil, err
+	}
+	if projected.Format != submission.PlanFormat || projected.IntentRevision != plan.IntentRevision {
+		return nil, errors.New("submission plan differs from the verified staged plan")
+	}
+	var plane submission.Plane
+	var expectedAuthority string
+	switch stage.ID {
+	case "provider-prerequisites":
+		plane = projected.Infrastructure
+		expectedAuthority = plan.Authorities.Infrastructure
+	case "cluster-lifecycle":
+		plane = projected.Management
+		expectedAuthority = plan.Authorities.Management
+	default:
+		return nil, errors.New("stage has no Contract-to-CAPI submission-plane adapter")
+	}
+	if plane.Identity != expectedAuthority || plane.Role == "" || len(plane.Objects) == 0 {
+		return nil, errors.New("submission plane authority or content differs from the selected stage")
+	}
+	return &SubmissionPlaneMutator{
+		binding: StageMutationBinding{
+			PlanDigest: plan.PlanDigest, StageID: stage.ID, StageDigest: stageDigest,
+			Operation: stage.GrantOperation, Authority: stage.Authority, ContractRevision: plan.IntentRevision,
+		},
+		identity:  plan.ContractIdentity,
+		plane:     cloneSubmissionPlane(plane),
+		submitter: submitter,
+	}, nil
+}
+
+func (mutator *SubmissionPlaneMutator) Binding() StageMutationBinding {
+	if mutator == nil {
+		return StageMutationBinding{}
+	}
+	return mutator.binding
+}
+
+func (mutator *SubmissionPlaneMutator) Mutate(ctx context.Context, request StageMutationRequest) (StageMutationResult, error) {
+	if mutator == nil || request.StageMutationBinding != mutator.binding || request.ContractIdentity != mutator.identity || request.GrantID == "" || !stagedDigestPattern.MatchString(request.PredecessorDigest) {
+		return StageMutationResult{}, errors.New("submission mutation request differs from the preconstructed stage")
+	}
+	receipt, submitErr := mutator.submitter.Submit(ctx, cloneSubmissionPlane(mutator.plane))
+	mutationState, err := validateSubmissionPlaneOutcome(receipt, mutator.plane, submitErr != nil)
+	if err != nil {
+		return StageMutationResult{}, err
+	}
+	evidenceDigest, err := canonicalDigest(receipt)
+	if err != nil {
+		return StageMutationResult{}, errors.New("derive bounded submission evidence")
+	}
+	if submitErr != nil {
+		return StageMutationResult{Outcome: "STOPPED", MutationState: mutationState, EvidenceDigest: evidenceDigest}, errors.New("bounded submission stopped")
+	}
+	if mutationState != "ATTEMPTED" {
+		return StageMutationResult{Outcome: "STOPPED", MutationState: mutationState, EvidenceDigest: evidenceDigest}, nil
+	}
+	return StageMutationResult{Outcome: "SUCCEEDED", MutationState: mutationState, EvidenceDigest: evidenceDigest}, nil
+}
+
+func validateSubmissionPlaneOutcome(receipt submission.PlaneReceipt, plane submission.Plane, stopped bool) (string, error) {
+	wantState := "SUBMITTED"
+	if stopped {
+		wantState = "STOPPED_PARTIAL_OR_UNKNOWN"
+	}
+	if receipt.Format != submission.PlaneReceiptFormat || receipt.Authority != plane.Identity || receipt.Role != plane.Role || receipt.State != wantState || len(receipt.Results) > len(plane.Objects) || (!stopped && len(receipt.Results) != len(plane.Objects)) {
+		return "", errors.New("submission receipt differs from the preconstructed plane")
+	}
+	wantMutation := "NOT_ATTEMPTED"
+	for index, result := range receipt.Results {
+		expected := plane.Objects[index]
+		if result.Identity.APIVersion != expected.Identity.APIVersion || result.Identity.Kind != expected.Identity.Kind || result.Identity.Name != expected.Identity.Name || result.Identity.Namespace != expected.Identity.Namespace || result.Digest != expected.Digest || result.UID == "" || len(result.UID) > 128 {
+			return "", errors.New("submission receipt object differs from the preconstructed plane")
+		}
+		switch result.State {
+		case "CREATED":
+			wantMutation = "ATTEMPTED"
+		case "UNCHANGED":
+		default:
+			return "", errors.New("submission receipt object state is invalid")
+		}
+	}
+	if receipt.MutationState != wantMutation {
+		return "", errors.New("submission receipt mutation state is inconsistent")
+	}
+	return wantMutation, nil
+}
+
+func cloneSubmissionPlane(source submission.Plane) submission.Plane {
+	clone := submission.Plane{Identity: source.Identity, Role: source.Role, Objects: make([]submission.Object, len(source.Objects))}
+	for index, object := range source.Objects {
+		clone.Objects[index] = object
+		clone.Objects[index].Raw = append([]byte(nil), object.Raw...)
+	}
+	return clone
+}

--- a/internal/execution/staged_submission_test.go
+++ b/internal/execution/staged_submission_test.go
@@ -1,0 +1,164 @@
+package execution
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/ledger"
+	"github.com/openkubes/ok-cluster/internal/projection"
+	"github.com/openkubes/ok-cluster/internal/stagecursor"
+	"github.com/openkubes/ok-cluster/internal/stageplan"
+	"github.com/openkubes/ok-cluster/internal/stagereceipt"
+	"github.com/openkubes/ok-cluster/internal/submission"
+)
+
+func TestSubmissionPlaneMutatorCompletesStagedOperation(t *testing.T) {
+	plan := stagedPlan(t)
+	at := time.Date(2026, 8, 16, 18, 0, 0, 0, time.UTC)
+	projected := stagedSubmissionPlan(plan.IntentRevision, plan.Authorities.Infrastructure, plan.Authorities.Management)
+	submitter := &fakePlaneSubmitter{receipt: successfulPlaneReceipt(projected.Infrastructure, "CREATED", "ATTEMPTED")}
+	mutator, err := NewSubmissionPlaneMutator(plan, "provider-prerequisites", projected, submitter)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cursor, _ := stagecursor.Evaluate(plan, []stagereceipt.Verified{})
+	grant := stagedGrant(t, plan, "provider-prerequisites", []stagereceipt.Verified{}, at)
+	store, _ := ledger.Open(filepath.Join(t.TempDir(), "ledger"))
+	receipt, err := (StagedOperation{Ledger: store, Mutator: mutator, Clock: stagedClock(at)}).Run(context.Background(), plan, cursor, grant)
+	if err != nil || receipt.State != "COMPLETED_SUCCEEDED" || receipt.StageReceiptDigest == "" || submitter.calls != 1 {
+		t.Fatalf("typed submission stage did not complete: %#v calls=%d err=%v", receipt, submitter.calls, err)
+	}
+}
+
+func TestSubmissionPlaneMutatorBindsOneAuthorityPlane(t *testing.T) {
+	plan := stagedPlan(t)
+	projected := stagedSubmissionPlan(plan.IntentRevision, plan.Authorities.Infrastructure, plan.Authorities.Management)
+	submitter := &fakePlaneSubmitter{receipt: successfulPlaneReceipt(projected.Infrastructure, "CREATED", "ATTEMPTED")}
+	mutator, err := NewSubmissionPlaneMutator(plan, "provider-prerequisites", projected, submitter)
+	if err != nil {
+		t.Fatal(err)
+	}
+	projected.Infrastructure.Objects[0].Raw[0] = 'x'
+	result, err := mutator.Mutate(context.Background(), stagedMutationRequest(t, plan, mutator.Binding()))
+	if err != nil || result.Outcome != "SUCCEEDED" || result.MutationState != "ATTEMPTED" || result.EvidenceDigest == "" || submitter.calls != 1 {
+		t.Fatalf("unexpected plane mutation: %#v calls=%d err=%v", result, submitter.calls, err)
+	}
+	if string(submitter.plane.Objects[0].Raw) != "{\"apiVersion\":\"v1\",\"kind\":\"Namespace\"}" || submitter.plane.Identity != plan.Authorities.Infrastructure {
+		t.Fatalf("mutator did not retain the verified authority plane: %#v", submitter.plane)
+	}
+}
+
+func TestSubmissionPlaneMutatorNoWriteCannotClaimStageSuccess(t *testing.T) {
+	plan := stagedPlan(t)
+	projected := stagedSubmissionPlan(plan.IntentRevision, plan.Authorities.Infrastructure, plan.Authorities.Management)
+	submitter := &fakePlaneSubmitter{receipt: successfulPlaneReceipt(projected.Management, "UNCHANGED", "NOT_ATTEMPTED")}
+	mutator, err := NewSubmissionPlaneMutator(plan, "cluster-lifecycle", projected, submitter)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := mutator.Mutate(context.Background(), stagedMutationRequest(t, plan, mutator.Binding()))
+	if err != nil || result.Outcome != "STOPPED" || result.MutationState != "NOT_ATTEMPTED" {
+		t.Fatalf("no-write submission claimed success: %#v %v", result, err)
+	}
+}
+
+func TestSubmissionPlaneMutatorPreservesPartialStoppedEvidence(t *testing.T) {
+	plan := stagedPlan(t)
+	projected := stagedSubmissionPlan(plan.IntentRevision, plan.Authorities.Infrastructure, plan.Authorities.Management)
+	receipt := successfulPlaneReceipt(projected.Infrastructure, "CREATED", "ATTEMPTED")
+	receipt.State = "STOPPED_PARTIAL_OR_UNKNOWN"
+	submitter := &fakePlaneSubmitter{receipt: receipt, err: errors.New("sensitive API detail")}
+	mutator, _ := NewSubmissionPlaneMutator(plan, "provider-prerequisites", projected, submitter)
+	result, err := mutator.Mutate(context.Background(), stagedMutationRequest(t, plan, mutator.Binding()))
+	if err == nil || err.Error() != "bounded submission stopped" || result.Outcome != "STOPPED" || result.MutationState != "ATTEMPTED" || result.EvidenceDigest == "" {
+		t.Fatalf("partial submission result was not redacted and retained: %#v %v", result, err)
+	}
+}
+
+func TestSubmissionPlaneMutatorRejectsWrongStageAuthorityAndRequest(t *testing.T) {
+	plan := stagedPlan(t)
+	projected := stagedSubmissionPlan(plan.IntentRevision, plan.Authorities.Infrastructure, plan.Authorities.Management)
+	submitter := &fakePlaneSubmitter{}
+	if _, err := NewSubmissionPlaneMutator(plan, "enablement", projected, submitter); err == nil {
+		t.Fatal("generic submission adapter accepted Enablement stage")
+	}
+	wrong := projected
+	wrong.Infrastructure.Identity = plan.Authorities.Management
+	if _, err := NewSubmissionPlaneMutator(plan, "provider-prerequisites", wrong, submitter); err == nil {
+		t.Fatal("submission adapter accepted a different authority plane")
+	}
+	mutator, _ := NewSubmissionPlaneMutator(plan, "provider-prerequisites", projected, submitter)
+	request := stagedMutationRequest(t, plan, mutator.Binding())
+	request.ContractIdentity.Name = "another-cluster"
+	if _, err := mutator.Mutate(context.Background(), request); err == nil || submitter.calls != 0 {
+		t.Fatalf("foreign mutation request reached submitter: calls=%d err=%v", submitter.calls, err)
+	}
+}
+
+func TestSubmissionPlaneMutatorRejectsMalformedReceipt(t *testing.T) {
+	plan := stagedPlan(t)
+	projected := stagedSubmissionPlan(plan.IntentRevision, plan.Authorities.Infrastructure, plan.Authorities.Management)
+	receipt := successfulPlaneReceipt(projected.Infrastructure, "CREATED", "ATTEMPTED")
+	receipt.Results[0].Digest = stagedSHA("0")
+	submitter := &fakePlaneSubmitter{receipt: receipt}
+	mutator, _ := NewSubmissionPlaneMutator(plan, "provider-prerequisites", projected, submitter)
+	if _, err := mutator.Mutate(context.Background(), stagedMutationRequest(t, plan, mutator.Binding())); err == nil {
+		t.Fatal("malformed submission receipt was accepted")
+	}
+}
+
+type fakePlaneSubmitter struct {
+	receipt submission.PlaneReceipt
+	err     error
+	calls   int
+	plane   submission.Plane
+}
+
+func (submitter *fakePlaneSubmitter) Submit(_ context.Context, plane submission.Plane) (submission.PlaneReceipt, error) {
+	submitter.calls++
+	submitter.plane = plane
+	return submitter.receipt, submitter.err
+}
+
+func stagedSubmissionPlan(revision, infrastructure, management string) submission.Plan {
+	object := func(apiVersion, kind, namespace, name, value string) submission.Object {
+		return submission.Object{
+			Identity: projection.ResourceIdentity{APIVersion: apiVersion, Kind: kind, Namespace: namespace, Name: name},
+			Digest:   stagedSHA(value), CollectionPath: "/apis/example/v1/resources", ObjectPath: "/apis/example/v1/resources/" + name,
+			Raw: json.RawMessage("{\"apiVersion\":\"v1\",\"kind\":\"Namespace\"}"),
+		}
+	}
+	return submission.Plan{
+		Format: submission.PlanFormat, IntentRevision: revision, AuthorityMapDigest: stagedSHA("9"),
+		Infrastructure: submission.Plane{Identity: infrastructure, Role: "provider-runtime-and-golden-image-prerequisites", Objects: []submission.Object{object("v1", "Namespace", "", "disposable-ok147", "7")}},
+		Management:     submission.Plane{Identity: management, Role: "single-lifecycle-writer", Objects: []submission.Object{object("cluster.x-k8s.io/v1beta2", "Cluster", "disposable-ok147", "disposable-ok147", "8")}},
+	}
+}
+
+func successfulPlaneReceipt(plane submission.Plane, state, mutationState string) submission.PlaneReceipt {
+	results := make([]submission.ObjectResult, len(plane.Objects))
+	for index, object := range plane.Objects {
+		results[index] = submission.ObjectResult{
+			Identity: submission.ObjectIdentity{APIVersion: object.Identity.APIVersion, Kind: object.Identity.Kind, Namespace: object.Identity.Namespace, Name: object.Identity.Name},
+			Digest:   object.Digest, UID: "runtime-object-uid", State: state,
+		}
+	}
+	return submission.PlaneReceipt{
+		Format: submission.PlaneReceiptFormat, Authority: plane.Identity, Role: plane.Role,
+		State: "SUBMITTED", MutationState: mutationState, Results: results,
+	}
+}
+
+func stagedMutationRequest(t *testing.T, plan stageplan.Binding, binding StageMutationBinding) StageMutationRequest {
+	t.Helper()
+	return StageMutationRequest{
+		StageMutationBinding: binding,
+		ContractIdentity:     plan.ContractIdentity,
+		GrantID:              "ok147-stage-grant-20260816-01",
+		PredecessorDigest:    stagedSHA("6"),
+	}
+}


### PR DESCRIPTION
## What changed

- add a typed adapter for only the `provider-prerequisites` and `cluster-lifecycle` exact-create stages
- bind a copied, verified submission plane to its exact staged plan and authority
- convert complete or partial plane receipts into redaction-safe staged-operation outcomes
- reject Enablement/later writes, foreign authorities, foreign runtime requests and malformed receipts

## Why

The staged runner core needs concrete operation types without becoming a generic Kubernetes dispatcher. These first two adapters reuse the existing bounded exact-GET/create-only submission mechanism while keeping infrastructure and management authority separate.

## Impact

Tests use fake plane submitters only. No credentials are opened and no Kubernetes API is contacted.

## Validation

- `go test -ldflags=-linkmode=external ./...`
- `go vet ./...`
- race tests across the staged execution boundary and runtime packages
- 11 Python regression tests
- `git diff --check`
