### PR TITLE
feat(runner): plan exact stage package creates (OK-147)

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -1160,6 +1160,26 @@ output, writes the package with mode `0600`, and emits only the redaction-safe
 package receipt on stdout. The Job-template digest is required explicitly and
 is retained in that receipt.
 
+## Exact-create installation plan
+
+`PlanSubmissionStageInstallation` converts only an in-memory verified package
+into a redaction-safe, non-mutating create plan. It rechecks the package and
+component digests, exact three-object membership, namespace, names, immutable
+ConfigMap, NetworkPolicy selector, tokenless ServiceAccount reference and
+ConfigMap volume binding. The output fixes this sequence:
+
+```text
+1. exact GET ConfigMap       → collection POST only when absent
+2. exact GET NetworkPolicy   → collection POST only when absent
+3. exact GET Job             → collection POST only when absent
+```
+
+Every entry records the exact object and collection paths plus a canonical
+object digest. The plan has `mutationAllowed: false`; it contains no Secret,
+credential, generic path, update, patch, apply, delete, retry or API client.
+The future installer must remain a separately reviewed mutation boundary and
+must preserve the fail-closed order and absence preconditions.
+
 ## Tokenless submission runtime identity
 
 [`deploy/contract-executor-stage-runtime.yaml`](../deploy/contract-executor-stage-runtime.yaml)

