### PR TITLE
fix(runner): create network policy before stage job (OK-147)

### DIFF
--- a/deploy/contract-executor-stage-job.yaml.tpl
+++ b/deploy/contract-executor-stage-job.yaml.tpl
@@ -1,3 +1,20 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: "${OK147_RUN_ID}"
+  namespace: openkubes-execution-system
+spec:
+  podSelector:
+    matchLabels:
+      openkubes.io/execution-id: "${OK147_RUN_ID}"
+  policyTypes: ["Ingress", "Egress"]
+  ingress: []
+  egress:
+    - to: [{ipBlock: {cidr: "${OK147_LEDGER_API_CIDR}"}}]
+      ports: [{protocol: TCP, port: ${OK147_LEDGER_API_PORT}}]
+    - to: [{ipBlock: {cidr: "${OK147_AUTHORITY_API_CIDR}"}}]
+      ports: [{protocol: TCP, port: ${OK147_AUTHORITY_API_PORT}}]
+---
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -150,20 +167,3 @@ ${OK147_RECEIPT_CONFIGMAP_ITEM}        - name: ledger-credential
             items:
               - {key: token, path: token}
               - {key: ca.crt, path: ca.crt}
----
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  name: "${OK147_RUN_ID}"
-  namespace: openkubes-execution-system
-spec:
-  podSelector:
-    matchLabels:
-      openkubes.io/execution-id: "${OK147_RUN_ID}"
-  policyTypes: ["Ingress", "Egress"]
-  ingress: []
-  egress:
-    - to: [{ipBlock: {cidr: "${OK147_LEDGER_API_CIDR}"}}]
-      ports: [{protocol: TCP, port: ${OK147_LEDGER_API_PORT}}]
-    - to: [{ipBlock: {cidr: "${OK147_AUTHORITY_API_CIDR}"}}]
-      ports: [{protocol: TCP, port: ${OK147_AUTHORITY_API_PORT}}]

--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -1136,6 +1136,9 @@ inputs stop execution rather than authorizing them.
 
 `BuildSubmissionStagePackage` now composes the immutable input ConfigMap with
 the bounded Job and NetworkPolicy as one deterministic three-object stream.
+Its fixed create order is ConfigMap, NetworkPolicy, then Job, so the executable
+Pod is always the final object and cannot intentionally precede its egress
+boundary.
 The caller supplies only runtime object names, a digest-pinned image, a
 separately SHA-256-bound Job template and exact API endpoint/CIDR identities.
 Stage ID, Contract identities, evaluation time, input ConfigMap identity and

--- a/internal/runner/submission_stage_package.go
+++ b/internal/runner/submission_stage_package.go
@@ -94,7 +94,7 @@ func BuildSubmissionStagePackage(config SubmissionStagePackageConfig) (VerifiedS
 		PackageDigest: digest.SHA256(packageRaw), InputConfigMapDigest: inputReceipt.ConfigMapDigest,
 		ReceiptPrefixDigest: inputReceipt.ReceiptPrefixDigest, JobTemplateDigest: config.JobTemplateDigest,
 		JobEnvelopeDigest:  digest.SHA256(jobRaw),
-		ObjectKinds:        []string{"ConfigMap", "Job", "NetworkPolicy"},
+		ObjectKinds:        []string{"ConfigMap", "NetworkPolicy", "Job"},
 		AuthorizationState: "VERIFIED", MutationAllowed: false,
 	}
 	return VerifiedSubmissionStagePackage{raw: packageRaw, receipt: receipt, verified: true}, nil

--- a/internal/runner/submission_stage_package_test.go
+++ b/internal/runner/submission_stage_package_test.go
@@ -57,8 +57,13 @@ func TestBuildSubmissionStagePackageBindsInputAndJobEnvelope(t *testing.T) {
 			if receipt.JobTemplateDigest != digest.SHA256(config.JobTemplate) {
 				t.Fatal("package does not bind the exact Job template identity")
 			}
-			if !reflect.DeepEqual(receipt.ObjectKinds, []string{"ConfigMap", "Job", "NetworkPolicy"}) || receipt.AuthorizationState != "VERIFIED" {
+			if !reflect.DeepEqual(receipt.ObjectKinds, []string{"ConfigMap", "NetworkPolicy", "Job"}) || receipt.AuthorizationState != "VERIFIED" {
 				t.Fatalf("unexpected package object/authorization state: %#v", receipt)
+			}
+			policyPosition := bytes.Index(raw, []byte("\nkind: NetworkPolicy\n"))
+			jobPosition := bytes.Index(raw, []byte("\nkind: Job\n"))
+			if policyPosition < 0 || jobPosition < 0 || policyPosition >= jobPosition {
+				t.Fatal("executable Job appears before its NetworkPolicy boundary")
 			}
 			input, err := BuildSubmissionStageInput(fixture.config, config.InputConfigMap)
 			if err != nil {


### PR DESCRIPTION
## Outcome

Closes the package create-order window where a Job could be submitted before its NetworkPolicy.

- fixed order is now ConfigMap → NetworkPolicy → Job
- executable Pod is always the final package object
- package receipt records the same exact order
- tests fail if Job appears before NetworkPolicy
- Job-template digest intentionally changes; no historical digest is reinterpreted
- offline-only change, with no cluster mutation

## Validation

- full Go tests and vet
- targeted race suite
- Python regression suite (18 tests, 1 expected skip)
- `git diff --check`