### PR TITLE
feat(runner): observe lifecycle stage crash-safely (OK-147)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,11 @@ Powered by [Cluster API (CAPI)](https://cluster-api.sigs.k8s.io/), [CAPK (KubeVi
   capability and can safely select the next read-only stage after a restart.
   Successful Cluster-lifecycle submission also carries a SHA-256 binding of
   the exact CAPI Cluster UID through the durable outcome and stage receipt;
-  the raw UID is not emitted in redaction-safe evidence.
+  the raw UID is not emitted in redaction-safe evidence. The next typed
+  `lifecycle-observation` operation derives its target only from that receipt,
+  performs bounded read-only CAPI polling and persists one immutable stage
+  receipt. A restarted process reuses the persisted receipt without observing
+  again; a same-name replacement Cluster fails the UID-digest boundary.
 
 ---
 

--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -940,6 +940,50 @@ typed stage adapter must still prove its own authoritative evidence and append
 one canonical receipt. The command cannot turn `NEXT` into authorization or
 execute the selected stage.
 
+## Crash-safe lifecycle-observation stage
+
+The first read-only stage can now be executed through a typed operation rather
+than a generic dispatcher. Its constructor accepts only a verified cursor that
+selects `lifecycle-observation`, and derives the durable target identity from
+the successful `cluster-lifecycle` predecessor receipt:
+
+```text
+cluster-lifecycle receipt
+  targetClusterUidDigest
+            |
+            v
+exact CAPI Cluster GET on ok-mgmt
+  SHA-256(observed metadata.uid) == retained digest?
+            |
+      no -> fail closed
+      yes
+            v
+bind runtime policy to observed raw UID
+            |
+bounded InfrastructureReady + ControlPlaneAvailable polling
+            |
+immutable lifecycle-observation receipt
+```
+
+The raw Cluster UID exists only inside the runtime policy and normalized
+source evidence; redaction-safe stage output carries only evidence and receipt
+digests. A Cluster recreated under the same namespace, name and intent
+revision therefore cannot be mistaken for the originally submitted target.
+The observer has one exact GET path and no discovery, list, watch, mutation,
+authorization or retry of operational errors. Only verified `Unknown`
+readiness is polled until the bounded deadline; `True` succeeds, `False` fails
+and deadline expiry stops the stage.
+
+Before contacting its observer, the operation inspects the ledger's
+deterministic immutable stage-receipt slot. If a fully verified receipt already
+exists for the same plan and predecessor chain, it returns that receipt and
+does not observe again. This closes the process-termination window after
+receipt persistence but before caller acknowledgement without turning a
+read-only stage into a controller loop.
+
+This remains library-only composition. No CLI or Job activates the observer,
+and this checkpoint performs no Kubernetes request or infrastructure change.
+
 ## Cursor-to-grant binding
 
 Selecting a next stage is not claim authority. Before a later runner may claim

--- a/internal/execution/staged_observation.go
+++ b/internal/execution/staged_observation.go
@@ -1,0 +1,121 @@
+package execution
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/ledger"
+	"github.com/openkubes/ok-cluster/internal/stagecursor"
+	"github.com/openkubes/ok-cluster/internal/stageplan"
+	"github.com/openkubes/ok-cluster/internal/stagereceipt"
+)
+
+const ObservationStageReceiptFormat = "ok147-observation-stage-run-receipt/v1"
+
+type StageObservationBinding struct {
+	PlanDigest       string
+	StageID          string
+	StageDigest      string
+	Authority        string
+	ContractRevision string
+}
+
+type StageObservationResult struct {
+	Outcome        string
+	EvidenceDigest string
+	CompletedAt    time.Time
+}
+
+// StageObserver is preconstructed for exactly one read-only observation
+// stage. It has no mutation, authorization or dispatcher method.
+type StageObserver interface {
+	Binding() StageObservationBinding
+	Observe(context.Context) (StageObservationResult, error)
+}
+
+type ObservationStageOperation struct {
+	Ledger   *ledger.Ledger
+	Observer StageObserver
+}
+
+type ObservationStageRunReceipt struct {
+	Format             string `json:"format"`
+	State              string `json:"state"`
+	PlanDigest         string `json:"planDigest,omitempty"`
+	StageID            string `json:"stageId,omitempty"`
+	StageReceiptDigest string `json:"stageReceiptDigest,omitempty"`
+}
+
+type ObservationStageResultError struct{ State string }
+
+func (err *ObservationStageResultError) Error() string {
+	return "observation stage completed with " + err.State
+}
+
+// Run invokes at most one prebound read-only observer. An already persisted
+// receipt is returned without observing again, making process termination
+// after receipt persistence safe to resume.
+func (operation ObservationStageOperation) Run(ctx context.Context, plan stageplan.Binding, cursor stagecursor.Cursor) (ObservationStageRunReceipt, error) {
+	receipt := ObservationStageRunReceipt{Format: ObservationStageReceiptFormat, State: "PREOBSERVATION"}
+	if operation.Ledger == nil || operation.Observer == nil {
+		return receipt, errors.New("observation stage ledger and observer are required")
+	}
+	decision, err := cursor.Decision()
+	if err != nil {
+		return receipt, err
+	}
+	if decision.State != "NEXT" || decision.Kind != "Observation" || decision.RequiresAuthorization || decision.Operation != "" {
+		return receipt, errors.New("stage cursor does not select a read-only observation stage")
+	}
+	predecessors, err := cursor.Predecessors()
+	if err != nil {
+		return receipt, err
+	}
+	want := StageObservationBinding{
+		PlanDigest: plan.PlanDigest, StageID: decision.StageID, StageDigest: decision.StageDigest,
+		Authority: decision.Authority, ContractRevision: plan.IntentRevision,
+	}
+	if operation.Observer.Binding() != want {
+		return receipt, errors.New("preconstructed observer differs from the selected stage")
+	}
+	receipt.PlanDigest, receipt.StageID = plan.PlanDigest, decision.StageID
+	if existing, found, err := operation.Ledger.InspectStageReceipt(ctx, plan, decision.StageID, predecessors); err != nil {
+		return receipt, err
+	} else if found {
+		return finalizeObservationRunReceipt(receipt, existing)
+	}
+
+	result, observeErr := operation.Observer.Observe(ctx)
+	if observeErr != nil {
+		return receipt, errors.New("bounded stage observation failed")
+	}
+	if !oneOf(result.Outcome, "SUCCEEDED", "FAILED", "STOPPED") || !stagedDigestPattern.MatchString(result.EvidenceDigest) || result.CompletedAt.IsZero() {
+		return receipt, errors.New("stage observer returned an invalid redaction-safe result")
+	}
+	verified, err := stagereceipt.New(plan, decision.StageID, predecessors, result.Outcome, "NOT_APPLICABLE", "", result.EvidenceDigest, result.CompletedAt)
+	if err != nil {
+		return receipt, err
+	}
+	if _, err := operation.Ledger.StoreStageReceipt(ctx, plan, verified, predecessors); err != nil {
+		return receipt, err
+	}
+	return finalizeObservationRunReceipt(receipt, verified)
+}
+
+func finalizeObservationRunReceipt(receipt ObservationStageRunReceipt, verified stagereceipt.Verified) (ObservationStageRunReceipt, error) {
+	stageReceipt, err := verified.Receipt()
+	if err != nil {
+		return receipt, err
+	}
+	digest, err := verified.Digest()
+	if err != nil {
+		return receipt, err
+	}
+	receipt.StageReceiptDigest = digest
+	receipt.State = "COMPLETED_" + stageReceipt.State
+	if stageReceipt.State != "SUCCEEDED" {
+		return receipt, &ObservationStageResultError{State: receipt.State}
+	}
+	return receipt, nil
+}

