### PR TITLE
Add inspect-only staged CLI (OK-147)

### DIFF
--- a/cmd/ok/main.go
+++ b/cmd/ok/main.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"regexp"
+	"strings"
 	"time"
 
 	"github.com/openkubes/ok-cluster/internal/authorization"
@@ -16,6 +18,8 @@ import (
 	"github.com/openkubes/ok-cluster/internal/ledger"
 	"github.com/openkubes/ok-cluster/internal/projection"
 	"github.com/openkubes/ok-cluster/internal/runner"
+	"github.com/openkubes/ok-cluster/internal/stagecursor"
+	"github.com/openkubes/ok-cluster/internal/stageplan"
 )
 
 const (
@@ -23,8 +27,9 @@ const (
 )
 
 var (
-	version  = "0.0.0-dev"
-	revision = "unknown"
+	version                 = "0.0.0-dev"
+	revision                = "unknown"
+	stageReceiptFlagPattern = regexp.MustCompile(`^.+@sha256:[0-9a-f]{64}$`)
 )
 
 type createPlan struct {
@@ -43,6 +48,37 @@ type createPlan struct {
 	Ledger                  *ledger.Inspection      `json:"ledger,omitempty"`
 }
 
+type stageInspection struct {
+	Format             string               `json:"format"`
+	Decision           stagecursor.Decision `json:"decision"`
+	AuthorizationState string               `json:"authorizationState"`
+	MutationAllowed    bool                 `json:"mutationAllowed"`
+}
+
+type receiptFlags []string
+
+func (values *receiptFlags) String() string { return strings.Join(*values, ",") }
+
+func (values *receiptFlags) Set(value string) error {
+	*values = append(*values, value)
+	return nil
+}
+
+var inspectSubmissionStage = func(config runner.SubmissionStageBundleConfig) (stageInspection, error) {
+	bundle, err := runner.LoadSubmissionStageBundle(config)
+	if err != nil {
+		return stageInspection{}, err
+	}
+	decision, err := bundle.Decision()
+	if err != nil {
+		return stageInspection{}, err
+	}
+	return stageInspection{
+		Format: "ok147-stage-inspection/v1", Decision: decision,
+		AuthorizationState: "VERIFIED", MutationAllowed: false,
+	}, nil
+}
+
 func main() {
 	if err := run(os.Args[1:], os.Stdout, os.Stderr); err != nil {
 		fmt.Fprintln(os.Stderr, "ERROR:", err)
@@ -55,9 +91,16 @@ func run(arguments []string, stdout, stderr io.Writer) error {
 		fmt.Fprintf(stdout, "%s %s\n", version, revision)
 		return nil
 	}
-	if len(arguments) < 2 || arguments[0] != "cluster" || arguments[1] != "create" {
-		return errors.New("usage: ok cluster create --contract PATH --schema PATH --dry-run [--projection-manifest PATH] [--authorization PATH --authorization-key PATH --evaluation-time RFC3339] [--ledger-inspect --ledger-api-endpoint URL --ledger-token-file PATH --ledger-ca-file PATH]")
+	if len(arguments) >= 2 && arguments[0] == "cluster" && arguments[1] == "create" {
+		return runClusterCreate(arguments[2:], stdout, stderr)
 	}
+	if len(arguments) >= 3 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "inspect" {
+		return runClusterStageInspect(arguments[3:], stdout, stderr)
+	}
+	return errors.New("usage: ok cluster create ... | ok cluster stage inspect ...")
+}
+
+func runClusterCreate(arguments []string, stdout, stderr io.Writer) error {
 	flags := flag.NewFlagSet("ok cluster create", flag.ContinueOnError)
 	flags.SetOutput(stderr)
 	contractPath := flags.String("contract", "", "path to the versioned cluster contract")
@@ -72,7 +115,7 @@ func run(arguments []string, stdout, stderr io.Writer) error {
 	ledgerAPIEndpoint := flags.String("ledger-api-endpoint", "", "TLS Kubernetes API endpoint for the durable ledger")
 	ledgerTokenFile := flags.String("ledger-token-file", "", "path to a projected short-lived ledger ServiceAccount token")
 	ledgerCAFile := flags.String("ledger-ca-file", "", "path to the projected Kubernetes API CA bundle")
-	if err := flags.Parse(arguments[2:]); err != nil {
+	if err := flags.Parse(arguments); err != nil {
 		return err
 	}
 	if flags.NArg() != 0 {
@@ -185,6 +228,79 @@ func run(arguments []string, stdout, stderr io.Writer) error {
 	encoder.SetEscapeHTML(false)
 	encoder.SetIndent("", "  ")
 	return encoder.Encode(plan)
+}
+
+func runClusterStageInspect(arguments []string, stdout, stderr io.Writer) error {
+	flags := flag.NewFlagSet("ok cluster stage inspect", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	planPath := flags.String("plan", "", "path to the bounded staged execution plan")
+	contractNamespace := flags.String("contract-namespace", "", "expected Contract namespace")
+	contractName := flags.String("contract-name", "", "expected Contract name")
+	intentRevision := flags.String("intent-revision", "", "expected normalized Contract revision R")
+	enablementRevision := flags.String("enablement-revision", "", "expected Enablement revision E")
+	platformRevision := flags.String("platform-revision", "", "expected Platform revision P")
+	executionFixture := flags.String("execution-fixture", "", "expected execution FixtureDigest")
+	infrastructureAuthority := flags.String("infrastructure-authority", "", "expected infrastructure authority identity")
+	managementAuthority := flags.String("management-authority", "", "expected management authority identity")
+	gitOpsAuthority := flags.String("gitops-authority", "", "expected GitOps authority identity")
+	var receiptValues receiptFlags
+	flags.Var(&receiptValues, "receipt", "ordered canonical predecessor receipt as PATH@sha256:<digest>; repeat for each receipt")
+	grantPath := flags.String("grant", "", "path to the signed single-stage grant")
+	grantKeyPath := flags.String("grant-key", "", "path to the trusted stage-authority public key")
+	projectionManifest := flags.String("projection-manifest", "", "path to the immutable projection manifest")
+	projectionRoot := flags.String("projection-root", "", "directory containing projection artifacts (defaults to manifest directory)")
+	evaluationTime := flags.String("evaluation-time", "", "explicit RFC3339 grant evaluation time")
+	if err := flags.Parse(arguments); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return errors.New("positional arguments are not accepted")
+	}
+	required := []struct {
+		name  string
+		value string
+	}{
+		{"--plan", *planPath}, {"--contract-namespace", *contractNamespace}, {"--contract-name", *contractName},
+		{"--intent-revision", *intentRevision}, {"--enablement-revision", *enablementRevision}, {"--platform-revision", *platformRevision},
+		{"--execution-fixture", *executionFixture}, {"--infrastructure-authority", *infrastructureAuthority},
+		{"--management-authority", *managementAuthority}, {"--gitops-authority", *gitOpsAuthority},
+		{"--grant", *grantPath}, {"--grant-key", *grantKeyPath}, {"--projection-manifest", *projectionManifest}, {"--evaluation-time", *evaluationTime},
+	}
+	for _, input := range required {
+		if input.value == "" {
+			return fmt.Errorf("%s is required", input.name)
+		}
+	}
+	at, err := time.Parse(time.RFC3339, *evaluationTime)
+	if err != nil {
+		return fmt.Errorf("parse evaluation time: %w", err)
+	}
+	receipts := make([]runner.StageReceiptSource, 0, len(receiptValues))
+	for _, value := range receiptValues {
+		if !stageReceiptFlagPattern.MatchString(value) {
+			return errors.New("receipt must use PATH@sha256:<64 lowercase hex> format")
+		}
+		separator := strings.LastIndex(value, "@sha256:")
+		receipts = append(receipts, runner.StageReceiptSource{Path: value[:separator], Digest: value[separator+1:]})
+	}
+	inspection, err := inspectSubmissionStage(runner.SubmissionStageBundleConfig{
+		PlanPath: *planPath,
+		PlanExpected: stageplan.Expected{
+			ContractIdentity: contract.Identity{Namespace: *contractNamespace, Name: *contractName},
+			IntentRevision:   *intentRevision, EnablementRevision: *enablementRevision,
+			PlatformRevision: *platformRevision, ExecutionFixture: *executionFixture,
+			InfrastructureAuthority: *infrastructureAuthority, ManagementAuthority: *managementAuthority, GitOpsAuthority: *gitOpsAuthority,
+		},
+		Receipts: receipts, GrantPath: *grantPath, GrantPublicKeyPath: *grantKeyPath,
+		ProjectionManifestPath: *projectionManifest, ProjectionRoot: *projectionRoot, EvaluationTime: at,
+	})
+	if err != nil {
+		return err
+	}
+	encoder := json.NewEncoder(stdout)
+	encoder.SetEscapeHTML(false)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(inspection)
 }
 
 func countNonEmpty(values ...string) int {

--- a/cmd/ok/main_test.go
+++ b/cmd/ok/main_test.go
@@ -7,6 +7,10 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/runner"
+	"github.com/openkubes/ok-cluster/internal/stagecursor"
 )
 
 func fixturePath(t *testing.T, name string) string {
@@ -101,3 +105,83 @@ func TestArbitraryCommandsAreAbsent(t *testing.T) {
 		}
 	}
 }
+
+func TestStageInspectBindsInputsAndEmitsNonMutatingDecision(t *testing.T) {
+	previous := inspectSubmissionStage
+	defer func() { inspectSubmissionStage = previous }()
+	var captured runner.SubmissionStageBundleConfig
+	inspectSubmissionStage = func(config runner.SubmissionStageBundleConfig) (stageInspection, error) {
+		captured = config
+		return stageInspection{
+			Format: "ok147-stage-inspection/v1",
+			Decision: stagecursor.Decision{
+				Format: stagecursor.DecisionFormat, State: "NEXT", PlanDigest: testSHA("9"), StageID: "cluster-lifecycle",
+				StageOrder: 2, StageDigest: testSHA("8"), Kind: "Submission", Authority: "management",
+				Operation: "CreateCluster", RequiresAuthorization: true, Predecessors: []stagecursor.Predecessor{},
+			},
+			AuthorizationState: "VERIFIED", MutationAllowed: false,
+		}, nil
+	}
+	arguments := stageInspectArguments()
+	arguments = append(arguments, "--receipt", "/tmp/provider.json@"+testSHA("7"))
+	var stdout, stderr bytes.Buffer
+	if err := run(arguments, &stdout, &stderr); err != nil {
+		t.Fatalf("run: %v; stderr=%s", err, stderr.String())
+	}
+	if captured.PlanPath != "/tmp/plan.json" || captured.PlanExpected.ContractIdentity.Name != "disposable-ok147" || len(captured.Receipts) != 1 {
+		t.Fatalf("unexpected bundle config: %#v", captured)
+	}
+	if captured.Receipts[0].Path != "/tmp/provider.json" || captured.Receipts[0].Digest != testSHA("7") || !captured.EvaluationTime.Equal(time.Date(2026, 8, 16, 14, 0, 0, 0, time.UTC)) {
+		t.Fatalf("unexpected receipt/time binding: %#v %s", captured.Receipts, captured.EvaluationTime)
+	}
+	var result stageInspection
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatal(err)
+	}
+	if result.Format != "ok147-stage-inspection/v1" || result.Decision.StageID != "cluster-lifecycle" || result.AuthorizationState != "VERIFIED" || result.MutationAllowed {
+		t.Fatalf("unsafe inspection output: %#v", result)
+	}
+}
+
+func TestStageInspectRequiresCompleteInputsAndStrictReceipts(t *testing.T) {
+	for name, arguments := range map[string][]string{
+		"missing bindings": {"cluster", "stage", "inspect", "--plan", "/tmp/plan.json"},
+		"positional":       append(stageInspectArguments(), "unexpected"),
+		"bad receipt":      append(stageInspectArguments(), "--receipt", "/tmp/provider.json"),
+		"bad time":         replaceArgument(stageInspectArguments(), "--evaluation-time", "now"),
+	} {
+		t.Run(name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			if err := run(arguments, &stdout, &stderr); err == nil {
+				t.Fatal("incomplete or ambiguous stage inspection was accepted")
+			}
+			if stdout.Len() != 0 {
+				t.Fatalf("unexpected stdout: %s", stdout.String())
+			}
+		})
+	}
+}
+
+func stageInspectArguments() []string {
+	return []string{
+		"cluster", "stage", "inspect",
+		"--plan", "/tmp/plan.json", "--contract-namespace", "disposable-ok147", "--contract-name", "disposable-ok147",
+		"--intent-revision", testSHA("a"), "--enablement-revision", testSHA("b"), "--platform-revision", testSHA("c"),
+		"--execution-fixture", testSHA("d"), "--infrastructure-authority", "ok-infra", "--management-authority", "ok-mgmt", "--gitops-authority", "ok-shared",
+		"--grant", "/tmp/grant.json", "--grant-key", "/tmp/grant.pub", "--projection-manifest", "/tmp/projection.json",
+		"--evaluation-time", "2026-08-16T14:00:00Z",
+	}
+}
+
+func replaceArgument(arguments []string, name, value string) []string {
+	result := append([]string(nil), arguments...)
+	for index := range result {
+		if result[index] == name && index+1 < len(result) {
+			result[index+1] = value
+			return result
+		}
+	}
+	return result
+}
+
+func testSHA(value string) string { return "sha256:" + strings.Repeat(value, 64) }

--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -1023,6 +1023,23 @@ only an explicit later `Run` can inspect or claim the ledger and invoke the
 single bound mutator. No CLI command, Job entry point, retry or live cluster
 access is introduced by this checkpoint.
 
+## Inspect-only staged CLI
+
+`ok cluster stage inspect` is the first production entry point for the shared
+bundle loader. Callers must provide every expected R/E/P/fixture and authority
+identity, the bounded plan, an explicitly ordered zero-or-more receipt prefix,
+the projection manifest, the signed stage grant and one explicit RFC3339
+evaluation time. Receipt arguments bind a source file to an independently
+supplied canonical digest; malformed or positional input fails before loading.
+
+The command emits only the redaction-safe verified cursor decision plus
+`AuthorizationState=VERIFIED` and `MutationAllowed=false`. It does not accept
+ledger or Kubernetes credentials and cannot open or run the bound operation.
+Consequently it provides an executable local preclaim inspection path without
+introducing submission, claim, mutation, retry, discovery or cluster contact.
+The future Job can use the same bundle loader rather than a second artifact
+interpretation path.
+
 ## Typed first-run Platform capability boundary
 
 First-run capability production now has a separate lazy resolver from the


### PR DESCRIPTION
## Outcome
- adds ok cluster stage inspect as the first production entry point for the verified staged bundle
- binds explicit R/E/P/fixture, authority, ordered receipt, projection, signed grant, and evaluation-time inputs
- emits only a redaction-safe verified decision with MutationAllowed=false

## Safety boundary
No ledger or Kubernetes credentials, API contact, claim, submission, mutation, retry, discovery, or Job activation.

## Validation
- full Go test suite
- go vet
- targeted race suite including cmd/ok and staged execution packages
- 18 Python regression tests (1 expected skip)
- git diff --check