### PR TITLE
Load bounded stage grants (OK-147)

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -984,6 +984,18 @@ environment-neutral: the same value can be invoked by a later local CLI path or
 ephemeral Job path. Invocation, artifact loading, cursor/grant loading and CLI
 activation remain outside this checkpoint.
 
+## Bounded stage-authorization loading
+
+A signed per-stage grant and its trusted Ed25519 public key can now be loaded
+through one shared file boundary before verification. Both inputs must be
+non-empty regular non-symlink files within separate size limits; source paths
+are neither retained nor disclosed by loader errors. The resulting grant is
+identical to in-memory `VerifyStage` output and remains bound to the exact plan,
+cursor stage, predecessor receipts and evaluation time.
+
+This loader reads and verifies only. It does not consume the grant, construct a
+writer, inspect the ledger, contact Kubernetes or activate a CLI command.
+
 ## Typed first-run Platform capability boundary
 
 First-run capability production now has a separate lazy resolver from the

--- a/internal/authorization/stage.go
+++ b/internal/authorization/stage.go
@@ -7,6 +7,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"os"
 	"regexp"
 	"time"
 
@@ -20,6 +22,9 @@ import (
 const (
 	StageFormat   = "ok147-stage-authorization/v1"
 	StageAudience = "ok-cluster-staged-executor"
+
+	maximumStageGrantBytes = 128 * 1024
+	maximumPublicKeyBytes  = 4 * 1024
 )
 
 var (
@@ -129,6 +134,21 @@ func BindStageGrant(grant VerifiedStageGrant, plan stageplan.Binding, expectedSt
 		return StageConsumptionBinding{}, errors.New("verified stage grant differs from the selected stage cursor")
 	}
 	return binding, nil
+}
+
+// LoadStage reads one bounded regular grant and trusted public-key file before
+// performing the same in-memory verification as VerifyStage. Source paths are
+// never retained in the verified grant or returned errors.
+func LoadStage(grantPath, publicKeyPath string, plan stageplan.Binding, expectedStageID string, expectedPredecessors []stagereceipt.Verified, at time.Time) (VerifiedStageGrant, error) {
+	raw, err := readStageAuthorizationFile(grantPath, maximumStageGrantBytes, "stage authorization")
+	if err != nil {
+		return VerifiedStageGrant{}, err
+	}
+	publicKeyRaw, err := readStageAuthorizationFile(publicKeyPath, maximumPublicKeyBytes, "stage authorization public key")
+	if err != nil {
+		return VerifiedStageGrant{}, err
+	}
+	return VerifyStage(raw, publicKeyRaw, plan, expectedStageID, expectedPredecessors, at)
 }
 
 // VerifyStage verifies a signature and binds it to one exact mutating stage
@@ -292,4 +312,27 @@ func verifiedStagePredecessors(expected []stagereceipt.Verified, required []stri
 		return nil, "", err
 	}
 	return bindings, digest.SHA256(canonical), nil
+}
+
+func readStageAuthorizationFile(path string, maximum int64, label string) ([]byte, error) {
+	if path == "" {
+		return nil, fmt.Errorf("%s path is required", label)
+	}
+	info, err := os.Lstat(path)
+	if err != nil {
+		return nil, fmt.Errorf("inspect %s", label)
+	}
+	if !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 || info.Size() <= 0 || info.Size() > maximum {
+		return nil, fmt.Errorf("%s metadata is invalid", label)
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open %s", label)
+	}
+	defer file.Close()
+	raw, err := io.ReadAll(io.LimitReader(file, maximum+1))
+	if err != nil || len(raw) == 0 || int64(len(raw)) > maximum {
+		return nil, fmt.Errorf("read bounded %s", label)
+	}
+	return raw, nil
 }

--- a/internal/authorization/stage_test.go
+++ b/internal/authorization/stage_test.go
@@ -5,6 +5,8 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -197,6 +199,56 @@ func TestBindStageGrantRejectsUnverifiedGrantAndReadOnlyStage(t *testing.T) {
 	}
 	if _, err := BindStageGrant(grant, plan, "lifecycle-observation", stagePredecessorReceipts(t, plan, "lifecycle-observation", at)); err == nil {
 		t.Fatal("read-only cursor stage accepted a mutation grant")
+	}
+}
+
+func TestLoadStageReadsBoundedGrantAndTrustedKey(t *testing.T) {
+	plan := stagePlanFixture(t)
+	at := time.Date(2026, 8, 16, 14, 0, 0, 0, time.UTC)
+	publicKey, privateKey, _ := ed25519.GenerateKey(rand.Reader)
+	root := t.TempDir()
+	grantPath := filepath.Join(root, "stage-grant.json")
+	keyPath := filepath.Join(root, "stage-authority.pub")
+	if err := os.WriteFile(grantPath, signStage(t, stagePayloadFixture(t, plan, "enablement", at), publicKey, privateKey), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keyPath, []byte(base64.StdEncoding.EncodeToString(publicKey)+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	grant, err := LoadStage(grantPath, keyPath, plan, "enablement", stagePredecessorReceipts(t, plan, "enablement", at), at)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if grant.Receipt().StageID != "enablement" || grant.Receipt().State != "VERIFIED" {
+		t.Fatalf("unexpected loaded grant: %#v", grant.Receipt())
+	}
+}
+
+func TestLoadStageRejectsUnsafeFilesWithoutPathDisclosure(t *testing.T) {
+	plan := stagePlanFixture(t)
+	at := time.Date(2026, 8, 16, 14, 0, 0, 0, time.UTC)
+	publicKey, privateKey, _ := ed25519.GenerateKey(rand.Reader)
+	root := t.TempDir()
+	grantPath := filepath.Join(root, "stage-grant.json")
+	keyPath := filepath.Join(root, "stage-authority.pub")
+	if err := os.WriteFile(grantPath, signStage(t, stagePayloadFixture(t, plan, "enablement", at), publicKey, privateKey), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keyPath, []byte(base64.StdEncoding.EncodeToString(publicKey)), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	linkPath := filepath.Join(root, "grant-link")
+	if err := os.Symlink(grantPath, linkPath); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadStage(linkPath, keyPath, plan, "enablement", stagePredecessorReceipts(t, plan, "enablement", at), at); err == nil || strings.Contains(err.Error(), root) {
+		t.Fatalf("unsafe symlink accepted or disclosed path: %v", err)
+	}
+	if err := os.WriteFile(grantPath, []byte(strings.Repeat("x", maximumStageGrantBytes+1)), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadStage(grantPath, keyPath, plan, "enablement", stagePredecessorReceipts(t, plan, "enablement", at), at); err == nil || strings.Contains(err.Error(), root) {
+		t.Fatalf("oversized grant accepted or disclosed path: %v", err)
 	}
 }
 


### PR DESCRIPTION
## What changed

- add bounded file loading for one signed per-stage authorization and trusted Ed25519 public key
- require regular, non-symlink, non-empty inputs under independent size limits
- preserve the existing exact plan/stage/predecessor/time verification semantics
- ensure loader errors do not retain or disclose source paths

## Why

Local CLI and ephemeral Job entry points need one shared safe file boundary before they may hand a grant to the staged operation. This closes that boundary without consuming a grant or constructing a writer.

## Impact

Read and verify only. No ledger claim, credential use, Kubernetes contact or CLI activation is added.

## Validation

- `go test -ldflags=-linkmode=external ./...`
- `go vet ./...`
- race tests across staged execution and runtime packages
- 11 Python regression tests
- `git diff --check`