--- a/internal/execution/staged_observation_test.go
+++ b/internal/execution/staged_observation_test.go
@@ -1,0 +1,118 @@
+package execution
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/ledger"
+	"github.com/openkubes/ok-cluster/internal/stagecursor"
+	"github.com/openkubes/ok-cluster/internal/stageplan"
+	"github.com/openkubes/ok-cluster/internal/stagereceipt"
+)
+
+func TestObservationStagePersistsAndResumesWithoutReobservation(t *testing.T) {
+	plan, cursor, at := lifecycleObservationCursor(t)
+	store, _ := ledger.Open(filepath.Join(t.TempDir(), "ledger"))
+	observer := &fakeStageObserver{
+		binding: observationBinding(t, plan, "lifecycle-observation"),
+		result:  StageObservationResult{Outcome: "SUCCEEDED", EvidenceDigest: stagedSHA("e"), CompletedAt: at},
+	}
+	operation := ObservationStageOperation{Ledger: store, Observer: observer}
+	first, err := operation.Run(context.Background(), plan, cursor)
+	if err != nil || first.State != "COMPLETED_SUCCEEDED" || first.StageReceiptDigest == "" || observer.calls != 1 {
+		t.Fatalf("unexpected observation run: %#v calls=%d err=%v", first, observer.calls, err)
+	}
+	replayed, err := operation.Run(context.Background(), plan, cursor)
+	if err != nil || replayed != first || observer.calls != 1 {
+		t.Fatalf("persisted observation was executed again: %#v calls=%d err=%v", replayed, observer.calls, err)
+	}
+}
+
+func TestObservationStagePersistsTerminalResultWithoutRawError(t *testing.T) {
+	plan, cursor, at := lifecycleObservationCursor(t)
+	store, _ := ledger.Open(filepath.Join(t.TempDir(), "ledger"))
+	observer := &fakeStageObserver{
+		binding: observationBinding(t, plan, "lifecycle-observation"),
+		result:  StageObservationResult{Outcome: "STOPPED", EvidenceDigest: stagedSHA("f"), CompletedAt: at},
+	}
+	receipt, err := (ObservationStageOperation{Ledger: store, Observer: observer}).Run(context.Background(), plan, cursor)
+	var resultErr *ObservationStageResultError
+	if !errors.As(err, &resultErr) || receipt.State != "COMPLETED_STOPPED" || receipt.StageReceiptDigest == "" {
+		t.Fatalf("terminal observation was not retained: %#v %v", receipt, err)
+	}
+}
+
+func TestObservationStageFailsClosedBeforePersistence(t *testing.T) {
+	plan, cursor, at := lifecycleObservationCursor(t)
+	for name, mutate := range map[string]func(*fakeStageObserver){
+		"foreign binding": func(observer *fakeStageObserver) { observer.binding.Authority = "workload" },
+		"raw failure":     func(observer *fakeStageObserver) { observer.err = errors.New("sensitive endpoint detail") },
+		"bad result":      func(observer *fakeStageObserver) { observer.result.EvidenceDigest = "invalid" },
+	} {
+		t.Run(name, func(t *testing.T) {
+			store, _ := ledger.Open(filepath.Join(t.TempDir(), "ledger"))
+			observer := &fakeStageObserver{
+				binding: observationBinding(t, plan, "lifecycle-observation"),
+				result:  StageObservationResult{Outcome: "SUCCEEDED", EvidenceDigest: stagedSHA("e"), CompletedAt: at},
+			}
+			mutate(observer)
+			receipt, err := (ObservationStageOperation{Ledger: store, Observer: observer}).Run(context.Background(), plan, cursor)
+			if err == nil || strings.Contains(err.Error(), "sensitive") || receipt.StageReceiptDigest != "" {
+				t.Fatalf("unsafe observation result was accepted: %#v %v", receipt, err)
+			}
+		})
+	}
+}
+
+func TestObservationStageRejectsMutatingCursor(t *testing.T) {
+	plan := stagedPlan(t)
+	cursor, _ := stagecursor.Evaluate(plan, []stagereceipt.Verified{})
+	store, _ := ledger.Open(filepath.Join(t.TempDir(), "ledger"))
+	observer := &fakeStageObserver{}
+	if _, err := (ObservationStageOperation{Ledger: store, Observer: observer}).Run(context.Background(), plan, cursor); err == nil || observer.calls != 0 {
+		t.Fatalf("mutating cursor reached observer: calls=%d err=%v", observer.calls, err)
+	}
+}
+
+type fakeStageObserver struct {
+	binding StageObservationBinding
+	result  StageObservationResult
+	err     error
+	calls   int
+}
+
+func (observer *fakeStageObserver) Binding() StageObservationBinding { return observer.binding }
+
+func (observer *fakeStageObserver) Observe(context.Context) (StageObservationResult, error) {
+	observer.calls++
+	return observer.result, observer.err
+}
+
+func lifecycleObservationCursor(t *testing.T) (stageplan.Binding, stagecursor.Cursor, time.Time) {
+	t.Helper()
+	plan := stagedPlan(t)
+	at := time.Date(2026, 8, 16, 19, 0, 0, 0, time.UTC)
+	provider, _ := stagereceipt.New(plan, "provider-prerequisites", []stagereceipt.Verified{}, "SUCCEEDED", "ATTEMPTED", stagedSHA("1"), stagedSHA("a"), at.Add(-2*time.Second))
+	lifecycle, err := stagereceipt.NewWithTargetClusterUIDDigest(plan, "cluster-lifecycle", []stagereceipt.Verified{provider}, "SUCCEEDED", "ATTEMPTED", stagedSHA("2"), stagedSHA("b"), stagedSHA("7"), at.Add(-time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	cursor, err := stagecursor.Evaluate(plan, []stagereceipt.Verified{provider, lifecycle})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return plan, cursor, at
+}
+
+func observationBinding(t *testing.T, plan stageplan.Binding, stageID string) StageObservationBinding {
+	t.Helper()
+	stage, stageDigest, err := plan.Stage(stageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return StageObservationBinding{PlanDigest: plan.PlanDigest, StageID: stageID, StageDigest: stageDigest, Authority: stage.Authority, ContractRevision: plan.IntentRevision}
+}

--- a/internal/ledger/stage_receipt.go
+++ b/internal/ledger/stage_receipt.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/openkubes/ok-cluster/internal/digest"
 	"github.com/openkubes/ok-cluster/internal/stageplan"
 	"github.com/openkubes/ok-cluster/internal/stagereceipt"
 )
@@ -54,6 +55,33 @@ func (ledger *Ledger) StoreStageReceipt(ctx context.Context, plan stageplan.Bind
 		return "", fmt.Errorf("verify existing stage receipt: %w", err)
 	}
 	return receiptDigest, nil
+}
+
+// InspectStageReceipt reads the deterministic immutable slot and fully
+// verifies any existing receipt against the supplied plan and predecessor
+// chain. It is intended for crash-safe read-only stage replay, where the
+// process may have terminated after persistence but before returning a digest.
+func (ledger *Ledger) InspectStageReceipt(ctx context.Context, plan stageplan.Binding, stageID string, predecessors []stagereceipt.Verified) (stagereceipt.Verified, bool, error) {
+	key, err := stageReceiptKey(plan, stageID)
+	if err != nil {
+		return stagereceipt.Verified{}, false, err
+	}
+	raw, err := ledger.store.Get(ctx, "stage-receipts", key)
+	if errors.Is(err, ErrRecordNotFound) {
+		return stagereceipt.Verified{}, false, nil
+	}
+	if err != nil {
+		return stagereceipt.Verified{}, false, fmt.Errorf("read immutable stage receipt: %w", err)
+	}
+	verified, err := stagereceipt.Verify(raw, digest.SHA256(raw), plan, predecessors)
+	if err != nil {
+		return stagereceipt.Verified{}, false, fmt.Errorf("verify immutable stage receipt: %w", err)
+	}
+	receipt, err := verified.Receipt()
+	if err != nil || receipt.StageID != stageID {
+		return stagereceipt.Verified{}, false, errors.New("immutable stage receipt occupies a different stage")
+	}
+	return verified, true, nil
 }
 
 // LoadStageReceipt reads one deterministic slot and requires the receipt

--- a/internal/observation/capi_kubernetes.go
+++ b/internal/observation/capi_kubernetes.go
@@ -12,6 +12,8 @@ import (
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
 )
 
 const (
@@ -82,36 +84,74 @@ func (observer *CAPILifecycleObserver) Collect(ctx context.Context, policy Polic
 	if err := validatePolicy(policy, true); err != nil {
 		return nil, err
 	}
+	cluster, err := observer.readCluster(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return normalizeCAPICluster(cluster, policy)
+}
+
+// CollectBound establishes the raw-UID-free runtime correlation required
+// after executor restart. The policy must not already carry a caller-selected
+// UID; the exact Cluster GET supplies it and its digest must equal the durable
+// lifecycle-submission binding before any Conditions are normalized.
+func (observer *CAPILifecycleObserver) CollectBound(ctx context.Context, policy Policy, expectedTargetUIDDigest string) (Policy, []Evidence, error) {
+	if err := validatePolicy(policy, false); err != nil || policy.TargetClusterUID != "" || !validDigest(expectedTargetUIDDigest) {
+		return Policy{}, nil, errors.New("unbound CAPI observation policy or target identity digest is invalid")
+	}
+	cluster, err := observer.readCluster(ctx)
+	if err != nil {
+		return Policy{}, nil, err
+	}
+	if digest.SHA256([]byte(cluster.Metadata.UID)) != expectedTargetUIDDigest {
+		return Policy{}, nil, errors.New("CAPI Cluster runtime identity differs from durable lifecycle binding")
+	}
+	bound, err := BindTarget(policy, cluster.Metadata.UID)
+	if err != nil {
+		return Policy{}, nil, err
+	}
+	evidence, err := normalizeCAPICluster(cluster, bound)
+	if err != nil {
+		return Policy{}, nil, err
+	}
+	return bound, evidence, nil
+}
+
+func (observer *CAPILifecycleObserver) readCluster(ctx context.Context) (capiCluster, error) {
 	endpoint := *observer.endpoint
 	endpoint.Path = "/apis/cluster.x-k8s.io/v1beta2/namespaces/" + observer.namespace + "/clusters/" + observer.name
 	request, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint.String(), nil)
 	if err != nil {
-		return nil, errors.New("construct bounded CAPI observation request")
+		return capiCluster{}, errors.New("construct bounded CAPI observation request")
 	}
 	request.Header.Set("Accept", "application/json")
 	request.Header.Set("Authorization", "Bearer "+observer.token)
 	response, err := observer.client.Do(request)
 	if err != nil {
-		return nil, errors.New("bounded CAPI observation request failed")
+		return capiCluster{}, errors.New("bounded CAPI observation request failed")
 	}
 	defer response.Body.Close()
 	raw, err := io.ReadAll(io.LimitReader(response.Body, maximumCAPIResponse+1))
 	if err != nil || len(raw) > maximumCAPIResponse {
-		return nil, errors.New("bounded CAPI observation response exceeds accepted size")
+		return capiCluster{}, errors.New("bounded CAPI observation response exceeds accepted size")
 	}
 	if response.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("bounded CAPI observation returned HTTP %d", response.StatusCode)
+		return capiCluster{}, fmt.Errorf("bounded CAPI observation returned HTTP %d", response.StatusCode)
 	}
 	cluster, err := decodeCAPICluster(raw)
 	if err != nil {
-		return nil, err
+		return capiCluster{}, err
 	}
 	if cluster.APIVersion != capiClusterAPIVersion || cluster.Kind != capiClusterKind || cluster.Metadata.Namespace != observer.namespace || cluster.Metadata.Name != observer.name {
-		return nil, errors.New("CAPI observation object identity differs from the exact target")
+		return capiCluster{}, errors.New("CAPI observation object identity differs from the exact target")
 	}
 	if !validUID(cluster.Metadata.UID) || cluster.Metadata.ResourceVersion == "" || cluster.Metadata.Generation <= 0 {
-		return nil, errors.New("CAPI observation object lacks runtime identity")
+		return capiCluster{}, errors.New("CAPI observation object lacks runtime identity")
 	}
+	return cluster, nil
+}
+
+func normalizeCAPICluster(cluster capiCluster, policy Policy) ([]Evidence, error) {
 	observedRevision := cluster.Metadata.Annotations[intentRevisionKey]
 	if !validDigest(observedRevision) {
 		observedRevision = ""

--- a/internal/observation/capi_kubernetes_test.go
+++ b/internal/observation/capi_kubernetes_test.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"net/http"
 	"testing"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
 )
 
 func TestCAPILifecycleObserverCollectsCurrentExactEvidence(t *testing.T) {
@@ -43,6 +45,37 @@ func TestCAPILifecycleObserverCollectsCurrentExactEvidence(t *testing.T) {
 	receipt, _ := result.Receipt()
 	if receipt.Ready != "True" {
 		t.Fatalf("current authoritative evidence did not converge: %#v", receipt)
+	}
+}
+
+func TestCAPILifecycleObserverBindsExactRuntimeIdentityAfterRestart(t *testing.T) {
+	policy := testPolicy(t)
+	policy.TargetClusterUID = ""
+	const runtimeUID = "cluster-runtime-uid-147"
+	client := &http.Client{Transport: capiRoundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		return capiJSONResponse(t, http.StatusOK, capiFixture(policy, runtimeUID, policy.IntentRevision, 7, 7)), nil
+	})}
+	bound, evidence, err := newTestCAPIObserver(t, client).CollectBound(context.Background(), policy, digest.SHA256([]byte(runtimeUID)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bound.TargetClusterUID != runtimeUID || len(evidence) != 2 || evidence[0].SourceUID != runtimeUID || evidence[0].TargetClusterUID != runtimeUID {
+		t.Fatalf("runtime correlation differs: %#v %#v", bound, evidence)
+	}
+}
+
+func TestCAPILifecycleObserverRejectsChangedRuntimeIdentityAfterRestart(t *testing.T) {
+	policy := testPolicy(t)
+	policy.TargetClusterUID = ""
+	client := &http.Client{Transport: capiRoundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		return capiJSONResponse(t, http.StatusOK, capiFixture(policy, "replacement-cluster-uid", policy.IntentRevision, 7, 7)), nil
+	})}
+	if _, _, err := newTestCAPIObserver(t, client).CollectBound(context.Background(), policy, digest.SHA256([]byte("original-cluster-uid"))); err == nil {
+		t.Fatal("replacement Cluster with the same name and revision was accepted")
+	}
+	policy.TargetClusterUID = "caller-selected-uid"
+	if _, _, err := newTestCAPIObserver(t, client).CollectBound(context.Background(), policy, digest.SHA256([]byte("caller-selected-uid"))); err == nil {
+		t.Fatal("caller-selected target UID was accepted at resume boundary")
 	}
 }
 

--- a/internal/runner/lifecycle_stage_observer.go
+++ b/internal/runner/lifecycle_stage_observer.go
@@ -1,0 +1,187 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/execution"
+	"github.com/openkubes/ok-cluster/internal/observation"
+	"github.com/openkubes/ok-cluster/internal/stagecursor"
+	"github.com/openkubes/ok-cluster/internal/stageplan"
+)
+
+type RuntimeBoundCAPISource interface {
+	CollectBound(context.Context, observation.Policy, string) (observation.Policy, []observation.Evidence, error)
+	Collect(context.Context, observation.Policy) ([]observation.Evidence, error)
+}
+
+type LifecycleStageObserverConfig struct {
+	Plan         stageplan.Binding
+	Cursor       stagecursor.Cursor
+	Source       RuntimeBoundCAPISource
+	PollInterval time.Duration
+	PollTimeout  time.Duration
+	Clock        func() time.Time
+	Wait         ObservationWaiter
+}
+
+type KubernetesLifecycleStageObserverConfig struct {
+	Plan         stageplan.Binding
+	Cursor       stagecursor.Cursor
+	Management   KubernetesAuthorityConfig
+	PollInterval time.Duration
+	PollTimeout  time.Duration
+	Clock        func() time.Time
+	Wait         ObservationWaiter
+}
+
+type LifecycleStageObserver struct {
+	binding                execution.StageObservationBinding
+	source                 RuntimeBoundCAPISource
+	policy                 observation.Policy
+	targetClusterUIDDigest string
+	pollInterval           time.Duration
+	pollLimit              time.Duration
+	clock                  func() time.Time
+	wait                   ObservationWaiter
+}
+
+var _ execution.StageObserver = (*LifecycleStageObserver)(nil)
+
+// OpenKubernetesLifecycleStageObserver binds the exact management authority
+// and reads its bounded credential files, but performs no Kubernetes request.
+func OpenKubernetesLifecycleStageObserver(config KubernetesLifecycleStageObserverConfig) (*LifecycleStageObserver, error) {
+	source, err := OpenKubernetesCAPILifecycleObserver(
+		config.Management,
+		config.Plan.Authorities.Management,
+		config.Plan.ContractIdentity.Namespace,
+		config.Plan.ContractIdentity.Name,
+	)
+	if err != nil {
+		return nil, errors.New("open bounded lifecycle observation source")
+	}
+	return NewLifecycleStageObserver(LifecycleStageObserverConfig{
+		Plan: config.Plan, Cursor: config.Cursor, Source: source,
+		PollInterval: config.PollInterval, PollTimeout: config.PollTimeout,
+		Clock: config.Clock, Wait: config.Wait,
+	})
+}
+
+// NewLifecycleStageObserver derives its target binding only from the verified
+// cluster-lifecycle predecessor receipt. No caller-supplied UID is accepted.
+func NewLifecycleStageObserver(config LifecycleStageObserverConfig) (*LifecycleStageObserver, error) {
+	if config.Source == nil || config.Clock == nil || config.Wait == nil {
+		return nil, errors.New("lifecycle stage observer source, clock, and waiter are required")
+	}
+	decision, err := config.Cursor.Decision()
+	if err != nil {
+		return nil, err
+	}
+	if decision.State != "NEXT" || decision.StageID != "lifecycle-observation" || decision.Kind != "Observation" || decision.Authority != "management" || decision.RequiresAuthorization {
+		return nil, errors.New("stage cursor does not select lifecycle observation")
+	}
+	predecessors, err := config.Cursor.Predecessors()
+	if err != nil || len(predecessors) != 1 {
+		return nil, errors.New("lifecycle observation predecessor is incomplete")
+	}
+	predecessor, err := predecessors[0].Receipt()
+	if err != nil || predecessor.PlanDigest != config.Plan.PlanDigest || predecessor.StageID != "cluster-lifecycle" || !platformInputDigestPattern.MatchString(predecessor.TargetClusterUIDDigest) {
+		return nil, errors.New("lifecycle predecessor lacks durable target correlation")
+	}
+	stage, stageDigest, err := config.Plan.Stage(decision.StageID)
+	if err != nil || stageDigest != decision.StageDigest {
+		return nil, errors.New("lifecycle observation stage differs from verified plan")
+	}
+	policy := observation.Policy{
+		Format: observation.PolicyFormat, IntentRevision: config.Plan.IntentRevision,
+		EnablementRevision: config.Plan.EnablementRevision, PlatformRevision: config.Plan.PlatformRevision,
+		Required: []string{"InfrastructureReady", "ControlPlaneAvailable"},
+	}
+	return &LifecycleStageObserver{
+		binding: execution.StageObservationBinding{
+			PlanDigest: config.Plan.PlanDigest, StageID: stage.ID, StageDigest: stageDigest,
+			Authority: stage.Authority, ContractRevision: config.Plan.IntentRevision,
+		},
+		source: config.Source, policy: policy, targetClusterUIDDigest: predecessor.TargetClusterUIDDigest,
+		pollInterval: config.PollInterval, pollLimit: config.PollTimeout, clock: config.Clock, wait: config.Wait,
+	}, nil
+}
+
+func (observer *LifecycleStageObserver) Binding() execution.StageObservationBinding {
+	if observer == nil {
+		return execution.StageObservationBinding{}
+	}
+	return observer.binding
+}
+
+func (observer *LifecycleStageObserver) Observe(ctx context.Context) (execution.StageObservationResult, error) {
+	if observer == nil {
+		return execution.StageObservationResult{}, errors.New("lifecycle stage observer is required")
+	}
+	boundPolicy, evidence, err := observer.source.CollectBound(ctx, observer.policy, observer.targetClusterUIDDigest)
+	if err != nil {
+		return execution.StageObservationResult{}, errors.New("establish durable lifecycle observation correlation")
+	}
+	first, err := evaluateLifecycleEvidence(boundPolicy, evidence, observer.clock())
+	if err != nil {
+		return execution.StageObservationResult{}, errors.New("evaluate initial lifecycle evidence")
+	}
+	source := &lifecyclePollingSource{first: &first, source: observer.source, clock: observer.clock}
+	polling, err := NewBoundedPollingObserver(BoundedPollingObserverConfig{
+		Source: source, Interval: observer.pollInterval, Timeout: observer.pollLimit,
+		Clock: observer.clock, Wait: observer.wait,
+	})
+	if err != nil {
+		return execution.StageObservationResult{}, err
+	}
+	result, err := polling.Observe(ctx, boundPolicy)
+	if err != nil {
+		return execution.StageObservationResult{}, errors.New("bounded lifecycle convergence observation failed")
+	}
+	receipt, err := result.Receipt()
+	if err != nil {
+		return execution.StageObservationResult{}, err
+	}
+	evidenceDigest, err := result.EvidenceDigest()
+	if err != nil {
+		return execution.StageObservationResult{}, err
+	}
+	completedAt, err := time.Parse(time.RFC3339Nano, receipt.EvaluatedAt)
+	if err != nil {
+		return execution.StageObservationResult{}, errors.New("lifecycle observation completion time is invalid")
+	}
+	outcome := "STOPPED"
+	if receipt.Ready == "True" {
+		outcome = "SUCCEEDED"
+	} else if receipt.Ready == "False" {
+		outcome = "FAILED"
+	}
+	return execution.StageObservationResult{Outcome: outcome, EvidenceDigest: evidenceDigest, CompletedAt: completedAt}, nil
+}
+
+type lifecyclePollingSource struct {
+	first  *observation.VerifiedResult
+	source RuntimeBoundCAPISource
+	clock  func() time.Time
+}
+
+func (source *lifecyclePollingSource) Observe(ctx context.Context, policy observation.Policy) (observation.VerifiedResult, error) {
+	if source.first != nil {
+		result := *source.first
+		source.first = nil
+		return result, nil
+	}
+	evidence, err := source.source.Collect(ctx, policy)
+	if err != nil {
+		return observation.VerifiedResult{}, err
+	}
+	return evaluateLifecycleEvidence(policy, evidence, source.clock())
+}
+
+func evaluateLifecycleEvidence(policy observation.Policy, evidence []observation.Evidence, at time.Time) (observation.VerifiedResult, error) {
+	return observation.Evaluate(policy, observation.Bundle{
+		Format: observation.BundleFormat, IntentRevision: policy.IntentRevision,
+		EvaluatedAt: at.UTC().Format(time.RFC3339Nano), Evidence: evidence,
+	})
+}

