### PR TITLE
OK-147: plan lifecycle observation installation

### DIFF
--- a/internal/runner/lifecycle_observation_stage_installation_plan.go
+++ b/internal/runner/lifecycle_observation_stage_installation_plan.go
@@ -1,0 +1,148 @@
+package runner
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"gopkg.in/yaml.v3"
+)
+
+const LifecycleObservationStageInstallationPlanFormat = "ok147-lifecycle-observation-stage-installation-plan/v1"
+
+// LifecycleObservationStageInstallationPlan is an offline exact-create
+// description. It grants no authority to perform any recorded request.
+type LifecycleObservationStageInstallationPlan struct {
+	Format                   string                      `json:"format"`
+	State                    string                      `json:"state"`
+	StageID                  string                      `json:"stageId"`
+	ObservationPackageDigest string                      `json:"observationPackageDigest"`
+	Authority                string                      `json:"authority"`
+	Creates                  []SubmissionStageCreatePlan `json:"creates"`
+	MutationAllowed          bool                        `json:"mutationAllowed"`
+}
+
+// PlanLifecycleObservationStageInstallation verifies the immutable input,
+// NetworkPolicy and Job identities and derives their exact create order. It
+// performs no API request and opens no credential.
+func PlanLifecycleObservationStageInstallation(packaged VerifiedLifecycleObservationStagePackage) (LifecycleObservationStageInstallationPlan, error) {
+	receipt, err := packaged.Receipt()
+	if err != nil {
+		return LifecycleObservationStageInstallationPlan{}, err
+	}
+	expectedKinds := []string{"ConfigMap", "NetworkPolicy", "Job"}
+	if !equalStringList(receipt.ObjectKinds, expectedKinds) {
+		return LifecycleObservationStageInstallationPlan{}, errors.New("lifecycle observation package object inventory is invalid")
+	}
+	documents := bytes.Split(packaged.raw, []byte("\n---\n"))
+	if len(documents) != len(expectedKinds) || digest.SHA256(documents[0]) != receipt.InputConfigMapDigest || digest.SHA256(bytes.Join(documents[1:], []byte("\n---\n"))) != receipt.JobEnvelopeDigest {
+		return LifecycleObservationStageInstallationPlan{}, errors.New("lifecycle observation package component identity differs")
+	}
+	decoder := yaml.NewDecoder(bytes.NewReader(packaged.raw))
+	objects := make([]map[string]any, 0, len(expectedKinds))
+	for {
+		var object map[string]any
+		err := decoder.Decode(&object)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil || len(object) == 0 {
+			return LifecycleObservationStageInstallationPlan{}, errors.New("decode lifecycle observation package")
+		}
+		objects = append(objects, object)
+	}
+	if len(objects) != len(expectedKinds) {
+		return LifecycleObservationStageInstallationPlan{}, errors.New("lifecycle observation package object count is invalid")
+	}
+
+	configMapName, runID := "", ""
+	creates := make([]SubmissionStageCreatePlan, 0, len(objects))
+	for index, object := range objects {
+		apiVersion, _ := object["apiVersion"].(string)
+		kind, _ := object["kind"].(string)
+		if kind != expectedKinds[index] {
+			return LifecycleObservationStageInstallationPlan{}, errors.New("lifecycle observation package create order is invalid")
+		}
+		metadata, ok := object["metadata"].(map[string]any)
+		if !ok {
+			return LifecycleObservationStageInstallationPlan{}, errors.New("lifecycle observation package object metadata is invalid")
+		}
+		name, _ := metadata["name"].(string)
+		namespace, _ := metadata["namespace"].(string)
+		if !submissionStageInputNamePattern.MatchString(name) || len(name) > 63 || namespace != submissionStageInputNamespace || metadata["generateName"] != nil {
+			return LifecycleObservationStageInstallationPlan{}, errors.New("lifecycle observation package object identity is invalid")
+		}
+		collectionPath, objectPath, err := submissionStageCreatePaths(apiVersion, kind, namespace, name)
+		if err != nil {
+			return LifecycleObservationStageInstallationPlan{}, err
+		}
+		canonical, err := json.Marshal(object)
+		if err != nil {
+			return LifecycleObservationStageInstallationPlan{}, errors.New("encode lifecycle observation package object")
+		}
+		creates = append(creates, SubmissionStageCreatePlan{
+			Order: index + 1, APIVersion: apiVersion, Kind: kind, Namespace: namespace, Name: name,
+			PreflightMethod: "GET", ObjectPath: objectPath, CreateMethod: "POST", CollectionPath: collectionPath,
+			ObjectDigest: digest.SHA256(canonical),
+		})
+		switch kind {
+		case "ConfigMap":
+			labels, _ := metadata["labels"].(map[string]any)
+			if object["immutable"] != true || labels["openkubes.io/stage-id"] != receipt.StageID {
+				return LifecycleObservationStageInstallationPlan{}, errors.New("lifecycle observation input ConfigMap semantics differ")
+			}
+			configMapName = name
+		case "NetworkPolicy":
+			runID = name
+			spec, _ := object["spec"].(map[string]any)
+			selector, _ := spec["podSelector"].(map[string]any)
+			matchLabels, _ := selector["matchLabels"].(map[string]any)
+			if matchLabels["openkubes.io/execution-id"] != runID {
+				return LifecycleObservationStageInstallationPlan{}, errors.New("lifecycle observation NetworkPolicy selector differs from run identity")
+			}
+		case "Job":
+			if name != runID {
+				return LifecycleObservationStageInstallationPlan{}, errors.New("lifecycle observation Job and NetworkPolicy identities differ")
+			}
+			spec, _ := object["spec"].(map[string]any)
+			template, _ := spec["template"].(map[string]any)
+			podSpec, _ := template["spec"].(map[string]any)
+			if podSpec["serviceAccountName"] != "ok147-contract-executor-runtime" || podSpec["automountServiceAccountToken"] != false {
+				return LifecycleObservationStageInstallationPlan{}, errors.New("lifecycle observation Job runtime identity is invalid")
+			}
+			if !jobMountsInputConfigMap(podSpec, configMapName) || !jobUsesManagementAuthority(podSpec, packaged.managementAuthority) || !jobUsesLifecycleObservationCredentialSecrets(podSpec, packaged.ledgerCredential, packaged.managementCredential) {
+				return LifecycleObservationStageInstallationPlan{}, errors.New("lifecycle observation Job binding differs from verified package")
+			}
+		}
+	}
+	return LifecycleObservationStageInstallationPlan{
+		Format: LifecycleObservationStageInstallationPlanFormat, State: "VERIFIED", StageID: receipt.StageID,
+		ObservationPackageDigest: receipt.PackageDigest, Authority: packaged.managementAuthority,
+		Creates: creates, MutationAllowed: false,
+	}, nil
+}
+
+func jobUsesLifecycleObservationCredentialSecrets(podSpec map[string]any, ledger, management string) bool {
+	volumes, ok := podSpec["volumes"].([]any)
+	if !ok {
+		return false
+	}
+	found := map[string]string{}
+	for _, item := range volumes {
+		volume, _ := item.(map[string]any)
+		name, _ := volume["name"].(string)
+		if name != "ledger-credential" && name != "management-credential" {
+			continue
+		}
+		secret, _ := volume["secret"].(map[string]any)
+		secretName, _ := secret["secretName"].(string)
+		items, _ := secret["items"].([]any)
+		if len(items) != 2 || !credentialSecretItems(items) {
+			return false
+		}
+		found[name] = secretName
+	}
+	return len(found) == 2 && found["ledger-credential"] == ledger && found["management-credential"] == management
+}

