### PR TITLE
OK-147: bind lifecycle observation credentials

### DIFF
--- a/internal/runner/lifecycle_observation_stage_credentials.go
+++ b/internal/runner/lifecycle_observation_stage_credentials.go
@@ -1,0 +1,150 @@
+package runner
+
+import (
+	"crypto/subtle"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+const LifecycleObservationStageCredentialPackageFormat = "ok147-lifecycle-observation-stage-credential-package/v1"
+
+type LifecycleObservationStageCredentialPackageConfig struct {
+	Package             VerifiedLifecycleObservationStagePackage
+	MaterializationTime time.Time
+	Ledger              SubmissionStageCredentialSource
+	ManagementObserver  SubmissionStageCredentialSource
+}
+
+type LifecycleObservationStageCredentialPackageReceipt struct {
+	Format                   string                                   `json:"format"`
+	State                    string                                   `json:"state"`
+	StageID                  string                                   `json:"stageId"`
+	ObservationPackageDigest string                                   `json:"observationPackageDigest"`
+	InstallationAuthority    string                                   `json:"installationAuthority"`
+	MaterializedAt           string                                   `json:"materializedAt"`
+	PackageDigest            string                                   `json:"packageDigest"`
+	Credentials              []SubmissionStageCredentialObjectReceipt `json:"credentials"`
+	MutationAllowed          bool                                     `json:"mutationAllowed"`
+}
+
+type lifecycleObservationStageCredentialPackageIdentity struct {
+	ObservationPackageDigest string                                   `json:"observationPackageDigest"`
+	InstallationAuthority    string                                   `json:"installationAuthority"`
+	MaterializedAt           string                                   `json:"materializedAt"`
+	Credentials              []SubmissionStageCredentialObjectReceipt `json:"credentials"`
+}
+
+// VerifiedLifecycleObservationStageCredentialPackage retains the two exact
+// immutable Secret objects privately for a later installer boundary. Its
+// public receipt contains neither token, CA, subject nor source path.
+type VerifiedLifecycleObservationStageCredentialPackage struct {
+	objects               []submissionStageCredentialObject
+	receipt               LifecycleObservationStageCredentialPackageReceipt
+	installationAuthority string
+	verified              bool
+}
+
+// BuildLifecycleObservationStageCredentialPackage verifies two independently
+// obtained short-lived TokenRequest results and creates the private ledger and
+// read-only management observer Secrets entirely offline.
+func BuildLifecycleObservationStageCredentialPackage(config LifecycleObservationStageCredentialPackageConfig) (VerifiedLifecycleObservationStageCredentialPackage, error) {
+	packageReceipt, err := config.Package.Receipt()
+	if err != nil || config.Package.managementAuthority == "" || config.Package.ledgerCredential == "" || config.Package.managementCredential == "" {
+		return VerifiedLifecycleObservationStageCredentialPackage{}, errors.New("verified lifecycle observation package is required")
+	}
+	if config.Package.ledgerCredential == config.Package.managementCredential {
+		return VerifiedLifecycleObservationStageCredentialPackage{}, errors.New("lifecycle observation credential names must be distinct")
+	}
+	if config.MaterializationTime.IsZero() || !config.MaterializationTime.Equal(config.MaterializationTime.Truncate(time.Second)) {
+		return VerifiedLifecycleObservationStageCredentialPackage{}, errors.New("lifecycle observation credential materialization time is required")
+	}
+	bindings := []struct {
+		role   string
+		name   string
+		source SubmissionStageCredentialSource
+	}{
+		{role: "ledger", name: config.Package.ledgerCredential, source: config.Ledger},
+		{role: "observer", name: config.Package.managementCredential, source: config.ManagementObserver},
+	}
+	objects := make([]submissionStageCredentialObject, 0, len(bindings))
+	receipts := make([]SubmissionStageCredentialObjectReceipt, 0, len(bindings))
+	tokens := make([][]byte, 0, len(bindings))
+	for _, binding := range bindings {
+		object, receipt, token, err := buildSubmissionStageCredentialObject(
+			packageReceipt.StageID, config.MaterializationTime.UTC(), binding.role, binding.name,
+			config.Package.managementAuthority, binding.source,
+		)
+		if err != nil {
+			return VerifiedLifecycleObservationStageCredentialPackage{}, err
+		}
+		objects = append(objects, object)
+		receipts = append(receipts, receipt)
+		tokens = append(tokens, token)
+	}
+	if len(tokens[0]) == len(tokens[1]) && subtle.ConstantTimeCompare(tokens[0], tokens[1]) == 1 {
+		return VerifiedLifecycleObservationStageCredentialPackage{}, errors.New("lifecycle observation ledger and observer credentials must be distinct")
+	}
+	materializedAt := config.MaterializationTime.UTC().Format(time.RFC3339)
+	identity, err := json.Marshal(lifecycleObservationStageCredentialPackageIdentity{
+		ObservationPackageDigest: packageReceipt.PackageDigest,
+		InstallationAuthority:    config.Package.managementAuthority,
+		MaterializedAt:           materializedAt, Credentials: receipts,
+	})
+	if err != nil {
+		return VerifiedLifecycleObservationStageCredentialPackage{}, errors.New("encode lifecycle observation credential package identity")
+	}
+	receipt := LifecycleObservationStageCredentialPackageReceipt{
+		Format: LifecycleObservationStageCredentialPackageFormat, State: "VERIFIED", StageID: packageReceipt.StageID,
+		ObservationPackageDigest: packageReceipt.PackageDigest, InstallationAuthority: config.Package.managementAuthority,
+		MaterializedAt: materializedAt, PackageDigest: digest.SHA256(identity), Credentials: receipts,
+		MutationAllowed: false,
+	}
+	return VerifiedLifecycleObservationStageCredentialPackage{
+		objects: cloneStageCredentialObjects(objects), receipt: receipt,
+		installationAuthority: config.Package.managementAuthority, verified: true,
+	}, nil
+}
+
+func (packaged VerifiedLifecycleObservationStageCredentialPackage) Receipt() (LifecycleObservationStageCredentialPackageReceipt, error) {
+	if err := verifyLifecycleObservationStageCredentialPackage(packaged); err != nil {
+		return LifecycleObservationStageCredentialPackageReceipt{}, errors.New("lifecycle observation credential package was not produced by verification")
+	}
+	receipt := packaged.receipt
+	receipt.Credentials = append([]SubmissionStageCredentialObjectReceipt(nil), packaged.receipt.Credentials...)
+	for index := range receipt.Credentials {
+		receipt.Credentials[index].Audiences = append([]string(nil), packaged.receipt.Credentials[index].Audiences...)
+	}
+	return receipt, nil
+}
+
+func verifyLifecycleObservationStageCredentialPackage(packaged VerifiedLifecycleObservationStageCredentialPackage) error {
+	if !packaged.verified || packaged.receipt.Format != LifecycleObservationStageCredentialPackageFormat || packaged.receipt.State != "VERIFIED" || packaged.receipt.StageID != "lifecycle-observation" || packaged.installationAuthority == "" || packaged.receipt.InstallationAuthority != packaged.installationAuthority || len(packaged.objects) != 2 || len(packaged.receipt.Credentials) != 2 {
+		return errors.New("lifecycle observation credential package identity is incomplete")
+	}
+	if !stageReceiptPrefixDigestPattern.MatchString(packaged.receipt.ObservationPackageDigest) {
+		return errors.New("lifecycle observation package digest is invalid")
+	}
+	identity, err := json.Marshal(lifecycleObservationStageCredentialPackageIdentity{
+		ObservationPackageDigest: packaged.receipt.ObservationPackageDigest,
+		InstallationAuthority:    packaged.receipt.InstallationAuthority,
+		MaterializedAt:           packaged.receipt.MaterializedAt,
+		Credentials:              packaged.receipt.Credentials,
+	})
+	if err != nil || digest.SHA256(identity) != packaged.receipt.PackageDigest {
+		return errors.New("lifecycle observation credential package identity changed after verification")
+	}
+	if _, err := time.Parse(time.RFC3339, packaged.receipt.MaterializedAt); err != nil {
+		return errors.New("lifecycle observation credential materialization time is invalid")
+	}
+	expectedRoles := []string{"ledger", "observer"}
+	for index, object := range packaged.objects {
+		receipt := packaged.receipt.Credentials[index]
+		if object.role != expectedRoles[index] || receipt.Role != expectedRoles[index] || object.role != receipt.Role || object.authority != packaged.installationAuthority || receipt.Authority != packaged.installationAuthority || object.name != receipt.Name || receipt.Namespace != submissionStageInputNamespace || digest.SHA256(object.raw) != receipt.ObjectDigest {
+			return errors.New("lifecycle observation credential object identity changed after verification")
+		}
+	}
+	return nil
+}

--- a/internal/runner/lifecycle_observation_stage_credentials_test.go
+++ b/internal/runner/lifecycle_observation_stage_credentials_test.go
@@ -1,0 +1,163 @@
+package runner
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+func TestBuildLifecycleObservationStageCredentialPackageBindsDistinctPrivateSecrets(t *testing.T) {
+	config, ledgerToken, observerToken := lifecycleObservationCredentialConfig(t)
+	packaged, err := BuildLifecycleObservationStageCredentialPackage(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := packaged.Receipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	observationReceipt, _ := config.Package.Receipt()
+	if receipt.Format != LifecycleObservationStageCredentialPackageFormat || receipt.State != "VERIFIED" || receipt.StageID != "lifecycle-observation" || receipt.ObservationPackageDigest != observationReceipt.PackageDigest || receipt.InstallationAuthority != "ok-mgmt" || receipt.MaterializedAt != config.MaterializationTime.Format(time.RFC3339) || !stageReceiptPrefixDigestPattern.MatchString(receipt.PackageDigest) || receipt.MutationAllowed || len(receipt.Credentials) != 2 {
+		t.Fatalf("unexpected lifecycle observation credential receipt: %#v", receipt)
+	}
+	want := []struct {
+		role  string
+		name  string
+		token []byte
+	}{
+		{role: "ledger", name: config.Package.ledgerCredential, token: ledgerToken},
+		{role: "observer", name: config.Package.managementCredential, token: observerToken},
+	}
+	for index, expected := range want {
+		object := packaged.objects[index]
+		objectReceipt := receipt.Credentials[index]
+		if object.role != expected.role || object.authority != "ok-mgmt" || object.name != expected.name || digest.SHA256(object.raw) != objectReceipt.ObjectDigest {
+			t.Fatalf("private observation credential %d differs: %#v %#v", index, object, objectReceipt)
+		}
+		var secret map[string]any
+		if err := json.Unmarshal(object.raw, &secret); err != nil {
+			t.Fatal(err)
+		}
+		metadata := secret["metadata"].(map[string]any)
+		labels := metadata["labels"].(map[string]any)
+		annotations := metadata["annotations"].(map[string]any)
+		data := secret["data"].(map[string]any)
+		decodedToken, err := base64.StdEncoding.DecodeString(data["token"].(string))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if secret["immutable"] != true || metadata["namespace"] != submissionStageInputNamespace || labels["openkubes.io/stage-id"] != "lifecycle-observation" || labels["openkubes.io/credential-role"] != expected.role || annotations["openkubes.io/authority-identity"] != "ok-mgmt" || !bytes.Equal(decodedToken, expected.token) {
+			t.Fatalf("observation credential Secret %d differs: %#v", index, secret)
+		}
+	}
+	public, err := json.Marshal(receipt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range []string{string(ledgerToken), string(observerToken), config.Ledger.TokenFile, config.Ledger.CAFile, config.Ledger.ExpectedSubject, config.ManagementObserver.ExpectedSubject} {
+		if bytes.Contains(public, []byte(forbidden)) {
+			t.Fatalf("observation credential receipt exposed private value %q", forbidden)
+		}
+	}
+	receipt.Credentials[0].Audiences[0] = "changed"
+	again, err := packaged.Receipt()
+	if err != nil || again.Credentials[0].Audiences[0] == "changed" {
+		t.Fatal("caller mutated retained observation credential receipt")
+	}
+}
+
+func TestBuildLifecycleObservationStageCredentialPackageFailsClosed(t *testing.T) {
+	for name, mutate := range map[string]func(*LifecycleObservationStageCredentialPackageConfig){
+		"foreign observer authority": func(config *LifecycleObservationStageCredentialPackageConfig) {
+			config.ManagementObserver.AuthorityIdentity = "ok-infra"
+		},
+		"shared token": func(config *LifecycleObservationStageCredentialPackageConfig) {
+			config.ManagementObserver.TokenFile = config.Ledger.TokenFile
+			config.ManagementObserver.TokenDigest = config.Ledger.TokenDigest
+			config.ManagementObserver.ExpectedIssuer = config.Ledger.ExpectedIssuer
+			config.ManagementObserver.ExpectedSubject = config.Ledger.ExpectedSubject
+			config.ManagementObserver.ExpectedAudiences = append([]string(nil), config.Ledger.ExpectedAudiences...)
+			config.ManagementObserver.IssuedAt = config.Ledger.IssuedAt
+			config.ManagementObserver.ExpiresAt = config.Ledger.ExpiresAt
+		},
+		"wrong token digest": func(config *LifecycleObservationStageCredentialPackageConfig) {
+			config.ManagementObserver.TokenDigest = prefixSHA("1")
+		},
+		"missing evidence": func(config *LifecycleObservationStageCredentialPackageConfig) {
+			config.Ledger.TokenRequestEvidenceDigest = ""
+		},
+		"unverified package": func(config *LifecycleObservationStageCredentialPackageConfig) {
+			config.Package = VerifiedLifecycleObservationStagePackage{}
+		},
+		"changed package identity": func(config *LifecycleObservationStageCredentialPackageConfig) {
+			config.Package.receipt.PackageDigest = prefixSHA("2")
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			config, _, _ := lifecycleObservationCredentialConfig(t)
+			mutate(&config)
+			_, err := BuildLifecycleObservationStageCredentialPackage(config)
+			if err == nil || strings.Contains(err.Error(), config.Ledger.TokenFile) || strings.Contains(err.Error(), config.ManagementObserver.TokenFile) {
+				t.Fatalf("unsafe observation credential package accepted: %v", err)
+			}
+		})
+	}
+	if _, err := (VerifiedLifecycleObservationStageCredentialPackage{}).Receipt(); err == nil {
+		t.Fatal("unverified lifecycle observation credential receipt was exposed")
+	}
+	config, _, _ := lifecycleObservationCredentialConfig(t)
+	packaged, err := BuildLifecycleObservationStageCredentialPackage(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	packaged.objects[1].raw = append(packaged.objects[1].raw, '\n')
+	if _, err := packaged.Receipt(); err == nil {
+		t.Fatal("changed private observation credential was accepted")
+	}
+}
+
+func lifecycleObservationCredentialConfig(t *testing.T) (LifecycleObservationStageCredentialPackageConfig, []byte, []byte) {
+	t.Helper()
+	now := time.Date(2026, 8, 16, 12, 0, 0, 0, time.UTC)
+	issuedAt, expiresAt := now.Add(-time.Minute), now.Add(30*time.Minute)
+	audiences := []string{"https://kubernetes.default.svc"}
+	issuer := "https://kubernetes.default.svc.cluster.local"
+	ledgerSubject := "system:serviceaccount:openkubes-execution-system:ok147-ledger-writer"
+	observerSubject := "system:serviceaccount:openkubes-execution-system:ok147-lifecycle-observer"
+	ledgerToken := stageCredentialJWT(t, issuer, ledgerSubject, audiences, issuedAt, expiresAt, 'c')
+	observerToken := stageCredentialJWT(t, issuer, observerSubject, audiences, issuedAt, expiresAt, 'd')
+	root := t.TempDir()
+	ca := testCA(t)
+	caPath := filepath.Join(root, "ca.crt")
+	ledgerPath := filepath.Join(root, "ledger-token")
+	observerPath := filepath.Join(root, "observer-token")
+	for path, raw := range map[string][]byte{caPath: ca, ledgerPath: ledgerToken, observerPath: observerToken} {
+		if err := os.WriteFile(path, raw, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	source := func(tokenPath, subject, evidence string, token []byte) SubmissionStageCredentialSource {
+		return SubmissionStageCredentialSource{
+			AuthorityIdentity: "ok-mgmt", TokenFile: tokenPath, TokenDigest: digest.SHA256(token),
+			CAFile: caPath, CABundleDigest: digest.SHA256(ca), TokenRequestEvidenceDigest: prefixSHA(evidence),
+			ExpectedIssuer: issuer, ExpectedSubject: subject, ExpectedAudiences: audiences,
+			IssuedAt: issuedAt, ExpiresAt: expiresAt,
+		}
+	}
+	observationPackage, err := BuildLifecycleObservationStagePackage(lifecycleObservationStagePackageConfig(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return LifecycleObservationStageCredentialPackageConfig{
+		Package: observationPackage, MaterializationTime: now,
+		Ledger:             source(ledgerPath, ledgerSubject, "a", ledgerToken),
+		ManagementObserver: source(observerPath, observerSubject, "b", observerToken),
+	}, ledgerToken, observerToken
+}

--- a/internal/runner/lifecycle_observation_stage_package.go
+++ b/internal/runner/lifecycle_observation_stage_package.go
@@ -41,9 +41,12 @@ type LifecycleObservationStagePackageReceipt struct {
 }
 
 type VerifiedLifecycleObservationStagePackage struct {
-	raw      []byte
-	receipt  LifecycleObservationStagePackageReceipt
-	verified bool
+	raw                  []byte
+	receipt              LifecycleObservationStagePackageReceipt
+	ledgerCredential     string
+	managementCredential string
+	managementAuthority  string
+	verified             bool
 }
 
 // BuildLifecycleObservationStagePackage composes one immutable public input
@@ -88,7 +91,11 @@ func BuildLifecycleObservationStagePackage(config LifecycleObservationStagePacka
 		JobEnvelopeDigest: digest.SHA256(jobRaw), ObjectKinds: []string{"ConfigMap", "NetworkPolicy", "Job"},
 		AuthorizationState: "NOT_REQUIRED", MutationAllowed: false,
 	}
-	return VerifiedLifecycleObservationStagePackage{raw: packageRaw, receipt: receipt, verified: true}, nil
+	return VerifiedLifecycleObservationStagePackage{
+		raw: packageRaw, receipt: receipt,
+		ledgerCredential: config.LedgerCredentialSecret, managementCredential: config.ManagementCredentialSecret,
+		managementAuthority: config.Bundle.PlanExpected.ManagementAuthority, verified: true,
+	}, nil
 }
 
 func (packaged VerifiedLifecycleObservationStagePackage) Bytes() ([]byte, error) {
@@ -99,7 +106,7 @@ func (packaged VerifiedLifecycleObservationStagePackage) Bytes() ([]byte, error)
 }
 
 func (packaged VerifiedLifecycleObservationStagePackage) Receipt() (LifecycleObservationStagePackageReceipt, error) {
-	if !packaged.verified || packaged.receipt.State != "VERIFIED" {
+	if !packaged.verified || packaged.receipt.State != "VERIFIED" || digest.SHA256(packaged.raw) != packaged.receipt.PackageDigest || packaged.managementAuthority == "" || packaged.ledgerCredential == "" || packaged.managementCredential == "" || packaged.ledgerCredential == packaged.managementCredential {
 		return LifecycleObservationStagePackageReceipt{}, errors.New("lifecycle observation package was not produced by verification")
 	}
 	receipt := packaged.receipt


### PR DESCRIPTION
## What changed

- add an offline lifecycle-observation credential package
- bind distinct short-lived ledger-writer and read-only management-observer credentials
- retain exact immutable Secret bytes privately while exposing only redaction-safe digests and metadata
- strengthen lifecycle-observation package identity checks before credential materialization

## Why

The lifecycle-observation Job needs two independent credentials without inheriting the mutation authority of submission stages. This checkpoint establishes that boundary before any installer or live launch path exists.

## Impact

- no cluster contact or infrastructure mutation
- no credential installation or Job launch
- no token, CA, subject, or local source path in public receipts
- unsafe, shared, foreign, stale, or tampered inputs fail closed

## Validation

- `go test -ldflags=-linkmode=external ./...`
- `go vet ./...`
- `go test -race -ldflags=-linkmode=external ./cmd/ok ./internal/runner ./internal/execution ./internal/ledger ./internal/observation`
- `python3 -m unittest discover -s tests -p '*_test.py'` (18 tests, 1 expected skip)
