### PR TITLE
Render bounded submission-stage Jobs (OK-147)

### DIFF
--- a/cmd/ok/main.go
+++ b/cmd/ok/main.go
@@ -69,6 +69,7 @@ func (values *receiptFlags) Set(value string) error {
 }
 
 type stageBundleFlags struct {
+	expectedStage                                                 *string
 	planPath, contractNamespace, contractName                     *string
 	intentRevision, enablementRevision, platformRevision          *string
 	executionFixture                                              *string
@@ -81,6 +82,7 @@ type stageBundleFlags struct {
 
 func addStageBundleFlags(flags *flag.FlagSet) *stageBundleFlags {
 	values := &stageBundleFlags{}
+	values.expectedStage = flags.String("expected-stage", "", "independently expected Contract-to-CAPI stage")
 	values.planPath = flags.String("plan", "", "path to the bounded staged execution plan")
 	values.contractNamespace = flags.String("contract-namespace", "", "expected Contract namespace")
 	values.contractName = flags.String("contract-name", "", "expected Contract name")
@@ -107,6 +109,7 @@ func (values *stageBundleFlags) config() (runner.SubmissionStageBundleConfig, er
 		name  string
 		value string
 	}{
+		{"--expected-stage", *values.expectedStage},
 		{"--plan", *values.planPath}, {"--contract-namespace", *values.contractNamespace}, {"--contract-name", *values.contractName},
 		{"--intent-revision", *values.intentRevision}, {"--enablement-revision", *values.enablementRevision}, {"--platform-revision", *values.platformRevision},
 		{"--execution-fixture", *values.executionFixture}, {"--infrastructure-authority", *values.infrastructureAuthority},
@@ -143,7 +146,7 @@ func (values *stageBundleFlags) config() (runner.SubmissionStageBundleConfig, er
 		}
 	}
 	return runner.SubmissionStageBundleConfig{
-		PlanPath: *values.planPath,
+		ExpectedStageID: *values.expectedStage, PlanPath: *values.planPath,
 		PlanExpected: stageplan.Expected{
 			ContractIdentity: contract.Identity{Namespace: *values.contractNamespace, Name: *values.contractName},
 			IntentRevision:   *values.intentRevision, EnablementRevision: *values.enablementRevision,

--- a/cmd/ok/main_test.go
+++ b/cmd/ok/main_test.go
@@ -128,12 +128,13 @@ func TestStageInspectBindsInputsAndEmitsNonMutatingDecision(t *testing.T) {
 		}, nil
 	}
 	arguments := stageInspectArguments()
+	arguments = replaceArgument(arguments, "--expected-stage", "cluster-lifecycle")
 	arguments = append(arguments, "--receipt", "/tmp/provider.json@"+testSHA("7"))
 	var stdout, stderr bytes.Buffer
 	if err := run(arguments, &stdout, &stderr); err != nil {
 		t.Fatalf("run: %v; stderr=%s", err, stderr.String())
 	}
-	if captured.PlanPath != "/tmp/plan.json" || captured.PlanExpected.ContractIdentity.Name != "disposable-ok147" || len(captured.Receipts) != 1 {
+	if captured.ExpectedStageID != "cluster-lifecycle" || captured.PlanPath != "/tmp/plan.json" || captured.PlanExpected.ContractIdentity.Name != "disposable-ok147" || len(captured.Receipts) != 1 {
 		t.Fatalf("unexpected bundle config: %#v", captured)
 	}
 	if captured.Receipts[0].Path != "/tmp/provider.json" || captured.Receipts[0].Digest != testSHA("7") || !captured.EvaluationTime.Equal(time.Date(2026, 8, 16, 14, 0, 0, 0, time.UTC)) {
@@ -272,6 +273,7 @@ func TestSubmissionStageAuthorityIsDerivedFromVerifiedTopology(t *testing.T) {
 func stageInspectArguments() []string {
 	return []string{
 		"cluster", "stage", "inspect",
+		"--expected-stage", "provider-prerequisites",
 		"--plan", "/tmp/plan.json", "--contract-namespace", "disposable-ok147", "--contract-name", "disposable-ok147",
 		"--intent-revision", testSHA("a"), "--enablement-revision", testSHA("b"), "--platform-revision", testSHA("c"),
 		"--execution-fixture", testSHA("d"), "--infrastructure-authority", "ok-infra", "--management-authority", "ok-mgmt", "--gitops-authority", "ok-shared",

--- a/deploy/contract-executor-stage-job.yaml.tpl
+++ b/deploy/contract-executor-stage-job.yaml.tpl
@@ -1,0 +1,169 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "${OK147_RUN_ID}"
+  namespace: openkubes-execution-system
+  labels:
+    app.kubernetes.io/name: ok-cluster-contract-executor
+    openkubes.io/execution-id: "${OK147_RUN_ID}"
+    openkubes.io/stage-id: "${OK147_STAGE_ID}"
+spec:
+  backoffLimit: 0
+  completions: 1
+  parallelism: 1
+  activeDeadlineSeconds: 660
+  ttlSecondsAfterFinished: 3600
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ok-cluster-contract-executor
+        openkubes.io/execution-id: "${OK147_RUN_ID}"
+    spec:
+      serviceAccountName: ok147-contract-executor-runtime
+      automountServiceAccountToken: false
+      enableServiceLinks: false
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/control-plane
+                    operator: DoesNotExist
+      containers:
+        - name: executor
+          image: "${OK147_IMAGE_DIGEST}"
+          imagePullPolicy: IfNotPresent
+          command: ["/ok"]
+          args:
+            - cluster
+            - stage
+            - run
+            - --execute
+            - --expected-stage
+            - "${OK147_STAGE_ID}"
+            - --plan
+            - /var/run/openkubes/input/staged-plan.json
+            - --contract-namespace
+            - "${OK147_CONTRACT_NAMESPACE}"
+            - --contract-name
+            - "${OK147_CONTRACT_NAME}"
+            - --intent-revision
+            - "${OK147_R}"
+            - --enablement-revision
+            - "${OK147_E}"
+            - --platform-revision
+            - "${OK147_P}"
+            - --execution-fixture
+            - "${OK147_FIXTURE}"
+            - --infrastructure-authority
+            - "${OK147_INFRA_AUTHORITY}"
+            - --management-authority
+            - "${OK147_MGMT_AUTHORITY}"
+            - --gitops-authority
+            - "${OK147_GITOPS_AUTHORITY}"
+            - --receipt-prefix
+            - /var/run/openkubes/input/receipt-prefix.json
+            - --receipt-prefix-digest
+            - "${OK147_RECEIPT_PREFIX_DIGEST}"
+            - --grant
+            - /var/run/openkubes/input/stage-grant.json
+            - --grant-key
+            - /var/run/openkubes/input/stage-authority.pub
+            - --projection-manifest
+            - /var/run/openkubes/input/projection-manifest.json
+            - --projection-root
+            - /var/run/openkubes/input
+            - --evaluation-time
+            - "${OK147_EVALUATION_TIME}"
+            - --ledger-api-endpoint
+            - "${OK147_LEDGER_API_URL}"
+            - --ledger-token-file
+            - /var/run/openkubes/ledger/token
+            - --ledger-ca-file
+            - /var/run/openkubes/ledger/ca.crt
+            - --authority-api-endpoint
+            - "${OK147_AUTHORITY_API_URL}"
+            - --authority-token-file
+            - /var/run/openkubes/authority/token
+            - --authority-ca-file
+            - /var/run/openkubes/authority/ca.crt
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+              ephemeral-storage: 32Mi
+            limits:
+              cpu: 250m
+              memory: 128Mi
+              ephemeral-storage: 64Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+            - {name: input, mountPath: /var/run/openkubes/input/staged-plan.json, subPath: staged-plan.json, readOnly: true}
+            - {name: input, mountPath: /var/run/openkubes/input/receipt-prefix.json, subPath: receipt-prefix.json, readOnly: true}
+            - {name: input, mountPath: /var/run/openkubes/input/stage-grant.json, subPath: stage-grant.json, readOnly: true}
+            - {name: input, mountPath: /var/run/openkubes/input/stage-authority.pub, subPath: stage-authority.pub, readOnly: true}
+            - {name: input, mountPath: /var/run/openkubes/input/projection-manifest.json, subPath: projection-manifest.json, readOnly: true}
+            - {name: input, mountPath: /var/run/openkubes/input/authority-map.json, subPath: authority-map.json, readOnly: true}
+            - {name: input, mountPath: /var/run/openkubes/input/ok-infra-prerequisites.yaml, subPath: ok-infra-prerequisites.yaml, readOnly: true}
+            - {name: input, mountPath: /var/run/openkubes/input/ok-mgmt-lifecycle.yaml, subPath: ok-mgmt-lifecycle.yaml, readOnly: true}
+${OK147_RECEIPT_VOLUME_MOUNT}            - {name: ledger-credential, mountPath: /var/run/openkubes/ledger/token, subPath: token, readOnly: true}
+            - {name: ledger-credential, mountPath: /var/run/openkubes/ledger/ca.crt, subPath: ca.crt, readOnly: true}
+            - {name: authority-credential, mountPath: /var/run/openkubes/authority/token, subPath: token, readOnly: true}
+            - {name: authority-credential, mountPath: /var/run/openkubes/authority/ca.crt, subPath: ca.crt, readOnly: true}
+      volumes:
+        - name: input
+          configMap:
+            name: "${OK147_INPUT_CONFIGMAP}"
+            defaultMode: 0444
+            items:
+              - {key: staged-plan.json, path: staged-plan.json}
+              - {key: receipt-prefix.json, path: receipt-prefix.json}
+              - {key: stage-grant.json, path: stage-grant.json}
+              - {key: stage-authority.pub, path: stage-authority.pub}
+              - {key: projection-manifest.json, path: projection-manifest.json}
+              - {key: authority-map.json, path: authority-map.json}
+              - {key: ok-infra-prerequisites.yaml, path: ok-infra-prerequisites.yaml}
+              - {key: ok-mgmt-lifecycle.yaml, path: ok-mgmt-lifecycle.yaml}
+${OK147_RECEIPT_CONFIGMAP_ITEM}        - name: ledger-credential
+          secret:
+            secretName: "${OK147_LEDGER_CREDENTIAL_SECRET}"
+            defaultMode: 0440
+            items:
+              - {key: token, path: token}
+              - {key: ca.crt, path: ca.crt}
+        - name: authority-credential
+          secret:
+            secretName: "${OK147_AUTHORITY_CREDENTIAL_SECRET}"
+            defaultMode: 0440
+            items:
+              - {key: token, path: token}
+              - {key: ca.crt, path: ca.crt}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: "${OK147_RUN_ID}"
+  namespace: openkubes-execution-system
+spec:
+  podSelector:
+    matchLabels:
+      openkubes.io/execution-id: "${OK147_RUN_ID}"
+  policyTypes: ["Ingress", "Egress"]
+  ingress: []
+  egress:
+    - to: [{ipBlock: {cidr: "${OK147_LEDGER_API_CIDR}"}}]
+      ports: [{protocol: TCP, port: ${OK147_LEDGER_API_PORT}}]
+    - to: [{ipBlock: {cidr: "${OK147_AUTHORITY_API_CIDR}"}}]
+      ports: [{protocol: TCP, port: ${OK147_AUTHORITY_API_PORT}}]

--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -1072,6 +1072,38 @@ concrete artifact/runtime path with local TLS material only. It does not run
 the command against a cluster, create credentials, install the CLI, activate a
 Job, or change live infrastructure.
 
+## Bounded submission-stage Job envelope
+
+The separate `contract-executor-stage-job.yaml.tpl` now materializes the same
+`ok cluster stage run --execute` path for either `provider-prerequisites` or
+`cluster-lifecycle`. The expected stage is independently bound in the Job and
+rechecked against the verified cursor before credentials can be opened. The
+cluster-lifecycle variant adds exactly one code-owned provider-receipt mount;
+callers cannot inject an arbitrary YAML or argument fragment.
+
+Every input ConfigMap key is mounted as an individual read-only `subPath` file.
+This deliberately presents regular files to the bounded loaders instead of the
+symlink layout of a whole projected ConfigMap volume. The ConfigMap item set is
+allowlisted; unrelated keys are not mounted. Ledger and write credentials use
+two distinct Secret names and four separate token/CA `subPath` mounts, with no
+automounted Pod token. Equal token contents are still rejected when the runtime
+opens. Supplying and expiring those short-lived Secrets remains an external
+prerequisite, not authority granted by the Job template.
+
+The non-retrying, single-completion Job runs as non-root with a read-only root
+filesystem, dropped capabilities, explicit resources and an eleven-minute Pod
+deadline around the runner's ten-minute context. Its deny-all NetworkPolicy has
+exactly two egress entries: the literal ledger API IP/port and the literal
+selected-authority API IP/port. DNS names, implicit ports and broad CIDRs fail
+materialization. Provider submission requires an authority endpoint distinct
+from the management ledger, while Cluster lifecycle requires the same
+management endpoint with a distinct credential Secret. The image remains
+SHA-256-bound.
+
+This is an offline rendering checkpoint. It creates neither the immutable
+input ConfigMap nor credential Secrets, ServiceAccount/RBAC, Job or
+NetworkPolicy, and it made no Kubernetes request.
+
 ## Typed first-run Platform capability boundary
 
 First-run capability production now has a separate lazy resolver from the

--- a/internal/runner/staged_submission_bundle.go
+++ b/internal/runner/staged_submission_bundle.go
@@ -24,6 +24,7 @@ type StageReceiptSource struct {
 // paths, digests and expected identities. An explicit empty receipt slice is
 // required for the first stage.
 type SubmissionStageBundleConfig struct {
+	ExpectedStageID        string
 	PlanPath               string
 	PlanExpected           stageplan.Expected
 	Receipts               []StageReceiptSource
@@ -93,6 +94,12 @@ func LoadSubmissionStageBundle(config SubmissionStageBundleConfig) (VerifiedSubm
 	}
 	if decision.State != "NEXT" || !decision.RequiresAuthorization {
 		return VerifiedSubmissionStageBundle{}, errors.New("artifact bundle does not select a mutating next stage")
+	}
+	if config.ExpectedStageID != "provider-prerequisites" && config.ExpectedStageID != "cluster-lifecycle" {
+		return VerifiedSubmissionStageBundle{}, errors.New("expected Contract-to-CAPI stage is required")
+	}
+	if decision.StageID != config.ExpectedStageID {
+		return VerifiedSubmissionStageBundle{}, errors.New("stage cursor differs from the independently expected stage")
 	}
 	artifactName, inputName, err := submissionStageArtifact(decision.StageID)
 	if err != nil {

--- a/internal/runner/staged_submission_bundle_test.go
+++ b/internal/runner/staged_submission_bundle_test.go
@@ -49,6 +49,12 @@ func TestLoadSubmissionStageBundleRejectsImplicitPrefixAndProjectionMismatch(t *
 	if _, err := LoadSubmissionStageBundle(fixture.config); err == nil || !strings.Contains(err.Error(), "differs from verified artifact") {
 		t.Fatalf("projection digest mismatch was accepted: %v", err)
 	}
+
+	fixture = submissionBundleFixture(t, false, "")
+	fixture.config.ExpectedStageID = "cluster-lifecycle"
+	if _, err := LoadSubmissionStageBundle(fixture.config); err == nil || !strings.Contains(err.Error(), "differs from the independently expected stage") {
+		t.Fatalf("foreign cursor stage was accepted: %v", err)
+	}
 }
 
 func TestSubmissionStageBundleOpenIsOfflineAndRequiresDistinctCredentials(t *testing.T) {
@@ -159,7 +165,7 @@ func submissionBundleFixture(t *testing.T, completedProvider bool, overrideProvi
 	grantPath, keyPath := writeSubmissionStageGrant(t, root, plan, stageID, predecessors, at)
 	return submissionBundleTestFixture{
 		config: SubmissionStageBundleConfig{
-			PlanPath: planPath, PlanExpected: expected, Receipts: receipts, GrantPath: grantPath, GrantPublicKeyPath: keyPath,
+			ExpectedStageID: stageID, PlanPath: planPath, PlanExpected: expected, Receipts: receipts, GrantPath: grantPath, GrantPublicKeyPath: keyPath,
 			ProjectionManifestPath: manifestPath, ProjectionRoot: root, EvaluationTime: at,
 		},
 		plan: plan,

--- a/internal/runner/submission_stage_job.go
+++ b/internal/runner/submission_stage_job.go
@@ -1,0 +1,133 @@
+package runner
+
+import (
+	"errors"
+	"fmt"
+	"net/netip"
+	"net/url"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/stageplan"
+)
+
+// SubmissionStageJobValues bind one non-retrying Job to the exact verified
+// artifact, credential and network identities needed by stage run.
+type SubmissionStageJobValues struct {
+	RunID                     string
+	StageID                   string
+	ImageDigest               string
+	EvaluationTime            string
+	Expected                  stageplan.Expected
+	InputConfigMap            string
+	ReceiptPrefixDigest       string
+	LedgerAPIURL              string
+	LedgerAPICIDR             string
+	LedgerCredentialSecret    string
+	AuthorityAPIURL           string
+	AuthorityAPICIDR          string
+	AuthorityCredentialSecret string
+}
+
+// RenderSubmissionStageJobTemplate performs only validated literal
+// substitutions. The sole stage-dependent YAML fragments are code-owned.
+func RenderSubmissionStageJobTemplate(template []byte, values SubmissionStageJobValues) ([]byte, error) {
+	if len(template) == 0 || len(template) > 1024*1024 {
+		return nil, errors.New("submission stage Job template size is invalid")
+	}
+	dnsLabel := regexp.MustCompile(`^[a-z0-9](?:[-a-z0-9]*[a-z0-9])?$`)
+	if !dnsLabel.MatchString(values.RunID) || len(values.RunID) > 63 || !strings.HasPrefix(values.RunID, "ok147-") {
+		return nil, errors.New("submission stage Job run ID is invalid")
+	}
+	for _, value := range []string{values.InputConfigMap, values.LedgerCredentialSecret, values.AuthorityCredentialSecret} {
+		if !dnsLabel.MatchString(value) || len(value) > 63 {
+			return nil, errors.New("submission stage Job object name is invalid")
+		}
+	}
+	if values.LedgerCredentialSecret == values.AuthorityCredentialSecret {
+		return nil, errors.New("submission stage Job credentials must use distinct Secrets")
+	}
+	if !regexp.MustCompile(`^[a-z0-9][a-z0-9./:_-]*@sha256:[0-9a-f]{64}$`).MatchString(values.ImageDigest) {
+		return nil, errors.New("submission stage Job image is not digest-bound")
+	}
+	if !stageReceiptPrefixDigestPattern.MatchString(values.ReceiptPrefixDigest) {
+		return nil, errors.New("submission stage Job receipt-prefix digest is invalid")
+	}
+	if _, err := time.Parse(time.RFC3339, values.EvaluationTime); err != nil {
+		return nil, errors.New("submission stage Job evaluation time is not RFC3339")
+	}
+	if err := stageplan.ValidateExpected(values.Expected); err != nil {
+		return nil, fmt.Errorf("submission stage Job expected binding: %w", err)
+	}
+	ledgerPort, ledgerEndpoint, err := exactAPIEndpoint(values.LedgerAPIURL, values.LedgerAPICIDR)
+	if err != nil {
+		return nil, fmt.Errorf("submission stage Job ledger endpoint: %w", err)
+	}
+	authorityPort, authorityEndpoint, err := exactAPIEndpoint(values.AuthorityAPIURL, values.AuthorityAPICIDR)
+	if err != nil {
+		return nil, fmt.Errorf("submission stage Job authority endpoint: %w", err)
+	}
+	receiptMount, receiptItem := "", ""
+	switch values.StageID {
+	case "provider-prerequisites":
+		if authorityEndpoint == ledgerEndpoint {
+			return nil, errors.New("provider stage authority must be outside the management ledger endpoint")
+		}
+	case "cluster-lifecycle":
+		if authorityEndpoint != ledgerEndpoint {
+			return nil, errors.New("cluster lifecycle authority must use the management ledger endpoint")
+		}
+		receiptMount = "            - name: input\n              mountPath: /var/run/openkubes/input/provider-receipt.json\n              subPath: provider-receipt.json\n              readOnly: true\n"
+		receiptItem = "              - key: provider-receipt.json\n                path: provider-receipt.json\n"
+	default:
+		return nil, errors.New("submission stage Job supports only Contract-to-CAPI stages")
+	}
+	replacements := map[string]string{
+		"${OK147_RUN_ID}": values.RunID, "${OK147_STAGE_ID}": values.StageID,
+		"${OK147_IMAGE_DIGEST}": values.ImageDigest, "${OK147_EVALUATION_TIME}": values.EvaluationTime,
+		"${OK147_CONTRACT_NAMESPACE}": values.Expected.ContractIdentity.Namespace, "${OK147_CONTRACT_NAME}": values.Expected.ContractIdentity.Name,
+		"${OK147_R}": values.Expected.IntentRevision, "${OK147_E}": values.Expected.EnablementRevision,
+		"${OK147_P}": values.Expected.PlatformRevision, "${OK147_FIXTURE}": values.Expected.ExecutionFixture,
+		"${OK147_INFRA_AUTHORITY}": values.Expected.InfrastructureAuthority, "${OK147_MGMT_AUTHORITY}": values.Expected.ManagementAuthority,
+		"${OK147_GITOPS_AUTHORITY}": values.Expected.GitOpsAuthority, "${OK147_INPUT_CONFIGMAP}": values.InputConfigMap,
+		"${OK147_RECEIPT_PREFIX_DIGEST}": values.ReceiptPrefixDigest,
+		"${OK147_LEDGER_API_URL}":        values.LedgerAPIURL, "${OK147_LEDGER_API_CIDR}": values.LedgerAPICIDR,
+		"${OK147_LEDGER_API_PORT}": ledgerPort, "${OK147_LEDGER_CREDENTIAL_SECRET}": values.LedgerCredentialSecret,
+		"${OK147_AUTHORITY_API_URL}": values.AuthorityAPIURL, "${OK147_AUTHORITY_API_CIDR}": values.AuthorityAPICIDR,
+		"${OK147_AUTHORITY_API_PORT}": authorityPort, "${OK147_AUTHORITY_CREDENTIAL_SECRET}": values.AuthorityCredentialSecret,
+		"${OK147_RECEIPT_VOLUME_MOUNT}": receiptMount, "${OK147_RECEIPT_CONFIGMAP_ITEM}": receiptItem,
+	}
+	result := string(template)
+	for placeholder, value := range replacements {
+		if !strings.Contains(result, placeholder) {
+			return nil, fmt.Errorf("submission stage Job template lacks %s", placeholder)
+		}
+		result = strings.ReplaceAll(result, placeholder, value)
+	}
+	if strings.Contains(result, "${") {
+		return nil, errors.New("submission stage Job template contains an unknown placeholder")
+	}
+	return []byte(result), nil
+}
+
+func exactAPIEndpoint(rawURL, rawCIDR string) (string, string, error) {
+	endpoint, err := url.Parse(rawURL)
+	if err != nil || endpoint.Scheme != "https" || endpoint.User != nil || endpoint.Path != "" || endpoint.RawQuery != "" || endpoint.Fragment != "" {
+		return "", "", errors.New("API URL must be an exact HTTPS IP endpoint")
+	}
+	address, err := netip.ParseAddr(endpoint.Hostname())
+	if err != nil {
+		return "", "", errors.New("API URL must use an IP address")
+	}
+	port, err := strconv.Atoi(endpoint.Port())
+	if err != nil || port < 1 || port > 65535 {
+		return "", "", errors.New("API URL must contain an explicit valid port")
+	}
+	prefix, err := netip.ParsePrefix(rawCIDR)
+	if err != nil || prefix.Bits() != address.BitLen() || prefix.Addr() != address {
+		return "", "", errors.New("API CIDR must bind only the endpoint IP")
+	}
+	return strconv.Itoa(port), netip.AddrPortFrom(address, uint16(port)).String(), nil
+}

--- a/internal/runner/submission_stage_job_test.go
+++ b/internal/runner/submission_stage_job_test.go
@@ -1,0 +1,168 @@
+package runner
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/openkubes/ok-cluster/internal/contract"
+	"github.com/openkubes/ok-cluster/internal/stageplan"
+	"gopkg.in/yaml.v3"
+)
+
+func TestSubmissionStageJobIsBoundedToStageCredentialsAndEndpoints(t *testing.T) {
+	raw := submissionStageJobTemplate(t)
+	for _, stageID := range []string{"provider-prerequisites", "cluster-lifecycle"} {
+		t.Run(stageID, func(t *testing.T) {
+			values := validSubmissionStageJobValues()
+			values.StageID = stageID
+			if stageID == "cluster-lifecycle" {
+				values.AuthorityAPIURL, values.AuthorityAPICIDR = values.LedgerAPIURL, values.LedgerAPICIDR
+			}
+			materialized, err := RenderSubmissionStageJobTemplate(raw, values)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if bytes.Contains(materialized, []byte("${")) || bytes.Contains(materialized, []byte("system:masters")) || bytes.Contains(materialized, []byte("privileged: true")) {
+				t.Fatal("materialized Job contains an unresolved or privileged boundary")
+			}
+			objects := decodeJobObjects(t, materialized)
+			job, policy := objects["Job"], objects["NetworkPolicy"]
+			if job == nil || policy == nil {
+				t.Fatal("submission template must contain one Job and NetworkPolicy")
+			}
+			jobSpec := objectAt(t, job, "spec")
+			if jobSpec["backoffLimit"] != 0 || jobSpec["parallelism"] != 1 || jobSpec["completions"] != 1 {
+				t.Fatalf("Job retry/singleton boundary differs: %#v", jobSpec)
+			}
+			podSpec := objectAt(t, objectAt(t, jobSpec, "template"), "spec")
+			if podSpec["serviceAccountName"] != "ok147-contract-executor-runtime" || podSpec["automountServiceAccountToken"] != false || podSpec["restartPolicy"] != "Never" {
+				t.Fatalf("unexpected Pod identity: %#v", podSpec)
+			}
+			containers := arrayAt(t, podSpec, "containers")
+			if len(containers) != 1 {
+				t.Fatalf("containers=%d, want 1", len(containers))
+			}
+			container := containers[0].(map[string]any)
+			args := stringArray(t, container, "args")
+			for _, required := range []string{"cluster", "stage", "run", "--execute", "--expected-stage", "--receipt-prefix", "--receipt-prefix-digest", "--ledger-token-file", "--authority-token-file"} {
+				if !contains(args, required) {
+					t.Fatalf("Job args do not bind %s: %v", required, args)
+				}
+			}
+			for _, forbidden := range []string{"shell", "apply", "delete", "--command", "--receipt"} {
+				if contains(args, forbidden) {
+					t.Fatalf("Job args contain forbidden operation %s", forbidden)
+				}
+			}
+			mounts := arrayAt(t, container, "volumeMounts")
+			wantMounts := 12
+			if stageID == "cluster-lifecycle" {
+				wantMounts = 13
+			}
+			if len(mounts) != wantMounts {
+				t.Fatalf("volumeMounts=%d, want %d", len(mounts), wantMounts)
+			}
+			providerMounted := false
+			for _, rawMount := range mounts {
+				mount := rawMount.(map[string]any)
+				if mount["subPath"] == nil || mount["readOnly"] != true {
+					t.Fatalf("input/credential is not a read-only subPath mount: %#v", mount)
+				}
+				providerMounted = providerMounted || mount["subPath"] == "provider-receipt.json"
+			}
+			if providerMounted != (stageID == "cluster-lifecycle") {
+				t.Fatalf("provider receipt mount differs for %s", stageID)
+			}
+			policySpec := objectAt(t, policy, "spec")
+			if ingress := arrayAt(t, policySpec, "ingress"); len(ingress) != 0 {
+				t.Fatal("NetworkPolicy ingress is not deny-all")
+			}
+			if egress := arrayAt(t, policySpec, "egress"); len(egress) != 2 {
+				t.Fatalf("NetworkPolicy egress=%d, want 2", len(egress))
+			}
+		})
+	}
+}
+
+func TestRenderSubmissionStageJobFailsClosed(t *testing.T) {
+	template := submissionStageJobTemplate(t)
+	for name, mutate := range map[string]func(*SubmissionStageJobValues){
+		"unsupported stage": func(values *SubmissionStageJobValues) { values.StageID = "enablement" },
+		"shared credential": func(values *SubmissionStageJobValues) {
+			values.AuthorityCredentialSecret = values.LedgerCredentialSecret
+		},
+		"mutable image": func(values *SubmissionStageJobValues) { values.ImageDigest = "ghcr.io/openkubes/ok-cluster:latest" },
+		"DNS endpoint":  func(values *SubmissionStageJobValues) { values.AuthorityAPIURL = "https://kubernetes.default.svc:6443" },
+		"broad CIDR":    func(values *SubmissionStageJobValues) { values.AuthorityAPICIDR = "192.0.2.0/24" },
+		"missing port":  func(values *SubmissionStageJobValues) { values.AuthorityAPIURL = "https://192.0.2.11" },
+		"foreign authority": func(values *SubmissionStageJobValues) {
+			values.Expected.ManagementAuthority = values.Expected.InfrastructureAuthority
+		},
+		"provider on ledger": func(values *SubmissionStageJobValues) {
+			values.AuthorityAPIURL, values.AuthorityAPICIDR = values.LedgerAPIURL, values.LedgerAPICIDR
+		},
+		"cluster outside ledger": func(values *SubmissionStageJobValues) { values.StageID = "cluster-lifecycle" },
+	} {
+		t.Run(name, func(t *testing.T) {
+			values := validSubmissionStageJobValues()
+			mutate(&values)
+			if _, err := RenderSubmissionStageJobTemplate(template, values); err == nil {
+				t.Fatal("unsafe submission stage Job was accepted")
+			}
+		})
+	}
+	if _, err := RenderSubmissionStageJobTemplate(append(template, []byte("\n${UNKNOWN}")...), validSubmissionStageJobValues()); err == nil {
+		t.Fatal("unknown placeholder was accepted")
+	}
+}
+
+func validSubmissionStageJobValues() SubmissionStageJobValues {
+	return SubmissionStageJobValues{
+		RunID: "ok147-provider-20260816-01", StageID: "provider-prerequisites",
+		ImageDigest: "ghcr.io/openkubes/ok-cluster@sha256:" + strings.Repeat("a", 64), EvaluationTime: "2026-08-16T15:00:00Z",
+		Expected: stageplan.Expected{
+			ContractIdentity: contract.Identity{Namespace: "disposable-ok147", Name: "disposable-ok147"},
+			IntentRevision:   prefixSHA("a"), EnablementRevision: prefixSHA("b"), PlatformRevision: prefixSHA("c"), ExecutionFixture: prefixSHA("d"),
+			InfrastructureAuthority: "ok-infra", ManagementAuthority: "ok-mgmt", GitOpsAuthority: "ok-shared",
+		},
+		InputConfigMap: "ok147-provider-input", ReceiptPrefixDigest: prefixSHA("e"),
+		LedgerAPIURL: "https://192.0.2.12:6443", LedgerAPICIDR: "192.0.2.12/32", LedgerCredentialSecret: "ok147-ledger-credential",
+		AuthorityAPIURL: "https://192.0.2.11:6443", AuthorityAPICIDR: "192.0.2.11/32", AuthorityCredentialSecret: "ok147-authority-credential",
+	}
+}
+
+func submissionStageJobTemplate(t *testing.T) []byte {
+	t.Helper()
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("cannot resolve test path")
+	}
+	raw, err := os.ReadFile(filepath.Join(filepath.Dir(filename), "..", "..", "deploy", "contract-executor-stage-job.yaml.tpl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return raw
+}
+
+func decodeJobObjects(t *testing.T, raw []byte) map[string]map[string]any {
+	t.Helper()
+	decoder := yaml.NewDecoder(bytes.NewReader(raw))
+	objects := map[string]map[string]any{}
+	for {
+		var object map[string]any
+		if err := decoder.Decode(&object); err != nil {
+			if errors.Is(err, io.EOF) {
+				return objects
+			}
+			t.Fatal(err)
+		}
+		kind, _ := object["kind"].(string)
+		objects[kind] = object
+	}
+}

--- a/internal/stageplan/plan.go
+++ b/internal/stageplan/plan.go
@@ -150,7 +150,7 @@ func Load(path string, expected Expected) (Binding, error) {
 // Verify validates plan content already held in memory. It is exported so a
 // caller can verify a plan delivered by a bounded non-filesystem transport.
 func Verify(raw []byte, expected Expected) (Binding, error) {
-	if err := validateExpected(expected); err != nil {
+	if err := ValidateExpected(expected); err != nil {
 		return Binding{}, err
 	}
 	var source document
@@ -202,7 +202,9 @@ func Verify(raw []byte, expected Expected) (Binding, error) {
 	}, nil
 }
 
-func validateExpected(expected Expected) error {
+// ValidateExpected checks independently supplied Contract, fixture and
+// topology identities without loading or accepting a staged plan.
+func ValidateExpected(expected Expected) error {
 	if expected.ContractIdentity.Name == "" || expected.ContractIdentity.Namespace == "" {
 		return errors.New("expected Contract identity is incomplete")
 	}


### PR DESCRIPTION
## Outcome
- adds a separate non-retrying stage-run Job and exact two-endpoint NetworkPolicy template
- independently binds expected stage to cursor, CLI, mount variant, and Job metadata
- mounts allowlisted ConfigMap inputs and distinct ledger/writer Secret files as regular read-only subPaths
- enforces provider outside management endpoint and cluster lifecycle on management with distinct credential Secrets

## Runtime boundary
Digest-bound image, non-root, read-only filesystem, dropped capabilities, no automounted token, explicit resources, fixed deadline, no shell, retry, discovery, or dynamic operation.

## Validation
Both stage variants parse as Kubernetes YAML; full Go suite, vet, race suite, 18 Python regression tests (1 expected skip), and diff checks pass.

Offline rendering only. No ConfigMap, Secret, RBAC, Job, NetworkPolicy, credential, API request, or infrastructure mutation was created.