### PR TITLE
feat(runner): install stage package create-only (OK-147)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,11 @@ Powered by [Cluster API (CAPI)](https://cluster-api.sigs.k8s.io/), [CAPK (KubeVi
   the first two Contract-to-CAPI submission stages with a durable ledger,
   exact split authorities and no retry. `cluster stage package` produces the
   digest-bound immutable ConfigMap/Job/NetworkPolicy envelope offline; the
-  tokenless runtime identity and credential Secrets remain separately managed
-  prerequisites. The runner image is digest-pinned, multi-architecture,
-  non-root, SBOM- and provenance-producing behind a protected publisher.
+  single-use Create-only installer can submit only that verified envelope
+  after a complete zero-write preflight. Its tokenless runtime identity and
+  credential Secrets remain separately managed prerequisites. The runner
+  image is digest-pinned, multi-architecture, non-root, SBOM- and
+  provenance-producing behind a protected publisher.
 
 ---
 

--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -1177,8 +1177,24 @@ ConfigMap volume binding. The output fixes this sequence:
 Every entry records the exact object and collection paths plus a canonical
 object digest. The plan has `mutationAllowed: false`; it contains no Secret,
 credential, generic path, update, patch, apply, delete, retry or API client.
-The future installer must remain a separately reviewed mutation boundary and
-must preserve the fail-closed order and absence preconditions.
+The bounded installer consumes only that in-memory verified package. It first
+performs all three exact object GETs; any existing object or unexpected API
+result stops before the first write. Only after the complete absence preflight
+does it POST ConfigMap, NetworkPolicy and Job in that order. Created responses
+must contain every exact desired field plus a UID and resourceVersion. Its
+redaction-safe receipt retains digests of those runtime identities and the
+verified created prefix, never their raw values.
+
+The installer is single-use and exposes no caller-selected manifest, object
+name or API path. It has no update, patch, apply, delete, list, watch,
+discovery, adoption, retry or rollback operation. A failure after a POST stops
+with `STOPPED_PARTIAL_OR_UNKNOWN`; cleanup is deliberately outside this
+boundary. The separately opened installer credential must identify the
+package's verified management authority, use an exact IP-literal HTTPS
+endpoint and carry a CA bundle matching its bound digest. It is distinct from
+the ledger and selected-authority credential Secrets mounted by the future
+Job. This checkpoint verifies the mutation behavior against an in-memory API
+transport only; it does not authorize or perform a live installation.
 
 ## Tokenless submission runtime identity
 

--- a/internal/runner/submission_stage_installation_plan.go
+++ b/internal/runner/submission_stage_installation_plan.go
@@ -44,6 +44,9 @@ func PlanSubmissionStageInstallation(packaged VerifiedSubmissionStagePackage) (S
 	if !packaged.verified || len(packaged.raw) == 0 || packaged.receipt.State != "VERIFIED" {
 		return SubmissionStageInstallationPlan{}, errors.New("submission stage package was not produced by verification")
 	}
+	if packaged.installationAuthority == "" {
+		return SubmissionStageInstallationPlan{}, errors.New("submission stage package installation authority is missing")
+	}
 	if digest.SHA256(packaged.raw) != packaged.receipt.PackageDigest {
 		return SubmissionStageInstallationPlan{}, errors.New("submission stage package changed after verification")
 	}
@@ -133,12 +136,36 @@ func PlanSubmissionStageInstallation(packaged VerifiedSubmissionStagePackage) (S
 			if !jobMountsInputConfigMap(podSpec, configMapName) {
 				return SubmissionStageInstallationPlan{}, errors.New("submission stage Job input ConfigMap differs")
 			}
+			if !jobUsesManagementAuthority(podSpec, packaged.installationAuthority) {
+				return SubmissionStageInstallationPlan{}, errors.New("submission stage Job management authority differs from installation authority")
+			}
 		}
 	}
 	return SubmissionStageInstallationPlan{
 		Format: SubmissionStageInstallationPlanFormat, State: "VERIFIED", StageID: packaged.receipt.StageID,
 		PackageDigest: packaged.receipt.PackageDigest, Creates: creates, MutationAllowed: false,
 	}, nil
+}
+
+func jobUsesManagementAuthority(podSpec map[string]any, authority string) bool {
+	containers, ok := podSpec["containers"].([]any)
+	if !ok || len(containers) != 1 {
+		return false
+	}
+	container, _ := containers[0].(map[string]any)
+	if container["name"] != "executor" {
+		return false
+	}
+	arguments, ok := container["args"].([]any)
+	if !ok {
+		return false
+	}
+	for index := 0; index+1 < len(arguments); index++ {
+		if arguments[index] == "--management-authority" && arguments[index+1] == authority {
+			return true
+		}
+	}
+	return false
 }
 
 func submissionStageCreatePaths(apiVersion, kind, namespace, name string) (string, string, error) {

--- a/internal/runner/submission_stage_installer.go
+++ b/internal/runner/submission_stage_installer.go
@@ -1,0 +1,283 @@
+package runner
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	SubmissionStageInstallationReceiptFormat = "ok147-submission-stage-installation-receipt/v1"
+	maximumStageInstallationResponseBytes    = 4 * 1024 * 1024
+)
+
+// SubmissionStageInstalledObject records only redaction-safe runtime identity
+// for the exact successfully created prefix. Raw UID and resourceVersion
+// values remain private to the execution environment.
+type SubmissionStageInstalledObject struct {
+	Order                 int    `json:"order"`
+	APIVersion            string `json:"apiVersion"`
+	Kind                  string `json:"kind"`
+	Namespace             string `json:"namespace"`
+	Name                  string `json:"name"`
+	ObjectDigest          string `json:"objectDigest"`
+	UIDDigest             string `json:"uidDigest"`
+	ResourceVersionDigest string `json:"resourceVersionDigest"`
+	State                 string `json:"state"`
+}
+
+// SubmissionStageInstallationReceipt is useful on success and failure. Its
+// Results are only the exact prefix whose create responses were verified.
+type SubmissionStageInstallationReceipt struct {
+	Format        string                           `json:"format"`
+	StageID       string                           `json:"stageId"`
+	PackageDigest string                           `json:"packageDigest"`
+	Authority     string                           `json:"authority"`
+	State         string                           `json:"state"`
+	MutationState string                           `json:"mutationState"`
+	Results       []SubmissionStageInstalledObject `json:"results"`
+}
+
+type submissionStageInstallObject struct {
+	plan SubmissionStageCreatePlan
+	raw  []byte
+}
+
+// KubernetesSubmissionStagePackageInstaller is single-use and can perform
+// only the exact GET/POST sequence retained from one verified package.
+type KubernetesSubmissionStagePackageInstaller struct {
+	mu        sync.Mutex
+	used      bool
+	endpoint  *url.URL
+	token     string
+	client    *http.Client
+	authority string
+	plan      SubmissionStageInstallationPlan
+	objects   []submissionStageInstallObject
+}
+
+type submissionStageInstallerClientConfig struct {
+	Endpoint          string
+	BearerToken       string
+	AuthorityIdentity string
+	Client            *http.Client
+}
+
+// OpenKubernetesSubmissionStagePackageInstaller opens one TLS-only installer
+// from an exact verified package and a separately supplied installer
+// credential. It performs no API request and does not read either credential
+// Secret named by the future Job.
+func OpenKubernetesSubmissionStagePackageInstaller(config KubernetesAuthorityConfig, packaged VerifiedSubmissionStagePackage) (*KubernetesSubmissionStagePackageInstaller, error) {
+	if _, _, err := prepareSubmissionStageInstallation(packaged); err != nil {
+		return nil, err
+	}
+	if config.AuthorityIdentity == "" || config.AuthorityIdentity != packaged.installationAuthority {
+		return nil, errors.New("stage package installer authority differs from verified management authority")
+	}
+	if !stageReceiptPrefixDigestPattern.MatchString(config.CABundleDigest) {
+		return nil, errors.New("stage package installer CA identity is required")
+	}
+	token, ca, client, err := openBoundedKubernetesMaterial(config.TokenFile, config.CAFile)
+	if err != nil {
+		return nil, errors.New("open bounded stage package installer credential")
+	}
+	if digest.SHA256(ca) != config.CABundleDigest {
+		return nil, errors.New("stage package installer CA differs from bound identity")
+	}
+	return newKubernetesSubmissionStagePackageInstaller(submissionStageInstallerClientConfig{
+		Endpoint: config.Endpoint, BearerToken: token, AuthorityIdentity: config.AuthorityIdentity, Client: client,
+	}, packaged)
+}
+
+func newKubernetesSubmissionStagePackageInstaller(config submissionStageInstallerClientConfig, packaged VerifiedSubmissionStagePackage) (*KubernetesSubmissionStagePackageInstaller, error) {
+	plan, objects, err := prepareSubmissionStageInstallation(packaged)
+	if err != nil {
+		return nil, err
+	}
+	if config.AuthorityIdentity == "" || config.AuthorityIdentity != packaged.installationAuthority {
+		return nil, errors.New("stage package installer authority differs from verified management authority")
+	}
+	endpoint, err := url.Parse(config.Endpoint)
+	if err != nil || endpoint.Host == "" || endpoint.User != nil || endpoint.RawQuery != "" || endpoint.Fragment != "" || endpoint.Path != "" && endpoint.Path != "/" || endpoint.Port() == "" || net.ParseIP(endpoint.Hostname()) == nil {
+		return nil, errors.New("stage package installer Kubernetes endpoint is invalid")
+	}
+	if endpoint.Scheme != "https" && !(endpoint.Scheme == "http" && endpoint.Hostname() == "127.0.0.1") {
+		return nil, errors.New("stage package installer Kubernetes endpoint must use HTTPS")
+	}
+	if config.BearerToken == "" || strings.TrimSpace(config.BearerToken) != config.BearerToken || strings.ContainsAny(config.BearerToken, "\r\n") || config.Client == nil {
+		return nil, errors.New("stage package installer Kubernetes credential or client is invalid")
+	}
+	client := *config.Client
+	client.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+	if client.Timeout == 0 {
+		client.Timeout = 15 * time.Second
+	}
+	endpoint.Path, endpoint.RawPath = "", ""
+	return &KubernetesSubmissionStagePackageInstaller{
+		endpoint: endpoint, token: config.BearerToken, client: &client,
+		authority: config.AuthorityIdentity, plan: plan, objects: objects,
+	}, nil
+}
+
+// Install performs a complete zero-write preflight before the first POST,
+// then creates ConfigMap, NetworkPolicy and Job in that fixed order. It never
+// adopts, updates, patches, applies, deletes, lists, watches or retries.
+func (installer *KubernetesSubmissionStagePackageInstaller) Install(ctx context.Context) (SubmissionStageInstallationReceipt, error) {
+	receipt := installer.newReceipt()
+	if installer == nil || installer.client == nil {
+		return receipt, errors.New("stage package installer is required")
+	}
+	installer.mu.Lock()
+	if installer.used {
+		installer.mu.Unlock()
+		return stoppedStageInstallation(receipt, "STOPPED_ZERO_WRITE", errors.New("stage package installer is single-use"))
+	}
+	installer.used = true
+	installer.mu.Unlock()
+
+	for _, object := range installer.objects {
+		_, status, err := installer.request(ctx, http.MethodGet, object.plan.ObjectPath, nil)
+		if err != nil {
+			return stoppedStageInstallation(receipt, "STOPPED_ZERO_WRITE", err)
+		}
+		switch status {
+		case http.StatusNotFound:
+			// Exact absence is the only state that can reach the create phase.
+		case http.StatusOK:
+			return stoppedStageInstallation(receipt, "STOPPED_ZERO_WRITE", errors.New("stage package object already exists; zero-write preflight stopped"))
+		default:
+			return stoppedStageInstallation(receipt, "STOPPED_ZERO_WRITE", stageInstallationStatusError(http.MethodGet, status))
+		}
+	}
+
+	receipt.State = "CREATING"
+	for _, object := range installer.objects {
+		receipt.MutationState = "ATTEMPTED_UNKNOWN"
+		raw, status, err := installer.request(ctx, http.MethodPost, object.plan.CollectionPath, object.raw)
+		if err != nil {
+			return stoppedStageInstallation(receipt, "STOPPED_PARTIAL_OR_UNKNOWN", err)
+		}
+		if status != http.StatusCreated {
+			receipt.MutationState = "ATTEMPTED"
+			return stoppedStageInstallation(receipt, "STOPPED_PARTIAL_OR_UNKNOWN", stageInstallationStatusError(http.MethodPost, status))
+		}
+		uid, resourceVersion, err := verifySubmissionStageCreatedObject(raw, object)
+		if err != nil {
+			return stoppedStageInstallation(receipt, "STOPPED_PARTIAL_OR_UNKNOWN", errors.New("created stage package object differs from verified package"))
+		}
+		receipt.MutationState = "ATTEMPTED"
+		receipt.Results = append(receipt.Results, SubmissionStageInstalledObject{
+			Order: object.plan.Order, APIVersion: object.plan.APIVersion, Kind: object.plan.Kind,
+			Namespace: object.plan.Namespace, Name: object.plan.Name, ObjectDigest: object.plan.ObjectDigest,
+			UIDDigest: digest.SHA256([]byte(uid)), ResourceVersionDigest: digest.SHA256([]byte(resourceVersion)), State: "CREATED",
+		})
+	}
+	receipt.State = "INSTALLED"
+	return receipt, nil
+}
+
+func (installer *KubernetesSubmissionStagePackageInstaller) newReceipt() SubmissionStageInstallationReceipt {
+	receipt := SubmissionStageInstallationReceipt{
+		Format: SubmissionStageInstallationReceiptFormat, State: "PREFLIGHT", MutationState: "NOT_ATTEMPTED",
+		Results: []SubmissionStageInstalledObject{},
+	}
+	if installer != nil {
+		receipt.StageID, receipt.PackageDigest, receipt.Authority = installer.plan.StageID, installer.plan.PackageDigest, installer.authority
+	}
+	return receipt
+}
+
+func stoppedStageInstallation(receipt SubmissionStageInstallationReceipt, state string, err error) (SubmissionStageInstallationReceipt, error) {
+	receipt.State = state
+	return receipt, err
+}
+
+func (installer *KubernetesSubmissionStagePackageInstaller) request(ctx context.Context, method, path string, body []byte) ([]byte, int, error) {
+	endpoint := *installer.endpoint
+	endpoint.Path = path
+	request, err := http.NewRequestWithContext(ctx, method, endpoint.String(), bytes.NewReader(body))
+	if err != nil {
+		return nil, 0, errors.New("construct bounded stage package request")
+	}
+	request.Header.Set("Accept", "application/json")
+	request.Header.Set("Authorization", "Bearer "+installer.token)
+	if body != nil {
+		request.Header.Set("Content-Type", "application/json")
+	}
+	response, err := installer.client.Do(request)
+	if err != nil {
+		return nil, 0, fmt.Errorf("bounded stage package %s request failed", method)
+	}
+	defer response.Body.Close()
+	raw, readErr := io.ReadAll(io.LimitReader(response.Body, maximumStageInstallationResponseBytes+1))
+	if readErr != nil || len(raw) > maximumStageInstallationResponseBytes {
+		return nil, 0, errors.New("bounded stage package response exceeds accepted size")
+	}
+	if len(raw) > 0 {
+		mediaType, _, err := mime.ParseMediaType(response.Header.Get("Content-Type"))
+		if err != nil || mediaType != "application/json" {
+			return nil, 0, errors.New("bounded stage package response is not JSON")
+		}
+	}
+	return raw, response.StatusCode, nil
+}
+
+func prepareSubmissionStageInstallation(packaged VerifiedSubmissionStagePackage) (SubmissionStageInstallationPlan, []submissionStageInstallObject, error) {
+	plan, err := PlanSubmissionStageInstallation(packaged)
+	if err != nil {
+		return SubmissionStageInstallationPlan{}, nil, err
+	}
+	decoder := yaml.NewDecoder(bytes.NewReader(packaged.raw))
+	objects := make([]submissionStageInstallObject, 0, len(plan.Creates))
+	for index := range plan.Creates {
+		var value map[string]any
+		if err := decoder.Decode(&value); err != nil || len(value) == 0 {
+			return SubmissionStageInstallationPlan{}, nil, errors.New("decode verified stage package installation object")
+		}
+		raw, err := json.Marshal(value)
+		if err != nil || digest.SHA256(raw) != plan.Creates[index].ObjectDigest {
+			return SubmissionStageInstallationPlan{}, nil, errors.New("stage package installation object differs from plan")
+		}
+		objects = append(objects, submissionStageInstallObject{plan: plan.Creates[index], raw: raw})
+	}
+	var trailing map[string]any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		return SubmissionStageInstallationPlan{}, nil, errors.New("stage package installation contains trailing object")
+	}
+	return plan, objects, nil
+}
+
+func verifySubmissionStageCreatedObject(raw []byte, expected submissionStageInstallObject) (string, string, error) {
+	observed, err := decodeCapabilityJSONObject(raw)
+	if err != nil {
+		return "", "", err
+	}
+	desired, err := decodeCapabilityJSONObject(expected.raw)
+	if err != nil || !capabilitySubset(desired, observed) {
+		return "", "", errors.New("observed object does not contain exact package fields")
+	}
+	metadata, _ := observed["metadata"].(map[string]any)
+	uid, _ := metadata["uid"].(string)
+	resourceVersion, _ := metadata["resourceVersion"].(string)
+	if !runtimeInputUIDPattern.MatchString(uid) || !runtimeInputUIDPattern.MatchString(resourceVersion) {
+		return "", "", errors.New("created object lacks bounded runtime identity")
+	}
+	return uid, resourceVersion, nil
+}
+
+func stageInstallationStatusError(method string, status int) error {
+	return fmt.Errorf("bounded stage package %s returned HTTP %d", method, status)
+}

