### PR TITLE
feat(runner): materialize immutable stage inputs (OK-147)

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -1104,6 +1104,31 @@ This is an offline rendering checkpoint. It creates neither the immutable
 input ConfigMap nor credential Secrets, ServiceAccount/RBAC, Job or
 NetworkPolicy, and it made no Kubernetes request.
 
+## Immutable submission-stage inputs
+
+`BuildSubmissionStageInput` now materializes the Job's immutable input
+ConfigMap from exactly one fully verified submission-stage bundle. The
+materializer first verifies the staged plan, explicit receipt prefix, cursor,
+projection, stage grant and public signing key. It then copies only the fixed
+public input set expected by the Job and repeats full bundle verification after
+capturing the source files. A provider stage contains an explicit empty receipt
+prefix; a cluster-lifecycle stage contains exactly the verified provider
+receipt under the code-owned `provider-receipt.json` identity.
+
+The resulting ConfigMap is fixed to `openkubes-execution-system`, must use an
+`ok147-` DNS-label name and has `immutable: true`. Every source must be a
+bounded regular non-symlink UTF-8 file without NUL bytes, and the complete JSON
+object must remain below the fail-closed 900 KiB limit. The materialization
+receipt binds the ConfigMap digest, receipt-prefix digest, selected stage and
+sorted data-key inventory without exposing source paths or content.
+
+Tokens, CA files, kubeconfigs, private signing keys and Secret material have no
+input slot and cannot be packaged by this API. Credential Secrets,
+ServiceAccount/RBAC, ConfigMap creation, Job creation and any Kubernetes
+request remain external prerequisites. The Job independently reverifies all
+mounted artifacts before it opens credentials, so source races or changed
+inputs stop execution rather than authorizing them.
+
 ## Typed first-run Platform capability boundary
 
 First-run capability production now has a separate lazy resolver from the

