### PR TITLE
feat(runner): define tokenless stage runtime (OK-147)

### DIFF
--- a/deploy/contract-executor-stage-runtime.yaml
+++ b/deploy/contract-executor-stage-runtime.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ok147-contract-executor-runtime
+  namespace: openkubes-execution-system
+  labels:
+    app.kubernetes.io/name: ok-cluster-contract-executor
+    openkubes.io/runtime-boundary: submission-stage
+automountServiceAccountToken: false

--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -1154,6 +1154,21 @@ output, writes the package with mode `0600`, and emits only the redaction-safe
 package receipt on stdout. The Job-template digest is required explicitly and
 is retained in that receipt.
 
+## Tokenless submission runtime identity
+
+[`deploy/contract-executor-stage-runtime.yaml`](../deploy/contract-executor-stage-runtime.yaml)
+defines the sole in-cluster identity referenced by the bounded submission Job:
+`ServiceAccount/ok147-contract-executor-runtime` in the existing execution
+namespace. It has `automountServiceAccountToken: false` and deliberately has no
+Role, RoleBinding, ClusterRole or ClusterRoleBinding.
+
+The Job therefore receives no implicit local API credential or Kubernetes
+permission from its Pod identity. Its ledger and selected-authority access can
+only come from the two separately named, externally materialized short-lived
+Secret mounts already bound by the Job envelope. Creating the ServiceAccount,
+credential Secrets or package objects remains an external authorized
+operation; this checkpoint only defines and tests the prerequisite manifest.
+
 ## Typed first-run Platform capability boundary
 
 First-run capability production now has a separate lazy resolver from the

--- a/internal/runner/submission_stage_runtime_test.go
+++ b/internal/runner/submission_stage_runtime_test.go
@@ -1,0 +1,58 @@
+package runner
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestSubmissionStageRuntimeHasTokenlessIdentityAndNoRBAC(t *testing.T) {
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("cannot resolve test path")
+	}
+	raw, err := os.ReadFile(filepath.Join(filepath.Dir(filename), "..", "..", "deploy", "contract-executor-stage-runtime.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoder := yaml.NewDecoder(bytes.NewReader(raw))
+	objects := []map[string]any{}
+	for {
+		var object map[string]any
+		if err := decoder.Decode(&object); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			t.Fatal(err)
+		}
+		if len(object) != 0 {
+			objects = append(objects, object)
+		}
+	}
+	if len(objects) != 1 || objects[0]["apiVersion"] != "v1" || objects[0]["kind"] != "ServiceAccount" {
+		t.Fatalf("runtime prerequisite contains an unexpected object set: %#v", objects)
+	}
+	serviceAccount := objects[0]
+	metadata := objectAt(t, serviceAccount, "metadata")
+	if metadata["name"] != "ok147-contract-executor-runtime" || metadata["namespace"] != submissionStageInputNamespace {
+		t.Fatalf("unexpected runtime identity: %#v", metadata)
+	}
+	labels := objectAt(t, metadata, "labels")
+	if labels["openkubes.io/runtime-boundary"] != "submission-stage" {
+		t.Fatalf("runtime boundary label is absent: %#v", labels)
+	}
+	if serviceAccount["automountServiceAccountToken"] != false {
+		t.Fatal("submission runtime would receive an implicit Kubernetes credential")
+	}
+	for _, forbidden := range []string{"Role", "RoleBinding", "ClusterRole", "ClusterRoleBinding", "Secret"} {
+		if bytes.Contains(raw, []byte("kind: "+forbidden+"\n")) {
+			t.Fatalf("runtime prerequisite unexpectedly contains %s", forbidden)
+		}
+	}
+}


### PR DESCRIPTION
## Outcome

Defines the exact in-cluster ServiceAccount identity referenced by the bounded submission-stage Job.

- fixed `ok147-contract-executor-runtime` identity in `openkubes-execution-system`
- `automountServiceAccountToken: false`
- deliberately no Role, RoleBinding, ClusterRole, ClusterRoleBinding, or Secret
- preserves ledger and selected-authority credentials as separate external short-lived prerequisites
- deployment candidate only; no cluster contact or mutation

## Validation

- full Go tests and vet
- targeted race tests for CLI/stage/runtime packages
- Python regression suite (18 tests, 1 expected skip)
- exact object-set/RBAC-absence test
- `git diff --check`