### PR TITLE
Load verified staged run bundle (OK-147)

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -996,6 +996,33 @@ cursor stage, predecessor receipts and evaluation time.
 This loader reads and verifies only. It does not consume the grant, construct a
 writer, inspect the ledger, contact Kubernetes or activate a CLI command.
 
+## Verified staged submission bundle
+
+The first two Contract-to-CAPI stages can now be assembled from one complete
+preclaim artifact chain shared by a future local CLI and ephemeral Job:
+
+```text
+verified staged plan + explicit canonical receipt prefix
+        -> verified NEXT cursor
+        -> exact projection artifact digest bound to the selected stage input
+        -> exact signed single-stage grant
+        -> one verified submission-stage bundle
+```
+
+An explicit empty receipt list is required for the first stage. A successful
+provider receipt advances the same loader to `cluster-lifecycle`; omitted,
+reordered, foreign or changed receipts fail closed. The selected plan input
+must carry the verified raw digest of `ok-infra-prerequisites.yaml` or
+`ok-mgmt-lifecycle.yaml`, so a valid plan and a valid projection cannot be
+combined when they describe different submission content.
+
+Opening the bundle reads independently supplied ledger and one-authority
+credentials, requires the two token contents to differ, and preconstructs the
+same typed operation for every environment. Opening performs no API request;
+only an explicit later `Run` can inspect or claim the ledger and invoke the
+single bound mutator. No CLI command, Job entry point, retry or live cluster
+access is introduced by this checkpoint.
+
 ## Typed first-run Platform capability boundary
 
 First-run capability production now has a separate lazy resolver from the