--- a/internal/runner/lifecycle_observation_stage_installation_plan_test.go
+++ b/internal/runner/lifecycle_observation_stage_installation_plan_test.go
@@ -1,0 +1,86 @@
+package runner
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+func TestPlanLifecycleObservationStageInstallationProducesExactSafeOrder(t *testing.T) {
+	packaged, err := BuildLifecycleObservationStagePackage(lifecycleObservationStagePackageConfig(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan, err := PlanLifecycleObservationStageInstallation(packaged)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, _ := packaged.Receipt()
+	if plan.Format != LifecycleObservationStageInstallationPlanFormat || plan.State != "VERIFIED" || plan.StageID != "lifecycle-observation" || plan.ObservationPackageDigest != receipt.PackageDigest || plan.Authority != "ok-mgmt" || plan.MutationAllowed {
+		t.Fatalf("unexpected lifecycle observation installation plan: %#v", plan)
+	}
+	wantKinds := []string{"ConfigMap", "NetworkPolicy", "Job"}
+	wantCollections := []string{
+		"/api/v1/namespaces/openkubes-execution-system/configmaps",
+		"/apis/networking.k8s.io/v1/namespaces/openkubes-execution-system/networkpolicies",
+		"/apis/batch/v1/namespaces/openkubes-execution-system/jobs",
+	}
+	if len(plan.Creates) != len(wantKinds) {
+		t.Fatalf("creates=%d, want 3", len(plan.Creates))
+	}
+	for index, create := range plan.Creates {
+		if create.Order != index+1 || create.Kind != wantKinds[index] || create.Namespace != submissionStageInputNamespace || create.PreflightMethod != "GET" || create.CreateMethod != "POST" || create.CollectionPath != wantCollections[index] || create.ObjectPath != create.CollectionPath+"/"+create.Name || !stageReceiptPrefixDigestPattern.MatchString(create.ObjectDigest) {
+			t.Fatalf("unexpected lifecycle observation create %d: %#v", index, create)
+		}
+		if strings.Contains(strings.ToLower(create.ObjectPath), "secret") {
+			t.Fatalf("installation plan unexpectedly contains credential path: %#v", create)
+		}
+	}
+	if plan.Creates[1].Name != plan.Creates[2].Name {
+		t.Fatal("NetworkPolicy and Job run identities differ")
+	}
+}
+
+func TestPlanLifecycleObservationStageInstallationFailsClosed(t *testing.T) {
+	valid, err := BuildLifecycleObservationStagePackage(lifecycleObservationStagePackageConfig(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := PlanLifecycleObservationStageInstallation(VerifiedLifecycleObservationStagePackage{}); err == nil {
+		t.Fatal("unverified lifecycle observation package was planned")
+	}
+
+	tests := map[string]func(*VerifiedLifecycleObservationStagePackage){
+		"wrong inventory": func(packaged *VerifiedLifecycleObservationStagePackage) {
+			packaged.receipt.ObjectKinds = []string{"ConfigMap", "Job", "NetworkPolicy"}
+		},
+		"foreign authority": func(packaged *VerifiedLifecycleObservationStagePackage) {
+			packaged.managementAuthority = "ok-infra"
+		},
+		"changed runtime": func(packaged *VerifiedLifecycleObservationStagePackage) {
+			packaged.raw = bytes.Replace(packaged.raw, []byte("ok147-contract-executor-runtime"), []byte("ok147-foreign-runtime"), 1)
+			packaged.receipt.PackageDigest = digest.SHA256(packaged.raw)
+		},
+		"changed credential": func(packaged *VerifiedLifecycleObservationStagePackage) {
+			packaged.raw = bytes.Replace(packaged.raw, []byte(packaged.managementCredential), []byte("ok147-foreign-observer"), 1)
+			packaged.receipt.PackageDigest = digest.SHA256(packaged.raw)
+		},
+		"extra object": func(packaged *VerifiedLifecycleObservationStagePackage) {
+			packaged.raw = append(packaged.raw, []byte("\n---\napiVersion: v1\nkind: Secret\nmetadata: {name: forbidden}\n")...)
+			packaged.receipt.PackageDigest = digest.SHA256(packaged.raw)
+		},
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			packaged := valid
+			packaged.raw = append([]byte(nil), valid.raw...)
+			packaged.receipt.ObjectKinds = append([]string(nil), valid.receipt.ObjectKinds...)
+			mutate(&packaged)
+			if _, err := PlanLifecycleObservationStageInstallation(packaged); err == nil {
+				t.Fatal("changed lifecycle observation package was planned")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What changed

- add a non-mutating lifecycle-observation installation plan
- verify the exact ConfigMap, NetworkPolicy and Job inventory and create order
- bind the Job to the verified management authority, runtime ServiceAccount, input ConfigMap and distinct credential Secret names
- reject changed, reordered or additional objects fail closed

## Why

The observation stage needs an independently reviewable object plan before credentials, runtime prerequisites and live create behavior are combined into a launch boundary.

## Impact

- no Kubernetes client or API request
- no credential read or installation
- no Job launch or infrastructure mutation
- the plan explicitly reports `MutationAllowed: false`

## Validation

- `go test -ldflags=-linkmode=external ./...`
- `go vet ./...`
- `go test -race -ldflags=-linkmode=external ./cmd/ok ./internal/runner ./internal/execution ./internal/ledger ./internal/observation`
- `python3 -m unittest discover -s tests -p '*_test.py'` (18 tests, 1 expected skip)
