### PR TITLE
feat(runner): ensure tokenless stage runtime (OK-147)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,10 @@ Powered by [Cluster API (CAPI)](https://cluster-api.sigs.k8s.io/), [CAPK (KubeVi
   two short-lived immutable credential Secrets are built as a separate
   private, digest-bound package and have their own single-use exact-create
   installer. TokenRequest issuance and live installation remain separately
-  managed prerequisites. The runner image is digest-pinned,
-  multi-architecture, non-root, SBOM- and provenance-producing behind a
-  protected publisher.
+  managed prerequisites. The shared runtime ServiceAccount also has a bounded
+  exact-create-or-verify path and remains tokenless and RBAC-free. The runner
+  image is digest-pinned, multi-architecture, non-root, SBOM- and
+  provenance-producing behind a protected publisher.
 
 ---
 

--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -1253,9 +1253,21 @@ Role, RoleBinding, ClusterRole or ClusterRoleBinding.
 The Job therefore receives no implicit local API credential or Kubernetes
 permission from its Pod identity. Its ledger and selected-authority access can
 only come from the two separately named, externally materialized short-lived
-Secret mounts already bound by the Job envelope. Creating the ServiceAccount,
-credential Secrets or package objects remains an external authorized
-operation; this checkpoint only defines and tests the prerequisite manifest.
+Secret mounts already bound by the Job envelope.
+
+`BuildSubmissionStageRuntimePrerequisite` binds this exact one-object manifest
+and its canonical ServiceAccount representation to a verified stage package.
+The matching single-use installer performs one exact GET and creates the
+ServiceAccount only when absent. Existing state is accepted only when its
+token setting, exact two labels and absence of annotations, image-pull Secrets
+or other runtime semantics match the prerequisite. Server-generated identity
+and managed-fields metadata are allowed and retained only as digests in the
+receipt. There is no update, patch, apply, delete, list, watch, discovery or
+retry operation.
+
+This prerequisite installer is tested only against an in-memory API transport
+in this checkpoint. Creating the ServiceAccount, credential Secrets or stage
+package remains a separately authorized live operation.
 
 ## Typed first-run Platform capability boundary
 

--- a/internal/runner/submission_stage_runtime.go
+++ b/internal/runner/submission_stage_runtime.go
@@ -1,0 +1,78 @@
+package runner
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"gopkg.in/yaml.v3"
+)
+
+const SubmissionStageRuntimePrerequisiteFormat = "ok147-submission-stage-runtime-prerequisite/v1"
+
+type SubmissionStageRuntimePrerequisiteReceipt struct {
+	Format             string `json:"format"`
+	State              string `json:"state"`
+	StagePackageDigest string `json:"stagePackageDigest"`
+	ManifestDigest     string `json:"manifestDigest"`
+	ObjectDigest       string `json:"objectDigest"`
+	Authority          string `json:"authority"`
+	Namespace          string `json:"namespace"`
+	Name               string `json:"name"`
+	MutationAllowed    bool   `json:"mutationAllowed"`
+}
+
+type VerifiedSubmissionStageRuntimePrerequisite struct {
+	raw      []byte
+	receipt  SubmissionStageRuntimePrerequisiteReceipt
+	verified bool
+}
+
+// BuildSubmissionStageRuntimePrerequisite binds the exact shared tokenless
+// ServiceAccount manifest to one verified stage package. It performs no API
+// request and retains only canonical JSON for the later exact installer.
+func BuildSubmissionStageRuntimePrerequisite(packaged VerifiedSubmissionStagePackage, manifest []byte, expectedDigest string) (VerifiedSubmissionStageRuntimePrerequisite, error) {
+	plan, err := PlanSubmissionStageInstallation(packaged)
+	if err != nil {
+		return VerifiedSubmissionStageRuntimePrerequisite{}, err
+	}
+	if len(manifest) == 0 || !stageReceiptPrefixDigestPattern.MatchString(expectedDigest) || digest.SHA256(manifest) != expectedDigest {
+		return VerifiedSubmissionStageRuntimePrerequisite{}, errors.New("submission stage runtime manifest differs from expected identity")
+	}
+	decoder := yaml.NewDecoder(bytes.NewReader(manifest))
+	var object map[string]any
+	if err := decoder.Decode(&object); err != nil || len(object) == 0 {
+		return VerifiedSubmissionStageRuntimePrerequisite{}, errors.New("decode submission stage runtime manifest")
+	}
+	var trailing map[string]any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		return VerifiedSubmissionStageRuntimePrerequisite{}, errors.New("submission stage runtime manifest contains multiple objects")
+	}
+	metadata, _ := object["metadata"].(map[string]any)
+	labels, _ := metadata["labels"].(map[string]any)
+	if object["apiVersion"] != "v1" || object["kind"] != "ServiceAccount" || object["automountServiceAccountToken"] != false || metadata["name"] != "ok147-contract-executor-runtime" || metadata["namespace"] != submissionStageInputNamespace || labels["app.kubernetes.io/name"] != "ok-cluster-contract-executor" || labels["openkubes.io/runtime-boundary"] != "submission-stage" {
+		return VerifiedSubmissionStageRuntimePrerequisite{}, errors.New("submission stage runtime ServiceAccount semantics are invalid")
+	}
+	if len(object) != 4 || len(metadata) != 3 || len(labels) != 2 {
+		return VerifiedSubmissionStageRuntimePrerequisite{}, errors.New("submission stage runtime ServiceAccount contains unbound fields")
+	}
+	raw, err := json.Marshal(object)
+	if err != nil {
+		return VerifiedSubmissionStageRuntimePrerequisite{}, errors.New("encode submission stage runtime ServiceAccount")
+	}
+	receipt := SubmissionStageRuntimePrerequisiteReceipt{
+		Format: SubmissionStageRuntimePrerequisiteFormat, State: "VERIFIED", StagePackageDigest: plan.PackageDigest,
+		ManifestDigest: expectedDigest, ObjectDigest: digest.SHA256(raw), Authority: packaged.installationAuthority,
+		Namespace: submissionStageInputNamespace, Name: "ok147-contract-executor-runtime", MutationAllowed: false,
+	}
+	return VerifiedSubmissionStageRuntimePrerequisite{raw: raw, receipt: receipt, verified: true}, nil
+}
+
+func (runtime VerifiedSubmissionStageRuntimePrerequisite) Receipt() (SubmissionStageRuntimePrerequisiteReceipt, error) {
+	if !runtime.verified || runtime.receipt.State != "VERIFIED" || len(runtime.raw) == 0 {
+		return SubmissionStageRuntimePrerequisiteReceipt{}, errors.New("submission stage runtime prerequisite was not produced by verification")
+	}
+	return runtime.receipt, nil
+}

