### PR TITLE
OK-147: bind lifecycle observation launch plan

### DIFF
--- a/internal/runner/lifecycle_observation_stage_launch_plan.go
+++ b/internal/runner/lifecycle_observation_stage_launch_plan.go
@@ -1,0 +1,84 @@
+package runner
+
+import "errors"
+
+const LifecycleObservationStageLaunchPlanFormat = "ok147-lifecycle-observation-stage-launch-plan/v1"
+
+// LifecycleObservationStageLaunchPlan correlates every exact object needed to
+// start one observation Job. It contains no object body or credential content
+// and authorizes no mutation.
+type LifecycleObservationStageLaunchPlan struct {
+	Format                   string                           `json:"format"`
+	State                    string                           `json:"state"`
+	StageID                  string                           `json:"stageId"`
+	Authority                string                           `json:"authority"`
+	ObservationPackageDigest string                           `json:"observationPackageDigest"`
+	CredentialPackageDigest  string                           `json:"credentialPackageDigest"`
+	RuntimeManifestDigest    string                           `json:"runtimeManifestDigest"`
+	PreflightBarrier         string                           `json:"preflightBarrier"`
+	Preflights               []SubmissionStageLaunchPreflight `json:"preflights"`
+	Creates                  []SubmissionStageLaunchCreate    `json:"creates"`
+	MutationAllowed          bool                             `json:"mutationAllowed"`
+}
+
+// PlanLifecycleObservationStageLaunch requires one coherent observation
+// package, credential package and stage-specific runtime prerequisite. Every
+// preflight must pass before any create may be attempted.
+func PlanLifecycleObservationStageLaunch(packaged VerifiedLifecycleObservationStagePackage, credentials VerifiedLifecycleObservationStageCredentialPackage, runtime VerifiedLifecycleObservationStageRuntimePrerequisite) (LifecycleObservationStageLaunchPlan, error) {
+	stage, err := PlanLifecycleObservationStageInstallation(packaged)
+	if err != nil {
+		return LifecycleObservationStageLaunchPlan{}, err
+	}
+	if err := verifyLifecycleObservationStageCredentialPackage(credentials); err != nil {
+		return LifecycleObservationStageLaunchPlan{}, err
+	}
+	if err := verifyLifecycleObservationStageRuntimePrerequisite(runtime); err != nil {
+		return LifecycleObservationStageLaunchPlan{}, err
+	}
+	if stage.ObservationPackageDigest != credentials.receipt.ObservationPackageDigest || stage.ObservationPackageDigest != runtime.receipt.ObservationPackageDigest || stage.StageID != credentials.receipt.StageID || stage.Authority != credentials.installationAuthority || stage.Authority != runtime.receipt.Authority {
+		return LifecycleObservationStageLaunchPlan{}, errors.New("lifecycle observation launch components do not share one verified identity")
+	}
+
+	preflights := make([]SubmissionStageLaunchPreflight, 0, 6)
+	creates := make([]SubmissionStageLaunchCreate, 0, 6)
+	appendObject := func(order int, phase, apiVersion, kind, namespace, name, objectPath, collectionPath, objectDigest, existingPolicy, createPolicy string) {
+		preflights = append(preflights, SubmissionStageLaunchPreflight{
+			Order: order, Phase: phase, APIVersion: apiVersion, Kind: kind, Namespace: namespace, Name: name,
+			Method: "GET", ObjectPath: objectPath, ResponseMode: "FULL_OBJECT", ExistingPolicy: existingPolicy,
+			ObjectDigest: objectDigest,
+		})
+		creates = append(creates, SubmissionStageLaunchCreate{
+			Order: order, Phase: phase, APIVersion: apiVersion, Kind: kind, Namespace: namespace, Name: name,
+			Method: "POST", CollectionPath: collectionPath, CreatePolicy: createPolicy, ObjectDigest: objectDigest,
+		})
+	}
+	runtimeCollection := "/api/v1/namespaces/" + runtime.receipt.Namespace + "/serviceaccounts"
+	appendObject(1, "runtime", "v1", "ServiceAccount", runtime.receipt.Namespace, runtime.receipt.Name,
+		runtimeCollection+"/"+runtime.receipt.Name, runtimeCollection, runtime.receipt.ObjectDigest,
+		"VERIFY_EXACT", "CREATE_IF_ABSENT_OR_VERIFY_EXISTING")
+
+	// The Job is held until the input, policy and both credentials are planned.
+	for index, object := range stage.Creates[:2] {
+		appendObject(index+2, "stage-prerequisites", object.APIVersion, object.Kind, object.Namespace, object.Name,
+			object.ObjectPath, object.CollectionPath, object.ObjectDigest,
+			"VERIFY_EXACT_GLOBAL_STATE", "CREATE_ONLY_AFTER_GLOBAL_ABSENCE")
+	}
+	for index, object := range credentials.objects {
+		collection := "/api/v1/namespaces/" + submissionStageInputNamespace + "/secrets"
+		appendObject(index+4, "credentials", "v1", "Secret", submissionStageInputNamespace, object.name,
+			collection+"/"+object.name, collection, credentials.receipt.Credentials[index].ObjectDigest,
+			"VERIFY_EXACT_GLOBAL_STATE", "CREATE_ONLY_AFTER_GLOBAL_ABSENCE")
+	}
+	job := stage.Creates[2]
+	appendObject(6, "job", job.APIVersion, job.Kind, job.Namespace, job.Name,
+		job.ObjectPath, job.CollectionPath, job.ObjectDigest,
+		"VERIFY_EXACT_GLOBAL_STATE", "CREATE_ONLY_AFTER_GLOBAL_ABSENCE")
+
+	return LifecycleObservationStageLaunchPlan{
+		Format: LifecycleObservationStageLaunchPlanFormat, State: "VERIFIED", StageID: stage.StageID,
+		Authority: stage.Authority, ObservationPackageDigest: stage.ObservationPackageDigest,
+		CredentialPackageDigest: credentials.receipt.PackageDigest, RuntimeManifestDigest: runtime.receipt.ManifestDigest,
+		PreflightBarrier: "ALL_ABSENT_OR_RUNTIME_ONLY_OR_ALL_EXACT", Preflights: preflights, Creates: creates,
+		MutationAllowed: false,
+	}, nil
+}

