### PR TITLE
Open bounded submission stage operation (OK-147)

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -969,6 +969,21 @@ Malformed or foreign receipts stop indeterminately rather than manufacturing a
 stage outcome. Tests use a fake plane submitter: Kubernetes credentials and the
 live client are not yet composed into the staged runner path.
 
+## Runtime composition for one submission stage
+
+The runner package can now construct one staged submission operation from an
+explicit ledger credential, one explicit write-authority credential, the
+verified staged plan and the already verified projection plan. The selected
+stage determines exactly one expected authority: infrastructure for provider
+prerequisites or management for Cluster lifecycle. Ledger and writer tokens
+must be distinct even when both APIs are served by `ok-mgmt`.
+
+Construction reads bounded token and CA files and creates redirect-denying TLS
+clients, but makes no API request. The returned `execution.StagedOperation` is
+environment-neutral: the same value can be invoked by a later local CLI path or
+ephemeral Job path. Invocation, artifact loading, cursor/grant loading and CLI
+activation remain outside this checkpoint.
+
 ## Typed first-run Platform capability boundary
 
 First-run capability production now has a separate lazy resolver from the

--- a/internal/runner/kubernetes.go
+++ b/internal/runner/kubernetes.go
@@ -94,20 +94,29 @@ func InspectKubernetesLedger(ctx context.Context, grant authorization.VerifiedGr
 // bounded projected files. The caller is responsible for using a short-lived
 // token with the dedicated ledger ServiceAccount.
 func OpenKubernetesLedger(config KubernetesLedgerConfig) (*ledger.Ledger, error) {
+	store, _, err := openKubernetesLedger(config)
+	return store, err
+}
+
+func openKubernetesLedger(config KubernetesLedgerConfig) (*ledger.Ledger, string, error) {
 	if config.Endpoint == "" || config.Namespace == "" || config.TokenFile == "" || config.CAFile == "" {
-		return nil, errors.New("Kubernetes ledger endpoint, namespace, token file, and CA file are required")
+		return nil, "", errors.New("Kubernetes ledger endpoint, namespace, token file, and CA file are required")
 	}
 	token, client, err := openBoundedKubernetesHTTP(config.TokenFile, config.CAFile)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	backend, err := ledger.NewKubernetesStore(ledger.KubernetesStoreConfig{
 		Endpoint: config.Endpoint, Namespace: config.Namespace, BearerToken: token, Client: client,
 	})
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
-	return ledger.New(backend)
+	store, err := ledger.New(backend)
+	if err != nil {
+		return nil, "", err
+	}
+	return store, token, nil
 }
 
 // OpenKubernetesSubmissionClient materializes a redirect-denying TLS client

--- a/internal/runner/staged_submission_operation.go
+++ b/internal/runner/staged_submission_operation.go
@@ -1,0 +1,64 @@
+package runner
+
+import (
+	"crypto/subtle"
+	"errors"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/execution"
+	"github.com/openkubes/ok-cluster/internal/stageplan"
+	"github.com/openkubes/ok-cluster/internal/submission"
+)
+
+// KubernetesSubmissionStageOperationConfig binds one staged exact-create
+// operation to one ledger and one write authority. It has no authority map,
+// dispatcher, retry or fallback credential.
+type KubernetesSubmissionStageOperationConfig struct {
+	Ledger     KubernetesLedgerConfig
+	Authority  KubernetesAuthorityConfig
+	Plan       stageplan.Binding
+	StageID    string
+	Projection submission.Plan
+	Clock      func() time.Time
+}
+
+// OpenKubernetesSubmissionStageOperation constructs the same staged operation
+// usable by a local process or ephemeral Job. Construction reads bounded
+// credential files but performs no Kubernetes API request.
+func OpenKubernetesSubmissionStageOperation(config KubernetesSubmissionStageOperationConfig) (execution.StagedOperation, error) {
+	if config.Clock == nil {
+		return execution.StagedOperation{}, errors.New("staged submission operation clock is required")
+	}
+	stage, _, err := config.Plan.Stage(config.StageID)
+	if err != nil {
+		return execution.StagedOperation{}, err
+	}
+	var expectedAuthority string
+	switch stage.ID {
+	case "provider-prerequisites":
+		expectedAuthority = config.Plan.Authorities.Infrastructure
+	case "cluster-lifecycle":
+		expectedAuthority = config.Plan.Authorities.Management
+	default:
+		return execution.StagedOperation{}, errors.New("stage has no Kubernetes submission-operation composition")
+	}
+	if config.Authority.AuthorityIdentity != expectedAuthority {
+		return execution.StagedOperation{}, errors.New("submission credential authority differs from the selected stage")
+	}
+	store, ledgerToken, err := openKubernetesLedger(config.Ledger)
+	if err != nil {
+		return execution.StagedOperation{}, errors.New("open staged execution ledger")
+	}
+	submitter, authorityToken, err := openKubernetesSubmissionClient(config.Authority)
+	if err != nil {
+		return execution.StagedOperation{}, errors.New("open staged submission authority")
+	}
+	if len(ledgerToken) == len(authorityToken) && subtle.ConstantTimeCompare([]byte(ledgerToken), []byte(authorityToken)) == 1 {
+		return execution.StagedOperation{}, errors.New("ledger and write authority credentials must be distinct")
+	}
+	mutator, err := execution.NewSubmissionPlaneMutator(config.Plan, stage.ID, config.Projection, submitter)
+	if err != nil {
+		return execution.StagedOperation{}, err
+	}
+	return execution.StagedOperation{Ledger: store, Mutator: mutator, Clock: config.Clock}, nil
+}

--- a/internal/runner/staged_submission_operation_test.go
+++ b/internal/runner/staged_submission_operation_test.go
@@ -1,0 +1,160 @@
+package runner
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/contract"
+	"github.com/openkubes/ok-cluster/internal/projection"
+	"github.com/openkubes/ok-cluster/internal/stageplan"
+	"github.com/openkubes/ok-cluster/internal/submission"
+)
+
+func TestOpenKubernetesSubmissionStageOperationBindsOneAuthority(t *testing.T) {
+	plan := runnerStagedPlan(t)
+	config := runnerStagedOperationConfig(t, plan, "provider-prerequisites")
+	operation, err := OpenKubernetesSubmissionStageOperation(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if operation.Ledger == nil || operation.Mutator == nil || operation.Clock == nil {
+		t.Fatalf("incomplete staged operation: %#v", operation)
+	}
+	binding := operation.Mutator.Binding()
+	if binding.StageID != "provider-prerequisites" || binding.Operation != "CreateProviderPrerequisites" || binding.PlanDigest != plan.PlanDigest {
+		t.Fatalf("operation bound a different stage: %#v", binding)
+	}
+}
+
+func TestOpenKubernetesSubmissionStageOperationRejectsAuthorityAndCredentialAliasing(t *testing.T) {
+	plan := runnerStagedPlan(t)
+	config := runnerStagedOperationConfig(t, plan, "cluster-lifecycle")
+	config.Authority.AuthorityIdentity = plan.Authorities.Infrastructure
+	if _, err := OpenKubernetesSubmissionStageOperation(config); err == nil {
+		t.Fatal("different stage authority was accepted")
+	}
+
+	config = runnerStagedOperationConfig(t, plan, "cluster-lifecycle")
+	ledgerToken, err := os.ReadFile(config.Ledger.TokenFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(config.Authority.TokenFile, ledgerToken, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := OpenKubernetesSubmissionStageOperation(config); err == nil {
+		t.Fatal("shared ledger and write credential was accepted")
+	}
+}
+
+func TestOpenKubernetesSubmissionStageOperationRejectsUnsupportedOrForeignInputs(t *testing.T) {
+	plan := runnerStagedPlan(t)
+	config := runnerStagedOperationConfig(t, plan, "provider-prerequisites")
+	config.StageID = "enablement"
+	if _, err := OpenKubernetesSubmissionStageOperation(config); err == nil {
+		t.Fatal("Enablement was accepted by the CAPI submission composition")
+	}
+	config = runnerStagedOperationConfig(t, plan, "provider-prerequisites")
+	config.Projection.IntentRevision = runnerStageSHA("0")
+	if _, err := OpenKubernetesSubmissionStageOperation(config); err == nil {
+		t.Fatal("foreign projection revision was accepted")
+	}
+	config = runnerStagedOperationConfig(t, plan, "provider-prerequisites")
+	config.Clock = nil
+	if _, err := OpenKubernetesSubmissionStageOperation(config); err == nil {
+		t.Fatal("missing explicit clock was accepted")
+	}
+}
+
+func runnerStagedOperationConfig(t *testing.T, plan stageplan.Binding, stageID string) KubernetesSubmissionStageOperationConfig {
+	t.Helper()
+	root := t.TempDir()
+	caPath := filepath.Join(root, "ca.crt")
+	ledgerToken := filepath.Join(root, "ledger-token")
+	authorityToken := filepath.Join(root, "authority-token")
+	for path, value := range map[string][]byte{
+		caPath:         testCA(t),
+		ledgerToken:    []byte("short-lived-ledger-token"),
+		authorityToken: []byte("short-lived-authority-token"),
+	} {
+		if err := os.WriteFile(path, value, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	authority := plan.Authorities.Infrastructure
+	endpoint := "https://192.0.2.11:6443"
+	if stageID == "cluster-lifecycle" {
+		authority = plan.Authorities.Management
+		endpoint = "https://192.0.2.12:6443"
+	}
+	return KubernetesSubmissionStageOperationConfig{
+		Ledger: KubernetesLedgerConfig{
+			Endpoint: "https://192.0.2.12:6443", Namespace: "openkubes-execution-system", TokenFile: ledgerToken, CAFile: caPath,
+		},
+		Authority: KubernetesAuthorityConfig{
+			Endpoint: endpoint, AuthorityIdentity: authority, TokenFile: authorityToken, CAFile: caPath,
+		},
+		Plan: plan, StageID: stageID,
+		Projection: runnerSubmissionPlan(plan.IntentRevision, plan.Authorities.Infrastructure, plan.Authorities.Management),
+		Clock:      func() time.Time { return time.Date(2026, 8, 16, 20, 0, 0, 0, time.UTC) },
+	}
+}
+
+func runnerSubmissionPlan(revision, infrastructure, management string) submission.Plan {
+	object := func(apiVersion, kind, namespace, name, value string) submission.Object {
+		return submission.Object{
+			Identity: projection.ResourceIdentity{APIVersion: apiVersion, Kind: kind, Namespace: namespace, Name: name},
+			Digest:   runnerStageSHA(value), CollectionPath: "/apis/example/v1/resources", ObjectPath: "/apis/example/v1/resources/" + name,
+			Raw: json.RawMessage("{\"apiVersion\":\"v1\",\"kind\":\"Namespace\"}"),
+		}
+	}
+	return submission.Plan{
+		Format: submission.PlanFormat, IntentRevision: revision, AuthorityMapDigest: runnerStageSHA("9"),
+		Infrastructure: submission.Plane{Identity: infrastructure, Role: "provider-runtime-and-golden-image-prerequisites", Objects: []submission.Object{object("v1", "Namespace", "", "disposable-ok147", "7")}},
+		Management:     submission.Plane{Identity: management, Role: "single-lifecycle-writer", Objects: []submission.Object{object("cluster.x-k8s.io/v1beta2", "Cluster", "disposable-ok147", "disposable-ok147", "8")}},
+	}
+}
+
+func runnerStagedPlan(t *testing.T) stageplan.Binding {
+	t.Helper()
+	identity := contract.Identity{Namespace: "disposable-ok147", Name: "disposable-ok147"}
+	ids := []string{"provider-prerequisites", "cluster-lifecycle", "lifecycle-observation", "enablement", "network-observation", "runtime-binding", "target-access", "target-credential", "target-registration", "platform-applications", "platform-observation", "aggregate-evidence"}
+	kinds := []string{"Submission", "Submission", "Observation", "Submission", "Observation", "Binding", "Submission", "Credential", "Submission", "Submission", "Observation", "Evaluation"}
+	authorities := []string{"infrastructure", "management", "management", "management", "workload", "runner", "workload", "workload", "gitops", "gitops", "gitops", "runner"}
+	operations := []string{"CreateProviderPrerequisites", "CreateCluster", "", "CreateEnablement", "", "", "CreateTargetAccess", "IssueTargetCredential", "RegisterTarget", "CreatePlatformApplications", "", ""}
+	stages := make([]map[string]any, len(ids))
+	for index := range ids {
+		requires := []string{}
+		if index > 0 {
+			requires = []string{ids[index-1]}
+		}
+		stages[index] = map[string]any{
+			"id": ids[index], "order": index + 1, "kind": kinds[index], "authority": authorities[index], "requires": requires,
+			"inputs": []map[string]any{{"name": "stage." + ids[index], "digest": runnerStageSHA(string("abcdef012345"[index]))}},
+		}
+		if operations[index] != "" {
+			stages[index]["grantOperation"] = operations[index]
+		}
+	}
+	raw, _ := json.Marshal(map[string]any{
+		"format": stageplan.Format, "contractIdentity": identity,
+		"intentRevision": runnerStageSHA("a"), "enablementRevision": runnerStageSHA("b"), "platformRevision": runnerStageSHA("c"), "executionFixture": runnerStageSHA("d"),
+		"authorizationState": "NO-GO",
+		"authorities":        map[string]any{"infrastructure": "ok-infra", "management": "ok-mgmt", "gitOps": "ok-shared", "workloadIdentityMode": "capi-cluster-uid/v1", "runnerIdentityMode": "bounded-job/v1"},
+		"stages":             stages,
+	})
+	plan, err := stageplan.Verify(raw, stageplan.Expected{
+		ContractIdentity: identity, IntentRevision: runnerStageSHA("a"), EnablementRevision: runnerStageSHA("b"), PlatformRevision: runnerStageSHA("c"), ExecutionFixture: runnerStageSHA("d"),
+		InfrastructureAuthority: "ok-infra", ManagementAuthority: "ok-mgmt", GitOpsAuthority: "ok-shared",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return plan
+}
+
+func runnerStageSHA(value string) string { return "sha256:" + strings.Repeat(value, 64) }


### PR DESCRIPTION
## What changed

- add runtime composition for one typed provider-prerequisites or Cluster-lifecycle stage
- bind one explicit ledger credential and one explicit write-authority credential
- reject authority mismatch and shared ledger/writer token material
- return the same environment-neutral staged operation for future local CLI and ephemeral Job callers

## Why

The staged operation and typed submission adapters need one safe construction boundary before artifact loading and CLI/Job activation can be added. The factory keeps each authority isolated and prevents a ledger credential from becoming a writer credential.

## Impact

Construction reads bounded credential files and builds TLS clients but performs no Kubernetes request. Tests use reserved unreachable endpoints to enforce that property.

## Validation

- `go test -ldflags=-linkmode=external ./...`
- `go vet ./...`
- race tests across staged execution and runtime packages
- 11 Python regression tests
- `git diff --check`