--- a/internal/runner/submission_stage_runtime_installer.go
+++ b/internal/runner/submission_stage_runtime_installer.go
@@ -1,0 +1,264 @@
+package runner
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+const SubmissionStageRuntimeInstallationReceiptFormat = "ok147-submission-stage-runtime-installation-receipt/v1"
+
+type SubmissionStageRuntimeInstallationReceipt struct {
+	Format                string `json:"format"`
+	StagePackageDigest    string `json:"stagePackageDigest"`
+	ManifestDigest        string `json:"manifestDigest"`
+	ObjectDigest          string `json:"objectDigest"`
+	Authority             string `json:"authority"`
+	Namespace             string `json:"namespace"`
+	Name                  string `json:"name"`
+	State                 string `json:"state"`
+	MutationState         string `json:"mutationState"`
+	ObjectState           string `json:"objectState,omitempty"`
+	UIDDigest             string `json:"uidDigest,omitempty"`
+	ResourceVersionDigest string `json:"resourceVersionDigest,omitempty"`
+}
+
+type KubernetesSubmissionStageRuntimeInstaller struct {
+	mu       sync.Mutex
+	used     bool
+	endpoint *url.URL
+	token    string
+	client   *http.Client
+	runtime  VerifiedSubmissionStageRuntimePrerequisite
+}
+
+type submissionStageRuntimeInstallerClientConfig struct {
+	Endpoint          string
+	BearerToken       string
+	AuthorityIdentity string
+	Client            *http.Client
+}
+
+// OpenKubernetesSubmissionStageRuntimeInstaller opens a bounded management
+// client for one verified tokenless ServiceAccount prerequisite. It performs
+// no API request.
+func OpenKubernetesSubmissionStageRuntimeInstaller(config KubernetesAuthorityConfig, runtime VerifiedSubmissionStageRuntimePrerequisite) (*KubernetesSubmissionStageRuntimeInstaller, error) {
+	if err := verifySubmissionStageRuntimePrerequisite(runtime); err != nil {
+		return nil, err
+	}
+	if config.AuthorityIdentity == "" || config.AuthorityIdentity != runtime.receipt.Authority {
+		return nil, errors.New("stage runtime installer authority differs from verified management authority")
+	}
+	if !stageReceiptPrefixDigestPattern.MatchString(config.CABundleDigest) {
+		return nil, errors.New("stage runtime installer CA identity is required")
+	}
+	token, ca, client, err := openBoundedKubernetesMaterial(config.TokenFile, config.CAFile)
+	if err != nil {
+		return nil, errors.New("open bounded stage runtime installer credential")
+	}
+	if digest.SHA256(ca) != config.CABundleDigest {
+		return nil, errors.New("stage runtime installer CA differs from bound identity")
+	}
+	return newKubernetesSubmissionStageRuntimeInstaller(submissionStageRuntimeInstallerClientConfig{
+		Endpoint: config.Endpoint, BearerToken: token, AuthorityIdentity: config.AuthorityIdentity, Client: client,
+	}, runtime)
+}
+
+func newKubernetesSubmissionStageRuntimeInstaller(config submissionStageRuntimeInstallerClientConfig, runtime VerifiedSubmissionStageRuntimePrerequisite) (*KubernetesSubmissionStageRuntimeInstaller, error) {
+	if err := verifySubmissionStageRuntimePrerequisite(runtime); err != nil {
+		return nil, err
+	}
+	if config.AuthorityIdentity == "" || config.AuthorityIdentity != runtime.receipt.Authority {
+		return nil, errors.New("stage runtime installer authority differs from verified management authority")
+	}
+	endpoint, err := url.Parse(config.Endpoint)
+	if err != nil || endpoint.Host == "" || endpoint.User != nil || endpoint.RawQuery != "" || endpoint.Fragment != "" || endpoint.Path != "" && endpoint.Path != "/" || endpoint.Port() == "" || net.ParseIP(endpoint.Hostname()) == nil {
+		return nil, errors.New("stage runtime installer Kubernetes endpoint is invalid")
+	}
+	if endpoint.Scheme != "https" && !(endpoint.Scheme == "http" && endpoint.Hostname() == "127.0.0.1") {
+		return nil, errors.New("stage runtime installer Kubernetes endpoint must use HTTPS")
+	}
+	if config.BearerToken == "" || strings.TrimSpace(config.BearerToken) != config.BearerToken || strings.ContainsAny(config.BearerToken, "\r\n") || config.Client == nil {
+		return nil, errors.New("stage runtime installer Kubernetes credential or client is invalid")
+	}
+	client := *config.Client
+	client.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+	if client.Timeout == 0 {
+		client.Timeout = 15 * time.Second
+	}
+	endpoint.Path, endpoint.RawPath = "", ""
+	runtime.raw = append([]byte(nil), runtime.raw...)
+	return &KubernetesSubmissionStageRuntimeInstaller{endpoint: endpoint, token: config.BearerToken, client: &client, runtime: runtime}, nil
+}
+
+// Ensure performs exactly one GET and, only when absent, one POST. Existing
+// state is accepted only after exact semantic verification. There is no
+// update, patch, apply, delete, list, watch, discovery or retry operation.
+func (installer *KubernetesSubmissionStageRuntimeInstaller) Ensure(ctx context.Context) (SubmissionStageRuntimeInstallationReceipt, error) {
+	receipt := installer.newReceipt()
+	if installer == nil || installer.client == nil {
+		return receipt, errors.New("stage runtime installer is required")
+	}
+	installer.mu.Lock()
+	if installer.used {
+		installer.mu.Unlock()
+		receipt.State = "STOPPED_ZERO_WRITE"
+		return receipt, errors.New("stage runtime installer is single-use")
+	}
+	installer.used = true
+	installer.mu.Unlock()
+
+	objectPath := "/api/v1/namespaces/" + installer.runtime.receipt.Namespace + "/serviceaccounts/" + installer.runtime.receipt.Name
+	collectionPath := "/api/v1/namespaces/" + installer.runtime.receipt.Namespace + "/serviceaccounts"
+	raw, status, err := installer.request(ctx, http.MethodGet, objectPath, nil)
+	if err != nil {
+		receipt.State = "STOPPED_ZERO_WRITE"
+		return receipt, err
+	}
+	switch status {
+	case http.StatusOK:
+		uid, resourceVersion, err := verifySubmissionStageRuntimeObject(raw, installer.runtime.raw)
+		if err != nil {
+			receipt.State = "STOPPED_ZERO_WRITE"
+			return receipt, errors.New("existing stage runtime differs from verified prerequisite")
+		}
+		receipt.State, receipt.ObjectState = "READY", "EXISTING_VERIFIED"
+		receipt.UIDDigest, receipt.ResourceVersionDigest = digest.SHA256([]byte(uid)), digest.SHA256([]byte(resourceVersion))
+		return receipt, nil
+	case http.StatusNotFound:
+	default:
+		receipt.State = "STOPPED_ZERO_WRITE"
+		return receipt, stageRuntimeInstallationStatusError(http.MethodGet, status)
+	}
+
+	receipt.MutationState = "ATTEMPTED_UNKNOWN"
+	raw, status, err = installer.request(ctx, http.MethodPost, collectionPath, installer.runtime.raw)
+	if err != nil {
+		receipt.State = "STOPPED_PARTIAL_OR_UNKNOWN"
+		return receipt, err
+	}
+	if status != http.StatusCreated {
+		receipt.State, receipt.MutationState = "STOPPED_PARTIAL_OR_UNKNOWN", "ATTEMPTED"
+		return receipt, stageRuntimeInstallationStatusError(http.MethodPost, status)
+	}
+	uid, resourceVersion, err := verifySubmissionStageRuntimeObject(raw, installer.runtime.raw)
+	if err != nil {
+		receipt.State = "STOPPED_PARTIAL_OR_UNKNOWN"
+		return receipt, errors.New("created stage runtime differs from verified prerequisite")
+	}
+	receipt.State, receipt.MutationState, receipt.ObjectState = "READY", "ATTEMPTED", "CREATED"
+	receipt.UIDDigest, receipt.ResourceVersionDigest = digest.SHA256([]byte(uid)), digest.SHA256([]byte(resourceVersion))
+	return receipt, nil
+}
+
+func (installer *KubernetesSubmissionStageRuntimeInstaller) newReceipt() SubmissionStageRuntimeInstallationReceipt {
+	receipt := SubmissionStageRuntimeInstallationReceipt{Format: SubmissionStageRuntimeInstallationReceiptFormat, State: "PREFLIGHT", MutationState: "NOT_ATTEMPTED"}
+	if installer != nil {
+		receipt.StagePackageDigest = installer.runtime.receipt.StagePackageDigest
+		receipt.ManifestDigest = installer.runtime.receipt.ManifestDigest
+		receipt.ObjectDigest = installer.runtime.receipt.ObjectDigest
+		receipt.Authority = installer.runtime.receipt.Authority
+		receipt.Namespace = installer.runtime.receipt.Namespace
+		receipt.Name = installer.runtime.receipt.Name
+	}
+	return receipt
+}
+
+func (installer *KubernetesSubmissionStageRuntimeInstaller) request(ctx context.Context, method, path string, body []byte) ([]byte, int, error) {
+	endpoint := *installer.endpoint
+	endpoint.Path = path
+	request, err := http.NewRequestWithContext(ctx, method, endpoint.String(), bytes.NewReader(body))
+	if err != nil {
+		return nil, 0, errors.New("construct bounded stage runtime request")
+	}
+	request.Header.Set("Accept", "application/json")
+	request.Header.Set("Authorization", "Bearer "+installer.token)
+	if body != nil {
+		request.Header.Set("Content-Type", "application/json")
+	}
+	response, err := installer.client.Do(request)
+	if err != nil {
+		return nil, 0, fmt.Errorf("bounded stage runtime %s request failed", method)
+	}
+	defer response.Body.Close()
+	raw, readErr := io.ReadAll(io.LimitReader(response.Body, maximumStageInstallationResponseBytes+1))
+	if readErr != nil || len(raw) > maximumStageInstallationResponseBytes {
+		return nil, 0, errors.New("bounded stage runtime response exceeds accepted size")
+	}
+	if len(raw) > 0 {
+		mediaType, _, err := mime.ParseMediaType(response.Header.Get("Content-Type"))
+		if err != nil || mediaType != "application/json" {
+			return nil, 0, errors.New("bounded stage runtime response is not JSON")
+		}
+	}
+	return raw, response.StatusCode, nil
+}
+
+func verifySubmissionStageRuntimePrerequisite(runtime VerifiedSubmissionStageRuntimePrerequisite) error {
+	if !runtime.verified || runtime.receipt.Format != SubmissionStageRuntimePrerequisiteFormat || runtime.receipt.State != "VERIFIED" || runtime.receipt.Authority == "" || runtime.receipt.Namespace != submissionStageInputNamespace || runtime.receipt.Name != "ok147-contract-executor-runtime" || !stageReceiptPrefixDigestPattern.MatchString(runtime.receipt.StagePackageDigest) || !stageReceiptPrefixDigestPattern.MatchString(runtime.receipt.ManifestDigest) || digest.SHA256(runtime.raw) != runtime.receipt.ObjectDigest {
+		return errors.New("submission stage runtime prerequisite changed after verification")
+	}
+	var object map[string]any
+	if err := json.Unmarshal(runtime.raw, &object); err != nil {
+		return errors.New("submission stage runtime prerequisite is invalid JSON")
+	}
+	metadata, _ := object["metadata"].(map[string]any)
+	labels, _ := metadata["labels"].(map[string]any)
+	if object["apiVersion"] != "v1" || object["kind"] != "ServiceAccount" || object["automountServiceAccountToken"] != false || metadata["name"] != runtime.receipt.Name || metadata["namespace"] != runtime.receipt.Namespace || labels["app.kubernetes.io/name"] != "ok-cluster-contract-executor" || labels["openkubes.io/runtime-boundary"] != "submission-stage" || len(object) != 4 || len(metadata) != 3 || len(labels) != 2 {
+		return errors.New("submission stage runtime prerequisite semantics changed after verification")
+	}
+	return nil
+}
+
+func verifySubmissionStageRuntimeObject(raw, desiredRaw []byte) (string, string, error) {
+	observed, err := decodeCapabilityJSONObject(raw)
+	if err != nil {
+		return "", "", err
+	}
+	desired, err := decodeCapabilityJSONObject(desiredRaw)
+	if err != nil || !capabilitySubset(desired, observed) {
+		return "", "", errors.New("observed ServiceAccount does not contain exact prerequisite fields")
+	}
+	allowedTopLevel := map[string]bool{"apiVersion": true, "kind": true, "metadata": true, "automountServiceAccountToken": true}
+	for key := range observed {
+		if !allowedTopLevel[key] {
+			return "", "", errors.New("observed ServiceAccount contains additional runtime semantics")
+		}
+	}
+	metadata, _ := observed["metadata"].(map[string]any)
+	allowedMetadata := map[string]bool{
+		"name": true, "namespace": true, "labels": true, "uid": true, "resourceVersion": true,
+		"creationTimestamp": true, "managedFields": true,
+	}
+	for key := range metadata {
+		if !allowedMetadata[key] {
+			return "", "", errors.New("observed ServiceAccount metadata contains additional runtime semantics")
+		}
+	}
+	labels, _ := metadata["labels"].(map[string]any)
+	if len(labels) != 2 || labels["app.kubernetes.io/name"] != "ok-cluster-contract-executor" || labels["openkubes.io/runtime-boundary"] != "submission-stage" {
+		return "", "", errors.New("observed ServiceAccount labels differ from exact prerequisite")
+	}
+	uid, _ := metadata["uid"].(string)
+	resourceVersion, _ := metadata["resourceVersion"].(string)
+	if !runtimeInputUIDPattern.MatchString(uid) || !runtimeInputUIDPattern.MatchString(resourceVersion) {
+		return "", "", errors.New("stage runtime lacks bounded runtime identity")
+	}
+	return uid, resourceVersion, nil
+}
+
+func stageRuntimeInstallationStatusError(method string, status int) error {
+	return fmt.Errorf("bounded stage runtime %s returned HTTP %d", method, status)
+}

