### PR TITLE
feat(runner): bind lifecycle observation bundle (OK-147)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,11 @@ Powered by [Cluster API (CAPI)](https://cluster-api.sigs.k8s.io/), [CAPK (KubeVi
   `lifecycle-observation` operation derives its target only from that receipt,
   performs bounded read-only CAPI polling and persists one immutable stage
   receipt. A restarted process reuses the persisted receipt without observing
-  again; a same-name replacement Cluster fails the UID-digest boundary.
+  again; a same-name replacement Cluster fails the UID-digest boundary. A
+  verified lifecycle-observation bundle now retains the plan and receipt
+  cursor privately, opens distinct ledger and management-observer credentials
+  exactly once and exposes only the bounded stage `Run` method. This bundle is
+  not yet activated by a CLI command or Job.
 
 ---
 

--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -984,6 +984,21 @@ read-only stage into a controller loop.
 This remains library-only composition. No CLI or Job activates the observer,
 and this checkpoint performs no Kubernetes request or infrastructure change.
 
+The next composition boundary retains the reverified plan and cursor in a
+private lifecycle-observation bundle. It rejects any prefix that selects a
+different stage or whose lifecycle predecessor lacks the durable target UID
+digest. Opening the bundle reads the ledger and management-observer credential
+files exactly once, requires distinct token values and binds the observer's
+namespace, name and authority to the plan rather than caller input. Opening
+constructs TLS clients but performs no Kubernetes request.
+
+The resulting value exposes only one bounded `Run` method. Callers cannot
+replace its plan, cursor, predecessor, source implementation or credential
+after verification. An unverified zero value cannot expose a decision, open
+credentials or run. This provides the environment-neutral boundary needed by
+a later local CLI or short-lived Job without activating either one in this
+checkpoint.
+
 ## Cursor-to-grant binding
 
 Selecting a next stage is not claim authority. Before a later runner may claim

--- a/internal/runner/kubernetes.go
+++ b/internal/runner/kubernetes.go
@@ -151,19 +151,31 @@ func openKubernetesSubmissionClient(config KubernetesAuthorityConfig) (*submissi
 // observer for one exact CAPI Cluster. The independently supplied expected
 // authority must match the credential identity bound by the projection plan.
 func OpenKubernetesCAPILifecycleObserver(config KubernetesAuthorityConfig, expectedAuthority, namespace, name string) (*observation.CAPILifecycleObserver, error) {
+	observer, _, err := openKubernetesCAPILifecycleObserver(config, expectedAuthority, namespace, name)
+	return observer, err
+}
+
+// openKubernetesCAPILifecycleObserver also returns the bounded token so a
+// stage-level composition can prove that observation and ledger writes use
+// distinct credentials. The token never leaves this package.
+func openKubernetesCAPILifecycleObserver(config KubernetesAuthorityConfig, expectedAuthority, namespace, name string) (*observation.CAPILifecycleObserver, string, error) {
 	if config.Endpoint == "" || config.AuthorityIdentity == "" || config.TokenFile == "" || config.CAFile == "" {
-		return nil, errors.New("Kubernetes CAPI observer endpoint, identity, token file, and CA file are required")
+		return nil, "", errors.New("Kubernetes CAPI observer endpoint, identity, token file, and CA file are required")
 	}
 	if expectedAuthority == "" || config.AuthorityIdentity != expectedAuthority {
-		return nil, errors.New("Kubernetes CAPI observer authority differs from the verified management plane")
+		return nil, "", errors.New("Kubernetes CAPI observer authority differs from the verified management plane")
 	}
 	token, client, err := openBoundedKubernetesHTTP(config.TokenFile, config.CAFile)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
-	return observation.NewCAPILifecycleObserver(observation.CAPILifecycleObserverConfig{
+	observer, err := observation.NewCAPILifecycleObserver(observation.CAPILifecycleObserverConfig{
 		Endpoint: config.Endpoint, BearerToken: token, Namespace: namespace, Name: name, Client: client,
 	})
+	if err != nil {
+		return nil, "", err
+	}
+	return observer, token, nil
 }
 
 // OpenKubernetesNetworkSourceCollector materializes two isolated TLS clients:

--- a/internal/runner/lifecycle_observation_bundle.go
+++ b/internal/runner/lifecycle_observation_bundle.go
@@ -1,0 +1,115 @@
+package runner
+
+import (
+	"context"
+	"crypto/subtle"
+	"errors"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/execution"
+	"github.com/openkubes/ok-cluster/internal/stagecursor"
+	"github.com/openkubes/ok-cluster/internal/stageplan"
+)
+
+// VerifiedLifecycleObservationStageBundle retains one reverified plan and
+// receipt prefix. Its private fields prevent a caller from substituting a
+// cursor or predecessor between local verification and runtime opening.
+type VerifiedLifecycleObservationStageBundle struct {
+	plan     stageplan.Binding
+	cursor   stagecursor.Cursor
+	verified bool
+}
+
+type LifecycleObservationStageRuntimeConfig struct {
+	Ledger       KubernetesLedgerConfig
+	Management   KubernetesAuthorityConfig
+	PollInterval time.Duration
+	PollTimeout  time.Duration
+	Clock        func() time.Time
+	Wait         ObservationWaiter
+}
+
+// OpenedLifecycleObservationStage exposes only the one bounded Run method.
+// Plan, cursor, credentials and source implementation remain private.
+type OpenedLifecycleObservationStage struct {
+	operation execution.ObservationStageOperation
+	plan      stageplan.Binding
+	cursor    stagecursor.Cursor
+	verified  bool
+}
+
+// LoadLifecycleObservationStageBundle verifies an explicit canonical receipt
+// prefix and requires it to select exactly lifecycle-observation.
+func LoadLifecycleObservationStageBundle(config StageResumeConfig) (VerifiedLifecycleObservationStageBundle, error) {
+	plan, cursor, err := loadStageResume(config)
+	if err != nil {
+		return VerifiedLifecycleObservationStageBundle{}, err
+	}
+	decision, err := cursor.Decision()
+	if err != nil {
+		return VerifiedLifecycleObservationStageBundle{}, err
+	}
+	if decision.State != "NEXT" || decision.StageID != "lifecycle-observation" || decision.Kind != "Observation" || decision.Authority != "management" || decision.RequiresAuthorization || decision.Operation != "" {
+		return VerifiedLifecycleObservationStageBundle{}, errors.New("verified prefix does not select lifecycle observation")
+	}
+	predecessors, err := cursor.Predecessors()
+	if err != nil || len(predecessors) != 1 {
+		return VerifiedLifecycleObservationStageBundle{}, errors.New("lifecycle observation predecessor is incomplete")
+	}
+	predecessor, err := predecessors[0].Receipt()
+	if err != nil || predecessor.StageID != "cluster-lifecycle" || !platformInputDigestPattern.MatchString(predecessor.TargetClusterUIDDigest) {
+		return VerifiedLifecycleObservationStageBundle{}, errors.New("lifecycle predecessor lacks durable target correlation")
+	}
+	return VerifiedLifecycleObservationStageBundle{plan: plan, cursor: cursor, verified: true}, nil
+}
+
+// Decision returns the already verified, redaction-safe cursor decision.
+func (bundle VerifiedLifecycleObservationStageBundle) Decision() (stagecursor.Decision, error) {
+	if !bundle.verified {
+		return stagecursor.Decision{}, errors.New("lifecycle observation stage bundle is not verified")
+	}
+	return bundle.cursor.Decision()
+}
+
+// Open constructs the exact ledger and management observation capabilities.
+// It reads bounded credentials once but performs no Kubernetes API request.
+func (bundle VerifiedLifecycleObservationStageBundle) Open(config LifecycleObservationStageRuntimeConfig) (OpenedLifecycleObservationStage, error) {
+	if !bundle.verified || config.Clock == nil || config.Wait == nil {
+		return OpenedLifecycleObservationStage{}, errors.New("verified lifecycle observation bundle, clock, and waiter are required")
+	}
+	store, ledgerToken, err := openKubernetesLedger(config.Ledger)
+	if err != nil {
+		return OpenedLifecycleObservationStage{}, errors.New("open lifecycle observation ledger")
+	}
+	source, managementToken, err := openKubernetesCAPILifecycleObserver(
+		config.Management,
+		bundle.plan.Authorities.Management,
+		bundle.plan.ContractIdentity.Namespace,
+		bundle.plan.ContractIdentity.Name,
+	)
+	if err != nil {
+		return OpenedLifecycleObservationStage{}, errors.New("open lifecycle observation management source")
+	}
+	if len(ledgerToken) == len(managementToken) && subtle.ConstantTimeCompare([]byte(ledgerToken), []byte(managementToken)) == 1 {
+		return OpenedLifecycleObservationStage{}, errors.New("ledger and observation credentials must be distinct")
+	}
+	observer, err := NewLifecycleStageObserver(LifecycleStageObserverConfig{
+		Plan: bundle.plan, Cursor: bundle.cursor, Source: source,
+		PollInterval: config.PollInterval, PollTimeout: config.PollTimeout,
+		Clock: config.Clock, Wait: config.Wait,
+	})
+	if err != nil {
+		return OpenedLifecycleObservationStage{}, err
+	}
+	return OpenedLifecycleObservationStage{
+		operation: execution.ObservationStageOperation{Ledger: store, Observer: observer},
+		plan:      bundle.plan, cursor: bundle.cursor, verified: true,
+	}, nil
+}
+
+func (stage OpenedLifecycleObservationStage) Run(ctx context.Context) (execution.ObservationStageRunReceipt, error) {
+	if !stage.verified {
+		return execution.ObservationStageRunReceipt{}, errors.New("lifecycle observation stage is not opened")
+	}
+	return stage.operation.Run(ctx, stage.plan, stage.cursor)
+}

--- a/internal/runner/lifecycle_observation_bundle_test.go
+++ b/internal/runner/lifecycle_observation_bundle_test.go
@@ -1,0 +1,133 @@
+package runner
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/stagereceipt"
+)
+
+func TestLifecycleObservationStageBundleLoadsExactReadOnlyCursor(t *testing.T) {
+	config := lifecycleObservationBundleConfig(t, true)
+	bundle, err := LoadLifecycleObservationStageBundle(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decision, err := bundle.Decision()
+	if err != nil || decision.StageID != "lifecycle-observation" || decision.RequiresAuthorization || decision.Operation != "" {
+		t.Fatalf("unexpected lifecycle bundle decision: %#v %v", decision, err)
+	}
+	if _, err := (VerifiedLifecycleObservationStageBundle{}).Decision(); err == nil {
+		t.Fatal("unverified lifecycle bundle exposed a decision")
+	}
+}
+
+func TestLifecycleObservationStageBundleRejectsWrongStageOrMissingCorrelation(t *testing.T) {
+	providerOnly := submissionBundleFixture(t, true, "")
+	if _, err := LoadLifecycleObservationStageBundle(StageResumeConfig{
+		PlanPath: providerOnly.config.PlanPath, PlanExpected: providerOnly.config.PlanExpected, Receipts: providerOnly.config.Receipts,
+	}); err == nil || !strings.Contains(err.Error(), "does not select") {
+		t.Fatalf("mutating lifecycle cursor was accepted: %v", err)
+	}
+	if _, err := LoadLifecycleObservationStageBundle(lifecycleObservationBundleConfig(t, false)); err == nil || !strings.Contains(err.Error(), "durable target") {
+		t.Fatalf("lifecycle receipt without runtime correlation was accepted: %v", err)
+	}
+}
+
+func TestLifecycleObservationStageBundleOpensWithoutClusterContact(t *testing.T) {
+	bundle, err := LoadLifecycleObservationStageBundle(lifecycleObservationBundleConfig(t, true))
+	if err != nil {
+		t.Fatal(err)
+	}
+	runtime := lifecycleObservationRuntime(t, "ledger-token", "management-observer-token")
+	opened, err := bundle.Open(runtime)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !opened.verified {
+		t.Fatal("opened lifecycle stage is not verified")
+	}
+	if _, err := (OpenedLifecycleObservationStage{}).Run(context.Background()); err == nil {
+		t.Fatal("unopened lifecycle stage could run")
+	}
+}
+
+func TestLifecycleObservationStageBundleRequiresDistinctBoundedCredentials(t *testing.T) {
+	bundle, err := LoadLifecycleObservationStageBundle(lifecycleObservationBundleConfig(t, true))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := bundle.Open(lifecycleObservationRuntime(t, "shared-token", "shared-token")); err == nil {
+		t.Fatal("shared ledger and management observation credential was accepted")
+	}
+	runtime := lifecycleObservationRuntime(t, "ledger-token", "management-observer-token")
+	runtime.Management.AuthorityIdentity = "foreign-management"
+	if _, err := bundle.Open(runtime); err == nil {
+		t.Fatal("foreign management observation authority was accepted")
+	}
+	if _, err := (VerifiedLifecycleObservationStageBundle{}).Open(runtime); err == nil {
+		t.Fatal("unverified lifecycle bundle opened runtime credentials")
+	}
+}
+
+func lifecycleObservationBundleConfig(t *testing.T, withTargetDigest bool) StageResumeConfig {
+	t.Helper()
+	fixture := submissionBundleFixture(t, true, "")
+	provider, err := stagereceipt.Load(fixture.config.Receipts[0].Path, fixture.config.Receipts[0].Digest, fixture.plan, []stagereceipt.Verified{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	at := time.Date(2026, 8, 16, 20, 0, 0, 0, time.UTC)
+	var lifecycle stagereceipt.Verified
+	if withTargetDigest {
+		lifecycle, err = stagereceipt.NewWithTargetClusterUIDDigest(
+			fixture.plan, "cluster-lifecycle", []stagereceipt.Verified{provider}, "SUCCEEDED", "ATTEMPTED",
+			bundleSHA("1"), bundleSHA("2"), digest.SHA256([]byte("cluster-runtime-uid-147")), at,
+		)
+	} else {
+		lifecycle, err = stagereceipt.New(
+			fixture.plan, "cluster-lifecycle", []stagereceipt.Verified{provider}, "SUCCEEDED", "ATTEMPTED",
+			bundleSHA("1"), bundleSHA("2"), at,
+		)
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, _ := lifecycle.Bytes()
+	receiptDigest, _ := lifecycle.Digest()
+	lifecycleSource := StageReceiptSource{Path: writeBundleFile(t, t.TempDir(), "cluster-lifecycle.json", raw), Digest: receiptDigest}
+	return StageResumeConfig{
+		PlanPath: fixture.config.PlanPath, PlanExpected: fixture.config.PlanExpected,
+		Receipts: append(append([]StageReceiptSource{}, fixture.config.Receipts...), lifecycleSource),
+	}
+}
+
+func lifecycleObservationRuntime(t *testing.T, ledgerToken, managementToken string) LifecycleObservationStageRuntimeConfig {
+	t.Helper()
+	root := t.TempDir()
+	caPath := filepath.Join(root, "ca.crt")
+	ledgerTokenPath := filepath.Join(root, "ledger-token")
+	managementTokenPath := filepath.Join(root, "management-token")
+	for path, content := range map[string][]byte{
+		caPath: testCA(t), ledgerTokenPath: []byte(ledgerToken), managementTokenPath: []byte(managementToken),
+	} {
+		if err := os.WriteFile(path, content, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return LifecycleObservationStageRuntimeConfig{
+		Ledger: KubernetesLedgerConfig{
+			Endpoint: "https://192.0.2.10:6443", Namespace: "openkubes-execution-system", TokenFile: ledgerTokenPath, CAFile: caPath,
+		},
+		Management: KubernetesAuthorityConfig{
+			Endpoint: "https://192.0.2.10:6443", AuthorityIdentity: "ok-mgmt", TokenFile: managementTokenPath, CAFile: caPath,
+		},
+		PollInterval: time.Second, PollTimeout: time.Minute, Clock: time.Now,
+		Wait: func(context.Context, time.Duration) error { return nil },
+	}
+}

--- a/internal/runner/stage_resume.go
+++ b/internal/runner/stage_resume.go
@@ -21,26 +21,34 @@ type StageResumeConfig struct {
 // safe cursor decision. It performs no credential read, ledger access,
 // Kubernetes request, mutation or stage execution.
 func InspectStageResume(config StageResumeConfig) (stagecursor.Decision, error) {
+	_, cursor, err := loadStageResume(config)
+	if err != nil {
+		return stagecursor.Decision{}, err
+	}
+	return cursor.Decision()
+}
+
+func loadStageResume(config StageResumeConfig) (stageplan.Binding, stagecursor.Cursor, error) {
 	if config.Receipts == nil {
-		return stagecursor.Decision{}, errors.New("stage receipt prefix must be explicit")
+		return stageplan.Binding{}, stagecursor.Cursor{}, errors.New("stage receipt prefix must be explicit")
 	}
 	plan, err := stageplan.Load(config.PlanPath, config.PlanExpected)
 	if err != nil {
-		return stagecursor.Decision{}, err
+		return stageplan.Binding{}, stagecursor.Cursor{}, err
 	}
 	prefix := make([]stagereceipt.Verified, 0, len(config.Receipts))
 	predecessors := []stagereceipt.Verified{}
 	for _, source := range config.Receipts {
 		verified, err := stagereceipt.Load(source.Path, source.Digest, plan, predecessors)
 		if err != nil {
-			return stagecursor.Decision{}, err
+			return stageplan.Binding{}, stagecursor.Cursor{}, err
 		}
 		prefix = append(prefix, verified)
 		predecessors = []stagereceipt.Verified{verified}
 	}
 	cursor, err := stagecursor.Evaluate(plan, prefix)
 	if err != nil {
-		return stagecursor.Decision{}, err
+		return stageplan.Binding{}, stagecursor.Cursor{}, err
 	}
-	return cursor.Decision()
+	return plan, cursor, nil
 }


### PR DESCRIPTION
## What changed

- retain the reverified staged plan and lifecycle-observation cursor in one private bundle
- reject prefixes that select another stage or lack the durable CAPI Cluster UID digest
- open the ledger and management CAPI observer from bounded credentials exactly once
- require distinct ledger and observation token values
- bind management authority plus Cluster namespace/name to the verified plan
- expose only the bounded stage `Run` method after opening

## Why

The lifecycle observer must be activatable later by either the local CLI or a short-lived Job without allowing callers to swap its plan, predecessor, target identity or runtime capability after verification.

## Impact

This remains library-only. Opening reads bounded local credential files and constructs TLS clients but performs no Kubernetes request. No CLI/Job activation or infrastructure change is included.

## Validation

- full Go test suite
- `go vet ./...`
- race tests for runner, execution, ledger and observation
- Python contract suite (18 tests, 1 expected skip)
