### PR TITLE
feat(runner): package lifecycle observation job (OK-147)

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,9 @@ Powered by [Cluster API (CAPI)](https://cluster-api.sigs.k8s.io/), [CAPK (KubeVi
   stage observe lifecycle --execute` is the first activation path: it accepts
   no grant or projection, requires an explicit receipt prefix and bounded
   polling window, reads only the exact CAPI Cluster and persists only its
-  immutable stage receipt. It is not yet packaged or launched as a Job.
+  immutable stage receipt. `ok cluster stage observe lifecycle package`
+  additionally creates a digest-bound immutable ConfigMap, NetworkPolicy and
+  non-retrying Job envelope offline; it does not install or launch them.
 
 ---
 

--- a/cmd/ok/main.go
+++ b/cmd/ok/main.go
@@ -52,6 +52,19 @@ var materializeSubmissionStagePackage = func(config runner.SubmissionStagePackag
 	return raw, receipt, err
 }
 
+var materializeLifecycleObservationStagePackage = func(config runner.LifecycleObservationStagePackageConfig) ([]byte, runner.LifecycleObservationStagePackageReceipt, error) {
+	packaged, err := runner.BuildLifecycleObservationStagePackage(config)
+	if err != nil {
+		return nil, runner.LifecycleObservationStagePackageReceipt{}, err
+	}
+	raw, err := packaged.Bytes()
+	if err != nil {
+		return nil, runner.LifecycleObservationStagePackageReceipt{}, err
+	}
+	receipt, err := packaged.Receipt()
+	return raw, receipt, err
+}
+
 var prepareSubmissionStageLaunch = func(config runner.SubmissionStageLaunchMaterialConfig) (stageLaunchPreparation, error) {
 	material, err := runner.BuildSubmissionStageLaunchMaterial(config)
 	if err != nil {
@@ -392,6 +405,9 @@ func runContext(ctx context.Context, arguments []string, stdout, stderr io.Write
 	if len(arguments) >= 3 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "resume" {
 		return runClusterStageResume(arguments[3:], stdout, stderr)
 	}
+	if len(arguments) >= 5 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "observe" && arguments[3] == "lifecycle" && arguments[4] == "package" {
+		return runClusterStageObserveLifecyclePackage(arguments[5:], stdout, stderr)
+	}
 	if len(arguments) >= 4 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "observe" && arguments[3] == "lifecycle" {
 		return runClusterStageObserveLifecycle(ctx, arguments[4:], stdout, stderr)
 	}
@@ -407,7 +423,7 @@ func runContext(ctx context.Context, arguments []string, stdout, stderr io.Write
 	if len(arguments) >= 4 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "launch" && arguments[3] == "execute" {
 		return runClusterStageLaunchExecute(ctx, arguments[4:], stdout, stderr)
 	}
-	return errors.New("usage: ok cluster create ... | ok cluster stage inspect ... | ok cluster stage resume ... | ok cluster stage observe lifecycle ... | ok cluster stage run ... | ok cluster stage package ... | ok cluster stage launch prepare ... | ok cluster stage launch execute ...")
+	return errors.New("usage: ok cluster create ... | ok cluster stage inspect ... | ok cluster stage resume ... | ok cluster stage observe lifecycle ... | ok cluster stage observe lifecycle package ... | ok cluster stage run ... | ok cluster stage package ... | ok cluster stage launch prepare ... | ok cluster stage launch execute ...")
 }
 
 func runClusterCreate(arguments []string, stdout, stderr io.Writer) error {
@@ -647,6 +663,70 @@ func runClusterStageObserveLifecycle(ctx context.Context, arguments []string, st
 		}
 	}
 	return runErr
+}
+
+func runClusterStageObserveLifecyclePackage(arguments []string, stdout, stderr io.Writer) error {
+	flags := flag.NewFlagSet("ok cluster stage observe lifecycle package", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	resumeFlags := addStageResumeFlags(flags)
+	jobTemplate := flags.String("job-template", "", "path to the bounded lifecycle-observation Job template")
+	jobTemplateDigest := flags.String("job-template-digest", "", "expected SHA-256 identity of the Job template")
+	output := flags.String("output", "", "new local file for the verified ConfigMap/Job/NetworkPolicy package")
+	runID := flags.String("run-id", "", "bounded OK-147 observation Job identity")
+	imageDigest := flags.String("image", "", "digest-pinned ok image")
+	inputConfigMap := flags.String("input-configmap", "", "immutable observation input ConfigMap name")
+	ledgerAPIURL := flags.String("ledger-api-url", "", "exact management-ledger HTTPS IP endpoint")
+	ledgerAPICIDR := flags.String("ledger-api-cidr", "", "single-address management-ledger CIDR")
+	ledgerCredentialSecret := flags.String("ledger-credential-secret", "", "externally materialized ledger credential Secret name")
+	managementAPIURL := flags.String("management-api-url", "", "exact management-observer HTTPS IP endpoint")
+	managementAPICIDR := flags.String("management-api-cidr", "", "single-address management-observer CIDR")
+	managementCredentialSecret := flags.String("management-credential-secret", "", "externally materialized read-only management credential Secret name")
+	pollInterval := flags.Duration("poll-interval", 0, "bounded interval between verified Unknown observations")
+	pollTimeout := flags.Duration("poll-timeout", 0, "maximum bounded lifecycle observation duration")
+	if err := flags.Parse(arguments); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return errors.New("positional arguments are not accepted")
+	}
+	bundleConfig, err := resumeFlags.config()
+	if err != nil {
+		return err
+	}
+	for _, input := range []struct{ name, value string }{
+		{"--job-template", *jobTemplate}, {"--job-template-digest", *jobTemplateDigest}, {"--output", *output},
+		{"--run-id", *runID}, {"--image", *imageDigest}, {"--input-configmap", *inputConfigMap},
+		{"--ledger-api-url", *ledgerAPIURL}, {"--ledger-api-cidr", *ledgerAPICIDR}, {"--ledger-credential-secret", *ledgerCredentialSecret},
+		{"--management-api-url", *managementAPIURL}, {"--management-api-cidr", *managementAPICIDR}, {"--management-credential-secret", *managementCredentialSecret},
+	} {
+		if input.value == "" {
+			return fmt.Errorf("%s is required", input.name)
+		}
+	}
+	if *pollInterval < time.Second || *pollInterval > 5*time.Minute || *pollTimeout < *pollInterval || *pollTimeout > 6*time.Hour {
+		return errors.New("--poll-interval and --poll-timeout must define a valid bounded observation of at most 6h")
+	}
+	template, err := readBoundedLocalFile(*jobTemplate, 1024*1024)
+	if err != nil {
+		return fmt.Errorf("read lifecycle observation Job template: %w", err)
+	}
+	raw, receipt, err := materializeLifecycleObservationStagePackage(runner.LifecycleObservationStagePackageConfig{
+		Bundle: bundleConfig, JobTemplate: template, JobTemplateDigest: *jobTemplateDigest,
+		RunID: *runID, ImageDigest: *imageDigest, InputConfigMap: *inputConfigMap,
+		LedgerAPIURL: *ledgerAPIURL, LedgerAPICIDR: *ledgerAPICIDR, LedgerCredentialSecret: *ledgerCredentialSecret,
+		ManagementAPIURL: *managementAPIURL, ManagementAPICIDR: *managementAPICIDR, ManagementCredentialSecret: *managementCredentialSecret,
+		PollInterval: *pollInterval, PollTimeout: *pollTimeout,
+	})
+	if err != nil {
+		return err
+	}
+	if err := writeNewLocalFile(*output, raw); err != nil {
+		return fmt.Errorf("write lifecycle observation stage package: %w", err)
+	}
+	encoder := json.NewEncoder(stdout)
+	encoder.SetEscapeHTML(false)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(receipt)
 }
 
 func runClusterStageRun(ctx context.Context, arguments []string, stdout, stderr io.Writer) error {

--- a/cmd/ok/main_test.go
+++ b/cmd/ok/main_test.go
@@ -348,6 +348,81 @@ func TestStageObserveLifecycleEmitsPersistedTerminalReceipt(t *testing.T) {
 	}
 }
 
+func TestStageObserveLifecyclePackageWritesVerifiedOfflineArtifact(t *testing.T) {
+	previous := materializeLifecycleObservationStagePackage
+	defer func() { materializeLifecycleObservationStagePackage = previous }()
+	var captured runner.LifecycleObservationStagePackageConfig
+	materializeLifecycleObservationStagePackage = func(config runner.LifecycleObservationStagePackageConfig) ([]byte, runner.LifecycleObservationStagePackageReceipt, error) {
+		captured = config
+		return []byte("verified-observation-package\n"), runner.LifecycleObservationStagePackageReceipt{
+			Format: runner.LifecycleObservationStagePackageFormat, State: "VERIFIED", StageID: "lifecycle-observation",
+			PackageDigest: testSHA("1"), InputConfigMapDigest: testSHA("2"), ReceiptPrefixDigest: testSHA("3"),
+			JobTemplateDigest: testSHA("4"), JobEnvelopeDigest: testSHA("5"), ObjectKinds: []string{"ConfigMap", "NetworkPolicy", "Job"},
+			AuthorizationState: "NOT_REQUIRED", MutationAllowed: false,
+		}, nil
+	}
+	root := t.TempDir()
+	template := filepath.Join(root, "observation-job.yaml.tpl")
+	if err := os.WriteFile(template, []byte("bounded-observation-template"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	output := filepath.Join(root, "observation-package.yaml")
+	arguments := stageObserveLifecyclePackageArguments(template, output)
+	var stdout, stderr bytes.Buffer
+	if err := run(arguments, &stdout, &stderr); err != nil {
+		t.Fatalf("run: %v; stderr=%s", err, stderr.String())
+	}
+	if captured.Bundle.PlanPath != "/tmp/plan.json" || len(captured.Bundle.Receipts) != 2 || captured.RunID != "ok147-lifecycle-observation-01" || captured.PollTimeout != 5*time.Minute {
+		t.Fatalf("unexpected observation package config: %#v", captured)
+	}
+	if string(captured.JobTemplate) != "bounded-observation-template" || captured.JobTemplateDigest != digest.SHA256([]byte("bounded-observation-template")) || captured.LedgerCredentialSecret == captured.ManagementCredentialSecret {
+		t.Fatalf("template or credentials were not bound: %#v", captured)
+	}
+	written, err := os.ReadFile(output)
+	if err != nil || string(written) != "verified-observation-package\n" {
+		t.Fatalf("unexpected observation package: %q %v", written, err)
+	}
+	info, err := os.Stat(output)
+	if err != nil || info.Mode().Perm() != 0o600 {
+		t.Fatalf("observation package mode is not 0600: %v %v", info, err)
+	}
+	var receipt runner.LifecycleObservationStagePackageReceipt
+	if err := json.Unmarshal(stdout.Bytes(), &receipt); err != nil {
+		t.Fatal(err)
+	}
+	if receipt.AuthorizationState != "NOT_REQUIRED" || receipt.MutationAllowed {
+		t.Fatalf("unsafe observation package receipt: %#v", receipt)
+	}
+	stdout.Reset()
+	if err := run(arguments, &stdout, &stderr); err == nil || stdout.Len() != 0 {
+		t.Fatal("existing observation package was overwritten")
+	}
+}
+
+func TestStageObserveLifecyclePackageRejectsIncompleteInputs(t *testing.T) {
+	root := t.TempDir()
+	template := filepath.Join(root, "observation-job.yaml.tpl")
+	if err := os.WriteFile(template, []byte("bounded-observation-template"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	output := filepath.Join(root, "observation-package.yaml")
+	valid := stageObserveLifecyclePackageArguments(template, output)
+	for name, arguments := range map[string][]string{
+		"execute":                   append(append([]string{}, valid...), "--execute"),
+		"missing template digest":   removeArgumentWithValue(valid, "--job-template-digest"),
+		"missing management secret": removeArgumentWithValue(valid, "--management-credential-secret"),
+		"missing poll timeout":      removeArgumentWithValue(valid, "--poll-timeout"),
+		"positional":                append(append([]string{}, valid...), "unexpected"),
+	} {
+		t.Run(name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			if err := run(arguments, &stdout, &stderr); err == nil || stdout.Len() != 0 {
+				t.Fatalf("unsafe observation package input was accepted: %v %s", err, stdout.String())
+			}
+		})
+	}
+}
+
 func TestStageRunRequiresExplicitExecutionAndBindsOneRuntime(t *testing.T) {
 	previous := executeSubmissionStage
 	defer func() { executeSubmissionStage = previous }()
@@ -734,6 +809,23 @@ func stageObserveLifecycleArguments() []string {
 		"--execute",
 		"--ledger-api-endpoint", "https://192.0.2.12:6443", "--ledger-token-file", "/tmp/ledger-token", "--ledger-ca-file", "/tmp/ledger-ca",
 		"--management-api-endpoint", "https://192.0.2.12:6443", "--management-token-file", "/tmp/management-observer-token", "--management-ca-file", "/tmp/management-ca",
+		"--poll-interval", "15s", "--poll-timeout", "5m",
+	)
+}
+
+func stageObserveLifecyclePackageArguments(template, output string) []string {
+	arguments := stageObserveLifecycleArguments()
+	arguments = removeArgument(arguments, "--execute")
+	for _, name := range []string{"--ledger-api-endpoint", "--ledger-token-file", "--ledger-ca-file", "--management-api-endpoint", "--management-token-file", "--management-ca-file", "--poll-interval", "--poll-timeout"} {
+		arguments = removeArgumentWithValue(arguments, name)
+	}
+	arguments = append(arguments[:4], append([]string{"package"}, arguments[4:]...)...)
+	return append(arguments,
+		"--job-template", template, "--job-template-digest", digest.SHA256([]byte("bounded-observation-template")),
+		"--output", output, "--run-id", "ok147-lifecycle-observation-01",
+		"--image", "ghcr.io/openkubes/ok-cluster@"+testSHA("a"), "--input-configmap", "ok147-lifecycle-observation-input",
+		"--ledger-api-url", "https://192.0.2.12:6443", "--ledger-api-cidr", "192.0.2.12/32", "--ledger-credential-secret", "ok147-ledger-observation",
+		"--management-api-url", "https://192.0.2.12:6443", "--management-api-cidr", "192.0.2.12/32", "--management-credential-secret", "ok147-management-observer",
 		"--poll-interval", "15s", "--poll-timeout", "5m",
 	)
 }

--- a/deploy/contract-executor-lifecycle-observation-job.yaml.tpl
+++ b/deploy/contract-executor-lifecycle-observation-job.yaml.tpl
@@ -1,0 +1,143 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: "${OK147_RUN_ID}"
+  namespace: openkubes-execution-system
+spec:
+  podSelector:
+    matchLabels:
+      openkubes.io/execution-id: "${OK147_RUN_ID}"
+  policyTypes: ["Ingress", "Egress"]
+  ingress: []
+  egress:
+    - to: [{ipBlock: {cidr: "${OK147_LEDGER_API_CIDR}"}}]
+      ports: [{protocol: TCP, port: ${OK147_LEDGER_API_PORT}}]
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "${OK147_RUN_ID}"
+  namespace: openkubes-execution-system
+  labels:
+    app.kubernetes.io/name: ok-cluster-contract-executor
+    openkubes.io/execution-id: "${OK147_RUN_ID}"
+    openkubes.io/stage-id: lifecycle-observation
+spec:
+  backoffLimit: 0
+  completions: 1
+  parallelism: 1
+  activeDeadlineSeconds: ${OK147_ACTIVE_DEADLINE_SECONDS}
+  ttlSecondsAfterFinished: 3600
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ok-cluster-contract-executor
+        openkubes.io/execution-id: "${OK147_RUN_ID}"
+    spec:
+      serviceAccountName: ok147-contract-executor-runtime
+      automountServiceAccountToken: false
+      enableServiceLinks: false
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+        seccompProfile: {type: RuntimeDefault}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - {key: node-role.kubernetes.io/control-plane, operator: DoesNotExist}
+      containers:
+        - name: executor
+          image: "${OK147_IMAGE_DIGEST}"
+          imagePullPolicy: IfNotPresent
+          command: ["/ok"]
+          args:
+            - cluster
+            - stage
+            - observe
+            - lifecycle
+            - --execute
+            - --plan
+            - /var/run/openkubes/input/staged-plan.json
+            - --contract-namespace
+            - "${OK147_CONTRACT_NAMESPACE}"
+            - --contract-name
+            - "${OK147_CONTRACT_NAME}"
+            - --intent-revision
+            - "${OK147_R}"
+            - --enablement-revision
+            - "${OK147_E}"
+            - --platform-revision
+            - "${OK147_P}"
+            - --execution-fixture
+            - "${OK147_FIXTURE}"
+            - --infrastructure-authority
+            - "${OK147_INFRA_AUTHORITY}"
+            - --management-authority
+            - "${OK147_MGMT_AUTHORITY}"
+            - --gitops-authority
+            - "${OK147_GITOPS_AUTHORITY}"
+            - --receipt-prefix
+            - /var/run/openkubes/input/receipt-prefix.json
+            - --receipt-prefix-digest
+            - "${OK147_RECEIPT_PREFIX_DIGEST}"
+            - --ledger-api-endpoint
+            - "${OK147_LEDGER_API_URL}"
+            - --ledger-token-file
+            - /var/run/openkubes/ledger/token
+            - --ledger-ca-file
+            - /var/run/openkubes/ledger/ca.crt
+            - --management-api-endpoint
+            - "${OK147_MANAGEMENT_API_URL}"
+            - --management-token-file
+            - /var/run/openkubes/management/token
+            - --management-ca-file
+            - /var/run/openkubes/management/ca.crt
+            - --poll-interval
+            - "${OK147_POLL_INTERVAL}"
+            - --poll-timeout
+            - "${OK147_POLL_TIMEOUT}"
+          resources:
+            requests: {cpu: 25m, memory: 48Mi, ephemeral-storage: 16Mi}
+            limits: {cpu: 200m, memory: 96Mi, ephemeral-storage: 32Mi}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities: {drop: ["ALL"]}
+          volumeMounts:
+            - {name: input, mountPath: /var/run/openkubes/input/staged-plan.json, subPath: staged-plan.json, readOnly: true}
+            - {name: input, mountPath: /var/run/openkubes/input/receipt-prefix.json, subPath: receipt-prefix.json, readOnly: true}
+            - {name: input, mountPath: /var/run/openkubes/input/provider-receipt.json, subPath: provider-receipt.json, readOnly: true}
+            - {name: input, mountPath: /var/run/openkubes/input/lifecycle-receipt.json, subPath: lifecycle-receipt.json, readOnly: true}
+            - {name: ledger-credential, mountPath: /var/run/openkubes/ledger/token, subPath: token, readOnly: true}
+            - {name: ledger-credential, mountPath: /var/run/openkubes/ledger/ca.crt, subPath: ca.crt, readOnly: true}
+            - {name: management-credential, mountPath: /var/run/openkubes/management/token, subPath: token, readOnly: true}
+            - {name: management-credential, mountPath: /var/run/openkubes/management/ca.crt, subPath: ca.crt, readOnly: true}
+      volumes:
+        - name: input
+          configMap:
+            name: "${OK147_INPUT_CONFIGMAP}"
+            defaultMode: 0444
+            items:
+              - {key: staged-plan.json, path: staged-plan.json}
+              - {key: receipt-prefix.json, path: receipt-prefix.json}
+              - {key: provider-receipt.json, path: provider-receipt.json}
+              - {key: lifecycle-receipt.json, path: lifecycle-receipt.json}
+        - name: ledger-credential
+          secret:
+            secretName: "${OK147_LEDGER_CREDENTIAL_SECRET}"
+            defaultMode: 0440
+            items:
+              - {key: token, path: token}
+              - {key: ca.crt, path: ca.crt}
+        - name: management-credential
+          secret:
+            secretName: "${OK147_MANAGEMENT_CREDENTIAL_SECRET}"
+            defaultMode: 0440
+            items:
+              - {key: token, path: token}
+              - {key: ca.crt, path: ca.crt}

--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -1017,8 +1017,37 @@ management API and persists evidence in the ledger. The context is bounded to
 the caller's poll timeout plus one minute of fixed completion overhead. Invalid
 timing or incomplete runtime input fails before credential opening; terminal
 `FAILED` and `STOPPED` receipts are still emitted while the process returns an
-error. This checkpoint does not package, launch or deploy an observation Job,
-and its tests make no Kubernetes request.
+error. The execution command does not implicitly package, launch or deploy an
+observation Job, and its tests make no Kubernetes request.
+
+## Lifecycle-observation Job package
+
+The same command is now represented by a separate offline Job envelope. Its
+input ConfigMap contains exactly four public files: the staged plan, canonical
+receipt-prefix manifest, provider receipt and lifecycle receipt. It contains no
+grant, trusted key, projection, authority map, credential or rendered resource.
+
+```text
+ok cluster stage observe lifecycle package
+      -> immutable public input ConfigMap
+      -> single-endpoint egress NetworkPolicy
+      -> backoffLimit: 0 lifecycle-observation Job
+```
+
+The Job mounts distinct externally materialized ledger-writer and read-only
+management-observer Secrets. Both capabilities are bound to the same exact
+management API IP and port, but token object names must differ. The Pod has no
+automounted ServiceAccount token, runs non-root with a read-only filesystem,
+drops all capabilities and cannot schedule on a control-plane node. Its active
+deadline is derived deterministically from the verified polling timeout plus
+one minute of receipt-completion overhead.
+
+The packager reverifies the complete plan/receipt chain before and after source
+capture, binds the template and each emitted component by SHA-256, writes only
+a new `0600` local file and reports `authorizationState: NOT_REQUIRED` with
+`mutationAllowed: false`. Packaging is not installation or execution. No Job,
+ConfigMap, NetworkPolicy or credential Secret is created by this checkpoint,
+and all tests remain offline.
 
 ## Cursor-to-grant binding
 

--- a/internal/runner/lifecycle_observation_stage_input.go
+++ b/internal/runner/lifecycle_observation_stage_input.go
@@ -1,0 +1,118 @@
+package runner
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"sort"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+const LifecycleObservationStageInputFormat = "ok147-lifecycle-observation-stage-input/v1"
+
+type LifecycleObservationStageInputReceipt struct {
+	Format              string   `json:"format"`
+	State               string   `json:"state"`
+	StageID             string   `json:"stageId"`
+	ConfigMapName       string   `json:"configMapName"`
+	ConfigMapDigest     string   `json:"configMapDigest"`
+	ReceiptPrefixDigest string   `json:"receiptPrefixDigest"`
+	DataKeys            []string `json:"dataKeys"`
+}
+
+type VerifiedLifecycleObservationStageInput struct {
+	raw      []byte
+	receipt  LifecycleObservationStageInputReceipt
+	verified bool
+}
+
+// BuildLifecycleObservationStageInput packages only the plan and the exact
+// provider/lifecycle receipt prefix. It contains no grant, projection or
+// credential material and performs no Kubernetes request.
+func BuildLifecycleObservationStageInput(config StageResumeConfig, configMapName string) (VerifiedLifecycleObservationStageInput, error) {
+	if !submissionStageInputNamePattern.MatchString(configMapName) || len(configMapName) > 63 || !strings.HasPrefix(configMapName, "ok147-") {
+		return VerifiedLifecycleObservationStageInput{}, errors.New("lifecycle observation input ConfigMap name is invalid")
+	}
+	if _, err := LoadLifecycleObservationStageBundle(config); err != nil {
+		return VerifiedLifecycleObservationStageInput{}, err
+	}
+	if len(config.Receipts) != 2 {
+		return VerifiedLifecycleObservationStageInput{}, errors.New("lifecycle observation input requires provider and lifecycle receipts")
+	}
+	keys := []string{"provider-receipt.json", "lifecycle-receipt.json"}
+	prefix := stageReceiptPrefixDocument{Format: StageReceiptPrefixFormat, Receipts: make([]stageReceiptPrefixEntry, 2)}
+	paths := map[string]string{"staged-plan.json": config.PlanPath}
+	for index, key := range keys {
+		paths[key] = config.Receipts[index].Path
+		prefix.Receipts[index] = stageReceiptPrefixEntry{File: key, Digest: config.Receipts[index].Digest}
+	}
+	prefixRaw, err := json.Marshal(prefix)
+	if err != nil {
+		return VerifiedLifecycleObservationStageInput{}, errors.New("encode lifecycle observation receipt prefix")
+	}
+	data := make(map[string]string, len(paths)+1)
+	data["receipt-prefix.json"] = string(prefixRaw)
+	for key, path := range paths {
+		raw, err := readBoundedRegular(path, maximumSubmissionStageInputBytes)
+		if err != nil {
+			return VerifiedLifecycleObservationStageInput{}, errors.New("read bounded lifecycle observation input " + key)
+		}
+		if !utf8.Valid(raw) || bytes.IndexByte(raw, 0) >= 0 {
+			return VerifiedLifecycleObservationStageInput{}, errors.New("lifecycle observation input is not valid ConfigMap text")
+		}
+		data[key] = string(raw)
+	}
+	if _, err := LoadLifecycleObservationStageBundle(config); err != nil {
+		return VerifiedLifecycleObservationStageInput{}, errors.New("lifecycle observation inputs changed during materialization")
+	}
+	configMap := submissionStageInputConfigMap{
+		APIVersion: "v1", Kind: "ConfigMap",
+		Metadata: submissionStageInputObjectMeta{
+			Name: configMapName, Namespace: submissionStageInputNamespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/name": "ok-cluster-contract-executor", "openkubes.io/stage-id": "lifecycle-observation",
+			},
+			Annotations: map[string]string{
+				"openkubes.io/input-format": LifecycleObservationStageInputFormat, "openkubes.io/receipt-prefix-digest": digest.SHA256(prefixRaw),
+			},
+		},
+		Immutable: true, Data: data,
+	}
+	raw, err := json.Marshal(configMap)
+	if err != nil {
+		return VerifiedLifecycleObservationStageInput{}, errors.New("encode lifecycle observation input ConfigMap")
+	}
+	if len(raw) > maximumSubmissionStageInputBytes {
+		return VerifiedLifecycleObservationStageInput{}, errors.New("lifecycle observation input ConfigMap exceeds size limit")
+	}
+	dataKeys := make([]string, 0, len(data))
+	for key := range data {
+		dataKeys = append(dataKeys, key)
+	}
+	sort.Strings(dataKeys)
+	receipt := LifecycleObservationStageInputReceipt{
+		Format: LifecycleObservationStageInputFormat, State: "VERIFIED", StageID: "lifecycle-observation",
+		ConfigMapName: configMapName, ConfigMapDigest: digest.SHA256(raw),
+		ReceiptPrefixDigest: digest.SHA256(prefixRaw), DataKeys: dataKeys,
+	}
+	return VerifiedLifecycleObservationStageInput{raw: raw, receipt: receipt, verified: true}, nil
+}
+
+func (input VerifiedLifecycleObservationStageInput) Bytes() ([]byte, error) {
+	if !input.verified || len(input.raw) == 0 {
+		return nil, errors.New("lifecycle observation input was not produced by verification")
+	}
+	return append([]byte(nil), input.raw...), nil
+}
+
+func (input VerifiedLifecycleObservationStageInput) Receipt() (LifecycleObservationStageInputReceipt, error) {
+	if !input.verified || input.receipt.State != "VERIFIED" {
+		return LifecycleObservationStageInputReceipt{}, errors.New("lifecycle observation input was not produced by verification")
+	}
+	receipt := input.receipt
+	receipt.DataKeys = append([]string(nil), input.receipt.DataKeys...)
+	return receipt, nil
+}

--- a/internal/runner/lifecycle_observation_stage_job.go
+++ b/internal/runner/lifecycle_observation_stage_job.go
@@ -1,0 +1,100 @@
+package runner
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/stageplan"
+)
+
+const lifecycleObservationJobOverhead = time.Minute
+
+// LifecycleObservationStageJobValues contain only public runtime identities.
+// Credential contents remain in separately materialized Secrets.
+type LifecycleObservationStageJobValues struct {
+	RunID                      string
+	ImageDigest                string
+	Expected                   stageplan.Expected
+	InputConfigMap             string
+	ReceiptPrefixDigest        string
+	LedgerAPIURL               string
+	LedgerAPICIDR              string
+	LedgerCredentialSecret     string
+	ManagementAPIURL           string
+	ManagementAPICIDR          string
+	ManagementCredentialSecret string
+	PollInterval               time.Duration
+	PollTimeout                time.Duration
+}
+
+// RenderLifecycleObservationStageJobTemplate performs validated literal
+// substitution for exactly one lifecycle-observation NetworkPolicy and Job.
+func RenderLifecycleObservationStageJobTemplate(template []byte, values LifecycleObservationStageJobValues) ([]byte, error) {
+	if len(template) == 0 || len(template) > 1024*1024 {
+		return nil, errors.New("lifecycle observation Job template size is invalid")
+	}
+	dnsLabel := regexp.MustCompile(`^[a-z0-9](?:[-a-z0-9]*[a-z0-9])?$`)
+	if !dnsLabel.MatchString(values.RunID) || len(values.RunID) > 63 || !strings.HasPrefix(values.RunID, "ok147-") {
+		return nil, errors.New("lifecycle observation Job run ID is invalid")
+	}
+	for _, value := range []string{values.InputConfigMap, values.LedgerCredentialSecret, values.ManagementCredentialSecret} {
+		if !dnsLabel.MatchString(value) || len(value) > 63 {
+			return nil, errors.New("lifecycle observation Job object name is invalid")
+		}
+	}
+	if values.InputConfigMap == values.LedgerCredentialSecret || values.InputConfigMap == values.ManagementCredentialSecret || values.LedgerCredentialSecret == values.ManagementCredentialSecret {
+		return nil, errors.New("lifecycle observation Job input and credentials must use distinct objects")
+	}
+	if !regexp.MustCompile(`^[a-z0-9][a-z0-9./:_-]*@sha256:[0-9a-f]{64}$`).MatchString(values.ImageDigest) {
+		return nil, errors.New("lifecycle observation Job image is not digest-bound")
+	}
+	if !stageReceiptPrefixDigestPattern.MatchString(values.ReceiptPrefixDigest) {
+		return nil, errors.New("lifecycle observation Job receipt-prefix digest is invalid")
+	}
+	if err := stageplan.ValidateExpected(values.Expected); err != nil {
+		return nil, fmt.Errorf("lifecycle observation Job expected binding: %w", err)
+	}
+	if values.PollInterval < time.Second || values.PollInterval > 5*time.Minute || values.PollTimeout < values.PollInterval || values.PollTimeout > 6*time.Hour || values.PollInterval%time.Second != 0 || values.PollTimeout%time.Second != 0 {
+		return nil, errors.New("lifecycle observation Job polling window is invalid")
+	}
+	ledgerPort, ledgerEndpoint, err := exactAPIEndpoint(values.LedgerAPIURL, values.LedgerAPICIDR)
+	if err != nil {
+		return nil, fmt.Errorf("lifecycle observation Job ledger endpoint: %w", err)
+	}
+	managementPort, managementEndpoint, err := exactAPIEndpoint(values.ManagementAPIURL, values.ManagementAPICIDR)
+	if err != nil {
+		return nil, fmt.Errorf("lifecycle observation Job management endpoint: %w", err)
+	}
+	if ledgerEndpoint != managementEndpoint || ledgerPort != managementPort {
+		return nil, errors.New("lifecycle observation ledger and management source must use the same verified management API")
+	}
+	replacements := map[string]string{
+		"${OK147_RUN_ID}": values.RunID, "${OK147_IMAGE_DIGEST}": values.ImageDigest,
+		"${OK147_CONTRACT_NAMESPACE}": values.Expected.ContractIdentity.Namespace, "${OK147_CONTRACT_NAME}": values.Expected.ContractIdentity.Name,
+		"${OK147_R}": values.Expected.IntentRevision, "${OK147_E}": values.Expected.EnablementRevision,
+		"${OK147_P}": values.Expected.PlatformRevision, "${OK147_FIXTURE}": values.Expected.ExecutionFixture,
+		"${OK147_INFRA_AUTHORITY}": values.Expected.InfrastructureAuthority, "${OK147_MGMT_AUTHORITY}": values.Expected.ManagementAuthority,
+		"${OK147_GITOPS_AUTHORITY}": values.Expected.GitOpsAuthority,
+		"${OK147_INPUT_CONFIGMAP}":  values.InputConfigMap, "${OK147_RECEIPT_PREFIX_DIGEST}": values.ReceiptPrefixDigest,
+		"${OK147_LEDGER_API_URL}": values.LedgerAPIURL, "${OK147_LEDGER_API_CIDR}": values.LedgerAPICIDR,
+		"${OK147_LEDGER_API_PORT}": ledgerPort, "${OK147_LEDGER_CREDENTIAL_SECRET}": values.LedgerCredentialSecret,
+		"${OK147_MANAGEMENT_API_URL}": values.ManagementAPIURL, "${OK147_MANAGEMENT_CREDENTIAL_SECRET}": values.ManagementCredentialSecret,
+		"${OK147_POLL_INTERVAL}": values.PollInterval.String(), "${OK147_POLL_TIMEOUT}": values.PollTimeout.String(),
+		"${OK147_ACTIVE_DEADLINE_SECONDS}": strconv.FormatInt(int64((values.PollTimeout+lifecycleObservationJobOverhead)/time.Second), 10),
+	}
+	result := string(template)
+	for placeholder, value := range replacements {
+		if !strings.Contains(result, placeholder) {
+			return nil, fmt.Errorf("lifecycle observation Job template lacks %s", placeholder)
+		}
+		result = strings.ReplaceAll(result, placeholder, value)
+	}
+	if strings.Contains(result, "${") {
+		return nil, errors.New("lifecycle observation Job template contains an unknown placeholder")
+	}
+	return []byte(result), nil
+}

--- a/internal/runner/lifecycle_observation_stage_job_test.go
+++ b/internal/runner/lifecycle_observation_stage_job_test.go
@@ -1,0 +1,98 @@
+package runner
+
+import (
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRenderLifecycleObservationStageJobTemplateBindsExactEnvelope(t *testing.T) {
+	values := validLifecycleObservationStageJobValues()
+	raw, err := RenderLifecycleObservationStageJobTemplate(lifecycleObservationJobTemplate(t), values)
+	if err != nil {
+		t.Fatal(err)
+	}
+	objects := decodeJobObjects(t, raw)
+	if len(objects) != 2 || objects["NetworkPolicy"] == nil || objects["Job"] == nil {
+		t.Fatalf("unexpected lifecycle observation object set: %#v", objects)
+	}
+	job := objects["Job"]
+	spec := objectAt(t, job, "spec")
+	if spec["backoffLimit"] != 0 || spec["activeDeadlineSeconds"] != 360 {
+		t.Fatalf("Job retry or deadline differs: %#v", spec)
+	}
+	podSpec := objectAt(t, objectAt(t, spec, "template"), "spec")
+	if podSpec["automountServiceAccountToken"] != false || podSpec["restartPolicy"] != "Never" {
+		t.Fatalf("unsafe Pod identity or restart policy: %#v", podSpec)
+	}
+	container := arrayAt(t, podSpec, "containers")[0].(map[string]any)
+	args := stringArray(t, container, "args")
+	if !reflect.DeepEqual(args[:5], []string{"cluster", "stage", "observe", "lifecycle", "--execute"}) {
+		t.Fatalf("unexpected lifecycle command: %v", args)
+	}
+	if argumentValue(args, "--receipt-prefix-digest") != values.ReceiptPrefixDigest || argumentValue(args, "--poll-interval") != "15s" || argumentValue(args, "--poll-timeout") != "5m0s" {
+		t.Fatalf("observation inputs differ: %v", args)
+	}
+	if argumentValue(args, "--management-api-endpoint") != values.ManagementAPIURL || argumentValue(args, "--ledger-api-endpoint") != values.LedgerAPIURL {
+		t.Fatalf("management endpoint binding differs: %v", args)
+	}
+	policy := objects["NetworkPolicy"]
+	egress := arrayAt(t, objectAt(t, policy, "spec"), "egress")
+	if len(egress) != 1 {
+		t.Fatalf("observation Job has unexpected egress: %#v", egress)
+	}
+	if strings.Contains(string(raw), "stage-grant") || strings.Contains(string(raw), "projection-manifest") || strings.Contains(string(raw), "authority-map") {
+		t.Fatal("read-only observation Job contains mutating-stage inputs")
+	}
+}
+
+func TestRenderLifecycleObservationStageJobTemplateFailsClosed(t *testing.T) {
+	valid := validLifecycleObservationStageJobValues()
+	for name, mutate := range map[string]func(*LifecycleObservationStageJobValues){
+		"mutable image": func(values *LifecycleObservationStageJobValues) {
+			values.ImageDigest = "ghcr.io/openkubes/ok-cluster:latest"
+		},
+		"shared credential": func(values *LifecycleObservationStageJobValues) {
+			values.ManagementCredentialSecret = values.LedgerCredentialSecret
+		},
+		"foreign management endpoint": func(values *LifecycleObservationStageJobValues) {
+			values.ManagementAPIURL, values.ManagementAPICIDR = "https://192.0.2.13:6443", "192.0.2.13/32"
+		},
+		"subsecond polling":       func(values *LifecycleObservationStageJobValues) { values.PollInterval = 500 * time.Millisecond },
+		"timeout before interval": func(values *LifecycleObservationStageJobValues) { values.PollTimeout = 10 * time.Second },
+		"fractional duration":     func(values *LifecycleObservationStageJobValues) { values.PollInterval = 1500 * time.Millisecond },
+	} {
+		t.Run(name, func(t *testing.T) {
+			candidate := valid
+			mutate(&candidate)
+			if _, err := RenderLifecycleObservationStageJobTemplate(lifecycleObservationJobTemplate(t), candidate); err == nil {
+				t.Fatal("unsafe lifecycle observation Job values were accepted")
+			}
+		})
+	}
+	template := append(lifecycleObservationJobTemplate(t), []byte("\n${UNKNOWN}")...)
+	if _, err := RenderLifecycleObservationStageJobTemplate(template, valid); err == nil {
+		t.Fatal("unknown observation Job placeholder was accepted")
+	}
+}
+
+func validLifecycleObservationStageJobValues() LifecycleObservationStageJobValues {
+	return LifecycleObservationStageJobValues{
+		RunID: "ok147-lifecycle-observation-01", ImageDigest: "ghcr.io/openkubes/ok-cluster@" + bundleSHA("a"),
+		Expected: validSubmissionStageJobValues().Expected, InputConfigMap: "ok147-lifecycle-observation-input", ReceiptPrefixDigest: bundleSHA("b"),
+		LedgerAPIURL: "https://192.0.2.12:6443", LedgerAPICIDR: "192.0.2.12/32", LedgerCredentialSecret: "ok147-ledger-observation",
+		ManagementAPIURL: "https://192.0.2.12:6443", ManagementAPICIDR: "192.0.2.12/32", ManagementCredentialSecret: "ok147-management-observer",
+		PollInterval: 15 * time.Second, PollTimeout: 5 * time.Minute,
+	}
+}
+
+func lifecycleObservationJobTemplate(t *testing.T) []byte {
+	t.Helper()
+	raw, err := os.ReadFile("../../deploy/contract-executor-lifecycle-observation-job.yaml.tpl")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return raw
+}

--- a/internal/runner/lifecycle_observation_stage_package.go
+++ b/internal/runner/lifecycle_observation_stage_package.go
@@ -1,0 +1,108 @@
+package runner
+
+import (
+	"errors"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+const LifecycleObservationStagePackageFormat = "ok147-lifecycle-observation-stage-package/v1"
+
+type LifecycleObservationStagePackageConfig struct {
+	Bundle                     StageResumeConfig
+	JobTemplate                []byte
+	JobTemplateDigest          string
+	RunID                      string
+	ImageDigest                string
+	InputConfigMap             string
+	LedgerAPIURL               string
+	LedgerAPICIDR              string
+	LedgerCredentialSecret     string
+	ManagementAPIURL           string
+	ManagementAPICIDR          string
+	ManagementCredentialSecret string
+	PollInterval               time.Duration
+	PollTimeout                time.Duration
+}
+
+type LifecycleObservationStagePackageReceipt struct {
+	Format               string   `json:"format"`
+	State                string   `json:"state"`
+	StageID              string   `json:"stageId"`
+	PackageDigest        string   `json:"packageDigest"`
+	InputConfigMapDigest string   `json:"inputConfigMapDigest"`
+	ReceiptPrefixDigest  string   `json:"receiptPrefixDigest"`
+	JobTemplateDigest    string   `json:"jobTemplateDigest"`
+	JobEnvelopeDigest    string   `json:"jobEnvelopeDigest"`
+	ObjectKinds          []string `json:"objectKinds"`
+	AuthorizationState   string   `json:"authorizationState"`
+	MutationAllowed      bool     `json:"mutationAllowed"`
+}
+
+type VerifiedLifecycleObservationStagePackage struct {
+	raw      []byte
+	receipt  LifecycleObservationStagePackageReceipt
+	verified bool
+}
+
+// BuildLifecycleObservationStagePackage composes one immutable public input
+// ConfigMap and one bounded NetworkPolicy/Job envelope entirely offline.
+func BuildLifecycleObservationStagePackage(config LifecycleObservationStagePackageConfig) (VerifiedLifecycleObservationStagePackage, error) {
+	if !stageReceiptPrefixDigestPattern.MatchString(config.JobTemplateDigest) || digest.SHA256(config.JobTemplate) != config.JobTemplateDigest {
+		return VerifiedLifecycleObservationStagePackage{}, errors.New("lifecycle observation Job template digest differs from expected identity")
+	}
+	if config.InputConfigMap == config.LedgerCredentialSecret || config.InputConfigMap == config.ManagementCredentialSecret {
+		return VerifiedLifecycleObservationStagePackage{}, errors.New("lifecycle observation input and credential object names must be distinct")
+	}
+	input, err := BuildLifecycleObservationStageInput(config.Bundle, config.InputConfigMap)
+	if err != nil {
+		return VerifiedLifecycleObservationStagePackage{}, err
+	}
+	inputRaw, err := input.Bytes()
+	if err != nil {
+		return VerifiedLifecycleObservationStagePackage{}, err
+	}
+	inputReceipt, err := input.Receipt()
+	if err != nil {
+		return VerifiedLifecycleObservationStagePackage{}, err
+	}
+	jobRaw, err := RenderLifecycleObservationStageJobTemplate(config.JobTemplate, LifecycleObservationStageJobValues{
+		RunID: config.RunID, ImageDigest: config.ImageDigest, Expected: config.Bundle.PlanExpected,
+		InputConfigMap: config.InputConfigMap, ReceiptPrefixDigest: inputReceipt.ReceiptPrefixDigest,
+		LedgerAPIURL: config.LedgerAPIURL, LedgerAPICIDR: config.LedgerAPICIDR, LedgerCredentialSecret: config.LedgerCredentialSecret,
+		ManagementAPIURL: config.ManagementAPIURL, ManagementAPICIDR: config.ManagementAPICIDR, ManagementCredentialSecret: config.ManagementCredentialSecret,
+		PollInterval: config.PollInterval, PollTimeout: config.PollTimeout,
+	})
+	if err != nil {
+		return VerifiedLifecycleObservationStagePackage{}, err
+	}
+	packageRaw := make([]byte, 0, len(inputRaw)+len(jobRaw)+6)
+	packageRaw = append(packageRaw, inputRaw...)
+	packageRaw = append(packageRaw, '\n', '-', '-', '-', '\n')
+	packageRaw = append(packageRaw, jobRaw...)
+	receipt := LifecycleObservationStagePackageReceipt{
+		Format: LifecycleObservationStagePackageFormat, State: "VERIFIED", StageID: "lifecycle-observation",
+		PackageDigest: digest.SHA256(packageRaw), InputConfigMapDigest: inputReceipt.ConfigMapDigest,
+		ReceiptPrefixDigest: inputReceipt.ReceiptPrefixDigest, JobTemplateDigest: config.JobTemplateDigest,
+		JobEnvelopeDigest: digest.SHA256(jobRaw), ObjectKinds: []string{"ConfigMap", "NetworkPolicy", "Job"},
+		AuthorizationState: "NOT_REQUIRED", MutationAllowed: false,
+	}
+	return VerifiedLifecycleObservationStagePackage{raw: packageRaw, receipt: receipt, verified: true}, nil
+}
+
+func (packaged VerifiedLifecycleObservationStagePackage) Bytes() ([]byte, error) {
+	if !packaged.verified || len(packaged.raw) == 0 {
+		return nil, errors.New("lifecycle observation package was not produced by verification")
+	}
+	return append([]byte(nil), packaged.raw...), nil
+}
+
+func (packaged VerifiedLifecycleObservationStagePackage) Receipt() (LifecycleObservationStagePackageReceipt, error) {
+	if !packaged.verified || packaged.receipt.State != "VERIFIED" {
+		return LifecycleObservationStagePackageReceipt{}, errors.New("lifecycle observation package was not produced by verification")
+	}
+	receipt := packaged.receipt
+	receipt.ObjectKinds = append([]string(nil), packaged.receipt.ObjectKinds...)
+	return receipt, nil
+}

--- a/internal/runner/lifecycle_observation_stage_package_test.go
+++ b/internal/runner/lifecycle_observation_stage_package_test.go
@@ -1,0 +1,133 @@
+package runner
+
+import (
+	"bytes"
+	"reflect"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+func TestBuildLifecycleObservationStagePackageBindsMinimalInputAndEnvelope(t *testing.T) {
+	config := lifecycleObservationStagePackageConfig(t)
+	packaged, err := BuildLifecycleObservationStagePackage(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := packaged.Bytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := packaged.Receipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	objects := decodeJobObjects(t, raw)
+	if len(objects) != 3 || objects["ConfigMap"] == nil || objects["NetworkPolicy"] == nil || objects["Job"] == nil {
+		t.Fatalf("unexpected lifecycle observation package: %#v", objects)
+	}
+	configMap := objects["ConfigMap"]
+	if configMap["immutable"] != true || objectAt(t, configMap, "metadata")["name"] != config.InputConfigMap {
+		t.Fatalf("unexpected observation input ConfigMap: %#v", configMap)
+	}
+	data := objectAt(t, configMap, "data")
+	wantKeys := []string{"lifecycle-receipt.json", "provider-receipt.json", "receipt-prefix.json", "staged-plan.json"}
+	gotKeys := make([]string, 0, len(data))
+	for key := range data {
+		gotKeys = append(gotKeys, key)
+	}
+	sort.Strings(gotKeys)
+	if !reflect.DeepEqual(gotKeys, wantKeys) || data["stage-grant.json"] != nil || data["projection-manifest.json"] != nil {
+		t.Fatalf("observation input is not minimal: keys=%v", gotKeys)
+	}
+	job := objects["Job"]
+	podSpec := objectAt(t, objectAt(t, objectAt(t, job, "spec"), "template"), "spec")
+	container := arrayAt(t, podSpec, "containers")[0].(map[string]any)
+	args := stringArray(t, container, "args")
+	if argumentValue(args, "--receipt-prefix-digest") != receipt.ReceiptPrefixDigest || argumentValue(args, "--poll-timeout") != "5m0s" {
+		t.Fatalf("Job does not bind package inputs: %v %#v", args, receipt)
+	}
+	if receipt.Format != LifecycleObservationStagePackageFormat || receipt.StageID != "lifecycle-observation" || receipt.PackageDigest != digest.SHA256(raw) || receipt.AuthorizationState != "NOT_REQUIRED" || receipt.MutationAllowed {
+		t.Fatalf("unexpected observation package receipt: %#v", receipt)
+	}
+	parts := bytes.SplitN(raw, []byte("\n---\n"), 2)
+	if len(parts) != 2 || receipt.InputConfigMapDigest != digest.SHA256(parts[0]) || receipt.JobEnvelopeDigest != digest.SHA256(parts[1]) {
+		t.Fatal("observation package component digests differ")
+	}
+	if !reflect.DeepEqual(receipt.ObjectKinds, []string{"ConfigMap", "NetworkPolicy", "Job"}) {
+		t.Fatalf("unexpected observation package kinds: %v", receipt.ObjectKinds)
+	}
+	input, err := BuildLifecycleObservationStageInput(config.Bundle, config.InputConfigMap)
+	if err != nil {
+		t.Fatal(err)
+	}
+	inputReceipt, _ := input.Receipt()
+	if inputReceipt.ConfigMapDigest != receipt.InputConfigMapDigest || inputReceipt.ReceiptPrefixDigest != receipt.ReceiptPrefixDigest || !reflect.DeepEqual(inputReceipt.DataKeys, wantKeys) {
+		t.Fatalf("input and package receipts differ: %#v %#v", inputReceipt, receipt)
+	}
+	raw[0] = 'x'
+	again, _ := packaged.Bytes()
+	if again[0] != '{' {
+		t.Fatal("caller mutated retained observation package")
+	}
+	receipt.ObjectKinds[0] = "Changed"
+	againReceipt, _ := packaged.Receipt()
+	if againReceipt.ObjectKinds[0] != "ConfigMap" {
+		t.Fatal("caller mutated retained observation package receipt")
+	}
+}
+
+func TestBuildLifecycleObservationStagePackageFailsClosed(t *testing.T) {
+	valid := lifecycleObservationStagePackageConfig(t)
+	for name, mutate := range map[string]func(*LifecycleObservationStagePackageConfig){
+		"changed template": func(config *LifecycleObservationStagePackageConfig) {
+			config.JobTemplate = append(config.JobTemplate, '\n')
+		},
+		"wrong template digest": func(config *LifecycleObservationStagePackageConfig) { config.JobTemplateDigest = bundleSHA("f") },
+		"input reuses ledger secret": func(config *LifecycleObservationStagePackageConfig) {
+			config.InputConfigMap = config.LedgerCredentialSecret
+		},
+		"shared credentials": func(config *LifecycleObservationStagePackageConfig) {
+			config.ManagementCredentialSecret = config.LedgerCredentialSecret
+		},
+		"mutable image": func(config *LifecycleObservationStagePackageConfig) {
+			config.ImageDigest = "ghcr.io/openkubes/ok-cluster:latest"
+		},
+		"foreign endpoint": func(config *LifecycleObservationStagePackageConfig) {
+			config.ManagementAPIURL, config.ManagementAPICIDR = "https://192.0.2.13:6443", "192.0.2.13/32"
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			config := valid
+			config.JobTemplate = append([]byte(nil), valid.JobTemplate...)
+			mutate(&config)
+			if _, err := BuildLifecycleObservationStagePackage(config); err == nil {
+				t.Fatal("unsafe lifecycle observation package was accepted")
+			}
+		})
+	}
+	if _, err := (VerifiedLifecycleObservationStagePackage{}).Bytes(); err == nil {
+		t.Fatal("unverified observation package bytes were exposed")
+	}
+	if _, err := (VerifiedLifecycleObservationStagePackage{}).Receipt(); err == nil {
+		t.Fatal("unverified observation package receipt was exposed")
+	}
+	if _, err := (VerifiedLifecycleObservationStageInput{}).Bytes(); err == nil {
+		t.Fatal("unverified observation input bytes were exposed")
+	}
+}
+
+func lifecycleObservationStagePackageConfig(t *testing.T) LifecycleObservationStagePackageConfig {
+	t.Helper()
+	values := validLifecycleObservationStageJobValues()
+	template := lifecycleObservationJobTemplate(t)
+	return LifecycleObservationStagePackageConfig{
+		Bundle: lifecycleObservationBundleConfig(t, true), JobTemplate: template, JobTemplateDigest: digest.SHA256(template),
+		RunID: values.RunID, ImageDigest: values.ImageDigest, InputConfigMap: values.InputConfigMap,
+		LedgerAPIURL: values.LedgerAPIURL, LedgerAPICIDR: values.LedgerAPICIDR, LedgerCredentialSecret: values.LedgerCredentialSecret,
+		ManagementAPIURL: values.ManagementAPIURL, ManagementAPICIDR: values.ManagementAPICIDR, ManagementCredentialSecret: values.ManagementCredentialSecret,
+		PollInterval: 15 * time.Second, PollTimeout: 5 * time.Minute,
+	}
+}


### PR DESCRIPTION
## What changed

- add an offline `ok cluster stage observe lifecycle package` command
- materialize an immutable input ConfigMap containing only plan plus provider/lifecycle receipts
- add a dedicated single-endpoint NetworkPolicy and non-retrying lifecycle-observation Job template
- bind exact image, template, R/E/P/Fixture, receipt-prefix, endpoint, credential-Secret and polling identities
- require distinct ledger-writer and read-only management-observer Secret names
- derive `activeDeadlineSeconds` from the bounded poll timeout plus fixed completion overhead

## Why

The typed lifecycle observation command needs the same reproducible local/Job boundary as the submission stages, without inheriting their grant, projection or write-authority inputs.

## Impact

Packaging writes only one new local `0600` file and reports `mutationAllowed: false`. It does not install the ConfigMap, NetworkPolicy, Job or credentials and performs no Kubernetes request.

## Validation

- full Go test suite
- `go vet ./...`
- race tests for CLI, runner, execution, ledger and observation
- Python contract suite (18 tests, 1 expected skip)
