### PR TITLE
docs(runner): describe current execution boundary (OK-147)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,14 +26,15 @@ Powered by [Cluster API (CAPI)](https://cluster-api.sigs.k8s.io/), [CAPK (KubeVi
 - **Blue/Green upgrades** — rolling Kubernetes version upgrades with workload migration
 - **GitOps-ready** — all cluster state is declarative YAML, rendered from templates
 - **Single Makefile UX** — `make new`, `make install`, `make status`, `make upgrade`
-- **Bounded Contract Executor MVP** — a shared Go core for local CLI and future
-  short-lived `ok-mgmt` Jobs; it remains dry-run-only while verifying the
-  OK-141 revision, existing projection, authority split, signed grant binding,
-  fail-closed single-use receipt semantics, and an offline-tested durable
-  Kubernetes ledger plus short-lived read-only Job preflight boundary; its
-  container build is digest-pinned, multi-architecture, non-root, SBOM- and
-  provenance-producing, with a separate manual, protected and digest-verifying
-  GHCR publication boundary
+- **Bounded Contract Executor MVP** — one shared Go core for the local `ok` CLI
+  and short-lived `ok-mgmt` Jobs. `cluster create` remains non-mutating, while
+  the separately authorized `cluster stage run --execute` path supports only
+  the first two Contract-to-CAPI submission stages with a durable ledger,
+  exact split authorities and no retry. `cluster stage package` produces the
+  digest-bound immutable ConfigMap/Job/NetworkPolicy envelope offline; the
+  tokenless runtime identity and credential Secrets remain separately managed
+  prerequisites. The runner image is digest-pinned, multi-architecture,
+  non-root, SBOM- and provenance-producing behind a protected publisher.
 
 ---
 

--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -1,8 +1,11 @@
 # OK-147 bounded Contract Executor MVP
 
-The implementation establishes a shared, side-effect-free core for local CLI
-and future in-cluster Job execution. The second checkpoint adds verified
-projection and authorization boundaries without adding Kubernetes access.
+The implementation started with a shared, side-effect-free core for local CLI
+and in-cluster Job execution. The current boundary retains non-mutating
+Contract planning and adds exactly two separately authorized Contract-to-CAPI
+submission stages, a durable ledger, bounded observation components and an
+offline ConfigMap/Job/NetworkPolicy packager. It is still an MVP rather than a
+general lifecycle runner or controller.
 
 ```text
 versioned contract + test schema
@@ -20,7 +23,7 @@ R = SHA-256(canonical contract)
 non-mutating CreateCluster plan
 ```
 
-The command is intentionally dry-run-only:
+The `cluster create` command is intentionally dry-run-only:
 
 ```bash
 go run ./cmd/ok cluster create \
@@ -30,9 +33,9 @@ go run ./cmd/ok cluster create \
 ```
 
 It performs no cluster discovery, credential read, API contact, submission, or
-observation. A command without `--dry-run` fails closed. Submission will be
-added only after the authorization, projection, idempotency, and evidence
-interfaces have executable tests.
+observation. A command without `--dry-run` fails closed. Mutating submission is
+available only through the later, independently authorized staged execution
+path described below; it cannot be activated through `cluster create`.
 
 The emitted `ok147-create-plan/v1` document is an internal, test-only format.
 It is deliberately not shaped as a Kubernetes API object and does not establish


### PR DESCRIPTION
## Outcome

Corrects stale `dry-run-only` wording after the bounded staged execution and offline Job package checkpoints.

- keeps `cluster create` explicitly non-mutating
- documents that only the first two Contract-to-CAPI stages can execute
- distinguishes `stage run --execute` from offline `stage package`
- records the durable ledger, split authority, no-retry and external credential prerequisites
- does not change code or infrastructure

## Validation

- full Go test suite
- `git diff --check`