--- a/internal/runner/submission_stage_installer_test.go
+++ b/internal/runner/submission_stage_installer_test.go
@@ -1,0 +1,273 @@
+package runner
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+func TestSubmissionStageInstallerPreflightsAllObjectsThenCreatesExactOrder(t *testing.T) {
+	packaged := submissionStageInstallerPackage(t)
+	api := newSubmissionStageInstallerAPI(t)
+	installer := newSubmissionStageInstaller(t, packaged, api.client())
+	receipt, err := installer.Install(context.Background())
+	if err != nil || receipt.State != "INSTALLED" || receipt.MutationState != "ATTEMPTED" || len(receipt.Results) != 3 {
+		t.Fatalf("stage package installation failed: %#v %v", receipt, err)
+	}
+	plan, err := PlanSubmissionStageInstallation(packaged)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if receipt.Format != SubmissionStageInstallationReceiptFormat || receipt.PackageDigest != plan.PackageDigest || receipt.StageID != plan.StageID || receipt.Authority != "ok-mgmt" {
+		t.Fatalf("installation receipt identity differs: %#v", receipt)
+	}
+	receiptJSON, err := json.Marshal(receipt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(receiptJSON, []byte("created-stage-uid")) || bytes.Contains(receiptJSON, []byte("short-lived-installer-token")) {
+		t.Fatal("installation receipt exposed raw runtime identity or credential")
+	}
+	if len(api.requests) != 6 {
+		t.Fatalf("requests=%d, want three GETs then three POSTs: %#v", len(api.requests), api.requests)
+	}
+	for index, create := range plan.Creates {
+		preflight, submission := api.requests[index], api.requests[index+3]
+		if preflight.method != http.MethodGet || preflight.path != create.ObjectPath || len(preflight.body) != 0 {
+			t.Fatalf("preflight %d differs: %#v", index, preflight)
+		}
+		if submission.method != http.MethodPost || submission.path != create.CollectionPath || len(submission.body) == 0 {
+			t.Fatalf("create %d differs: %#v", index, submission)
+		}
+		if digest.SHA256(submission.body) != create.ObjectDigest {
+			t.Fatalf("create body %d differs from verified object digest", index)
+		}
+		result := receipt.Results[index]
+		if result.Order != create.Order || result.Kind != create.Kind || result.Name != create.Name || result.ObjectDigest != create.ObjectDigest || result.State != "CREATED" || !stageReceiptPrefixDigestPattern.MatchString(result.UIDDigest) || !stageReceiptPrefixDigestPattern.MatchString(result.ResourceVersionDigest) {
+			t.Fatalf("result %d differs: %#v", index, result)
+		}
+		if strings.Contains(strings.ToLower(preflight.path+submission.path), "secret") {
+			t.Fatalf("installer accessed credential object: %#v %#v", preflight, submission)
+		}
+	}
+}
+
+func TestSubmissionStageInstallerStopsZeroWriteWhenAnyObjectExists(t *testing.T) {
+	packaged := submissionStageInstallerPackage(t)
+	api := newSubmissionStageInstallerAPI(t)
+	plan, err := PlanSubmissionStageInstallation(packaged)
+	if err != nil {
+		t.Fatal(err)
+	}
+	api.objects[plan.Creates[2].ObjectPath] = map[string]any{"kind": "Job"}
+	installer := newSubmissionStageInstaller(t, packaged, api.client())
+	receipt, err := installer.Install(context.Background())
+	if err == nil || receipt.State != "STOPPED_ZERO_WRITE" || receipt.MutationState != "NOT_ATTEMPTED" || len(receipt.Results) != 0 || api.posts != 0 {
+		t.Fatalf("existing object did not stop zero-write: %#v posts=%d err=%v", receipt, api.posts, err)
+	}
+	if len(api.requests) != 3 {
+		t.Fatalf("preflight did not reach bound existing object: %#v", api.requests)
+	}
+	for _, request := range api.requests {
+		if request.method != http.MethodGet {
+			t.Fatalf("write observed in failed preflight: %#v", request)
+		}
+	}
+}
+
+func TestSubmissionStageInstallerPreservesPartialPrefixAndCannotRetry(t *testing.T) {
+	packaged := submissionStageInstallerPackage(t)
+	api := newSubmissionStageInstallerAPI(t)
+	api.failPost = 2
+	installer := newSubmissionStageInstaller(t, packaged, api.client())
+	receipt, err := installer.Install(context.Background())
+	if err == nil || receipt.State != "STOPPED_PARTIAL_OR_UNKNOWN" || receipt.MutationState != "ATTEMPTED" || len(receipt.Results) != 1 || receipt.Results[0].Kind != "ConfigMap" {
+		t.Fatalf("partial prefix differs: %#v %v", receipt, err)
+	}
+	requestCount := len(api.requests)
+	retry, retryErr := installer.Install(context.Background())
+	if retryErr == nil || retry.State != "STOPPED_ZERO_WRITE" || retry.MutationState != "NOT_ATTEMPTED" || len(api.requests) != requestCount {
+		t.Fatalf("single-use boundary failed: %#v requests=%d/%d err=%v", retry, len(api.requests), requestCount, retryErr)
+	}
+}
+
+func TestSubmissionStageInstallerTreatsUnverifiedResponseAndTransportFailureAsUnknown(t *testing.T) {
+	for name, configure := range map[string]func(*submissionStageInstallerAPI){
+		"response identity differs": func(api *submissionStageInstallerAPI) { api.mismatchPost = 1 },
+		"transport outcome unknown": func(api *submissionStageInstallerAPI) { api.errorPost = 1 },
+	} {
+		t.Run(name, func(t *testing.T) {
+			packaged := submissionStageInstallerPackage(t)
+			api := newSubmissionStageInstallerAPI(t)
+			configure(api)
+			installer := newSubmissionStageInstaller(t, packaged, api.client())
+			receipt, err := installer.Install(context.Background())
+			if err == nil || receipt.State != "STOPPED_PARTIAL_OR_UNKNOWN" || receipt.MutationState != "ATTEMPTED_UNKNOWN" || len(receipt.Results) != 0 {
+				t.Fatalf("unknown outcome accepted: %#v %v", receipt, err)
+			}
+			if strings.Contains(err.Error(), "short-lived-installer-token") {
+				t.Fatal("installer error exposed bearer token")
+			}
+		})
+	}
+}
+
+func TestSubmissionStageInstallerRejectsForeignAuthorityTamperingAndRedirect(t *testing.T) {
+	packaged := submissionStageInstallerPackage(t)
+	api := newSubmissionStageInstallerAPI(t)
+	if _, err := newKubernetesSubmissionStagePackageInstaller(submissionStageInstallerClientConfig{
+		Endpoint: "http://127.0.0.1:12345", BearerToken: "short-lived-installer-token", AuthorityIdentity: "ok-infra", Client: api.client(),
+	}, packaged); err == nil || len(api.requests) != 0 {
+		t.Fatal("foreign installer authority was accepted")
+	}
+
+	tampered := packaged
+	tampered.raw = append([]byte(nil), packaged.raw...)
+	tampered.raw[0] = 'x'
+	if _, err := newKubernetesSubmissionStagePackageInstaller(submissionStageInstallerClientConfig{
+		Endpoint: "http://127.0.0.1:12345", BearerToken: "short-lived-installer-token", AuthorityIdentity: "ok-mgmt", Client: api.client(),
+	}, tampered); err == nil || len(api.requests) != 0 {
+		t.Fatal("tampered package reached credentials or API")
+	}
+
+	calls := 0
+	redirectClient := &http.Client{Transport: stageInstallerRoundTripFunc(func(*http.Request) (*http.Response, error) {
+		calls++
+		return stageInstallerJSONResponse(http.StatusTemporaryRedirect, nil, map[string]string{"Location": "http://127.0.0.1:12346/foreign"}), nil
+	})}
+	installer := newSubmissionStageInstaller(t, packaged, redirectClient)
+	receipt, err := installer.Install(context.Background())
+	if err == nil || calls != 1 || receipt.State != "STOPPED_ZERO_WRITE" || receipt.MutationState != "NOT_ATTEMPTED" {
+		t.Fatalf("redirect followed or accepted: calls=%d receipt=%#v err=%v", calls, receipt, err)
+	}
+}
+
+func TestSubmissionStageInstallerRejectsNonIPOrUnboundedEndpoint(t *testing.T) {
+	packaged := submissionStageInstallerPackage(t)
+	for _, endpoint := range []string{
+		"https://ok-mgmt.example:6443", "https://192.0.2.10", "https://192.0.2.10:6443/path",
+		"https://user@192.0.2.10:6443", "https://192.0.2.10:6443?x=1", "http://192.0.2.10:6443",
+	} {
+		if _, err := newKubernetesSubmissionStagePackageInstaller(submissionStageInstallerClientConfig{
+			Endpoint: endpoint, BearerToken: "short-lived-installer-token", AuthorityIdentity: "ok-mgmt", Client: &http.Client{},
+		}, packaged); err == nil {
+			t.Fatalf("unbounded endpoint accepted: %s", endpoint)
+		}
+	}
+}
+
+func submissionStageInstallerPackage(t *testing.T) VerifiedSubmissionStagePackage {
+	t.Helper()
+	fixture := submissionBundleFixture(t, false, "")
+	packaged, err := BuildSubmissionStagePackage(submissionStagePackageConfig(t, fixture, "provider-prerequisites"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return packaged
+}
+
+func newSubmissionStageInstaller(t *testing.T, packaged VerifiedSubmissionStagePackage, client *http.Client) *KubernetesSubmissionStagePackageInstaller {
+	t.Helper()
+	installer, err := newKubernetesSubmissionStagePackageInstaller(submissionStageInstallerClientConfig{
+		Endpoint: "http://127.0.0.1:12345", BearerToken: "short-lived-installer-token", AuthorityIdentity: "ok-mgmt", Client: client,
+	}, packaged)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return installer
+}
+
+type submissionStageInstallerRequest struct {
+	method string
+	path   string
+	body   []byte
+}
+
+type submissionStageInstallerAPI struct {
+	t            *testing.T
+	mu           sync.Mutex
+	objects      map[string]map[string]any
+	requests     []submissionStageInstallerRequest
+	posts        int
+	failPost     int
+	mismatchPost int
+	errorPost    int
+}
+
+func newSubmissionStageInstallerAPI(t *testing.T) *submissionStageInstallerAPI {
+	return &submissionStageInstallerAPI{t: t, objects: map[string]map[string]any{}}
+}
+
+func (api *submissionStageInstallerAPI) client() *http.Client {
+	return &http.Client{Transport: stageInstallerRoundTripFunc(api.roundTrip)}
+}
+
+func (api *submissionStageInstallerAPI) roundTrip(request *http.Request) (*http.Response, error) {
+	api.mu.Lock()
+	defer api.mu.Unlock()
+	body, _ := io.ReadAll(request.Body)
+	api.requests = append(api.requests, submissionStageInstallerRequest{method: request.Method, path: request.URL.Path, body: body})
+	if request.Header.Get("Authorization") != "Bearer short-lived-installer-token" {
+		return stageInstallerJSONResponse(http.StatusUnauthorized, map[string]any{"reason": "Unauthorized"}, nil), nil
+	}
+	switch request.Method {
+	case http.MethodGet:
+		object, ok := api.objects[request.URL.Path]
+		if !ok {
+			return stageInstallerJSONResponse(http.StatusNotFound, map[string]any{"reason": "NotFound"}, nil), nil
+		}
+		return stageInstallerJSONResponse(http.StatusOK, object, nil), nil
+	case http.MethodPost:
+		api.posts++
+		if api.errorPost == api.posts {
+			return nil, errors.New("simulated transport failure")
+		}
+		if api.failPost == api.posts {
+			return stageInstallerJSONResponse(http.StatusForbidden, map[string]any{"reason": "Denied"}, nil), nil
+		}
+		var object map[string]any
+		decoder := json.NewDecoder(bytes.NewReader(body))
+		decoder.UseNumber()
+		if err := decoder.Decode(&object); err != nil {
+			api.t.Fatal(err)
+		}
+		metadata := object["metadata"].(map[string]any)
+		metadata["uid"] = "created-stage-uid-" + string(rune('a'+api.posts-1))
+		metadata["resourceVersion"] = string(rune('1' + api.posts - 1))
+		path := request.URL.Path + "/" + metadata["name"].(string)
+		api.objects[path] = object
+		if api.mismatchPost == api.posts {
+			metadata["name"] = "foreign-object"
+		}
+		return stageInstallerJSONResponse(http.StatusCreated, object, nil), nil
+	default:
+		return stageInstallerJSONResponse(http.StatusMethodNotAllowed, map[string]any{"reason": "MethodNotAllowed"}, nil), nil
+	}
+}
+
+type stageInstallerRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (function stageInstallerRoundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return function(request)
+}
+
+func stageInstallerJSONResponse(status int, value any, headers map[string]string) *http.Response {
+	var raw []byte
+	if value != nil {
+		raw, _ = json.Marshal(value)
+	}
+	header := make(http.Header)
+	header.Set("Content-Type", "application/json")
+	for key, value := range headers {
+		header.Set(key, value)
+	}
+	return &http.Response{StatusCode: status, Header: header, Body: io.NopCloser(bytes.NewReader(raw))}
+}

--- a/internal/runner/submission_stage_package.go
+++ b/internal/runner/submission_stage_package.go
@@ -45,9 +45,10 @@ type SubmissionStagePackageReceipt struct {
 }
 
 type VerifiedSubmissionStagePackage struct {
-	raw      []byte
-	receipt  SubmissionStagePackageReceipt
-	verified bool
+	raw                   []byte
+	receipt               SubmissionStagePackageReceipt
+	installationAuthority string
+	verified              bool
 }
 
 // BuildSubmissionStagePackage composes one immutable input ConfigMap with one
@@ -97,7 +98,11 @@ func BuildSubmissionStagePackage(config SubmissionStagePackageConfig) (VerifiedS
 		ObjectKinds:        []string{"ConfigMap", "NetworkPolicy", "Job"},
 		AuthorizationState: "VERIFIED", MutationAllowed: false,
 	}
-	return VerifiedSubmissionStagePackage{raw: packageRaw, receipt: receipt, verified: true}, nil
+	return VerifiedSubmissionStagePackage{
+		raw: packageRaw, receipt: receipt,
+		installationAuthority: config.Bundle.PlanExpected.ManagementAuthority,
+		verified:              true,
+	}, nil
 }
 
 func (packaged VerifiedSubmissionStagePackage) Bytes() ([]byte, error) {


### PR DESCRIPTION
## Summary
- add a single-use Create-only installer that consumes only a verified stage package
- run all three exact absence GETs before fixed ConfigMap → NetworkPolicy → Job POSTs
- bind installer credentials to the verified management authority and CA digest
- preserve a redaction-safe created prefix on partial or unknown outcomes

## Safety boundary
- no CLI/live invocation in this checkpoint
- no Secret access, update, patch, apply, delete, list, watch, discovery, adoption, retry, rollback, or cleanup
- in-memory Kubernetes transport tests only

## Validation
- `go test -ldflags=-linkmode=external ./...`
- `go vet ./...`
- `go test -race -ldflags=-linkmode=external ./internal/runner ./internal/submission ./internal/execution ./internal/ledger`
- `python3 -m unittest discover -s tests -p "*_test.py"` (18 tests, 1 expected skip)
- `git diff --check`