### PR TITLE
feat(cli): execute exact stage launch candidate (OK-147)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,11 @@ Powered by [Cluster API (CAPI)](https://cluster-api.sigs.k8s.io/), [CAPK (KubeVi
   correlates all package, credential, runtime and candidate inputs without
   exposing their bytes or contacting Kubernetes. `ok cluster stage launch
   prepare` exposes only the redacted material/candidate receipts and rejects
-  execution. The runner image is digest-pinned, multi-architecture, non-root,
-  SBOM- and provenance-producing behind a protected publisher.
+  execution. A separate `ok cluster stage launch execute` boundary requires the
+  exact prepared candidate, explicit `--execute`, bounded installer credentials
+  and a single-use global-preflight launcher. The runner image is digest-pinned,
+  multi-architecture, non-root, SBOM- and provenance-producing behind a
+  protected publisher.
 
 ---
 

--- a/cmd/ok/main.go
+++ b/cmd/ok/main.go
@@ -26,13 +26,15 @@ import (
 )
 
 const (
-	ledgerNamespace = "openkubes-execution-system"
-	stageRunTimeout = 10 * time.Minute
+	ledgerNamespace    = "openkubes-execution-system"
+	stageRunTimeout    = 10 * time.Minute
+	stageLaunchTimeout = 5 * time.Minute
 )
 
 var (
 	version                 = "0.0.0-dev"
 	revision                = "unknown"
+	sha256DigestPattern     = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
 	stageReceiptFlagPattern = regexp.MustCompile(`^.+@sha256:[0-9a-f]{64}$`)
 )
 
@@ -66,6 +68,25 @@ var prepareSubmissionStageLaunch = func(config runner.SubmissionStageLaunchMater
 		Format: "ok147-submission-stage-launch-preparation/v1", State: "PREPARED",
 		Material: materialReceipt, Candidate: candidateReceipt, MutationAllowed: false,
 	}, nil
+}
+
+var executeSubmissionStageLaunch = func(ctx context.Context, config runner.SubmissionStageLaunchMaterialConfig, authority runner.KubernetesAuthorityConfig, expectedCandidateDigest string) (runner.SubmissionStageLaunchReceipt, error) {
+	material, err := runner.BuildSubmissionStageLaunchMaterial(config)
+	if err != nil {
+		return runner.SubmissionStageLaunchReceipt{}, err
+	}
+	candidate, err := material.CandidateReceipt()
+	if err != nil {
+		return runner.SubmissionStageLaunchReceipt{}, err
+	}
+	authority.AuthorityIdentity = candidate.Authority
+	launcher, err := material.Open(runner.SubmissionStageLaunchOpenConfig{
+		Authority: authority, Clock: func() time.Time { return time.Now().UTC() }, ExpectedCandidateDigest: expectedCandidateDigest,
+	})
+	if err != nil {
+		return runner.SubmissionStageLaunchReceipt{}, err
+	}
+	return launcher.Launch(ctx)
 }
 
 type createPlan struct {
@@ -278,7 +299,10 @@ func runContext(ctx context.Context, arguments []string, stdout, stderr io.Write
 	if len(arguments) >= 4 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "launch" && arguments[3] == "prepare" {
 		return runClusterStageLaunchPrepare(arguments[4:], stdout, stderr)
 	}
-	return errors.New("usage: ok cluster create ... | ok cluster stage inspect ... | ok cluster stage run ... | ok cluster stage package ... | ok cluster stage launch prepare ...")
+	if len(arguments) >= 4 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "launch" && arguments[3] == "execute" {
+		return runClusterStageLaunchExecute(ctx, arguments[4:], stdout, stderr)
+	}
+	return errors.New("usage: ok cluster create ... | ok cluster stage inspect ... | ok cluster stage run ... | ok cluster stage package ... | ok cluster stage launch prepare ... | ok cluster stage launch execute ...")
 }
 
 func runClusterCreate(arguments []string, stdout, stderr io.Writer) error {
@@ -606,94 +630,117 @@ func (values *stageLaunchCredentialFlags) source(prefix string) (runner.Submissi
 	}, nil
 }
 
+type stageLaunchMaterialFlags struct {
+	bundle                                                                                       *stageBundleFlags
+	jobTemplate, jobTemplateDigest, runID, imageDigest, inputConfigMap                           *string
+	ledgerAPIURL, ledgerAPICIDR, ledgerCredentialSecret                                          *string
+	authorityAPIURL, authorityAPICIDR, authorityCredentialSecret                                 *string
+	materializedAt, runtimeManifest, runtimeManifestDigest                                       *string
+	installerAPIEndpoint, installerCADigest, installerTokenDigest, installerEvidence, preparedAt *string
+	ledgerCredential, authorityCredential                                                        *stageLaunchCredentialFlags
+}
+
+func addStageLaunchMaterialFlags(flags *flag.FlagSet) *stageLaunchMaterialFlags {
+	values := &stageLaunchMaterialFlags{bundle: addStageBundleFlags(flags)}
+	values.jobTemplate = flags.String("job-template", "", "path to the bounded submission-stage Job template")
+	values.jobTemplateDigest = flags.String("job-template-digest", "", "expected SHA-256 identity of the Job template")
+	values.runID = flags.String("run-id", "", "bounded OK-147 Job identity")
+	values.imageDigest = flags.String("image", "", "digest-pinned ok image")
+	values.inputConfigMap = flags.String("input-configmap", "", "immutable input ConfigMap name")
+	values.ledgerAPIURL = flags.String("ledger-api-url", "", "exact management-ledger HTTPS IP endpoint")
+	values.ledgerAPICIDR = flags.String("ledger-api-cidr", "", "single-address management-ledger CIDR")
+	values.ledgerCredentialSecret = flags.String("ledger-credential-secret", "", "ledger credential Secret name")
+	values.authorityAPIURL = flags.String("authority-api-url", "", "exact selected-authority HTTPS IP endpoint")
+	values.authorityAPICIDR = flags.String("authority-api-cidr", "", "single-address selected-authority CIDR")
+	values.authorityCredentialSecret = flags.String("authority-credential-secret", "", "authority credential Secret name")
+	values.materializedAt = flags.String("credential-materialized-at", "", "exact credential materialization time")
+	values.ledgerCredential = addStageLaunchCredentialFlags(flags, "ledger-job", "ledger Job credential")
+	values.authorityCredential = addStageLaunchCredentialFlags(flags, "authority-job", "selected-authority Job credential")
+	values.runtimeManifest = flags.String("runtime-manifest", "", "path to the tokenless runtime ServiceAccount manifest")
+	values.runtimeManifestDigest = flags.String("runtime-manifest-digest", "", "expected runtime manifest digest")
+	values.installerAPIEndpoint = flags.String("installer-api-endpoint", "", "exact management installer HTTPS IP endpoint")
+	values.installerCADigest = flags.String("installer-ca-digest", "", "expected management installer CA digest")
+	values.installerTokenDigest = flags.String("installer-token-digest", "", "private expected management installer token digest")
+	values.installerEvidence = flags.String("installer-tokenrequest-evidence-digest", "", "management installer TokenRequest evidence digest")
+	values.preparedAt = flags.String("prepared-at", "", "exact launch candidate preparation time")
+	return values
+}
+
+func (values *stageLaunchMaterialFlags) config() (runner.SubmissionStageLaunchMaterialConfig, error) {
+	bundleConfig, err := values.bundle.config()
+	if err != nil {
+		return runner.SubmissionStageLaunchMaterialConfig{}, err
+	}
+	for _, input := range []struct{ name, value string }{
+		{"--job-template", *values.jobTemplate}, {"--job-template-digest", *values.jobTemplateDigest}, {"--run-id", *values.runID}, {"--image", *values.imageDigest},
+		{"--input-configmap", *values.inputConfigMap}, {"--ledger-api-url", *values.ledgerAPIURL}, {"--ledger-api-cidr", *values.ledgerAPICIDR},
+		{"--ledger-credential-secret", *values.ledgerCredentialSecret}, {"--authority-api-url", *values.authorityAPIURL},
+		{"--authority-api-cidr", *values.authorityAPICIDR}, {"--authority-credential-secret", *values.authorityCredentialSecret},
+		{"--credential-materialized-at", *values.materializedAt}, {"--runtime-manifest", *values.runtimeManifest},
+		{"--runtime-manifest-digest", *values.runtimeManifestDigest}, {"--installer-api-endpoint", *values.installerAPIEndpoint},
+		{"--installer-ca-digest", *values.installerCADigest}, {"--installer-token-digest", *values.installerTokenDigest},
+		{"--installer-tokenrequest-evidence-digest", *values.installerEvidence}, {"--prepared-at", *values.preparedAt},
+	} {
+		if input.value == "" {
+			return runner.SubmissionStageLaunchMaterialConfig{}, fmt.Errorf("%s is required", input.name)
+		}
+	}
+	materializationTime, err := time.Parse(time.RFC3339, *values.materializedAt)
+	if err != nil {
+		return runner.SubmissionStageLaunchMaterialConfig{}, fmt.Errorf("parse credential materialization time: %w", err)
+	}
+	candidateTime, err := time.Parse(time.RFC3339, *values.preparedAt)
+	if err != nil {
+		return runner.SubmissionStageLaunchMaterialConfig{}, fmt.Errorf("parse candidate preparation time: %w", err)
+	}
+	ledgerSource, err := values.ledgerCredential.source("ledger-job")
+	if err != nil {
+		return runner.SubmissionStageLaunchMaterialConfig{}, err
+	}
+	authoritySource, err := values.authorityCredential.source("authority-job")
+	if err != nil {
+		return runner.SubmissionStageLaunchMaterialConfig{}, err
+	}
+	template, err := readBoundedLocalFile(*values.jobTemplate, 1024*1024)
+	if err != nil {
+		return runner.SubmissionStageLaunchMaterialConfig{}, fmt.Errorf("read Job template: %w", err)
+	}
+	runtimeRaw, err := readBoundedLocalFile(*values.runtimeManifest, 128*1024)
+	if err != nil {
+		return runner.SubmissionStageLaunchMaterialConfig{}, fmt.Errorf("read runtime manifest: %w", err)
+	}
+	return runner.SubmissionStageLaunchMaterialConfig{
+		Package: runner.SubmissionStagePackageConfig{
+			Bundle: bundleConfig, JobTemplate: template, JobTemplateDigest: *values.jobTemplateDigest,
+			RunID: *values.runID, ImageDigest: *values.imageDigest, InputConfigMap: *values.inputConfigMap,
+			LedgerAPIURL: *values.ledgerAPIURL, LedgerAPICIDR: *values.ledgerAPICIDR, LedgerCredentialSecret: *values.ledgerCredentialSecret,
+			AuthorityAPIURL: *values.authorityAPIURL, AuthorityAPICIDR: *values.authorityAPICIDR, AuthorityCredentialSecret: *values.authorityCredentialSecret,
+		},
+		MaterializationTime: materializationTime, Ledger: ledgerSource, SelectedAuthority: authoritySource,
+		RuntimeManifest: runtimeRaw, RuntimeManifestDigest: *values.runtimeManifestDigest,
+		Candidate: runner.SubmissionStageLaunchCandidateConfig{
+			AuthorityEndpoint: *values.installerAPIEndpoint, CABundleDigest: *values.installerCADigest,
+			InstallerTokenDigest: *values.installerTokenDigest, InstallerCredentialEvidenceDigest: *values.installerEvidence,
+			PreparedAt: candidateTime,
+		},
+	}, nil
+}
+
 func runClusterStageLaunchPrepare(arguments []string, stdout, stderr io.Writer) error {
 	flags := flag.NewFlagSet("ok cluster stage launch prepare", flag.ContinueOnError)
 	flags.SetOutput(stderr)
-	bundleFlags := addStageBundleFlags(flags)
-	jobTemplate := flags.String("job-template", "", "path to the bounded submission-stage Job template")
-	jobTemplateDigest := flags.String("job-template-digest", "", "expected SHA-256 identity of the Job template")
-	runID := flags.String("run-id", "", "bounded OK-147 Job identity")
-	imageDigest := flags.String("image", "", "digest-pinned ok image")
-	inputConfigMap := flags.String("input-configmap", "", "immutable input ConfigMap name")
-	ledgerAPIURL := flags.String("ledger-api-url", "", "exact management-ledger HTTPS IP endpoint")
-	ledgerAPICIDR := flags.String("ledger-api-cidr", "", "single-address management-ledger CIDR")
-	ledgerCredentialSecret := flags.String("ledger-credential-secret", "", "ledger credential Secret name")
-	authorityAPIURL := flags.String("authority-api-url", "", "exact selected-authority HTTPS IP endpoint")
-	authorityAPICIDR := flags.String("authority-api-cidr", "", "single-address selected-authority CIDR")
-	authorityCredentialSecret := flags.String("authority-credential-secret", "", "authority credential Secret name")
-	materializedAt := flags.String("credential-materialized-at", "", "exact credential materialization time")
-	ledgerCredential := addStageLaunchCredentialFlags(flags, "ledger-job", "ledger Job credential")
-	authorityCredential := addStageLaunchCredentialFlags(flags, "authority-job", "selected-authority Job credential")
-	runtimeManifest := flags.String("runtime-manifest", "", "path to the tokenless runtime ServiceAccount manifest")
-	runtimeManifestDigest := flags.String("runtime-manifest-digest", "", "expected runtime manifest digest")
-	installerAPIEndpoint := flags.String("installer-api-endpoint", "", "exact management installer HTTPS IP endpoint")
-	installerCADigest := flags.String("installer-ca-digest", "", "expected management installer CA digest")
-	installerTokenDigest := flags.String("installer-token-digest", "", "private expected management installer token digest")
-	installerEvidenceDigest := flags.String("installer-tokenrequest-evidence-digest", "", "management installer TokenRequest evidence digest")
-	preparedAt := flags.String("prepared-at", "", "exact launch candidate preparation time")
+	materialFlags := addStageLaunchMaterialFlags(flags)
 	if err := flags.Parse(arguments); err != nil {
 		return err
 	}
 	if flags.NArg() != 0 {
 		return errors.New("positional arguments are not accepted")
 	}
-	bundleConfig, err := bundleFlags.config()
+	config, err := materialFlags.config()
 	if err != nil {
 		return err
 	}
-	for _, input := range []struct{ name, value string }{
-		{"--job-template", *jobTemplate}, {"--job-template-digest", *jobTemplateDigest}, {"--run-id", *runID}, {"--image", *imageDigest},
-		{"--input-configmap", *inputConfigMap}, {"--ledger-api-url", *ledgerAPIURL}, {"--ledger-api-cidr", *ledgerAPICIDR},
-		{"--ledger-credential-secret", *ledgerCredentialSecret}, {"--authority-api-url", *authorityAPIURL},
-		{"--authority-api-cidr", *authorityAPICIDR}, {"--authority-credential-secret", *authorityCredentialSecret},
-		{"--credential-materialized-at", *materializedAt}, {"--runtime-manifest", *runtimeManifest},
-		{"--runtime-manifest-digest", *runtimeManifestDigest}, {"--installer-api-endpoint", *installerAPIEndpoint},
-		{"--installer-ca-digest", *installerCADigest}, {"--installer-token-digest", *installerTokenDigest},
-		{"--installer-tokenrequest-evidence-digest", *installerEvidenceDigest}, {"--prepared-at", *preparedAt},
-	} {
-		if input.value == "" {
-			return fmt.Errorf("%s is required", input.name)
-		}
-	}
-	materializationTime, err := time.Parse(time.RFC3339, *materializedAt)
-	if err != nil {
-		return fmt.Errorf("parse credential materialization time: %w", err)
-	}
-	candidateTime, err := time.Parse(time.RFC3339, *preparedAt)
-	if err != nil {
-		return fmt.Errorf("parse candidate preparation time: %w", err)
-	}
-	ledgerSource, err := ledgerCredential.source("ledger-job")
-	if err != nil {
-		return err
-	}
-	authoritySource, err := authorityCredential.source("authority-job")
-	if err != nil {
-		return err
-	}
-	template, err := readBoundedLocalFile(*jobTemplate, 1024*1024)
-	if err != nil {
-		return fmt.Errorf("read Job template: %w", err)
-	}
-	runtimeRaw, err := readBoundedLocalFile(*runtimeManifest, 128*1024)
-	if err != nil {
-		return fmt.Errorf("read runtime manifest: %w", err)
-	}
-	preparation, err := prepareSubmissionStageLaunch(runner.SubmissionStageLaunchMaterialConfig{
-		Package: runner.SubmissionStagePackageConfig{
-			Bundle: bundleConfig, JobTemplate: template, JobTemplateDigest: *jobTemplateDigest,
-			RunID: *runID, ImageDigest: *imageDigest, InputConfigMap: *inputConfigMap,
-			LedgerAPIURL: *ledgerAPIURL, LedgerAPICIDR: *ledgerAPICIDR, LedgerCredentialSecret: *ledgerCredentialSecret,
-			AuthorityAPIURL: *authorityAPIURL, AuthorityAPICIDR: *authorityAPICIDR, AuthorityCredentialSecret: *authorityCredentialSecret,
-		},
-		MaterializationTime: materializationTime, Ledger: ledgerSource, SelectedAuthority: authoritySource,
-		RuntimeManifest: runtimeRaw, RuntimeManifestDigest: *runtimeManifestDigest,
-		Candidate: runner.SubmissionStageLaunchCandidateConfig{
-			AuthorityEndpoint: *installerAPIEndpoint, CABundleDigest: *installerCADigest,
-			InstallerTokenDigest: *installerTokenDigest, InstallerCredentialEvidenceDigest: *installerEvidenceDigest,
-			PreparedAt: candidateTime,
-		},
-	})
+	preparation, err := prepareSubmissionStageLaunch(config)
 	if err != nil {
 		return err
 	}
@@ -701,6 +748,54 @@ func runClusterStageLaunchPrepare(arguments []string, stdout, stderr io.Writer) 
 	encoder.SetEscapeHTML(false)
 	encoder.SetIndent("", "  ")
 	return encoder.Encode(preparation)
+}
+
+func runClusterStageLaunchExecute(ctx context.Context, arguments []string, stdout, stderr io.Writer) error {
+	flags := flag.NewFlagSet("ok cluster stage launch execute", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	materialFlags := addStageLaunchMaterialFlags(flags)
+	execute := flags.Bool("execute", false, "perform the exact single-use six-object launch")
+	expectedCandidateDigest := flags.String("expected-candidate-digest", "", "exact digest emitted by launch prepare")
+	installerTokenFile := flags.String("installer-token-file", "", "bounded short-lived management installer token file")
+	installerCAFile := flags.String("installer-ca-file", "", "bounded management installer CA file")
+	if err := flags.Parse(arguments); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return errors.New("positional arguments are not accepted")
+	}
+	if !*execute {
+		return errors.New("stage launch mutation requires explicit --execute")
+	}
+	for _, input := range []struct{ name, value string }{
+		{"--expected-candidate-digest", *expectedCandidateDigest}, {"--installer-token-file", *installerTokenFile}, {"--installer-ca-file", *installerCAFile},
+	} {
+		if input.value == "" {
+			return fmt.Errorf("%s is required", input.name)
+		}
+	}
+	if !sha256DigestPattern.MatchString(*expectedCandidateDigest) {
+		return errors.New("--expected-candidate-digest must be sha256:<64 lowercase hex>")
+	}
+	config, err := materialFlags.config()
+	if err != nil {
+		return err
+	}
+	boundedContext, cancel := context.WithTimeout(ctx, stageLaunchTimeout)
+	defer cancel()
+	receipt, launchErr := executeSubmissionStageLaunch(boundedContext, config, runner.KubernetesAuthorityConfig{
+		Endpoint: config.Candidate.AuthorityEndpoint, TokenFile: *installerTokenFile,
+		CAFile: *installerCAFile, CABundleDigest: config.Candidate.CABundleDigest,
+	}, *expectedCandidateDigest)
+	if receipt.Format != "" {
+		encoder := json.NewEncoder(stdout)
+		encoder.SetEscapeHTML(false)
+		encoder.SetIndent("", "  ")
+		if err := encoder.Encode(receipt); err != nil {
+			return err
+		}
+	}
+	return launchErr
 }
 
 func readBoundedLocalFile(path string, maximum int64) ([]byte, error) {

--- a/cmd/ok/main_test.go
+++ b/cmd/ok/main_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -426,6 +427,124 @@ func TestStageLaunchPrepareRejectsExecuteIncompleteAndSymlinkInputs(t *testing.T
 	}
 }
 
+func TestStageLaunchExecuteUsesExactSingleUseBoundary(t *testing.T) {
+	previous := executeSubmissionStageLaunch
+	defer func() { executeSubmissionStageLaunch = previous }()
+	var calls int
+	var capturedAuthority runner.KubernetesAuthorityConfig
+	var capturedCandidate string
+	executeSubmissionStageLaunch = func(ctx context.Context, config runner.SubmissionStageLaunchMaterialConfig, authority runner.KubernetesAuthorityConfig, expectedCandidateDigest string) (runner.SubmissionStageLaunchReceipt, error) {
+		calls++
+		capturedAuthority, capturedCandidate = authority, expectedCandidateDigest
+		deadline, ok := ctx.Deadline()
+		if !ok || time.Until(deadline) <= 0 || time.Until(deadline) > stageLaunchTimeout {
+			t.Fatal("stage launch context is not bounded")
+		}
+		if config.Package.RunID != "ok147-provider-20260816-01" || config.Candidate.AuthorityEndpoint != "https://192.0.2.12:6443" {
+			t.Fatalf("stage launch material differs: %#v", config)
+		}
+		return runner.SubmissionStageLaunchReceipt{
+			Format: runner.SubmissionStageLaunchReceiptFormat, StageID: "provider-prerequisites", Authority: "ok-mgmt",
+			State: "LAUNCHED", MutationState: "ATTEMPTED", Results: []runner.SubmissionStageLaunchResult{},
+		}, nil
+	}
+	root := t.TempDir()
+	template := filepath.Join(root, "job.yaml.tpl")
+	runtimeManifest := filepath.Join(root, "runtime.yaml")
+	if err := os.WriteFile(template, []byte("bounded-template"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(runtimeManifest, []byte("bounded-runtime"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	arguments := stageLaunchExecuteArguments(template, runtimeManifest)
+	var stdout, stderr bytes.Buffer
+	if err := run(arguments, &stdout, &stderr); err != nil {
+		t.Fatalf("run: %v; stderr=%s", err, stderr.String())
+	}
+	if calls != 1 || capturedCandidate != testSHA("9") {
+		t.Fatalf("exact launch candidate was not used: calls=%d digest=%q", calls, capturedCandidate)
+	}
+	if capturedAuthority.Endpoint != "https://192.0.2.12:6443" || capturedAuthority.TokenFile != "/private/tmp/installer-token" || capturedAuthority.CAFile != "/private/tmp/installer-ca" || capturedAuthority.CABundleDigest != testSHA("2") {
+		t.Fatalf("installer authority differs: %#v", capturedAuthority)
+	}
+	var receipt runner.SubmissionStageLaunchReceipt
+	if err := json.Unmarshal(stdout.Bytes(), &receipt); err != nil {
+		t.Fatal(err)
+	}
+	if receipt.Format != runner.SubmissionStageLaunchReceiptFormat || receipt.State != "LAUNCHED" || receipt.MutationState != "ATTEMPTED" {
+		t.Fatalf("launch receipt differs: %#v", receipt)
+	}
+}
+
+func TestStageLaunchExecuteFailsClosedBeforeLauncher(t *testing.T) {
+	previous := executeSubmissionStageLaunch
+	defer func() { executeSubmissionStageLaunch = previous }()
+	var calls int
+	executeSubmissionStageLaunch = func(context.Context, runner.SubmissionStageLaunchMaterialConfig, runner.KubernetesAuthorityConfig, string) (runner.SubmissionStageLaunchReceipt, error) {
+		calls++
+		return runner.SubmissionStageLaunchReceipt{}, nil
+	}
+	root := t.TempDir()
+	template := filepath.Join(root, "job.yaml.tpl")
+	runtimeManifest := filepath.Join(root, "runtime.yaml")
+	if err := os.WriteFile(template, []byte("bounded-template"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(runtimeManifest, []byte("bounded-runtime"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	valid := stageLaunchExecuteArguments(template, runtimeManifest)
+	for name, arguments := range map[string][]string{
+		"missing execute":           removeArgument(valid, "--execute"),
+		"missing candidate":         removeArgumentWithValue(valid, "--expected-candidate-digest"),
+		"malformed candidate":       replaceArgument(valid, "--expected-candidate-digest", "sha256:ABC"),
+		"missing installer token":   removeArgumentWithValue(valid, "--installer-token-file"),
+		"missing installer CA file": removeArgumentWithValue(valid, "--installer-ca-file"),
+	} {
+		t.Run(name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			if err := run(arguments, &stdout, &stderr); err == nil || stdout.Len() != 0 {
+				t.Fatal("unsafe stage launch input was accepted")
+			}
+		})
+	}
+	if calls != 0 {
+		t.Fatalf("launcher was reached %d times for invalid input", calls)
+	}
+}
+
+func TestStageLaunchExecuteEmitsStoppedReceipt(t *testing.T) {
+	previous := executeSubmissionStageLaunch
+	defer func() { executeSubmissionStageLaunch = previous }()
+	executeSubmissionStageLaunch = func(context.Context, runner.SubmissionStageLaunchMaterialConfig, runner.KubernetesAuthorityConfig, string) (runner.SubmissionStageLaunchReceipt, error) {
+		return runner.SubmissionStageLaunchReceipt{
+			Format: runner.SubmissionStageLaunchReceiptFormat, StageID: "provider-prerequisites", Authority: "ok-mgmt",
+			State: "STOPPED_ZERO_WRITE", MutationState: "NOT_ATTEMPTED", Results: []runner.SubmissionStageLaunchResult{},
+		}, errors.New("bounded launch stopped")
+	}
+	root := t.TempDir()
+	template := filepath.Join(root, "job.yaml.tpl")
+	runtimeManifest := filepath.Join(root, "runtime.yaml")
+	if err := os.WriteFile(template, []byte("bounded-template"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(runtimeManifest, []byte("bounded-runtime"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	if err := run(stageLaunchExecuteArguments(template, runtimeManifest), &stdout, &stderr); err == nil {
+		t.Fatal("stopped launch returned success")
+	}
+	var receipt runner.SubmissionStageLaunchReceipt
+	if err := json.Unmarshal(stdout.Bytes(), &receipt); err != nil {
+		t.Fatal(err)
+	}
+	if receipt.State != "STOPPED_ZERO_WRITE" || receipt.MutationState != "NOT_ATTEMPTED" {
+		t.Fatalf("stopped launch receipt was lost: %#v", receipt)
+	}
+}
+
 func stageInspectArguments() []string {
 	return []string{
 		"cluster", "stage", "inspect",
@@ -491,6 +610,15 @@ func stageLaunchPrepareArguments(template, runtimeManifest string) []string {
 		"--installer-api-endpoint", "https://192.0.2.12:6443", "--installer-ca-digest", testSHA("2"),
 		"--installer-token-digest", testSHA("7"), "--installer-tokenrequest-evidence-digest", testSHA("8"),
 		"--prepared-at", "2026-08-16T12:01:00Z",
+	)
+}
+
+func stageLaunchExecuteArguments(template, runtimeManifest string) []string {
+	arguments := stageLaunchPrepareArguments(template, runtimeManifest)
+	arguments[3] = "execute"
+	return append(arguments,
+		"--execute", "--expected-candidate-digest", testSHA("9"),
+		"--installer-token-file", "/private/tmp/installer-token", "--installer-ca-file", "/private/tmp/installer-ca",
 	)
 }
 

--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -1377,6 +1377,31 @@ client is constructed. A future execution command must rebuild the same
 material, require the exact emitted candidate digest and retain a separate
 critical live-authorization boundary.
 
+That separate boundary is exposed as:
+
+```text
+ok cluster stage launch execute
+  + every exact preparation input
+  + --execute
+  + --expected-candidate-digest sha256:...
+  + --installer-token-file PATH
+  + --installer-ca-file PATH
+```
+
+The command rejects missing or malformed candidate identity before rebuilding
+the launch material. It then rebuilds the complete private material, requires
+the recomputed candidate to equal the separately supplied digest, and only
+after that opens the bounded installer credential. Execution has a five-minute
+outer deadline and delegates to the single-use launcher: all six exact GET
+preflights complete before the first create, followed by at most six fixed-order
+create requests. There is no update, patch, apply, delete, list, watch, retry or
+rollback path.
+
+The command emits the redaction-safe launch receipt whenever the launcher
+returns one, including `STOPPED_ZERO_WRITE` or
+`STOPPED_PARTIAL_OR_UNKNOWN`. A stopped receipt is evidence of the observed
+boundary, never permission for an automatic retry.
+
 ## Typed first-run Platform capability boundary
 
 First-run capability production now has a separate lazy resolver from the


### PR DESCRIPTION
## What changed

- add `ok cluster stage launch execute` as the separate live boundary after `launch prepare`
- require every preparation input, explicit `--execute`, the exact prepared candidate digest and bounded installer token/CA files
- rebuild and reverify the complete private material before opening the installer credential
- apply a five-minute outer deadline and emit redaction-safe stopped receipts on failure
- share material flag parsing between prepare and execute without adding execution capability to prepare

## Why

OK-147 needs an executable CLI boundary that preserves the exact candidate approval identity and delegates only to the existing single-use, six-object global-preflight launcher.

## Safety boundary

- missing or malformed candidate identity stops before the launcher
- every one of six GET preflights completes before the first create
- at most six fixed-order create operations
- no update, patch, apply, delete, list, watch, retry or rollback path
- tests use an injected in-memory launcher; this checkpoint made no cluster request or mutation

## Validation

- `git diff --check`
- `GOCACHE=/private/tmp/ok147-go-build-cache go test -ldflags=-linkmode=external ./...`
- `GOCACHE=/private/tmp/ok147-go-build-cache go vet ./...`
- `GOCACHE=/private/tmp/ok147-go-build-cache go test -race -ldflags=-linkmode=external ./cmd/ok ./internal/runner`
- `python3 -m unittest discover -s tests -p '*_test.py'` (18 passed, 1 expected skip)