--- a/internal/runner/staged_submission_bundle.go
+++ b/internal/runner/staged_submission_bundle.go
@@ -1,0 +1,182 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/authorization"
+	"github.com/openkubes/ok-cluster/internal/execution"
+	"github.com/openkubes/ok-cluster/internal/projection"
+	"github.com/openkubes/ok-cluster/internal/stagecursor"
+	"github.com/openkubes/ok-cluster/internal/stageplan"
+	"github.com/openkubes/ok-cluster/internal/stagereceipt"
+	"github.com/openkubes/ok-cluster/internal/submission"
+)
+
+type StageReceiptSource struct {
+	Path   string
+	Digest string
+}
+
+// SubmissionStageBundleConfig contains only independently supplied artifact
+// paths, digests and expected identities. An explicit empty receipt slice is
+// required for the first stage.
+type SubmissionStageBundleConfig struct {
+	PlanPath               string
+	PlanExpected           stageplan.Expected
+	Receipts               []StageReceiptSource
+	GrantPath              string
+	GrantPublicKeyPath     string
+	ProjectionManifestPath string
+	ProjectionRoot         string
+	EvaluationTime         time.Time
+}
+
+// VerifiedSubmissionStageBundle retains only values produced by verification.
+// Its internals are consumed by the shared local/Job runtime below.
+type VerifiedSubmissionStageBundle struct {
+	plan       stageplan.Binding
+	cursor     stagecursor.Cursor
+	grant      authorization.VerifiedStageGrant
+	projection submission.Plan
+	stageID    string
+	verified   bool
+}
+
+type SubmissionStageRuntimeConfig struct {
+	Ledger    KubernetesLedgerConfig
+	Authority KubernetesAuthorityConfig
+	Clock     func() time.Time
+}
+
+type BoundSubmissionStage struct {
+	operation execution.StagedOperation
+	plan      stageplan.Binding
+	cursor    stagecursor.Cursor
+	grant     authorization.VerifiedStageGrant
+	verified  bool
+}
+
+// LoadSubmissionStageBundle verifies the full preclaim artifact chain for one
+// of the two typed Contract-to-CAPI submission stages. It performs no mutation,
+// credential read, ledger access or Kubernetes request.
+func LoadSubmissionStageBundle(config SubmissionStageBundleConfig) (VerifiedSubmissionStageBundle, error) {
+	if config.Receipts == nil {
+		return VerifiedSubmissionStageBundle{}, errors.New("stage receipt prefix must be explicit")
+	}
+	if config.EvaluationTime.IsZero() {
+		return VerifiedSubmissionStageBundle{}, errors.New("stage authorization evaluation time is required")
+	}
+	plan, err := stageplan.Load(config.PlanPath, config.PlanExpected)
+	if err != nil {
+		return VerifiedSubmissionStageBundle{}, err
+	}
+	prefix := make([]stagereceipt.Verified, 0, len(config.Receipts))
+	predecessors := []stagereceipt.Verified{}
+	for _, source := range config.Receipts {
+		verified, err := stagereceipt.Load(source.Path, source.Digest, plan, predecessors)
+		if err != nil {
+			return VerifiedSubmissionStageBundle{}, err
+		}
+		prefix = append(prefix, verified)
+		predecessors = []stagereceipt.Verified{verified}
+	}
+	cursor, err := stagecursor.Evaluate(plan, prefix)
+	if err != nil {
+		return VerifiedSubmissionStageBundle{}, err
+	}
+	decision, err := cursor.Decision()
+	if err != nil {
+		return VerifiedSubmissionStageBundle{}, err
+	}
+	if decision.State != "NEXT" || !decision.RequiresAuthorization {
+		return VerifiedSubmissionStageBundle{}, errors.New("artifact bundle does not select a mutating next stage")
+	}
+	artifactName, inputName, err := submissionStageArtifact(decision.StageID)
+	if err != nil {
+		return VerifiedSubmissionStageBundle{}, err
+	}
+	root := config.ProjectionRoot
+	if root == "" && config.ProjectionManifestPath != "" {
+		root = filepath.Dir(config.ProjectionManifestPath)
+	}
+	projectionBinding, err := projection.Verify(config.ProjectionManifestPath, root, plan.IntentRevision, plan.ContractIdentity)
+	if err != nil {
+		return VerifiedSubmissionStageBundle{}, err
+	}
+	artifactDigest, err := verifiedProjectionArtifact(projectionBinding, artifactName)
+	if err != nil {
+		return VerifiedSubmissionStageBundle{}, err
+	}
+	if err := plan.RequireInput(decision.StageID, inputName, artifactDigest); err != nil {
+		return VerifiedSubmissionStageBundle{}, err
+	}
+	projected, err := submission.Load(root, projectionBinding)
+	if err != nil {
+		return VerifiedSubmissionStageBundle{}, err
+	}
+	directPredecessors, err := cursor.Predecessors()
+	if err != nil {
+		return VerifiedSubmissionStageBundle{}, err
+	}
+	grant, err := authorization.LoadStage(config.GrantPath, config.GrantPublicKeyPath, plan, decision.StageID, directPredecessors, config.EvaluationTime)
+	if err != nil {
+		return VerifiedSubmissionStageBundle{}, err
+	}
+	if _, err := authorization.BindStageGrant(grant, plan, decision.StageID, directPredecessors); err != nil {
+		return VerifiedSubmissionStageBundle{}, err
+	}
+	return VerifiedSubmissionStageBundle{plan: plan, cursor: cursor, grant: grant, projection: projected, stageID: decision.StageID, verified: true}, nil
+}
+
+func (bundle VerifiedSubmissionStageBundle) Decision() (stagecursor.Decision, error) {
+	if !bundle.verified {
+		return stagecursor.Decision{}, errors.New("submission stage bundle was not produced by verification")
+	}
+	return bundle.cursor.Decision()
+}
+
+// Open binds the verified artifact bundle to runtime credentials without
+// invoking it. Local and Job callers receive the same BoundSubmissionStage.
+func (bundle VerifiedSubmissionStageBundle) Open(config SubmissionStageRuntimeConfig) (BoundSubmissionStage, error) {
+	if !bundle.verified {
+		return BoundSubmissionStage{}, errors.New("submission stage bundle was not produced by verification")
+	}
+	operation, err := OpenKubernetesSubmissionStageOperation(KubernetesSubmissionStageOperationConfig{
+		Ledger: config.Ledger, Authority: config.Authority, Plan: bundle.plan,
+		StageID: bundle.stageID, Projection: bundle.projection, Clock: config.Clock,
+	})
+	if err != nil {
+		return BoundSubmissionStage{}, err
+	}
+	return BoundSubmissionStage{operation: operation, plan: bundle.plan, cursor: bundle.cursor, grant: bundle.grant, verified: true}, nil
+}
+
+func (stage BoundSubmissionStage) Run(ctx context.Context) (execution.StagedOperationReceipt, error) {
+	if !stage.verified {
+		return execution.StagedOperationReceipt{}, errors.New("submission stage runtime was not produced by verification")
+	}
+	return stage.operation.Run(ctx, stage.plan, stage.cursor, stage.grant)
+}
+
+func submissionStageArtifact(stageID string) (string, string, error) {
+	switch stageID {
+	case "provider-prerequisites":
+		return "ok-infra-prerequisites.yaml", "projection.provider-prerequisites", nil
+	case "cluster-lifecycle":
+		return "ok-mgmt-lifecycle.yaml", "projection.cluster-lifecycle", nil
+	default:
+		return "", "", errors.New("next stage has no Contract-to-CAPI artifact binding")
+	}
+}
+
+func verifiedProjectionArtifact(binding projection.Binding, name string) (string, error) {
+	for _, artifact := range binding.Artifacts {
+		if artifact.Name == name {
+			return artifact.Digest, nil
+		}
+	}
+	return "", errors.New("verified projection does not contain the selected stage artifact")
+}

