### PR TITLE
feat(runner): compose private launch material (OK-147)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,11 @@ Powered by [Cluster API (CAPI)](https://cluster-api.sigs.k8s.io/), [CAPK (KubeVi
   or rollback path. Its public opener additionally requires an exact,
   expiry-bound launch-candidate digest that binds destination, CA and installer
   credential evidence; preparing it remains non-mutating. Live invocation is
-  still a separate critical boundary. The runner image is digest-pinned,
-  multi-architecture, non-root, SBOM- and provenance-producing behind a
-  protected publisher.
+  still a separate critical boundary. A private launch-material builder now
+  correlates all package, credential, runtime and candidate inputs without
+  exposing their bytes or contacting Kubernetes. The runner image is
+  digest-pinned, multi-architecture, non-root, SBOM- and
+  provenance-producing behind a protected publisher.
 
 ---
 

--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -1338,6 +1338,21 @@ before any API request. Preparing this candidate remains non-mutating and is
 not itself permission to launch; it provides the exact digest to which a later
 critical execution approval can be bound.
 
+`BuildSubmissionStageLaunchMaterial` closes the remaining local composition
+gap. One call now rebuilds and verifies the stage package, reads the two
+bounded Job credential sources into the private immutable Secret package,
+binds the tokenless runtime manifest, and prepares the exact launch candidate.
+The returned `ok147-submission-stage-launch-material/v1` receipt contains only
+the correlated digests, stage, authority and validity limit.
+
+The verified material keeps all four private components in memory and exposes
+no bytes accessor. Its `Open` method requires the caller to repeat the exact
+candidate digest and supplies the retained candidate to the public launcher;
+the caller cannot substitute a package or candidate after composition. Local
+composition still performs no Kubernetes request. The installer credential is
+opened only by `Open`, and mutation remains possible only after a separate call
+to the single-use launch operation.
+
 ## Typed first-run Platform capability boundary
 
 First-run capability production now has a separate lazy resolver from the

--- a/internal/runner/submission_stage_launch_material.go
+++ b/internal/runner/submission_stage_launch_material.go
@@ -1,0 +1,126 @@
+package runner
+
+import (
+	"errors"
+	"time"
+)
+
+const SubmissionStageLaunchMaterialFormat = "ok147-submission-stage-launch-material/v1"
+
+type SubmissionStageLaunchMaterialConfig struct {
+	Package               SubmissionStagePackageConfig
+	MaterializationTime   time.Time
+	Ledger                SubmissionStageCredentialSource
+	SelectedAuthority     SubmissionStageCredentialSource
+	RuntimeManifest       []byte
+	RuntimeManifestDigest string
+	Candidate             SubmissionStageLaunchCandidateConfig
+}
+
+type SubmissionStageLaunchMaterialReceipt struct {
+	Format                  string `json:"format"`
+	State                   string `json:"state"`
+	StageID                 string `json:"stageId"`
+	Authority               string `json:"authority"`
+	StagePackageDigest      string `json:"stagePackageDigest"`
+	CredentialPackageDigest string `json:"credentialPackageDigest"`
+	RuntimeManifestDigest   string `json:"runtimeManifestDigest"`
+	LaunchPlanDigest        string `json:"launchPlanDigest"`
+	CandidateDigest         string `json:"candidateDigest"`
+	ValidUntil              string `json:"validUntil"`
+	MutationAllowed         bool   `json:"mutationAllowed"`
+}
+
+type VerifiedSubmissionStageLaunchMaterial struct {
+	packaged    VerifiedSubmissionStagePackage
+	credentials VerifiedSubmissionStageCredentialPackage
+	runtime     VerifiedSubmissionStageRuntimePrerequisite
+	candidate   VerifiedSubmissionStageLaunchCandidate
+	receipt     SubmissionStageLaunchMaterialReceipt
+	verified    bool
+}
+
+type SubmissionStageLaunchOpenConfig struct {
+	Authority               KubernetesAuthorityConfig
+	Clock                   func() time.Time
+	ExpectedCandidateDigest string
+}
+
+// BuildSubmissionStageLaunchMaterial constructs the complete private launch
+// input from independently bound sources. It opens only bounded local source
+// files and performs no Kubernetes request.
+func BuildSubmissionStageLaunchMaterial(config SubmissionStageLaunchMaterialConfig) (VerifiedSubmissionStageLaunchMaterial, error) {
+	packaged, err := BuildSubmissionStagePackage(config.Package)
+	if err != nil {
+		return VerifiedSubmissionStageLaunchMaterial{}, err
+	}
+	credentials, err := BuildSubmissionStageCredentialPackage(SubmissionStageCredentialPackageConfig{
+		Package: packaged, MaterializationTime: config.MaterializationTime,
+		Ledger: config.Ledger, SelectedAuthority: config.SelectedAuthority,
+	})
+	if err != nil {
+		return VerifiedSubmissionStageLaunchMaterial{}, err
+	}
+	runtime, err := BuildSubmissionStageRuntimePrerequisite(packaged, config.RuntimeManifest, config.RuntimeManifestDigest)
+	if err != nil {
+		return VerifiedSubmissionStageLaunchMaterial{}, err
+	}
+	candidate, err := PrepareSubmissionStageLaunchCandidate(config.Candidate, packaged, credentials, runtime)
+	if err != nil {
+		return VerifiedSubmissionStageLaunchMaterial{}, err
+	}
+	candidateReceipt, err := candidate.Receipt()
+	if err != nil {
+		return VerifiedSubmissionStageLaunchMaterial{}, err
+	}
+	receipt := SubmissionStageLaunchMaterialReceipt{
+		Format: SubmissionStageLaunchMaterialFormat, State: "VERIFIED", StageID: candidateReceipt.StageID,
+		Authority: candidateReceipt.Authority, StagePackageDigest: candidateReceipt.StagePackageDigest,
+		CredentialPackageDigest: candidateReceipt.CredentialPackageDigest, RuntimeManifestDigest: candidateReceipt.RuntimeManifestDigest,
+		LaunchPlanDigest: candidateReceipt.LaunchPlanDigest, CandidateDigest: candidateReceipt.CandidateDigest,
+		ValidUntil: candidateReceipt.ValidUntil, MutationAllowed: false,
+	}
+	return VerifiedSubmissionStageLaunchMaterial{
+		packaged: packaged, credentials: credentials, runtime: runtime, candidate: candidate, receipt: receipt, verified: true,
+	}, nil
+}
+
+func (material VerifiedSubmissionStageLaunchMaterial) Receipt() (SubmissionStageLaunchMaterialReceipt, error) {
+	if err := verifySubmissionStageLaunchMaterial(material); err != nil {
+		return SubmissionStageLaunchMaterialReceipt{}, err
+	}
+	return material.receipt, nil
+}
+
+// Open requires the caller to repeat the exact candidate digest but does not
+// allow it to replace any verified package or candidate component.
+func (material VerifiedSubmissionStageLaunchMaterial) Open(config SubmissionStageLaunchOpenConfig) (*KubernetesSubmissionStageLauncher, error) {
+	if err := verifySubmissionStageLaunchMaterial(material); err != nil {
+		return nil, err
+	}
+	if config.ExpectedCandidateDigest == "" || config.ExpectedCandidateDigest != material.receipt.CandidateDigest {
+		return nil, errors.New("stage launch open requires the exact candidate digest")
+	}
+	return OpenKubernetesSubmissionStageLauncher(SubmissionStageLauncherConfig{
+		Authority: config.Authority, Clock: config.Clock, Candidate: material.candidate,
+		ExpectedCandidateDigest: config.ExpectedCandidateDigest,
+	}, material.packaged, material.credentials, material.runtime)
+}
+
+func verifySubmissionStageLaunchMaterial(material VerifiedSubmissionStageLaunchMaterial) error {
+	if !material.verified || material.receipt.Format != SubmissionStageLaunchMaterialFormat || material.receipt.State != "VERIFIED" || material.receipt.MutationAllowed {
+		return errors.New("stage launch material was not produced by verification")
+	}
+	plan, err := PlanSubmissionStageLaunch(material.packaged, material.credentials, material.runtime)
+	if err != nil {
+		return err
+	}
+	candidateReceipt, err := material.candidate.Receipt()
+	if err != nil {
+		return err
+	}
+	if material.receipt.StageID != plan.StageID || material.receipt.Authority != plan.Authority || material.receipt.StagePackageDigest != plan.StagePackageDigest || material.receipt.CredentialPackageDigest != plan.CredentialPackageDigest || material.receipt.RuntimeManifestDigest != plan.RuntimeManifestDigest || material.receipt.StageID != candidateReceipt.StageID || material.receipt.Authority != candidateReceipt.Authority || material.receipt.StagePackageDigest != candidateReceipt.StagePackageDigest || material.receipt.CredentialPackageDigest != candidateReceipt.CredentialPackageDigest || material.receipt.RuntimeManifestDigest != candidateReceipt.RuntimeManifestDigest || material.receipt.LaunchPlanDigest != candidateReceipt.LaunchPlanDigest || material.receipt.CandidateDigest != candidateReceipt.CandidateDigest || material.receipt.ValidUntil != candidateReceipt.ValidUntil {
+		return errors.New("stage launch material identity changed after verification")
+	}
+	return nil
+}

--- a/internal/runner/submission_stage_launch_material_test.go
+++ b/internal/runner/submission_stage_launch_material_test.go
@@ -1,0 +1,123 @@
+package runner
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+func TestBuildSubmissionStageLaunchMaterialProducesOneRedactedIdentity(t *testing.T) {
+	config, installerToken, ledgerToken, authorityToken := submissionStageLaunchMaterialConfig(t)
+	material, err := BuildSubmissionStageLaunchMaterial(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := material.Receipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	again, err := BuildSubmissionStageLaunchMaterial(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	againReceipt, _ := again.Receipt()
+	if receipt.Format != SubmissionStageLaunchMaterialFormat || receipt.State != "VERIFIED" || receipt.StageID != "provider-prerequisites" || receipt.Authority != "ok-mgmt" || receipt.ValidUntil != "2026-08-16T12:15:00Z" || receipt.MutationAllowed || receipt.CandidateDigest != againReceipt.CandidateDigest {
+		t.Fatalf("launch material identity differs: %#v", receipt)
+	}
+	for _, value := range []string{receipt.StagePackageDigest, receipt.CredentialPackageDigest, receipt.RuntimeManifestDigest, receipt.LaunchPlanDigest, receipt.CandidateDigest} {
+		if !stageReceiptPrefixDigestPattern.MatchString(value) {
+			t.Fatalf("launch material digest is invalid: %q", value)
+		}
+	}
+	public, err := json.Marshal(receipt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range [][]byte{
+		installerToken, ledgerToken, authorityToken, config.RuntimeManifest, config.Package.JobTemplate,
+		[]byte(config.Ledger.TokenFile), []byte(config.Ledger.CAFile), []byte(config.Candidate.AuthorityEndpoint), []byte(config.Candidate.InstallerTokenDigest),
+	} {
+		if bytes.Contains(public, forbidden) {
+			t.Fatal("launch material receipt exposed private source content")
+		}
+	}
+
+	tampered := material
+	tampered.receipt.CandidateDigest = digest.SHA256([]byte("foreign-candidate"))
+	if _, err := tampered.Receipt(); err == nil {
+		t.Fatal("changed launch material identity was accepted")
+	}
+}
+
+func TestSubmissionStageLaunchMaterialOpensOnlyExactCandidate(t *testing.T) {
+	config, installerToken, _, _ := submissionStageLaunchMaterialConfig(t)
+	material, err := BuildSubmissionStageLaunchMaterial(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, _ := material.Receipt()
+	root := t.TempDir()
+	tokenPath := filepath.Join(root, "installer-token")
+	if err := os.WriteFile(tokenPath, installerToken, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	openConfig := SubmissionStageLaunchOpenConfig{
+		Authority: KubernetesAuthorityConfig{
+			Endpoint: config.Candidate.AuthorityEndpoint, AuthorityIdentity: "ok-mgmt", TokenFile: tokenPath,
+			CAFile: config.Ledger.CAFile, CABundleDigest: config.Candidate.CABundleDigest,
+		},
+		Clock: func() time.Time { return time.Date(2026, 8, 16, 12, 16, 0, 0, time.UTC) }, ExpectedCandidateDigest: receipt.CandidateDigest,
+	}
+	launcher, err := material.Open(openConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	launchReceipt, err := launcher.Launch(context.Background())
+	if err == nil || launchReceipt.State != "STOPPED_ZERO_WRITE" || launchReceipt.MutationState != "NOT_ATTEMPTED" {
+		t.Fatalf("expired material reached API: %#v %v", launchReceipt, err)
+	}
+
+	openConfig.ExpectedCandidateDigest = digest.SHA256([]byte("wrong-candidate"))
+	if _, err := material.Open(openConfig); err == nil {
+		t.Fatal("wrong explicit candidate digest was accepted")
+	}
+}
+
+func TestBuildSubmissionStageLaunchMaterialRejectsChangedSources(t *testing.T) {
+	config, _, _, _ := submissionStageLaunchMaterialConfig(t)
+	config.RuntimeManifestDigest = digest.SHA256([]byte("other-runtime"))
+	if _, err := BuildSubmissionStageLaunchMaterial(config); err == nil {
+		t.Fatal("changed runtime source was accepted")
+	}
+
+	config, _, _, _ = submissionStageLaunchMaterialConfig(t)
+	config.Candidate.PreparedAt = time.Date(2026, 8, 16, 12, 16, 0, 0, time.UTC)
+	if _, err := BuildSubmissionStageLaunchMaterial(config); err == nil {
+		t.Fatal("expired candidate input was accepted")
+	}
+}
+
+func submissionStageLaunchMaterialConfig(t *testing.T) (SubmissionStageLaunchMaterialConfig, []byte, []byte, []byte) {
+	t.Helper()
+	credentialConfig, ledgerToken, authorityToken := submissionStageCredentialConfig(t)
+	fixture := submissionBundleFixture(t, false, "")
+	packageConfig := submissionStagePackageConfig(t, fixture, "provider-prerequisites")
+	runtimeManifest := submissionStageRuntimeManifest(t)
+	installerToken := []byte("material-installer-token-v1")
+	return SubmissionStageLaunchMaterialConfig{
+		Package: packageConfig, MaterializationTime: credentialConfig.MaterializationTime,
+		Ledger: credentialConfig.Ledger, SelectedAuthority: credentialConfig.SelectedAuthority,
+		RuntimeManifest: runtimeManifest, RuntimeManifestDigest: digest.SHA256(runtimeManifest),
+		Candidate: SubmissionStageLaunchCandidateConfig{
+			AuthorityEndpoint: "https://192.0.2.10:6443", CABundleDigest: credentialConfig.Ledger.CABundleDigest,
+			InstallerTokenDigest: digest.SHA256(installerToken), InstallerCredentialEvidenceDigest: digest.SHA256([]byte("material-installer-evidence")),
+			PreparedAt: time.Date(2026, 8, 16, 12, 1, 0, 0, time.UTC),
+		},
+	}, installerToken, ledgerToken, authorityToken
+}


### PR DESCRIPTION
## Summary
- compose stage package, Job credentials, tokenless runtime, and exact candidate as one verified private value
- expose only a redaction-safe correlated receipt
- require the exact candidate digest when opening the retained material

## Validation
- GOCACHE=/private/tmp/ok147-go-build-cache go test -ldflags=-linkmode=external ./...
- GOCACHE=/private/tmp/ok147-go-build-cache go vet ./...
- GOCACHE=/private/tmp/ok147-go-build-cache go test -race -ldflags=-linkmode=external ./internal/runner
- python3 -m unittest discover -s tests -p '*_test.py'
- git diff --check

## Boundary
Composition reads only bounded local credential sources. It performs no Kubernetes request and does not authorize a live launch.