--- a/internal/runner/lifecycle_observation_stage_launch_plan_test.go
+++ b/internal/runner/lifecycle_observation_stage_launch_plan_test.go
@@ -1,0 +1,99 @@
+package runner
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+func TestPlanLifecycleObservationStageLaunchBindsSixObjectsBehindOneBarrier(t *testing.T) {
+	stage, credentials, runtime, ledgerToken, observerToken := lifecycleObservationStageLaunchFixture(t)
+	plan, err := PlanLifecycleObservationStageLaunch(stage, credentials, runtime)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stageReceipt, _ := stage.Receipt()
+	credentialReceipt, _ := credentials.Receipt()
+	runtimeReceipt, _ := runtime.Receipt()
+	if plan.Format != LifecycleObservationStageLaunchPlanFormat || plan.State != "VERIFIED" || plan.StageID != "lifecycle-observation" || plan.Authority != "ok-mgmt" || plan.ObservationPackageDigest != stageReceipt.PackageDigest || plan.CredentialPackageDigest != credentialReceipt.PackageDigest || plan.RuntimeManifestDigest != runtimeReceipt.ManifestDigest || plan.PreflightBarrier != "ALL_ABSENT_OR_RUNTIME_ONLY_OR_ALL_EXACT" || plan.MutationAllowed {
+		t.Fatalf("unexpected lifecycle observation launch identity: %#v", plan)
+	}
+	wantKinds := []string{"ServiceAccount", "ConfigMap", "NetworkPolicy", "Secret", "Secret", "Job"}
+	wantPhases := []string{"runtime", "stage-prerequisites", "stage-prerequisites", "credentials", "credentials", "job"}
+	if len(plan.Preflights) != len(wantKinds) || len(plan.Creates) != len(wantKinds) {
+		t.Fatalf("unexpected launch object count: %d %d", len(plan.Preflights), len(plan.Creates))
+	}
+	for index := range wantKinds {
+		preflight, create := plan.Preflights[index], plan.Creates[index]
+		if preflight.Order != index+1 || create.Order != index+1 || preflight.Phase != wantPhases[index] || create.Phase != wantPhases[index] || preflight.Kind != wantKinds[index] || create.Kind != wantKinds[index] || preflight.Name != create.Name || preflight.Namespace != create.Namespace || preflight.ObjectDigest != create.ObjectDigest || preflight.Method != "GET" || create.Method != "POST" || preflight.ResponseMode != "FULL_OBJECT" {
+			t.Fatalf("lifecycle observation launch step %d differs: %#v %#v", index+1, preflight, create)
+		}
+		if index == 0 {
+			if preflight.ExistingPolicy != "VERIFY_EXACT" || create.CreatePolicy != "CREATE_IF_ABSENT_OR_VERIFY_EXISTING" {
+				t.Fatalf("runtime policy differs: %#v %#v", preflight, create)
+			}
+		} else if preflight.ExistingPolicy != "VERIFY_EXACT_GLOBAL_STATE" || create.CreatePolicy != "CREATE_ONLY_AFTER_GLOBAL_ABSENCE" {
+			t.Fatalf("global policy differs at %d: %#v %#v", index+1, preflight, create)
+		}
+	}
+	public, err := json.Marshal(plan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range [][]byte{ledgerToken, observerToken, credentials.objects[0].raw, credentials.objects[1].raw, runtime.raw, stage.raw} {
+		if bytes.Contains(public, forbidden) {
+			t.Fatal("lifecycle observation launch plan exposed private object content")
+		}
+	}
+}
+
+func TestPlanLifecycleObservationStageLaunchRejectsMismatchedComponents(t *testing.T) {
+	stage, credentials, runtime, _, _ := lifecycleObservationStageLaunchFixture(t)
+	tests := map[string]func() (VerifiedLifecycleObservationStagePackage, VerifiedLifecycleObservationStageCredentialPackage, VerifiedLifecycleObservationStageRuntimePrerequisite){
+		"empty stage": func() (VerifiedLifecycleObservationStagePackage, VerifiedLifecycleObservationStageCredentialPackage, VerifiedLifecycleObservationStageRuntimePrerequisite) {
+			return VerifiedLifecycleObservationStagePackage{}, credentials, runtime
+		},
+		"empty credentials": func() (VerifiedLifecycleObservationStagePackage, VerifiedLifecycleObservationStageCredentialPackage, VerifiedLifecycleObservationStageRuntimePrerequisite) {
+			return stage, VerifiedLifecycleObservationStageCredentialPackage{}, runtime
+		},
+		"empty runtime": func() (VerifiedLifecycleObservationStagePackage, VerifiedLifecycleObservationStageCredentialPackage, VerifiedLifecycleObservationStageRuntimePrerequisite) {
+			return stage, credentials, VerifiedLifecycleObservationStageRuntimePrerequisite{}
+		},
+		"foreign credential package": func() (VerifiedLifecycleObservationStagePackage, VerifiedLifecycleObservationStageCredentialPackage, VerifiedLifecycleObservationStageRuntimePrerequisite) {
+			changed := credentials
+			changed.receipt.ObservationPackageDigest = digest.SHA256([]byte("foreign"))
+			return stage, changed, runtime
+		},
+		"foreign runtime package": func() (VerifiedLifecycleObservationStagePackage, VerifiedLifecycleObservationStageCredentialPackage, VerifiedLifecycleObservationStageRuntimePrerequisite) {
+			changed := runtime
+			changed.receipt.ObservationPackageDigest = digest.SHA256([]byte("foreign"))
+			return stage, credentials, changed
+		},
+	}
+	for name, values := range tests {
+		t.Run(name, func(t *testing.T) {
+			candidateStage, candidateCredentials, candidateRuntime := values()
+			if _, err := PlanLifecycleObservationStageLaunch(candidateStage, candidateCredentials, candidateRuntime); err == nil {
+				t.Fatal("mismatched lifecycle observation launch components accepted")
+			}
+		})
+	}
+}
+
+func lifecycleObservationStageLaunchFixture(t *testing.T) (VerifiedLifecycleObservationStagePackage, VerifiedLifecycleObservationStageCredentialPackage, VerifiedLifecycleObservationStageRuntimePrerequisite, []byte, []byte) {
+	t.Helper()
+	credentialConfig, ledgerToken, observerToken := lifecycleObservationCredentialConfig(t)
+	stage := credentialConfig.Package
+	credentials, err := BuildLifecycleObservationStageCredentialPackage(credentialConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest := submissionStageRuntimeManifest(t)
+	runtime, err := BuildLifecycleObservationStageRuntimePrerequisite(stage, manifest, digest.SHA256(manifest))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return stage, credentials, runtime, ledgerToken, observerToken
+}

--- a/internal/runner/lifecycle_observation_stage_runtime.go
+++ b/internal/runner/lifecycle_observation_stage_runtime.go
@@ -1,0 +1,62 @@
+package runner
+
+import (
+	"errors"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+const LifecycleObservationStageRuntimePrerequisiteFormat = "ok147-lifecycle-observation-stage-runtime-prerequisite/v1"
+
+type LifecycleObservationStageRuntimePrerequisiteReceipt struct {
+	Format                   string `json:"format"`
+	State                    string `json:"state"`
+	ObservationPackageDigest string `json:"observationPackageDigest"`
+	ManifestDigest           string `json:"manifestDigest"`
+	ObjectDigest             string `json:"objectDigest"`
+	Authority                string `json:"authority"`
+	Namespace                string `json:"namespace"`
+	Name                     string `json:"name"`
+	MutationAllowed          bool   `json:"mutationAllowed"`
+}
+
+type VerifiedLifecycleObservationStageRuntimePrerequisite struct {
+	raw      []byte
+	receipt  LifecycleObservationStageRuntimePrerequisiteReceipt
+	verified bool
+}
+
+// BuildLifecycleObservationStageRuntimePrerequisite binds the shared,
+// tokenless runtime ServiceAccount to this exact observation package. It
+// neither reads a credential nor contacts Kubernetes.
+func BuildLifecycleObservationStageRuntimePrerequisite(packaged VerifiedLifecycleObservationStagePackage, manifest []byte, expectedDigest string) (VerifiedLifecycleObservationStageRuntimePrerequisite, error) {
+	plan, err := PlanLifecycleObservationStageInstallation(packaged)
+	if err != nil {
+		return VerifiedLifecycleObservationStageRuntimePrerequisite{}, err
+	}
+	raw, objectDigest, err := buildStageRuntimePrerequisiteObject(manifest, expectedDigest)
+	if err != nil {
+		return VerifiedLifecycleObservationStageRuntimePrerequisite{}, err
+	}
+	receipt := LifecycleObservationStageRuntimePrerequisiteReceipt{
+		Format: LifecycleObservationStageRuntimePrerequisiteFormat, State: "VERIFIED",
+		ObservationPackageDigest: plan.ObservationPackageDigest, ManifestDigest: expectedDigest,
+		ObjectDigest: objectDigest, Authority: plan.Authority,
+		Namespace: submissionStageInputNamespace, Name: "ok147-contract-executor-runtime", MutationAllowed: false,
+	}
+	return VerifiedLifecycleObservationStageRuntimePrerequisite{raw: raw, receipt: receipt, verified: true}, nil
+}
+
+func (runtime VerifiedLifecycleObservationStageRuntimePrerequisite) Receipt() (LifecycleObservationStageRuntimePrerequisiteReceipt, error) {
+	if err := verifyLifecycleObservationStageRuntimePrerequisite(runtime); err != nil {
+		return LifecycleObservationStageRuntimePrerequisiteReceipt{}, err
+	}
+	return runtime.receipt, nil
+}
+
+func verifyLifecycleObservationStageRuntimePrerequisite(runtime VerifiedLifecycleObservationStageRuntimePrerequisite) error {
+	if !runtime.verified || runtime.receipt.Format != LifecycleObservationStageRuntimePrerequisiteFormat || runtime.receipt.State != "VERIFIED" || runtime.receipt.Authority == "" || runtime.receipt.Namespace != submissionStageInputNamespace || runtime.receipt.Name != "ok147-contract-executor-runtime" || runtime.receipt.MutationAllowed || !stageReceiptPrefixDigestPattern.MatchString(runtime.receipt.ObservationPackageDigest) || !stageReceiptPrefixDigestPattern.MatchString(runtime.receipt.ManifestDigest) || digest.SHA256(runtime.raw) != runtime.receipt.ObjectDigest {
+		return errors.New("lifecycle observation runtime prerequisite was not produced by verification")
+	}
+	return nil
+}

--- a/internal/runner/lifecycle_observation_stage_runtime_test.go
+++ b/internal/runner/lifecycle_observation_stage_runtime_test.go
@@ -1,0 +1,49 @@
+package runner
+
+import (
+	"testing"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+func TestBuildLifecycleObservationStageRuntimePrerequisiteBindsExactPackage(t *testing.T) {
+	packaged, err := BuildLifecycleObservationStagePackage(lifecycleObservationStagePackageConfig(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest := submissionStageRuntimeManifest(t)
+	runtime, err := BuildLifecycleObservationStageRuntimePrerequisite(packaged, manifest, digest.SHA256(manifest))
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := runtime.Receipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	packageReceipt, _ := packaged.Receipt()
+	if receipt.Format != LifecycleObservationStageRuntimePrerequisiteFormat || receipt.State != "VERIFIED" || receipt.ObservationPackageDigest != packageReceipt.PackageDigest || receipt.Authority != "ok-mgmt" || receipt.Namespace != submissionStageInputNamespace || receipt.Name != "ok147-contract-executor-runtime" || receipt.ManifestDigest != digest.SHA256(manifest) || receipt.ObjectDigest != digest.SHA256(runtime.raw) || receipt.MutationAllowed {
+		t.Fatalf("unexpected lifecycle observation runtime receipt: %#v", receipt)
+	}
+}
+
+func TestBuildLifecycleObservationStageRuntimePrerequisiteFailsClosed(t *testing.T) {
+	packaged, err := BuildLifecycleObservationStagePackage(lifecycleObservationStagePackageConfig(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest := submissionStageRuntimeManifest(t)
+	if _, err := BuildLifecycleObservationStageRuntimePrerequisite(VerifiedLifecycleObservationStagePackage{}, manifest, digest.SHA256(manifest)); err == nil {
+		t.Fatal("unverified observation package accepted")
+	}
+	if _, err := BuildLifecycleObservationStageRuntimePrerequisite(packaged, append(manifest, '\n'), digest.SHA256(manifest)); err == nil {
+		t.Fatal("changed runtime manifest accepted")
+	}
+	runtime, err := BuildLifecycleObservationStageRuntimePrerequisite(packaged, manifest, digest.SHA256(manifest))
+	if err != nil {
+		t.Fatal(err)
+	}
+	runtime.raw[0] = 'x'
+	if _, err := runtime.Receipt(); err == nil {
+		t.Fatal("changed runtime object accepted")
+	}
+}

--- a/internal/runner/submission_stage_runtime.go
+++ b/internal/runner/submission_stage_runtime.go
@@ -38,36 +38,44 @@ func BuildSubmissionStageRuntimePrerequisite(packaged VerifiedSubmissionStagePac
 	if err != nil {
 		return VerifiedSubmissionStageRuntimePrerequisite{}, err
 	}
+	raw, objectDigest, err := buildStageRuntimePrerequisiteObject(manifest, expectedDigest)
+	if err != nil {
+		return VerifiedSubmissionStageRuntimePrerequisite{}, err
+	}
+	receipt := SubmissionStageRuntimePrerequisiteReceipt{
+		Format: SubmissionStageRuntimePrerequisiteFormat, State: "VERIFIED", StagePackageDigest: plan.PackageDigest,
+		ManifestDigest: expectedDigest, ObjectDigest: objectDigest, Authority: packaged.installationAuthority,
+		Namespace: submissionStageInputNamespace, Name: "ok147-contract-executor-runtime", MutationAllowed: false,
+	}
+	return VerifiedSubmissionStageRuntimePrerequisite{raw: raw, receipt: receipt, verified: true}, nil
+}
+
+func buildStageRuntimePrerequisiteObject(manifest []byte, expectedDigest string) ([]byte, string, error) {
 	if len(manifest) == 0 || !stageReceiptPrefixDigestPattern.MatchString(expectedDigest) || digest.SHA256(manifest) != expectedDigest {
-		return VerifiedSubmissionStageRuntimePrerequisite{}, errors.New("submission stage runtime manifest differs from expected identity")
+		return nil, "", errors.New("stage runtime manifest differs from expected identity")
 	}
 	decoder := yaml.NewDecoder(bytes.NewReader(manifest))
 	var object map[string]any
 	if err := decoder.Decode(&object); err != nil || len(object) == 0 {
-		return VerifiedSubmissionStageRuntimePrerequisite{}, errors.New("decode submission stage runtime manifest")
+		return nil, "", errors.New("decode stage runtime manifest")
 	}
 	var trailing map[string]any
 	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
-		return VerifiedSubmissionStageRuntimePrerequisite{}, errors.New("submission stage runtime manifest contains multiple objects")
+		return nil, "", errors.New("stage runtime manifest contains multiple objects")
 	}
 	metadata, _ := object["metadata"].(map[string]any)
 	labels, _ := metadata["labels"].(map[string]any)
 	if object["apiVersion"] != "v1" || object["kind"] != "ServiceAccount" || object["automountServiceAccountToken"] != false || metadata["name"] != "ok147-contract-executor-runtime" || metadata["namespace"] != submissionStageInputNamespace || labels["app.kubernetes.io/name"] != "ok-cluster-contract-executor" || labels["openkubes.io/runtime-boundary"] != "submission-stage" {
-		return VerifiedSubmissionStageRuntimePrerequisite{}, errors.New("submission stage runtime ServiceAccount semantics are invalid")
+		return nil, "", errors.New("stage runtime ServiceAccount semantics are invalid")
 	}
 	if len(object) != 4 || len(metadata) != 3 || len(labels) != 2 {
-		return VerifiedSubmissionStageRuntimePrerequisite{}, errors.New("submission stage runtime ServiceAccount contains unbound fields")
+		return nil, "", errors.New("stage runtime ServiceAccount contains unbound fields")
 	}
 	raw, err := json.Marshal(object)
 	if err != nil {
-		return VerifiedSubmissionStageRuntimePrerequisite{}, errors.New("encode submission stage runtime ServiceAccount")
+		return nil, "", errors.New("encode stage runtime ServiceAccount")
 	}
-	receipt := SubmissionStageRuntimePrerequisiteReceipt{
-		Format: SubmissionStageRuntimePrerequisiteFormat, State: "VERIFIED", StagePackageDigest: plan.PackageDigest,
-		ManifestDigest: expectedDigest, ObjectDigest: digest.SHA256(raw), Authority: packaged.installationAuthority,
-		Namespace: submissionStageInputNamespace, Name: "ok147-contract-executor-runtime", MutationAllowed: false,
-	}
-	return VerifiedSubmissionStageRuntimePrerequisite{raw: raw, receipt: receipt, verified: true}, nil
+	return raw, digest.SHA256(raw), nil
 }
 
 func (runtime VerifiedSubmissionStageRuntimePrerequisite) Receipt() (SubmissionStageRuntimePrerequisiteReceipt, error) {


### PR DESCRIPTION
## What changed

- bind the shared tokenless runtime ServiceAccount to the exact lifecycle-observation package
- add a redaction-safe six-object lifecycle-observation launch plan
- require one global preflight barrier before any create
- order runtime, input, policy and credentials before the Job
- share the existing strict runtime-manifest parser without changing submission behavior

## Why

The observation Job must not reuse a runtime receipt bound to a different stage. This checkpoint correlates package, credentials and runtime explicitly before a later bounded launcher is implemented.

## Impact

- no Kubernetes client or API request
- no token or CA read beyond the already verified offline credential package
- no object body or credential content in the launch plan
- no installation, Job launch or infrastructure mutation

## Validation

- `go test -ldflags=-linkmode=external ./...`
- `go vet ./...`
- `go test -race -ldflags=-linkmode=external ./cmd/ok ./internal/runner ./internal/execution ./internal/ledger ./internal/observation`
- `python3 -m unittest discover -s tests -p '*_test.py'` (18 tests, 1 expected skip)