--- a/internal/runner/staged_submission_bundle_test.go
+++ b/internal/runner/staged_submission_bundle_test.go
@@ -1,0 +1,279 @@
+package runner
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/authorization"
+	"github.com/openkubes/ok-cluster/internal/contract"
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/stageplan"
+	"github.com/openkubes/ok-cluster/internal/stagereceipt"
+)
+
+func TestLoadSubmissionStageBundleSelectsBoundProjectionStage(t *testing.T) {
+	for _, completedProvider := range []bool{false, true} {
+		name := "provider-prerequisites"
+		if completedProvider {
+			name = "cluster-lifecycle"
+		}
+		t.Run(name, func(t *testing.T) {
+			fixture := submissionBundleFixture(t, completedProvider, "")
+			bundle, err := LoadSubmissionStageBundle(fixture.config)
+			if err != nil {
+				t.Fatal(err)
+			}
+			decision, err := bundle.Decision()
+			if err != nil || decision.StageID != name || decision.State != "NEXT" || !decision.RequiresAuthorization {
+				t.Fatalf("unexpected decision: %#v %v", decision, err)
+			}
+		})
+	}
+}
+
+func TestLoadSubmissionStageBundleRejectsImplicitPrefixAndProjectionMismatch(t *testing.T) {
+	fixture := submissionBundleFixture(t, false, "")
+	fixture.config.Receipts = nil
+	if _, err := LoadSubmissionStageBundle(fixture.config); err == nil {
+		t.Fatal("implicit empty receipt prefix was accepted")
+	}
+
+	fixture = submissionBundleFixture(t, false, bundleSHA("f"))
+	if _, err := LoadSubmissionStageBundle(fixture.config); err == nil || !strings.Contains(err.Error(), "differs from verified artifact") {
+		t.Fatalf("projection digest mismatch was accepted: %v", err)
+	}
+}
+
+func TestSubmissionStageBundleOpenIsOfflineAndRequiresDistinctCredentials(t *testing.T) {
+	fixture := submissionBundleFixture(t, false, "")
+	bundle, err := LoadSubmissionStageBundle(fixture.config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runtime := submissionBundleRuntime(t, fixture.plan, "provider-prerequisites")
+	bound, err := bundle.Open(runtime)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bound.verified {
+		t.Fatal("opened runtime is not marked verified")
+	}
+
+	authorityToken, err := os.ReadFile(runtime.Authority.TokenFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(runtime.Ledger.TokenFile, authorityToken, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := bundle.Open(runtime); err == nil {
+		t.Fatal("shared ledger and writer credential was accepted")
+	}
+	if _, err := (VerifiedSubmissionStageBundle{}).Open(runtime); err == nil {
+		t.Fatal("unverified bundle was opened")
+	}
+}
+
+type submissionBundleTestFixture struct {
+	config SubmissionStageBundleConfig
+	plan   stageplan.Binding
+}
+
+func submissionBundleFixture(t *testing.T, completedProvider bool, overrideProviderDigest string) submissionBundleTestFixture {
+	t.Helper()
+	root := t.TempDir()
+	at := time.Date(2026, 8, 16, 14, 0, 0, 0, time.UTC)
+	identity := contract.Identity{Namespace: "disposable-ok147", Name: "disposable-ok147"}
+	revision := bundleSHA("a")
+	infra := []byte("apiVersion: v1\nkind: Namespace\nmetadata:\n  name: disposable-ok147\n  annotations:\n    openkubes.io/contract-name: disposable-ok147\n    openkubes.io/contract-namespace: disposable-ok147\n    openkubes.io/intent-revision: " + revision + "\n")
+	management := []byte("apiVersion: cluster.x-k8s.io/v1beta2\nkind: Cluster\nmetadata:\n  name: disposable-ok147\n  namespace: disposable-ok147\n  annotations:\n    openkubes.io/contract-name: disposable-ok147\n    openkubes.io/contract-namespace: disposable-ok147\n    openkubes.io/intent-revision: " + revision + "\nspec:\n  clusterNetwork:\n    services:\n      cidrBlocks: [10.100.0.0/20]\n")
+	authority := mustJSON(t, map[string]any{
+		"format": "ok141-contract-to-capi-projection/v2", "contractIdentity": identity, "intentRevision": revision,
+		"infrastructurePlane": map[string]any{
+			"identity": "ok-infra", "role": "provider-runtime-and-golden-image-prerequisites",
+			"resources": []map[string]any{{"apiVersion": "v1", "kind": "Namespace", "name": "disposable-ok147"}},
+		},
+		"managementPlane": map[string]any{
+			"identity": "ok-mgmt", "role": "single-lifecycle-writer",
+			"resources": []map[string]any{{"apiVersion": "cluster.x-k8s.io/v1beta2", "kind": "Cluster", "namespace": "disposable-ok147", "name": "disposable-ok147"}},
+		},
+		"providerAccess": map[string]any{}, "excludedRendererArtifacts": []any{},
+	})
+	writeBundleFile(t, root, "authority-map.json", authority)
+	writeBundleFile(t, root, "ok-infra-prerequisites.yaml", infra)
+	writeBundleFile(t, root, "ok-mgmt-lifecycle.yaml", management)
+
+	manifest := mustJSON(t, map[string]any{
+		"format": "ok141-contract-to-capi-projection/v2", "R": revision, "authorizationState": "NO-GO",
+		"artifacts": map[string]any{
+			"authority-map.json": digest.SHA256(authority), "ok-infra-prerequisites.yaml": digest.SHA256(infra), "ok-mgmt-lifecycle.yaml": digest.SHA256(management),
+		},
+		"objectSets": map[string]any{
+			"okInfraPrerequisites": map[string]any{"count": 1, "digest": bundleSHA("1")},
+			"okMgmtLifecycle":      map[string]any{"count": 1, "digest": bundleSHA("2")},
+		},
+		"providerAccess": map[string]any{}, "source": map[string]any{},
+	})
+	manifestPath := writeBundleFile(t, root, "projection-manifest.json", manifest)
+
+	providerDigest := digest.SHA256(infra)
+	if overrideProviderDigest != "" {
+		providerDigest = overrideProviderDigest
+	}
+	expected := stageplan.Expected{
+		ContractIdentity: identity, IntentRevision: revision, EnablementRevision: bundleSHA("b"), PlatformRevision: bundleSHA("c"), ExecutionFixture: bundleSHA("d"),
+		InfrastructureAuthority: "ok-infra", ManagementAuthority: "ok-mgmt", GitOpsAuthority: "ok-shared",
+	}
+	planPath := writeBundleFile(t, root, "staged-plan.json", submissionBundlePlan(t, expected, providerDigest, digest.SHA256(management)))
+	plan, err := stageplan.Load(planPath, expected)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipts := []StageReceiptSource{}
+	predecessors := []stagereceipt.Verified{}
+	stageID := "provider-prerequisites"
+	if completedProvider {
+		provider, err := stagereceipt.New(plan, "provider-prerequisites", []stagereceipt.Verified{}, "SUCCEEDED", "ATTEMPTED", bundleSHA("8"), bundleSHA("9"), at.Add(-2*time.Minute))
+		if err != nil {
+			t.Fatal(err)
+		}
+		raw, err := provider.Bytes()
+		if err != nil {
+			t.Fatal(err)
+		}
+		receiptDigest, err := provider.Digest()
+		if err != nil {
+			t.Fatal(err)
+		}
+		receipts = append(receipts, StageReceiptSource{Path: writeBundleFile(t, root, "provider-receipt.json", raw), Digest: receiptDigest})
+		predecessors = []stagereceipt.Verified{provider}
+		stageID = "cluster-lifecycle"
+	}
+	grantPath, keyPath := writeSubmissionStageGrant(t, root, plan, stageID, predecessors, at)
+	return submissionBundleTestFixture{
+		config: SubmissionStageBundleConfig{
+			PlanPath: planPath, PlanExpected: expected, Receipts: receipts, GrantPath: grantPath, GrantPublicKeyPath: keyPath,
+			ProjectionManifestPath: manifestPath, ProjectionRoot: root, EvaluationTime: at,
+		},
+		plan: plan,
+	}
+}
+
+func submissionBundlePlan(t *testing.T, expected stageplan.Expected, providerDigest, managementDigest string) []byte {
+	t.Helper()
+	ids := []string{"provider-prerequisites", "cluster-lifecycle", "lifecycle-observation", "enablement", "network-observation", "runtime-binding", "target-access", "target-credential", "target-registration", "platform-applications", "platform-observation", "aggregate-evidence"}
+	kinds := []string{"Submission", "Submission", "Observation", "Submission", "Observation", "Binding", "Submission", "Credential", "Submission", "Submission", "Observation", "Evaluation"}
+	authorities := []string{"infrastructure", "management", "management", "management", "workload", "runner", "workload", "workload", "gitops", "gitops", "gitops", "runner"}
+	operations := []string{"CreateProviderPrerequisites", "CreateCluster", "", "CreateEnablement", "", "", "CreateTargetAccess", "IssueTargetCredential", "RegisterTarget", "CreatePlatformApplications", "", ""}
+	stages := make([]map[string]any, len(ids))
+	for index := range ids {
+		requires := []string{}
+		if index > 0 {
+			requires = []string{ids[index-1]}
+		}
+		name, inputDigest := "stage."+ids[index], bundleSHA(string("abcdef012345"[index]))
+		if index == 0 {
+			name, inputDigest = "projection.provider-prerequisites", providerDigest
+		} else if index == 1 {
+			name, inputDigest = "projection.cluster-lifecycle", managementDigest
+		}
+		stages[index] = map[string]any{
+			"id": ids[index], "order": index + 1, "kind": kinds[index], "authority": authorities[index], "requires": requires,
+			"inputs": []map[string]any{{"name": name, "digest": inputDigest}},
+		}
+		if operations[index] != "" {
+			stages[index]["grantOperation"] = operations[index]
+		}
+	}
+	return mustJSON(t, map[string]any{
+		"format": stageplan.Format, "contractIdentity": expected.ContractIdentity,
+		"intentRevision": expected.IntentRevision, "enablementRevision": expected.EnablementRevision, "platformRevision": expected.PlatformRevision, "executionFixture": expected.ExecutionFixture,
+		"authorizationState": "NO-GO",
+		"authorities":        map[string]any{"infrastructure": expected.InfrastructureAuthority, "management": expected.ManagementAuthority, "gitOps": expected.GitOpsAuthority, "workloadIdentityMode": "capi-cluster-uid/v1", "runnerIdentityMode": "bounded-job/v1"},
+		"stages":             stages,
+	})
+}
+
+func writeSubmissionStageGrant(t *testing.T, root string, plan stageplan.Binding, stageID string, predecessors []stagereceipt.Verified, at time.Time) (string, string) {
+	t.Helper()
+	stage, stageDigest, err := plan.Stage(stageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	links := make([]authorization.StagePredecessor, len(predecessors))
+	for index, predecessor := range predecessors {
+		receipt, err := predecessor.Receipt()
+		if err != nil {
+			t.Fatal(err)
+		}
+		receiptDigest, err := predecessor.Digest()
+		if err != nil {
+			t.Fatal(err)
+		}
+		links[index] = authorization.StagePredecessor{StageID: receipt.StageID, OutcomeDigest: receiptDigest}
+	}
+	payload := authorization.StagePayload{
+		Audience: authorization.StageAudience, GrantID: "ok147-bundle-stage-01", Decision: "ALLOW",
+		PlanDigest: plan.PlanDigest, ContractIdentity: plan.ContractIdentity, ContractRevision: plan.IntentRevision,
+		EnablementRevision: plan.EnablementRevision, PlatformRevision: plan.PlatformRevision, ExecutionFixture: plan.ExecutionFixture,
+		StageID: stage.ID, StageOrder: stage.Order, StageDigest: stageDigest, Operation: stage.GrantOperation, Authority: stage.Authority,
+		Predecessors: links, NotBefore: at.Add(-time.Minute).Format(time.RFC3339), NotAfter: at.Add(20 * time.Minute).Format(time.RFC3339), MaxUses: 1,
+	}
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	signed, err := authorization.StageSigningBytes(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	envelope := mustJSON(t, map[string]any{
+		"format": authorization.StageFormat, "payload": payload,
+		"signature": map[string]any{"algorithm": "Ed25519", "keyId": digest.SHA256(publicKey), "value": base64.StdEncoding.EncodeToString(ed25519.Sign(privateKey, signed))},
+	})
+	return writeBundleFile(t, root, "stage-grant.json", envelope), writeBundleFile(t, root, "stage-authority.pub", []byte(base64.StdEncoding.EncodeToString(publicKey)+"\n"))
+}
+
+func submissionBundleRuntime(t *testing.T, plan stageplan.Binding, stageID string) SubmissionStageRuntimeConfig {
+	t.Helper()
+	root := t.TempDir()
+	caPath := writeBundleFile(t, root, "ca.crt", testCA(t))
+	ledgerToken := writeBundleFile(t, root, "ledger-token", []byte("bundle-ledger-token"))
+	authorityToken := writeBundleFile(t, root, "authority-token", []byte("bundle-authority-token"))
+	authority, endpoint := plan.Authorities.Infrastructure, "https://192.0.2.11:6443"
+	if stageID == "cluster-lifecycle" {
+		authority, endpoint = plan.Authorities.Management, "https://192.0.2.12:6443"
+	}
+	return SubmissionStageRuntimeConfig{
+		Ledger:    KubernetesLedgerConfig{Endpoint: "https://192.0.2.12:6443", Namespace: "openkubes-execution-system", TokenFile: ledgerToken, CAFile: caPath},
+		Authority: KubernetesAuthorityConfig{Endpoint: endpoint, AuthorityIdentity: authority, TokenFile: authorityToken, CAFile: caPath},
+		Clock:     func() time.Time { return time.Date(2026, 8, 16, 14, 1, 0, 0, time.UTC) },
+	}
+}
+
+func writeBundleFile(t *testing.T, root, name string, raw []byte) string {
+	t.Helper()
+	path := filepath.Join(root, name)
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func mustJSON(t *testing.T, value any) []byte {
+	t.Helper()
+	raw, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return raw
+}
+
+func bundleSHA(value string) string { return "sha256:" + strings.Repeat(value, 64) }

--- a/internal/stageplan/plan.go
+++ b/internal/stageplan/plan.go
@@ -334,3 +334,24 @@ func (binding Binding) Stage(id string) (Stage, string, error) {
 	}
 	return Stage{}, "", fmt.Errorf("stage %q is not part of the verified execution plan", id)
 }
+
+// RequireInput rechecks that one exact immutable artifact identity is bound to
+// the selected verified stage. It does not interpret or load that artifact.
+func (binding Binding) RequireInput(stageID, name, expectedDigest string) error {
+	stage, _, err := binding.Stage(stageID)
+	if err != nil {
+		return err
+	}
+	if !namePattern.MatchString(name) || !digestPattern.MatchString(expectedDigest) {
+		return errors.New("required staged execution input identity is invalid")
+	}
+	for _, input := range stage.Inputs {
+		if input.Name == name {
+			if input.Digest != expectedDigest {
+				return errors.New("staged execution input digest differs from verified artifact")
+			}
+			return nil
+		}
+	}
+	return errors.New("staged execution plan does not bind the required artifact")
+}

--- a/internal/stageplan/plan_test.go
+++ b/internal/stageplan/plan_test.go
@@ -27,6 +27,26 @@ func TestVerifyAcceptsExactBoundedSequence(t *testing.T) {
 	}
 }
 
+func TestRequireInputBindsExactArtifactIdentity(t *testing.T) {
+	binding, err := Verify(planJSON(t, validDocument()), expected())
+	if err != nil {
+		t.Fatal(err)
+	}
+	stage, _, err := binding.Stage("provider-prerequisites")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := binding.RequireInput(stage.ID, stage.Inputs[0].Name, stage.Inputs[0].Digest); err != nil {
+		t.Fatal(err)
+	}
+	if err := binding.RequireInput(stage.ID, stage.Inputs[0].Name, sha("f")); err == nil {
+		t.Fatal("different artifact digest was accepted")
+	}
+	if err := binding.RequireInput(stage.ID, "projection.other", stage.Inputs[0].Digest); err == nil {
+		t.Fatal("different artifact name was accepted")
+	}
+}
+
 func TestVerifyRejectsSequenceAuthorityAndGrantChanges(t *testing.T) {
 	tests := map[string]func(*document){
 		"missing stage":       func(plan *document) { plan.Stages = plan.Stages[:11] },


### PR DESCRIPTION
## Outcome
- binds the verified staged plan, explicit receipt prefix, exact projection artifact, and signed per-stage grant
- selects only provider-prerequisites or cluster-lifecycle and opens one shared typed runtime for later CLI or Job callers
- rejects implicit prefixes, projection drift, foreign receipt chains, and credential aliasing fail closed

## Validation
- full Go test suite
- go vet
- race tests for staged execution packages
- 18 Python regression tests (1 expected skip)
- git diff --check

## Scope
Offline composition only. No CLI or Job activation, Kubernetes request, mutation, retry, or live infrastructure action.