--- a/internal/runner/submission_stage_installation_plan.go
+++ b/internal/runner/submission_stage_installation_plan.go
@@ -1,0 +1,184 @@
+package runner
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"gopkg.in/yaml.v3"
+)
+
+const SubmissionStageInstallationPlanFormat = "ok147-submission-stage-installation-plan/v1"
+
+type SubmissionStageCreatePlan struct {
+	Order           int    `json:"order"`
+	APIVersion      string `json:"apiVersion"`
+	Kind            string `json:"kind"`
+	Namespace       string `json:"namespace"`
+	Name            string `json:"name"`
+	PreflightMethod string `json:"preflightMethod"`
+	ObjectPath      string `json:"objectPath"`
+	CreateMethod    string `json:"createMethod"`
+	CollectionPath  string `json:"collectionPath"`
+	ObjectDigest    string `json:"objectDigest"`
+}
+
+// SubmissionStageInstallationPlan is an offline exact-create description. It
+// is not authorization to invoke any of the recorded paths.
+type SubmissionStageInstallationPlan struct {
+	Format          string                      `json:"format"`
+	State           string                      `json:"state"`
+	StageID         string                      `json:"stageId"`
+	PackageDigest   string                      `json:"packageDigest"`
+	Creates         []SubmissionStageCreatePlan `json:"creates"`
+	MutationAllowed bool                        `json:"mutationAllowed"`
+}
+
+// PlanSubmissionStageInstallation derives the exact absence/create sequence
+// from a package that can only have been produced by BuildSubmissionStagePackage.
+// It performs no API request and opens no credential.
+func PlanSubmissionStageInstallation(packaged VerifiedSubmissionStagePackage) (SubmissionStageInstallationPlan, error) {
+	if !packaged.verified || len(packaged.raw) == 0 || packaged.receipt.State != "VERIFIED" {
+		return SubmissionStageInstallationPlan{}, errors.New("submission stage package was not produced by verification")
+	}
+	if digest.SHA256(packaged.raw) != packaged.receipt.PackageDigest {
+		return SubmissionStageInstallationPlan{}, errors.New("submission stage package changed after verification")
+	}
+	expectedKinds := []string{"ConfigMap", "NetworkPolicy", "Job"}
+	if !equalStringList(packaged.receipt.ObjectKinds, expectedKinds) {
+		return SubmissionStageInstallationPlan{}, errors.New("submission stage package object inventory is invalid")
+	}
+	documents := bytes.Split(packaged.raw, []byte("\n---\n"))
+	if len(documents) != len(expectedKinds) || digest.SHA256(documents[0]) != packaged.receipt.InputConfigMapDigest || digest.SHA256(bytes.Join(documents[1:], []byte("\n---\n"))) != packaged.receipt.JobEnvelopeDigest {
+		return SubmissionStageInstallationPlan{}, errors.New("submission stage package component identity differs")
+	}
+	decoder := yaml.NewDecoder(bytes.NewReader(packaged.raw))
+	objects := make([]map[string]any, 0, len(expectedKinds))
+	for {
+		var object map[string]any
+		err := decoder.Decode(&object)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil || len(object) == 0 {
+			return SubmissionStageInstallationPlan{}, errors.New("decode submission stage package")
+		}
+		objects = append(objects, object)
+	}
+	if len(objects) != len(expectedKinds) {
+		return SubmissionStageInstallationPlan{}, errors.New("submission stage package object count is invalid")
+	}
+
+	configMapName, runID := "", ""
+	creates := make([]SubmissionStageCreatePlan, 0, len(objects))
+	for index, object := range objects {
+		apiVersion, _ := object["apiVersion"].(string)
+		kind, _ := object["kind"].(string)
+		if kind != expectedKinds[index] {
+			return SubmissionStageInstallationPlan{}, errors.New("submission stage package create order is invalid")
+		}
+		metadata, ok := object["metadata"].(map[string]any)
+		if !ok {
+			return SubmissionStageInstallationPlan{}, errors.New("submission stage package object metadata is invalid")
+		}
+		name, _ := metadata["name"].(string)
+		namespace, _ := metadata["namespace"].(string)
+		if !submissionStageInputNamePattern.MatchString(name) || len(name) > 63 || namespace != submissionStageInputNamespace || metadata["generateName"] != nil {
+			return SubmissionStageInstallationPlan{}, errors.New("submission stage package object identity is invalid")
+		}
+		collectionPath, objectPath, err := submissionStageCreatePaths(apiVersion, kind, namespace, name)
+		if err != nil {
+			return SubmissionStageInstallationPlan{}, err
+		}
+		canonical, err := json.Marshal(object)
+		if err != nil {
+			return SubmissionStageInstallationPlan{}, errors.New("encode submission stage package object")
+		}
+		creates = append(creates, SubmissionStageCreatePlan{
+			Order: index + 1, APIVersion: apiVersion, Kind: kind, Namespace: namespace, Name: name,
+			PreflightMethod: "GET", ObjectPath: objectPath, CreateMethod: "POST", CollectionPath: collectionPath,
+			ObjectDigest: digest.SHA256(canonical),
+		})
+		switch kind {
+		case "ConfigMap":
+			if object["immutable"] != true {
+				return SubmissionStageInstallationPlan{}, errors.New("submission stage input ConfigMap is not immutable")
+			}
+			labels, _ := metadata["labels"].(map[string]any)
+			if labels["openkubes.io/stage-id"] != packaged.receipt.StageID {
+				return SubmissionStageInstallationPlan{}, errors.New("submission stage input label differs from package stage")
+			}
+			configMapName = name
+		case "NetworkPolicy":
+			runID = name
+			spec, _ := object["spec"].(map[string]any)
+			selector, _ := spec["podSelector"].(map[string]any)
+			matchLabels, _ := selector["matchLabels"].(map[string]any)
+			if matchLabels["openkubes.io/execution-id"] != runID {
+				return SubmissionStageInstallationPlan{}, errors.New("submission stage NetworkPolicy selector differs from run identity")
+			}
+		case "Job":
+			if name != runID {
+				return SubmissionStageInstallationPlan{}, errors.New("submission stage Job and NetworkPolicy identities differ")
+			}
+			spec, _ := object["spec"].(map[string]any)
+			template, _ := spec["template"].(map[string]any)
+			podSpec, _ := template["spec"].(map[string]any)
+			if podSpec["serviceAccountName"] != "ok147-contract-executor-runtime" || podSpec["automountServiceAccountToken"] != false {
+				return SubmissionStageInstallationPlan{}, errors.New("submission stage Job runtime identity is invalid")
+			}
+			if !jobMountsInputConfigMap(podSpec, configMapName) {
+				return SubmissionStageInstallationPlan{}, errors.New("submission stage Job input ConfigMap differs")
+			}
+		}
+	}
+	return SubmissionStageInstallationPlan{
+		Format: SubmissionStageInstallationPlanFormat, State: "VERIFIED", StageID: packaged.receipt.StageID,
+		PackageDigest: packaged.receipt.PackageDigest, Creates: creates, MutationAllowed: false,
+	}, nil
+}
+
+func submissionStageCreatePaths(apiVersion, kind, namespace, name string) (string, string, error) {
+	var collection string
+	switch {
+	case apiVersion == "v1" && kind == "ConfigMap":
+		collection = "/api/v1/namespaces/" + namespace + "/configmaps"
+	case apiVersion == "networking.k8s.io/v1" && kind == "NetworkPolicy":
+		collection = "/apis/networking.k8s.io/v1/namespaces/" + namespace + "/networkpolicies"
+	case apiVersion == "batch/v1" && kind == "Job":
+		collection = "/apis/batch/v1/namespaces/" + namespace + "/jobs"
+	default:
+		return "", "", fmt.Errorf("submission stage package contains unsupported %s %s", apiVersion, kind)
+	}
+	return collection, collection + "/" + name, nil
+}
+
+func jobMountsInputConfigMap(podSpec map[string]any, name string) bool {
+	volumes, ok := podSpec["volumes"].([]any)
+	if !ok {
+		return false
+	}
+	for _, item := range volumes {
+		volume, _ := item.(map[string]any)
+		configMap, _ := volume["configMap"].(map[string]any)
+		if volume["name"] == "input" && configMap["name"] == name {
+			return true
+		}
+	}
+	return false
+}
+
+func equalStringList(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for index := range left {
+		if left[index] != right[index] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/runner/submission_stage_installation_plan_test.go
+++ b/internal/runner/submission_stage_installation_plan_test.go
@@ -1,0 +1,88 @@
+package runner
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+func TestPlanSubmissionStageInstallationProducesExactSafeOrder(t *testing.T) {
+	for _, completedProvider := range []bool{false, true} {
+		stageID := "provider-prerequisites"
+		if completedProvider {
+			stageID = "cluster-lifecycle"
+		}
+		t.Run(stageID, func(t *testing.T) {
+			fixture := submissionBundleFixture(t, completedProvider, "")
+			packaged, err := BuildSubmissionStagePackage(submissionStagePackageConfig(t, fixture, stageID))
+			if err != nil {
+				t.Fatal(err)
+			}
+			plan, err := PlanSubmissionStageInstallation(packaged)
+			if err != nil {
+				t.Fatal(err)
+			}
+			receipt, err := packaged.Receipt()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if plan.Format != SubmissionStageInstallationPlanFormat || plan.State != "VERIFIED" || plan.StageID != stageID || plan.PackageDigest != receipt.PackageDigest || plan.MutationAllowed {
+				t.Fatalf("unexpected installation plan: %#v", plan)
+			}
+			wantKinds := []string{"ConfigMap", "NetworkPolicy", "Job"}
+			wantCollections := []string{
+				"/api/v1/namespaces/openkubes-execution-system/configmaps",
+				"/apis/networking.k8s.io/v1/namespaces/openkubes-execution-system/networkpolicies",
+				"/apis/batch/v1/namespaces/openkubes-execution-system/jobs",
+			}
+			if len(plan.Creates) != len(wantKinds) {
+				t.Fatalf("creates=%d, want 3", len(plan.Creates))
+			}
+			for index, create := range plan.Creates {
+				if create.Order != index+1 || create.Kind != wantKinds[index] || create.Namespace != submissionStageInputNamespace || create.PreflightMethod != "GET" || create.CreateMethod != "POST" || create.CollectionPath != wantCollections[index] || create.ObjectPath != create.CollectionPath+"/"+create.Name {
+					t.Fatalf("unexpected create %d: %#v", index, create)
+				}
+				if !stageReceiptPrefixDigestPattern.MatchString(create.ObjectDigest) || strings.Contains(strings.ToLower(create.ObjectPath), "secret") {
+					t.Fatalf("unsafe create identity: %#v", create)
+				}
+			}
+			if plan.Creates[1].Name != plan.Creates[2].Name {
+				t.Fatal("input or run identity differs across the installation plan")
+			}
+		})
+	}
+}
+
+func TestPlanSubmissionStageInstallationRejectsChangedPackage(t *testing.T) {
+	fixture := submissionBundleFixture(t, false, "")
+	valid, err := BuildSubmissionStagePackage(submissionStagePackageConfig(t, fixture, "provider-prerequisites"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := PlanSubmissionStageInstallation(VerifiedSubmissionStagePackage{}); err == nil {
+		t.Fatal("unverified package was planned")
+	}
+
+	wrongInventory := valid
+	wrongInventory.receipt.ObjectKinds = []string{"ConfigMap", "Job", "NetworkPolicy"}
+	if _, err := PlanSubmissionStageInstallation(wrongInventory); err == nil {
+		t.Fatal("changed object inventory was planned")
+	}
+
+	changedRuntime := valid
+	changedRuntime.raw = append([]byte(nil), valid.raw...)
+	changedRuntime.raw = bytes.Replace(changedRuntime.raw, []byte("ok147-contract-executor-runtime"), []byte("ok147-foreign-runtime"), 1)
+	changedRuntime.receipt.PackageDigest = digest.SHA256(changedRuntime.raw)
+	if _, err := PlanSubmissionStageInstallation(changedRuntime); err == nil {
+		t.Fatal("changed runtime identity was planned")
+	}
+
+	extraObject := valid
+	extraObject.raw = append(append([]byte(nil), valid.raw...), []byte("\n---\napiVersion: v1\nkind: Secret\nmetadata: {name: forbidden}\n")...)
+	extraObject.receipt.PackageDigest = digest.SHA256(extraObject.raw)
+	if _, err := PlanSubmissionStageInstallation(extraObject); err == nil {
+		t.Fatal("extra package object was planned")
+	}
+}


### PR DESCRIPTION
## Outcome

Derives a non-mutating exact-create installation plan from only an in-memory verified stage package.

- rechecks package and component digests plus exact 3-object membership
- validates immutable ConfigMap, NetworkPolicy selector, runtime ServiceAccount, and input volume binding
- fixes GET-before-POST paths in order ConfigMap → NetworkPolicy → Job
- records canonical object digests and exact collection/object paths
- rejects extra objects, changed runtime identity, changed order, and package drift
- contains no API client, Secret, credential, update, patch, apply, delete, or retry
- `mutationAllowed` remains false

## Validation

- full Go tests and vet
- targeted race suite
- Python regression suite (18 tests, 1 expected skip)
- `git diff --check`