### PR TITLE
feat(runner): compose verified stage package (OK-147)

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -1129,6 +1129,24 @@ request remain external prerequisites. The Job independently reverifies all
 mounted artifacts before it opens credentials, so source races or changed
 inputs stop execution rather than authorizing them.
 
+## Coherent submission-stage package
+
+`BuildSubmissionStagePackage` now composes the immutable input ConfigMap with
+the bounded Job and NetworkPolicy as one deterministic three-object stream.
+The caller supplies only runtime object names, a digest-pinned image and exact
+API endpoint/CIDR identities. Stage ID, Contract identities, evaluation time,
+input ConfigMap identity and receipt-prefix digest are derived from the same
+verified bundle and materialization receipt, so they cannot drift across the
+two artifacts.
+
+The package receipt independently binds the complete stream, ConfigMap and
+Job/NetworkPolicy envelope digests plus the exact object-kind inventory. It is
+explicitly non-mutating (`mutationAllowed: false`): package construction does
+not read credential content, contact Kubernetes, create the externally named
+credential Secrets or apply any of its objects. Reusing a credential Secret
+name as the input ConfigMap identity is rejected in addition to the Job's
+existing distinct-credential and endpoint boundaries.
+
 ## Typed first-run Platform capability boundary
 
 First-run capability production now has a separate lazy resolver from the

