### PR TITLE
feat(runner): verify idempotent stage launch (OK-147)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,13 +42,14 @@ Powered by [Cluster API (CAPI)](https://cluster-api.sigs.k8s.io/), [CAPK (KubeVi
   non-mutating launch plan binds all six objects behind one complete preflight
   barrier and fixes their eventual create order without exposing object bodies
   or credentials. A single-use composite launcher implements the same order,
-  preserves a redaction-safe partial receipt and has no update, delete, retry
-  or rollback path. Its public opener additionally requires an exact,
-  expiry-bound launch-candidate digest that binds destination, CA and installer
-  credential evidence; preparing it remains non-mutating. Live invocation is
-  still a separate critical boundary. A private launch-material builder now
-  correlates all package, credential, runtime and candidate inputs without
-  exposing their bytes or contacting Kubernetes. `ok cluster stage launch
+  verifies a complete exact duplicate as `ALREADY_LAUNCHED`, rejects every
+  mixed partial state, preserves a redaction-safe receipt and has no update,
+  delete, retry or rollback path. Its public opener additionally requires an
+  exact, expiry-bound launch-candidate digest that binds destination, CA and
+  installer credential evidence; preparing it remains non-mutating. Live
+  invocation is still a separate critical boundary. A private launch-material
+  builder now correlates all package, credential, runtime and candidate inputs
+  without exposing their bytes or contacting Kubernetes. `ok cluster stage launch
   prepare` exposes only the redacted material/candidate receipts and rejects
   execution. A separate `ok cluster stage launch execute` boundary requires the
   exact prepared candidate, explicit `--execute`, bounded installer credentials

--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -1282,13 +1282,14 @@ The plan places all six object checks behind one global barrier:
 
 ```text
 GET ServiceAccount (verify exact or absent)
-GET ledger Secret (PartialObjectMetadata, must be absent)
-GET authority Secret (PartialObjectMetadata, must be absent)
-GET ConfigMap (must be absent)
-GET NetworkPolicy (must be absent)
-GET Job (must be absent)
+GET ledger Secret (verify exact or absent)
+GET authority Secret (verify exact or absent)
+GET ConfigMap (verify exact or absent)
+GET NetworkPolicy (verify exact or absent)
+GET Job (verify exact or absent)
         |
-        +-- any failure or conflicting state --> STOP, zero writes
+        +-- all exact --> ALREADY_LAUNCHED, zero writes
+        +-- any mixed, changed or uncertain state --> STOP, zero writes
         v
 fixed create sequence:
 ServiceAccount -> ledger Secret -> authority Secret
@@ -1306,15 +1307,19 @@ as one single-use operation. It opens one separately supplied short-lived
 management installer credential, rechecks that this credential is distinct
 from both Job credentials, and rejects launch when either Job credential has
 less than 15 minutes remaining. All six exact GETs then run before the first
-POST. Secret GETs request only `PartialObjectMetadata`; the other objects never
-fall back to list, watch or discovery.
+POST. Full Secret bodies are required only to compare them with the already
+held private package; they never enter a receipt or error. No object lookup
+falls back to list, watch or discovery.
 
-Only an exactly matching existing tokenless ServiceAccount may be reused. The
-other five objects must all be absent. After the barrier, the launcher creates
-the absent ServiceAccount, both immutable Secrets and the ConfigMap,
+Exactly three global outcomes are accepted: all six objects absent; only the
+exact tokenless ServiceAccount present; or all six objects present and exact.
+The last outcome returns `ALREADY_LAUNCHED` with six redaction-safe
+`EXISTING_VERIFIED` results and performs no POST. Every mixed state, including
+an exact partial prefix, stops zero-write. For an absent set, the launcher
+creates the ServiceAccount, both immutable Secrets and the ConfigMap,
 NetworkPolicy and Job in fixed order. Every create response must contain the
-exact desired fields and bounded runtime identity. Failure stops without
-retry, rollback or cleanup and retains only a redaction-safe verified prefix;
+exact desired fields and bounded runtime identity. Failure stops without retry,
+rollback or cleanup and retains only a redaction-safe verified prefix;
 transport-ambiguous results remain explicitly unknown.
 
 The launcher has no update, patch, apply, delete, list, watch, discovery,
@@ -1394,8 +1399,9 @@ the recomputed candidate to equal the separately supplied digest, and only
 after that opens the bounded installer credential. Execution has a five-minute
 outer deadline and delegates to the single-use launcher: all six exact GET
 preflights complete before the first create, followed by at most six fixed-order
-create requests. There is no update, patch, apply, delete, list, watch, retry or
-rollback path.
+create requests. A complete exact duplicate instead returns
+`ALREADY_LAUNCHED` with zero writes. There is no update, patch, apply, delete,
+list, watch, retry or rollback path.
 
 The command emits the redaction-safe launch receipt whenever the launcher
 returns one, including `STOPPED_ZERO_WRITE` or

--- a/internal/runner/submission_stage_launch_plan.go
+++ b/internal/runner/submission_stage_launch_plan.go
@@ -2,7 +2,7 @@ package runner
 
 import "errors"
 
-const SubmissionStageLaunchPlanFormat = "ok147-submission-stage-launch-plan/v1"
+const SubmissionStageLaunchPlanFormat = "ok147-submission-stage-launch-plan/v2"
 
 type SubmissionStageLaunchPreflight struct {
 	Order          int    `json:"order"`
@@ -85,30 +85,30 @@ func PlanSubmissionStageLaunch(packaged VerifiedSubmissionStagePackage, credenti
 		preflights = append(preflights, SubmissionStageLaunchPreflight{
 			Order: index + 2, Phase: "credentials", APIVersion: "v1", Kind: "Secret",
 			Namespace: submissionStageInputNamespace, Name: object.name, Method: "GET", ObjectPath: object.objectPath,
-			ResponseMode: "PARTIAL_OBJECT_METADATA", ExistingPolicy: "STOP_ZERO_WRITE", ObjectDigest: object.objectDigest,
+			ResponseMode: "FULL_OBJECT", ExistingPolicy: "VERIFY_EXACT_GLOBAL_STATE", ObjectDigest: object.objectDigest,
 		})
 		creates = append(creates, SubmissionStageLaunchCreate{
 			Order: index + 2, Phase: "credentials", APIVersion: "v1", Kind: "Secret",
 			Namespace: submissionStageInputNamespace, Name: object.name, Method: "POST", CollectionPath: object.collectionPath,
-			CreatePolicy: "CREATE_ONLY_AFTER_ABSENCE", ObjectDigest: object.objectDigest,
+			CreatePolicy: "CREATE_ONLY_AFTER_GLOBAL_ABSENCE", ObjectDigest: object.objectDigest,
 		})
 	}
 	for index, object := range stage.Creates {
 		preflights = append(preflights, SubmissionStageLaunchPreflight{
 			Order: index + 4, Phase: "stage-package", APIVersion: object.APIVersion, Kind: object.Kind,
 			Namespace: object.Namespace, Name: object.Name, Method: object.PreflightMethod, ObjectPath: object.ObjectPath,
-			ResponseMode: "FULL_OBJECT", ExistingPolicy: "STOP_ZERO_WRITE", ObjectDigest: object.ObjectDigest,
+			ResponseMode: "FULL_OBJECT", ExistingPolicy: "VERIFY_EXACT_GLOBAL_STATE", ObjectDigest: object.ObjectDigest,
 		})
 		creates = append(creates, SubmissionStageLaunchCreate{
 			Order: index + 4, Phase: "stage-package", APIVersion: object.APIVersion, Kind: object.Kind,
 			Namespace: object.Namespace, Name: object.Name, Method: object.CreateMethod, CollectionPath: object.CollectionPath,
-			CreatePolicy: "CREATE_ONLY_AFTER_ABSENCE", ObjectDigest: object.ObjectDigest,
+			CreatePolicy: "CREATE_ONLY_AFTER_GLOBAL_ABSENCE", ObjectDigest: object.ObjectDigest,
 		})
 	}
 	return SubmissionStageLaunchPlan{
 		Format: SubmissionStageLaunchPlanFormat, State: "VERIFIED", StageID: stage.StageID,
 		Authority: packaged.installationAuthority, StagePackageDigest: stage.PackageDigest,
 		CredentialPackageDigest: credentialReceipt.PackageDigest, RuntimeManifestDigest: runtime.receipt.ManifestDigest,
-		PreflightBarrier: "ALL_SIX_PASS_BEFORE_FIRST_CREATE", Preflights: preflights, Creates: creates, MutationAllowed: false,
+		PreflightBarrier: "ALL_ABSENT_OR_RUNTIME_ONLY_OR_ALL_EXACT", Preflights: preflights, Creates: creates, MutationAllowed: false,
 	}, nil
 }

--- a/internal/runner/submission_stage_launch_plan_test.go
+++ b/internal/runner/submission_stage_launch_plan_test.go
@@ -26,7 +26,7 @@ func TestPlanSubmissionStageLaunchBindsSixObjectsBehindOneBarrier(t *testing.T) 
 	if err != nil {
 		t.Fatal(err)
 	}
-	if plan.Format != SubmissionStageLaunchPlanFormat || plan.State != "VERIFIED" || plan.StageID != stageReceipt.StageID || plan.Authority != "ok-mgmt" || plan.StagePackageDigest != stageReceipt.PackageDigest || plan.CredentialPackageDigest != credentialReceipt.PackageDigest || plan.RuntimeManifestDigest != runtimeReceipt.ManifestDigest || plan.PreflightBarrier != "ALL_SIX_PASS_BEFORE_FIRST_CREATE" || plan.MutationAllowed {
+	if plan.Format != SubmissionStageLaunchPlanFormat || plan.State != "VERIFIED" || plan.StageID != stageReceipt.StageID || plan.Authority != "ok-mgmt" || plan.StagePackageDigest != stageReceipt.PackageDigest || plan.CredentialPackageDigest != credentialReceipt.PackageDigest || plan.RuntimeManifestDigest != runtimeReceipt.ManifestDigest || plan.PreflightBarrier != "ALL_ABSENT_OR_RUNTIME_ONLY_OR_ALL_EXACT" || plan.MutationAllowed {
 		t.Fatalf("unexpected launch identity: %#v", plan)
 	}
 	if len(plan.Preflights) != 6 || len(plan.Creates) != 6 {
@@ -45,13 +45,10 @@ func TestPlanSubmissionStageLaunchBindsSixObjectsBehindOneBarrier(t *testing.T) 
 			}
 			continue
 		}
-		if preflight.ExistingPolicy != "STOP_ZERO_WRITE" || create.CreatePolicy != "CREATE_ONLY_AFTER_ABSENCE" {
-			t.Fatalf("create-only policy differs at step %d: %#v %#v", index+1, preflight, create)
+		if preflight.ExistingPolicy != "VERIFY_EXACT_GLOBAL_STATE" || create.CreatePolicy != "CREATE_ONLY_AFTER_GLOBAL_ABSENCE" {
+			t.Fatalf("idempotent global policy differs at step %d: %#v %#v", index+1, preflight, create)
 		}
-		if index < 3 && preflight.ResponseMode != "PARTIAL_OBJECT_METADATA" {
-			t.Fatalf("Secret preflight could expose a body: %#v", preflight)
-		}
-		if index >= 3 && preflight.ResponseMode != "FULL_OBJECT" {
+		if preflight.ResponseMode != "FULL_OBJECT" {
 			t.Fatalf("stage object preflight mode differs: %#v", preflight)
 		}
 	}

--- a/internal/runner/submission_stage_launcher.go
+++ b/internal/runner/submission_stage_launcher.go
@@ -170,9 +170,10 @@ func newKubernetesSubmissionStageLauncher(config submissionStageLauncherClientCo
 	}, nil
 }
 
-// Launch performs the complete six-object preflight and only then creates the
-// absent runtime, both Secrets and the three stage objects in fixed order. It
-// has no update, patch, apply, delete, list, watch, retry or rollback path.
+// Launch performs the complete six-object preflight and only then either
+// reports one exact existing set or creates the globally absent objects in
+// fixed order. Mixed state stops zero-write. It has no update, patch, apply,
+// delete, list, watch, retry or rollback path.
 func (launcher *KubernetesSubmissionStageLauncher) Launch(ctx context.Context) (SubmissionStageLaunchReceipt, error) {
 	receipt := launcher.newReceipt()
 	if launcher == nil || launcher.client == nil || launcher.clock == nil {
@@ -200,38 +201,40 @@ func (launcher *KubernetesSubmissionStageLauncher) Launch(ctx context.Context) (
 		}
 	}
 
-	runtimeExists := false
-	runtimeUID, runtimeResourceVersion := "", ""
+	existing := make(map[int]SubmissionStageLaunchResult, len(launcher.plan.Preflights))
 	for _, preflight := range launcher.plan.Preflights {
 		raw, status, err := launcher.request(ctx, http.MethodGet, preflight.ObjectPath, nil, preflight.ResponseMode)
 		if err != nil {
 			return stopSubmissionStageLaunch(receipt, "STOPPED_ZERO_WRITE", err)
 		}
-		if preflight.Order == 1 {
-			switch status {
-			case http.StatusNotFound:
-			case http.StatusOK:
-				runtimeUID, runtimeResourceVersion, err = verifySubmissionStageRuntimeObject(raw, launcher.runtime.raw)
-				if err != nil {
-					return stopSubmissionStageLaunch(receipt, "STOPPED_ZERO_WRITE", errors.New("existing stage runtime differs from verified prerequisite"))
-				}
-				runtimeExists = true
-			default:
-				return stopSubmissionStageLaunch(receipt, "STOPPED_ZERO_WRITE", submissionStageLaunchStatusError(http.MethodGet, status))
-			}
+		switch status {
+		case http.StatusNotFound:
 			continue
-		}
-		if status == http.StatusOK {
-			return stopSubmissionStageLaunch(receipt, "STOPPED_ZERO_WRITE", errors.New("stage launch object already exists; global preflight stopped"))
-		}
-		if status != http.StatusNotFound {
+		case http.StatusOK:
+			result, err := launcher.verifyExisting(preflight, raw)
+			if err != nil {
+				return stopSubmissionStageLaunch(receipt, "STOPPED_ZERO_WRITE", err)
+			}
+			existing[preflight.Order] = result
+		default:
 			return stopSubmissionStageLaunch(receipt, "STOPPED_ZERO_WRITE", submissionStageLaunchStatusError(http.MethodGet, status))
 		}
+	}
+	if len(existing) == len(launcher.plan.Preflights) {
+		receipt.State = "ALREADY_LAUNCHED"
+		for order := 1; order <= len(launcher.plan.Preflights); order++ {
+			receipt.Results = append(receipt.Results, existing[order])
+		}
+		return receipt, nil
+	}
+	runtime, runtimeExists := existing[1]
+	if len(existing) != 0 && !(len(existing) == 1 && runtimeExists) {
+		return stopSubmissionStageLaunch(receipt, "STOPPED_ZERO_WRITE", errors.New("stage launch found an exact partial state; global preflight stopped"))
 	}
 
 	receipt.State = "LAUNCHING"
 	if runtimeExists {
-		receipt.Results = append(receipt.Results, launcher.result(1, "runtime", "v1", "ServiceAccount", launcher.runtime.receipt.Namespace, launcher.runtime.receipt.Name, launcher.runtime.receipt.ObjectDigest, "EXISTING_VERIFIED", runtimeUID, runtimeResourceVersion))
+		receipt.Results = append(receipt.Results, runtime)
 	} else {
 		receipt.MutationState = "ATTEMPTED_UNKNOWN"
 		result, err := launcher.createRuntime(ctx)
@@ -261,6 +264,33 @@ func (launcher *KubernetesSubmissionStageLauncher) Launch(ctx context.Context) (
 	}
 	receipt.State, receipt.MutationState = "LAUNCHED", "ATTEMPTED"
 	return receipt, nil
+}
+
+func (launcher *KubernetesSubmissionStageLauncher) verifyExisting(preflight SubmissionStageLaunchPreflight, raw []byte) (SubmissionStageLaunchResult, error) {
+	var uid, resourceVersion string
+	var err error
+	switch preflight.Phase {
+	case "runtime":
+		uid, resourceVersion, err = verifySubmissionStageRuntimeObject(raw, launcher.runtime.raw)
+	case "credentials":
+		index := preflight.Order - 2
+		if index < 0 || index >= len(launcher.secrets) {
+			return SubmissionStageLaunchResult{}, errors.New("stage launch credential preflight order is invalid")
+		}
+		uid, resourceVersion, err = verifySubmissionStageCredentialCreatedObject(raw, launcher.secrets[index])
+	case "stage-package":
+		index := preflight.Order - 4
+		if index < 0 || index >= len(launcher.objects) {
+			return SubmissionStageLaunchResult{}, errors.New("stage launch package preflight order is invalid")
+		}
+		uid, resourceVersion, err = verifySubmissionStageCreatedObject(raw, launcher.objects[index])
+	default:
+		return SubmissionStageLaunchResult{}, errors.New("stage launch preflight phase is invalid")
+	}
+	if err != nil {
+		return SubmissionStageLaunchResult{}, errors.New("existing stage launch object differs from verified plan")
+	}
+	return launcher.result(preflight.Order, preflight.Phase, preflight.APIVersion, preflight.Kind, preflight.Namespace, preflight.Name, preflight.ObjectDigest, "EXISTING_VERIFIED", uid, resourceVersion), nil
 }
 
 func (launcher *KubernetesSubmissionStageLauncher) createRuntime(ctx context.Context) (SubmissionStageLaunchResult, error) {

--- a/internal/runner/submission_stage_launcher_test.go
+++ b/internal/runner/submission_stage_launcher_test.go
@@ -29,11 +29,7 @@ func TestSubmissionStageLauncherPreflightsSixThenCreatesInFixedOrder(t *testing.
 		if preflight.method != http.MethodGet || preflight.path != launcher.plan.Preflights[index].ObjectPath || create.method != http.MethodPost || create.path != launcher.plan.Creates[index].CollectionPath || digest.SHA256(create.body) != launcher.plan.Creates[index].ObjectDigest {
 			t.Fatalf("request order %d differs: preflight=%#v create=%#v", index+1, preflight, create)
 		}
-		if index == 1 || index == 2 {
-			if preflight.accept != partialObjectMetadataAccept {
-				t.Fatalf("Secret preflight %d did not request metadata only", index+1)
-			}
-		} else if preflight.accept != "application/json" {
+		if preflight.accept != "application/json" {
 			t.Fatalf("object preflight %d media type differs: %q", index+1, preflight.accept)
 		}
 		result := receipt.Results[index]
@@ -54,6 +50,56 @@ func TestSubmissionStageLauncherPreflightsSixThenCreatesInFixedOrder(t *testing.
 	retry, retryErr := launcher.Launch(context.Background())
 	if retryErr == nil || retry.State != "STOPPED_ZERO_WRITE" || len(api.requests) != requests {
 		t.Fatalf("launcher retried: receipt=%#v err=%v", retry, retryErr)
+	}
+}
+
+func TestSubmissionStageLauncherTreatsExactDuplicateAsAlreadyLaunched(t *testing.T) {
+	stage, credentials, runtime, ledgerToken, authorityToken := submissionStageLaunchFixture(t)
+	api := newSubmissionStageLauncherAPI(t)
+	now := time.Date(2026, 8, 16, 12, 1, 0, 0, time.UTC)
+	first := newSubmissionStageLauncher(t, stage, credentials, runtime, api, now)
+	firstReceipt, err := first.Launch(context.Background())
+	if err != nil || firstReceipt.State != "LAUNCHED" || api.posts != 6 {
+		t.Fatalf("first launch failed: %#v posts=%d err=%v", firstReceipt, api.posts, err)
+	}
+	requests := len(api.requests)
+	duplicate := newSubmissionStageLauncher(t, stage, credentials, runtime, api, now)
+	receipt, err := duplicate.Launch(context.Background())
+	if err != nil || receipt.State != "ALREADY_LAUNCHED" || receipt.MutationState != "NOT_ATTEMPTED" || len(receipt.Results) != 6 || api.posts != 6 || len(api.requests) != requests+6 {
+		t.Fatalf("exact duplicate was not idempotent: %#v requests=%d posts=%d err=%v", receipt, len(api.requests), api.posts, err)
+	}
+	for index, result := range receipt.Results {
+		if result.Order != index+1 || result.ObjectState != "EXISTING_VERIFIED" {
+			t.Fatalf("duplicate result %d differs: %#v", index+1, result)
+		}
+	}
+	public, err := json.Marshal(receipt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range [][]byte{ledgerToken, authorityToken, credentials.objects[0].raw, credentials.objects[1].raw, []byte("short-lived-installer-token"), []byte("created-uid")} {
+		if bytes.Contains(public, forbidden) {
+			t.Fatal("duplicate launch receipt exposed private content")
+		}
+	}
+}
+
+func TestSubmissionStageLauncherRejectsChangedDuplicateSecret(t *testing.T) {
+	stage, credentials, runtime, _, _ := submissionStageLaunchFixture(t)
+	api := newSubmissionStageLauncherAPI(t)
+	now := time.Date(2026, 8, 16, 12, 1, 0, 0, time.UTC)
+	first := newSubmissionStageLauncher(t, stage, credentials, runtime, api, now)
+	if receipt, err := first.Launch(context.Background()); err != nil || receipt.State != "LAUNCHED" {
+		t.Fatalf("first launch failed: %#v %v", receipt, err)
+	}
+	secret := api.objects[first.plan.Preflights[1].ObjectPath]
+	data := secret["data"].(map[string]any)
+	data["token"] = "dGFtcGVyZWQ="
+	requests, posts := len(api.requests), api.posts
+	duplicate := newSubmissionStageLauncher(t, stage, credentials, runtime, api, now)
+	receipt, err := duplicate.Launch(context.Background())
+	if err == nil || receipt.State != "STOPPED_ZERO_WRITE" || receipt.MutationState != "NOT_ATTEMPTED" || len(api.requests) != requests+2 || api.posts != posts || len(receipt.Results) != 0 {
+		t.Fatalf("changed duplicate Secret was accepted: %#v requests=%d posts=%d err=%v", receipt, len(api.requests), api.posts, err)
 	}
 }
 
@@ -92,6 +138,20 @@ func TestSubmissionStageLauncherStopsGloballyBeforeWrite(t *testing.T) {
 	receipt, err := launcher.Launch(context.Background())
 	if err == nil || receipt.State != "STOPPED_ZERO_WRITE" || receipt.MutationState != "NOT_ATTEMPTED" || api.posts != 0 || len(api.requests) != 5 || len(receipt.Results) != 0 {
 		t.Fatalf("global preflight did not stop zero-write: receipt=%#v requests=%d posts=%d err=%v", receipt, len(api.requests), api.posts, err)
+	}
+}
+
+func TestSubmissionStageLauncherRejectsExactPartialState(t *testing.T) {
+	stage, credentials, runtime, _, _ := submissionStageLaunchFixture(t)
+	api := newSubmissionStageLauncherAPI(t)
+	launcher := newSubmissionStageLauncher(t, stage, credentials, runtime, api, time.Date(2026, 8, 16, 12, 1, 0, 0, time.UTC))
+	existing := decodeCapabilityJSONForTest(t, launcher.objects[1].raw)
+	metadata := existing["metadata"].(map[string]any)
+	metadata["uid"], metadata["resourceVersion"] = "existing-network-policy-uid", "9"
+	api.objects[launcher.plan.Preflights[4].ObjectPath] = existing
+	receipt, err := launcher.Launch(context.Background())
+	if err == nil || receipt.State != "STOPPED_ZERO_WRITE" || receipt.MutationState != "NOT_ATTEMPTED" || api.posts != 0 || len(api.requests) != 6 || len(receipt.Results) != 0 {
+		t.Fatalf("exact partial state reached mutation: receipt=%#v requests=%d posts=%d err=%v", receipt, len(api.requests), api.posts, err)
 	}
 }
 
@@ -182,6 +242,8 @@ func (api *submissionStageLauncherAPI) roundTrip(request *http.Request) (*http.R
 		metadata := object["metadata"].(map[string]any)
 		metadata["uid"] = "created-uid-" + string(rune('a'+api.posts-1))
 		metadata["resourceVersion"] = string(rune('1' + api.posts - 1))
+		name, _ := metadata["name"].(string)
+		api.objects[request.URL.Path+"/"+name] = object
 		return submissionStageLauncherJSONResponse(http.StatusCreated, object), nil
 	default:
 		return submissionStageLauncherJSONResponse(http.StatusMethodNotAllowed, map[string]any{"reason": "MethodNotAllowed"}), nil


### PR DESCRIPTION
## What changed

- version the launch plan as v2 with an explicit global existing-state invariant
- accept exactly three states: all six absent, only the exact tokenless runtime present, or all six present and exact
- return `ALREADY_LAUNCHED` with six redaction-safe `EXISTING_VERIFIED` results for an exact duplicate
- reject exact partial state, drifted objects and changed Secret content with zero writes
- retain the fixed six-create path only for the globally absent/runtime-only cases

## Why

OK-147 acceptance requires duplicate invocation of the same authorized submission to produce no duplicate objects. The previous launcher stopped safely but could not distinguish an exact completed duplicate from conflicting pre-existing state.

## Safety boundary

- full Secret bodies are compared only in memory against the already private verified package
- Secret values, UIDs and resourceVersions remain absent from receipts and errors
- every mixed, changed or uncertain state stops before the first POST
- no update, patch, apply, delete, list, watch, retry or rollback path was added

## Validation

- `git diff --check`
- `GOCACHE=/private/tmp/ok147-go-build-cache go test -ldflags=-linkmode=external ./...`
- `GOCACHE=/private/tmp/ok147-go-build-cache go vet ./...`
- `GOCACHE=/private/tmp/ok147-go-build-cache go test -race -ldflags=-linkmode=external ./internal/runner ./cmd/ok`
- `python3 -m unittest discover -s tests -p '*_test.py'` (18 passed, 1 expected skip)
- focused post-review rerun: runner unit and race tests
