### PR TITLE
feat(cli): prepare exact stage launch candidate (OK-147)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,10 @@ Powered by [Cluster API (CAPI)](https://cluster-api.sigs.k8s.io/), [CAPK (KubeVi
   credential evidence; preparing it remains non-mutating. Live invocation is
   still a separate critical boundary. A private launch-material builder now
   correlates all package, credential, runtime and candidate inputs without
-  exposing their bytes or contacting Kubernetes. The runner image is
-  digest-pinned, multi-architecture, non-root, SBOM- and
-  provenance-producing behind a protected publisher.
+  exposing their bytes or contacting Kubernetes. `ok cluster stage launch
+  prepare` exposes only the redacted material/candidate receipts and rejects
+  execution. The runner image is digest-pinned, multi-architecture, non-root,
+  SBOM- and provenance-producing behind a protected publisher.
 
 ---
 

--- a/cmd/ok/main.go
+++ b/cmd/ok/main.go
@@ -49,6 +49,25 @@ var materializeSubmissionStagePackage = func(config runner.SubmissionStagePackag
 	return raw, receipt, err
 }
 
+var prepareSubmissionStageLaunch = func(config runner.SubmissionStageLaunchMaterialConfig) (stageLaunchPreparation, error) {
+	material, err := runner.BuildSubmissionStageLaunchMaterial(config)
+	if err != nil {
+		return stageLaunchPreparation{}, err
+	}
+	materialReceipt, err := material.Receipt()
+	if err != nil {
+		return stageLaunchPreparation{}, err
+	}
+	candidateReceipt, err := material.CandidateReceipt()
+	if err != nil {
+		return stageLaunchPreparation{}, err
+	}
+	return stageLaunchPreparation{
+		Format: "ok147-submission-stage-launch-preparation/v1", State: "PREPARED",
+		Material: materialReceipt, Candidate: candidateReceipt, MutationAllowed: false,
+	}, nil
+}
+
 type createPlan struct {
 	Format                  string                  `json:"format"`
 	Operation               string                  `json:"operation"`
@@ -70,6 +89,14 @@ type stageInspection struct {
 	Decision           stagecursor.Decision `json:"decision"`
 	AuthorizationState string               `json:"authorizationState"`
 	MutationAllowed    bool                 `json:"mutationAllowed"`
+}
+
+type stageLaunchPreparation struct {
+	Format          string                                       `json:"format"`
+	State           string                                       `json:"state"`
+	Material        runner.SubmissionStageLaunchMaterialReceipt  `json:"material"`
+	Candidate       runner.SubmissionStageLaunchCandidateReceipt `json:"candidate"`
+	MutationAllowed bool                                         `json:"mutationAllowed"`
 }
 
 type receiptFlags []string
@@ -248,7 +275,10 @@ func runContext(ctx context.Context, arguments []string, stdout, stderr io.Write
 	if len(arguments) >= 3 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "package" {
 		return runClusterStagePackage(arguments[3:], stdout, stderr)
 	}
-	return errors.New("usage: ok cluster create ... | ok cluster stage inspect ... | ok cluster stage run ... | ok cluster stage package ...")
+	if len(arguments) >= 4 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "launch" && arguments[3] == "prepare" {
+		return runClusterStageLaunchPrepare(arguments[4:], stdout, stderr)
+	}
+	return errors.New("usage: ok cluster create ... | ok cluster stage inspect ... | ok cluster stage run ... | ok cluster stage package ... | ok cluster stage launch prepare ...")
 }
 
 func runClusterCreate(arguments []string, stdout, stderr io.Writer) error {
@@ -517,6 +547,160 @@ func runClusterStagePackage(arguments []string, stdout, stderr io.Writer) error 
 	encoder.SetEscapeHTML(false)
 	encoder.SetIndent("", "  ")
 	return encoder.Encode(receipt)
+}
+
+type stageLaunchCredentialFlags struct {
+	authority, tokenFile, tokenDigest, caFile, caDigest, evidenceDigest *string
+	issuer, subject, audiences, issuedAt, expiresAt                     *string
+}
+
+func addStageLaunchCredentialFlags(flags *flag.FlagSet, prefix, description string) *stageLaunchCredentialFlags {
+	values := &stageLaunchCredentialFlags{}
+	values.authority = flags.String(prefix+"-authority", "", description+" authority identity")
+	values.tokenFile = flags.String(prefix+"-token-file", "", description+" bounded token file")
+	values.tokenDigest = flags.String(prefix+"-token-digest", "", description+" expected token digest")
+	values.caFile = flags.String(prefix+"-ca-file", "", description+" bounded CA file")
+	values.caDigest = flags.String(prefix+"-ca-digest", "", description+" expected CA digest")
+	values.evidenceDigest = flags.String(prefix+"-tokenrequest-evidence-digest", "", description+" TokenRequest evidence digest")
+	values.issuer = flags.String(prefix+"-issuer", "", description+" expected token issuer")
+	values.subject = flags.String(prefix+"-subject", "", description+" expected ServiceAccount subject")
+	values.audiences = flags.String(prefix+"-audiences", "", description+" comma-separated exact token audiences")
+	values.issuedAt = flags.String(prefix+"-issued-at", "", description+" exact token issued-at time")
+	values.expiresAt = flags.String(prefix+"-expires-at", "", description+" exact token expiration time")
+	return values
+}
+
+func (values *stageLaunchCredentialFlags) source(prefix string) (runner.SubmissionStageCredentialSource, error) {
+	required := []struct{ name, value string }{
+		{"--" + prefix + "-authority", *values.authority}, {"--" + prefix + "-token-file", *values.tokenFile},
+		{"--" + prefix + "-token-digest", *values.tokenDigest}, {"--" + prefix + "-ca-file", *values.caFile},
+		{"--" + prefix + "-ca-digest", *values.caDigest}, {"--" + prefix + "-tokenrequest-evidence-digest", *values.evidenceDigest},
+		{"--" + prefix + "-issuer", *values.issuer}, {"--" + prefix + "-subject", *values.subject},
+		{"--" + prefix + "-audiences", *values.audiences}, {"--" + prefix + "-issued-at", *values.issuedAt},
+		{"--" + prefix + "-expires-at", *values.expiresAt},
+	}
+	for _, input := range required {
+		if input.value == "" {
+			return runner.SubmissionStageCredentialSource{}, fmt.Errorf("%s is required", input.name)
+		}
+	}
+	issuedAt, err := time.Parse(time.RFC3339, *values.issuedAt)
+	if err != nil {
+		return runner.SubmissionStageCredentialSource{}, fmt.Errorf("parse %s issued-at: %w", prefix, err)
+	}
+	expiresAt, err := time.Parse(time.RFC3339, *values.expiresAt)
+	if err != nil {
+		return runner.SubmissionStageCredentialSource{}, fmt.Errorf("parse %s expires-at: %w", prefix, err)
+	}
+	audiences := strings.Split(*values.audiences, ",")
+	for _, audience := range audiences {
+		if audience == "" || strings.TrimSpace(audience) != audience {
+			return runner.SubmissionStageCredentialSource{}, fmt.Errorf("--%s-audiences must contain exact non-empty values", prefix)
+		}
+	}
+	return runner.SubmissionStageCredentialSource{
+		AuthorityIdentity: *values.authority, TokenFile: *values.tokenFile, TokenDigest: *values.tokenDigest,
+		CAFile: *values.caFile, CABundleDigest: *values.caDigest, TokenRequestEvidenceDigest: *values.evidenceDigest,
+		ExpectedIssuer: *values.issuer, ExpectedSubject: *values.subject, ExpectedAudiences: audiences,
+		IssuedAt: issuedAt, ExpiresAt: expiresAt,
+	}, nil
+}
+
+func runClusterStageLaunchPrepare(arguments []string, stdout, stderr io.Writer) error {
+	flags := flag.NewFlagSet("ok cluster stage launch prepare", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	bundleFlags := addStageBundleFlags(flags)
+	jobTemplate := flags.String("job-template", "", "path to the bounded submission-stage Job template")
+	jobTemplateDigest := flags.String("job-template-digest", "", "expected SHA-256 identity of the Job template")
+	runID := flags.String("run-id", "", "bounded OK-147 Job identity")
+	imageDigest := flags.String("image", "", "digest-pinned ok image")
+	inputConfigMap := flags.String("input-configmap", "", "immutable input ConfigMap name")
+	ledgerAPIURL := flags.String("ledger-api-url", "", "exact management-ledger HTTPS IP endpoint")
+	ledgerAPICIDR := flags.String("ledger-api-cidr", "", "single-address management-ledger CIDR")
+	ledgerCredentialSecret := flags.String("ledger-credential-secret", "", "ledger credential Secret name")
+	authorityAPIURL := flags.String("authority-api-url", "", "exact selected-authority HTTPS IP endpoint")
+	authorityAPICIDR := flags.String("authority-api-cidr", "", "single-address selected-authority CIDR")
+	authorityCredentialSecret := flags.String("authority-credential-secret", "", "authority credential Secret name")
+	materializedAt := flags.String("credential-materialized-at", "", "exact credential materialization time")
+	ledgerCredential := addStageLaunchCredentialFlags(flags, "ledger-job", "ledger Job credential")
+	authorityCredential := addStageLaunchCredentialFlags(flags, "authority-job", "selected-authority Job credential")
+	runtimeManifest := flags.String("runtime-manifest", "", "path to the tokenless runtime ServiceAccount manifest")
+	runtimeManifestDigest := flags.String("runtime-manifest-digest", "", "expected runtime manifest digest")
+	installerAPIEndpoint := flags.String("installer-api-endpoint", "", "exact management installer HTTPS IP endpoint")
+	installerCADigest := flags.String("installer-ca-digest", "", "expected management installer CA digest")
+	installerTokenDigest := flags.String("installer-token-digest", "", "private expected management installer token digest")
+	installerEvidenceDigest := flags.String("installer-tokenrequest-evidence-digest", "", "management installer TokenRequest evidence digest")
+	preparedAt := flags.String("prepared-at", "", "exact launch candidate preparation time")
+	if err := flags.Parse(arguments); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return errors.New("positional arguments are not accepted")
+	}
+	bundleConfig, err := bundleFlags.config()
+	if err != nil {
+		return err
+	}
+	for _, input := range []struct{ name, value string }{
+		{"--job-template", *jobTemplate}, {"--job-template-digest", *jobTemplateDigest}, {"--run-id", *runID}, {"--image", *imageDigest},
+		{"--input-configmap", *inputConfigMap}, {"--ledger-api-url", *ledgerAPIURL}, {"--ledger-api-cidr", *ledgerAPICIDR},
+		{"--ledger-credential-secret", *ledgerCredentialSecret}, {"--authority-api-url", *authorityAPIURL},
+		{"--authority-api-cidr", *authorityAPICIDR}, {"--authority-credential-secret", *authorityCredentialSecret},
+		{"--credential-materialized-at", *materializedAt}, {"--runtime-manifest", *runtimeManifest},
+		{"--runtime-manifest-digest", *runtimeManifestDigest}, {"--installer-api-endpoint", *installerAPIEndpoint},
+		{"--installer-ca-digest", *installerCADigest}, {"--installer-token-digest", *installerTokenDigest},
+		{"--installer-tokenrequest-evidence-digest", *installerEvidenceDigest}, {"--prepared-at", *preparedAt},
+	} {
+		if input.value == "" {
+			return fmt.Errorf("%s is required", input.name)
+		}
+	}
+	materializationTime, err := time.Parse(time.RFC3339, *materializedAt)
+	if err != nil {
+		return fmt.Errorf("parse credential materialization time: %w", err)
+	}
+	candidateTime, err := time.Parse(time.RFC3339, *preparedAt)
+	if err != nil {
+		return fmt.Errorf("parse candidate preparation time: %w", err)
+	}
+	ledgerSource, err := ledgerCredential.source("ledger-job")
+	if err != nil {
+		return err
+	}
+	authoritySource, err := authorityCredential.source("authority-job")
+	if err != nil {
+		return err
+	}
+	template, err := readBoundedLocalFile(*jobTemplate, 1024*1024)
+	if err != nil {
+		return fmt.Errorf("read Job template: %w", err)
+	}
+	runtimeRaw, err := readBoundedLocalFile(*runtimeManifest, 128*1024)
+	if err != nil {
+		return fmt.Errorf("read runtime manifest: %w", err)
+	}
+	preparation, err := prepareSubmissionStageLaunch(runner.SubmissionStageLaunchMaterialConfig{
+		Package: runner.SubmissionStagePackageConfig{
+			Bundle: bundleConfig, JobTemplate: template, JobTemplateDigest: *jobTemplateDigest,
+			RunID: *runID, ImageDigest: *imageDigest, InputConfigMap: *inputConfigMap,
+			LedgerAPIURL: *ledgerAPIURL, LedgerAPICIDR: *ledgerAPICIDR, LedgerCredentialSecret: *ledgerCredentialSecret,
+			AuthorityAPIURL: *authorityAPIURL, AuthorityAPICIDR: *authorityAPICIDR, AuthorityCredentialSecret: *authorityCredentialSecret,
+		},
+		MaterializationTime: materializationTime, Ledger: ledgerSource, SelectedAuthority: authoritySource,
+		RuntimeManifest: runtimeRaw, RuntimeManifestDigest: *runtimeManifestDigest,
+		Candidate: runner.SubmissionStageLaunchCandidateConfig{
+			AuthorityEndpoint: *installerAPIEndpoint, CABundleDigest: *installerCADigest,
+			InstallerTokenDigest: *installerTokenDigest, InstallerCredentialEvidenceDigest: *installerEvidenceDigest,
+			PreparedAt: candidateTime,
+		},
+	})
+	if err != nil {
+		return err
+	}
+	encoder := json.NewEncoder(stdout)
+	encoder.SetEscapeHTML(false)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(preparation)
 }
 
 func readBoundedLocalFile(path string, maximum int64) ([]byte, error) {

--- a/cmd/ok/main_test.go
+++ b/cmd/ok/main_test.go
@@ -343,6 +343,89 @@ func TestStagePackageRejectsIncompleteAndSymlinkTemplate(t *testing.T) {
 	}
 }
 
+func TestStageLaunchPrepareBuildsOneNonMutatingCandidate(t *testing.T) {
+	previous := prepareSubmissionStageLaunch
+	defer func() { prepareSubmissionStageLaunch = previous }()
+	var captured runner.SubmissionStageLaunchMaterialConfig
+	prepareSubmissionStageLaunch = func(config runner.SubmissionStageLaunchMaterialConfig) (stageLaunchPreparation, error) {
+		captured = config
+		return stageLaunchPreparation{
+			Format: "ok147-submission-stage-launch-preparation/v1", State: "PREPARED",
+			Material: runner.SubmissionStageLaunchMaterialReceipt{
+				Format: runner.SubmissionStageLaunchMaterialFormat, State: "VERIFIED", StageID: "provider-prerequisites",
+				Authority: "ok-mgmt", CandidateDigest: testSHA("1"), MutationAllowed: false,
+			},
+			Candidate: runner.SubmissionStageLaunchCandidateReceipt{
+				Format: runner.SubmissionStageLaunchCandidateFormat, State: "PREPARED", CandidateDigest: testSHA("1"), MutationAllowed: false,
+			},
+			MutationAllowed: false,
+		}, nil
+	}
+	root := t.TempDir()
+	template := filepath.Join(root, "job.yaml.tpl")
+	runtimeManifest := filepath.Join(root, "runtime.yaml")
+	if err := os.WriteFile(template, []byte("bounded-template"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(runtimeManifest, []byte("bounded-runtime"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	arguments := stageLaunchPrepareArguments(template, runtimeManifest)
+	var stdout, stderr bytes.Buffer
+	if err := run(arguments, &stdout, &stderr); err != nil {
+		t.Fatalf("run: %v; stderr=%s", err, stderr.String())
+	}
+	if captured.Package.Bundle.ExpectedStageID != "provider-prerequisites" || captured.Package.RunID != "ok147-provider-20260816-01" || captured.Package.InputConfigMap != "ok147-provider-input" || string(captured.Package.JobTemplate) != "bounded-template" || string(captured.RuntimeManifest) != "bounded-runtime" {
+		t.Fatalf("launch package/runtime input differs: %#v", captured)
+	}
+	if captured.Ledger.AuthorityIdentity != "ok-mgmt" || captured.SelectedAuthority.AuthorityIdentity != "ok-infra" || captured.Ledger.TokenFile != "/private/tmp/ledger-job-token" || captured.SelectedAuthority.TokenFile != "/private/tmp/authority-job-token" || len(captured.Ledger.ExpectedAudiences) != 1 || captured.Ledger.ExpectedAudiences[0] != "https://kubernetes.default.svc" {
+		t.Fatalf("launch credential input differs: %#v %#v", captured.Ledger, captured.SelectedAuthority)
+	}
+	if captured.Candidate.AuthorityEndpoint != "https://192.0.2.12:6443" || captured.Candidate.InstallerTokenDigest != testSHA("7") || captured.Candidate.PreparedAt.Format(time.RFC3339) != "2026-08-16T12:01:00Z" {
+		t.Fatalf("launch candidate input differs: %#v", captured.Candidate)
+	}
+	var preparation stageLaunchPreparation
+	if err := json.Unmarshal(stdout.Bytes(), &preparation); err != nil {
+		t.Fatal(err)
+	}
+	if preparation.Format != "ok147-submission-stage-launch-preparation/v1" || preparation.State != "PREPARED" || preparation.MutationAllowed || preparation.Material.MutationAllowed || preparation.Candidate.MutationAllowed {
+		t.Fatalf("unsafe launch preparation: %#v", preparation)
+	}
+}
+
+func TestStageLaunchPrepareRejectsExecuteIncompleteAndSymlinkInputs(t *testing.T) {
+	root := t.TempDir()
+	template := filepath.Join(root, "job.yaml.tpl")
+	runtimeManifest := filepath.Join(root, "runtime.yaml")
+	if err := os.WriteFile(template, []byte("bounded-template"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(runtimeManifest, []byte("bounded-runtime"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	valid := stageLaunchPrepareArguments(template, runtimeManifest)
+	for name, arguments := range map[string][]string{
+		"execute flag":             append(append([]string(nil), valid...), "--execute"),
+		"missing installer digest": removeArgumentWithValue(valid, "--installer-token-digest"),
+		"spaced audience":          replaceArgument(valid, "--ledger-job-audiences", "https://kubernetes.default.svc, other"),
+	} {
+		t.Run(name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			if err := run(arguments, &stdout, &stderr); err == nil || stdout.Len() != 0 {
+				t.Fatal("unsafe launch preparation input was accepted")
+			}
+		})
+	}
+	runtimeLink := filepath.Join(root, "runtime-link.yaml")
+	if err := os.Symlink(runtimeManifest, runtimeLink); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	if err := run(stageLaunchPrepareArguments(template, runtimeLink), &stdout, &stderr); err == nil || stdout.Len() != 0 {
+		t.Fatal("symlink runtime manifest was accepted")
+	}
+}
+
 func stageInspectArguments() []string {
 	return []string{
 		"cluster", "stage", "inspect",
@@ -375,6 +458,39 @@ func stagePackageArguments(template, output string) []string {
 		"--input-configmap", "ok147-provider-input",
 		"--ledger-api-url", "https://192.0.2.12:6443", "--ledger-api-cidr", "192.0.2.12/32", "--ledger-credential-secret", "ok147-ledger-credential",
 		"--authority-api-url", "https://192.0.2.11:6443", "--authority-api-cidr", "192.0.2.11/32", "--authority-credential-secret", "ok147-authority-credential",
+	)
+}
+
+func stageLaunchPrepareArguments(template, runtimeManifest string) []string {
+	bundle := stageInspectArguments()
+	arguments := append([]string{"cluster", "stage", "launch", "prepare"}, bundle[3:]...)
+	arguments = append(arguments,
+		"--job-template", template, "--job-template-digest", digest.SHA256([]byte("bounded-template")),
+		"--run-id", "ok147-provider-20260816-01", "--image", "ghcr.io/openkubes/ok-cluster@"+testSHA("a"),
+		"--input-configmap", "ok147-provider-input",
+		"--ledger-api-url", "https://192.0.2.12:6443", "--ledger-api-cidr", "192.0.2.12/32", "--ledger-credential-secret", "ok147-ledger-credential",
+		"--authority-api-url", "https://192.0.2.11:6443", "--authority-api-cidr", "192.0.2.11/32", "--authority-credential-secret", "ok147-authority-credential",
+		"--credential-materialized-at", "2026-08-16T12:00:00Z",
+	)
+	for _, credential := range []struct{ prefix, authority, tokenFile, tokenDigest, caFile, caDigest, evidence, subject string }{
+		{"ledger-job", "ok-mgmt", "/private/tmp/ledger-job-token", testSHA("1"), "/private/tmp/ledger-job-ca", testSHA("2"), testSHA("3"), "system:serviceaccount:openkubes-execution-system:ok147-ledger-writer"},
+		{"authority-job", "ok-infra", "/private/tmp/authority-job-token", testSHA("4"), "/private/tmp/authority-job-ca", testSHA("5"), testSHA("6"), "system:serviceaccount:openkubes-execution-system:ok147-provider-writer"},
+	} {
+		arguments = append(arguments,
+			"--"+credential.prefix+"-authority", credential.authority,
+			"--"+credential.prefix+"-token-file", credential.tokenFile, "--"+credential.prefix+"-token-digest", credential.tokenDigest,
+			"--"+credential.prefix+"-ca-file", credential.caFile, "--"+credential.prefix+"-ca-digest", credential.caDigest,
+			"--"+credential.prefix+"-tokenrequest-evidence-digest", credential.evidence,
+			"--"+credential.prefix+"-issuer", "https://kubernetes.default.svc.cluster.local", "--"+credential.prefix+"-subject", credential.subject,
+			"--"+credential.prefix+"-audiences", "https://kubernetes.default.svc",
+			"--"+credential.prefix+"-issued-at", "2026-08-16T11:59:00Z", "--"+credential.prefix+"-expires-at", "2026-08-16T12:30:00Z",
+		)
+	}
+	return append(arguments,
+		"--runtime-manifest", runtimeManifest, "--runtime-manifest-digest", digest.SHA256([]byte("bounded-runtime")),
+		"--installer-api-endpoint", "https://192.0.2.12:6443", "--installer-ca-digest", testSHA("2"),
+		"--installer-token-digest", testSHA("7"), "--installer-tokenrequest-evidence-digest", testSHA("8"),
+		"--prepared-at", "2026-08-16T12:01:00Z",
 	)
 }
 

--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -1353,6 +1353,30 @@ composition still performs no Kubernetes request. The installer credential is
 opened only by `Open`, and mutation remains possible only after a separate call
 to the single-use launch operation.
 
+The local CLI exposes only this preparation boundary:
+
+```text
+ok cluster stage launch prepare
+  + verified stage-bundle flags
+  + package/template identities
+  + two bounded Job credential-source identities
+  + tokenless runtime manifest identity
+  + installer endpoint, CA, token and TokenRequest-evidence digests
+  + exact materialization/preparation times
+```
+
+It emits `ok147-submission-stage-launch-preparation/v1`, containing the
+redaction-safe material and candidate receipts. Credential files, endpoint,
+token digest, manifest bodies and local source paths are not emitted. Every
+input is explicit; audiences use an exact comma-separated set and bounded
+template/runtime files must be regular non-symlink files.
+
+There is deliberately no execute flag on this command. `--execute` is rejected
+as an unknown option, no installer token file is opened, and no Kubernetes
+client is constructed. A future execution command must rebuild the same
+material, require the exact emitted candidate digest and retain a separate
+critical live-authorization boundary.
+
 ## Typed first-run Platform capability boundary
 
 First-run capability production now has a separate lazy resolver from the

--- a/internal/runner/submission_stage_launch_material.go
+++ b/internal/runner/submission_stage_launch_material.go
@@ -92,6 +92,15 @@ func (material VerifiedSubmissionStageLaunchMaterial) Receipt() (SubmissionStage
 	return material.receipt, nil
 }
 
+// CandidateReceipt exposes only the redaction-safe exact approval identity.
+// Private launch material remains inaccessible to the caller.
+func (material VerifiedSubmissionStageLaunchMaterial) CandidateReceipt() (SubmissionStageLaunchCandidateReceipt, error) {
+	if err := verifySubmissionStageLaunchMaterial(material); err != nil {
+		return SubmissionStageLaunchCandidateReceipt{}, err
+	}
+	return material.candidate.Receipt()
+}
+
 // Open requires the caller to repeat the exact candidate digest but does not
 // allow it to replace any verified package or candidate component.
 func (material VerifiedSubmissionStageLaunchMaterial) Open(config SubmissionStageLaunchOpenConfig) (*KubernetesSubmissionStageLauncher, error) {


### PR DESCRIPTION
## What changed

- add `ok cluster stage launch prepare` to compose the verified submission-stage package, two bounded Job credentials, tokenless runtime prerequisite and exact launch candidate
- emit only redaction-safe material and candidate receipts
- reject `--execute`, incomplete identities, malformed audience sets and symlinked bounded inputs
- expose the verified candidate receipt without exposing private launch material

## Why

OK-147 needs a command-line preparation boundary that produces the exact digest a later live authorization can bind, while remaining unable to contact or mutate Kubernetes.

## Safety boundary

- no installer token file is opened
- no Kubernetes client is constructed
- no endpoint, token, local path or manifest body is emitted
- live execution remains a separate future command and authorization boundary

## Validation

- `git diff --check`
- `GOCACHE=/private/tmp/ok147-go-build-cache go test -ldflags=-linkmode=external ./...`
- `GOCACHE=/private/tmp/ok147-go-build-cache go vet ./...`
- `GOCACHE=/private/tmp/ok147-go-build-cache go test -race -ldflags=-linkmode=external ./cmd/ok ./internal/runner`
- `python3 -m unittest discover -s tests -p '*_test.py'` (18 passed, 1 expected skip)
