### PR TITLE
feat(runner): install stage credentials create-only (OK-147)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,9 @@ Powered by [Cluster API (CAPI)](https://cluster-api.sigs.k8s.io/), [CAPK (KubeVi
   single-use Create-only installer can submit only that verified envelope
   after a complete zero-write preflight. Its tokenless runtime identity and
   two short-lived immutable credential Secrets are built as a separate
-  private, digest-bound package; TokenRequest issuance and Secret installation
-  remain separately managed prerequisites. The runner image is digest-pinned,
+  private, digest-bound package and have their own single-use exact-create
+  installer. TokenRequest issuance and live installation remain separately
+  managed prerequisites. The runner image is digest-pinned,
   multi-architecture, non-root, SBOM- and provenance-producing behind a
   protected publisher.
 

--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -1224,6 +1224,24 @@ retaining tokens, CAs, subjects or source paths. Building this package is
 non-mutating. Secret installation, TokenRequest issuance and live execution
 remain separate boundaries.
 
+The matching `KubernetesSubmissionStageCredentialInstaller` consumes only
+that private verified package. Before contacting Kubernetes it rechecks the
+credential-package digest, management installation authority, exact Secret
+semantics and at least 15 minutes of remaining token lifetime. Its own bounded
+management writer credential must be different from both Job credentials.
+It then performs both exact Secret absence GETs before the first write and, if
+both are absent, creates the ledger Secret followed by the selected-authority
+Secret. The GETs request `PartialObjectMetadata`; lack of server support stops
+zero-write instead of falling back to a full Secret response. Existing state
+is never adopted or returned.
+
+The installer is single-use and has no caller-selected Secret, path or body.
+It exposes no update, patch, apply, delete, list, watch, discovery, retry,
+rollback or cleanup operation. A redaction-safe receipt contains only the
+verified created prefix and digested runtime identities. This implementation
+is exercised only through an in-memory API transport in this checkpoint; it
+does not issue TokenRequests or authorize a live Secret installation.
+
 ## Tokenless submission runtime identity
 
 [`deploy/contract-executor-stage-runtime.yaml`](../deploy/contract-executor-stage-runtime.yaml)

--- a/internal/runner/submission_stage_credential_installer.go
+++ b/internal/runner/submission_stage_credential_installer.go
@@ -1,0 +1,339 @@
+package runner
+
+import (
+	"bytes"
+	"context"
+	"crypto/subtle"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+const (
+	SubmissionStageCredentialInstallationReceiptFormat = "ok147-submission-stage-credential-installation-receipt/v1"
+	partialObjectMetadataAccept                        = "application/json;as=PartialObjectMetadata;g=meta.k8s.io;v=v1"
+)
+
+type SubmissionStageCredentialInstallerConfig struct {
+	Authority KubernetesAuthorityConfig
+	Clock     func() time.Time
+}
+
+type SubmissionStageInstalledCredential struct {
+	Order                 int    `json:"order"`
+	Role                  string `json:"role"`
+	Authority             string `json:"authority"`
+	Namespace             string `json:"namespace"`
+	Name                  string `json:"name"`
+	ObjectDigest          string `json:"objectDigest"`
+	UIDDigest             string `json:"uidDigest"`
+	ResourceVersionDigest string `json:"resourceVersionDigest"`
+	State                 string `json:"state"`
+}
+
+type SubmissionStageCredentialInstallationReceipt struct {
+	Format                  string                               `json:"format"`
+	StageID                 string                               `json:"stageId"`
+	StagePackageDigest      string                               `json:"stagePackageDigest"`
+	CredentialPackageDigest string                               `json:"credentialPackageDigest"`
+	Authority               string                               `json:"authority"`
+	State                   string                               `json:"state"`
+	MutationState           string                               `json:"mutationState"`
+	Results                 []SubmissionStageInstalledCredential `json:"results"`
+}
+
+type submissionStageCredentialInstallObject struct {
+	order          int
+	role           string
+	authority      string
+	name           string
+	objectPath     string
+	collectionPath string
+	objectDigest   string
+	expiresAt      time.Time
+	raw            []byte
+	token          []byte
+}
+
+type KubernetesSubmissionStageCredentialInstaller struct {
+	mu        sync.Mutex
+	used      bool
+	endpoint  *url.URL
+	token     string
+	client    *http.Client
+	clock     func() time.Time
+	authority string
+	receipt   SubmissionStageCredentialPackageReceipt
+	objects   []submissionStageCredentialInstallObject
+}
+
+type submissionStageCredentialInstallerClientConfig struct {
+	Endpoint          string
+	BearerToken       string
+	AuthorityIdentity string
+	Client            *http.Client
+	Clock             func() time.Time
+}
+
+// OpenKubernetesSubmissionStageCredentialInstaller opens the separately
+// credentialed management-plane writer for exactly one private two-Secret
+// package. It performs no API request.
+func OpenKubernetesSubmissionStageCredentialInstaller(config SubmissionStageCredentialInstallerConfig, packaged VerifiedSubmissionStageCredentialPackage) (*KubernetesSubmissionStageCredentialInstaller, error) {
+	if _, _, err := prepareSubmissionStageCredentialInstallation(packaged); err != nil {
+		return nil, err
+	}
+	if config.Authority.AuthorityIdentity == "" || config.Authority.AuthorityIdentity != packaged.installationAuthority {
+		return nil, errors.New("stage credential installer authority differs from verified management authority")
+	}
+	if !stageReceiptPrefixDigestPattern.MatchString(config.Authority.CABundleDigest) {
+		return nil, errors.New("stage credential installer CA identity is required")
+	}
+	token, ca, client, err := openBoundedKubernetesMaterial(config.Authority.TokenFile, config.Authority.CAFile)
+	if err != nil {
+		return nil, errors.New("open bounded stage credential installer credential")
+	}
+	if digest.SHA256(ca) != config.Authority.CABundleDigest {
+		return nil, errors.New("stage credential installer CA differs from bound identity")
+	}
+	return newKubernetesSubmissionStageCredentialInstaller(submissionStageCredentialInstallerClientConfig{
+		Endpoint: config.Authority.Endpoint, BearerToken: token, AuthorityIdentity: config.Authority.AuthorityIdentity,
+		Client: client, Clock: config.Clock,
+	}, packaged)
+}
+
+func newKubernetesSubmissionStageCredentialInstaller(config submissionStageCredentialInstallerClientConfig, packaged VerifiedSubmissionStageCredentialPackage) (*KubernetesSubmissionStageCredentialInstaller, error) {
+	receipt, objects, err := prepareSubmissionStageCredentialInstallation(packaged)
+	if err != nil {
+		return nil, err
+	}
+	if config.AuthorityIdentity == "" || config.AuthorityIdentity != packaged.installationAuthority {
+		return nil, errors.New("stage credential installer authority differs from verified management authority")
+	}
+	endpoint, err := url.Parse(config.Endpoint)
+	if err != nil || endpoint.Host == "" || endpoint.User != nil || endpoint.RawQuery != "" || endpoint.Fragment != "" || endpoint.Path != "" && endpoint.Path != "/" || endpoint.Port() == "" || net.ParseIP(endpoint.Hostname()) == nil {
+		return nil, errors.New("stage credential installer Kubernetes endpoint is invalid")
+	}
+	if endpoint.Scheme != "https" && !(endpoint.Scheme == "http" && endpoint.Hostname() == "127.0.0.1") {
+		return nil, errors.New("stage credential installer Kubernetes endpoint must use HTTPS")
+	}
+	if config.BearerToken == "" || strings.TrimSpace(config.BearerToken) != config.BearerToken || strings.ContainsAny(config.BearerToken, "\r\n") || config.Client == nil || config.Clock == nil {
+		return nil, errors.New("stage credential installer Kubernetes credential, client, or clock is invalid")
+	}
+	for _, object := range objects {
+		if len(config.BearerToken) == len(object.token) && subtle.ConstantTimeCompare([]byte(config.BearerToken), object.token) == 1 {
+			return nil, errors.New("stage credential installer and Job credentials must be distinct")
+		}
+	}
+	client := *config.Client
+	client.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+	if client.Timeout == 0 {
+		client.Timeout = 15 * time.Second
+	}
+	endpoint.Path, endpoint.RawPath = "", ""
+	return &KubernetesSubmissionStageCredentialInstaller{
+		endpoint: endpoint, token: config.BearerToken, client: &client, clock: config.Clock,
+		authority: config.AuthorityIdentity, receipt: receipt, objects: objects,
+	}, nil
+}
+
+// Install performs both exact absence GETs before the first Secret POST. It
+// never adopts, returns, updates, patches, deletes, lists, watches or retries
+// a Secret. Expired or nearly expired credentials stop locally with zero writes.
+func (installer *KubernetesSubmissionStageCredentialInstaller) Install(ctx context.Context) (SubmissionStageCredentialInstallationReceipt, error) {
+	receipt := installer.newReceipt()
+	if installer == nil || installer.client == nil || installer.clock == nil {
+		return receipt, errors.New("stage credential installer is required")
+	}
+	installer.mu.Lock()
+	if installer.used {
+		installer.mu.Unlock()
+		return stoppedStageCredentialInstallation(receipt, "STOPPED_ZERO_WRITE", errors.New("stage credential installer is single-use"))
+	}
+	installer.used = true
+	installer.mu.Unlock()
+
+	now := installer.clock().UTC()
+	materializedAt, err := time.Parse(time.RFC3339, installer.receipt.MaterializedAt)
+	if err != nil || now.Before(materializedAt) {
+		return stoppedStageCredentialInstallation(receipt, "STOPPED_ZERO_WRITE", errors.New("stage credential installation time precedes verified materialization"))
+	}
+	for _, object := range installer.objects {
+		if object.expiresAt.Sub(now) < minimumStageCredentialRemaining {
+			return stoppedStageCredentialInstallation(receipt, "STOPPED_ZERO_WRITE", errors.New("stage credential has insufficient remaining lifetime"))
+		}
+	}
+	for _, object := range installer.objects {
+		_, status, err := installer.request(ctx, http.MethodGet, object.objectPath, nil)
+		if err != nil {
+			return stoppedStageCredentialInstallation(receipt, "STOPPED_ZERO_WRITE", err)
+		}
+		switch status {
+		case http.StatusNotFound:
+		case http.StatusOK:
+			return stoppedStageCredentialInstallation(receipt, "STOPPED_ZERO_WRITE", errors.New("stage credential Secret already exists; zero-write preflight stopped"))
+		default:
+			return stoppedStageCredentialInstallation(receipt, "STOPPED_ZERO_WRITE", stageCredentialInstallationStatusError(http.MethodGet, status))
+		}
+	}
+
+	receipt.State = "CREATING"
+	for _, object := range installer.objects {
+		receipt.MutationState = "ATTEMPTED_UNKNOWN"
+		raw, status, err := installer.request(ctx, http.MethodPost, object.collectionPath, object.raw)
+		if err != nil {
+			return stoppedStageCredentialInstallation(receipt, "STOPPED_PARTIAL_OR_UNKNOWN", err)
+		}
+		if status != http.StatusCreated {
+			receipt.MutationState = "ATTEMPTED"
+			return stoppedStageCredentialInstallation(receipt, "STOPPED_PARTIAL_OR_UNKNOWN", stageCredentialInstallationStatusError(http.MethodPost, status))
+		}
+		uid, resourceVersion, err := verifySubmissionStageCredentialCreatedObject(raw, object)
+		if err != nil {
+			return stoppedStageCredentialInstallation(receipt, "STOPPED_PARTIAL_OR_UNKNOWN", errors.New("created stage credential differs from verified package"))
+		}
+		receipt.MutationState = "ATTEMPTED"
+		receipt.Results = append(receipt.Results, SubmissionStageInstalledCredential{
+			Order: object.order, Role: object.role, Authority: object.authority, Namespace: submissionStageInputNamespace,
+			Name: object.name, ObjectDigest: object.objectDigest, UIDDigest: digest.SHA256([]byte(uid)),
+			ResourceVersionDigest: digest.SHA256([]byte(resourceVersion)), State: "CREATED",
+		})
+	}
+	receipt.State = "INSTALLED"
+	return receipt, nil
+}
+
+func (installer *KubernetesSubmissionStageCredentialInstaller) newReceipt() SubmissionStageCredentialInstallationReceipt {
+	receipt := SubmissionStageCredentialInstallationReceipt{
+		Format: SubmissionStageCredentialInstallationReceiptFormat, State: "PREFLIGHT", MutationState: "NOT_ATTEMPTED",
+		Results: []SubmissionStageInstalledCredential{},
+	}
+	if installer != nil {
+		receipt.StageID = installer.receipt.StageID
+		receipt.StagePackageDigest = installer.receipt.StagePackageDigest
+		receipt.CredentialPackageDigest = installer.receipt.PackageDigest
+		receipt.Authority = installer.authority
+	}
+	return receipt
+}
+
+func stoppedStageCredentialInstallation(receipt SubmissionStageCredentialInstallationReceipt, state string, err error) (SubmissionStageCredentialInstallationReceipt, error) {
+	receipt.State = state
+	return receipt, err
+}
+
+func (installer *KubernetesSubmissionStageCredentialInstaller) request(ctx context.Context, method, path string, body []byte) ([]byte, int, error) {
+	endpoint := *installer.endpoint
+	endpoint.Path = path
+	request, err := http.NewRequestWithContext(ctx, method, endpoint.String(), bytes.NewReader(body))
+	if err != nil {
+		return nil, 0, errors.New("construct bounded stage credential request")
+	}
+	request.Header.Set("Accept", "application/json")
+	if method == http.MethodGet {
+		request.Header.Set("Accept", partialObjectMetadataAccept)
+	}
+	request.Header.Set("Authorization", "Bearer "+installer.token)
+	if body != nil {
+		request.Header.Set("Content-Type", "application/json")
+	}
+	response, err := installer.client.Do(request)
+	if err != nil {
+		return nil, 0, fmt.Errorf("bounded stage credential %s request failed", method)
+	}
+	defer response.Body.Close()
+	raw, readErr := io.ReadAll(io.LimitReader(response.Body, maximumStageInstallationResponseBytes+1))
+	if readErr != nil || len(raw) > maximumStageInstallationResponseBytes {
+		return nil, 0, errors.New("bounded stage credential response exceeds accepted size")
+	}
+	if len(raw) > 0 {
+		mediaType, _, err := mime.ParseMediaType(response.Header.Get("Content-Type"))
+		if err != nil || mediaType != "application/json" {
+			return nil, 0, errors.New("bounded stage credential response is not JSON")
+		}
+	}
+	return raw, response.StatusCode, nil
+}
+
+func prepareSubmissionStageCredentialInstallation(packaged VerifiedSubmissionStageCredentialPackage) (SubmissionStageCredentialPackageReceipt, []submissionStageCredentialInstallObject, error) {
+	if !packaged.verified || packaged.receipt.Format != SubmissionStageCredentialPackageFormat || packaged.receipt.State != "VERIFIED" || packaged.installationAuthority == "" || len(packaged.objects) != 2 || len(packaged.receipt.Credentials) != 2 {
+		return SubmissionStageCredentialPackageReceipt{}, nil, errors.New("stage credential package was not produced by verification")
+	}
+	identity, err := json.Marshal(submissionStageCredentialPackageIdentity{
+		StagePackageDigest: packaged.receipt.StagePackageDigest, InstallationAuthority: packaged.receipt.InstallationAuthority,
+		MaterializedAt: packaged.receipt.MaterializedAt,
+		Credentials:    packaged.receipt.Credentials,
+	})
+	if err != nil || digest.SHA256(identity) != packaged.receipt.PackageDigest || !stageReceiptPrefixDigestPattern.MatchString(packaged.receipt.StagePackageDigest) || packaged.receipt.InstallationAuthority != packaged.installationAuthority {
+		return SubmissionStageCredentialPackageReceipt{}, nil, errors.New("stage credential package identity changed after verification")
+	}
+	if _, err := time.Parse(time.RFC3339, packaged.receipt.MaterializedAt); err != nil {
+		return SubmissionStageCredentialPackageReceipt{}, nil, errors.New("stage credential package materialization time is invalid")
+	}
+	expectedRoles := []string{"ledger", "authority"}
+	objects := make([]submissionStageCredentialInstallObject, 0, 2)
+	for index, private := range packaged.objects {
+		public := packaged.receipt.Credentials[index]
+		if private.role != expectedRoles[index] || private.role != public.Role || private.authority != public.Authority || private.name != public.Name || public.Namespace != submissionStageInputNamespace || digest.SHA256(private.raw) != public.ObjectDigest {
+			return SubmissionStageCredentialPackageReceipt{}, nil, errors.New("stage credential object identity changed after verification")
+		}
+		var secret map[string]any
+		if err := json.Unmarshal(private.raw, &secret); err != nil {
+			return SubmissionStageCredentialPackageReceipt{}, nil, errors.New("stage credential object is invalid JSON")
+		}
+		metadata, _ := secret["metadata"].(map[string]any)
+		labels, _ := metadata["labels"].(map[string]any)
+		annotations, _ := metadata["annotations"].(map[string]any)
+		data, _ := secret["data"].(map[string]any)
+		if secret["apiVersion"] != "v1" || secret["kind"] != "Secret" || secret["immutable"] != true || secret["type"] != "Opaque" || metadata["name"] != private.name || metadata["namespace"] != submissionStageInputNamespace || labels["openkubes.io/stage-id"] != packaged.receipt.StageID || labels["openkubes.io/credential-role"] != private.role || annotations["openkubes.io/authority-identity"] != private.authority || annotations["openkubes.io/expires-at"] != public.ExpiresAt || len(data) != 2 {
+			return SubmissionStageCredentialPackageReceipt{}, nil, errors.New("stage credential Secret semantics changed after verification")
+		}
+		tokenEncoded, tokenOK := data["token"].(string)
+		caEncoded, caOK := data["ca.crt"].(string)
+		token, tokenErr := base64.StdEncoding.DecodeString(tokenEncoded)
+		ca, caErr := base64.StdEncoding.DecodeString(caEncoded)
+		expiresAt, timeErr := time.Parse(time.RFC3339, public.ExpiresAt)
+		if !tokenOK || !caOK || tokenErr != nil || caErr != nil || len(token) == 0 || len(ca) == 0 || timeErr != nil || digest.SHA256(ca) != public.CABundleDigest {
+			return SubmissionStageCredentialPackageReceipt{}, nil, errors.New("stage credential Secret data changed after verification")
+		}
+		collectionPath := "/api/v1/namespaces/" + submissionStageInputNamespace + "/secrets"
+		objects = append(objects, submissionStageCredentialInstallObject{
+			order: index + 1, role: private.role, authority: private.authority, name: private.name,
+			objectPath: collectionPath + "/" + private.name, collectionPath: collectionPath,
+			objectDigest: public.ObjectDigest, expiresAt: expiresAt, raw: append([]byte(nil), private.raw...), token: token,
+		})
+	}
+	return packaged.receipt, objects, nil
+}
+
+func verifySubmissionStageCredentialCreatedObject(raw []byte, expected submissionStageCredentialInstallObject) (string, string, error) {
+	observed, err := decodeCapabilityJSONObject(raw)
+	if err != nil {
+		return "", "", err
+	}
+	desired, err := decodeCapabilityJSONObject(expected.raw)
+	if err != nil || !capabilitySubset(desired, observed) {
+		return "", "", errors.New("observed Secret does not contain exact package fields")
+	}
+	metadata, _ := observed["metadata"].(map[string]any)
+	uid, _ := metadata["uid"].(string)
+	resourceVersion, _ := metadata["resourceVersion"].(string)
+	if !runtimeInputUIDPattern.MatchString(uid) || !runtimeInputUIDPattern.MatchString(resourceVersion) {
+		return "", "", errors.New("created Secret lacks bounded runtime identity")
+	}
+	return uid, resourceVersion, nil
+}
+
+func stageCredentialInstallationStatusError(method string, status int) error {
+	return fmt.Errorf("bounded stage credential %s returned HTTP %d", method, status)
+}

--- a/internal/runner/submission_stage_credential_installer_test.go
+++ b/internal/runner/submission_stage_credential_installer_test.go
@@ -1,0 +1,252 @@
+package runner
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+func TestSubmissionStageCredentialInstallerPreflightsThenCreatesExactSecrets(t *testing.T) {
+	packaged, _, _ := submissionStageCredentialInstallerPackage(t)
+	api := newStageCredentialInstallerAPI(t)
+	installer := newStageCredentialInstaller(t, packaged, api.client(), time.Date(2026, 8, 16, 12, 1, 0, 0, time.UTC), "short-lived-installer-token")
+	receipt, err := installer.Install(context.Background())
+	if err != nil || receipt.State != "INSTALLED" || receipt.MutationState != "ATTEMPTED" || len(receipt.Results) != 2 {
+		t.Fatalf("credential installation failed: %#v %v", receipt, err)
+	}
+	credentialReceipt, err := packaged.Receipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if receipt.Format != SubmissionStageCredentialInstallationReceiptFormat || receipt.StageID != credentialReceipt.StageID || receipt.StagePackageDigest != credentialReceipt.StagePackageDigest || receipt.CredentialPackageDigest != credentialReceipt.PackageDigest || receipt.Authority != "ok-mgmt" {
+		t.Fatalf("credential installation receipt identity differs: %#v", receipt)
+	}
+	if len(api.requests) != 4 {
+		t.Fatalf("requests=%d, want two GETs then two POSTs", len(api.requests))
+	}
+	for index, object := range installer.objects {
+		preflight, submission := api.requests[index], api.requests[index+2]
+		if preflight.method != http.MethodGet || preflight.path != object.objectPath || len(preflight.body) != 0 || submission.method != http.MethodPost || submission.path != object.collectionPath || digest.SHA256(submission.body) != object.objectDigest {
+			t.Fatalf("credential request %d differs from binding", index)
+		}
+		result := receipt.Results[index]
+		if result.Order != index+1 || result.Role != object.role || result.Authority != object.authority || result.Name != object.name || result.ObjectDigest != object.objectDigest || result.State != "CREATED" || !stageReceiptPrefixDigestPattern.MatchString(result.UIDDigest) || !stageReceiptPrefixDigestPattern.MatchString(result.ResourceVersionDigest) {
+			t.Fatalf("credential result %d differs: %#v", index, result)
+		}
+	}
+	public, err := json.Marshal(receipt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range []string{"short-lived-installer-token", "created-secret-uid", string(installer.objects[0].token), string(installer.objects[1].token)} {
+		if bytes.Contains(public, []byte(forbidden)) {
+			t.Fatalf("credential installation receipt exposed %q", forbidden)
+		}
+	}
+}
+
+func TestSubmissionStageCredentialInstallerStopsZeroWriteForExistingOrStaleCredentials(t *testing.T) {
+	t.Run("existing second Secret", func(t *testing.T) {
+		packaged, _, _ := submissionStageCredentialInstallerPackage(t)
+		api := newStageCredentialInstallerAPI(t)
+		installer := newStageCredentialInstaller(t, packaged, api.client(), time.Date(2026, 8, 16, 12, 1, 0, 0, time.UTC), "short-lived-installer-token")
+		api.objects[installer.objects[1].objectPath] = map[string]any{"kind": "Secret"}
+		receipt, err := installer.Install(context.Background())
+		if err == nil || receipt.State != "STOPPED_ZERO_WRITE" || receipt.MutationState != "NOT_ATTEMPTED" || api.posts != 0 || len(api.requests) != 2 {
+			t.Fatalf("existing Secret did not stop zero-write: %#v posts=%d requests=%d err=%v", receipt, api.posts, len(api.requests), err)
+		}
+	})
+
+	t.Run("insufficient remaining lifetime", func(t *testing.T) {
+		packaged, _, _ := submissionStageCredentialInstallerPackage(t)
+		api := newStageCredentialInstallerAPI(t)
+		installer := newStageCredentialInstaller(t, packaged, api.client(), time.Date(2026, 8, 16, 12, 16, 0, 0, time.UTC), "short-lived-installer-token")
+		receipt, err := installer.Install(context.Background())
+		if err == nil || receipt.State != "STOPPED_ZERO_WRITE" || receipt.MutationState != "NOT_ATTEMPTED" || len(api.requests) != 0 {
+			t.Fatalf("stale credential reached API: %#v requests=%d err=%v", receipt, len(api.requests), err)
+		}
+	})
+}
+
+func TestSubmissionStageCredentialInstallerPreservesPartialPrefixAndCannotRetry(t *testing.T) {
+	packaged, _, _ := submissionStageCredentialInstallerPackage(t)
+	api := newStageCredentialInstallerAPI(t)
+	api.failPost = 2
+	installer := newStageCredentialInstaller(t, packaged, api.client(), time.Date(2026, 8, 16, 12, 1, 0, 0, time.UTC), "short-lived-installer-token")
+	receipt, err := installer.Install(context.Background())
+	if err == nil || receipt.State != "STOPPED_PARTIAL_OR_UNKNOWN" || receipt.MutationState != "ATTEMPTED" || len(receipt.Results) != 1 || receipt.Results[0].Role != "ledger" {
+		t.Fatalf("partial credential prefix differs: %#v %v", receipt, err)
+	}
+	requests := len(api.requests)
+	retry, retryErr := installer.Install(context.Background())
+	if retryErr == nil || retry.State != "STOPPED_ZERO_WRITE" || len(api.requests) != requests {
+		t.Fatalf("credential installer retried: %#v %v", retry, retryErr)
+	}
+}
+
+func TestSubmissionStageCredentialInstallerRejectsSharedCredentialTamperingAndRedirect(t *testing.T) {
+	packaged, ledgerToken, _ := submissionStageCredentialInstallerPackage(t)
+	api := newStageCredentialInstallerAPI(t)
+	if _, err := newKubernetesSubmissionStageCredentialInstaller(submissionStageCredentialInstallerClientConfig{
+		Endpoint: "http://127.0.0.1:12345", BearerToken: string(ledgerToken), AuthorityIdentity: "ok-mgmt", Client: api.client(), Clock: time.Now,
+	}, packaged); err == nil || len(api.requests) != 0 {
+		t.Fatal("Job credential was accepted as installer credential")
+	}
+
+	tampered := packaged
+	tampered.objects = cloneStageCredentialObjects(packaged.objects)
+	tampered.objects[0].raw[0] = 'x'
+	if _, err := newKubernetesSubmissionStageCredentialInstaller(submissionStageCredentialInstallerClientConfig{
+		Endpoint: "http://127.0.0.1:12345", BearerToken: "short-lived-installer-token", AuthorityIdentity: "ok-mgmt", Client: api.client(), Clock: time.Now,
+	}, tampered); err == nil || len(api.requests) != 0 {
+		t.Fatal("tampered credential package reached API")
+	}
+
+	calls := 0
+	redirect := &http.Client{Transport: stageCredentialInstallerRoundTripFunc(func(*http.Request) (*http.Response, error) {
+		calls++
+		return stageCredentialInstallerJSONResponse(http.StatusTemporaryRedirect, nil, map[string]string{"Location": "http://127.0.0.1:12346/foreign"}), nil
+	})}
+	installer := newStageCredentialInstaller(t, packaged, redirect, time.Date(2026, 8, 16, 12, 1, 0, 0, time.UTC), "short-lived-installer-token")
+	receipt, err := installer.Install(context.Background())
+	if err == nil || calls != 1 || receipt.State != "STOPPED_ZERO_WRITE" || receipt.MutationState != "NOT_ATTEMPTED" {
+		t.Fatalf("redirect followed or accepted: calls=%d receipt=%#v err=%v", calls, receipt, err)
+	}
+}
+
+func TestSubmissionStageCredentialInstallerTreatsResponseMismatchAndTransportAsUnknown(t *testing.T) {
+	for name, configure := range map[string]func(*stageCredentialInstallerAPI){
+		"response mismatch": func(api *stageCredentialInstallerAPI) { api.mismatchPost = 1 },
+		"transport error":   func(api *stageCredentialInstallerAPI) { api.errorPost = 1 },
+	} {
+		t.Run(name, func(t *testing.T) {
+			packaged, _, _ := submissionStageCredentialInstallerPackage(t)
+			api := newStageCredentialInstallerAPI(t)
+			configure(api)
+			installer := newStageCredentialInstaller(t, packaged, api.client(), time.Date(2026, 8, 16, 12, 1, 0, 0, time.UTC), "short-lived-installer-token")
+			receipt, err := installer.Install(context.Background())
+			if err == nil || receipt.State != "STOPPED_PARTIAL_OR_UNKNOWN" || receipt.MutationState != "ATTEMPTED_UNKNOWN" || len(receipt.Results) != 0 || strings.Contains(err.Error(), "short-lived-installer-token") {
+				t.Fatalf("unknown credential outcome accepted or leaked: %#v %v", receipt, err)
+			}
+		})
+	}
+}
+
+func submissionStageCredentialInstallerPackage(t *testing.T) (VerifiedSubmissionStageCredentialPackage, []byte, []byte) {
+	t.Helper()
+	config, ledgerToken, authorityToken := submissionStageCredentialConfig(t)
+	packaged, err := BuildSubmissionStageCredentialPackage(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return packaged, ledgerToken, authorityToken
+}
+
+func newStageCredentialInstaller(t *testing.T, packaged VerifiedSubmissionStageCredentialPackage, client *http.Client, now time.Time, token string) *KubernetesSubmissionStageCredentialInstaller {
+	t.Helper()
+	installer, err := newKubernetesSubmissionStageCredentialInstaller(submissionStageCredentialInstallerClientConfig{
+		Endpoint: "http://127.0.0.1:12345", BearerToken: token, AuthorityIdentity: "ok-mgmt", Client: client,
+		Clock: func() time.Time { return now },
+	}, packaged)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return installer
+}
+
+type stageCredentialInstallerRequest struct {
+	method string
+	path   string
+	body   []byte
+}
+
+type stageCredentialInstallerAPI struct {
+	t            *testing.T
+	mu           sync.Mutex
+	objects      map[string]map[string]any
+	requests     []stageCredentialInstallerRequest
+	posts        int
+	failPost     int
+	mismatchPost int
+	errorPost    int
+}
+
+func newStageCredentialInstallerAPI(t *testing.T) *stageCredentialInstallerAPI {
+	return &stageCredentialInstallerAPI{t: t, objects: map[string]map[string]any{}}
+}
+
+func (api *stageCredentialInstallerAPI) client() *http.Client {
+	return &http.Client{Transport: stageCredentialInstallerRoundTripFunc(api.roundTrip)}
+}
+
+func (api *stageCredentialInstallerAPI) roundTrip(request *http.Request) (*http.Response, error) {
+	api.mu.Lock()
+	defer api.mu.Unlock()
+	body, _ := io.ReadAll(request.Body)
+	api.requests = append(api.requests, stageCredentialInstallerRequest{method: request.Method, path: request.URL.Path, body: body})
+	if request.Header.Get("Authorization") != "Bearer short-lived-installer-token" {
+		return stageCredentialInstallerJSONResponse(http.StatusUnauthorized, map[string]any{"reason": "Unauthorized"}, nil), nil
+	}
+	if request.Method == http.MethodGet && request.Header.Get("Accept") != partialObjectMetadataAccept {
+		return stageCredentialInstallerJSONResponse(http.StatusNotAcceptable, map[string]any{"reason": "NotAcceptable"}, nil), nil
+	}
+	switch request.Method {
+	case http.MethodGet:
+		object, ok := api.objects[request.URL.Path]
+		if !ok {
+			return stageCredentialInstallerJSONResponse(http.StatusNotFound, map[string]any{"reason": "NotFound"}, nil), nil
+		}
+		return stageCredentialInstallerJSONResponse(http.StatusOK, object, nil), nil
+	case http.MethodPost:
+		api.posts++
+		if api.errorPost == api.posts {
+			return nil, errors.New("simulated transport error")
+		}
+		if api.failPost == api.posts {
+			return stageCredentialInstallerJSONResponse(http.StatusForbidden, map[string]any{"reason": "Denied"}, nil), nil
+		}
+		var secret map[string]any
+		if err := json.Unmarshal(body, &secret); err != nil {
+			api.t.Fatal(err)
+		}
+		metadata := secret["metadata"].(map[string]any)
+		metadata["uid"] = "created-secret-uid-" + string(rune('a'+api.posts-1))
+		metadata["resourceVersion"] = string(rune('1' + api.posts - 1))
+		path := request.URL.Path + "/" + metadata["name"].(string)
+		api.objects[path] = secret
+		if api.mismatchPost == api.posts {
+			metadata["name"] = "foreign-secret"
+		}
+		return stageCredentialInstallerJSONResponse(http.StatusCreated, secret, nil), nil
+	default:
+		return stageCredentialInstallerJSONResponse(http.StatusMethodNotAllowed, map[string]any{"reason": "MethodNotAllowed"}, nil), nil
+	}
+}
+
+type stageCredentialInstallerRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (function stageCredentialInstallerRoundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return function(request)
+}
+
+func stageCredentialInstallerJSONResponse(status int, value any, headers map[string]string) *http.Response {
+	var raw []byte
+	if value != nil {
+		raw, _ = json.Marshal(value)
+	}
+	header := make(http.Header)
+	header.Set("Content-Type", "application/json")
+	for key, value := range headers {
+		header.Set(key, value)
+	}
+	return &http.Response{StatusCode: status, Header: header, Body: io.NopCloser(bytes.NewReader(raw))}
+}

--- a/internal/runner/submission_stage_credentials.go
+++ b/internal/runner/submission_stage_credentials.go
@@ -62,14 +62,15 @@ type SubmissionStageCredentialObjectReceipt struct {
 // SubmissionStageCredentialPackageReceipt contains no token, CA, subject or
 // source path. ObjectDigest binds the private exact Secret object.
 type SubmissionStageCredentialPackageReceipt struct {
-	Format             string                                   `json:"format"`
-	State              string                                   `json:"state"`
-	StageID            string                                   `json:"stageId"`
-	StagePackageDigest string                                   `json:"stagePackageDigest"`
-	MaterializedAt     string                                   `json:"materializedAt"`
-	PackageDigest      string                                   `json:"packageDigest"`
-	Credentials        []SubmissionStageCredentialObjectReceipt `json:"credentials"`
-	MutationAllowed    bool                                     `json:"mutationAllowed"`
+	Format                string                                   `json:"format"`
+	State                 string                                   `json:"state"`
+	StageID               string                                   `json:"stageId"`
+	StagePackageDigest    string                                   `json:"stagePackageDigest"`
+	InstallationAuthority string                                   `json:"installationAuthority"`
+	MaterializedAt        string                                   `json:"materializedAt"`
+	PackageDigest         string                                   `json:"packageDigest"`
+	Credentials           []SubmissionStageCredentialObjectReceipt `json:"credentials"`
+	MutationAllowed       bool                                     `json:"mutationAllowed"`
 }
 
 type submissionStageCredentialObject struct {
@@ -79,13 +80,21 @@ type submissionStageCredentialObject struct {
 	raw       []byte
 }
 
+type submissionStageCredentialPackageIdentity struct {
+	StagePackageDigest    string                                   `json:"stagePackageDigest"`
+	InstallationAuthority string                                   `json:"installationAuthority"`
+	MaterializedAt        string                                   `json:"materializedAt"`
+	Credentials           []SubmissionStageCredentialObjectReceipt `json:"credentials"`
+}
+
 // VerifiedSubmissionStageCredentialPackage deliberately exposes only its
 // redaction-safe receipt. Secret bytes stay in-package for the later exact
 // installer boundary.
 type VerifiedSubmissionStageCredentialPackage struct {
-	objects  []submissionStageCredentialObject
-	receipt  SubmissionStageCredentialPackageReceipt
-	verified bool
+	objects               []submissionStageCredentialObject
+	receipt               SubmissionStageCredentialPackageReceipt
+	installationAuthority string
+	verified              bool
 }
 
 type submissionStageTokenClaims struct {
@@ -133,20 +142,23 @@ func BuildSubmissionStageCredentialPackage(config SubmissionStageCredentialPacka
 	if len(tokens[0]) == len(tokens[1]) && subtle.ConstantTimeCompare(tokens[0], tokens[1]) == 1 {
 		return VerifiedSubmissionStageCredentialPackage{}, errors.New("stage ledger and authority credentials must be distinct")
 	}
-	packageIdentity, err := json.Marshal(struct {
-		StagePackageDigest string                                   `json:"stagePackageDigest"`
-		MaterializedAt     string                                   `json:"materializedAt"`
-		Credentials        []SubmissionStageCredentialObjectReceipt `json:"credentials"`
-	}{StagePackageDigest: stagePlan.PackageDigest, MaterializedAt: materializedAt, Credentials: receipts})
+	packageIdentity, err := json.Marshal(submissionStageCredentialPackageIdentity{
+		StagePackageDigest: stagePlan.PackageDigest, InstallationAuthority: config.Package.installationAuthority,
+		MaterializedAt: materializedAt, Credentials: receipts,
+	})
 	if err != nil {
 		return VerifiedSubmissionStageCredentialPackage{}, errors.New("encode stage credential package identity")
 	}
 	receipt := SubmissionStageCredentialPackageReceipt{
 		Format: SubmissionStageCredentialPackageFormat, State: "VERIFIED", StageID: stagePlan.StageID,
-		StagePackageDigest: stagePlan.PackageDigest, MaterializedAt: materializedAt, PackageDigest: digest.SHA256(packageIdentity),
+		StagePackageDigest: stagePlan.PackageDigest, InstallationAuthority: config.Package.installationAuthority,
+		MaterializedAt: materializedAt, PackageDigest: digest.SHA256(packageIdentity),
 		Credentials: receipts, MutationAllowed: false,
 	}
-	return VerifiedSubmissionStageCredentialPackage{objects: cloneStageCredentialObjects(objects), receipt: receipt, verified: true}, nil
+	return VerifiedSubmissionStageCredentialPackage{
+		objects: cloneStageCredentialObjects(objects), receipt: receipt,
+		installationAuthority: config.Package.installationAuthority, verified: true,
+	}, nil
 }
 
 func (packaged VerifiedSubmissionStageCredentialPackage) Receipt() (SubmissionStageCredentialPackageReceipt, error) {

--- a/internal/runner/submission_stage_credentials_test.go
+++ b/internal/runner/submission_stage_credentials_test.go
@@ -27,7 +27,7 @@ func TestBuildSubmissionStageCredentialPackageBindsTwoPrivateImmutableSecrets(t 
 	if err != nil {
 		t.Fatal(err)
 	}
-	if receipt.Format != SubmissionStageCredentialPackageFormat || receipt.State != "VERIFIED" || receipt.StageID != "provider-prerequisites" || receipt.StagePackageDigest != stageReceipt.PackageDigest || receipt.MaterializedAt != config.MaterializationTime.Format(time.RFC3339) || !stageReceiptPrefixDigestPattern.MatchString(receipt.PackageDigest) || receipt.MutationAllowed || len(receipt.Credentials) != 2 {
+	if receipt.Format != SubmissionStageCredentialPackageFormat || receipt.State != "VERIFIED" || receipt.StageID != "provider-prerequisites" || receipt.StagePackageDigest != stageReceipt.PackageDigest || receipt.InstallationAuthority != "ok-mgmt" || receipt.MaterializedAt != config.MaterializationTime.Format(time.RFC3339) || !stageReceiptPrefixDigestPattern.MatchString(receipt.PackageDigest) || receipt.MutationAllowed || len(receipt.Credentials) != 2 {
 		t.Fatalf("unexpected credential receipt: %#v", receipt)
 	}
 	want := []struct {


### PR DESCRIPTION
## Summary
- add a single-use exact-create installer for the verified two-Secret credential package
- require both PartialObjectMetadata absence GETs before any Secret POST
- create ledger credential before the stage-selected authority credential
- stop locally for insufficient lifetime and preserve a redaction-safe partial prefix

## Safety boundary
- no caller-selected Secret, body, name, or API path
- installer credential is distinct from both Job credentials
- no update, patch, apply, delete, list, watch, discovery, retry, rollback, or cleanup
- in-memory Kubernetes transport tests only; no live cluster contact

## Validation
- `go test -ldflags=-linkmode=external ./...`
- `go vet ./...`
- `go test -race -ldflags=-linkmode=external ./internal/runner`
- `python3 -m unittest discover -s tests -p "*_test.py"` (18 tests, 1 expected skip)
- `git diff --check`