### PR TITLE
feat(runner): bind exact stage launch candidate (OK-147)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,12 @@ Powered by [Cluster API (CAPI)](https://cluster-api.sigs.k8s.io/), [CAPK (KubeVi
   barrier and fixes their eventual create order without exposing object bodies
   or credentials. A single-use composite launcher implements the same order,
   preserves a redaction-safe partial receipt and has no update, delete, retry
-  or rollback path; live invocation remains a separate critical boundary. The
-  runner image is digest-pinned, multi-architecture, non-root, SBOM- and
-  provenance-producing behind a protected publisher.
+  or rollback path. Its public opener additionally requires an exact,
+  expiry-bound launch-candidate digest that binds destination, CA and installer
+  credential evidence; preparing it remains non-mutating. Live invocation is
+  still a separate critical boundary. The runner image is digest-pinned,
+  multi-architecture, non-root, SBOM- and provenance-producing behind a
+  protected publisher.
 
 ---
 

--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -1322,6 +1322,22 @@ adoption or retry API. This checkpoint exercises it only with an in-memory
 Kubernetes transport. Opening live credentials or invoking it against a
 cluster remains a separate, critical execution decision.
 
+That decision is now represented by a separate
+`ok147-submission-stage-launch-candidate/v1`. Candidate preparation binds the
+launch-plan digest, all three package identities, the hashed exact API
+destination, CA digest, installer TokenRequest-evidence digest and a private
+installer-token identity. The receipt exposes only a double-bound credential
+identity, never the endpoint, token digest, token path or token. Its validity
+ends 15 minutes before the earliest Job credential expires.
+
+The public launcher opener requires the exact candidate digest, recomputes the
+launch plan, verifies the destination and CA, and reads the installer token
+only after all public candidate checks pass. The opened token must match the
+candidate's retained private identity. An expired candidate stops locally
+before any API request. Preparing this candidate remains non-mutating and is
+not itself permission to launch; it provides the exact digest to which a later
+critical execution approval can be bound.
+
 ## Typed first-run Platform capability boundary
 
 First-run capability production now has a separate lazy resolver from the

--- a/internal/runner/submission_stage_launch_candidate.go
+++ b/internal/runner/submission_stage_launch_candidate.go
@@ -1,0 +1,194 @@
+package runner
+
+import (
+	"encoding/json"
+	"errors"
+	"net"
+	"net/url"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+const SubmissionStageLaunchCandidateFormat = "ok147-submission-stage-launch-candidate/v1"
+
+type SubmissionStageLaunchCandidateConfig struct {
+	AuthorityEndpoint                 string
+	CABundleDigest                    string
+	InstallerTokenDigest              string
+	InstallerCredentialEvidenceDigest string
+	PreparedAt                        time.Time
+}
+
+type SubmissionStageLaunchCandidateReceipt struct {
+	Format                            string `json:"format"`
+	State                             string `json:"state"`
+	StageID                           string `json:"stageId"`
+	Authority                         string `json:"authority"`
+	StagePackageDigest                string `json:"stagePackageDigest"`
+	CredentialPackageDigest           string `json:"credentialPackageDigest"`
+	RuntimeManifestDigest             string `json:"runtimeManifestDigest"`
+	LaunchPlanDigest                  string `json:"launchPlanDigest"`
+	AuthorityEndpointDigest           string `json:"authorityEndpointDigest"`
+	CABundleDigest                    string `json:"caBundleDigest"`
+	InstallerCredentialBindingDigest  string `json:"installerCredentialBindingDigest"`
+	InstallerCredentialEvidenceDigest string `json:"installerCredentialEvidenceDigest"`
+	PreparedAt                        string `json:"preparedAt"`
+	ValidUntil                        string `json:"validUntil"`
+	CandidateDigest                   string `json:"candidateDigest"`
+	MutationAllowed                   bool   `json:"mutationAllowed"`
+}
+
+type submissionStageLaunchCandidateIdentity struct {
+	StageID                           string `json:"stageId"`
+	Authority                         string `json:"authority"`
+	StagePackageDigest                string `json:"stagePackageDigest"`
+	CredentialPackageDigest           string `json:"credentialPackageDigest"`
+	RuntimeManifestDigest             string `json:"runtimeManifestDigest"`
+	LaunchPlanDigest                  string `json:"launchPlanDigest"`
+	AuthorityEndpointDigest           string `json:"authorityEndpointDigest"`
+	CABundleDigest                    string `json:"caBundleDigest"`
+	InstallerCredentialBindingDigest  string `json:"installerCredentialBindingDigest"`
+	InstallerCredentialEvidenceDigest string `json:"installerCredentialEvidenceDigest"`
+	PreparedAt                        string `json:"preparedAt"`
+	ValidUntil                        string `json:"validUntil"`
+}
+
+type submissionStageInstallerCredentialIdentity struct {
+	TokenDigest    string `json:"tokenDigest"`
+	EvidenceDigest string `json:"evidenceDigest"`
+}
+
+// VerifiedSubmissionStageLaunchCandidate retains the private endpoint and
+// token identity that are deliberately absent from its public receipt.
+type VerifiedSubmissionStageLaunchCandidate struct {
+	receipt              SubmissionStageLaunchCandidateReceipt
+	authorityEndpoint    string
+	installerTokenDigest string
+	verified             bool
+}
+
+// PrepareSubmissionStageLaunchCandidate binds one coherent launch to one API
+// destination, CA and independently evidenced installer credential. It reads
+// no credential and performs no API request.
+func PrepareSubmissionStageLaunchCandidate(config SubmissionStageLaunchCandidateConfig, packaged VerifiedSubmissionStagePackage, credentials VerifiedSubmissionStageCredentialPackage, runtime VerifiedSubmissionStageRuntimePrerequisite) (VerifiedSubmissionStageLaunchCandidate, error) {
+	plan, err := PlanSubmissionStageLaunch(packaged, credentials, runtime)
+	if err != nil {
+		return VerifiedSubmissionStageLaunchCandidate{}, err
+	}
+	credentialReceipt, secrets, err := prepareSubmissionStageCredentialInstallation(credentials)
+	if err != nil {
+		return VerifiedSubmissionStageLaunchCandidate{}, err
+	}
+	endpoint, err := normalizeSubmissionStageLaunchEndpoint(config.AuthorityEndpoint)
+	if err != nil {
+		return VerifiedSubmissionStageLaunchCandidate{}, err
+	}
+	if !stageReceiptPrefixDigestPattern.MatchString(config.CABundleDigest) || !stageReceiptPrefixDigestPattern.MatchString(config.InstallerTokenDigest) || !stageReceiptPrefixDigestPattern.MatchString(config.InstallerCredentialEvidenceDigest) {
+		return VerifiedSubmissionStageLaunchCandidate{}, errors.New("stage launch candidate credential identities are invalid")
+	}
+	if config.PreparedAt.IsZero() || !config.PreparedAt.Equal(config.PreparedAt.Truncate(time.Second)) {
+		return VerifiedSubmissionStageLaunchCandidate{}, errors.New("stage launch candidate preparation time is required")
+	}
+	materializedAt, err := time.Parse(time.RFC3339, credentialReceipt.MaterializedAt)
+	if err != nil || config.PreparedAt.Before(materializedAt) {
+		return VerifiedSubmissionStageLaunchCandidate{}, errors.New("stage launch candidate predates credential materialization")
+	}
+	validUntil := secrets[0].expiresAt.Add(-minimumStageCredentialRemaining)
+	for _, secret := range secrets[1:] {
+		candidate := secret.expiresAt.Add(-minimumStageCredentialRemaining)
+		if candidate.Before(validUntil) {
+			validUntil = candidate
+		}
+	}
+	if config.PreparedAt.After(validUntil) {
+		return VerifiedSubmissionStageLaunchCandidate{}, errors.New("stage launch candidate credentials cannot retain minimum lifetime")
+	}
+	planRaw, err := json.Marshal(plan)
+	if err != nil {
+		return VerifiedSubmissionStageLaunchCandidate{}, errors.New("encode stage launch plan identity")
+	}
+	credentialBindingRaw, err := json.Marshal(submissionStageInstallerCredentialIdentity{TokenDigest: config.InstallerTokenDigest, EvidenceDigest: config.InstallerCredentialEvidenceDigest})
+	if err != nil {
+		return VerifiedSubmissionStageLaunchCandidate{}, errors.New("encode stage launcher credential identity")
+	}
+	identity := submissionStageLaunchCandidateIdentity{
+		StageID: plan.StageID, Authority: plan.Authority, StagePackageDigest: plan.StagePackageDigest,
+		CredentialPackageDigest: plan.CredentialPackageDigest, RuntimeManifestDigest: plan.RuntimeManifestDigest,
+		LaunchPlanDigest: digest.SHA256(planRaw), AuthorityEndpointDigest: digest.SHA256([]byte(endpoint)),
+		CABundleDigest: config.CABundleDigest, InstallerCredentialBindingDigest: digest.SHA256(credentialBindingRaw),
+		InstallerCredentialEvidenceDigest: config.InstallerCredentialEvidenceDigest,
+		PreparedAt:                        config.PreparedAt.UTC().Format(time.RFC3339), ValidUntil: validUntil.UTC().Format(time.RFC3339),
+	}
+	identityRaw, err := json.Marshal(identity)
+	if err != nil {
+		return VerifiedSubmissionStageLaunchCandidate{}, errors.New("encode stage launch candidate identity")
+	}
+	receipt := SubmissionStageLaunchCandidateReceipt{
+		Format: SubmissionStageLaunchCandidateFormat, State: "PREPARED", StageID: identity.StageID, Authority: identity.Authority,
+		StagePackageDigest: identity.StagePackageDigest, CredentialPackageDigest: identity.CredentialPackageDigest,
+		RuntimeManifestDigest: identity.RuntimeManifestDigest, LaunchPlanDigest: identity.LaunchPlanDigest,
+		AuthorityEndpointDigest: identity.AuthorityEndpointDigest, CABundleDigest: identity.CABundleDigest,
+		InstallerCredentialBindingDigest:  identity.InstallerCredentialBindingDigest,
+		InstallerCredentialEvidenceDigest: identity.InstallerCredentialEvidenceDigest,
+		PreparedAt:                        identity.PreparedAt, ValidUntil: identity.ValidUntil, CandidateDigest: digest.SHA256(identityRaw), MutationAllowed: false,
+	}
+	return VerifiedSubmissionStageLaunchCandidate{receipt: receipt, authorityEndpoint: endpoint, installerTokenDigest: config.InstallerTokenDigest, verified: true}, nil
+}
+
+func (candidate VerifiedSubmissionStageLaunchCandidate) Receipt() (SubmissionStageLaunchCandidateReceipt, error) {
+	if err := verifySubmissionStageLaunchCandidate(candidate); err != nil {
+		return SubmissionStageLaunchCandidateReceipt{}, err
+	}
+	return candidate.receipt, nil
+}
+
+func verifySubmissionStageLaunchCandidate(candidate VerifiedSubmissionStageLaunchCandidate) error {
+	if !candidate.verified || candidate.receipt.Format != SubmissionStageLaunchCandidateFormat || candidate.receipt.State != "PREPARED" || candidate.receipt.MutationAllowed || candidate.authorityEndpoint == "" || !stageReceiptPrefixDigestPattern.MatchString(candidate.installerTokenDigest) {
+		return errors.New("stage launch candidate was not produced by verification")
+	}
+	for _, value := range []string{
+		candidate.receipt.StagePackageDigest, candidate.receipt.CredentialPackageDigest, candidate.receipt.RuntimeManifestDigest,
+		candidate.receipt.LaunchPlanDigest, candidate.receipt.AuthorityEndpointDigest, candidate.receipt.CABundleDigest,
+		candidate.receipt.InstallerCredentialBindingDigest, candidate.receipt.InstallerCredentialEvidenceDigest, candidate.receipt.CandidateDigest,
+	} {
+		if !stageReceiptPrefixDigestPattern.MatchString(value) {
+			return errors.New("stage launch candidate contains an invalid digest")
+		}
+	}
+	credentialBindingRaw, err := json.Marshal(submissionStageInstallerCredentialIdentity{TokenDigest: candidate.installerTokenDigest, EvidenceDigest: candidate.receipt.InstallerCredentialEvidenceDigest})
+	if err != nil || digest.SHA256(credentialBindingRaw) != candidate.receipt.InstallerCredentialBindingDigest {
+		return errors.New("stage launch candidate credential identity changed after verification")
+	}
+	identity := submissionStageLaunchCandidateIdentity{
+		StageID: candidate.receipt.StageID, Authority: candidate.receipt.Authority,
+		StagePackageDigest: candidate.receipt.StagePackageDigest, CredentialPackageDigest: candidate.receipt.CredentialPackageDigest,
+		RuntimeManifestDigest: candidate.receipt.RuntimeManifestDigest, LaunchPlanDigest: candidate.receipt.LaunchPlanDigest,
+		AuthorityEndpointDigest: candidate.receipt.AuthorityEndpointDigest, CABundleDigest: candidate.receipt.CABundleDigest,
+		InstallerCredentialBindingDigest:  candidate.receipt.InstallerCredentialBindingDigest,
+		InstallerCredentialEvidenceDigest: candidate.receipt.InstallerCredentialEvidenceDigest,
+		PreparedAt:                        candidate.receipt.PreparedAt, ValidUntil: candidate.receipt.ValidUntil,
+	}
+	raw, err := json.Marshal(identity)
+	if err != nil || digest.SHA256(raw) != candidate.receipt.CandidateDigest || digest.SHA256([]byte(candidate.authorityEndpoint)) != candidate.receipt.AuthorityEndpointDigest {
+		return errors.New("stage launch candidate identity changed after verification")
+	}
+	preparedAt, err := time.Parse(time.RFC3339, candidate.receipt.PreparedAt)
+	if err != nil {
+		return errors.New("stage launch candidate preparation time is invalid")
+	}
+	validUntil, err := time.Parse(time.RFC3339, candidate.receipt.ValidUntil)
+	if err != nil || validUntil.Before(preparedAt) {
+		return errors.New("stage launch candidate validity is invalid")
+	}
+	return nil
+}
+
+func normalizeSubmissionStageLaunchEndpoint(raw string) (string, error) {
+	endpoint, err := url.Parse(raw)
+	if err != nil || endpoint.Host == "" || endpoint.User != nil || endpoint.RawQuery != "" || endpoint.Fragment != "" || endpoint.Path != "" && endpoint.Path != "/" || endpoint.Port() == "" || net.ParseIP(endpoint.Hostname()) == nil || endpoint.Scheme != "https" {
+		return "", errors.New("stage launch candidate requires an exact IP-literal HTTPS endpoint")
+	}
+	endpoint.Path, endpoint.RawPath = "", ""
+	return endpoint.String(), nil
+}

--- a/internal/runner/submission_stage_launch_candidate_test.go
+++ b/internal/runner/submission_stage_launch_candidate_test.go
@@ -1,0 +1,170 @@
+package runner
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+func TestPrepareSubmissionStageLaunchCandidateBindsExactDestinationAndCredential(t *testing.T) {
+	stage, credentials, runtime, _, _ := submissionStageLaunchFixture(t)
+	config := submissionStageLaunchCandidateConfig()
+	candidate, err := PrepareSubmissionStageLaunchCandidate(config, stage, credentials, runtime)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := candidate.Receipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	again, err := PrepareSubmissionStageLaunchCandidate(config, stage, credentials, runtime)
+	if err != nil {
+		t.Fatal(err)
+	}
+	againReceipt, _ := again.Receipt()
+	if receipt.Format != SubmissionStageLaunchCandidateFormat || receipt.State != "PREPARED" || receipt.StageID != "provider-prerequisites" || receipt.Authority != "ok-mgmt" || receipt.PreparedAt != "2026-08-16T12:01:00Z" || receipt.ValidUntil != "2026-08-16T12:15:00Z" || receipt.MutationAllowed || receipt.CandidateDigest != againReceipt.CandidateDigest {
+		t.Fatalf("candidate identity differs: %#v", receipt)
+	}
+	for _, value := range []string{receipt.StagePackageDigest, receipt.CredentialPackageDigest, receipt.RuntimeManifestDigest, receipt.LaunchPlanDigest, receipt.AuthorityEndpointDigest, receipt.CABundleDigest, receipt.InstallerCredentialBindingDigest, receipt.InstallerCredentialEvidenceDigest, receipt.CandidateDigest} {
+		if !stageReceiptPrefixDigestPattern.MatchString(value) {
+			t.Fatalf("candidate digest is invalid: %q", value)
+		}
+	}
+	public, err := json.Marshal(receipt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range []string{config.AuthorityEndpoint, config.InstallerTokenDigest, "installer-token-v1"} {
+		if bytes.Contains(public, []byte(forbidden)) {
+			t.Fatalf("candidate receipt exposed private launch input %q", forbidden)
+		}
+	}
+
+	changed := config
+	changed.AuthorityEndpoint = "https://192.0.2.11:6443"
+	other, err := PrepareSubmissionStageLaunchCandidate(changed, stage, credentials, runtime)
+	if err != nil {
+		t.Fatal(err)
+	}
+	otherReceipt, _ := other.Receipt()
+	if otherReceipt.CandidateDigest == receipt.CandidateDigest {
+		t.Fatal("changed endpoint retained candidate identity")
+	}
+	changed = config
+	changed.InstallerTokenDigest = digest.SHA256([]byte("other-installer-token"))
+	other, err = PrepareSubmissionStageLaunchCandidate(changed, stage, credentials, runtime)
+	if err != nil {
+		t.Fatal(err)
+	}
+	otherReceipt, _ = other.Receipt()
+	if otherReceipt.CandidateDigest == receipt.CandidateDigest {
+		t.Fatal("changed installer token retained candidate identity")
+	}
+	tampered := candidate
+	tampered.receipt.ValidUntil = "2026-08-16T12:16:00Z"
+	if _, err := tampered.Receipt(); err == nil {
+		t.Fatal("changed candidate receipt was accepted")
+	}
+	tampered = candidate
+	tampered.installerTokenDigest = digest.SHA256([]byte("foreign-private-token"))
+	if _, err := tampered.Receipt(); err == nil {
+		t.Fatal("changed private credential binding was accepted")
+	}
+}
+
+func TestPrepareSubmissionStageLaunchCandidateFailsClosed(t *testing.T) {
+	stage, credentials, runtime, _, _ := submissionStageLaunchFixture(t)
+	valid := submissionStageLaunchCandidateConfig()
+	for name, mutate := range map[string]func(*SubmissionStageLaunchCandidateConfig){
+		"DNS endpoint": func(config *SubmissionStageLaunchCandidateConfig) {
+			config.AuthorityEndpoint = "https://ok-mgmt.example:6443"
+		},
+		"HTTP endpoint": func(config *SubmissionStageLaunchCandidateConfig) {
+			config.AuthorityEndpoint = "http://192.0.2.10:6443"
+		},
+		"missing CA":       func(config *SubmissionStageLaunchCandidateConfig) { config.CABundleDigest = "" },
+		"missing evidence": func(config *SubmissionStageLaunchCandidateConfig) { config.InstallerCredentialEvidenceDigest = "" },
+		"fractional time": func(config *SubmissionStageLaunchCandidateConfig) {
+			config.PreparedAt = config.PreparedAt.Add(time.Nanosecond)
+		},
+		"expired credentials": func(config *SubmissionStageLaunchCandidateConfig) {
+			config.PreparedAt = time.Date(2026, 8, 16, 12, 15, 1, 0, time.UTC)
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			config := valid
+			mutate(&config)
+			if _, err := PrepareSubmissionStageLaunchCandidate(config, stage, credentials, runtime); err == nil {
+				t.Fatal("invalid launch candidate was accepted")
+			}
+		})
+	}
+}
+
+func TestOpenSubmissionStageLauncherRequiresExactCandidateBeforeCredentialUse(t *testing.T) {
+	stage, credentials, runtime, _, _ := submissionStageLaunchFixture(t)
+	installerToken := []byte("installer-token-v1")
+	ca := testCA(t)
+	config := submissionStageLaunchCandidateConfig()
+	config.CABundleDigest = digest.SHA256(ca)
+	config.InstallerTokenDigest = digest.SHA256(installerToken)
+	candidate, err := PrepareSubmissionStageLaunchCandidate(config, stage, credentials, runtime)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, _ := candidate.Receipt()
+	root := t.TempDir()
+	tokenPath, caPath := filepath.Join(root, "installer-token"), filepath.Join(root, "ca.crt")
+	if err := os.WriteFile(tokenPath, installerToken, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(caPath, ca, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	launcherConfig := SubmissionStageLauncherConfig{
+		Authority: KubernetesAuthorityConfig{
+			Endpoint: config.AuthorityEndpoint, AuthorityIdentity: "ok-mgmt", TokenFile: tokenPath, CAFile: caPath, CABundleDigest: config.CABundleDigest,
+		},
+		Clock: func() time.Time { return time.Date(2026, 8, 16, 12, 16, 0, 0, time.UTC) }, Candidate: candidate, ExpectedCandidateDigest: receipt.CandidateDigest,
+	}
+	launcher, err := OpenKubernetesSubmissionStageLauncher(launcherConfig, stage, credentials, runtime)
+	if err != nil {
+		t.Fatal(err)
+	}
+	launchReceipt, err := launcher.Launch(context.Background())
+	if err == nil || launchReceipt.State != "STOPPED_ZERO_WRITE" || launchReceipt.MutationState != "NOT_ATTEMPTED" {
+		t.Fatalf("expired candidate did not stop before API contact: %#v %v", launchReceipt, err)
+	}
+
+	wrong := launcherConfig
+	wrong.ExpectedCandidateDigest = digest.SHA256([]byte("other-candidate"))
+	if _, err := OpenKubernetesSubmissionStageLauncher(wrong, stage, credentials, runtime); err == nil {
+		t.Fatal("wrong expected candidate digest was accepted")
+	}
+	wrong = launcherConfig
+	wrong.Authority.Endpoint = "https://192.0.2.11:6443"
+	if _, err := OpenKubernetesSubmissionStageLauncher(wrong, stage, credentials, runtime); err == nil {
+		t.Fatal("wrong launch endpoint was accepted")
+	}
+	if err := os.WriteFile(tokenPath, []byte("changed-installer-token"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := OpenKubernetesSubmissionStageLauncher(launcherConfig, stage, credentials, runtime); err == nil {
+		t.Fatal("changed installer credential was accepted")
+	}
+}
+
+func submissionStageLaunchCandidateConfig() SubmissionStageLaunchCandidateConfig {
+	return SubmissionStageLaunchCandidateConfig{
+		AuthorityEndpoint: "https://192.0.2.10:6443", CABundleDigest: digest.SHA256([]byte("candidate-ca")),
+		InstallerTokenDigest:              digest.SHA256([]byte("installer-token-v1")),
+		InstallerCredentialEvidenceDigest: digest.SHA256([]byte("installer-tokenrequest-evidence")),
+		PreparedAt:                        time.Date(2026, 8, 16, 12, 1, 0, 0, time.UTC),
+	}
+}

--- a/internal/runner/submission_stage_launcher.go
+++ b/internal/runner/submission_stage_launcher.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/subtle"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -21,8 +22,10 @@ import (
 const SubmissionStageLaunchReceiptFormat = "ok147-submission-stage-launch-receipt/v1"
 
 type SubmissionStageLauncherConfig struct {
-	Authority KubernetesAuthorityConfig
-	Clock     func() time.Time
+	Authority               KubernetesAuthorityConfig
+	Clock                   func() time.Time
+	Candidate               VerifiedSubmissionStageLaunchCandidate
+	ExpectedCandidateDigest string
 }
 
 type SubmissionStageLaunchResult struct {
@@ -61,6 +64,7 @@ type KubernetesSubmissionStageLauncher struct {
 	token       string
 	client      *http.Client
 	clock       func() time.Time
+	validUntil  time.Time
 	plan        SubmissionStageLaunchPlan
 	runtime     VerifiedSubmissionStageRuntimePrerequisite
 	credentials SubmissionStageCredentialPackageReceipt
@@ -74,16 +78,33 @@ type submissionStageLauncherClientConfig struct {
 	AuthorityIdentity string
 	Client            *http.Client
 	Clock             func() time.Time
+	ValidUntil        time.Time
 }
 
 // OpenKubernetesSubmissionStageLauncher opens one exact management-plane
 // client for one coherent launch. It performs no API request.
 func OpenKubernetesSubmissionStageLauncher(config SubmissionStageLauncherConfig, packaged VerifiedSubmissionStagePackage, credentials VerifiedSubmissionStageCredentialPackage, runtime VerifiedSubmissionStageRuntimePrerequisite) (*KubernetesSubmissionStageLauncher, error) {
-	if _, err := PlanSubmissionStageLaunch(packaged, credentials, runtime); err != nil {
+	plan, err := PlanSubmissionStageLaunch(packaged, credentials, runtime)
+	if err != nil {
 		return nil, err
+	}
+	if err := verifySubmissionStageLaunchCandidate(config.Candidate); err != nil {
+		return nil, err
+	}
+	candidate := config.Candidate.receipt
+	planRaw, err := json.Marshal(plan)
+	if err != nil {
+		return nil, errors.New("encode stage launcher plan identity")
+	}
+	if config.ExpectedCandidateDigest != candidate.CandidateDigest || digest.SHA256(planRaw) != candidate.LaunchPlanDigest || plan.StageID != candidate.StageID || plan.Authority != candidate.Authority || plan.StagePackageDigest != candidate.StagePackageDigest || plan.CredentialPackageDigest != candidate.CredentialPackageDigest || plan.RuntimeManifestDigest != candidate.RuntimeManifestDigest {
+		return nil, errors.New("stage launcher components differ from exact launch candidate")
 	}
 	if config.Authority.AuthorityIdentity == "" || config.Authority.AuthorityIdentity != packaged.installationAuthority {
 		return nil, errors.New("stage launcher authority differs from verified management authority")
+	}
+	endpoint, err := normalizeSubmissionStageLaunchEndpoint(config.Authority.Endpoint)
+	if err != nil || endpoint != config.Candidate.authorityEndpoint || config.Authority.CABundleDigest != candidate.CABundleDigest {
+		return nil, errors.New("stage launcher destination differs from exact launch candidate")
 	}
 	if !stageReceiptPrefixDigestPattern.MatchString(config.Authority.CABundleDigest) {
 		return nil, errors.New("stage launcher CA identity is required")
@@ -92,12 +113,16 @@ func OpenKubernetesSubmissionStageLauncher(config SubmissionStageLauncherConfig,
 	if err != nil {
 		return nil, errors.New("open bounded stage launcher credential")
 	}
-	if digest.SHA256(ca) != config.Authority.CABundleDigest {
-		return nil, errors.New("stage launcher CA differs from bound identity")
+	if digest.SHA256(ca) != config.Authority.CABundleDigest || digest.SHA256([]byte(token)) != config.Candidate.installerTokenDigest {
+		return nil, errors.New("stage launcher credential differs from bound identity")
+	}
+	validUntil, err := time.Parse(time.RFC3339, candidate.ValidUntil)
+	if err != nil {
+		return nil, errors.New("stage launcher candidate validity is invalid")
 	}
 	return newKubernetesSubmissionStageLauncher(submissionStageLauncherClientConfig{
 		Endpoint: config.Authority.Endpoint, BearerToken: token, AuthorityIdentity: config.Authority.AuthorityIdentity,
-		Client: client, Clock: config.Clock,
+		Client: client, Clock: config.Clock, ValidUntil: validUntil,
 	}, packaged, credentials, runtime)
 }
 
@@ -140,7 +165,7 @@ func newKubernetesSubmissionStageLauncher(config submissionStageLauncherClientCo
 	endpoint.Path, endpoint.RawPath = "", ""
 	runtime.raw = append([]byte(nil), runtime.raw...)
 	return &KubernetesSubmissionStageLauncher{
-		endpoint: endpoint, token: config.BearerToken, client: &client, clock: config.Clock,
+		endpoint: endpoint, token: config.BearerToken, client: &client, clock: config.Clock, validUntil: config.ValidUntil,
 		plan: plan, runtime: runtime, credentials: credentialReceipt, secrets: secrets, objects: objects,
 	}, nil
 }
@@ -162,6 +187,9 @@ func (launcher *KubernetesSubmissionStageLauncher) Launch(ctx context.Context) (
 	launcher.mu.Unlock()
 
 	now := launcher.clock().UTC()
+	if !launcher.validUntil.IsZero() && now.After(launcher.validUntil) {
+		return stopSubmissionStageLaunch(receipt, "STOPPED_ZERO_WRITE", errors.New("stage launch candidate validity has expired"))
+	}
 	materializedAt, err := time.Parse(time.RFC3339, launcher.credentials.MaterializedAt)
 	if err != nil || now.Before(materializedAt) {
 		return stopSubmissionStageLaunch(receipt, "STOPPED_ZERO_WRITE", errors.New("stage launch time precedes credential materialization"))


### PR DESCRIPTION
## Summary
- bind the coherent six-object launch to one expiry-bounded candidate digest
- hash the exact destination, CA, launch plan, and installer credential evidence
- require the public launcher opener to verify the candidate before reading its credential

## Validation
- GOCACHE=/private/tmp/ok147-go-build-cache go test -ldflags=-linkmode=external ./...
- GOCACHE=/private/tmp/ok147-go-build-cache go vet ./...
- GOCACHE=/private/tmp/ok147-go-build-cache go test -race -ldflags=-linkmode=external ./internal/runner
- python3 -m unittest discover -s tests -p '*_test.py'
- git diff --check

## Boundary
Candidate preparation is non-mutating. No live credential was opened, no Kubernetes API was contacted, and no live launch was authorized.