### PR TITLE
feat(cli): run bounded lifecycle observation (OK-147)

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,11 @@ Powered by [Cluster API (CAPI)](https://cluster-api.sigs.k8s.io/), [CAPK (KubeVi
   again; a same-name replacement Cluster fails the UID-digest boundary. A
   verified lifecycle-observation bundle now retains the plan and receipt
   cursor privately, opens distinct ledger and management-observer credentials
-  exactly once and exposes only the bounded stage `Run` method. This bundle is
-  not yet activated by a CLI command or Job.
+  exactly once and exposes only the bounded stage `Run` method. `ok cluster
+  stage observe lifecycle --execute` is the first activation path: it accepts
+  no grant or projection, requires an explicit receipt prefix and bounded
+  polling window, reads only the exact CAPI Cluster and persists only its
+  immutable stage receipt. It is not yet packaged or launched as a Job.
 
 ---
 

--- a/cmd/ok/main.go
+++ b/cmd/ok/main.go
@@ -26,9 +26,10 @@ import (
 )
 
 const (
-	ledgerNamespace    = "openkubes-execution-system"
-	stageRunTimeout    = 10 * time.Minute
-	stageLaunchTimeout = 5 * time.Minute
+	ledgerNamespace                 = "openkubes-execution-system"
+	stageRunTimeout                 = 10 * time.Minute
+	stageLaunchTimeout              = 5 * time.Minute
+	lifecycleObservationRunOverhead = time.Minute
 )
 
 var (
@@ -340,6 +341,19 @@ var executeSubmissionStage = func(ctx context.Context, bundleConfig runner.Submi
 	return bound.Run(ctx)
 }
 
+var executeLifecycleObservationStage = func(ctx context.Context, bundleConfig runner.StageResumeConfig, runtimeConfig runner.LifecycleObservationStageRuntimeConfig) (execution.ObservationStageRunReceipt, error) {
+	bundle, err := runner.LoadLifecycleObservationStageBundle(bundleConfig)
+	if err != nil {
+		return execution.ObservationStageRunReceipt{}, err
+	}
+	runtimeConfig.Management.AuthorityIdentity = bundleConfig.PlanExpected.ManagementAuthority
+	opened, err := bundle.Open(runtimeConfig)
+	if err != nil {
+		return execution.ObservationStageRunReceipt{}, err
+	}
+	return opened.Run(ctx)
+}
+
 func submissionStageAuthority(decision stagecursor.Decision, expected stageplan.Expected) (string, error) {
 	switch decision.Authority {
 	case "infrastructure":
@@ -378,6 +392,9 @@ func runContext(ctx context.Context, arguments []string, stdout, stderr io.Write
 	if len(arguments) >= 3 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "resume" {
 		return runClusterStageResume(arguments[3:], stdout, stderr)
 	}
+	if len(arguments) >= 4 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "observe" && arguments[3] == "lifecycle" {
+		return runClusterStageObserveLifecycle(ctx, arguments[4:], stdout, stderr)
+	}
 	if len(arguments) >= 3 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "run" {
 		return runClusterStageRun(ctx, arguments[3:], stdout, stderr)
 	}
@@ -390,7 +407,7 @@ func runContext(ctx context.Context, arguments []string, stdout, stderr io.Write
 	if len(arguments) >= 4 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "launch" && arguments[3] == "execute" {
 		return runClusterStageLaunchExecute(ctx, arguments[4:], stdout, stderr)
 	}
-	return errors.New("usage: ok cluster create ... | ok cluster stage inspect ... | ok cluster stage resume ... | ok cluster stage run ... | ok cluster stage package ... | ok cluster stage launch prepare ... | ok cluster stage launch execute ...")
+	return errors.New("usage: ok cluster create ... | ok cluster stage inspect ... | ok cluster stage resume ... | ok cluster stage observe lifecycle ... | ok cluster stage run ... | ok cluster stage package ... | ok cluster stage launch prepare ... | ok cluster stage launch execute ...")
 }
 
 func runClusterCreate(arguments []string, stdout, stderr io.Writer) error {
@@ -569,6 +586,67 @@ func runClusterStageResume(arguments []string, stdout, stderr io.Writer) error {
 	encoder.SetEscapeHTML(false)
 	encoder.SetIndent("", "  ")
 	return encoder.Encode(inspection)
+}
+
+func runClusterStageObserveLifecycle(ctx context.Context, arguments []string, stdout, stderr io.Writer) error {
+	flags := flag.NewFlagSet("ok cluster stage observe lifecycle", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	resumeFlags := addStageResumeFlags(flags)
+	execute := flags.Bool("execute", false, "perform exactly the selected read-only observation and persist its receipt")
+	ledgerAPIEndpoint := flags.String("ledger-api-endpoint", "", "TLS Kubernetes API endpoint for the durable ledger")
+	ledgerTokenFile := flags.String("ledger-token-file", "", "path to the short-lived ledger token")
+	ledgerCAFile := flags.String("ledger-ca-file", "", "path to the ledger Kubernetes API CA bundle")
+	managementAPIEndpoint := flags.String("management-api-endpoint", "", "TLS Kubernetes API endpoint for exact CAPI observation")
+	managementTokenFile := flags.String("management-token-file", "", "path to the short-lived read-only management token")
+	managementCAFile := flags.String("management-ca-file", "", "path to the management Kubernetes API CA bundle")
+	pollInterval := flags.Duration("poll-interval", 0, "bounded interval between verified Unknown observations")
+	pollTimeout := flags.Duration("poll-timeout", 0, "maximum bounded lifecycle observation duration")
+	if err := flags.Parse(arguments); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return errors.New("positional arguments are not accepted")
+	}
+	if !*execute {
+		return errors.New("lifecycle observation requires explicit --execute")
+	}
+	bundleConfig, err := resumeFlags.config()
+	if err != nil {
+		return err
+	}
+	for _, input := range []struct{ name, value string }{
+		{"--ledger-api-endpoint", *ledgerAPIEndpoint}, {"--ledger-token-file", *ledgerTokenFile}, {"--ledger-ca-file", *ledgerCAFile},
+		{"--management-api-endpoint", *managementAPIEndpoint}, {"--management-token-file", *managementTokenFile}, {"--management-ca-file", *managementCAFile},
+	} {
+		if input.value == "" {
+			return fmt.Errorf("%s is required", input.name)
+		}
+	}
+	if *pollInterval < time.Second || *pollInterval > 5*time.Minute || *pollTimeout < *pollInterval || *pollTimeout > 6*time.Hour {
+		return errors.New("--poll-interval and --poll-timeout must define a valid bounded observation of at most 6h")
+	}
+	runTimeout := *pollTimeout + lifecycleObservationRunOverhead
+	boundedContext, cancel := context.WithTimeout(ctx, runTimeout)
+	defer cancel()
+	receipt, runErr := executeLifecycleObservationStage(boundedContext, bundleConfig, runner.LifecycleObservationStageRuntimeConfig{
+		Ledger: runner.KubernetesLedgerConfig{
+			Endpoint: *ledgerAPIEndpoint, Namespace: ledgerNamespace, TokenFile: *ledgerTokenFile, CAFile: *ledgerCAFile,
+		},
+		Management: runner.KubernetesAuthorityConfig{
+			Endpoint: *managementAPIEndpoint, TokenFile: *managementTokenFile, CAFile: *managementCAFile,
+		},
+		PollInterval: *pollInterval, PollTimeout: *pollTimeout,
+		Clock: func() time.Time { return time.Now().UTC() }, Wait: runner.WaitWithTimer,
+	})
+	if receipt.Format != "" {
+		encoder := json.NewEncoder(stdout)
+		encoder.SetEscapeHTML(false)
+		encoder.SetIndent("", "  ")
+		if err := encoder.Encode(receipt); err != nil {
+			return err
+		}
+	}
+	return runErr
 }
 
 func runClusterStageRun(ctx context.Context, arguments []string, stdout, stderr io.Writer) error {

--- a/cmd/ok/main_test.go
+++ b/cmd/ok/main_test.go
@@ -255,6 +255,99 @@ func TestStageResumeRequiresCompleteUnambiguousInputs(t *testing.T) {
 	}
 }
 
+func TestStageObserveLifecycleRequiresExplicitExecutionAndBindsRuntime(t *testing.T) {
+	previous := executeLifecycleObservationStage
+	defer func() { executeLifecycleObservationStage = previous }()
+	var capturedBundle runner.StageResumeConfig
+	var capturedRuntime runner.LifecycleObservationStageRuntimeConfig
+	var capturedContext context.Context
+	executeLifecycleObservationStage = func(ctx context.Context, bundle runner.StageResumeConfig, runtime runner.LifecycleObservationStageRuntimeConfig) (execution.ObservationStageRunReceipt, error) {
+		capturedContext, capturedBundle, capturedRuntime = ctx, bundle, runtime
+		return execution.ObservationStageRunReceipt{
+			Format: execution.ObservationStageReceiptFormat, State: "COMPLETED_SUCCEEDED",
+			PlanDigest: testSHA("9"), StageID: "lifecycle-observation", StageReceiptDigest: testSHA("8"),
+		}, nil
+	}
+	var stdout, stderr bytes.Buffer
+	if err := run(stageObserveLifecycleArguments(), &stdout, &stderr); err != nil {
+		t.Fatalf("run: %v; stderr=%s", err, stderr.String())
+	}
+	if capturedBundle.PlanPath != "/tmp/plan.json" || len(capturedBundle.Receipts) != 2 {
+		t.Fatalf("unexpected observation bundle: %#v", capturedBundle)
+	}
+	if capturedRuntime.Ledger.Namespace != ledgerNamespace || capturedRuntime.Ledger.TokenFile != "/tmp/ledger-token" || capturedRuntime.Management.TokenFile != "/tmp/management-observer-token" || capturedRuntime.Management.AuthorityIdentity != "" {
+		t.Fatalf("unexpected observation runtime: %#v", capturedRuntime)
+	}
+	if capturedRuntime.PollInterval != 15*time.Second || capturedRuntime.PollTimeout != 5*time.Minute || capturedRuntime.Clock == nil || capturedRuntime.Wait == nil {
+		t.Fatalf("bounded observation timing differs: %#v", capturedRuntime)
+	}
+	deadline, bounded := capturedContext.Deadline()
+	remaining := time.Until(deadline)
+	if !bounded || remaining > 6*time.Minute || remaining < 5*time.Minute {
+		t.Fatalf("lifecycle observation context is not bounded: %s %t", deadline, bounded)
+	}
+	var receipt execution.ObservationStageRunReceipt
+	if err := json.Unmarshal(stdout.Bytes(), &receipt); err != nil {
+		t.Fatal(err)
+	}
+	if receipt.State != "COMPLETED_SUCCEEDED" || receipt.StageID != "lifecycle-observation" {
+		t.Fatalf("unexpected observation receipt: %#v", receipt)
+	}
+}
+
+func TestStageObserveLifecycleFailsClosedBeforeExecution(t *testing.T) {
+	previous := executeLifecycleObservationStage
+	defer func() { executeLifecycleObservationStage = previous }()
+	calls := 0
+	executeLifecycleObservationStage = func(context.Context, runner.StageResumeConfig, runner.LifecycleObservationStageRuntimeConfig) (execution.ObservationStageRunReceipt, error) {
+		calls++
+		return execution.ObservationStageRunReceipt{}, nil
+	}
+	valid := stageObserveLifecycleArguments()
+	for name, arguments := range map[string][]string{
+		"missing execute":          removeArgument(valid, "--execute"),
+		"missing ledger token":     removeArgumentWithValue(valid, "--ledger-token-file"),
+		"missing management token": removeArgumentWithValue(valid, "--management-token-file"),
+		"missing poll timeout":     removeArgumentWithValue(valid, "--poll-timeout"),
+		"too frequent":             replaceArgument(valid, "--poll-interval", "500ms"),
+		"interval exceeds timeout": replaceArgument(valid, "--poll-interval", "6m"),
+		"too long":                 replaceArgument(valid, "--poll-timeout", "7h"),
+		"positional":               append(append([]string{}, valid...), "unexpected"),
+	} {
+		t.Run(name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			if err := run(arguments, &stdout, &stderr); err == nil || stdout.Len() != 0 {
+				t.Fatalf("unsafe lifecycle observation input was accepted: err=%v stdout=%s", err, stdout.String())
+			}
+		})
+	}
+	if calls != 0 {
+		t.Fatalf("observation execution was reached %d times for invalid input", calls)
+	}
+}
+
+func TestStageObserveLifecycleEmitsPersistedTerminalReceipt(t *testing.T) {
+	previous := executeLifecycleObservationStage
+	defer func() { executeLifecycleObservationStage = previous }()
+	executeLifecycleObservationStage = func(context.Context, runner.StageResumeConfig, runner.LifecycleObservationStageRuntimeConfig) (execution.ObservationStageRunReceipt, error) {
+		return execution.ObservationStageRunReceipt{
+			Format: execution.ObservationStageReceiptFormat, State: "COMPLETED_STOPPED",
+			PlanDigest: testSHA("9"), StageID: "lifecycle-observation", StageReceiptDigest: testSHA("8"),
+		}, errors.New("bounded observation stopped")
+	}
+	var stdout, stderr bytes.Buffer
+	if err := run(stageObserveLifecycleArguments(), &stdout, &stderr); err == nil {
+		t.Fatal("terminal lifecycle observation returned success")
+	}
+	var receipt execution.ObservationStageRunReceipt
+	if err := json.Unmarshal(stdout.Bytes(), &receipt); err != nil {
+		t.Fatal(err)
+	}
+	if receipt.State != "COMPLETED_STOPPED" || receipt.StageReceiptDigest == "" {
+		t.Fatalf("persisted terminal observation receipt was lost: %#v", receipt)
+	}
+}
+
 func TestStageRunRequiresExplicitExecutionAndBindsOneRuntime(t *testing.T) {
 	previous := executeSubmissionStage
 	defer func() { executeSubmissionStage = previous }()
@@ -629,6 +722,19 @@ func stageRunArguments() []string {
 		"--execute",
 		"--ledger-api-endpoint", "https://192.0.2.12:6443", "--ledger-token-file", "/tmp/ledger-token", "--ledger-ca-file", "/tmp/ledger-ca",
 		"--authority-api-endpoint", "https://192.0.2.11:6443", "--authority-token-file", "/tmp/authority-token", "--authority-ca-file", "/tmp/authority-ca",
+	)
+}
+
+func stageObserveLifecycleArguments() []string {
+	arguments := stageResumeArguments()
+	arguments = append([]string{"cluster", "stage", "observe", "lifecycle"}, arguments[3:]...)
+	return append(arguments,
+		"--receipt", "/tmp/provider.json@"+testSHA("6"),
+		"--receipt", "/tmp/lifecycle.json@"+testSHA("7"),
+		"--execute",
+		"--ledger-api-endpoint", "https://192.0.2.12:6443", "--ledger-token-file", "/tmp/ledger-token", "--ledger-ca-file", "/tmp/ledger-ca",
+		"--management-api-endpoint", "https://192.0.2.12:6443", "--management-token-file", "/tmp/management-observer-token", "--management-ca-file", "/tmp/management-ca",
+		"--poll-interval", "15s", "--poll-timeout", "5m",
 	)
 }
 

--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -996,8 +996,29 @@ The resulting value exposes only one bounded `Run` method. Callers cannot
 replace its plan, cursor, predecessor, source implementation or credential
 after verification. An unverified zero value cannot expose a decision, open
 credentials or run. This provides the environment-neutral boundary needed by
-a later local CLI or short-lived Job without activating either one in this
-checkpoint.
+a local CLI or short-lived Job.
+
+The local CLI now activates exactly this one read-only source-observation
+stage:
+
+```text
+ok cluster stage observe lifecycle --execute
+  + exact plan identities
+  + explicit canonical receipt prefix
+  + distinct bounded ledger and management-observer credentials
+  + poll interval and maximum duration
+      -> exact CAPI GET polling
+      -> immutable lifecycle-observation receipt
+```
+
+It accepts no grant, projection, renderer, authority map or implementation
+selector. `--execute` is still mandatory because the command contacts the
+management API and persists evidence in the ledger. The context is bounded to
+the caller's poll timeout plus one minute of fixed completion overhead. Invalid
+timing or incomplete runtime input fails before credential opening; terminal
+`FAILED` and `STOPPED` receipts are still emitted while the process returns an
+error. This checkpoint does not package, launch or deploy an observation Job,
+and its tests make no Kubernetes request.
 
 ## Cursor-to-grant binding
 


### PR DESCRIPTION
## What changed

- add `ok cluster stage observe lifecycle --execute`
- require an explicit verified receipt prefix and exact R/E/P/Fixture/authority identities
- accept no grant, projection, renderer or implementation selector
- bind distinct short-lived ledger and read-only management credentials
- enforce a 1s–5m polling interval and a bounded timeout of at most 6h
- emit persisted FAILED/STOPPED receipts while returning a non-zero result

## Why

The first read-only stage now has a typed, crash-safe runtime implementation and private bundle. This command activates only that boundary for local or Job use without widening the existing mutating `stage run` path.

## Impact

The code path can contact the exact management API and persist an evidence receipt only when explicitly invoked with `--execute`. This PR itself performs no cluster action and adds no Job package or deployment.

## Validation

- full Go test suite
- `go vet ./...`
- race tests for CLI, runner, execution, ledger and observation
- Python contract suite (18 tests, 1 expected skip)
