### PR TITLE
feat(cli): render verified stage package (OK-147)

### DIFF
--- a/cmd/ok/main.go
+++ b/cmd/ok/main.go
@@ -36,6 +36,19 @@ var (
 	stageReceiptFlagPattern = regexp.MustCompile(`^.+@sha256:[0-9a-f]{64}$`)
 )
 
+var materializeSubmissionStagePackage = func(config runner.SubmissionStagePackageConfig) ([]byte, runner.SubmissionStagePackageReceipt, error) {
+	packaged, err := runner.BuildSubmissionStagePackage(config)
+	if err != nil {
+		return nil, runner.SubmissionStagePackageReceipt{}, err
+	}
+	raw, err := packaged.Bytes()
+	if err != nil {
+		return nil, runner.SubmissionStagePackageReceipt{}, err
+	}
+	receipt, err := packaged.Receipt()
+	return raw, receipt, err
+}
+
 type createPlan struct {
 	Format                  string                  `json:"format"`
 	Operation               string                  `json:"operation"`
@@ -232,7 +245,10 @@ func runContext(ctx context.Context, arguments []string, stdout, stderr io.Write
 	if len(arguments) >= 3 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "run" {
 		return runClusterStageRun(ctx, arguments[3:], stdout, stderr)
 	}
-	return errors.New("usage: ok cluster create ... | ok cluster stage inspect ... | ok cluster stage run ...")
+	if len(arguments) >= 3 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "package" {
+		return runClusterStagePackage(arguments[3:], stdout, stderr)
+	}
+	return errors.New("usage: ok cluster create ... | ok cluster stage inspect ... | ok cluster stage run ... | ok cluster stage package ...")
 }
 
 func runClusterCreate(arguments []string, stdout, stderr io.Writer) error {
@@ -443,6 +459,116 @@ func runClusterStageRun(ctx context.Context, arguments []string, stdout, stderr 
 		}
 	}
 	return runErr
+}
+
+func runClusterStagePackage(arguments []string, stdout, stderr io.Writer) error {
+	flags := flag.NewFlagSet("ok cluster stage package", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	bundleFlags := addStageBundleFlags(flags)
+	jobTemplate := flags.String("job-template", "", "path to the bounded submission-stage Job template")
+	jobTemplateDigest := flags.String("job-template-digest", "", "expected SHA-256 identity of the Job template")
+	output := flags.String("output", "", "new local file for the verified ConfigMap/Job/NetworkPolicy package")
+	runID := flags.String("run-id", "", "bounded OK-147 Job identity")
+	imageDigest := flags.String("image", "", "digest-pinned ok image")
+	inputConfigMap := flags.String("input-configmap", "", "immutable input ConfigMap name")
+	ledgerAPIURL := flags.String("ledger-api-url", "", "exact management-ledger HTTPS IP endpoint")
+	ledgerAPICIDR := flags.String("ledger-api-cidr", "", "single-address management-ledger CIDR")
+	ledgerCredentialSecret := flags.String("ledger-credential-secret", "", "externally materialized ledger credential Secret name")
+	authorityAPIURL := flags.String("authority-api-url", "", "exact selected-authority HTTPS IP endpoint")
+	authorityAPICIDR := flags.String("authority-api-cidr", "", "single-address selected-authority CIDR")
+	authorityCredentialSecret := flags.String("authority-credential-secret", "", "externally materialized authority credential Secret name")
+	if err := flags.Parse(arguments); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return errors.New("positional arguments are not accepted")
+	}
+	bundleConfig, err := bundleFlags.config()
+	if err != nil {
+		return err
+	}
+	for _, input := range []struct{ name, value string }{
+		{"--job-template", *jobTemplate}, {"--job-template-digest", *jobTemplateDigest}, {"--output", *output}, {"--run-id", *runID}, {"--image", *imageDigest},
+		{"--input-configmap", *inputConfigMap}, {"--ledger-api-url", *ledgerAPIURL}, {"--ledger-api-cidr", *ledgerAPICIDR},
+		{"--ledger-credential-secret", *ledgerCredentialSecret}, {"--authority-api-url", *authorityAPIURL},
+		{"--authority-api-cidr", *authorityAPICIDR}, {"--authority-credential-secret", *authorityCredentialSecret},
+	} {
+		if input.value == "" {
+			return fmt.Errorf("%s is required", input.name)
+		}
+	}
+	template, err := readBoundedLocalFile(*jobTemplate, 1024*1024)
+	if err != nil {
+		return fmt.Errorf("read Job template: %w", err)
+	}
+	raw, receipt, err := materializeSubmissionStagePackage(runner.SubmissionStagePackageConfig{
+		Bundle: bundleConfig, JobTemplate: template, JobTemplateDigest: *jobTemplateDigest,
+		RunID: *runID, ImageDigest: *imageDigest, InputConfigMap: *inputConfigMap,
+		LedgerAPIURL: *ledgerAPIURL, LedgerAPICIDR: *ledgerAPICIDR, LedgerCredentialSecret: *ledgerCredentialSecret,
+		AuthorityAPIURL: *authorityAPIURL, AuthorityAPICIDR: *authorityAPICIDR, AuthorityCredentialSecret: *authorityCredentialSecret,
+	})
+	if err != nil {
+		return err
+	}
+	if err := writeNewLocalFile(*output, raw); err != nil {
+		return fmt.Errorf("write stage package: %w", err)
+	}
+	encoder := json.NewEncoder(stdout)
+	encoder.SetEscapeHTML(false)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(receipt)
+}
+
+func readBoundedLocalFile(path string, maximum int64) ([]byte, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return nil, err
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() || info.Size() <= 0 || info.Size() > maximum {
+		return nil, errors.New("local file metadata is invalid")
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	opened, err := file.Stat()
+	if err != nil || !os.SameFile(info, opened) || !opened.Mode().IsRegular() || opened.Size() <= 0 || opened.Size() > maximum {
+		return nil, errors.New("local file changed while opening")
+	}
+	raw, err := io.ReadAll(io.LimitReader(file, maximum+1))
+	if err != nil || int64(len(raw)) > maximum {
+		return nil, errors.New("read bounded local file")
+	}
+	return raw, nil
+}
+
+func writeNewLocalFile(path string, raw []byte) (err error) {
+	if path == "" || len(raw) == 0 {
+		return errors.New("non-empty output path and package are required")
+	}
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return err
+	}
+	complete := false
+	defer func() {
+		if !complete {
+			_ = file.Close()
+			_ = os.Remove(path)
+		}
+	}()
+	if _, err = file.Write(raw); err != nil {
+		return err
+	}
+	if err = file.Sync(); err != nil {
+		return err
+	}
+	if err = file.Close(); err != nil {
+		return err
+	}
+	complete = true
+	return nil
 }
 
 func countNonEmpty(values ...string) int {

--- a/cmd/ok/main_test.go
+++ b/cmd/ok/main_test.go
@@ -270,6 +270,79 @@ func TestSubmissionStageAuthorityIsDerivedFromVerifiedTopology(t *testing.T) {
 	}
 }
 
