### PR TITLE
OK-147: expose fail-closed stage resume cursor

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,10 @@ Powered by [Cluster API (CAPI)](https://cluster-api.sigs.k8s.io/), [CAPK (KubeVi
   exact prepared candidate, explicit `--execute`, bounded installer credentials
   and a single-use global-preflight launcher. The runner image is digest-pinned,
   multi-architecture, non-root, SBOM- and provenance-producing behind a
-  protected publisher.
+  protected publisher. `ok cluster stage resume` independently re-verifies an
+  explicit canonical receipt prefix and reports only the next, completed or
+  stopped cursor state; it has no grant, credential, endpoint or execution
+  capability and can safely select the next read-only stage after a restart.
 
 ---
 

--- a/cmd/ok/main.go
+++ b/cmd/ok/main.go
@@ -112,6 +112,12 @@ type stageInspection struct {
 	MutationAllowed    bool                 `json:"mutationAllowed"`
 }
 
+type stageResumeInspection struct {
+	Format          string               `json:"format"`
+	Decision        stagecursor.Decision `json:"decision"`
+	MutationAllowed bool                 `json:"mutationAllowed"`
+}
+
 type stageLaunchPreparation struct {
 	Format          string                                       `json:"format"`
 	State           string                                       `json:"state"`
@@ -139,6 +145,77 @@ type stageBundleFlags struct {
 	evaluationTime                                                *string
 	receipts                                                      receiptFlags
 	receiptPrefix, receiptPrefixDigest                            *string
+}
+
+type stageResumeFlags struct {
+	planPath, contractNamespace, contractName                     *string
+	intentRevision, enablementRevision, platformRevision          *string
+	executionFixture                                              *string
+	infrastructureAuthority, managementAuthority, gitOpsAuthority *string
+	receipts                                                      receiptFlags
+	receiptPrefix, receiptPrefixDigest                            *string
+}
+
+func addStageResumeFlags(flags *flag.FlagSet) *stageResumeFlags {
+	values := &stageResumeFlags{}
+	values.planPath = flags.String("plan", "", "path to the bounded staged execution plan")
+	values.contractNamespace = flags.String("contract-namespace", "", "expected Contract namespace")
+	values.contractName = flags.String("contract-name", "", "expected Contract name")
+	values.intentRevision = flags.String("intent-revision", "", "expected normalized Contract revision R")
+	values.enablementRevision = flags.String("enablement-revision", "", "expected Enablement revision E")
+	values.platformRevision = flags.String("platform-revision", "", "expected Platform revision P")
+	values.executionFixture = flags.String("execution-fixture", "", "expected execution FixtureDigest")
+	values.infrastructureAuthority = flags.String("infrastructure-authority", "", "expected infrastructure authority identity")
+	values.managementAuthority = flags.String("management-authority", "", "expected management authority identity")
+	values.gitOpsAuthority = flags.String("gitops-authority", "", "expected GitOps authority identity")
+	flags.Var(&values.receipts, "receipt", "ordered canonical receipt as PATH@sha256:<digest>; repeat for each completed stage")
+	values.receiptPrefix = flags.String("receipt-prefix", "", "path to a digest-bound ordered receipt-prefix manifest")
+	values.receiptPrefixDigest = flags.String("receipt-prefix-digest", "", "expected SHA-256 digest of the receipt-prefix manifest")
+	return values
+}
+
+func (values *stageResumeFlags) config() (runner.StageResumeConfig, error) {
+	required := []struct{ name, value string }{
+		{"--plan", *values.planPath}, {"--contract-namespace", *values.contractNamespace}, {"--contract-name", *values.contractName},
+		{"--intent-revision", *values.intentRevision}, {"--enablement-revision", *values.enablementRevision}, {"--platform-revision", *values.platformRevision},
+		{"--execution-fixture", *values.executionFixture}, {"--infrastructure-authority", *values.infrastructureAuthority},
+		{"--management-authority", *values.managementAuthority}, {"--gitops-authority", *values.gitOpsAuthority},
+	}
+	for _, input := range required {
+		if input.value == "" {
+			return runner.StageResumeConfig{}, fmt.Errorf("%s is required", input.name)
+		}
+	}
+	providedPrefix := countNonEmpty(*values.receiptPrefix, *values.receiptPrefixDigest)
+	if providedPrefix != 0 && (providedPrefix != 2 || len(values.receipts) != 0) {
+		return runner.StageResumeConfig{}, errors.New("--receipt-prefix and --receipt-prefix-digest must be provided together and cannot be combined with --receipt")
+	}
+	receipts := make([]runner.StageReceiptSource, 0, len(values.receipts))
+	var err error
+	if providedPrefix == 2 {
+		receipts, err = runner.LoadStageReceiptPrefix(*values.receiptPrefix, *values.receiptPrefixDigest)
+		if err != nil {
+			return runner.StageResumeConfig{}, err
+		}
+	} else {
+		for _, value := range values.receipts {
+			if !stageReceiptFlagPattern.MatchString(value) {
+				return runner.StageResumeConfig{}, errors.New("receipt must use PATH@sha256:<64 lowercase hex> format")
+			}
+			separator := strings.LastIndex(value, "@sha256:")
+			receipts = append(receipts, runner.StageReceiptSource{Path: value[:separator], Digest: value[separator+1:]})
+		}
+	}
+	return runner.StageResumeConfig{
+		PlanPath: *values.planPath,
+		PlanExpected: stageplan.Expected{
+			ContractIdentity: contract.Identity{Namespace: *values.contractNamespace, Name: *values.contractName},
+			IntentRevision:   *values.intentRevision, EnablementRevision: *values.enablementRevision,
+			PlatformRevision: *values.platformRevision, ExecutionFixture: *values.executionFixture,
+			InfrastructureAuthority: *values.infrastructureAuthority, ManagementAuthority: *values.managementAuthority, GitOpsAuthority: *values.gitOpsAuthority,
+		},
+		Receipts: receipts,
+	}, nil
 }
 
 func addStageBundleFlags(flags *flag.FlagSet) *stageBundleFlags {
@@ -234,6 +311,14 @@ var inspectSubmissionStage = func(config runner.SubmissionStageBundleConfig) (st
 	}, nil
 }
 
+var inspectStageResume = func(config runner.StageResumeConfig) (stageResumeInspection, error) {
+	decision, err := runner.InspectStageResume(config)
+	if err != nil {
+		return stageResumeInspection{}, err
+	}
+	return stageResumeInspection{Format: "ok147-stage-resume-inspection/v1", Decision: decision, MutationAllowed: false}, nil
+}
+
 var executeSubmissionStage = func(ctx context.Context, bundleConfig runner.SubmissionStageBundleConfig, runtimeConfig runner.SubmissionStageRuntimeConfig) (execution.StagedOperationReceipt, error) {
 	bundle, err := runner.LoadSubmissionStageBundle(bundleConfig)
 	if err != nil {
@@ -290,6 +375,9 @@ func runContext(ctx context.Context, arguments []string, stdout, stderr io.Write
 	if len(arguments) >= 3 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "inspect" {
 		return runClusterStageInspect(arguments[3:], stdout, stderr)
 	}
+	if len(arguments) >= 3 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "resume" {
+		return runClusterStageResume(arguments[3:], stdout, stderr)
+	}
 	if len(arguments) >= 3 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "run" {
 		return runClusterStageRun(ctx, arguments[3:], stdout, stderr)
 	}
@@ -302,7 +390,7 @@ func runContext(ctx context.Context, arguments []string, stdout, stderr io.Write
 	if len(arguments) >= 4 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "launch" && arguments[3] == "execute" {
 		return runClusterStageLaunchExecute(ctx, arguments[4:], stdout, stderr)
 	}
-	return errors.New("usage: ok cluster create ... | ok cluster stage inspect ... | ok cluster stage run ... | ok cluster stage package ... | ok cluster stage launch prepare ... | ok cluster stage launch execute ...")
+	return errors.New("usage: ok cluster create ... | ok cluster stage inspect ... | ok cluster stage resume ... | ok cluster stage run ... | ok cluster stage package ... | ok cluster stage launch prepare ... | ok cluster stage launch execute ...")
 }
 
 func runClusterCreate(arguments []string, stdout, stderr io.Writer) error {
@@ -450,6 +538,30 @@ func runClusterStageInspect(arguments []string, stdout, stderr io.Writer) error 
 		return err
 	}
 	inspection, err := inspectSubmissionStage(bundleConfig)
+	if err != nil {
+		return err
+	}
+	encoder := json.NewEncoder(stdout)
+	encoder.SetEscapeHTML(false)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(inspection)
+}
+
+func runClusterStageResume(arguments []string, stdout, stderr io.Writer) error {
+	flags := flag.NewFlagSet("ok cluster stage resume", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	resumeFlags := addStageResumeFlags(flags)
+	if err := flags.Parse(arguments); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return errors.New("positional arguments are not accepted")
+	}
+	config, err := resumeFlags.config()
+	if err != nil {
+		return err
+	}
+	inspection, err := inspectStageResume(config)
 	if err != nil {
 		return err
 	}

--- a/cmd/ok/main_test.go
+++ b/cmd/ok/main_test.go
@@ -199,6 +199,62 @@ func TestStageInspectLoadsDigestBoundReceiptPrefix(t *testing.T) {
 	}
 }
 
+func TestStageResumeSelectsReadOnlyStageWithoutGrantOrCredentials(t *testing.T) {
+	previous := inspectStageResume
+	defer func() { inspectStageResume = previous }()
+	var captured runner.StageResumeConfig
+	inspectStageResume = func(config runner.StageResumeConfig) (stageResumeInspection, error) {
+		captured = config
+		return stageResumeInspection{
+			Format: "ok147-stage-resume-inspection/v1",
+			Decision: stagecursor.Decision{
+				Format: stagecursor.DecisionFormat, State: "NEXT", PlanDigest: testSHA("9"), CompletedStages: 2,
+				StageID: "lifecycle-observation", StageOrder: 3, StageDigest: testSHA("8"), Kind: "Observation",
+				Authority: "management", RequiresAuthorization: false, Predecessors: []stagecursor.Predecessor{},
+			},
+			MutationAllowed: false,
+		}, nil
+	}
+	arguments := stageResumeArguments()
+	arguments = append(arguments,
+		"--receipt", "/tmp/provider.json@"+testSHA("6"),
+		"--receipt", "/tmp/lifecycle.json@"+testSHA("7"),
+	)
+	var stdout, stderr bytes.Buffer
+	if err := run(arguments, &stdout, &stderr); err != nil {
+		t.Fatalf("run: %v; stderr=%s", err, stderr.String())
+	}
+	if captured.PlanPath != "/tmp/plan.json" || captured.PlanExpected.ContractIdentity.Name != "disposable-ok147" || len(captured.Receipts) != 2 {
+		t.Fatalf("resume config differs: %#v", captured)
+	}
+	var result stageResumeInspection
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatal(err)
+	}
+	if result.Format != "ok147-stage-resume-inspection/v1" || result.Decision.StageID != "lifecycle-observation" || result.Decision.RequiresAuthorization || result.MutationAllowed {
+		t.Fatalf("unsafe resume inspection: %#v", result)
+	}
+}
+
+func TestStageResumeRequiresCompleteUnambiguousInputs(t *testing.T) {
+	for name, arguments := range map[string][]string{
+		"missing bindings": {"cluster", "stage", "resume", "--plan", "/tmp/plan.json"},
+		"positional":       append(stageResumeArguments(), "unexpected"),
+		"bad receipt":      append(stageResumeArguments(), "--receipt", "/tmp/provider.json"),
+		"half prefix":      append(stageResumeArguments(), "--receipt-prefix", "/tmp/prefix.json"),
+		"mixed prefix": append(append(stageResumeArguments(),
+			"--receipt-prefix", "/tmp/prefix.json", "--receipt-prefix-digest", testSHA("1")),
+			"--receipt", "/tmp/provider.json@"+testSHA("2")),
+	} {
+		t.Run(name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			if err := run(arguments, &stdout, &stderr); err == nil || stdout.Len() != 0 {
+				t.Fatalf("ambiguous resume input was accepted: err=%v stdout=%s", err, stdout.String())
+			}
+		})
+	}
+}
+
 func TestStageRunRequiresExplicitExecutionAndBindsOneRuntime(t *testing.T) {
 	previous := executeSubmissionStage
 	defer func() { executeSubmissionStage = previous }()
@@ -554,6 +610,15 @@ func stageInspectArguments() []string {
 		"--execution-fixture", testSHA("d"), "--infrastructure-authority", "ok-infra", "--management-authority", "ok-mgmt", "--gitops-authority", "ok-shared",
 		"--grant", "/tmp/grant.json", "--grant-key", "/tmp/grant.pub", "--projection-manifest", "/tmp/projection.json",
 		"--evaluation-time", "2026-08-16T14:00:00Z",
+	}
+}
+
+func stageResumeArguments() []string {
+	return []string{
+		"cluster", "stage", "resume",
+		"--plan", "/tmp/plan.json", "--contract-namespace", "disposable-ok147", "--contract-name", "disposable-ok147",
+		"--intent-revision", testSHA("a"), "--enablement-revision", testSHA("b"), "--platform-revision", testSHA("c"),
+		"--execution-fixture", testSHA("d"), "--infrastructure-authority", "ok-infra", "--management-authority", "ok-mgmt", "--gitops-authority", "ok-shared",
 	}
 }
 

--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -917,6 +917,29 @@ set. It contains no dispatcher, implementation registry, credential, endpoint
 or retry policy. Therefore it can guide a later local or Job runner without
 becoming a second desired-state source or allowing a terminal plan to resume.
 
+The same cursor is now available through a generic, local-only inspection
+entrypoint:
+
+```text
+ok cluster stage resume
+  + exact plan identity
+  + explicit canonical receipt prefix
+      -> NEXT | COMPLETED | STOPPED
+```
+
+Unlike the earlier submission-specific `stage inspect`, this command does not
+require a grant or projection and can therefore select read-only stages such
+as `lifecycle-observation`. It verifies every receipt and its direct
+predecessor again before returning a decision. It has no credential, endpoint,
+ledger, stage implementation, write or cluster-contact input. An explicit
+empty prefix selects only the first stage; changed, missing, reordered or
+foreign receipts fail closed.
+
+This is the resume decision boundary, not observation execution. A later
+typed stage adapter must still prove its own authoritative evidence and append
+one canonical receipt. The command cannot turn `NEXT` into authorization or
+execute the selected stage.
+
 ## Cursor-to-grant binding
 
 Selecting a next stage is not claim authority. Before a later runner may claim

--- a/internal/runner/stage_resume.go
+++ b/internal/runner/stage_resume.go
@@ -1,0 +1,46 @@
+package runner
+
+import (
+	"errors"
+
+	"github.com/openkubes/ok-cluster/internal/stagecursor"
+	"github.com/openkubes/ok-cluster/internal/stageplan"
+	"github.com/openkubes/ok-cluster/internal/stagereceipt"
+)
+
+// StageResumeConfig contains only the immutable plan identity and an explicit
+// canonical receipt prefix. It carries no grant, credential, endpoint or
+// implementation selector.
+type StageResumeConfig struct {
+	PlanPath     string
+	PlanExpected stageplan.Expected
+	Receipts     []StageReceiptSource
+}
+
+// InspectStageResume verifies the complete receipt prefix and returns the only
+// safe cursor decision. It performs no credential read, ledger access,
+// Kubernetes request, mutation or stage execution.
+func InspectStageResume(config StageResumeConfig) (stagecursor.Decision, error) {
+	if config.Receipts == nil {
+		return stagecursor.Decision{}, errors.New("stage receipt prefix must be explicit")
+	}
+	plan, err := stageplan.Load(config.PlanPath, config.PlanExpected)
+	if err != nil {
+		return stagecursor.Decision{}, err
+	}
+	prefix := make([]stagereceipt.Verified, 0, len(config.Receipts))
+	predecessors := []stagereceipt.Verified{}
+	for _, source := range config.Receipts {
+		verified, err := stagereceipt.Load(source.Path, source.Digest, plan, predecessors)
+		if err != nil {
+			return stagecursor.Decision{}, err
+		}
+		prefix = append(prefix, verified)
+		predecessors = []stagereceipt.Verified{verified}
+	}
+	cursor, err := stagecursor.Evaluate(plan, prefix)
+	if err != nil {
+		return stagecursor.Decision{}, err
+	}
+	return cursor.Decision()
+}

--- a/internal/runner/stage_resume_test.go
+++ b/internal/runner/stage_resume_test.go
@@ -1,0 +1,78 @@
+package runner
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/stagereceipt"
+)
+
+func TestInspectStageResumeSelectsReadOnlyStageFromVerifiedPrefix(t *testing.T) {
+	fixture := submissionBundleFixture(t, true, "")
+	provider, err := stagereceipt.Load(fixture.config.Receipts[0].Path, fixture.config.Receipts[0].Digest, fixture.plan, []stagereceipt.Verified{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	lifecycle, err := stagereceipt.New(fixture.plan, "cluster-lifecycle", []stagereceipt.Verified{provider}, "SUCCEEDED", "ATTEMPTED", bundleSHA("6"), bundleSHA("7"), time.Date(2026, 8, 16, 14, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, _ := lifecycle.Bytes()
+	digest, _ := lifecycle.Digest()
+	source := StageReceiptSource{Path: writeBundleFile(t, t.TempDir(), "lifecycle-receipt.json", raw), Digest: digest}
+
+	decision, err := InspectStageResume(StageResumeConfig{
+		PlanPath: fixture.config.PlanPath, PlanExpected: fixture.config.PlanExpected,
+		Receipts: append(append([]StageReceiptSource{}, fixture.config.Receipts...), source),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decision.State != "NEXT" || decision.StageID != "lifecycle-observation" || decision.Kind != "Observation" || decision.Authority != "management" || decision.RequiresAuthorization || decision.Operation != "" || decision.CompletedStages != 2 {
+		t.Fatalf("unexpected resume decision: %#v", decision)
+	}
+}
+
+func TestInspectStageResumeRejectsImplicitOrChangedPrefix(t *testing.T) {
+	fixture := submissionBundleFixture(t, true, "")
+	config := StageResumeConfig{PlanPath: fixture.config.PlanPath, PlanExpected: fixture.config.PlanExpected}
+	if _, err := InspectStageResume(config); err == nil {
+		t.Fatal("implicit receipt prefix was accepted")
+	}
+
+	config.Receipts = append([]StageReceiptSource{}, fixture.config.Receipts...)
+	config.Receipts[0].Digest = bundleSHA("f")
+	if _, err := InspectStageResume(config); err == nil || !strings.Contains(err.Error(), "digest differs") {
+		t.Fatalf("changed receipt identity was accepted: %v", err)
+	}
+}
+
+func TestInspectStageResumeReportsTerminalPlanWithoutExecution(t *testing.T) {
+	fixture := submissionBundleFixture(t, false, "")
+	predecessors := []stagereceipt.Verified{}
+	sources := []StageReceiptSource{}
+	root := t.TempDir()
+	started := time.Date(2026, 8, 16, 14, 0, 0, 0, time.UTC)
+	for index, stage := range fixture.plan.Stages {
+		state, mutation, operationDigest := "SUCCEEDED", "NOT_APPLICABLE", ""
+		if stage.GrantOperation != "" {
+			mutation, operationDigest = "ATTEMPTED", bundleSHA("8")
+		}
+		verified, err := stagereceipt.New(fixture.plan, stage.ID, predecessors, state, mutation, operationDigest, bundleSHA("9"), started.Add(time.Duration(index)*time.Second))
+		if err != nil {
+			t.Fatal(err)
+		}
+		raw, _ := verified.Bytes()
+		receiptDigest, _ := verified.Digest()
+		sources = append(sources, StageReceiptSource{Path: writeBundleFile(t, root, stage.ID+".json", raw), Digest: receiptDigest})
+		predecessors = []stagereceipt.Verified{verified}
+	}
+	decision, err := InspectStageResume(StageResumeConfig{PlanPath: fixture.config.PlanPath, PlanExpected: fixture.config.PlanExpected, Receipts: sources})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decision.State != "COMPLETED" || decision.CompletedStages != 12 || decision.RequiresAuthorization || decision.StageID != "" {
+		t.Fatalf("completed plan decision differs: %#v", decision)
+	}
+}


### PR DESCRIPTION
## Outcome

Adds a generic, fail-closed `ok cluster stage resume` inspection boundary.

The command re-verifies the exact staged plan and an explicit canonical receipt prefix, then returns only `NEXT`, `COMPLETED`, or `STOPPED`. Unlike the submission-specific inspection path, it needs no grant or projection and can safely select `lifecycle-observation` after the first two durable receipts.

## Safety boundary

- no credential or endpoint inputs
- no ledger or Kubernetes contact
- no stage implementation or dispatcher
- no authorization or mutation capability
- changed, missing, reordered, or foreign receipts fail closed
- an explicit empty prefix selects only the first stage

This is the resume decision boundary, not observation execution.

## Verification

- `git diff --check`
- `GOCACHE=/private/tmp/ok147-go-build-cache go test -ldflags=-linkmode=external ./...`
- `GOCACHE=/private/tmp/ok147-go-build-cache go vet ./...`
- `GOCACHE=/private/tmp/ok147-go-build-cache go test -race -ldflags=-linkmode=external ./cmd/ok ./internal/runner`
- `python3 -m unittest discover -s tests -p '*_test.py'` (18 passed, 1 expected skip)

Jira: OK-147
