### PR TITLE
feat(runner): bind short-lived stage credentials (OK-147)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,11 @@ Powered by [Cluster API (CAPI)](https://cluster-api.sigs.k8s.io/), [CAPK (KubeVi
   digest-bound immutable ConfigMap/Job/NetworkPolicy envelope offline; the
   single-use Create-only installer can submit only that verified envelope
   after a complete zero-write preflight. Its tokenless runtime identity and
-  credential Secrets remain separately managed prerequisites. The runner
-  image is digest-pinned, multi-architecture, non-root, SBOM- and
-  provenance-producing behind a protected publisher.
+  two short-lived immutable credential Secrets are built as a separate
+  private, digest-bound package; TokenRequest issuance and Secret installation
+  remain separately managed prerequisites. The runner image is digest-pinned,
+  multi-architecture, non-root, SBOM- and provenance-producing behind a
+  protected publisher.
 
 ---
 

--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -1196,6 +1196,34 @@ the ledger and selected-authority credential Secrets mounted by the future
 Job. This checkpoint verifies the mutation behavior against an in-memory API
 transport only; it does not authorize or perform a live installation.
 
+## Short-lived credential Secret package
+
+`BuildSubmissionStageCredentialPackage` creates the two credential objects
+referenced by a verified stage package entirely in memory: one ledger Secret
+for the management authority and one writer Secret for the stage-selected
+authority. The provider stage selects the infrastructure authority; the
+lifecycle stage selects management. Both Secrets are fixed to
+`openkubes-execution-system`, immutable, distinct, and contain exactly
+`token` and `ca.crt`. The package validates that the Job mounts those exact
+names and keys before reading any credential source.
+
+Each source must be a bounded regular non-symlink file and match independently
+supplied token, CA and TokenRequest-evidence digests. The TokenRequest JWT is
+checked structurally for an accepted asymmetric algorithm, encoded signature,
+exact issuer, ServiceAccount subject, audience set, `iat`, `nbf` and `exp`.
+The token must retain at least 15 minutes at materialization time and may have
+no more than a one-hour total lifetime. The CA bundle must contain only
+currently valid CA certificates. JWT signature authenticity is not established
+by local parsing; it remains a claim of the separately verified TokenRequest
+evidence and ultimately of API-server acceptance.
+
+Secret bytes have no public accessor. The redaction-safe receipt binds the
+source stage package, exact immutable Secret object digests, CA identities,
+TokenRequest evidence, authorities, audiences and expirations without
+retaining tokens, CAs, subjects or source paths. Building this package is
+non-mutating. Secret installation, TokenRequest issuance and live execution
+remain separate boundaries.
+
 ## Tokenless submission runtime identity
 
 [`deploy/contract-executor-stage-runtime.yaml`](../deploy/contract-executor-stage-runtime.yaml)

--- a/internal/runner/submission_stage_credentials.go
+++ b/internal/runner/submission_stage_credentials.go
@@ -1,0 +1,364 @@
+package runner
+
+import (
+	"bytes"
+	"crypto/subtle"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"io"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+const (
+	SubmissionStageCredentialPackageFormat = "ok147-submission-stage-credential-package/v1"
+	minimumStageCredentialRemaining        = 15 * time.Minute
+	maximumStageCredentialLifetime         = time.Hour
+	maximumStageCredentialObjectBytes      = 128 * 1024
+)
+
+// SubmissionStageCredentialSource binds one externally obtained TokenRequest
+// result without embedding any credential in a caller-visible receipt.
+type SubmissionStageCredentialSource struct {
+	AuthorityIdentity          string
+	TokenFile                  string
+	TokenDigest                string
+	CAFile                     string
+	CABundleDigest             string
+	TokenRequestEvidenceDigest string
+	ExpectedIssuer             string
+	ExpectedSubject            string
+	ExpectedAudiences          []string
+	IssuedAt                   time.Time
+	ExpiresAt                  time.Time
+}
+
+type SubmissionStageCredentialPackageConfig struct {
+	Package             VerifiedSubmissionStagePackage
+	MaterializationTime time.Time
+	Ledger              SubmissionStageCredentialSource
+	SelectedAuthority   SubmissionStageCredentialSource
+}
+
+type SubmissionStageCredentialObjectReceipt struct {
+	Role                       string   `json:"role"`
+	Authority                  string   `json:"authority"`
+	Namespace                  string   `json:"namespace"`
+	Name                       string   `json:"name"`
+	ExpiresAt                  string   `json:"expiresAt"`
+	Audiences                  []string `json:"audiences"`
+	CABundleDigest             string   `json:"caBundleDigest"`
+	TokenRequestEvidenceDigest string   `json:"tokenRequestEvidenceDigest"`
+	ObjectDigest               string   `json:"objectDigest"`
+}
+
+// SubmissionStageCredentialPackageReceipt contains no token, CA, subject or
+// source path. ObjectDigest binds the private exact Secret object.
+type SubmissionStageCredentialPackageReceipt struct {
+	Format             string                                   `json:"format"`
+	State              string                                   `json:"state"`
+	StageID            string                                   `json:"stageId"`
+	StagePackageDigest string                                   `json:"stagePackageDigest"`
+	MaterializedAt     string                                   `json:"materializedAt"`
+	PackageDigest      string                                   `json:"packageDigest"`
+	Credentials        []SubmissionStageCredentialObjectReceipt `json:"credentials"`
+	MutationAllowed    bool                                     `json:"mutationAllowed"`
+}
+
+type submissionStageCredentialObject struct {
+	role      string
+	authority string
+	name      string
+	raw       []byte
+}
+
+// VerifiedSubmissionStageCredentialPackage deliberately exposes only its
+// redaction-safe receipt. Secret bytes stay in-package for the later exact
+// installer boundary.
+type VerifiedSubmissionStageCredentialPackage struct {
+	objects  []submissionStageCredentialObject
+	receipt  SubmissionStageCredentialPackageReceipt
+	verified bool
+}
+
+type submissionStageTokenClaims struct {
+	Issuer    string          `json:"iss"`
+	Subject   string          `json:"sub"`
+	Audience  json.RawMessage `json:"aud"`
+	ExpiresAt json.Number     `json:"exp"`
+	IssuedAt  json.Number     `json:"iat"`
+	NotBefore json.Number     `json:"nbf"`
+}
+
+// BuildSubmissionStageCredentialPackage reads two bounded TokenRequest/CA
+// sources and creates two private immutable Secret objects. It performs no
+// Kubernetes request and has no method that exposes the Secret bytes.
+func BuildSubmissionStageCredentialPackage(config SubmissionStageCredentialPackageConfig) (VerifiedSubmissionStageCredentialPackage, error) {
+	stagePlan, err := PlanSubmissionStageInstallation(config.Package)
+	if err != nil {
+		return VerifiedSubmissionStageCredentialPackage{}, err
+	}
+	if config.MaterializationTime.IsZero() || !config.MaterializationTime.Equal(config.MaterializationTime.Truncate(time.Second)) {
+		return VerifiedSubmissionStageCredentialPackage{}, errors.New("stage credential materialization time is required")
+	}
+	materializedAt := config.MaterializationTime.UTC().Format(time.RFC3339)
+	bindings := []struct {
+		role      string
+		name      string
+		authority string
+		source    SubmissionStageCredentialSource
+	}{
+		{role: "ledger", name: config.Package.ledgerCredential, authority: config.Package.ledgerAuthority, source: config.Ledger},
+		{role: "authority", name: config.Package.selectedCredential, authority: config.Package.selectedAuthority, source: config.SelectedAuthority},
+	}
+	objects := make([]submissionStageCredentialObject, 0, len(bindings))
+	receipts := make([]SubmissionStageCredentialObjectReceipt, 0, len(bindings))
+	tokens := make([][]byte, 0, len(bindings))
+	for _, binding := range bindings {
+		object, objectReceipt, token, err := buildSubmissionStageCredentialObject(stagePlan.StageID, config.MaterializationTime.UTC(), binding.role, binding.name, binding.authority, binding.source)
+		if err != nil {
+			return VerifiedSubmissionStageCredentialPackage{}, err
+		}
+		objects = append(objects, object)
+		receipts = append(receipts, objectReceipt)
+		tokens = append(tokens, token)
+	}
+	if len(tokens[0]) == len(tokens[1]) && subtle.ConstantTimeCompare(tokens[0], tokens[1]) == 1 {
+		return VerifiedSubmissionStageCredentialPackage{}, errors.New("stage ledger and authority credentials must be distinct")
+	}
+	packageIdentity, err := json.Marshal(struct {
+		StagePackageDigest string                                   `json:"stagePackageDigest"`
+		MaterializedAt     string                                   `json:"materializedAt"`
+		Credentials        []SubmissionStageCredentialObjectReceipt `json:"credentials"`
+	}{StagePackageDigest: stagePlan.PackageDigest, MaterializedAt: materializedAt, Credentials: receipts})
+	if err != nil {
+		return VerifiedSubmissionStageCredentialPackage{}, errors.New("encode stage credential package identity")
+	}
+	receipt := SubmissionStageCredentialPackageReceipt{
+		Format: SubmissionStageCredentialPackageFormat, State: "VERIFIED", StageID: stagePlan.StageID,
+		StagePackageDigest: stagePlan.PackageDigest, MaterializedAt: materializedAt, PackageDigest: digest.SHA256(packageIdentity),
+		Credentials: receipts, MutationAllowed: false,
+	}
+	return VerifiedSubmissionStageCredentialPackage{objects: cloneStageCredentialObjects(objects), receipt: receipt, verified: true}, nil
+}
+
+func (packaged VerifiedSubmissionStageCredentialPackage) Receipt() (SubmissionStageCredentialPackageReceipt, error) {
+	if !packaged.verified || packaged.receipt.State != "VERIFIED" || len(packaged.objects) != 2 {
+		return SubmissionStageCredentialPackageReceipt{}, errors.New("stage credential package was not produced by verification")
+	}
+	receipt := packaged.receipt
+	receipt.Credentials = append([]SubmissionStageCredentialObjectReceipt(nil), packaged.receipt.Credentials...)
+	for index := range receipt.Credentials {
+		receipt.Credentials[index].Audiences = append([]string(nil), packaged.receipt.Credentials[index].Audiences...)
+	}
+	return receipt, nil
+}
+
+func buildSubmissionStageCredentialObject(stageID string, now time.Time, role, name, authority string, source SubmissionStageCredentialSource) (submissionStageCredentialObject, SubmissionStageCredentialObjectReceipt, []byte, error) {
+	if source.AuthorityIdentity != authority || authority == "" {
+		return submissionStageCredentialObject{}, SubmissionStageCredentialObjectReceipt{}, nil, errors.New("stage credential authority differs from verified package")
+	}
+	if !submissionStageInputNamePattern.MatchString(name) || len(name) > 63 || source.TokenFile == "" || source.CAFile == "" {
+		return submissionStageCredentialObject{}, SubmissionStageCredentialObjectReceipt{}, nil, errors.New("stage credential object or source identity is invalid")
+	}
+	if !stageReceiptPrefixDigestPattern.MatchString(source.TokenDigest) || !stageReceiptPrefixDigestPattern.MatchString(source.CABundleDigest) || !stageReceiptPrefixDigestPattern.MatchString(source.TokenRequestEvidenceDigest) {
+		return submissionStageCredentialObject{}, SubmissionStageCredentialObjectReceipt{}, nil, errors.New("stage credential source digest is invalid")
+	}
+	token, err := readBoundedRegular(source.TokenFile, maximumTokenBytes)
+	if err != nil || digest.SHA256(token) != source.TokenDigest {
+		return submissionStageCredentialObject{}, SubmissionStageCredentialObjectReceipt{}, nil, errors.New("stage credential token differs from bound source")
+	}
+	ca, err := readBoundedRegular(source.CAFile, maximumCABytes)
+	if err != nil || digest.SHA256(ca) != source.CABundleDigest || !validStageCredentialCA(ca, now) {
+		return submissionStageCredentialObject{}, SubmissionStageCredentialObjectReceipt{}, nil, errors.New("stage credential CA differs from bound source")
+	}
+	claims, err := verifyStageCredentialJWT(token, source, now)
+	if err != nil {
+		return submissionStageCredentialObject{}, SubmissionStageCredentialObjectReceipt{}, nil, err
+	}
+	audiences, err := tokenAudiences(claims.Audience)
+	if err != nil {
+		return submissionStageCredentialObject{}, SubmissionStageCredentialObjectReceipt{}, nil, err
+	}
+	secret := map[string]any{
+		"apiVersion": "v1", "kind": "Secret", "immutable": true, "type": "Opaque",
+		"metadata": map[string]any{
+			"name": name, "namespace": submissionStageInputNamespace,
+			"labels": map[string]any{
+				"app.kubernetes.io/name": "ok-cluster-contract-executor",
+				"openkubes.io/stage-id":  stageID, "openkubes.io/credential-role": role,
+			},
+			"annotations": map[string]any{
+				"openkubes.io/authority-identity": authority,
+				"openkubes.io/expires-at":         source.ExpiresAt.UTC().Format(time.RFC3339),
+			},
+		},
+		"data": map[string]any{
+			"token":  base64.StdEncoding.EncodeToString(token),
+			"ca.crt": base64.StdEncoding.EncodeToString(ca),
+		},
+	}
+	raw, err := json.Marshal(secret)
+	if err != nil || len(raw) > maximumStageCredentialObjectBytes {
+		return submissionStageCredentialObject{}, SubmissionStageCredentialObjectReceipt{}, nil, errors.New("stage credential Secret exceeds accepted size")
+	}
+	object := submissionStageCredentialObject{role: role, authority: authority, name: name, raw: raw}
+	receipt := SubmissionStageCredentialObjectReceipt{
+		Role: role, Authority: authority, Namespace: submissionStageInputNamespace, Name: name,
+		ExpiresAt: source.ExpiresAt.UTC().Format(time.RFC3339), Audiences: audiences,
+		CABundleDigest: source.CABundleDigest, TokenRequestEvidenceDigest: source.TokenRequestEvidenceDigest,
+		ObjectDigest: digest.SHA256(raw),
+	}
+	return object, receipt, append([]byte(nil), token...), nil
+}
+
+func verifyStageCredentialJWT(token []byte, source SubmissionStageCredentialSource, now time.Time) (submissionStageTokenClaims, error) {
+	parts := strings.Split(string(token), ".")
+	if len(parts) != 3 || parts[0] == "" || parts[1] == "" || parts[2] == "" {
+		return submissionStageTokenClaims{}, errors.New("stage credential token is not a signed JWT")
+	}
+	headerRaw, err := base64.RawURLEncoding.DecodeString(parts[0])
+	if err != nil {
+		return submissionStageTokenClaims{}, errors.New("stage credential JWT header is invalid")
+	}
+	var header struct {
+		Algorithm string `json:"alg"`
+	}
+	if err := json.Unmarshal(headerRaw, &header); err != nil || header.Algorithm != "RS256" && header.Algorithm != "ES256" {
+		return submissionStageTokenClaims{}, errors.New("stage credential JWT algorithm is not accepted")
+	}
+	signature, err := base64.RawURLEncoding.DecodeString(parts[2])
+	if err != nil || len(signature) < 32 {
+		return submissionStageTokenClaims{}, errors.New("stage credential JWT signature encoding is invalid")
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return submissionStageTokenClaims{}, errors.New("stage credential JWT payload is invalid")
+	}
+	decoder := json.NewDecoder(bytes.NewReader(payload))
+	decoder.UseNumber()
+	var claims submissionStageTokenClaims
+	if err := decoder.Decode(&claims); err != nil {
+		return submissionStageTokenClaims{}, errors.New("stage credential JWT claims are invalid")
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		return submissionStageTokenClaims{}, errors.New("stage credential JWT claims contain trailing data")
+	}
+	issuedAt, err := exactJWTUnix(claims.IssuedAt)
+	if err != nil {
+		return submissionStageTokenClaims{}, errors.New("stage credential JWT issued-at claim is invalid")
+	}
+	expiresAt, err := exactJWTUnix(claims.ExpiresAt)
+	if err != nil {
+		return submissionStageTokenClaims{}, errors.New("stage credential JWT expiration claim is invalid")
+	}
+	notBefore, err := exactJWTUnix(claims.NotBefore)
+	if err != nil {
+		return submissionStageTokenClaims{}, errors.New("stage credential JWT not-before claim is invalid")
+	}
+	if source.ExpectedIssuer == "" || claims.Issuer != source.ExpectedIssuer || source.ExpectedSubject == "" || claims.Subject != source.ExpectedSubject || !validStageCredentialSubject(claims.Subject) {
+		return submissionStageTokenClaims{}, errors.New("stage credential JWT issuer or subject differs from bound source")
+	}
+	audiences, err := tokenAudiences(claims.Audience)
+	if err != nil || !equalAudienceSet(audiences, source.ExpectedAudiences) {
+		return submissionStageTokenClaims{}, errors.New("stage credential JWT audiences differ from bound source")
+	}
+	issued := time.Unix(issuedAt, 0).UTC()
+	expires := time.Unix(expiresAt, 0).UTC()
+	if source.IssuedAt.IsZero() || source.ExpiresAt.IsZero() || !source.IssuedAt.Equal(source.IssuedAt.Truncate(time.Second)) || !source.ExpiresAt.Equal(source.ExpiresAt.Truncate(time.Second)) || !issued.Equal(source.IssuedAt) || !expires.Equal(source.ExpiresAt) || notBefore != issuedAt {
+		return submissionStageTokenClaims{}, errors.New("stage credential JWT time claims differ from bound source")
+	}
+	if now.Before(issued) || expires.Sub(now) < minimumStageCredentialRemaining || expires.Sub(issued) > maximumStageCredentialLifetime || !expires.After(issued) {
+		return submissionStageTokenClaims{}, errors.New("stage credential JWT is outside the accepted short-lived window")
+	}
+	return claims, nil
+}
+
+func exactJWTUnix(value json.Number) (int64, error) {
+	if value == "" || strings.ContainsAny(string(value), ".eE") {
+		return 0, errors.New("JWT time is not an integer")
+	}
+	return strconv.ParseInt(string(value), 10, 64)
+}
+
+func tokenAudiences(raw json.RawMessage) ([]string, error) {
+	var multiple []string
+	if err := json.Unmarshal(raw, &multiple); err != nil {
+		var single string
+		if err := json.Unmarshal(raw, &single); err != nil || single == "" {
+			return nil, errors.New("stage credential JWT audience claim is invalid")
+		}
+		multiple = []string{single}
+	}
+	if len(multiple) == 0 {
+		return nil, errors.New("stage credential JWT audience claim is empty")
+	}
+	result := append([]string(nil), multiple...)
+	sort.Strings(result)
+	for index, audience := range result {
+		if audience == "" || strings.TrimSpace(audience) != audience || index > 0 && audience == result[index-1] {
+			return nil, errors.New("stage credential JWT audience claim is invalid")
+		}
+	}
+	return result, nil
+}
+
+func equalAudienceSet(actual, expected []string) bool {
+	want := append([]string(nil), expected...)
+	sort.Strings(want)
+	if len(actual) != len(want) || len(want) == 0 {
+		return false
+	}
+	for index := range actual {
+		if want[index] == "" || strings.TrimSpace(want[index]) != want[index] || index > 0 && want[index] == want[index-1] || actual[index] != want[index] {
+			return false
+		}
+	}
+	return true
+}
+
+func validStageCredentialSubject(subject string) bool {
+	const prefix = "system:serviceaccount:" + submissionStageInputNamespace + ":"
+	name := strings.TrimPrefix(subject, prefix)
+	return name != subject && submissionStageInputNamePattern.MatchString(name) && len(name) <= 63
+}
+
+func validStageCredentialCA(raw []byte, now time.Time) bool {
+	found := false
+	remaining := bytes.TrimSpace(raw)
+	for len(remaining) > 0 {
+		if !bytes.HasPrefix(remaining, []byte("-----BEGIN CERTIFICATE-----")) {
+			return false
+		}
+		block, rest := pem.Decode(remaining)
+		if block == nil {
+			return false
+		}
+		remaining = bytes.TrimSpace(rest)
+		if block.Type != "CERTIFICATE" {
+			return false
+		}
+		certificate, err := x509.ParseCertificate(block.Bytes)
+		if err != nil || !certificate.IsCA || now.Before(certificate.NotBefore) || now.After(certificate.NotAfter) {
+			return false
+		}
+		found = true
+	}
+	return found
+}
+
+func cloneStageCredentialObjects(objects []submissionStageCredentialObject) []submissionStageCredentialObject {
+	result := append([]submissionStageCredentialObject(nil), objects...)
+	for index := range result {
+		result[index].raw = append([]byte(nil), objects[index].raw...)
+	}
+	return result
+}

--- a/internal/runner/submission_stage_credentials_test.go
+++ b/internal/runner/submission_stage_credentials_test.go
@@ -1,0 +1,236 @@
+package runner
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+func TestBuildSubmissionStageCredentialPackageBindsTwoPrivateImmutableSecrets(t *testing.T) {
+	config, ledgerToken, authorityToken := submissionStageCredentialConfig(t)
+	packaged, err := BuildSubmissionStageCredentialPackage(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := packaged.Receipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	stageReceipt, err := config.Package.Receipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if receipt.Format != SubmissionStageCredentialPackageFormat || receipt.State != "VERIFIED" || receipt.StageID != "provider-prerequisites" || receipt.StagePackageDigest != stageReceipt.PackageDigest || receipt.MaterializedAt != config.MaterializationTime.Format(time.RFC3339) || !stageReceiptPrefixDigestPattern.MatchString(receipt.PackageDigest) || receipt.MutationAllowed || len(receipt.Credentials) != 2 {
+		t.Fatalf("unexpected credential receipt: %#v", receipt)
+	}
+	want := []struct {
+		role      string
+		authority string
+		name      string
+		token     []byte
+	}{
+		{role: "ledger", authority: "ok-mgmt", name: config.Package.ledgerCredential, token: ledgerToken},
+		{role: "authority", authority: "ok-infra", name: config.Package.selectedCredential, token: authorityToken},
+	}
+	for index, expected := range want {
+		object := packaged.objects[index]
+		objectReceipt := receipt.Credentials[index]
+		if object.role != expected.role || object.authority != expected.authority || object.name != expected.name || digest.SHA256(object.raw) != objectReceipt.ObjectDigest {
+			t.Fatalf("private credential object %d differs: %#v %#v", index, object, objectReceipt)
+		}
+		var secret map[string]any
+		if err := json.Unmarshal(object.raw, &secret); err != nil {
+			t.Fatal(err)
+		}
+		metadata := secret["metadata"].(map[string]any)
+		labels := metadata["labels"].(map[string]any)
+		annotations := metadata["annotations"].(map[string]any)
+		data := secret["data"].(map[string]any)
+		decodedToken, err := base64.StdEncoding.DecodeString(data["token"].(string))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if secret["apiVersion"] != "v1" || secret["kind"] != "Secret" || secret["immutable"] != true || secret["type"] != "Opaque" || metadata["namespace"] != submissionStageInputNamespace || metadata["name"] != expected.name || labels["openkubes.io/stage-id"] != "provider-prerequisites" || labels["openkubes.io/credential-role"] != expected.role || annotations["openkubes.io/authority-identity"] != expected.authority || !bytes.Equal(decodedToken, expected.token) || data["ca.crt"] == "" || len(data) != 2 {
+			t.Fatalf("credential Secret %d differs from exact binding: %#v", index, secret)
+		}
+	}
+	public, err := json.Marshal(receipt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range []string{string(ledgerToken), string(authorityToken), config.Ledger.TokenFile, config.Ledger.CAFile, config.Ledger.ExpectedSubject, config.SelectedAuthority.ExpectedSubject} {
+		if bytes.Contains(public, []byte(forbidden)) {
+			t.Fatalf("credential receipt exposed private source %q", forbidden)
+		}
+	}
+
+	receipt.Credentials[0].Audiences[0] = "changed"
+	again, err := packaged.Receipt()
+	if err != nil || again.Credentials[0].Audiences[0] == "changed" {
+		t.Fatal("caller mutated retained credential receipt")
+	}
+}
+
+func TestBuildSubmissionStageCredentialPackageRejectsUnsafeSources(t *testing.T) {
+	for name, mutate := range map[string]func(*SubmissionStageCredentialPackageConfig){
+		"foreign authority": func(config *SubmissionStageCredentialPackageConfig) {
+			config.SelectedAuthority.AuthorityIdentity = "ok-mgmt"
+		},
+		"wrong token digest": func(config *SubmissionStageCredentialPackageConfig) {
+			config.Ledger.TokenDigest = prefixSHA("f")
+		},
+		"wrong CA digest": func(config *SubmissionStageCredentialPackageConfig) {
+			config.Ledger.CABundleDigest = prefixSHA("e")
+		},
+		"wrong audience": func(config *SubmissionStageCredentialPackageConfig) {
+			config.Ledger.ExpectedAudiences = []string{"foreign-audience"}
+		},
+		"wrong subject": func(config *SubmissionStageCredentialPackageConfig) {
+			config.Ledger.ExpectedSubject = "system:serviceaccount:default:foreign"
+		},
+		"expired": func(config *SubmissionStageCredentialPackageConfig) {
+			config.MaterializationTime = config.Ledger.ExpiresAt.Add(-time.Minute)
+		},
+		"lifetime too long": func(config *SubmissionStageCredentialPackageConfig) {
+			config.Ledger.ExpiresAt = config.Ledger.IssuedAt.Add(2 * time.Hour)
+		},
+		"missing TokenRequest evidence": func(config *SubmissionStageCredentialPackageConfig) {
+			config.Ledger.TokenRequestEvidenceDigest = ""
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			config, _, _ := submissionStageCredentialConfig(t)
+			mutate(&config)
+			_, err := BuildSubmissionStageCredentialPackage(config)
+			if err == nil || strings.Contains(err.Error(), config.Ledger.TokenFile) || strings.Contains(err.Error(), config.Ledger.CAFile) || strings.Contains(err.Error(), config.SelectedAuthority.TokenFile) || strings.Contains(err.Error(), config.SelectedAuthority.CAFile) {
+				t.Fatalf("unsafe credential source accepted: %v", err)
+			}
+		})
+	}
+}
+
+func TestBuildSubmissionStageCredentialPackageSelectsManagementForLifecycleStage(t *testing.T) {
+	config, _, _ := submissionStageCredentialConfig(t)
+	fixture := submissionBundleFixture(t, true, "")
+	stagePackage, err := BuildSubmissionStagePackage(submissionStagePackageConfig(t, fixture, "cluster-lifecycle"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	config.Package = stagePackage
+	config.SelectedAuthority.AuthorityIdentity = "ok-mgmt"
+	packaged, err := BuildSubmissionStageCredentialPackage(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := packaged.Receipt()
+	if err != nil || receipt.StageID != "cluster-lifecycle" || receipt.Credentials[0].Authority != "ok-mgmt" || receipt.Credentials[1].Authority != "ok-mgmt" {
+		t.Fatalf("lifecycle credential authorities differ: %#v %v", receipt, err)
+	}
+}
+
+func TestBuildSubmissionStageCredentialPackageRejectsSharedTokenAndSymlink(t *testing.T) {
+	config, _, _ := submissionStageCredentialConfig(t)
+	config.SelectedAuthority.TokenFile = config.Ledger.TokenFile
+	config.SelectedAuthority.TokenDigest = config.Ledger.TokenDigest
+	config.SelectedAuthority.ExpectedIssuer = config.Ledger.ExpectedIssuer
+	config.SelectedAuthority.ExpectedSubject = config.Ledger.ExpectedSubject
+	config.SelectedAuthority.ExpectedAudiences = append([]string(nil), config.Ledger.ExpectedAudiences...)
+	config.SelectedAuthority.IssuedAt = config.Ledger.IssuedAt
+	config.SelectedAuthority.ExpiresAt = config.Ledger.ExpiresAt
+	if _, err := BuildSubmissionStageCredentialPackage(config); err == nil {
+		t.Fatal("shared ledger/authority token was accepted")
+	}
+
+	config, _, _ = submissionStageCredentialConfig(t)
+	symlink := filepath.Join(filepath.Dir(config.Ledger.TokenFile), "token-link")
+	if err := os.Symlink(config.Ledger.TokenFile, symlink); err != nil {
+		t.Fatal(err)
+	}
+	config.Ledger.TokenFile = symlink
+	if _, err := BuildSubmissionStageCredentialPackage(config); err == nil || strings.Contains(err.Error(), symlink) {
+		t.Fatalf("symlink accepted or source path exposed: %v", err)
+	}
+}
+
+func TestBuildSubmissionStageCredentialPackageRejectsUnsignedJWT(t *testing.T) {
+	config, _, _ := submissionStageCredentialConfig(t)
+	token, err := os.ReadFile(config.Ledger.TokenFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	parts := strings.Split(string(token), ".")
+	header, _ := json.Marshal(map[string]string{"alg": "none", "typ": "JWT"})
+	parts[0] = base64.RawURLEncoding.EncodeToString(header)
+	unsafe := []byte(strings.Join(parts, "."))
+	if err := os.WriteFile(config.Ledger.TokenFile, unsafe, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	config.Ledger.TokenDigest = digest.SHA256(unsafe)
+	if _, err := BuildSubmissionStageCredentialPackage(config); err == nil {
+		t.Fatal("unsigned JWT algorithm was accepted")
+	}
+}
+
+func submissionStageCredentialConfig(t *testing.T) (SubmissionStageCredentialPackageConfig, []byte, []byte) {
+	t.Helper()
+	now := time.Date(2026, 8, 16, 12, 0, 0, 0, time.UTC)
+	issuedAt, expiresAt := now.Add(-time.Minute), now.Add(30*time.Minute)
+	audience := []string{"https://kubernetes.default.svc"}
+	issuer := "https://kubernetes.default.svc.cluster.local"
+	ledgerSubject := "system:serviceaccount:openkubes-execution-system:ok147-ledger-writer"
+	authoritySubject := "system:serviceaccount:openkubes-execution-system:ok147-provider-writer"
+	ledgerToken := stageCredentialJWT(t, issuer, ledgerSubject, audience, issuedAt, expiresAt, 'a')
+	authorityToken := stageCredentialJWT(t, issuer, authoritySubject, audience, issuedAt, expiresAt, 'b')
+	root := t.TempDir()
+	ca := testCA(t)
+	caPath := filepath.Join(root, "ca.crt")
+	ledgerPath := filepath.Join(root, "ledger-token")
+	authorityPath := filepath.Join(root, "authority-token")
+	for path, raw := range map[string][]byte{caPath: ca, ledgerPath: ledgerToken, authorityPath: authorityToken} {
+		if err := os.WriteFile(path, raw, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	fixture := submissionBundleFixture(t, false, "")
+	stagePackage, err := BuildSubmissionStagePackage(submissionStagePackageConfig(t, fixture, "provider-prerequisites"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	source := func(authority, tokenPath, subject, evidence string, token []byte) SubmissionStageCredentialSource {
+		return SubmissionStageCredentialSource{
+			AuthorityIdentity: authority, TokenFile: tokenPath, TokenDigest: digest.SHA256(token),
+			CAFile: caPath, CABundleDigest: digest.SHA256(ca), TokenRequestEvidenceDigest: prefixSHA(evidence),
+			ExpectedIssuer: issuer, ExpectedSubject: subject, ExpectedAudiences: audience,
+			IssuedAt: issuedAt, ExpiresAt: expiresAt,
+		}
+	}
+	return SubmissionStageCredentialPackageConfig{
+		Package: stagePackage, MaterializationTime: now,
+		Ledger:            source("ok-mgmt", ledgerPath, ledgerSubject, "8", ledgerToken),
+		SelectedAuthority: source("ok-infra", authorityPath, authoritySubject, "9", authorityToken),
+	}, ledgerToken, authorityToken
+}
+
+func stageCredentialJWT(t *testing.T, issuer, subject string, audiences []string, issuedAt, expiresAt time.Time, signatureByte byte) []byte {
+	t.Helper()
+	header, err := json.Marshal(map[string]string{"alg": "RS256", "typ": "JWT", "kid": "ok147-test-key"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	claims, err := json.Marshal(map[string]any{
+		"iss": issuer, "sub": subject, "aud": audiences,
+		"iat": issuedAt.Unix(), "nbf": issuedAt.Unix(), "exp": expiresAt.Unix(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	signature := bytes.Repeat([]byte{signatureByte}, 64)
+	return []byte(base64.RawURLEncoding.EncodeToString(header) + "." + base64.RawURLEncoding.EncodeToString(claims) + "." + base64.RawURLEncoding.EncodeToString(signature))
+}

--- a/internal/runner/submission_stage_installation_plan.go
+++ b/internal/runner/submission_stage_installation_plan.go
@@ -47,6 +47,9 @@ func PlanSubmissionStageInstallation(packaged VerifiedSubmissionStagePackage) (S
 	if packaged.installationAuthority == "" {
 		return SubmissionStageInstallationPlan{}, errors.New("submission stage package installation authority is missing")
 	}
+	if packaged.ledgerAuthority != packaged.installationAuthority || packaged.selectedAuthority == "" || packaged.ledgerCredential == "" || packaged.selectedCredential == "" || packaged.ledgerCredential == packaged.selectedCredential {
+		return SubmissionStageInstallationPlan{}, errors.New("submission stage package credential binding is invalid")
+	}
 	if digest.SHA256(packaged.raw) != packaged.receipt.PackageDigest {
 		return SubmissionStageInstallationPlan{}, errors.New("submission stage package changed after verification")
 	}
@@ -139,12 +142,52 @@ func PlanSubmissionStageInstallation(packaged VerifiedSubmissionStagePackage) (S
 			if !jobUsesManagementAuthority(podSpec, packaged.installationAuthority) {
 				return SubmissionStageInstallationPlan{}, errors.New("submission stage Job management authority differs from installation authority")
 			}
+			if !jobUsesCredentialSecrets(podSpec, packaged.ledgerCredential, packaged.selectedCredential) {
+				return SubmissionStageInstallationPlan{}, errors.New("submission stage Job credential Secrets differ from package binding")
+			}
 		}
 	}
 	return SubmissionStageInstallationPlan{
 		Format: SubmissionStageInstallationPlanFormat, State: "VERIFIED", StageID: packaged.receipt.StageID,
 		PackageDigest: packaged.receipt.PackageDigest, Creates: creates, MutationAllowed: false,
 	}, nil
+}
+
+func jobUsesCredentialSecrets(podSpec map[string]any, ledger, selected string) bool {
+	volumes, ok := podSpec["volumes"].([]any)
+	if !ok {
+		return false
+	}
+	found := map[string]string{}
+	for _, item := range volumes {
+		volume, _ := item.(map[string]any)
+		name, _ := volume["name"].(string)
+		if name != "ledger-credential" && name != "authority-credential" {
+			continue
+		}
+		secret, _ := volume["secret"].(map[string]any)
+		secretName, _ := secret["secretName"].(string)
+		items, _ := secret["items"].([]any)
+		if len(items) != 2 || !credentialSecretItems(items) {
+			return false
+		}
+		found[name] = secretName
+	}
+	return len(found) == 2 && found["ledger-credential"] == ledger && found["authority-credential"] == selected
+}
+
+func credentialSecretItems(items []any) bool {
+	expected := map[string]string{"token": "token", "ca.crt": "ca.crt"}
+	for _, item := range items {
+		entry, _ := item.(map[string]any)
+		key, _ := entry["key"].(string)
+		path, _ := entry["path"].(string)
+		if expected[key] != path {
+			return false
+		}
+		delete(expected, key)
+	}
+	return len(expected) == 0
 }
 
 func jobUsesManagementAuthority(podSpec map[string]any, authority string) bool {

--- a/internal/runner/submission_stage_installation_plan_test.go
+++ b/internal/runner/submission_stage_installation_plan_test.go
@@ -71,6 +71,19 @@ func TestPlanSubmissionStageInstallationRejectsChangedPackage(t *testing.T) {
 		t.Fatal("changed object inventory was planned")
 	}
 
+	sharedCredential := valid
+	sharedCredential.selectedCredential = sharedCredential.ledgerCredential
+	if _, err := PlanSubmissionStageInstallation(sharedCredential); err == nil {
+		t.Fatal("shared credential binding was planned")
+	}
+
+	foreignInstallationAuthority := valid
+	foreignInstallationAuthority.installationAuthority = "ok-infra"
+	foreignInstallationAuthority.ledgerAuthority = "ok-infra"
+	if _, err := PlanSubmissionStageInstallation(foreignInstallationAuthority); err == nil {
+		t.Fatal("foreign installation authority was planned")
+	}
+
 	changedRuntime := valid
 	changedRuntime.raw = append([]byte(nil), valid.raw...)
 	changedRuntime.raw = bytes.Replace(changedRuntime.raw, []byte("ok147-contract-executor-runtime"), []byte("ok147-foreign-runtime"), 1)

--- a/internal/runner/submission_stage_package.go
+++ b/internal/runner/submission_stage_package.go
@@ -48,6 +48,10 @@ type VerifiedSubmissionStagePackage struct {
 	raw                   []byte
 	receipt               SubmissionStagePackageReceipt
 	installationAuthority string
+	ledgerAuthority       string
+	selectedAuthority     string
+	ledgerCredential      string
+	selectedCredential    string
 	verified              bool
 }
 
@@ -98,9 +102,17 @@ func BuildSubmissionStagePackage(config SubmissionStagePackageConfig) (VerifiedS
 		ObjectKinds:        []string{"ConfigMap", "NetworkPolicy", "Job"},
 		AuthorizationState: "VERIFIED", MutationAllowed: false,
 	}
+	selectedAuthority := config.Bundle.PlanExpected.ManagementAuthority
+	if config.Bundle.ExpectedStageID == "provider-prerequisites" {
+		selectedAuthority = config.Bundle.PlanExpected.InfrastructureAuthority
+	}
 	return VerifiedSubmissionStagePackage{
 		raw: packageRaw, receipt: receipt,
 		installationAuthority: config.Bundle.PlanExpected.ManagementAuthority,
+		ledgerAuthority:       config.Bundle.PlanExpected.ManagementAuthority,
+		selectedAuthority:     selectedAuthority,
+		ledgerCredential:      config.LedgerCredentialSecret,
+		selectedCredential:    config.AuthorityCredentialSecret,
 		verified:              true,
 	}, nil
 }


### PR DESCRIPTION
## Summary
- build exactly two private immutable credential Secrets from a verified stage package
- bind ledger to management and writer credentials to the stage-selected authority
- validate bounded source files, digests, TokenRequest evidence, JWT identity/time claims, and CA lifetime
- expose only a redaction-safe credential package receipt

## Safety boundary
- no Secret bytes accessor
- no Kubernetes request or live mutation
- TokenRequest issuance and Secret installation remain separate
- local JWT parsing does not claim cryptographic authenticity

## Validation
- `go test -ldflags=-linkmode=external ./...`
- `go vet ./...`
- `go test -race -ldflags=-linkmode=external ./internal/runner ./internal/submission ./internal/execution ./internal/ledger`
- `python3 -m unittest discover -s tests -p "*_test.py"` (18 tests, 1 expected skip)
- `git diff --check`