--- a/internal/runner/submission_stage_input.go
+++ b/internal/runner/submission_stage_input.go
@@ -1,0 +1,176 @@
+package runner
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+const (
+	SubmissionStageInputFormat       = "ok147-submission-stage-input/v1"
+	submissionStageInputNamespace    = "openkubes-execution-system"
+	maximumSubmissionStageInputBytes = 900 * 1024
+	providerReceiptInputKey          = "provider-receipt.json"
+)
+
+var submissionStageInputNamePattern = regexp.MustCompile(`^[a-z0-9](?:[-a-z0-9]*[a-z0-9])?$`)
+
+// SubmissionStageInputReceipt contains only redaction-safe identities for an
+// immutable, credential-free Job input ConfigMap.
+type SubmissionStageInputReceipt struct {
+	Format              string   `json:"format"`
+	State               string   `json:"state"`
+	StageID             string   `json:"stageId"`
+	ConfigMapName       string   `json:"configMapName"`
+	ConfigMapDigest     string   `json:"configMapDigest"`
+	ReceiptPrefixDigest string   `json:"receiptPrefixDigest"`
+	DataKeys            []string `json:"dataKeys"`
+}
+
+// VerifiedSubmissionStageInput retains the exact ConfigMap bytes produced by
+// verification. Callers receive copies and cannot alter the verified value.
+type VerifiedSubmissionStageInput struct {
+	raw      []byte
+	receipt  SubmissionStageInputReceipt
+	verified bool
+}
+
+type submissionStageInputConfigMap struct {
+	APIVersion string                         `json:"apiVersion"`
+	Kind       string                         `json:"kind"`
+	Metadata   submissionStageInputObjectMeta `json:"metadata"`
+	Immutable  bool                           `json:"immutable"`
+	Data       map[string]string              `json:"data"`
+}
+
+type submissionStageInputObjectMeta struct {
+	Name        string            `json:"name"`
+	Namespace   string            `json:"namespace"`
+	Labels      map[string]string `json:"labels"`
+	Annotations map[string]string `json:"annotations"`
+}
+
+// BuildSubmissionStageInput materializes only the public artifacts consumed
+// by the bounded submission-stage Job. It performs no Kubernetes request and
+// cannot package tokens, CA material, kubeconfigs or private keys.
+func BuildSubmissionStageInput(config SubmissionStageBundleConfig, configMapName string) (VerifiedSubmissionStageInput, error) {
+	if !submissionStageInputNamePattern.MatchString(configMapName) || len(configMapName) > 63 || !strings.HasPrefix(configMapName, "ok147-") {
+		return VerifiedSubmissionStageInput{}, errors.New("submission stage input ConfigMap name is invalid")
+	}
+	if _, err := LoadSubmissionStageBundle(config); err != nil {
+		return VerifiedSubmissionStageInput{}, err
+	}
+
+	root := config.ProjectionRoot
+	if root == "" && config.ProjectionManifestPath != "" {
+		root = filepath.Dir(config.ProjectionManifestPath)
+	}
+	paths := map[string]string{
+		"staged-plan.json":            config.PlanPath,
+		"stage-grant.json":            config.GrantPath,
+		"stage-authority.pub":         config.GrantPublicKeyPath,
+		"projection-manifest.json":    config.ProjectionManifestPath,
+		"authority-map.json":          filepath.Join(root, "authority-map.json"),
+		"ok-infra-prerequisites.yaml": filepath.Join(root, "ok-infra-prerequisites.yaml"),
+		"ok-mgmt-lifecycle.yaml":      filepath.Join(root, "ok-mgmt-lifecycle.yaml"),
+	}
+	prefix := stageReceiptPrefixDocument{Format: StageReceiptPrefixFormat, Receipts: []stageReceiptPrefixEntry{}}
+	switch config.ExpectedStageID {
+	case "provider-prerequisites":
+		if len(config.Receipts) != 0 {
+			return VerifiedSubmissionStageInput{}, errors.New("provider stage input must use an empty receipt prefix")
+		}
+	case "cluster-lifecycle":
+		if len(config.Receipts) != 1 {
+			return VerifiedSubmissionStageInput{}, errors.New("cluster lifecycle input requires exactly one provider receipt")
+		}
+		paths[providerReceiptInputKey] = config.Receipts[0].Path
+		prefix.Receipts = append(prefix.Receipts, stageReceiptPrefixEntry{File: providerReceiptInputKey, Digest: config.Receipts[0].Digest})
+	default:
+		return VerifiedSubmissionStageInput{}, errors.New("submission stage input supports only Contract-to-CAPI stages")
+	}
+	prefixRaw, err := json.Marshal(prefix)
+	if err != nil {
+		return VerifiedSubmissionStageInput{}, errors.New("encode stage receipt prefix")
+	}
+
+	data := make(map[string]string, len(paths)+1)
+	data["receipt-prefix.json"] = string(prefixRaw)
+	for key, path := range paths {
+		raw, err := readBoundedRegular(path, maximumSubmissionStageInputBytes)
+		if err != nil {
+			return VerifiedSubmissionStageInput{}, errors.New("read bounded submission stage input " + key)
+		}
+		if !utf8.Valid(raw) || bytes.IndexByte(raw, 0) >= 0 {
+			return VerifiedSubmissionStageInput{}, errors.New("submission stage input is not valid ConfigMap text")
+		}
+		data[key] = string(raw)
+	}
+
+	// Reverify the artifact chain after capturing every source. The Job repeats
+	// the same verification before credentials are opened, so any residual
+	// source-file race can only stop execution, never authorize changed input.
+	if _, err := LoadSubmissionStageBundle(config); err != nil {
+		return VerifiedSubmissionStageInput{}, errors.New("submission stage inputs changed during materialization")
+	}
+
+	configMap := submissionStageInputConfigMap{
+		APIVersion: "v1",
+		Kind:       "ConfigMap",
+		Metadata: submissionStageInputObjectMeta{
+			Name:      configMapName,
+			Namespace: submissionStageInputNamespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/name": "ok-cluster-contract-executor",
+				"openkubes.io/stage-id":  config.ExpectedStageID,
+			},
+			Annotations: map[string]string{
+				"openkubes.io/input-format":          SubmissionStageInputFormat,
+				"openkubes.io/receipt-prefix-digest": digest.SHA256(prefixRaw),
+			},
+		},
+		Immutable: true,
+		Data:      data,
+	}
+	raw, err := json.Marshal(configMap)
+	if err != nil {
+		return VerifiedSubmissionStageInput{}, errors.New("encode submission stage input ConfigMap")
+	}
+	if len(raw) > maximumSubmissionStageInputBytes {
+		return VerifiedSubmissionStageInput{}, errors.New("submission stage input ConfigMap exceeds size limit")
+	}
+	keys := make([]string, 0, len(data))
+	for key := range data {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	receipt := SubmissionStageInputReceipt{
+		Format: SubmissionStageInputFormat, State: "VERIFIED", StageID: config.ExpectedStageID,
+		ConfigMapName: configMapName, ConfigMapDigest: digest.SHA256(raw),
+		ReceiptPrefixDigest: digest.SHA256(prefixRaw), DataKeys: keys,
+	}
+	return VerifiedSubmissionStageInput{raw: raw, receipt: receipt, verified: true}, nil
+}
+
+func (input VerifiedSubmissionStageInput) Bytes() ([]byte, error) {
+	if !input.verified || len(input.raw) == 0 {
+		return nil, errors.New("submission stage input was not produced by verification")
+	}
+	return append([]byte(nil), input.raw...), nil
+}
+
+func (input VerifiedSubmissionStageInput) Receipt() (SubmissionStageInputReceipt, error) {
+	if !input.verified || input.receipt.State != "VERIFIED" {
+		return SubmissionStageInputReceipt{}, errors.New("submission stage input was not produced by verification")
+	}
+	receipt := input.receipt
+	receipt.DataKeys = append([]string(nil), input.receipt.DataKeys...)
+	return receipt, nil
+}

