### PR TITLE
Load bounded stage receipt prefixes (OK-147)

### DIFF
--- a/cmd/ok/main.go
+++ b/cmd/ok/main.go
@@ -76,6 +76,7 @@ type stageBundleFlags struct {
 	grantPath, grantKeyPath, projectionManifest, projectionRoot   *string
 	evaluationTime                                                *string
 	receipts                                                      receiptFlags
+	receiptPrefix, receiptPrefixDigest                            *string
 }
 
 func addStageBundleFlags(flags *flag.FlagSet) *stageBundleFlags {
@@ -91,6 +92,8 @@ func addStageBundleFlags(flags *flag.FlagSet) *stageBundleFlags {
 	values.managementAuthority = flags.String("management-authority", "", "expected management authority identity")
 	values.gitOpsAuthority = flags.String("gitops-authority", "", "expected GitOps authority identity")
 	flags.Var(&values.receipts, "receipt", "ordered canonical predecessor receipt as PATH@sha256:<digest>; repeat for each receipt")
+	values.receiptPrefix = flags.String("receipt-prefix", "", "path to a digest-bound ordered receipt-prefix manifest")
+	values.receiptPrefixDigest = flags.String("receipt-prefix-digest", "", "expected SHA-256 digest of the receipt-prefix manifest")
 	values.grantPath = flags.String("grant", "", "path to the signed single-stage grant")
 	values.grantKeyPath = flags.String("grant-key", "", "path to the trusted stage-authority public key")
 	values.projectionManifest = flags.String("projection-manifest", "", "path to the immutable projection manifest")
@@ -119,13 +122,25 @@ func (values *stageBundleFlags) config() (runner.SubmissionStageBundleConfig, er
 	if err != nil {
 		return runner.SubmissionStageBundleConfig{}, fmt.Errorf("parse evaluation time: %w", err)
 	}
-	receipts := make([]runner.StageReceiptSource, 0, len(values.receipts))
-	for _, value := range values.receipts {
-		if !stageReceiptFlagPattern.MatchString(value) {
-			return runner.SubmissionStageBundleConfig{}, errors.New("receipt must use PATH@sha256:<64 lowercase hex> format")
+	providedPrefix := countNonEmpty(*values.receiptPrefix, *values.receiptPrefixDigest)
+	if providedPrefix != 0 && (providedPrefix != 2 || len(values.receipts) != 0) {
+		return runner.SubmissionStageBundleConfig{}, errors.New("--receipt-prefix and --receipt-prefix-digest must be provided together and cannot be combined with --receipt")
+	}
+	var receipts []runner.StageReceiptSource
+	if providedPrefix == 2 {
+		receipts, err = runner.LoadStageReceiptPrefix(*values.receiptPrefix, *values.receiptPrefixDigest)
+		if err != nil {
+			return runner.SubmissionStageBundleConfig{}, err
 		}
-		separator := strings.LastIndex(value, "@sha256:")
-		receipts = append(receipts, runner.StageReceiptSource{Path: value[:separator], Digest: value[separator+1:]})
+	} else {
+		receipts = make([]runner.StageReceiptSource, 0, len(values.receipts))
+		for _, value := range values.receipts {
+			if !stageReceiptFlagPattern.MatchString(value) {
+				return runner.SubmissionStageBundleConfig{}, errors.New("receipt must use PATH@sha256:<64 lowercase hex> format")
+			}
+			separator := strings.LastIndex(value, "@sha256:")
+			receipts = append(receipts, runner.StageReceiptSource{Path: value[:separator], Digest: value[separator+1:]})
+		}
 	}
 	return runner.SubmissionStageBundleConfig{
 		PlanPath: *values.planPath,

--- a/cmd/ok/main_test.go
+++ b/cmd/ok/main_test.go
@@ -4,12 +4,14 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/openkubes/ok-cluster/internal/digest"
 	"github.com/openkubes/ok-cluster/internal/execution"
 	"github.com/openkubes/ok-cluster/internal/runner"
 	"github.com/openkubes/ok-cluster/internal/stagecursor"
@@ -162,6 +164,36 @@ func TestStageInspectRequiresCompleteInputsAndStrictReceipts(t *testing.T) {
 				t.Fatalf("unexpected stdout: %s", stdout.String())
 			}
 		})
+	}
+}
+
+func TestStageInspectLoadsDigestBoundReceiptPrefix(t *testing.T) {
+	previous := inspectSubmissionStage
+	defer func() { inspectSubmissionStage = previous }()
+	var captured runner.SubmissionStageBundleConfig
+	inspectSubmissionStage = func(config runner.SubmissionStageBundleConfig) (stageInspection, error) {
+		captured = config
+		return stageInspection{Format: "ok147-stage-inspection/v1", Decision: stagecursor.Decision{Format: stagecursor.DecisionFormat, State: "NEXT"}, AuthorizationState: "VERIFIED"}, nil
+	}
+	root := t.TempDir()
+	raw := []byte(`{"format":"` + runner.StageReceiptPrefixFormat + `","receipts":[{"file":"provider.json","digest":"` + testSHA("7") + `"}]}`)
+	prefixPath := filepath.Join(root, "prefix.json")
+	if err := os.WriteFile(prefixPath, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	arguments := append(stageInspectArguments(), "--receipt-prefix", prefixPath, "--receipt-prefix-digest", digest.SHA256(raw))
+	var stdout, stderr bytes.Buffer
+	if err := run(arguments, &stdout, &stderr); err != nil {
+		t.Fatalf("run: %v; stderr=%s", err, stderr.String())
+	}
+	if len(captured.Receipts) != 1 || captured.Receipts[0].Path != filepath.Join(root, "provider.json") || captured.Receipts[0].Digest != testSHA("7") {
+		t.Fatalf("receipt-prefix manifest was not bound: %#v", captured.Receipts)
+	}
+
+	arguments = append(arguments, "--receipt", "/tmp/other.json@"+testSHA("8"))
+	stdout.Reset()
+	if err := run(arguments, &stdout, &stderr); err == nil {
+		t.Fatal("receipt-prefix manifest and direct receipt were combined")
 	}
 }
 

--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -1040,6 +1040,17 @@ introducing submission, claim, mutation, retry, discovery or cluster contact.
 The future Job can use the same bundle loader rather than a second artifact
 interpretation path.
 
+The receipt prefix can additionally be supplied as one independently
+digest-bound `ok147-stage-receipt-prefix/v1` document. It contains an explicit
+ordered array, including an explicit empty array for the first stage, and only
+plain sibling file names plus canonical receipt digests. The loader rejects
+symlinked, oversized, traversing, duplicate, unknown-field or implicitly empty
+prefix documents. Every referenced receipt is still reloaded and verified by
+the normal stage-receipt chain; the manifest cannot turn a file name into
+evidence. Direct repeated `--receipt` flags and a prefix document are mutually
+exclusive. This fixed single-file argument is the input shape required by a
+later non-shell Job template.
+
 ## Explicit local staged execution
 
 `ok cluster stage run` composes the same verified bundle with exactly one

--- a/internal/runner/stage_receipt_prefix.go
+++ b/internal/runner/stage_receipt_prefix.go
@@ -1,0 +1,83 @@
+package runner
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/jsonstrict"
+)
+
+const (
+	StageReceiptPrefixFormat       = "ok147-stage-receipt-prefix/v1"
+	maximumStageReceiptPrefixBytes = 16 * 1024
+	maximumStageReceiptPrefixItems = 12
+)
+
+var stageReceiptPrefixDigestPattern = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
+
+type stageReceiptPrefixDocument struct {
+	Format   string                    `json:"format"`
+	Receipts []stageReceiptPrefixEntry `json:"receipts"`
+}
+
+type stageReceiptPrefixEntry struct {
+	File   string `json:"file"`
+	Digest string `json:"digest"`
+}
+
+// LoadStageReceiptPrefix converts one digest-bound strict manifest into the
+// explicit ordered file/digest prefix consumed by LoadSubmissionStageBundle.
+// Receipt content remains subject to its normal canonical chain verification.
+func LoadStageReceiptPrefix(path, expectedDigest string) ([]StageReceiptSource, error) {
+	if path == "" || !stageReceiptPrefixDigestPattern.MatchString(expectedDigest) {
+		return nil, errors.New("stage receipt prefix path and digest are required")
+	}
+	info, err := os.Lstat(path)
+	if err != nil {
+		return nil, errors.New("inspect stage receipt prefix")
+	}
+	if !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 || info.Size() <= 0 || info.Size() > maximumStageReceiptPrefixBytes {
+		return nil, errors.New("stage receipt prefix metadata is invalid")
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, errors.New("open stage receipt prefix")
+	}
+	defer file.Close()
+	raw, err := io.ReadAll(io.LimitReader(file, maximumStageReceiptPrefixBytes+1))
+	if err != nil || len(raw) > maximumStageReceiptPrefixBytes {
+		return nil, errors.New("read bounded stage receipt prefix")
+	}
+	if digest.SHA256(raw) != expectedDigest {
+		return nil, errors.New("stage receipt prefix digest differs from expected identity")
+	}
+	var document stageReceiptPrefixDocument
+	if err := jsonstrict.Decode(raw, &document); err != nil {
+		return nil, fmt.Errorf("decode stage receipt prefix: %w", err)
+	}
+	if document.Format != StageReceiptPrefixFormat {
+		return nil, errors.New("stage receipt prefix format is not supported")
+	}
+	if document.Receipts == nil || len(document.Receipts) > maximumStageReceiptPrefixItems {
+		return nil, errors.New("stage receipt prefix must contain an explicit bounded list")
+	}
+	root := filepath.Dir(path)
+	result := make([]StageReceiptSource, 0, len(document.Receipts))
+	seen := map[string]struct{}{}
+	for _, item := range document.Receipts {
+		if item.File == "" || filepath.Base(item.File) != item.File || item.File == "." || !stageReceiptPrefixDigestPattern.MatchString(item.Digest) {
+			return nil, errors.New("stage receipt prefix item identity is invalid")
+		}
+		if _, duplicate := seen[item.File]; duplicate {
+			return nil, errors.New("stage receipt prefix repeats a file identity")
+		}
+		seen[item.File] = struct{}{}
+		result = append(result, StageReceiptSource{Path: filepath.Join(root, item.File), Digest: item.Digest})
+	}
+	return result, nil
+}

--- a/internal/runner/stage_receipt_prefix_test.go
+++ b/internal/runner/stage_receipt_prefix_test.go
@@ -1,0 +1,94 @@
+package runner
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+func TestLoadStageReceiptPrefixAcceptsExplicitEmptyAndOrderedSources(t *testing.T) {
+	root := t.TempDir()
+	empty := writeStagePrefix(t, root, "empty.json", map[string]any{"format": StageReceiptPrefixFormat, "receipts": []any{}})
+	loaded, err := LoadStageReceiptPrefix(empty, fileSHA(t, empty))
+	if err != nil || loaded == nil || len(loaded) != 0 {
+		t.Fatalf("explicit empty prefix was not retained: %#v %v", loaded, err)
+	}
+	one := writeStagePrefix(t, root, "one.json", map[string]any{
+		"format":   StageReceiptPrefixFormat,
+		"receipts": []map[string]any{{"file": "provider-receipt.json", "digest": prefixSHA("a")}},
+	})
+	loaded, err = LoadStageReceiptPrefix(one, fileSHA(t, one))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(loaded) != 1 || loaded[0].Path != filepath.Join(root, "provider-receipt.json") || loaded[0].Digest != prefixSHA("a") {
+		t.Fatalf("unexpected receipt prefix: %#v", loaded)
+	}
+}
+
+func TestLoadStageReceiptPrefixFailsClosed(t *testing.T) {
+	root := t.TempDir()
+	validDocument := map[string]any{"format": StageReceiptPrefixFormat, "receipts": []any{}}
+	valid := writeStagePrefix(t, root, "valid.json", validDocument)
+	link := filepath.Join(root, "link.json")
+	if err := os.Symlink(valid, link); err != nil {
+		t.Fatal(err)
+	}
+	tooMany := make([]map[string]any, maximumStageReceiptPrefixItems+1)
+	for index := range tooMany {
+		tooMany[index] = map[string]any{"file": strings.Repeat("x", index+1) + ".json", "digest": prefixSHA("a")}
+	}
+	tests := map[string]struct {
+		path, expected string
+	}{
+		"wrong digest": {valid, prefixSHA("f")},
+		"symlink":      {link, fileSHA(t, valid)},
+		"omitted list": {writeStagePrefix(t, root, "nil.json", map[string]any{"format": StageReceiptPrefixFormat}), ""},
+		"traversal": {writeStagePrefix(t, root, "traversal.json", map[string]any{
+			"format": StageReceiptPrefixFormat, "receipts": []map[string]any{{"file": "../receipt.json", "digest": prefixSHA("a")}},
+		}), ""},
+		"duplicate": {writeStagePrefix(t, root, "duplicate.json", map[string]any{
+			"format": StageReceiptPrefixFormat, "receipts": []map[string]any{{"file": "receipt.json", "digest": prefixSHA("a")}, {"file": "receipt.json", "digest": prefixSHA("b")}},
+		}), ""},
+		"too many": {writeStagePrefix(t, root, "many.json", map[string]any{"format": StageReceiptPrefixFormat, "receipts": tooMany}), ""},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			expected := test.expected
+			if expected == "" {
+				expected = fileSHA(t, test.path)
+			}
+			if _, err := LoadStageReceiptPrefix(test.path, expected); err == nil {
+				t.Fatal("unsafe receipt prefix was accepted")
+			}
+		})
+	}
+}
+
+func writeStagePrefix(t *testing.T, root, name string, value any) string {
+	t.Helper()
+	raw, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(root, name)
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func fileSHA(t *testing.T, path string) string {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return digest.SHA256(raw)
+}
+
+func prefixSHA(value string) string { return "sha256:" + strings.Repeat(value, 64) }


### PR DESCRIPTION
## Outcome
- adds a strict digest-bound ordered receipt-prefix document
- preserves explicit empty prefix semantics for the first stage
- supports one fixed CLI argument shape for later non-shell Job execution
- keeps every referenced receipt subject to canonical chain verification

## Fail-closed boundaries
Rejects symlinks, oversized or unknown-field documents, traversal, duplicates, implicit lists, digest drift, and mixing prefix files with direct receipt flags.

## Validation
Full Go tests, vet, targeted race suite, 18 Python regression tests (1 expected skip), and diff checks. No cluster contact or mutation.