--- a/internal/runner/submission_stage_package.go
+++ b/internal/runner/submission_stage_package.go
@@ -1,0 +1,111 @@
+package runner
+
+import (
+	"errors"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+const SubmissionStagePackageFormat = "ok147-submission-stage-package/v1"
+
+// SubmissionStagePackageConfig contains only operator-selected runtime object,
+// image, endpoint and credential-Secret identities. Stage, Contract,
+// evaluation-time and receipt-prefix values are derived from Bundle.
+type SubmissionStagePackageConfig struct {
+	Bundle                    SubmissionStageBundleConfig
+	JobTemplate               []byte
+	RunID                     string
+	ImageDigest               string
+	InputConfigMap            string
+	LedgerAPIURL              string
+	LedgerAPICIDR             string
+	LedgerCredentialSecret    string
+	AuthorityAPIURL           string
+	AuthorityAPICIDR          string
+	AuthorityCredentialSecret string
+}
+
+// SubmissionStagePackageReceipt is a redaction-safe proof of offline
+// composition. MutationAllowed is always false: producing a package is not a
+// Kubernetes apply or an execution authorization.
+type SubmissionStagePackageReceipt struct {
+	Format               string   `json:"format"`
+	State                string   `json:"state"`
+	StageID              string   `json:"stageId"`
+	PackageDigest        string   `json:"packageDigest"`
+	InputConfigMapDigest string   `json:"inputConfigMapDigest"`
+	ReceiptPrefixDigest  string   `json:"receiptPrefixDigest"`
+	JobEnvelopeDigest    string   `json:"jobEnvelopeDigest"`
+	ObjectKinds          []string `json:"objectKinds"`
+	AuthorizationState   string   `json:"authorizationState"`
+	MutationAllowed      bool     `json:"mutationAllowed"`
+}
+
+type VerifiedSubmissionStagePackage struct {
+	raw      []byte
+	receipt  SubmissionStagePackageReceipt
+	verified bool
+}
+
+// BuildSubmissionStagePackage composes one immutable input ConfigMap with one
+// bounded Job/NetworkPolicy envelope. It does not create Kubernetes objects,
+// read credentials or contact an API server.
+func BuildSubmissionStagePackage(config SubmissionStagePackageConfig) (VerifiedSubmissionStagePackage, error) {
+	if config.InputConfigMap == config.LedgerCredentialSecret || config.InputConfigMap == config.AuthorityCredentialSecret {
+		return VerifiedSubmissionStagePackage{}, errors.New("submission stage input and credential object names must be distinct")
+	}
+	input, err := BuildSubmissionStageInput(config.Bundle, config.InputConfigMap)
+	if err != nil {
+		return VerifiedSubmissionStagePackage{}, err
+	}
+	inputRaw, err := input.Bytes()
+	if err != nil {
+		return VerifiedSubmissionStagePackage{}, err
+	}
+	inputReceipt, err := input.Receipt()
+	if err != nil {
+		return VerifiedSubmissionStagePackage{}, err
+	}
+	jobRaw, err := RenderSubmissionStageJobTemplate(config.JobTemplate, SubmissionStageJobValues{
+		RunID: config.RunID, StageID: config.Bundle.ExpectedStageID,
+		ImageDigest: config.ImageDigest, EvaluationTime: config.Bundle.EvaluationTime.UTC().Format(time.RFC3339),
+		Expected: config.Bundle.PlanExpected, InputConfigMap: config.InputConfigMap,
+		ReceiptPrefixDigest: inputReceipt.ReceiptPrefixDigest,
+		LedgerAPIURL:        config.LedgerAPIURL, LedgerAPICIDR: config.LedgerAPICIDR,
+		LedgerCredentialSecret: config.LedgerCredentialSecret,
+		AuthorityAPIURL:        config.AuthorityAPIURL, AuthorityAPICIDR: config.AuthorityAPICIDR,
+		AuthorityCredentialSecret: config.AuthorityCredentialSecret,
+	})
+	if err != nil {
+		return VerifiedSubmissionStagePackage{}, err
+	}
+	packageRaw := make([]byte, 0, len(inputRaw)+len(jobRaw)+6)
+	packageRaw = append(packageRaw, inputRaw...)
+	packageRaw = append(packageRaw, '\n', '-', '-', '-', '\n')
+	packageRaw = append(packageRaw, jobRaw...)
+	receipt := SubmissionStagePackageReceipt{
+		Format: SubmissionStagePackageFormat, State: "VERIFIED", StageID: config.Bundle.ExpectedStageID,
+		PackageDigest: digest.SHA256(packageRaw), InputConfigMapDigest: inputReceipt.ConfigMapDigest,
+		ReceiptPrefixDigest: inputReceipt.ReceiptPrefixDigest, JobEnvelopeDigest: digest.SHA256(jobRaw),
+		ObjectKinds:        []string{"ConfigMap", "Job", "NetworkPolicy"},
+		AuthorizationState: "VERIFIED", MutationAllowed: false,
+	}
+	return VerifiedSubmissionStagePackage{raw: packageRaw, receipt: receipt, verified: true}, nil
+}
+
+func (packaged VerifiedSubmissionStagePackage) Bytes() ([]byte, error) {
+	if !packaged.verified || len(packaged.raw) == 0 {
+		return nil, errors.New("submission stage package was not produced by verification")
+	}
+	return append([]byte(nil), packaged.raw...), nil
+}
+
+func (packaged VerifiedSubmissionStagePackage) Receipt() (SubmissionStagePackageReceipt, error) {
+	if !packaged.verified || packaged.receipt.State != "VERIFIED" {
+		return SubmissionStagePackageReceipt{}, errors.New("submission stage package was not produced by verification")
+	}
+	receipt := packaged.receipt
+	receipt.ObjectKinds = append([]string(nil), packaged.receipt.ObjectKinds...)
+	return receipt, nil
+}

--- a/internal/runner/submission_stage_package_test.go
+++ b/internal/runner/submission_stage_package_test.go
@@ -1,0 +1,145 @@
+package runner
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+func TestBuildSubmissionStagePackageBindsInputAndJobEnvelope(t *testing.T) {
+	for _, completedProvider := range []bool{false, true} {
+		stageID := "provider-prerequisites"
+		if completedProvider {
+			stageID = "cluster-lifecycle"
+		}
+		t.Run(stageID, func(t *testing.T) {
+			fixture := submissionBundleFixture(t, completedProvider, "")
+			config := submissionStagePackageConfig(t, fixture, stageID)
+			packaged, err := BuildSubmissionStagePackage(config)
+			if err != nil {
+				t.Fatal(err)
+			}
+			raw, err := packaged.Bytes()
+			if err != nil {
+				t.Fatal(err)
+			}
+			receipt, err := packaged.Receipt()
+			if err != nil {
+				t.Fatal(err)
+			}
+			objects := decodeJobObjects(t, raw)
+			if len(objects) != 3 || objects["ConfigMap"] == nil || objects["Job"] == nil || objects["NetworkPolicy"] == nil {
+				t.Fatalf("unexpected package object set: %#v", objects)
+			}
+			configMap := objects["ConfigMap"]
+			if configMap["immutable"] != true || objectAt(t, configMap, "metadata")["name"] != config.InputConfigMap {
+				t.Fatalf("unexpected input ConfigMap: %#v", configMap)
+			}
+			job := objects["Job"]
+			podSpec := objectAt(t, objectAt(t, objectAt(t, job, "spec"), "template"), "spec")
+			container := arrayAt(t, podSpec, "containers")[0].(map[string]any)
+			args := stringArray(t, container, "args")
+			if argumentValue(args, "--expected-stage") != stageID || argumentValue(args, "--receipt-prefix-digest") != receipt.ReceiptPrefixDigest {
+				t.Fatalf("Job and package bindings differ: %v %#v", args, receipt)
+			}
+			if argumentValue(args, "--evaluation-time") != fixture.config.EvaluationTime.UTC().Format("2006-01-02T15:04:05Z07:00") {
+				t.Fatal("Job evaluation time was not derived from the verified bundle")
+			}
+			if receipt.Format != SubmissionStagePackageFormat || receipt.State != "VERIFIED" || receipt.StageID != stageID || receipt.PackageDigest != digest.SHA256(raw) || receipt.MutationAllowed {
+				t.Fatalf("unexpected package receipt: %#v", receipt)
+			}
+			parts := bytes.SplitN(raw, []byte("\n---\n"), 2)
+			if len(parts) != 2 || receipt.InputConfigMapDigest != digest.SHA256(parts[0]) || receipt.JobEnvelopeDigest != digest.SHA256(parts[1]) {
+				t.Fatal("package component digests do not match exact emitted bytes")
+			}
+			if !reflect.DeepEqual(receipt.ObjectKinds, []string{"ConfigMap", "Job", "NetworkPolicy"}) || receipt.AuthorizationState != "VERIFIED" {
+				t.Fatalf("unexpected package object/authorization state: %#v", receipt)
+			}
+			input, err := BuildSubmissionStageInput(fixture.config, config.InputConfigMap)
+			if err != nil {
+				t.Fatal(err)
+			}
+			inputReceipt, err := input.Receipt()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if receipt.InputConfigMapDigest != inputReceipt.ConfigMapDigest || receipt.ReceiptPrefixDigest != inputReceipt.ReceiptPrefixDigest {
+				t.Fatal("package does not bind the independently verified input")
+			}
+
+			raw[0] = 'x'
+			again, err := packaged.Bytes()
+			if err != nil || again[0] != '{' {
+				t.Fatal("caller mutated retained package")
+			}
+			receipt.ObjectKinds[0] = "Changed"
+			againReceipt, err := packaged.Receipt()
+			if err != nil || againReceipt.ObjectKinds[0] != "ConfigMap" {
+				t.Fatal("caller mutated retained package receipt")
+			}
+		})
+	}
+}
+
+func TestBuildSubmissionStagePackageFailsClosed(t *testing.T) {
+	fixture := submissionBundleFixture(t, false, "")
+	valid := submissionStagePackageConfig(t, fixture, "provider-prerequisites")
+	for name, mutate := range map[string]func(*SubmissionStagePackageConfig){
+		"input reuses ledger Secret": func(config *SubmissionStagePackageConfig) {
+			config.InputConfigMap = config.LedgerCredentialSecret
+		},
+		"input reuses authority Secret": func(config *SubmissionStagePackageConfig) {
+			config.InputConfigMap = config.AuthorityCredentialSecret
+		},
+		"mutable image": func(config *SubmissionStagePackageConfig) {
+			config.ImageDigest = "ghcr.io/openkubes/ok-cluster:latest"
+		},
+		"foreign provider endpoint": func(config *SubmissionStagePackageConfig) {
+			config.AuthorityAPIURL, config.AuthorityAPICIDR = config.LedgerAPIURL, config.LedgerAPICIDR
+		},
+		"changed template": func(config *SubmissionStagePackageConfig) {
+			config.JobTemplate = append(config.JobTemplate, []byte("\n${UNKNOWN}")...)
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			config := valid
+			config.JobTemplate = append([]byte(nil), valid.JobTemplate...)
+			mutate(&config)
+			if _, err := BuildSubmissionStagePackage(config); err == nil {
+				t.Fatal("incoherent submission stage package was accepted")
+			}
+		})
+	}
+	if _, err := (VerifiedSubmissionStagePackage{}).Bytes(); err == nil {
+		t.Fatal("unverified package bytes were exposed")
+	}
+	if _, err := (VerifiedSubmissionStagePackage{}).Receipt(); err == nil {
+		t.Fatal("unverified package receipt was exposed")
+	}
+}
+
+func submissionStagePackageConfig(t *testing.T, fixture submissionBundleTestFixture, stageID string) SubmissionStagePackageConfig {
+	t.Helper()
+	values := validSubmissionStageJobValues()
+	values.StageID = stageID
+	if stageID == "cluster-lifecycle" {
+		values.AuthorityAPIURL, values.AuthorityAPICIDR = values.LedgerAPIURL, values.LedgerAPICIDR
+	}
+	return SubmissionStagePackageConfig{
+		Bundle: fixture.config, JobTemplate: submissionStageJobTemplate(t),
+		RunID: values.RunID, ImageDigest: values.ImageDigest, InputConfigMap: values.InputConfigMap,
+		LedgerAPIURL: values.LedgerAPIURL, LedgerAPICIDR: values.LedgerAPICIDR, LedgerCredentialSecret: values.LedgerCredentialSecret,
+		AuthorityAPIURL: values.AuthorityAPIURL, AuthorityAPICIDR: values.AuthorityAPICIDR, AuthorityCredentialSecret: values.AuthorityCredentialSecret,
+	}
+}
+
+func argumentValue(arguments []string, name string) string {
+	for index := 0; index+1 < len(arguments); index++ {
+		if arguments[index] == name {
+			return arguments[index+1]
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
## Outcome

Composes the immutable Job input ConfigMap and bounded Job/NetworkPolicy envelope from one verified submission-stage bundle.

- derives stage, R/E/P/fixture, evaluation time, ConfigMap name and receipt-prefix digest from one chain
- prevents caller drift between the input artifact and executable envelope
- binds exact package, ConfigMap, Job-envelope, and object-inventory digests
- keeps package creation explicitly `mutationAllowed: false`
- rejects input/credential object-name reuse and preserves existing endpoint/credential boundaries
- performs no credential read, Kubernetes request, or live mutation

## Validation

- `go test -ldflags=-linkmode=external ./...`
- `go vet ./...`
- targeted race tests for CLI/stage/runtime packages
- `python3 -m unittest discover -s tests -p '*_test.py'` (18 tests, 1 expected skip)
- `git diff --check`