--- a/internal/runner/lifecycle_stage_observer_test.go
+++ b/internal/runner/lifecycle_stage_observer_test.go
@@ -1,0 +1,183 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/observation"
+	"github.com/openkubes/ok-cluster/internal/stagecursor"
+	"github.com/openkubes/ok-cluster/internal/stageplan"
+	"github.com/openkubes/ok-cluster/internal/stagereceipt"
+)
+
+func TestLifecycleStageObserverBindsSubmissionIdentityAndConverges(t *testing.T) {
+	plan, cursor, runtimeUID := lifecycleObserverCursor(t, true)
+	current := time.Date(2026, 8, 16, 20, 0, 0, 0, time.UTC)
+	source := &fakeRuntimeBoundCAPISource{runtimeUID: runtimeUID, followupStatus: "True"}
+	observer, err := NewLifecycleStageObserver(LifecycleStageObserverConfig{
+		Plan: plan, Cursor: cursor, Source: source, PollInterval: time.Second, PollTimeout: time.Minute,
+		Clock: func() time.Time { return current },
+		Wait:  func(_ context.Context, wait time.Duration) error { current = current.Add(wait); return nil },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := observer.Observe(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Outcome != "SUCCEEDED" || !platformInputDigestPattern.MatchString(result.EvidenceDigest) || source.boundCalls != 1 || source.collectCalls != 1 {
+		t.Fatalf("unexpected lifecycle observation: %#v source=%#v", result, source)
+	}
+	if source.boundDigest != digest.SHA256([]byte(runtimeUID)) || source.boundPolicy.TargetClusterUID != "" || source.collectPolicy.TargetClusterUID != runtimeUID {
+		t.Fatalf("runtime identity was not derived from the lifecycle receipt: %#v", source)
+	}
+}
+
+func TestLifecycleStageObserverReturnsTerminalFalseAndBoundedUnknown(t *testing.T) {
+	for name, testCase := range map[string]struct {
+		initial, followup, want string
+	}{
+		"terminal false":  {initial: "False", want: "FAILED"},
+		"bounded unknown": {initial: "Unknown", followup: "Unknown", want: "STOPPED"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			plan, cursor, runtimeUID := lifecycleObserverCursor(t, true)
+			current := time.Date(2026, 8, 16, 20, 0, 0, 0, time.UTC)
+			source := &fakeRuntimeBoundCAPISource{runtimeUID: runtimeUID, initialStatus: testCase.initial, followupStatus: testCase.followup}
+			observer, err := NewLifecycleStageObserver(LifecycleStageObserverConfig{
+				Plan: plan, Cursor: cursor, Source: source, PollInterval: time.Second, PollTimeout: 2 * time.Second,
+				Clock: func() time.Time { return current },
+				Wait:  func(_ context.Context, wait time.Duration) error { current = current.Add(wait); return nil },
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			result, err := observer.Observe(context.Background())
+			if err != nil || result.Outcome != testCase.want {
+				t.Fatalf("unexpected terminal lifecycle result: %#v %v", result, err)
+			}
+			if testCase.want == "FAILED" && source.collectCalls != 0 {
+				t.Fatal("terminal False lifecycle evidence was polled again")
+			}
+		})
+	}
+}
+
+func TestLifecycleStageObserverFailsClosedAtDurableCorrelationBoundary(t *testing.T) {
+	plan, cursor, runtimeUID := lifecycleObserverCursor(t, true)
+	for name, source := range map[string]*fakeRuntimeBoundCAPISource{
+		"same-name replacement": {runtimeUID: "replacement-runtime-uid", followupStatus: "True"},
+		"source failure":        {runtimeUID: runtimeUID, err: errors.New("sensitive management endpoint")},
+	} {
+		t.Run(name, func(t *testing.T) {
+			observer, err := NewLifecycleStageObserver(LifecycleStageObserverConfig{
+				Plan: plan, Cursor: cursor, Source: source, PollInterval: time.Second, PollTimeout: time.Minute,
+				Clock: time.Now, Wait: func(context.Context, time.Duration) error { return nil },
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, err = observer.Observe(context.Background())
+			if err == nil || strings.Contains(err.Error(), "sensitive") {
+				t.Fatalf("unsafe correlation failure was accepted or leaked: %v", err)
+			}
+		})
+	}
+}
+
+func TestLifecycleStageObserverRequiresReceiptBoundTargetIdentity(t *testing.T) {
+	plan, cursor, _ := lifecycleObserverCursor(t, false)
+	if _, err := NewLifecycleStageObserver(LifecycleStageObserverConfig{
+		Plan: plan, Cursor: cursor, Source: &fakeRuntimeBoundCAPISource{}, PollInterval: time.Second, PollTimeout: time.Minute,
+		Clock: time.Now, Wait: func(context.Context, time.Duration) error { return nil },
+	}); err == nil {
+		t.Fatal("historical lifecycle receipt without target UID digest was accepted")
+	}
+}
+
+type fakeRuntimeBoundCAPISource struct {
+	runtimeUID     string
+	initialStatus  string
+	followupStatus string
+	err            error
+	boundDigest    string
+	boundPolicy    observation.Policy
+	collectPolicy  observation.Policy
+	boundCalls     int
+	collectCalls   int
+}
+
+func (source *fakeRuntimeBoundCAPISource) CollectBound(_ context.Context, policy observation.Policy, expectedDigest string) (observation.Policy, []observation.Evidence, error) {
+	source.boundCalls++
+	source.boundDigest, source.boundPolicy = expectedDigest, policy
+	if source.err != nil {
+		return observation.Policy{}, nil, source.err
+	}
+	if digest.SHA256([]byte(source.runtimeUID)) != expectedDigest {
+		return observation.Policy{}, nil, errors.New("runtime identity mismatch")
+	}
+	bound, err := observation.BindTarget(policy, source.runtimeUID)
+	if err != nil {
+		return observation.Policy{}, nil, err
+	}
+	return bound, lifecycleEvidence(bound, source.initialStatus), nil
+}
+
+func (source *fakeRuntimeBoundCAPISource) Collect(_ context.Context, policy observation.Policy) ([]observation.Evidence, error) {
+	source.collectCalls++
+	source.collectPolicy = policy
+	if source.err != nil {
+		return nil, source.err
+	}
+	return lifecycleEvidence(policy, source.followupStatus), nil
+}
+
+func lifecycleEvidence(policy observation.Policy, status string) []observation.Evidence {
+	if status == "" || status == "Unknown" {
+		return nil
+	}
+	reason := "LifecycleReady"
+	if status == "False" {
+		reason = "LifecycleUnavailable"
+	}
+	evidence := make([]observation.Evidence, 0, 2)
+	for index, condition := range []string{"InfrastructureReady", "ControlPlaneAvailable"} {
+		evidence = append(evidence, observation.Evidence{
+			Type: condition, Source: "CAPICluster", SourceUID: policy.TargetClusterUID, TargetClusterUID: policy.TargetClusterUID,
+			Status: status, Reason: reason, DesiredRevision: policy.IntentRevision, ObservedRevision: policy.IntentRevision,
+			Generation: 7, ObservedGeneration: 7, EvidenceDigest: bundleSHA(string(rune('1' + index))),
+		})
+	}
+	return evidence
+}
+
+func lifecycleObserverCursor(t *testing.T, withTargetDigest bool) (stageplan.Binding, stagecursor.Cursor, string) {
+	t.Helper()
+	fixture := submissionBundleFixture(t, false, "")
+	plan := fixture.plan
+	at := time.Date(2026, 8, 16, 19, 0, 0, 0, time.UTC)
+	provider, err := stagereceipt.New(plan, "provider-prerequisites", []stagereceipt.Verified{}, "SUCCEEDED", "ATTEMPTED", bundleSHA("8"), bundleSHA("9"), at)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const runtimeUID = "cluster-runtime-uid-147"
+	var lifecycle stagereceipt.Verified
+	if withTargetDigest {
+		lifecycle, err = stagereceipt.NewWithTargetClusterUIDDigest(plan, "cluster-lifecycle", []stagereceipt.Verified{provider}, "SUCCEEDED", "ATTEMPTED", bundleSHA("1"), bundleSHA("2"), digest.SHA256([]byte(runtimeUID)), at.Add(time.Second))
+	} else {
+		lifecycle, err = stagereceipt.New(plan, "cluster-lifecycle", []stagereceipt.Verified{provider}, "SUCCEEDED", "ATTEMPTED", bundleSHA("1"), bundleSHA("2"), at.Add(time.Second))
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	cursor, err := stagecursor.Evaluate(plan, []stagereceipt.Verified{provider, lifecycle})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return plan, cursor, runtimeUID
+}


### PR DESCRIPTION
## What changed

- add a generic crash-safe operation for read-only staged observations
- persist one immutable observation receipt and replay it after restart without observing again
- carry the exact CAPI Cluster UID only as a SHA-256 lifecycle-receipt binding
- bind the lifecycle observer to the plan-derived Cluster identity and reject same-name replacement clusters
- evaluate and poll only `InfrastructureReady` and `ControlPlaneAvailable` through the existing bounded read-only observer
- document that the composition remains library-only and performs no live cluster action

## Why

After a successful `cluster-lifecycle` submission, the runner needs to resume at `lifecycle-observation` without accepting a caller-selected target or creating another lifecycle writer. The durable UID digest closes the same-name replacement gap, while deterministic receipt lookup closes the process-termination window after persistence.

## Impact

This adds no CLI activation, grant, mutation, retry, controller loop or infrastructure contact. It provides the typed in-memory boundary needed for a later Job-runner composition.

## Validation

- `GOCACHE=/private/tmp/ok147-go-build-cache go test -ldflags=-linkmode=external ./...`
- `GOCACHE=/private/tmp/ok147-go-build-cache go vet ./...`
- `GOCACHE=/private/tmp/ok147-go-build-cache go test -ldflags=-linkmode=external -race ./internal/ledger ./internal/execution ./internal/observation ./internal/runner`
- `python3 -m unittest discover -s tests -p '*_test.py'` (18 tests, 1 expected skip)
