### PR TITLE
feat(runner): plan coherent stage launch (OK-147)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,11 @@ Powered by [Cluster API (CAPI)](https://cluster-api.sigs.k8s.io/), [CAPK (KubeVi
   private, digest-bound package and have their own single-use exact-create
   installer. TokenRequest issuance and live installation remain separately
   managed prerequisites. The shared runtime ServiceAccount also has a bounded
-  exact-create-or-verify path and remains tokenless and RBAC-free. The runner
-  image is digest-pinned, multi-architecture, non-root, SBOM- and
-  provenance-producing behind a protected publisher.
+  exact-create-or-verify path and remains tokenless and RBAC-free. A unified
+  non-mutating launch plan binds all six objects behind one complete preflight
+  barrier and fixes their eventual create order without exposing object bodies
+  or credentials. The runner image is digest-pinned, multi-architecture,
+  non-root, SBOM- and provenance-producing behind a protected publisher.
 
 ---
 

--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -1269,6 +1269,38 @@ This prerequisite installer is tested only against an in-memory API transport
 in this checkpoint. Creating the ServiceAccount, credential Secrets or stage
 package remains a separately authorized live operation.
 
+## Coherent six-object launch plan
+
+`PlanSubmissionStageLaunch` correlates the verified runtime prerequisite,
+private credential package and three-object stage package before any of their
+installers can be composed into a live launch. It requires one exact stage ID,
+stage-package digest and management installation authority across all three
+inputs. The returned plan is redaction-safe and contains no object bodies,
+token, CA or Secret content.
+
+The plan places all six object checks behind one global barrier:
+
+```text
+GET ServiceAccount (verify exact or absent)
+GET ledger Secret (PartialObjectMetadata, must be absent)
+GET authority Secret (PartialObjectMetadata, must be absent)
+GET ConfigMap (must be absent)
+GET NetworkPolicy (must be absent)
+GET Job (must be absent)
+        |
+        +-- any failure or conflicting state --> STOP, zero writes
+        v
+fixed create sequence:
+ServiceAccount -> ledger Secret -> authority Secret
+               -> ConfigMap -> NetworkPolicy -> Job
+```
+
+This is a non-mutating plan (`mutationAllowed: false`), not an executor. It
+does not contact Kubernetes, open a credential, invoke a child installer or
+authorize a launch. The global barrier and fixed order are executable contract
+evidence for the next composition boundary; tests still use only in-memory
+objects and transports.
+
 ## Typed first-run Platform capability boundary
 
 First-run capability production now has a separate lazy resolver from the

--- a/internal/runner/submission_stage_launch_plan.go
+++ b/internal/runner/submission_stage_launch_plan.go
@@ -1,0 +1,114 @@
+package runner
+
+import "errors"
+
+const SubmissionStageLaunchPlanFormat = "ok147-submission-stage-launch-plan/v1"
+
+type SubmissionStageLaunchPreflight struct {
+	Order          int    `json:"order"`
+	Phase          string `json:"phase"`
+	APIVersion     string `json:"apiVersion"`
+	Kind           string `json:"kind"`
+	Namespace      string `json:"namespace"`
+	Name           string `json:"name"`
+	Method         string `json:"method"`
+	ObjectPath     string `json:"objectPath"`
+	ResponseMode   string `json:"responseMode"`
+	ExistingPolicy string `json:"existingPolicy"`
+	ObjectDigest   string `json:"objectDigest"`
+}
+
+type SubmissionStageLaunchCreate struct {
+	Order          int    `json:"order"`
+	Phase          string `json:"phase"`
+	APIVersion     string `json:"apiVersion"`
+	Kind           string `json:"kind"`
+	Namespace      string `json:"namespace"`
+	Name           string `json:"name"`
+	Method         string `json:"method"`
+	CollectionPath string `json:"collectionPath"`
+	CreatePolicy   string `json:"createPolicy"`
+	ObjectDigest   string `json:"objectDigest"`
+}
+
+// SubmissionStageLaunchPlan correlates every object needed to start one Job.
+// It is non-mutating and contains no object body or credential content.
+type SubmissionStageLaunchPlan struct {
+	Format                  string                           `json:"format"`
+	State                   string                           `json:"state"`
+	StageID                 string                           `json:"stageId"`
+	Authority               string                           `json:"authority"`
+	StagePackageDigest      string                           `json:"stagePackageDigest"`
+	CredentialPackageDigest string                           `json:"credentialPackageDigest"`
+	RuntimeManifestDigest   string                           `json:"runtimeManifestDigest"`
+	PreflightBarrier        string                           `json:"preflightBarrier"`
+	Preflights              []SubmissionStageLaunchPreflight `json:"preflights"`
+	Creates                 []SubmissionStageLaunchCreate    `json:"creates"`
+	MutationAllowed         bool                             `json:"mutationAllowed"`
+}
+
+// PlanSubmissionStageLaunch requires one coherent verified package,
+// credential package and runtime prerequisite. Every GET in Preflights must
+// pass before the first entry in Creates can be attempted.
+func PlanSubmissionStageLaunch(packaged VerifiedSubmissionStagePackage, credentials VerifiedSubmissionStageCredentialPackage, runtime VerifiedSubmissionStageRuntimePrerequisite) (SubmissionStageLaunchPlan, error) {
+	stage, err := PlanSubmissionStageInstallation(packaged)
+	if err != nil {
+		return SubmissionStageLaunchPlan{}, err
+	}
+	credentialReceipt, credentialObjects, err := prepareSubmissionStageCredentialInstallation(credentials)
+	if err != nil {
+		return SubmissionStageLaunchPlan{}, err
+	}
+	if err := verifySubmissionStageRuntimePrerequisite(runtime); err != nil {
+		return SubmissionStageLaunchPlan{}, err
+	}
+	if stage.PackageDigest != credentialReceipt.StagePackageDigest || stage.PackageDigest != runtime.receipt.StagePackageDigest || stage.StageID != credentialReceipt.StageID || packaged.installationAuthority != credentials.installationAuthority || packaged.installationAuthority != runtime.receipt.Authority || credentialReceipt.InstallationAuthority != packaged.installationAuthority {
+		return SubmissionStageLaunchPlan{}, errors.New("submission stage launch components do not share one verified identity")
+	}
+
+	preflights := make([]SubmissionStageLaunchPreflight, 0, 6)
+	creates := make([]SubmissionStageLaunchCreate, 0, 6)
+	runtimeCollection := "/api/v1/namespaces/" + runtime.receipt.Namespace + "/serviceaccounts"
+	preflights = append(preflights, SubmissionStageLaunchPreflight{
+		Order: 1, Phase: "runtime", APIVersion: "v1", Kind: "ServiceAccount",
+		Namespace: runtime.receipt.Namespace, Name: runtime.receipt.Name, Method: "GET",
+		ObjectPath: runtimeCollection + "/" + runtime.receipt.Name, ResponseMode: "FULL_OBJECT",
+		ExistingPolicy: "VERIFY_EXACT", ObjectDigest: runtime.receipt.ObjectDigest,
+	})
+	creates = append(creates, SubmissionStageLaunchCreate{
+		Order: 1, Phase: "runtime", APIVersion: "v1", Kind: "ServiceAccount",
+		Namespace: runtime.receipt.Namespace, Name: runtime.receipt.Name, Method: "POST",
+		CollectionPath: runtimeCollection, CreatePolicy: "CREATE_IF_ABSENT_OR_VERIFY_EXISTING", ObjectDigest: runtime.receipt.ObjectDigest,
+	})
+
+	for index, object := range credentialObjects {
+		preflights = append(preflights, SubmissionStageLaunchPreflight{
+			Order: index + 2, Phase: "credentials", APIVersion: "v1", Kind: "Secret",
+			Namespace: submissionStageInputNamespace, Name: object.name, Method: "GET", ObjectPath: object.objectPath,
+			ResponseMode: "PARTIAL_OBJECT_METADATA", ExistingPolicy: "STOP_ZERO_WRITE", ObjectDigest: object.objectDigest,
+		})
+		creates = append(creates, SubmissionStageLaunchCreate{
+			Order: index + 2, Phase: "credentials", APIVersion: "v1", Kind: "Secret",
+			Namespace: submissionStageInputNamespace, Name: object.name, Method: "POST", CollectionPath: object.collectionPath,
+			CreatePolicy: "CREATE_ONLY_AFTER_ABSENCE", ObjectDigest: object.objectDigest,
+		})
+	}
+	for index, object := range stage.Creates {
+		preflights = append(preflights, SubmissionStageLaunchPreflight{
+			Order: index + 4, Phase: "stage-package", APIVersion: object.APIVersion, Kind: object.Kind,
+			Namespace: object.Namespace, Name: object.Name, Method: object.PreflightMethod, ObjectPath: object.ObjectPath,
+			ResponseMode: "FULL_OBJECT", ExistingPolicy: "STOP_ZERO_WRITE", ObjectDigest: object.ObjectDigest,
+		})
+		creates = append(creates, SubmissionStageLaunchCreate{
+			Order: index + 4, Phase: "stage-package", APIVersion: object.APIVersion, Kind: object.Kind,
+			Namespace: object.Namespace, Name: object.Name, Method: object.CreateMethod, CollectionPath: object.CollectionPath,
+			CreatePolicy: "CREATE_ONLY_AFTER_ABSENCE", ObjectDigest: object.ObjectDigest,
+		})
+	}
+	return SubmissionStageLaunchPlan{
+		Format: SubmissionStageLaunchPlanFormat, State: "VERIFIED", StageID: stage.StageID,
+		Authority: packaged.installationAuthority, StagePackageDigest: stage.PackageDigest,
+		CredentialPackageDigest: credentialReceipt.PackageDigest, RuntimeManifestDigest: runtime.receipt.ManifestDigest,
+		PreflightBarrier: "ALL_SIX_PASS_BEFORE_FIRST_CREATE", Preflights: preflights, Creates: creates, MutationAllowed: false,
+	}, nil
+}

--- a/internal/runner/submission_stage_launch_plan_test.go
+++ b/internal/runner/submission_stage_launch_plan_test.go
@@ -1,0 +1,122 @@
+package runner
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+func TestPlanSubmissionStageLaunchBindsSixObjectsBehindOneBarrier(t *testing.T) {
+	stage, credentials, runtime, ledgerToken, authorityToken := submissionStageLaunchFixture(t)
+	plan, err := PlanSubmissionStageLaunch(stage, credentials, runtime)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stageReceipt, err := stage.Receipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	credentialReceipt, err := credentials.Receipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	runtimeReceipt, err := runtime.Receipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plan.Format != SubmissionStageLaunchPlanFormat || plan.State != "VERIFIED" || plan.StageID != stageReceipt.StageID || plan.Authority != "ok-mgmt" || plan.StagePackageDigest != stageReceipt.PackageDigest || plan.CredentialPackageDigest != credentialReceipt.PackageDigest || plan.RuntimeManifestDigest != runtimeReceipt.ManifestDigest || plan.PreflightBarrier != "ALL_SIX_PASS_BEFORE_FIRST_CREATE" || plan.MutationAllowed {
+		t.Fatalf("unexpected launch identity: %#v", plan)
+	}
+	if len(plan.Preflights) != 6 || len(plan.Creates) != 6 {
+		t.Fatalf("launch object count differs: preflights=%d creates=%d", len(plan.Preflights), len(plan.Creates))
+	}
+	wantKinds := []string{"ServiceAccount", "Secret", "Secret", "ConfigMap", "NetworkPolicy", "Job"}
+	wantPhases := []string{"runtime", "credentials", "credentials", "stage-package", "stage-package", "stage-package"}
+	for index := range wantKinds {
+		preflight, create := plan.Preflights[index], plan.Creates[index]
+		if preflight.Order != index+1 || create.Order != index+1 || preflight.Phase != wantPhases[index] || create.Phase != wantPhases[index] || preflight.Kind != wantKinds[index] || create.Kind != wantKinds[index] || preflight.Name != create.Name || preflight.Namespace != create.Namespace || preflight.ObjectDigest != create.ObjectDigest || preflight.Method != "GET" || create.Method != "POST" {
+			t.Fatalf("launch step %d differs: preflight=%#v create=%#v", index+1, preflight, create)
+		}
+		if index == 0 {
+			if preflight.ResponseMode != "FULL_OBJECT" || preflight.ExistingPolicy != "VERIFY_EXACT" || create.CreatePolicy != "CREATE_IF_ABSENT_OR_VERIFY_EXISTING" {
+				t.Fatalf("runtime policy differs: %#v %#v", preflight, create)
+			}
+			continue
+		}
+		if preflight.ExistingPolicy != "STOP_ZERO_WRITE" || create.CreatePolicy != "CREATE_ONLY_AFTER_ABSENCE" {
+			t.Fatalf("create-only policy differs at step %d: %#v %#v", index+1, preflight, create)
+		}
+		if index < 3 && preflight.ResponseMode != "PARTIAL_OBJECT_METADATA" {
+			t.Fatalf("Secret preflight could expose a body: %#v", preflight)
+		}
+		if index >= 3 && preflight.ResponseMode != "FULL_OBJECT" {
+			t.Fatalf("stage object preflight mode differs: %#v", preflight)
+		}
+	}
+	public, err := json.Marshal(plan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range [][]byte{ledgerToken, authorityToken, credentials.objects[0].raw, credentials.objects[1].raw, runtime.raw, stage.raw} {
+		if bytes.Contains(public, forbidden) {
+			t.Fatal("launch plan exposed private object or credential content")
+		}
+	}
+}
+
+func TestPlanSubmissionStageLaunchRejectsUnverifiedOrMismatchedComponents(t *testing.T) {
+	stage, credentials, runtime, _, _ := submissionStageLaunchFixture(t)
+	tests := map[string]func() (VerifiedSubmissionStagePackage, VerifiedSubmissionStageCredentialPackage, VerifiedSubmissionStageRuntimePrerequisite){
+		"empty stage": func() (VerifiedSubmissionStagePackage, VerifiedSubmissionStageCredentialPackage, VerifiedSubmissionStageRuntimePrerequisite) {
+			return VerifiedSubmissionStagePackage{}, credentials, runtime
+		},
+		"empty credentials": func() (VerifiedSubmissionStagePackage, VerifiedSubmissionStageCredentialPackage, VerifiedSubmissionStageRuntimePrerequisite) {
+			return stage, VerifiedSubmissionStageCredentialPackage{}, runtime
+		},
+		"empty runtime": func() (VerifiedSubmissionStagePackage, VerifiedSubmissionStageCredentialPackage, VerifiedSubmissionStageRuntimePrerequisite) {
+			return stage, credentials, VerifiedSubmissionStageRuntimePrerequisite{}
+		},
+		"changed credential package identity": func() (VerifiedSubmissionStagePackage, VerifiedSubmissionStageCredentialPackage, VerifiedSubmissionStageRuntimePrerequisite) {
+			changed := credentials
+			changed.receipt.StagePackageDigest = digest.SHA256([]byte("foreign-stage"))
+			return stage, changed, runtime
+		},
+		"changed runtime stage identity": func() (VerifiedSubmissionStagePackage, VerifiedSubmissionStageCredentialPackage, VerifiedSubmissionStageRuntimePrerequisite) {
+			changed := runtime
+			changed.receipt.StagePackageDigest = digest.SHA256([]byte("foreign-stage"))
+			return stage, credentials, changed
+		},
+		"changed runtime object": func() (VerifiedSubmissionStagePackage, VerifiedSubmissionStageCredentialPackage, VerifiedSubmissionStageRuntimePrerequisite) {
+			changed := runtime
+			changed.raw = append([]byte(nil), runtime.raw...)
+			changed.raw[0] = 'x'
+			return stage, credentials, changed
+		},
+	}
+	for name, values := range tests {
+		t.Run(name, func(t *testing.T) {
+			candidateStage, candidateCredentials, candidateRuntime := values()
+			if _, err := PlanSubmissionStageLaunch(candidateStage, candidateCredentials, candidateRuntime); err == nil {
+				t.Fatal("invalid launch components were accepted")
+			}
+		})
+	}
+}
+
+func submissionStageLaunchFixture(t *testing.T) (VerifiedSubmissionStagePackage, VerifiedSubmissionStageCredentialPackage, VerifiedSubmissionStageRuntimePrerequisite, []byte, []byte) {
+	t.Helper()
+	config, ledgerToken, authorityToken := submissionStageCredentialConfig(t)
+	stage := config.Package
+	credentials, err := BuildSubmissionStageCredentialPackage(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest := submissionStageRuntimeManifest(t)
+	runtime, err := BuildSubmissionStageRuntimePrerequisite(stage, manifest, digest.SHA256(manifest))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return stage, credentials, runtime, ledgerToken, authorityToken
+}


### PR DESCRIPTION
## Summary
- correlate the verified runtime, credential, and stage packages
- bind all six objects behind one global preflight barrier
- expose only a redaction-safe non-mutating launch plan with fixed create order

## Validation
- GOCACHE=/private/tmp/ok147-go-build-cache go test -ldflags=-linkmode=external ./...
- GOCACHE=/private/tmp/ok147-go-build-cache go vet ./...
- GOCACHE=/private/tmp/ok147-go-build-cache go test -race -ldflags=-linkmode=external ./internal/runner
- python3 -m unittest discover -s tests -p '*_test.py'
- git diff --check

## Boundary
No Kubernetes contact or mutation. This PR only proves the coherent six-object launch contract.