--- a/internal/runner/submission_stage_input_test.go
+++ b/internal/runner/submission_stage_input_test.go
@@ -1,0 +1,162 @@
+package runner
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+func TestBuildSubmissionStageInputMaterializesExactCredentialFreeConfigMap(t *testing.T) {
+	for _, completedProvider := range []bool{false, true} {
+		stageID := "provider-prerequisites"
+		expectedKeys := []string{
+			"authority-map.json", "ok-infra-prerequisites.yaml", "ok-mgmt-lifecycle.yaml",
+			"projection-manifest.json", "receipt-prefix.json", "stage-authority.pub",
+			"stage-grant.json", "staged-plan.json",
+		}
+		if completedProvider {
+			stageID = "cluster-lifecycle"
+			expectedKeys = append(expectedKeys, providerReceiptInputKey)
+		}
+		sort.Strings(expectedKeys)
+		t.Run(stageID, func(t *testing.T) {
+			fixture := submissionBundleFixture(t, completedProvider, "")
+			verified, err := BuildSubmissionStageInput(fixture.config, "ok147-"+stageID+"-input")
+			if err != nil {
+				t.Fatal(err)
+			}
+			raw, err := verified.Bytes()
+			if err != nil {
+				t.Fatal(err)
+			}
+			receipt, err := verified.Receipt()
+			if err != nil {
+				t.Fatal(err)
+			}
+			var configMap submissionStageInputConfigMap
+			if err := json.Unmarshal(raw, &configMap); err != nil {
+				t.Fatal(err)
+			}
+			if configMap.APIVersion != "v1" || configMap.Kind != "ConfigMap" || !configMap.Immutable {
+				t.Fatalf("unexpected ConfigMap envelope: %#v", configMap)
+			}
+			if configMap.Metadata.Name != "ok147-"+stageID+"-input" || configMap.Metadata.Namespace != submissionStageInputNamespace {
+				t.Fatalf("unexpected ConfigMap identity: %#v", configMap.Metadata)
+			}
+			if configMap.Metadata.Labels["openkubes.io/stage-id"] != stageID || configMap.Metadata.Annotations["openkubes.io/input-format"] != SubmissionStageInputFormat {
+				t.Fatalf("unexpected ConfigMap binding metadata: %#v", configMap.Metadata)
+			}
+			if !reflect.DeepEqual(receipt.DataKeys, expectedKeys) {
+				t.Fatalf("unexpected input keys: %#v", receipt.DataKeys)
+			}
+			if len(configMap.Data) != len(expectedKeys) {
+				t.Fatalf("unexpected ConfigMap data: %#v", configMap.Data)
+			}
+			for _, key := range expectedKeys {
+				if configMap.Data[key] == "" {
+					t.Fatalf("expected non-empty input %s", key)
+				}
+			}
+			for _, forbidden := range []string{"token", "kubeconfig", "private-key", "ca.crt"} {
+				for key := range configMap.Data {
+					if strings.Contains(strings.ToLower(key), forbidden) {
+						t.Fatalf("credential-shaped input key was packaged: %s", key)
+					}
+				}
+			}
+			if receipt.Format != SubmissionStageInputFormat || receipt.State != "VERIFIED" || receipt.StageID != stageID || receipt.ConfigMapDigest != digest.SHA256(raw) {
+				t.Fatalf("unexpected materialization receipt: %#v", receipt)
+			}
+
+			prefixRaw := []byte(configMap.Data["receipt-prefix.json"])
+			if receipt.ReceiptPrefixDigest != digest.SHA256(prefixRaw) || configMap.Metadata.Annotations["openkubes.io/receipt-prefix-digest"] != receipt.ReceiptPrefixDigest {
+				t.Fatal("receipt-prefix identity is not consistently bound")
+			}
+			var prefix stageReceiptPrefixDocument
+			if err := json.Unmarshal(prefixRaw, &prefix); err != nil {
+				t.Fatal(err)
+			}
+			if prefix.Format != StageReceiptPrefixFormat || prefix.Receipts == nil {
+				t.Fatalf("receipt prefix is not explicit: %#v", prefix)
+			}
+			if completedProvider {
+				if len(prefix.Receipts) != 1 || prefix.Receipts[0].File != providerReceiptInputKey || prefix.Receipts[0].Digest != fixture.config.Receipts[0].Digest {
+					t.Fatalf("provider receipt was not exactly rebound: %#v", prefix)
+				}
+				source, err := os.ReadFile(fixture.config.Receipts[0].Path)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if configMap.Data[providerReceiptInputKey] != string(source) {
+					t.Fatal("packaged provider receipt differs from verified source")
+				}
+			} else if len(prefix.Receipts) != 0 {
+				t.Fatalf("provider stage prefix is not empty: %#v", prefix)
+			}
+
+			raw[0] = 'x'
+			again, err := verified.Bytes()
+			if err != nil || again[0] != '{' {
+				t.Fatal("caller mutated retained verified ConfigMap")
+			}
+			receipt.DataKeys[0] = "changed"
+			againReceipt, err := verified.Receipt()
+			if err != nil || againReceipt.DataKeys[0] == "changed" {
+				t.Fatal("caller mutated retained materialization receipt")
+			}
+		})
+	}
+}
+
+func TestBuildSubmissionStageInputFailsClosed(t *testing.T) {
+	fixture := submissionBundleFixture(t, false, "")
+	if _, err := BuildSubmissionStageInput(fixture.config, "foreign-input"); err == nil {
+		t.Fatal("ConfigMap name outside OK-147 boundary was accepted")
+	}
+	if _, err := BuildSubmissionStageInput(fixture.config, "ok147-"); err == nil {
+		t.Fatal("invalid DNS label was accepted")
+	}
+	if _, err := (VerifiedSubmissionStageInput{}).Bytes(); err == nil {
+		t.Fatal("unverified input bytes were exposed")
+	}
+	if _, err := (VerifiedSubmissionStageInput{}).Receipt(); err == nil {
+		t.Fatal("unverified input receipt was exposed")
+	}
+
+	fixture = submissionBundleFixture(t, false, "")
+	if err := os.WriteFile(fixture.config.GrantPath, []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := BuildSubmissionStageInput(fixture.config, "ok147-tampered-input"); err == nil {
+		t.Fatal("tampered authorization was packaged")
+	}
+
+	fixture = submissionBundleFixture(t, false, "")
+	symlink := filepath.Join(t.TempDir(), "projection-manifest.json")
+	if err := os.Symlink(fixture.config.ProjectionManifestPath, symlink); err != nil {
+		t.Fatal(err)
+	}
+	fixture.config.ProjectionManifestPath = symlink
+	if _, err := BuildSubmissionStageInput(fixture.config, "ok147-symlink-input"); err == nil || !strings.Contains(err.Error(), "bounded submission stage input") {
+		t.Fatalf("symlink input was accepted: %v", err)
+	}
+
+	fixture = submissionBundleFixture(t, false, "")
+	manifest, err := os.ReadFile(fixture.config.ProjectionManifestPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	oversized := append([]byte(strings.Repeat(" ", maximumSubmissionStageInputBytes+1)), manifest...)
+	if err := os.WriteFile(fixture.config.ProjectionManifestPath, oversized, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := BuildSubmissionStageInput(fixture.config, "ok147-oversized-input"); err == nil || !strings.Contains(err.Error(), "bounded submission stage input") {
+		t.Fatalf("oversized input was accepted: %v", err)
+	}
+}


### PR DESCRIPTION
## Outcome

Materializes the bounded submission-stage Job input ConfigMap from one fully verified stage bundle.

- fixes the ConfigMap to `openkubes-execution-system` with `immutable: true`
- packages exactly 8 public inputs for `provider-prerequisites` and 9 for `cluster-lifecycle`
- creates an explicit canonical receipt-prefix manifest and normalizes the predecessor receipt name
- rejects symlinks, tampered authorization, invalid names, non-text input, and objects above 900 KiB
- returns only a redaction-safe digest/key receipt
- contains no credential slot and performs no Kubernetes request

## Validation

- `go test -ldflags=-linkmode=external ./...`
- `go vet ./...`
- targeted race tests for CLI/stage/runtime packages
- `python3 -m unittest discover -s tests -p '*_test.py'` (18 tests, 1 expected skip)
- `git diff --check`

No live infrastructure or credentials were accessed.