### PR TITLE
OK-147: persist lifecycle runtime correlation

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ Powered by [Cluster API (CAPI)](https://cluster-api.sigs.k8s.io/), [CAPK (KubeVi
   explicit canonical receipt prefix and reports only the next, completed or
   stopped cursor state; it has no grant, credential, endpoint or execution
   capability and can safely select the next read-only stage after a restart.
+  Successful Cluster-lifecycle submission also carries a SHA-256 binding of
+  the exact CAPI Cluster UID through the durable outcome and stage receipt;
+  the raw UID is not emitted in redaction-safe evidence.
 
 ---
 

--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -995,6 +995,15 @@ Malformed or foreign receipts stop indeterminately rather than manufacturing a
 stage outcome. Tests use a fake plane submitter: Kubernetes credentials and the
 live client are not yet composed into the staged runner path.
 
+The successful `cluster-lifecycle` stage additionally hashes the exact CAPI
+Cluster UID returned by the create response. That digest is carried through
+the immutable operation outcome and common stage receipt, so it survives
+executor termination and ledger recreation. The raw Kubernetes UID is not
+retained in redaction-safe output. A later lifecycle observer must hash the UID
+from its exact GET and match this durable value before it can correlate current
+Conditions. Successful lifecycle submission without that runtime identity, or
+a target-identity digest on any other stage, fails closed.
+
 ## Runtime composition for one submission stage
 
 The runner package can now construct one staged submission operation from an

--- a/internal/execution/staged.go
+++ b/internal/execution/staged.go
@@ -40,9 +40,10 @@ type StageMutationRequest struct {
 
 // StageMutationResult is the complete redaction-safe result of one call.
 type StageMutationResult struct {
-	Outcome        string
-	MutationState  string
-	EvidenceDigest string
+	Outcome                string
+	MutationState          string
+	EvidenceDigest         string
+	TargetClusterUIDDigest string
 }
 
 // StageMutator is a single, preconstructed mutation capability.
@@ -137,10 +138,10 @@ func (operation StagedOperation) Run(ctx context.Context, plan stageplan.Binding
 		GrantID:              binding.GrantID,
 		PredecessorDigest:    binding.PredecessorDigest,
 	})
-	if err := validateStageMutationResult(result, mutationErr); err != nil {
+	if err := validateStageMutationResult(decision.StageID, result, mutationErr); err != nil {
 		return receipt, err
 	}
-	outcome, err := operation.Ledger.CompleteStage(ctx, claim, result.Outcome, result.MutationState, result.EvidenceDigest, operation.Clock())
+	outcome, err := operation.Ledger.CompleteStageWithTarget(ctx, claim, result.Outcome, result.MutationState, result.EvidenceDigest, result.TargetClusterUIDDigest, operation.Clock())
 	if err != nil {
 		return receipt, err
 	}
@@ -169,12 +170,19 @@ func (operation StagedOperation) finalize(ctx context.Context, receipt StagedOpe
 	return receipt, nil
 }
 
-func validateStageMutationResult(result StageMutationResult, mutationErr error) error {
+func validateStageMutationResult(stageID string, result StageMutationResult, mutationErr error) error {
 	if !oneOf(result.Outcome, "SUCCEEDED", "FAILED", "STOPPED") || !oneOf(result.MutationState, "NOT_ATTEMPTED", "ATTEMPTED", "UNKNOWN") || !stagedDigestPattern.MatchString(result.EvidenceDigest) {
 		return errors.New("stage mutator returned an invalid redaction-safe result")
 	}
 	if result.Outcome == "SUCCEEDED" && (result.MutationState != "ATTEMPTED" || mutationErr != nil) {
 		return errors.New("stage mutator reported an inconsistent successful result")
+	}
+	if stageID == "cluster-lifecycle" && result.Outcome == "SUCCEEDED" {
+		if !stagedDigestPattern.MatchString(result.TargetClusterUIDDigest) {
+			return errors.New("successful Cluster lifecycle mutation lacks a runtime identity digest")
+		}
+	} else if result.TargetClusterUIDDigest != "" {
+		return errors.New("stage mutation returned runtime identity outside successful Cluster lifecycle")
 	}
 	return nil
 }

--- a/internal/execution/staged_submission.go
+++ b/internal/execution/staged_submission.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 
 	"github.com/openkubes/ok-cluster/internal/contract"
+	"github.com/openkubes/ok-cluster/internal/digest"
 	"github.com/openkubes/ok-cluster/internal/stageplan"
 	"github.com/openkubes/ok-cluster/internal/submission"
 )
@@ -93,7 +94,32 @@ func (mutator *SubmissionPlaneMutator) Mutate(ctx context.Context, request Stage
 	if mutationState != "ATTEMPTED" {
 		return StageMutationResult{Outcome: "STOPPED", MutationState: mutationState, EvidenceDigest: evidenceDigest}, nil
 	}
-	return StageMutationResult{Outcome: "SUCCEEDED", MutationState: mutationState, EvidenceDigest: evidenceDigest}, nil
+	result := StageMutationResult{Outcome: "SUCCEEDED", MutationState: mutationState, EvidenceDigest: evidenceDigest}
+	if mutator.binding.StageID == "cluster-lifecycle" {
+		uid, err := submittedLifecycleClusterUID(receipt, mutator.plane, mutator.identity)
+		if err != nil {
+			return StageMutationResult{}, err
+		}
+		result.TargetClusterUIDDigest = digest.SHA256([]byte(uid))
+	}
+	return result, nil
+}
+
+func submittedLifecycleClusterUID(receipt submission.PlaneReceipt, plane submission.Plane, identity contract.Identity) (string, error) {
+	var uid string
+	for index, object := range plane.Objects {
+		if object.Identity.APIVersion != "cluster.x-k8s.io/v1beta2" || object.Identity.Kind != "Cluster" || object.Identity.Namespace != identity.Namespace || object.Identity.Name != identity.Name {
+			continue
+		}
+		if uid != "" || index >= len(receipt.Results) || receipt.Results[index].UID == "" {
+			return "", errors.New("Cluster lifecycle submission has ambiguous runtime identity")
+		}
+		uid = receipt.Results[index].UID
+	}
+	if uid == "" {
+		return "", errors.New("Cluster lifecycle submission lacks exact runtime identity")
+	}
+	return uid, nil
 }
 
 func validateSubmissionPlaneOutcome(receipt submission.PlaneReceipt, plane submission.Plane, stopped bool) (string, error) {

--- a/internal/execution/staged_submission_test.go
+++ b/internal/execution/staged_submission_test.go
@@ -1,6 +1,7 @@
 package execution
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -8,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/openkubes/ok-cluster/internal/digest"
 	"github.com/openkubes/ok-cluster/internal/ledger"
 	"github.com/openkubes/ok-cluster/internal/projection"
 	"github.com/openkubes/ok-cluster/internal/stagecursor"
@@ -31,6 +33,46 @@ func TestSubmissionPlaneMutatorCompletesStagedOperation(t *testing.T) {
 	receipt, err := (StagedOperation{Ledger: store, Mutator: mutator, Clock: stagedClock(at)}).Run(context.Background(), plan, cursor, grant)
 	if err != nil || receipt.State != "COMPLETED_SUCCEEDED" || receipt.StageReceiptDigest == "" || submitter.calls != 1 {
 		t.Fatalf("typed submission stage did not complete: %#v calls=%d err=%v", receipt, submitter.calls, err)
+	}
+}
+
+func TestLifecycleSubmissionPersistsRuntimeCorrelationAcrossResume(t *testing.T) {
+	plan := stagedPlan(t)
+	at := time.Date(2026, 8, 16, 18, 0, 0, 0, time.UTC)
+	provider, err := stagereceipt.New(plan, "provider-prerequisites", []stagereceipt.Verified{}, "SUCCEEDED", "ATTEMPTED", stagedSHA("1"), stagedSHA("e"), at)
+	if err != nil {
+		t.Fatal(err)
+	}
+	projected := stagedSubmissionPlan(plan.IntentRevision, plan.Authorities.Infrastructure, plan.Authorities.Management)
+	submissionReceipt := successfulPlaneReceipt(projected.Management, "CREATED", "ATTEMPTED")
+	const targetUID = "cluster-runtime-uid-147"
+	submissionReceipt.Results[0].UID = targetUID
+	mutator, err := NewSubmissionPlaneMutator(plan, "cluster-lifecycle", projected, &fakePlaneSubmitter{receipt: submissionReceipt})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cursor, _ := stagecursor.Evaluate(plan, []stagereceipt.Verified{provider})
+	grant := stagedGrant(t, plan, "cluster-lifecycle", []stagereceipt.Verified{provider}, at.Add(time.Second))
+	store, _ := ledger.Open(filepath.Join(t.TempDir(), "ledger"))
+	receipt, err := (StagedOperation{Ledger: store, Mutator: mutator, Clock: stagedClock(at.Add(time.Second))}).Run(context.Background(), plan, cursor, grant)
+	if err != nil || receipt.State != "COMPLETED_SUCCEEDED" {
+		t.Fatalf("lifecycle stage did not complete: %#v %v", receipt, err)
+	}
+	verified, err := store.LoadStageReceipt(context.Background(), plan, "cluster-lifecycle", receipt.StageReceiptDigest, []stagereceipt.Verified{provider})
+	if err != nil {
+		t.Fatal(err)
+	}
+	stored, _ := verified.Receipt()
+	if stored.TargetClusterUIDDigest != digest.SHA256([]byte(targetUID)) {
+		t.Fatalf("runtime correlation did not survive durable resume: %#v", stored)
+	}
+	resumed, err := stagecursor.Evaluate(plan, []stagereceipt.Verified{provider, verified})
+	if err != nil {
+		t.Fatal(err)
+	}
+	decision, _ := resumed.Decision()
+	if decision.StageID != "lifecycle-observation" || decision.State != "NEXT" {
+		t.Fatalf("runtime-bound lifecycle receipt did not resume observation: %#v", decision)
 	}
 }
 
@@ -63,6 +105,36 @@ func TestSubmissionPlaneMutatorNoWriteCannotClaimStageSuccess(t *testing.T) {
 	result, err := mutator.Mutate(context.Background(), stagedMutationRequest(t, plan, mutator.Binding()))
 	if err != nil || result.Outcome != "STOPPED" || result.MutationState != "NOT_ATTEMPTED" {
 		t.Fatalf("no-write submission claimed success: %#v %v", result, err)
+	}
+}
+
+func TestSubmissionPlaneMutatorBindsLifecycleRuntimeIdentityWithoutExposingUID(t *testing.T) {
+	plan := stagedPlan(t)
+	projected := stagedSubmissionPlan(plan.IntentRevision, plan.Authorities.Infrastructure, plan.Authorities.Management)
+	receipt := successfulPlaneReceipt(projected.Management, "CREATED", "ATTEMPTED")
+	const runtimeUID = "cluster-runtime-uid-147"
+	receipt.Results[0].UID = runtimeUID
+	mutator, err := NewSubmissionPlaneMutator(plan, "cluster-lifecycle", projected, &fakePlaneSubmitter{receipt: receipt})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := mutator.Mutate(context.Background(), stagedMutationRequest(t, plan, mutator.Binding()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.TargetClusterUIDDigest != digest.SHA256([]byte(runtimeUID)) || bytes.Contains([]byte(result.TargetClusterUIDDigest), []byte(runtimeUID)) {
+		t.Fatalf("runtime identity was not safely bound: %#v", result)
+	}
+}
+
+func TestSubmissionPlaneMutatorRejectsMissingLifecycleRuntimeIdentity(t *testing.T) {
+	plan := stagedPlan(t)
+	projected := stagedSubmissionPlan(plan.IntentRevision, plan.Authorities.Infrastructure, plan.Authorities.Management)
+	receipt := successfulPlaneReceipt(projected.Management, "CREATED", "ATTEMPTED")
+	receipt.Results[0].UID = ""
+	mutator, _ := NewSubmissionPlaneMutator(plan, "cluster-lifecycle", projected, &fakePlaneSubmitter{receipt: receipt})
+	if _, err := mutator.Mutate(context.Background(), stagedMutationRequest(t, plan, mutator.Binding())); err == nil {
+		t.Fatal("successful lifecycle submission without runtime identity was accepted")
 	}
 }
 

--- a/internal/execution/staged_test.go
+++ b/internal/execution/staged_test.go
@@ -145,6 +145,29 @@ func TestStagedOperationRejectsReadOnlyCursor(t *testing.T) {
 	}
 }
 
+func TestStagedOperationRequiresLifecycleRuntimeIdentityDigest(t *testing.T) {
+	plan := stagedPlan(t)
+	at := time.Date(2026, 8, 16, 18, 0, 0, 0, time.UTC)
+	provider, err := stagereceipt.New(plan, "provider-prerequisites", []stagereceipt.Verified{}, "SUCCEEDED", "ATTEMPTED", stagedSHA("1"), stagedSHA("e"), at)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cursor, err := stagecursor.Evaluate(plan, []stagereceipt.Verified{provider})
+	if err != nil {
+		t.Fatal(err)
+	}
+	grant := stagedGrant(t, plan, "cluster-lifecycle", []stagereceipt.Verified{provider}, at.Add(time.Second))
+	store, _ := ledger.Open(filepath.Join(t.TempDir(), "ledger"))
+	mutator := &fakeStageMutator{
+		binding: stagedMutationBinding(t, plan, "cluster-lifecycle"),
+		result:  StageMutationResult{Outcome: "SUCCEEDED", MutationState: "ATTEMPTED", EvidenceDigest: stagedSHA("e")},
+	}
+	receipt, err := (StagedOperation{Ledger: store, Mutator: mutator, Clock: stagedClock(at.Add(time.Second))}).Run(context.Background(), plan, cursor, grant)
+	if err == nil || receipt.State != "CLAIMED_INDETERMINATE_STOP" || mutator.calls != 1 {
+		t.Fatalf("lifecycle result without target correlation did not stop: %#v calls=%d err=%v", receipt, mutator.calls, err)
+	}
+}
+
 type fakeStageMutator struct {
 	binding StageMutationBinding
 	result  StageMutationResult

--- a/internal/ledger/stage.go
+++ b/internal/ledger/stage.go
@@ -33,18 +33,19 @@ type StageClaimReceipt struct {
 }
 
 type StageOutcomeReceipt struct {
-	Format         string `json:"format"`
-	State          string `json:"state"`
-	GrantID        string `json:"grantId"`
-	PlanDigest     string `json:"planDigest"`
-	StageID        string `json:"stageId"`
-	StageDigest    string `json:"stageDigest"`
-	Operation      string `json:"operation"`
-	ClaimDigest    string `json:"claimDigest"`
-	Outcome        string `json:"outcome"`
-	MutationState  string `json:"mutationState"`
-	EvidenceDigest string `json:"evidenceDigest"`
-	CompletedAt    string `json:"completedAt"`
+	Format                 string `json:"format"`
+	State                  string `json:"state"`
+	GrantID                string `json:"grantId"`
+	PlanDigest             string `json:"planDigest"`
+	StageID                string `json:"stageId"`
+	StageDigest            string `json:"stageDigest"`
+	Operation              string `json:"operation"`
+	ClaimDigest            string `json:"claimDigest"`
+	Outcome                string `json:"outcome"`
+	MutationState          string `json:"mutationState"`
+	EvidenceDigest         string `json:"evidenceDigest"`
+	TargetClusterUIDDigest string `json:"targetClusterUidDigest,omitempty"`
+	CompletedAt            string `json:"completedAt"`
 }
 
 type StageInspection struct {
@@ -96,6 +97,13 @@ func (ledger *Ledger) ClaimStage(ctx context.Context, grant authorization.Verifi
 // CompleteStage records one immutable result. An exact repeat is idempotent;
 // a successful mutating stage must have attempted its mutation.
 func (ledger *Ledger) CompleteStage(ctx context.Context, claim StageClaimReceipt, outcome, mutationState, evidenceDigest string, at time.Time) (StageOutcomeReceipt, error) {
+	return ledger.CompleteStageWithTarget(ctx, claim, outcome, mutationState, evidenceDigest, "", at)
+}
+
+// CompleteStageWithTarget records the irreversible runtime correlation from a
+// successful Cluster lifecycle create without retaining the raw Kubernetes
+// UID in redaction-safe ledger evidence.
+func (ledger *Ledger) CompleteStageWithTarget(ctx context.Context, claim StageClaimReceipt, outcome, mutationState, evidenceDigest, targetClusterUIDDigest string, at time.Time) (StageOutcomeReceipt, error) {
 	if !allowed(outcome, "SUCCEEDED", "FAILED", "STOPPED") || !allowed(mutationState, "NOT_ATTEMPTED", "ATTEMPTED", "UNKNOWN") {
 		return StageOutcomeReceipt{}, errors.New("stage completion state is invalid")
 	}
@@ -104,6 +112,9 @@ func (ledger *Ledger) CompleteStage(ctx context.Context, claim StageClaimReceipt
 	}
 	if !validDigest(evidenceDigest) {
 		return StageOutcomeReceipt{}, errors.New("stage evidence digest is invalid")
+	}
+	if targetClusterUIDDigest != "" && (claim.StageID != "cluster-lifecycle" || outcome != "SUCCEEDED" || !validDigest(targetClusterUIDDigest)) {
+		return StageOutcomeReceipt{}, errors.New("stage target Cluster identity binding is invalid")
 	}
 	stored, claimDigest, err := ledger.readStageClaim(ctx, claim.GrantID)
 	if err != nil {
@@ -121,7 +132,7 @@ func (ledger *Ledger) CompleteStage(ctx context.Context, claim StageClaimReceipt
 		Format: StageOutcomeFormat, State: "COMPLETED", GrantID: claim.GrantID,
 		PlanDigest: claim.PlanDigest, StageID: claim.StageID, StageDigest: claim.StageDigest,
 		Operation: claim.Operation, ClaimDigest: claimDigest, Outcome: outcome,
-		MutationState: mutationState, EvidenceDigest: evidenceDigest,
+		MutationState: mutationState, EvidenceDigest: evidenceDigest, TargetClusterUIDDigest: targetClusterUIDDigest,
 		CompletedAt: at.UTC().Format(time.RFC3339Nano),
 	}
 	raw, expectedDigest, err := canonicalRecord(receipt)
@@ -236,6 +247,9 @@ func validateStageOutcome(value StageOutcomeReceipt) error {
 		if !validDigest(identity) {
 			return errors.New("stage outcome contains an invalid digest")
 		}
+	}
+	if value.TargetClusterUIDDigest != "" && (value.StageID != "cluster-lifecycle" || value.Outcome != "SUCCEEDED" || !validDigest(value.TargetClusterUIDDigest)) {
+		return errors.New("stage outcome contains an invalid target Cluster identity binding")
 	}
 	if _, err := time.Parse(time.RFC3339Nano, value.CompletedAt); err != nil {
 		return errors.New("stage outcome has an invalid timestamp")

--- a/internal/ledger/stage_finalize.go
+++ b/internal/ledger/stage_finalize.go
@@ -43,7 +43,7 @@ func (ledger *Ledger) FinalizeStageReceipt(ctx context.Context, plan stageplan.B
 	if err != nil {
 		return stagereceipt.Verified{}, errors.New("mutating stage completion time is invalid")
 	}
-	verified, err := stagereceipt.New(
+	verified, err := stagereceipt.NewWithTargetClusterUIDDigest(
 		plan,
 		stage.ID,
 		predecessors,
@@ -51,6 +51,7 @@ func (ledger *Ledger) FinalizeStageReceipt(ctx context.Context, plan stageplan.B
 		inspection.Outcome.MutationState,
 		inspection.OutcomeDigest,
 		inspection.Outcome.EvidenceDigest,
+		inspection.Outcome.TargetClusterUIDDigest,
 		completedAt,
 	)
 	if err != nil {

--- a/internal/ledger/stage_finalize_test.go
+++ b/internal/ledger/stage_finalize_test.go
@@ -1,11 +1,14 @@
 package ledger
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"path/filepath"
 	"testing"
 	"time"
 
+	"github.com/openkubes/ok-cluster/internal/digest"
 	"github.com/openkubes/ok-cluster/internal/stagereceipt"
 )
 
@@ -86,5 +89,60 @@ func TestFinalizeStageReceiptRejectsDifferentPredecessorChain(t *testing.T) {
 	}
 	if _, err := store.FinalizeStageReceipt(context.Background(), plan, grant, []stagereceipt.Verified{other}); err == nil {
 		t.Fatal("stage outcome was finalized against a different predecessor receipt")
+	}
+}
+
+func TestFinalizeLifecycleReceiptCarriesOnlyTargetUIDDigest(t *testing.T) {
+	store, _ := Open(filepath.Join(t.TempDir(), "ledger"))
+	plan := verifiedStagePlan(t)
+	at := time.Date(2026, 8, 16, 18, 0, 0, 0, time.UTC)
+	provider, err := stagereceipt.New(plan, "provider-prerequisites", []stagereceipt.Verified{}, "SUCCEEDED", "ATTEMPTED", stageSHA("1"), stageSHA("a"), at)
+	if err != nil {
+		t.Fatal(err)
+	}
+	grant := verifiedStageGrantFor(t, plan, "cluster-lifecycle", []stagereceipt.Verified{provider}, at.Add(time.Second))
+	claim, err := store.ClaimStage(context.Background(), grant, at.Add(time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	const rawUID = "cluster-runtime-uid-147"
+	targetDigest := digest.SHA256([]byte(rawUID))
+	outcome, err := store.CompleteStageWithTarget(context.Background(), claim, "SUCCEEDED", "ATTEMPTED", stageSHA("e"), targetDigest, at.Add(2*time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	verified, err := store.FinalizeStageReceipt(context.Background(), plan, grant, []stagereceipt.Verified{provider})
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, _ := verified.Receipt()
+	if outcome.TargetClusterUIDDigest != targetDigest || receipt.TargetClusterUIDDigest != targetDigest {
+		t.Fatalf("target identity digest did not survive finalization: %#v %#v", outcome, receipt)
+	}
+	for _, value := range []any{outcome, receipt} {
+		raw, _ := json.Marshal(value)
+		if bytes.Contains(raw, []byte(rawUID)) {
+			t.Fatalf("raw target UID escaped into redaction-safe evidence: %s", raw)
+		}
+	}
+	receiptDigest, _ := verified.Digest()
+	loaded, err := store.LoadStageReceipt(context.Background(), plan, "cluster-lifecycle", receiptDigest, []stagereceipt.Verified{provider})
+	if err != nil {
+		t.Fatal(err)
+	}
+	loadedReceipt, _ := loaded.Receipt()
+	if loadedReceipt.TargetClusterUIDDigest != targetDigest {
+		t.Fatal("persisted target identity digest was lost on restart")
+	}
+}
+
+func TestCompleteStageRejectsTargetBindingOutsideLifecycleSuccess(t *testing.T) {
+	store, _ := Open(filepath.Join(t.TempDir(), "ledger"))
+	plan := verifiedStagePlan(t)
+	at := time.Date(2026, 8, 16, 18, 0, 0, 0, time.UTC)
+	grant := verifiedStageGrantFor(t, plan, "provider-prerequisites", []stagereceipt.Verified{}, at)
+	claim, _ := store.ClaimStage(context.Background(), grant, at)
+	if _, err := store.CompleteStageWithTarget(context.Background(), claim, "SUCCEEDED", "ATTEMPTED", stageSHA("e"), stageSHA("7"), at.Add(time.Second)); err == nil {
+		t.Fatal("provider stage accepted a target Cluster identity binding")
 	}
 }

--- a/internal/stagereceipt/receipt.go
+++ b/internal/stagereceipt/receipt.go
@@ -50,6 +50,7 @@ type Receipt struct {
 	MutationState          string            `json:"mutationState"`
 	OperationOutcomeDigest string            `json:"operationOutcomeDigest,omitempty"`
 	EvidenceDigest         string            `json:"evidenceDigest"`
+	TargetClusterUIDDigest string            `json:"targetClusterUidDigest,omitempty"`
 	CompletedAt            string            `json:"completedAt"`
 }
 
@@ -65,6 +66,12 @@ type Verified struct {
 // New builds a receipt only after all direct predecessor receipts have been
 // verified, completed successfully and matched to the same staged plan.
 func New(plan stageplan.Binding, stageID string, predecessors []Verified, state, mutationState, operationOutcomeDigest, evidenceDigest string, completedAt time.Time) (Verified, error) {
+	return NewWithTargetClusterUIDDigest(plan, stageID, predecessors, state, mutationState, operationOutcomeDigest, evidenceDigest, "", completedAt)
+}
+
+// NewWithTargetClusterUIDDigest binds the raw-UID-free correlation emitted by
+// a successful Cluster lifecycle submission into its immutable receipt.
+func NewWithTargetClusterUIDDigest(plan stageplan.Binding, stageID string, predecessors []Verified, state, mutationState, operationOutcomeDigest, evidenceDigest, targetClusterUIDDigest string, completedAt time.Time) (Verified, error) {
 	stage, stageDigest, err := plan.Stage(stageID)
 	if err != nil {
 		return Verified{}, err
@@ -80,7 +87,8 @@ func New(plan stageplan.Binding, stageID string, predecessors []Verified, state,
 		StageID: stage.ID, StageOrder: stage.Order, StageDigest: stageDigest, Kind: stage.Kind,
 		Authority: stage.Authority, Operation: stage.GrantOperation, Predecessors: links,
 		State: state, MutationState: mutationState, OperationOutcomeDigest: operationOutcomeDigest,
-		EvidenceDigest: evidenceDigest, CompletedAt: completedAt.UTC().Format(time.RFC3339Nano),
+		EvidenceDigest: evidenceDigest, TargetClusterUIDDigest: targetClusterUIDDigest,
+		CompletedAt: completedAt.UTC().Format(time.RFC3339Nano),
 	}
 	return verifyReceipt(receipt, plan, predecessors)
 }
@@ -189,6 +197,9 @@ func verifyReceipt(receipt Receipt, plan stageplan.Binding, predecessors []Verif
 		}
 	} else if receipt.MutationState != "NOT_APPLICABLE" || receipt.OperationOutcomeDigest != "" {
 		return Verified{}, errors.New("read-only stage receipt contains mutation state")
+	}
+	if receipt.TargetClusterUIDDigest != "" && (stage.ID != "cluster-lifecycle" || receipt.State != "SUCCEEDED" || !receiptDigestPattern.MatchString(receipt.TargetClusterUIDDigest)) {
+		return Verified{}, errors.New("stage receipt target Cluster identity binding is invalid")
 	}
 	raw, receiptDigest, err := canonicalReceipt(receipt)
 	if err != nil {

--- a/internal/stagereceipt/receipt_test.go
+++ b/internal/stagereceipt/receipt_test.go
@@ -75,6 +75,23 @@ func TestReceiptEnforcesMutationBoundary(t *testing.T) {
 	}
 }
 
+func TestLifecycleReceiptBindsOnlyTargetUIDDigest(t *testing.T) {
+	plan := receiptPlan(t)
+	at := time.Date(2026, 8, 16, 16, 0, 0, 0, time.UTC)
+	provider, _ := New(plan, "provider-prerequisites", []Verified{}, "SUCCEEDED", "ATTEMPTED", receiptSHA("1"), receiptSHA("a"), at)
+	verified, err := NewWithTargetClusterUIDDigest(plan, "cluster-lifecycle", []Verified{provider}, "SUCCEEDED", "ATTEMPTED", receiptSHA("2"), receiptSHA("b"), receiptSHA("7"), at.Add(time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, _ := verified.Receipt()
+	if receipt.TargetClusterUIDDigest != receiptSHA("7") {
+		t.Fatalf("target UID digest differs: %#v", receipt)
+	}
+	if _, err := NewWithTargetClusterUIDDigest(plan, "provider-prerequisites", []Verified{}, "SUCCEEDED", "ATTEMPTED", receiptSHA("1"), receiptSHA("a"), receiptSHA("7"), at); err == nil {
+		t.Fatal("target identity binding outside Cluster lifecycle was accepted")
+	}
+}
+
 func TestReceiptRejectsCompletionBeforePredecessor(t *testing.T) {
 	plan := receiptPlan(t)
 	at := time.Date(2026, 8, 16, 16, 0, 0, 0, time.UTC)


### PR DESCRIPTION
## Outcome

Carries the exact CAPI Cluster runtime identity across the executor process boundary without exposing the raw UID.

On a successful `cluster-lifecycle` submission, the typed submitter now extracts the Cluster UID only from the already validated exact create receipt, hashes it, and binds that digest through the immutable operation outcome and common stage receipt. Ledger recreation preserves the correlation, allowing the verified cursor to resume at `lifecycle-observation`.

## Fail-closed boundaries

- successful Cluster lifecycle mutation without an exact runtime UID stops indeterminately
- a target UID digest on another stage or non-success outcome is rejected
- raw Kubernetes UIDs are absent from redaction-safe outcome and stage receipts
- no observation, credential, endpoint, Kubernetes contact, or new mutation path is added
- existing provider and stage authority boundaries remain unchanged

## Verification

- `git diff --check`
- `GOCACHE=/private/tmp/ok147-go-build-cache go test -ldflags=-linkmode=external ./...`
- `GOCACHE=/private/tmp/ok147-go-build-cache go vet ./...`
- `GOCACHE=/private/tmp/ok147-go-build-cache go test -race -ldflags=-linkmode=external ./internal/execution ./internal/ledger ./internal/stagereceipt ./internal/runner ./cmd/ok`
- `python3 -m unittest discover -s tests -p '*_test.py'` (18 passed, 1 expected skip)

Jira: OK-147