+func TestStagePackageWritesOneVerifiedOfflineArtifact(t *testing.T) {
+	previous := materializeSubmissionStagePackage
+	defer func() { materializeSubmissionStagePackage = previous }()
+	var captured runner.SubmissionStagePackageConfig
+	materializeSubmissionStagePackage = func(config runner.SubmissionStagePackageConfig) ([]byte, runner.SubmissionStagePackageReceipt, error) {
+		captured = config
+		return []byte("verified-package\n"), runner.SubmissionStagePackageReceipt{
+			Format: runner.SubmissionStagePackageFormat, State: "VERIFIED", StageID: "provider-prerequisites",
+			PackageDigest: testSHA("1"), InputConfigMapDigest: testSHA("2"), ReceiptPrefixDigest: testSHA("3"),
+			JobTemplateDigest: testSHA("4"), JobEnvelopeDigest: testSHA("5"), ObjectKinds: []string{"ConfigMap", "Job", "NetworkPolicy"},
+			AuthorizationState: "VERIFIED", MutationAllowed: false,
+		}, nil
+	}
+	root := t.TempDir()
+	template := filepath.Join(root, "job.yaml.tpl")
+	if err := os.WriteFile(template, []byte("bounded-template"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	output := filepath.Join(root, "package.yaml")
+	arguments := stagePackageArguments(template, output)
+	var stdout, stderr bytes.Buffer
+	if err := run(arguments, &stdout, &stderr); err != nil {
+		t.Fatalf("run: %v; stderr=%s", err, stderr.String())
+	}
+	if captured.Bundle.ExpectedStageID != "provider-prerequisites" || captured.RunID != "ok147-provider-20260816-01" || captured.InputConfigMap != "ok147-provider-input" {
+		t.Fatalf("unexpected package config: %#v", captured)
+	}
+	if string(captured.JobTemplate) != "bounded-template" || captured.JobTemplateDigest != digest.SHA256([]byte("bounded-template")) || captured.LedgerCredentialSecret == captured.AuthorityCredentialSecret {
+		t.Fatalf("template or credential identities were not bound: %#v", captured)
+	}
+	written, err := os.ReadFile(output)
+	if err != nil || string(written) != "verified-package\n" {
+		t.Fatalf("unexpected package file: %q %v", written, err)
+	}
+	info, err := os.Stat(output)
+	if err != nil || info.Mode().Perm() != 0o600 {
+		t.Fatalf("package mode is not 0600: %v %v", info, err)
+	}
+	var receipt runner.SubmissionStagePackageReceipt
+	if err := json.Unmarshal(stdout.Bytes(), &receipt); err != nil {
+		t.Fatal(err)
+	}
+	if receipt.State != "VERIFIED" || receipt.MutationAllowed {
+		t.Fatalf("unsafe package receipt: %#v", receipt)
+	}
+
+	stdout.Reset()
+	if err := run(arguments, &stdout, &stderr); err == nil || stdout.Len() != 0 {
+		t.Fatal("existing output was overwritten or emitted a false receipt")
+	}
+}
+
+func TestStagePackageRejectsIncompleteAndSymlinkTemplate(t *testing.T) {
+	root := t.TempDir()
+	template := filepath.Join(root, "job.yaml.tpl")
+	if err := os.WriteFile(template, []byte("bounded-template"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	output := filepath.Join(root, "package.yaml")
+	missingImage := removeArgumentWithValue(stagePackageArguments(template, output), "--image")
+	var stdout, stderr bytes.Buffer
+	if err := run(missingImage, &stdout, &stderr); err == nil {
+		t.Fatal("incomplete package input was accepted")
+	}
+	symlink := filepath.Join(root, "job-link.yaml.tpl")
+	if err := os.Symlink(template, symlink); err != nil {
+		t.Fatal(err)
+	}
+	if err := run(stagePackageArguments(symlink, output), &stdout, &stderr); err == nil {
+		t.Fatal("symlink Job template was accepted")
+	}
+}
+
 func stageInspectArguments() []string {
 	return []string{
 		"cluster", "stage", "inspect",
@@ -289,6 +362,19 @@ func stageRunArguments() []string {
 		"--execute",
 		"--ledger-api-endpoint", "https://192.0.2.12:6443", "--ledger-token-file", "/tmp/ledger-token", "--ledger-ca-file", "/tmp/ledger-ca",
 		"--authority-api-endpoint", "https://192.0.2.11:6443", "--authority-token-file", "/tmp/authority-token", "--authority-ca-file", "/tmp/authority-ca",
+	)
+}
+
+func stagePackageArguments(template, output string) []string {
+	arguments := stageInspectArguments()
+	arguments[2] = "package"
+	return append(arguments,
+		"--job-template", template, "--job-template-digest", digest.SHA256([]byte("bounded-template")), "--output", output,
+		"--run-id", "ok147-provider-20260816-01",
+		"--image", "ghcr.io/openkubes/ok-cluster@"+testSHA("a"),
+		"--input-configmap", "ok147-provider-input",
+		"--ledger-api-url", "https://192.0.2.12:6443", "--ledger-api-cidr", "192.0.2.12/32", "--ledger-credential-secret", "ok147-ledger-credential",
+		"--authority-api-url", "https://192.0.2.11:6443", "--authority-api-cidr", "192.0.2.11/32", "--authority-credential-secret", "ok147-authority-credential",
 	)
 }
 

--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -1133,11 +1133,11 @@ inputs stop execution rather than authorizing them.
 
 `BuildSubmissionStagePackage` now composes the immutable input ConfigMap with
 the bounded Job and NetworkPolicy as one deterministic three-object stream.
-The caller supplies only runtime object names, a digest-pinned image and exact
-API endpoint/CIDR identities. Stage ID, Contract identities, evaluation time,
-input ConfigMap identity and receipt-prefix digest are derived from the same
-verified bundle and materialization receipt, so they cannot drift across the
-two artifacts.
+The caller supplies only runtime object names, a digest-pinned image, a
+separately SHA-256-bound Job template and exact API endpoint/CIDR identities.
+Stage ID, Contract identities, evaluation time, input ConfigMap identity and
+receipt-prefix digest are derived from the same verified bundle and
+materialization receipt, so they cannot drift across the two artifacts.
 
 The package receipt independently binds the complete stream, ConfigMap and
 Job/NetworkPolicy envelope digests plus the exact object-kind inventory. It is
@@ -1146,6 +1146,13 @@ not read credential content, contact Kubernetes, create the externally named
 credential Secrets or apply any of its objects. Reusing a credential Secret
 name as the input ConfigMap identity is rejected in addition to the Job's
 existing distinct-credential and endpoint boundaries.
+
+`ok cluster stage package` exposes this composition as an offline CLI. It
+accepts no credential file and has no execute flag. The command reads the
+bounded regular non-symlink template, refuses to overwrite its requested local
+output, writes the package with mode `0600`, and emits only the redaction-safe
+package receipt on stdout. The Job-template digest is required explicitly and
+is retained in that receipt.
 
 ## Typed first-run Platform capability boundary
 

--- a/internal/runner/submission_stage_package.go
+++ b/internal/runner/submission_stage_package.go
@@ -15,6 +15,7 @@ const SubmissionStagePackageFormat = "ok147-submission-stage-package/v1"
 type SubmissionStagePackageConfig struct {
 	Bundle                    SubmissionStageBundleConfig
 	JobTemplate               []byte
+	JobTemplateDigest         string
 	RunID                     string
 	ImageDigest               string
 	InputConfigMap            string
@@ -36,6 +37,7 @@ type SubmissionStagePackageReceipt struct {
 	PackageDigest        string   `json:"packageDigest"`
 	InputConfigMapDigest string   `json:"inputConfigMapDigest"`
 	ReceiptPrefixDigest  string   `json:"receiptPrefixDigest"`
+	JobTemplateDigest    string   `json:"jobTemplateDigest"`
 	JobEnvelopeDigest    string   `json:"jobEnvelopeDigest"`
 	ObjectKinds          []string `json:"objectKinds"`
 	AuthorizationState   string   `json:"authorizationState"`
@@ -52,6 +54,9 @@ type VerifiedSubmissionStagePackage struct {
 // bounded Job/NetworkPolicy envelope. It does not create Kubernetes objects,
 // read credentials or contact an API server.
 func BuildSubmissionStagePackage(config SubmissionStagePackageConfig) (VerifiedSubmissionStagePackage, error) {
+	if !stageReceiptPrefixDigestPattern.MatchString(config.JobTemplateDigest) || digest.SHA256(config.JobTemplate) != config.JobTemplateDigest {
+		return VerifiedSubmissionStagePackage{}, errors.New("submission stage Job template digest differs from expected identity")
+	}
 	if config.InputConfigMap == config.LedgerCredentialSecret || config.InputConfigMap == config.AuthorityCredentialSecret {
 		return VerifiedSubmissionStagePackage{}, errors.New("submission stage input and credential object names must be distinct")
 	}
@@ -87,7 +92,8 @@ func BuildSubmissionStagePackage(config SubmissionStagePackageConfig) (VerifiedS
 	receipt := SubmissionStagePackageReceipt{
 		Format: SubmissionStagePackageFormat, State: "VERIFIED", StageID: config.Bundle.ExpectedStageID,
 		PackageDigest: digest.SHA256(packageRaw), InputConfigMapDigest: inputReceipt.ConfigMapDigest,
-		ReceiptPrefixDigest: inputReceipt.ReceiptPrefixDigest, JobEnvelopeDigest: digest.SHA256(jobRaw),
+		ReceiptPrefixDigest: inputReceipt.ReceiptPrefixDigest, JobTemplateDigest: config.JobTemplateDigest,
+		JobEnvelopeDigest:  digest.SHA256(jobRaw),
 		ObjectKinds:        []string{"ConfigMap", "Job", "NetworkPolicy"},
 		AuthorizationState: "VERIFIED", MutationAllowed: false,
 	}

--- a/internal/runner/submission_stage_package_test.go
+++ b/internal/runner/submission_stage_package_test.go
@@ -54,6 +54,9 @@ func TestBuildSubmissionStagePackageBindsInputAndJobEnvelope(t *testing.T) {
 			if len(parts) != 2 || receipt.InputConfigMapDigest != digest.SHA256(parts[0]) || receipt.JobEnvelopeDigest != digest.SHA256(parts[1]) {
 				t.Fatal("package component digests do not match exact emitted bytes")
 			}
+			if receipt.JobTemplateDigest != digest.SHA256(config.JobTemplate) {
+				t.Fatal("package does not bind the exact Job template identity")
+			}
 			if !reflect.DeepEqual(receipt.ObjectKinds, []string{"ConfigMap", "Job", "NetworkPolicy"}) || receipt.AuthorizationState != "VERIFIED" {
 				t.Fatalf("unexpected package object/authorization state: %#v", receipt)
 			}
@@ -102,6 +105,9 @@ func TestBuildSubmissionStagePackageFailsClosed(t *testing.T) {
 		"changed template": func(config *SubmissionStagePackageConfig) {
 			config.JobTemplate = append(config.JobTemplate, []byte("\n${UNKNOWN}")...)
 		},
+		"wrong template digest": func(config *SubmissionStagePackageConfig) {
+			config.JobTemplateDigest = prefixSHA("f")
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			config := valid
@@ -127,12 +133,14 @@ func submissionStagePackageConfig(t *testing.T, fixture submissionBundleTestFixt
 	if stageID == "cluster-lifecycle" {
 		values.AuthorityAPIURL, values.AuthorityAPICIDR = values.LedgerAPIURL, values.LedgerAPICIDR
 	}
-	return SubmissionStagePackageConfig{
+	config := SubmissionStagePackageConfig{
 		Bundle: fixture.config, JobTemplate: submissionStageJobTemplate(t),
 		RunID: values.RunID, ImageDigest: values.ImageDigest, InputConfigMap: values.InputConfigMap,
 		LedgerAPIURL: values.LedgerAPIURL, LedgerAPICIDR: values.LedgerAPICIDR, LedgerCredentialSecret: values.LedgerCredentialSecret,
 		AuthorityAPIURL: values.AuthorityAPIURL, AuthorityAPICIDR: values.AuthorityAPICIDR, AuthorityCredentialSecret: values.AuthorityCredentialSecret,
 	}
+	config.JobTemplateDigest = digest.SHA256(config.JobTemplate)
+	return config
 }
 
 func argumentValue(arguments []string, name string) string {


### PR DESCRIPTION
## Outcome

Adds `ok cluster stage package` as a strictly offline materialization path.

- composes the verified ConfigMap/Job/NetworkPolicy package without an execute flag
- requires an explicit SHA-256 identity for the bounded Job template
- accepts object, endpoint, CIDR and external Secret names, but no credential files
- rejects symlink templates and existing output paths
- writes one new local `0600` package and emits only its redaction-safe receipt
- retains `mutationAllowed: false` and performs no Kubernetes request

## Validation

- `go test -ldflags=-linkmode=external ./...`
- `go vet ./...`
- targeted race tests for CLI/stage/runtime packages
- `python3 -m unittest discover -s tests -p '*_test.py'` (18 tests, 1 expected skip)
- `git diff --check`