--- a/internal/runner/submission_stage_runtime_installer_test.go
+++ b/internal/runner/submission_stage_runtime_installer_test.go
@@ -1,0 +1,265 @@
+package runner
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+func TestSubmissionStageRuntimeInstallerCreatesOrVerifiesExactServiceAccount(t *testing.T) {
+	t.Run("create absent", func(t *testing.T) {
+		prerequisite := submissionStageRuntimePrerequisite(t)
+		api := newStageRuntimeInstallerAPI(t)
+		installer := newStageRuntimeInstaller(t, prerequisite, api.client())
+		receipt, err := installer.Ensure(context.Background())
+		if err != nil || receipt.State != "READY" || receipt.MutationState != "ATTEMPTED" || receipt.ObjectState != "CREATED" || len(api.requests) != 2 || api.requests[0].method != http.MethodGet || api.requests[1].method != http.MethodPost || digest.SHA256(api.requests[1].body) != receipt.ObjectDigest {
+			t.Fatalf("runtime creation differs: %#v requests=%#v err=%v", receipt, api.requests, err)
+		}
+		assertRuntimeReceiptRedacted(t, receipt)
+	})
+
+	t.Run("verify existing", func(t *testing.T) {
+		prerequisite := submissionStageRuntimePrerequisite(t)
+		api := newStageRuntimeInstallerAPI(t)
+		api.objects[stageRuntimeObjectPath] = api.runtimeObject(prerequisite.raw, "existing-runtime-uid", "7")
+		installer := newStageRuntimeInstaller(t, prerequisite, api.client())
+		receipt, err := installer.Ensure(context.Background())
+		if err != nil || receipt.State != "READY" || receipt.MutationState != "NOT_ATTEMPTED" || receipt.ObjectState != "EXISTING_VERIFIED" || len(api.requests) != 1 || api.posts != 0 {
+			t.Fatalf("existing runtime verification differs: %#v requests=%#v err=%v", receipt, api.requests, err)
+		}
+		assertRuntimeReceiptRedacted(t, receipt)
+	})
+}
+
+func TestSubmissionStageRuntimeInstallerStopsForDriftAndCannotRetry(t *testing.T) {
+	prerequisite := submissionStageRuntimePrerequisite(t)
+	api := newStageRuntimeInstallerAPI(t)
+	drifted := api.runtimeObject(prerequisite.raw, "existing-runtime-uid", "7")
+	drifted["automountServiceAccountToken"] = true
+	api.objects[stageRuntimeObjectPath] = drifted
+	installer := newStageRuntimeInstaller(t, prerequisite, api.client())
+	receipt, err := installer.Ensure(context.Background())
+	if err == nil || receipt.State != "STOPPED_ZERO_WRITE" || receipt.MutationState != "NOT_ATTEMPTED" || api.posts != 0 {
+		t.Fatalf("drifted runtime accepted: %#v %v", receipt, err)
+	}
+	requests := len(api.requests)
+	retry, retryErr := installer.Ensure(context.Background())
+	if retryErr == nil || retry.State != "STOPPED_ZERO_WRITE" || len(api.requests) != requests {
+		t.Fatalf("runtime installer retried: %#v %v", retry, retryErr)
+	}
+}
+
+func TestSubmissionStageRuntimeInstallerRejectsAdditionalServiceAccountSemantics(t *testing.T) {
+	for name, mutate := range map[string]func(map[string]any){
+		"image pull Secret": func(object map[string]any) {
+			object["imagePullSecrets"] = []any{map[string]any{"name": "foreign"}}
+		},
+		"identity annotation": func(object map[string]any) {
+			metadata := object["metadata"].(map[string]any)
+			metadata["annotations"] = map[string]any{"example.invalid/identity": "foreign"}
+		},
+		"extra label": func(object map[string]any) {
+			metadata := object["metadata"].(map[string]any)
+			metadata["labels"].(map[string]any)["example.invalid/extra"] = "true"
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			prerequisite := submissionStageRuntimePrerequisite(t)
+			api := newStageRuntimeInstallerAPI(t)
+			existing := api.runtimeObject(prerequisite.raw, "existing-runtime-uid", "7")
+			mutate(existing)
+			api.objects[stageRuntimeObjectPath] = existing
+			installer := newStageRuntimeInstaller(t, prerequisite, api.client())
+			receipt, err := installer.Ensure(context.Background())
+			if err == nil || receipt.State != "STOPPED_ZERO_WRITE" || receipt.MutationState != "NOT_ATTEMPTED" || api.posts != 0 {
+				t.Fatalf("additional ServiceAccount semantics accepted: %#v %v", receipt, err)
+			}
+		})
+	}
+}
+
+func TestSubmissionStageRuntimeInstallerTreatsUnknownCreateAsPartial(t *testing.T) {
+	for name, configure := range map[string]func(*stageRuntimeInstallerAPI){
+		"response mismatch": func(api *stageRuntimeInstallerAPI) { api.mismatch = true },
+		"transport error":   func(api *stageRuntimeInstallerAPI) { api.transportError = true },
+	} {
+		t.Run(name, func(t *testing.T) {
+			prerequisite := submissionStageRuntimePrerequisite(t)
+			api := newStageRuntimeInstallerAPI(t)
+			configure(api)
+			installer := newStageRuntimeInstaller(t, prerequisite, api.client())
+			receipt, err := installer.Ensure(context.Background())
+			if err == nil || receipt.State != "STOPPED_PARTIAL_OR_UNKNOWN" || receipt.MutationState != "ATTEMPTED_UNKNOWN" || strings.Contains(err.Error(), "short-lived-runtime-installer-token") {
+				t.Fatalf("unknown runtime outcome accepted or leaked: %#v %v", receipt, err)
+			}
+		})
+	}
+}
+
+func TestSubmissionStageRuntimePrerequisiteAndInstallerRejectTamperingOrForeignAuthority(t *testing.T) {
+	prerequisite := submissionStageRuntimePrerequisite(t)
+	tampered := prerequisite
+	tampered.raw = append([]byte(nil), prerequisite.raw...)
+	tampered.raw[0] = 'x'
+	if _, err := newKubernetesSubmissionStageRuntimeInstaller(submissionStageRuntimeInstallerClientConfig{
+		Endpoint: "http://127.0.0.1:12345", BearerToken: "short-lived-runtime-installer-token", AuthorityIdentity: "ok-mgmt", Client: newStageRuntimeInstallerAPI(t).client(),
+	}, tampered); err == nil {
+		t.Fatal("tampered runtime prerequisite was accepted")
+	}
+	if _, err := newKubernetesSubmissionStageRuntimeInstaller(submissionStageRuntimeInstallerClientConfig{
+		Endpoint: "http://127.0.0.1:12345", BearerToken: "short-lived-runtime-installer-token", AuthorityIdentity: "ok-infra", Client: newStageRuntimeInstallerAPI(t).client(),
+	}, prerequisite); err == nil {
+		t.Fatal("foreign runtime installer authority was accepted")
+	}
+
+	manifest := submissionStageRuntimeManifest(t)
+	changed := bytes.Replace(manifest, []byte("automountServiceAccountToken: false"), []byte("automountServiceAccountToken: true"), 1)
+	stagePackage := submissionStageInstallerPackage(t)
+	if _, err := BuildSubmissionStageRuntimePrerequisite(stagePackage, changed, digest.SHA256(changed)); err == nil {
+		t.Fatal("token-bearing runtime prerequisite was accepted")
+	}
+}
+
+func submissionStageRuntimePrerequisite(t *testing.T) VerifiedSubmissionStageRuntimePrerequisite {
+	t.Helper()
+	manifest := submissionStageRuntimeManifest(t)
+	prerequisite, err := BuildSubmissionStageRuntimePrerequisite(submissionStageInstallerPackage(t), manifest, digest.SHA256(manifest))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return prerequisite
+}
+
+func submissionStageRuntimeManifest(t *testing.T) []byte {
+	t.Helper()
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("cannot resolve runtime prerequisite test path")
+	}
+	raw, err := os.ReadFile(filepath.Join(filepath.Dir(filename), "..", "..", "deploy", "contract-executor-stage-runtime.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return raw
+}
+
+func newStageRuntimeInstaller(t *testing.T, prerequisite VerifiedSubmissionStageRuntimePrerequisite, client *http.Client) *KubernetesSubmissionStageRuntimeInstaller {
+	t.Helper()
+	installer, err := newKubernetesSubmissionStageRuntimeInstaller(submissionStageRuntimeInstallerClientConfig{
+		Endpoint: "http://127.0.0.1:12345", BearerToken: "short-lived-runtime-installer-token", AuthorityIdentity: "ok-mgmt", Client: client,
+	}, prerequisite)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return installer
+}
+
+func assertRuntimeReceiptRedacted(t *testing.T, receipt SubmissionStageRuntimeInstallationReceipt) {
+	t.Helper()
+	if receipt.Format != SubmissionStageRuntimeInstallationReceiptFormat || receipt.Authority != "ok-mgmt" || receipt.Namespace != submissionStageInputNamespace || receipt.Name != "ok147-contract-executor-runtime" || !stageReceiptPrefixDigestPattern.MatchString(receipt.StagePackageDigest) || !stageReceiptPrefixDigestPattern.MatchString(receipt.ManifestDigest) || !stageReceiptPrefixDigestPattern.MatchString(receipt.ObjectDigest) || !stageReceiptPrefixDigestPattern.MatchString(receipt.UIDDigest) || !stageReceiptPrefixDigestPattern.MatchString(receipt.ResourceVersionDigest) {
+		t.Fatalf("runtime receipt identity differs: %#v", receipt)
+	}
+	raw, err := json.Marshal(receipt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(raw, []byte("short-lived-runtime-installer-token")) || bytes.Contains(raw, []byte("runtime-uid")) {
+		t.Fatal("runtime receipt exposed credential or raw UID")
+	}
+}
+
+const stageRuntimeObjectPath = "/api/v1/namespaces/openkubes-execution-system/serviceaccounts/ok147-contract-executor-runtime"
+
+type stageRuntimeInstallerRequest struct {
+	method string
+	path   string
+	body   []byte
+}
+
+type stageRuntimeInstallerAPI struct {
+	t              *testing.T
+	mu             sync.Mutex
+	objects        map[string]map[string]any
+	requests       []stageRuntimeInstallerRequest
+	posts          int
+	mismatch       bool
+	transportError bool
+}
+
+func newStageRuntimeInstallerAPI(t *testing.T) *stageRuntimeInstallerAPI {
+	return &stageRuntimeInstallerAPI{t: t, objects: map[string]map[string]any{}}
+}
+
+func (api *stageRuntimeInstallerAPI) client() *http.Client {
+	return &http.Client{Transport: stageRuntimeInstallerRoundTripFunc(api.roundTrip)}
+}
+
+func (api *stageRuntimeInstallerAPI) roundTrip(request *http.Request) (*http.Response, error) {
+	api.mu.Lock()
+	defer api.mu.Unlock()
+	body, _ := io.ReadAll(request.Body)
+	api.requests = append(api.requests, stageRuntimeInstallerRequest{method: request.Method, path: request.URL.Path, body: body})
+	if request.Header.Get("Authorization") != "Bearer short-lived-runtime-installer-token" {
+		return stageRuntimeInstallerJSONResponse(http.StatusUnauthorized, map[string]any{"reason": "Unauthorized"}), nil
+	}
+	switch request.Method {
+	case http.MethodGet:
+		object, ok := api.objects[request.URL.Path]
+		if !ok {
+			return stageRuntimeInstallerJSONResponse(http.StatusNotFound, map[string]any{"reason": "NotFound"}), nil
+		}
+		return stageRuntimeInstallerJSONResponse(http.StatusOK, object), nil
+	case http.MethodPost:
+		api.posts++
+		if api.transportError {
+			return nil, errors.New("simulated transport failure")
+		}
+		var object map[string]any
+		if err := json.Unmarshal(body, &object); err != nil {
+			api.t.Fatal(err)
+		}
+		metadata := object["metadata"].(map[string]any)
+		metadata["uid"], metadata["resourceVersion"] = "created-runtime-uid", "1"
+		api.objects[stageRuntimeObjectPath] = object
+		if api.mismatch {
+			object["automountServiceAccountToken"] = true
+		}
+		return stageRuntimeInstallerJSONResponse(http.StatusCreated, object), nil
+	default:
+		return stageRuntimeInstallerJSONResponse(http.StatusMethodNotAllowed, map[string]any{"reason": "MethodNotAllowed"}), nil
+	}
+}
+
+func (api *stageRuntimeInstallerAPI) runtimeObject(raw []byte, uid, resourceVersion string) map[string]any {
+	var object map[string]any
+	if err := json.Unmarshal(raw, &object); err != nil {
+		api.t.Fatal(err)
+	}
+	metadata := object["metadata"].(map[string]any)
+	metadata["uid"], metadata["resourceVersion"] = uid, resourceVersion
+	return object
+}
+
+type stageRuntimeInstallerRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (function stageRuntimeInstallerRoundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return function(request)
+}
+
+func stageRuntimeInstallerJSONResponse(status int, value any) *http.Response {
+	raw, _ := json.Marshal(value)
+	header := make(http.Header)
+	header.Set("Content-Type", "application/json")
+	return &http.Response{StatusCode: status, Header: header, Body: io.NopCloser(bytes.NewReader(raw))}
+}


### PR DESCRIPTION
## Summary
- bind the exact tokenless runtime ServiceAccount manifest to a verified stage package
- add a single-use exact GET/create installer on the management authority
- accept existing state only after strict tokenless/RBAC-free runtime verification
- reject extra annotations, labels, imagePullSecrets, Secret references, or other runtime semantics

## Safety boundary
- one fixed ServiceAccount only
- no update, patch, apply, delete, list, watch, discovery, or retry
- in-memory Kubernetes transport tests only; no live cluster contact

## Validation
- `go test -ldflags=-linkmode=external ./...`
- `go vet ./...`
- `go test -race -ldflags=-linkmode=external ./internal/runner`
- `python3 -m unittest discover -s tests -p "*_test.py"` (18 tests, 1 expected skip)
- `git diff --check`