### PR TITLE
feat(runner): launch verified stage package (OK-147)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,11 @@ Powered by [Cluster API (CAPI)](https://cluster-api.sigs.k8s.io/), [CAPK (KubeVi
   exact-create-or-verify path and remains tokenless and RBAC-free. A unified
   non-mutating launch plan binds all six objects behind one complete preflight
   barrier and fixes their eventual create order without exposing object bodies
-  or credentials. The runner image is digest-pinned, multi-architecture,
-  non-root, SBOM- and provenance-producing behind a protected publisher.
+  or credentials. A single-use composite launcher implements the same order,
+  preserves a redaction-safe partial receipt and has no update, delete, retry
+  or rollback path; live invocation remains a separate critical boundary. The
+  runner image is digest-pinned, multi-architecture, non-root, SBOM- and
+  provenance-producing behind a protected publisher.
 
 ---
 

--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -1301,6 +1301,27 @@ authorize a launch. The global barrier and fixed order are executable contract
 evidence for the next composition boundary; tests still use only in-memory
 objects and transports.
 
+`KubernetesSubmissionStageLauncher` implements that next composition boundary
+as one single-use operation. It opens one separately supplied short-lived
+management installer credential, rechecks that this credential is distinct
+from both Job credentials, and rejects launch when either Job credential has
+less than 15 minutes remaining. All six exact GETs then run before the first
+POST. Secret GETs request only `PartialObjectMetadata`; the other objects never
+fall back to list, watch or discovery.
+
+Only an exactly matching existing tokenless ServiceAccount may be reused. The
+other five objects must all be absent. After the barrier, the launcher creates
+the absent ServiceAccount, both immutable Secrets and the ConfigMap,
+NetworkPolicy and Job in fixed order. Every create response must contain the
+exact desired fields and bounded runtime identity. Failure stops without
+retry, rollback or cleanup and retains only a redaction-safe verified prefix;
+transport-ambiguous results remain explicitly unknown.
+
+The launcher has no update, patch, apply, delete, list, watch, discovery,
+adoption or retry API. This checkpoint exercises it only with an in-memory
+Kubernetes transport. Opening live credentials or invoking it against a
+cluster remains a separate, critical execution decision.
+
 ## Typed first-run Platform capability boundary
 
 First-run capability production now has a separate lazy resolver from the

--- a/internal/runner/submission_stage_launcher.go
+++ b/internal/runner/submission_stage_launcher.go
@@ -1,0 +1,343 @@
+package runner
+
+import (
+	"bytes"
+	"context"
+	"crypto/subtle"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+const SubmissionStageLaunchReceiptFormat = "ok147-submission-stage-launch-receipt/v1"
+
+type SubmissionStageLauncherConfig struct {
+	Authority KubernetesAuthorityConfig
+	Clock     func() time.Time
+}
+
+type SubmissionStageLaunchResult struct {
+	Order                 int    `json:"order"`
+	Phase                 string `json:"phase"`
+	APIVersion            string `json:"apiVersion"`
+	Kind                  string `json:"kind"`
+	Namespace             string `json:"namespace"`
+	Name                  string `json:"name"`
+	ObjectDigest          string `json:"objectDigest"`
+	ObjectState           string `json:"objectState"`
+	UIDDigest             string `json:"uidDigest"`
+	ResourceVersionDigest string `json:"resourceVersionDigest"`
+}
+
+// SubmissionStageLaunchReceipt contains only the verified created prefix and
+// redaction-safe runtime identity. It never contains object bodies or tokens.
+type SubmissionStageLaunchReceipt struct {
+	Format                  string                        `json:"format"`
+	StageID                 string                        `json:"stageId"`
+	StagePackageDigest      string                        `json:"stagePackageDigest"`
+	CredentialPackageDigest string                        `json:"credentialPackageDigest"`
+	RuntimeManifestDigest   string                        `json:"runtimeManifestDigest"`
+	Authority               string                        `json:"authority"`
+	State                   string                        `json:"state"`
+	MutationState           string                        `json:"mutationState"`
+	Results                 []SubmissionStageLaunchResult `json:"results"`
+}
+
+// KubernetesSubmissionStageLauncher is a single-use six-object operation. It
+// completes every preflight before it can issue its first create request.
+type KubernetesSubmissionStageLauncher struct {
+	mu          sync.Mutex
+	used        bool
+	endpoint    *url.URL
+	token       string
+	client      *http.Client
+	clock       func() time.Time
+	plan        SubmissionStageLaunchPlan
+	runtime     VerifiedSubmissionStageRuntimePrerequisite
+	credentials SubmissionStageCredentialPackageReceipt
+	secrets     []submissionStageCredentialInstallObject
+	objects     []submissionStageInstallObject
+}
+
+type submissionStageLauncherClientConfig struct {
+	Endpoint          string
+	BearerToken       string
+	AuthorityIdentity string
+	Client            *http.Client
+	Clock             func() time.Time
+}
+
+// OpenKubernetesSubmissionStageLauncher opens one exact management-plane
+// client for one coherent launch. It performs no API request.
+func OpenKubernetesSubmissionStageLauncher(config SubmissionStageLauncherConfig, packaged VerifiedSubmissionStagePackage, credentials VerifiedSubmissionStageCredentialPackage, runtime VerifiedSubmissionStageRuntimePrerequisite) (*KubernetesSubmissionStageLauncher, error) {
+	if _, err := PlanSubmissionStageLaunch(packaged, credentials, runtime); err != nil {
+		return nil, err
+	}
+	if config.Authority.AuthorityIdentity == "" || config.Authority.AuthorityIdentity != packaged.installationAuthority {
+		return nil, errors.New("stage launcher authority differs from verified management authority")
+	}
+	if !stageReceiptPrefixDigestPattern.MatchString(config.Authority.CABundleDigest) {
+		return nil, errors.New("stage launcher CA identity is required")
+	}
+	token, ca, client, err := openBoundedKubernetesMaterial(config.Authority.TokenFile, config.Authority.CAFile)
+	if err != nil {
+		return nil, errors.New("open bounded stage launcher credential")
+	}
+	if digest.SHA256(ca) != config.Authority.CABundleDigest {
+		return nil, errors.New("stage launcher CA differs from bound identity")
+	}
+	return newKubernetesSubmissionStageLauncher(submissionStageLauncherClientConfig{
+		Endpoint: config.Authority.Endpoint, BearerToken: token, AuthorityIdentity: config.Authority.AuthorityIdentity,
+		Client: client, Clock: config.Clock,
+	}, packaged, credentials, runtime)
+}
+
+func newKubernetesSubmissionStageLauncher(config submissionStageLauncherClientConfig, packaged VerifiedSubmissionStagePackage, credentials VerifiedSubmissionStageCredentialPackage, runtime VerifiedSubmissionStageRuntimePrerequisite) (*KubernetesSubmissionStageLauncher, error) {
+	plan, err := PlanSubmissionStageLaunch(packaged, credentials, runtime)
+	if err != nil {
+		return nil, err
+	}
+	credentialReceipt, secrets, err := prepareSubmissionStageCredentialInstallation(credentials)
+	if err != nil {
+		return nil, err
+	}
+	_, objects, err := prepareSubmissionStageInstallation(packaged)
+	if err != nil {
+		return nil, err
+	}
+	if config.AuthorityIdentity == "" || config.AuthorityIdentity != plan.Authority {
+		return nil, errors.New("stage launcher authority differs from verified management authority")
+	}
+	endpoint, err := url.Parse(config.Endpoint)
+	if err != nil || endpoint.Host == "" || endpoint.User != nil || endpoint.RawQuery != "" || endpoint.Fragment != "" || endpoint.Path != "" && endpoint.Path != "/" || endpoint.Port() == "" || net.ParseIP(endpoint.Hostname()) == nil {
+		return nil, errors.New("stage launcher Kubernetes endpoint is invalid")
+	}
+	if endpoint.Scheme != "https" && !(endpoint.Scheme == "http" && endpoint.Hostname() == "127.0.0.1") {
+		return nil, errors.New("stage launcher Kubernetes endpoint must use HTTPS")
+	}
+	if config.BearerToken == "" || strings.TrimSpace(config.BearerToken) != config.BearerToken || strings.ContainsAny(config.BearerToken, "\r\n") || config.Client == nil || config.Clock == nil {
+		return nil, errors.New("stage launcher Kubernetes credential, client, or clock is invalid")
+	}
+	for _, secret := range secrets {
+		if len(config.BearerToken) == len(secret.token) && subtle.ConstantTimeCompare([]byte(config.BearerToken), secret.token) == 1 {
+			return nil, errors.New("stage launcher and Job credentials must be distinct")
+		}
+	}
+	client := *config.Client
+	client.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+	if client.Timeout == 0 {
+		client.Timeout = 15 * time.Second
+	}
+	endpoint.Path, endpoint.RawPath = "", ""
+	runtime.raw = append([]byte(nil), runtime.raw...)
+	return &KubernetesSubmissionStageLauncher{
+		endpoint: endpoint, token: config.BearerToken, client: &client, clock: config.Clock,
+		plan: plan, runtime: runtime, credentials: credentialReceipt, secrets: secrets, objects: objects,
+	}, nil
+}
+
+// Launch performs the complete six-object preflight and only then creates the
+// absent runtime, both Secrets and the three stage objects in fixed order. It
+// has no update, patch, apply, delete, list, watch, retry or rollback path.
+func (launcher *KubernetesSubmissionStageLauncher) Launch(ctx context.Context) (SubmissionStageLaunchReceipt, error) {
+	receipt := launcher.newReceipt()
+	if launcher == nil || launcher.client == nil || launcher.clock == nil {
+		return receipt, errors.New("stage launcher is required")
+	}
+	launcher.mu.Lock()
+	if launcher.used {
+		launcher.mu.Unlock()
+		return stopSubmissionStageLaunch(receipt, "STOPPED_ZERO_WRITE", errors.New("stage launcher is single-use"))
+	}
+	launcher.used = true
+	launcher.mu.Unlock()
+
+	now := launcher.clock().UTC()
+	materializedAt, err := time.Parse(time.RFC3339, launcher.credentials.MaterializedAt)
+	if err != nil || now.Before(materializedAt) {
+		return stopSubmissionStageLaunch(receipt, "STOPPED_ZERO_WRITE", errors.New("stage launch time precedes credential materialization"))
+	}
+	for _, secret := range launcher.secrets {
+		if secret.expiresAt.Sub(now) < minimumStageCredentialRemaining {
+			return stopSubmissionStageLaunch(receipt, "STOPPED_ZERO_WRITE", errors.New("stage launch credential has insufficient remaining lifetime"))
+		}
+	}
+
+	runtimeExists := false
+	runtimeUID, runtimeResourceVersion := "", ""
+	for _, preflight := range launcher.plan.Preflights {
+		raw, status, err := launcher.request(ctx, http.MethodGet, preflight.ObjectPath, nil, preflight.ResponseMode)
+		if err != nil {
+			return stopSubmissionStageLaunch(receipt, "STOPPED_ZERO_WRITE", err)
+		}
+		if preflight.Order == 1 {
+			switch status {
+			case http.StatusNotFound:
+			case http.StatusOK:
+				runtimeUID, runtimeResourceVersion, err = verifySubmissionStageRuntimeObject(raw, launcher.runtime.raw)
+				if err != nil {
+					return stopSubmissionStageLaunch(receipt, "STOPPED_ZERO_WRITE", errors.New("existing stage runtime differs from verified prerequisite"))
+				}
+				runtimeExists = true
+			default:
+				return stopSubmissionStageLaunch(receipt, "STOPPED_ZERO_WRITE", submissionStageLaunchStatusError(http.MethodGet, status))
+			}
+			continue
+		}
+		if status == http.StatusOK {
+			return stopSubmissionStageLaunch(receipt, "STOPPED_ZERO_WRITE", errors.New("stage launch object already exists; global preflight stopped"))
+		}
+		if status != http.StatusNotFound {
+			return stopSubmissionStageLaunch(receipt, "STOPPED_ZERO_WRITE", submissionStageLaunchStatusError(http.MethodGet, status))
+		}
+	}
+
+	receipt.State = "LAUNCHING"
+	if runtimeExists {
+		receipt.Results = append(receipt.Results, launcher.result(1, "runtime", "v1", "ServiceAccount", launcher.runtime.receipt.Namespace, launcher.runtime.receipt.Name, launcher.runtime.receipt.ObjectDigest, "EXISTING_VERIFIED", runtimeUID, runtimeResourceVersion))
+	} else {
+		receipt.MutationState = "ATTEMPTED_UNKNOWN"
+		result, err := launcher.createRuntime(ctx)
+		if err != nil {
+			return stopSubmissionStageLaunch(receipt, "STOPPED_PARTIAL_OR_UNKNOWN", err)
+		}
+		receipt.MutationState = "ATTEMPTED"
+		receipt.Results = append(receipt.Results, result)
+	}
+	for index, secret := range launcher.secrets {
+		receipt.MutationState = "ATTEMPTED_UNKNOWN"
+		result, err := launcher.createSecret(ctx, index+2, secret)
+		if err != nil {
+			return stopSubmissionStageLaunch(receipt, "STOPPED_PARTIAL_OR_UNKNOWN", err)
+		}
+		receipt.MutationState = "ATTEMPTED"
+		receipt.Results = append(receipt.Results, result)
+	}
+	for index, object := range launcher.objects {
+		receipt.MutationState = "ATTEMPTED_UNKNOWN"
+		result, err := launcher.createStageObject(ctx, index+4, object)
+		if err != nil {
+			return stopSubmissionStageLaunch(receipt, "STOPPED_PARTIAL_OR_UNKNOWN", err)
+		}
+		receipt.MutationState = "ATTEMPTED"
+		receipt.Results = append(receipt.Results, result)
+	}
+	receipt.State, receipt.MutationState = "LAUNCHED", "ATTEMPTED"
+	return receipt, nil
+}
+
+func (launcher *KubernetesSubmissionStageLauncher) createRuntime(ctx context.Context) (SubmissionStageLaunchResult, error) {
+	create := launcher.plan.Creates[0]
+	raw, status, err := launcher.create(ctx, create.CollectionPath, launcher.runtime.raw)
+	if err != nil || status != http.StatusCreated {
+		return SubmissionStageLaunchResult{}, submissionStageLaunchCreateError(status, err)
+	}
+	uid, resourceVersion, err := verifySubmissionStageRuntimeObject(raw, launcher.runtime.raw)
+	if err != nil {
+		return SubmissionStageLaunchResult{}, errors.New("created stage runtime differs from verified prerequisite")
+	}
+	return launcher.result(1, "runtime", "v1", "ServiceAccount", create.Namespace, create.Name, create.ObjectDigest, "CREATED", uid, resourceVersion), nil
+}
+
+func (launcher *KubernetesSubmissionStageLauncher) createSecret(ctx context.Context, order int, secret submissionStageCredentialInstallObject) (SubmissionStageLaunchResult, error) {
+	raw, status, err := launcher.create(ctx, secret.collectionPath, secret.raw)
+	if err != nil || status != http.StatusCreated {
+		return SubmissionStageLaunchResult{}, submissionStageLaunchCreateError(status, err)
+	}
+	uid, resourceVersion, err := verifySubmissionStageCredentialCreatedObject(raw, secret)
+	if err != nil {
+		return SubmissionStageLaunchResult{}, errors.New("created stage credential differs from verified package")
+	}
+	return launcher.result(order, "credentials", "v1", "Secret", submissionStageInputNamespace, secret.name, secret.objectDigest, "CREATED", uid, resourceVersion), nil
+}
+
+func (launcher *KubernetesSubmissionStageLauncher) createStageObject(ctx context.Context, order int, object submissionStageInstallObject) (SubmissionStageLaunchResult, error) {
+	raw, status, err := launcher.create(ctx, object.plan.CollectionPath, object.raw)
+	if err != nil || status != http.StatusCreated {
+		return SubmissionStageLaunchResult{}, submissionStageLaunchCreateError(status, err)
+	}
+	uid, resourceVersion, err := verifySubmissionStageCreatedObject(raw, object)
+	if err != nil {
+		return SubmissionStageLaunchResult{}, errors.New("created stage object differs from verified package")
+	}
+	return launcher.result(order, "stage-package", object.plan.APIVersion, object.plan.Kind, object.plan.Namespace, object.plan.Name, object.plan.ObjectDigest, "CREATED", uid, resourceVersion), nil
+}
+
+func (launcher *KubernetesSubmissionStageLauncher) create(ctx context.Context, path string, body []byte) ([]byte, int, error) {
+	return launcher.request(ctx, http.MethodPost, path, body, "FULL_OBJECT")
+}
+
+func (launcher *KubernetesSubmissionStageLauncher) request(ctx context.Context, method, path string, body []byte, responseMode string) ([]byte, int, error) {
+	endpoint := *launcher.endpoint
+	endpoint.Path = path
+	request, err := http.NewRequestWithContext(ctx, method, endpoint.String(), bytes.NewReader(body))
+	if err != nil {
+		return nil, 0, errors.New("construct bounded stage launch request")
+	}
+	request.Header.Set("Accept", "application/json")
+	if method == http.MethodGet && responseMode == "PARTIAL_OBJECT_METADATA" {
+		request.Header.Set("Accept", partialObjectMetadataAccept)
+	}
+	request.Header.Set("Authorization", "Bearer "+launcher.token)
+	if body != nil {
+		request.Header.Set("Content-Type", "application/json")
+	}
+	response, err := launcher.client.Do(request)
+	if err != nil {
+		return nil, 0, fmt.Errorf("bounded stage launch %s request failed", method)
+	}
+	defer response.Body.Close()
+	raw, readErr := io.ReadAll(io.LimitReader(response.Body, maximumStageInstallationResponseBytes+1))
+	if readErr != nil || len(raw) > maximumStageInstallationResponseBytes {
+		return nil, 0, errors.New("bounded stage launch response exceeds accepted size")
+	}
+	if len(raw) > 0 {
+		mediaType, _, err := mime.ParseMediaType(response.Header.Get("Content-Type"))
+		if err != nil || mediaType != "application/json" {
+			return nil, 0, errors.New("bounded stage launch response is not JSON")
+		}
+	}
+	return raw, response.StatusCode, nil
+}
+
+func (launcher *KubernetesSubmissionStageLauncher) newReceipt() SubmissionStageLaunchReceipt {
+	receipt := SubmissionStageLaunchReceipt{Format: SubmissionStageLaunchReceiptFormat, State: "PREFLIGHT", MutationState: "NOT_ATTEMPTED", Results: []SubmissionStageLaunchResult{}}
+	if launcher != nil {
+		receipt.StageID, receipt.StagePackageDigest = launcher.plan.StageID, launcher.plan.StagePackageDigest
+		receipt.CredentialPackageDigest, receipt.RuntimeManifestDigest = launcher.plan.CredentialPackageDigest, launcher.plan.RuntimeManifestDigest
+		receipt.Authority = launcher.plan.Authority
+	}
+	return receipt
+}
+
+func (launcher *KubernetesSubmissionStageLauncher) result(order int, phase, apiVersion, kind, namespace, name, objectDigest, state, uid, resourceVersion string) SubmissionStageLaunchResult {
+	return SubmissionStageLaunchResult{
+		Order: order, Phase: phase, APIVersion: apiVersion, Kind: kind, Namespace: namespace, Name: name,
+		ObjectDigest: objectDigest, ObjectState: state, UIDDigest: digest.SHA256([]byte(uid)), ResourceVersionDigest: digest.SHA256([]byte(resourceVersion)),
+	}
+}
+
+func stopSubmissionStageLaunch(receipt SubmissionStageLaunchReceipt, state string, err error) (SubmissionStageLaunchReceipt, error) {
+	receipt.State = state
+	return receipt, err
+}
+
+func submissionStageLaunchCreateError(status int, err error) error {
+	if err != nil {
+		return err
+	}
+	return submissionStageLaunchStatusError(http.MethodPost, status)
+}
+
+func submissionStageLaunchStatusError(method string, status int) error {
+	return fmt.Errorf("bounded stage launch %s returned HTTP %d", method, status)
+}

--- a/internal/runner/submission_stage_launcher_test.go
+++ b/internal/runner/submission_stage_launcher_test.go
@@ -1,0 +1,209 @@
+package runner
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+func TestSubmissionStageLauncherPreflightsSixThenCreatesInFixedOrder(t *testing.T) {
+	stage, credentials, runtime, ledgerToken, authorityToken := submissionStageLaunchFixture(t)
+	api := newSubmissionStageLauncherAPI(t)
+	launcher := newSubmissionStageLauncher(t, stage, credentials, runtime, api, time.Date(2026, 8, 16, 12, 1, 0, 0, time.UTC))
+	receipt, err := launcher.Launch(context.Background())
+	if err != nil || receipt.State != "LAUNCHED" || receipt.MutationState != "ATTEMPTED" || len(receipt.Results) != 6 {
+		t.Fatalf("launch failed: receipt=%#v err=%v", receipt, err)
+	}
+	if len(api.requests) != 12 || api.posts != 6 {
+		t.Fatalf("requests=%d posts=%d, want six GETs then six POSTs", len(api.requests), api.posts)
+	}
+	for index := 0; index < 6; index++ {
+		preflight, create := api.requests[index], api.requests[index+6]
+		if preflight.method != http.MethodGet || preflight.path != launcher.plan.Preflights[index].ObjectPath || create.method != http.MethodPost || create.path != launcher.plan.Creates[index].CollectionPath || digest.SHA256(create.body) != launcher.plan.Creates[index].ObjectDigest {
+			t.Fatalf("request order %d differs: preflight=%#v create=%#v", index+1, preflight, create)
+		}
+		if index == 1 || index == 2 {
+			if preflight.accept != partialObjectMetadataAccept {
+				t.Fatalf("Secret preflight %d did not request metadata only", index+1)
+			}
+		} else if preflight.accept != "application/json" {
+			t.Fatalf("object preflight %d media type differs: %q", index+1, preflight.accept)
+		}
+		result := receipt.Results[index]
+		if result.Order != index+1 || result.Kind != launcher.plan.Creates[index].Kind || result.ObjectState != "CREATED" || !stageReceiptPrefixDigestPattern.MatchString(result.UIDDigest) || !stageReceiptPrefixDigestPattern.MatchString(result.ResourceVersionDigest) {
+			t.Fatalf("result %d differs: %#v", index+1, result)
+		}
+	}
+	public, err := json.Marshal(receipt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range [][]byte{ledgerToken, authorityToken, credentials.objects[0].raw, credentials.objects[1].raw, []byte("short-lived-installer-token"), []byte("created-uid")} {
+		if bytes.Contains(public, forbidden) {
+			t.Fatal("launch receipt exposed private content")
+		}
+	}
+	requests := len(api.requests)
+	retry, retryErr := launcher.Launch(context.Background())
+	if retryErr == nil || retry.State != "STOPPED_ZERO_WRITE" || len(api.requests) != requests {
+		t.Fatalf("launcher retried: receipt=%#v err=%v", retry, retryErr)
+	}
+}
+
+func TestSubmissionStageLauncherAcceptsOnlyExactExistingRuntime(t *testing.T) {
+	stage, credentials, runtime, _, _ := submissionStageLaunchFixture(t)
+	api := newSubmissionStageLauncherAPI(t)
+	runtimeObject := decodeCapabilityJSONForTest(t, runtime.raw)
+	runtimeMetadata := runtimeObject["metadata"].(map[string]any)
+	runtimeMetadata["uid"], runtimeMetadata["resourceVersion"] = "runtime-existing-uid", "7"
+	api.objects[stageRuntimeObjectPath] = runtimeObject
+	launcher := newSubmissionStageLauncher(t, stage, credentials, runtime, api, time.Date(2026, 8, 16, 12, 1, 0, 0, time.UTC))
+	receipt, err := launcher.Launch(context.Background())
+	if err != nil || receipt.State != "LAUNCHED" || len(receipt.Results) != 6 || receipt.Results[0].ObjectState != "EXISTING_VERIFIED" || api.posts != 5 || len(api.requests) != 11 {
+		t.Fatalf("existing runtime was not reused exactly: receipt=%#v requests=%d posts=%d err=%v", receipt, len(api.requests), api.posts, err)
+	}
+
+	stage, credentials, runtime, _, _ = submissionStageLaunchFixture(t)
+	api = newSubmissionStageLauncherAPI(t)
+	runtimeObject = decodeCapabilityJSONForTest(t, runtime.raw)
+	runtimeObject["automountServiceAccountToken"] = true
+	runtimeMetadata = runtimeObject["metadata"].(map[string]any)
+	runtimeMetadata["uid"], runtimeMetadata["resourceVersion"] = "runtime-existing-uid", "7"
+	api.objects[stageRuntimeObjectPath] = runtimeObject
+	launcher = newSubmissionStageLauncher(t, stage, credentials, runtime, api, time.Date(2026, 8, 16, 12, 1, 0, 0, time.UTC))
+	receipt, err = launcher.Launch(context.Background())
+	if err == nil || receipt.State != "STOPPED_ZERO_WRITE" || api.posts != 0 || len(api.requests) != 1 {
+		t.Fatalf("changed runtime reached create phase: receipt=%#v requests=%d posts=%d err=%v", receipt, len(api.requests), api.posts, err)
+	}
+}
+
+func TestSubmissionStageLauncherStopsGloballyBeforeWrite(t *testing.T) {
+	stage, credentials, runtime, _, _ := submissionStageLaunchFixture(t)
+	api := newSubmissionStageLauncherAPI(t)
+	launcher := newSubmissionStageLauncher(t, stage, credentials, runtime, api, time.Date(2026, 8, 16, 12, 1, 0, 0, time.UTC))
+	api.objects[launcher.plan.Preflights[4].ObjectPath] = map[string]any{"kind": "NetworkPolicy"}
+	receipt, err := launcher.Launch(context.Background())
+	if err == nil || receipt.State != "STOPPED_ZERO_WRITE" || receipt.MutationState != "NOT_ATTEMPTED" || api.posts != 0 || len(api.requests) != 5 || len(receipt.Results) != 0 {
+		t.Fatalf("global preflight did not stop zero-write: receipt=%#v requests=%d posts=%d err=%v", receipt, len(api.requests), api.posts, err)
+	}
+}
+
+func TestSubmissionStageLauncherPreservesPartialPrefixAndStaleCredentialsStopLocally(t *testing.T) {
+	t.Run("partial prefix", func(t *testing.T) {
+		stage, credentials, runtime, _, _ := submissionStageLaunchFixture(t)
+		api := newSubmissionStageLauncherAPI(t)
+		api.failPost = 4
+		launcher := newSubmissionStageLauncher(t, stage, credentials, runtime, api, time.Date(2026, 8, 16, 12, 1, 0, 0, time.UTC))
+		receipt, err := launcher.Launch(context.Background())
+		if err == nil || receipt.State != "STOPPED_PARTIAL_OR_UNKNOWN" || receipt.MutationState != "ATTEMPTED_UNKNOWN" || len(receipt.Results) != 3 || api.posts != 4 || len(api.requests) != 10 {
+			t.Fatalf("partial prefix differs: receipt=%#v requests=%d posts=%d err=%v", receipt, len(api.requests), api.posts, err)
+		}
+	})
+
+	t.Run("stale credentials", func(t *testing.T) {
+		stage, credentials, runtime, _, _ := submissionStageLaunchFixture(t)
+		api := newSubmissionStageLauncherAPI(t)
+		launcher := newSubmissionStageLauncher(t, stage, credentials, runtime, api, time.Date(2026, 8, 16, 12, 16, 0, 0, time.UTC))
+		receipt, err := launcher.Launch(context.Background())
+		if err == nil || receipt.State != "STOPPED_ZERO_WRITE" || receipt.MutationState != "NOT_ATTEMPTED" || len(api.requests) != 0 {
+			t.Fatalf("stale credentials reached API: receipt=%#v requests=%d err=%v", receipt, len(api.requests), err)
+		}
+	})
+}
+
+func newSubmissionStageLauncher(t *testing.T, stage VerifiedSubmissionStagePackage, credentials VerifiedSubmissionStageCredentialPackage, runtime VerifiedSubmissionStageRuntimePrerequisite, api *submissionStageLauncherAPI, now time.Time) *KubernetesSubmissionStageLauncher {
+	t.Helper()
+	launcher, err := newKubernetesSubmissionStageLauncher(submissionStageLauncherClientConfig{
+		Endpoint: "http://127.0.0.1:12345", BearerToken: "short-lived-installer-token", AuthorityIdentity: "ok-mgmt", Client: api.client(), Clock: func() time.Time { return now },
+	}, stage, credentials, runtime)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return launcher
+}
+
+type submissionStageLauncherRequest struct {
+	method string
+	path   string
+	accept string
+	body   []byte
+}
+
+type submissionStageLauncherAPI struct {
+	t        *testing.T
+	mu       sync.Mutex
+	objects  map[string]map[string]any
+	requests []submissionStageLauncherRequest
+	posts    int
+	failPost int
+}
+
+func newSubmissionStageLauncherAPI(t *testing.T) *submissionStageLauncherAPI {
+	return &submissionStageLauncherAPI{t: t, objects: map[string]map[string]any{}}
+}
+
+func (api *submissionStageLauncherAPI) client() *http.Client {
+	return &http.Client{Transport: submissionStageLauncherRoundTripFunc(api.roundTrip)}
+}
+
+func (api *submissionStageLauncherAPI) roundTrip(request *http.Request) (*http.Response, error) {
+	api.mu.Lock()
+	defer api.mu.Unlock()
+	body, _ := io.ReadAll(request.Body)
+	api.requests = append(api.requests, submissionStageLauncherRequest{method: request.Method, path: request.URL.Path, accept: request.Header.Get("Accept"), body: body})
+	if request.Header.Get("Authorization") != "Bearer short-lived-installer-token" {
+		return submissionStageLauncherJSONResponse(http.StatusUnauthorized, map[string]any{"reason": "Unauthorized"}), nil
+	}
+	switch request.Method {
+	case http.MethodGet:
+		object, ok := api.objects[request.URL.Path]
+		if !ok {
+			return submissionStageLauncherJSONResponse(http.StatusNotFound, map[string]any{"reason": "NotFound"}), nil
+		}
+		return submissionStageLauncherJSONResponse(http.StatusOK, object), nil
+	case http.MethodPost:
+		api.posts++
+		if api.failPost == api.posts {
+			return submissionStageLauncherJSONResponse(http.StatusForbidden, map[string]any{"reason": "Denied"}), nil
+		}
+		var object map[string]any
+		decoder := json.NewDecoder(bytes.NewReader(body))
+		decoder.UseNumber()
+		if err := decoder.Decode(&object); err != nil {
+			api.t.Fatal(err)
+		}
+		metadata := object["metadata"].(map[string]any)
+		metadata["uid"] = "created-uid-" + string(rune('a'+api.posts-1))
+		metadata["resourceVersion"] = string(rune('1' + api.posts - 1))
+		return submissionStageLauncherJSONResponse(http.StatusCreated, object), nil
+	default:
+		return submissionStageLauncherJSONResponse(http.StatusMethodNotAllowed, map[string]any{"reason": "MethodNotAllowed"}), nil
+	}
+}
+
+type submissionStageLauncherRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (function submissionStageLauncherRoundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return function(request)
+}
+
+func submissionStageLauncherJSONResponse(status int, value any) *http.Response {
+	raw, _ := json.Marshal(value)
+	return &http.Response{StatusCode: status, Header: http.Header{"Content-Type": []string{"application/json"}}, Body: io.NopCloser(bytes.NewReader(raw))}
+}
+
+func decodeCapabilityJSONForTest(t *testing.T, raw []byte) map[string]any {
+	t.Helper()
+	var value map[string]any
+	if err := json.Unmarshal(raw, &value); err != nil {
+		t.Fatal(err)
+	}
+	return value
+}


### PR DESCRIPTION
## Summary
- implement one single-use six-object stage launch operation
- finish all exact preflights before the first create and preserve fixed create order
- fail closed with redaction-safe partial receipts and no update, delete, retry, or rollback path

## Validation
- GOCACHE=/private/tmp/ok147-go-build-cache go test -ldflags=-linkmode=external ./...
- GOCACHE=/private/tmp/ok147-go-build-cache go vet ./...
- GOCACHE=/private/tmp/ok147-go-build-cache go test -race -ldflags=-linkmode=external ./internal/runner
- python3 -m unittest discover -s tests -p '*_test.py'
- git diff --check

## Boundary
The operation is tested only with an in-memory Kubernetes transport. No live credential was opened and no cluster was contacted or mutated.