### PR TITLE
OK-147: seal lifecycle observation launch material

### DIFF
--- a/internal/runner/lifecycle_observation_stage_launch_material.go
+++ b/internal/runner/lifecycle_observation_stage_launch_material.go
@@ -1,0 +1,133 @@
+package runner
+
+import (
+	"errors"
+	"time"
+)
+
+const LifecycleObservationStageLaunchMaterialFormat = "ok147-lifecycle-observation-stage-launch-material/v1"
+
+type LifecycleObservationStageLaunchMaterialConfig struct {
+	Package               LifecycleObservationStagePackageConfig
+	MaterializationTime   time.Time
+	Ledger                SubmissionStageCredentialSource
+	ManagementObserver    SubmissionStageCredentialSource
+	RuntimeManifest       []byte
+	RuntimeManifestDigest string
+	Candidate             SubmissionStageLaunchCandidateConfig
+}
+
+type LifecycleObservationStageLaunchMaterialReceipt struct {
+	Format                   string `json:"format"`
+	State                    string `json:"state"`
+	StageID                  string `json:"stageId"`
+	Authority                string `json:"authority"`
+	ObservationPackageDigest string `json:"observationPackageDigest"`
+	CredentialPackageDigest  string `json:"credentialPackageDigest"`
+	RuntimeManifestDigest    string `json:"runtimeManifestDigest"`
+	LaunchPlanDigest         string `json:"launchPlanDigest"`
+	CandidateDigest          string `json:"candidateDigest"`
+	ValidUntil               string `json:"validUntil"`
+	MutationAllowed          bool   `json:"mutationAllowed"`
+}
+
+type VerifiedLifecycleObservationStageLaunchMaterial struct {
+	packaged    VerifiedLifecycleObservationStagePackage
+	credentials VerifiedLifecycleObservationStageCredentialPackage
+	runtime     VerifiedLifecycleObservationStageRuntimePrerequisite
+	candidate   VerifiedLifecycleObservationStageLaunchCandidate
+	receipt     LifecycleObservationStageLaunchMaterialReceipt
+	verified    bool
+}
+
+type LifecycleObservationStageLaunchOpenConfig struct {
+	Authority               KubernetesAuthorityConfig
+	Clock                   func() time.Time
+	ExpectedCandidateDigest string
+}
+
+// BuildLifecycleObservationStageLaunchMaterial constructs one sealed private
+// launch input from independently bound sources. It opens only bounded local
+// files and performs no Kubernetes request.
+func BuildLifecycleObservationStageLaunchMaterial(config LifecycleObservationStageLaunchMaterialConfig) (VerifiedLifecycleObservationStageLaunchMaterial, error) {
+	packaged, err := BuildLifecycleObservationStagePackage(config.Package)
+	if err != nil {
+		return VerifiedLifecycleObservationStageLaunchMaterial{}, err
+	}
+	credentials, err := BuildLifecycleObservationStageCredentialPackage(LifecycleObservationStageCredentialPackageConfig{
+		Package: packaged, MaterializationTime: config.MaterializationTime,
+		Ledger: config.Ledger, ManagementObserver: config.ManagementObserver,
+	})
+	if err != nil {
+		return VerifiedLifecycleObservationStageLaunchMaterial{}, err
+	}
+	runtime, err := BuildLifecycleObservationStageRuntimePrerequisite(packaged, config.RuntimeManifest, config.RuntimeManifestDigest)
+	if err != nil {
+		return VerifiedLifecycleObservationStageLaunchMaterial{}, err
+	}
+	candidate, err := PrepareLifecycleObservationStageLaunchCandidate(config.Candidate, packaged, credentials, runtime)
+	if err != nil {
+		return VerifiedLifecycleObservationStageLaunchMaterial{}, err
+	}
+	candidateReceipt, err := candidate.Receipt()
+	if err != nil {
+		return VerifiedLifecycleObservationStageLaunchMaterial{}, err
+	}
+	receipt := LifecycleObservationStageLaunchMaterialReceipt{
+		Format: LifecycleObservationStageLaunchMaterialFormat, State: "VERIFIED", StageID: candidateReceipt.StageID,
+		Authority: candidateReceipt.Authority, ObservationPackageDigest: candidateReceipt.ObservationPackageDigest,
+		CredentialPackageDigest: candidateReceipt.CredentialPackageDigest, RuntimeManifestDigest: candidateReceipt.RuntimeManifestDigest,
+		LaunchPlanDigest: candidateReceipt.LaunchPlanDigest, CandidateDigest: candidateReceipt.CandidateDigest,
+		ValidUntil: candidateReceipt.ValidUntil, MutationAllowed: false,
+	}
+	return VerifiedLifecycleObservationStageLaunchMaterial{
+		packaged: packaged, credentials: credentials, runtime: runtime, candidate: candidate, receipt: receipt, verified: true,
+	}, nil
+}
+
+func (material VerifiedLifecycleObservationStageLaunchMaterial) Receipt() (LifecycleObservationStageLaunchMaterialReceipt, error) {
+	if err := verifyLifecycleObservationStageLaunchMaterial(material); err != nil {
+		return LifecycleObservationStageLaunchMaterialReceipt{}, err
+	}
+	return material.receipt, nil
+}
+
+func (material VerifiedLifecycleObservationStageLaunchMaterial) CandidateReceipt() (LifecycleObservationStageLaunchCandidateReceipt, error) {
+	if err := verifyLifecycleObservationStageLaunchMaterial(material); err != nil {
+		return LifecycleObservationStageLaunchCandidateReceipt{}, err
+	}
+	return material.candidate.Receipt()
+}
+
+// Open requires the exact prepared candidate digest and never permits callers
+// to replace any private verified component retained by the material.
+func (material VerifiedLifecycleObservationStageLaunchMaterial) Open(config LifecycleObservationStageLaunchOpenConfig) (*KubernetesLifecycleObservationStageLauncher, error) {
+	if err := verifyLifecycleObservationStageLaunchMaterial(material); err != nil {
+		return nil, err
+	}
+	if config.ExpectedCandidateDigest == "" || config.ExpectedCandidateDigest != material.receipt.CandidateDigest {
+		return nil, errors.New("lifecycle observation launch open requires the exact candidate digest")
+	}
+	return OpenKubernetesLifecycleObservationStageLauncher(LifecycleObservationStageLauncherConfig{
+		Authority: config.Authority, Clock: config.Clock, Candidate: material.candidate,
+		ExpectedCandidateDigest: config.ExpectedCandidateDigest,
+	}, material.packaged, material.credentials, material.runtime)
+}
+
+func verifyLifecycleObservationStageLaunchMaterial(material VerifiedLifecycleObservationStageLaunchMaterial) error {
+	if !material.verified || material.receipt.Format != LifecycleObservationStageLaunchMaterialFormat || material.receipt.State != "VERIFIED" || material.receipt.MutationAllowed {
+		return errors.New("lifecycle observation launch material was not produced by verification")
+	}
+	plan, err := PlanLifecycleObservationStageLaunch(material.packaged, material.credentials, material.runtime)
+	if err != nil {
+		return err
+	}
+	candidateReceipt, err := material.candidate.Receipt()
+	if err != nil {
+		return err
+	}
+	if material.receipt.StageID != plan.StageID || material.receipt.Authority != plan.Authority || material.receipt.ObservationPackageDigest != plan.ObservationPackageDigest || material.receipt.CredentialPackageDigest != plan.CredentialPackageDigest || material.receipt.RuntimeManifestDigest != plan.RuntimeManifestDigest || material.receipt.StageID != candidateReceipt.StageID || material.receipt.Authority != candidateReceipt.Authority || material.receipt.ObservationPackageDigest != candidateReceipt.ObservationPackageDigest || material.receipt.CredentialPackageDigest != candidateReceipt.CredentialPackageDigest || material.receipt.RuntimeManifestDigest != candidateReceipt.RuntimeManifestDigest || material.receipt.LaunchPlanDigest != candidateReceipt.LaunchPlanDigest || material.receipt.CandidateDigest != candidateReceipt.CandidateDigest || material.receipt.ValidUntil != candidateReceipt.ValidUntil {
+		return errors.New("lifecycle observation launch material identity changed after verification")
+	}
+	return nil
+}

--- a/internal/runner/lifecycle_observation_stage_launch_material_test.go
+++ b/internal/runner/lifecycle_observation_stage_launch_material_test.go
@@ -1,0 +1,101 @@
+package runner
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+func TestBuildLifecycleObservationStageLaunchMaterialSealsPrivateComponents(t *testing.T) {
+	config, ledgerToken, observerToken := lifecycleObservationStageLaunchMaterialConfig(t)
+	material, err := BuildLifecycleObservationStageLaunchMaterial(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := material.Receipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	candidate, err := material.CandidateReceipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if receipt.Format != LifecycleObservationStageLaunchMaterialFormat || receipt.State != "VERIFIED" || receipt.StageID != "lifecycle-observation" || receipt.Authority != "ok-mgmt" || receipt.ObservationPackageDigest != candidate.ObservationPackageDigest || receipt.CandidateDigest != candidate.CandidateDigest || receipt.ValidUntil != candidate.ValidUntil || receipt.MutationAllowed {
+		t.Fatalf("unexpected lifecycle observation launch material: %#v", receipt)
+	}
+	public, err := json.Marshal(receipt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range [][]byte{ledgerToken, observerToken, material.packaged.raw, material.credentials.objects[0].raw, material.runtime.raw, []byte(config.Candidate.AuthorityEndpoint), []byte(config.Candidate.InstallerTokenDigest)} {
+		if bytes.Contains(public, forbidden) {
+			t.Fatal("launch material receipt exposed private source content")
+		}
+	}
+	changed := material
+	changed.receipt.CandidateDigest = digest.SHA256([]byte("foreign"))
+	if _, err := changed.Receipt(); err == nil {
+		t.Fatal("changed launch material identity accepted")
+	}
+}
+
+func TestLifecycleObservationStageLaunchMaterialOpenRetainsExactComponents(t *testing.T) {
+	config, _, _ := lifecycleObservationStageLaunchMaterialConfig(t)
+	material, err := BuildLifecycleObservationStageLaunchMaterial(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, _ := material.Receipt()
+	launcher, err := material.Open(LifecycleObservationStageLaunchOpenConfig{
+		Authority: KubernetesAuthorityConfig{
+			Endpoint: "http://127.0.0.1:12345", AuthorityIdentity: "ok-mgmt",
+		},
+		Clock:                   func() time.Time { return time.Date(2026, 8, 16, 12, 16, 0, 0, time.UTC) },
+		ExpectedCandidateDigest: receipt.CandidateDigest,
+	})
+	if err == nil || launcher != nil {
+		// Public Open requires the real bound endpoint and credential files; the
+		// in-memory client path is intentionally unavailable here.
+		t.Fatalf("unbound public launcher was opened: %v", err)
+	}
+	if _, err := material.Open(LifecycleObservationStageLaunchOpenConfig{ExpectedCandidateDigest: digest.SHA256([]byte("foreign"))}); err == nil {
+		t.Fatal("wrong exact candidate digest accepted")
+	}
+
+	api := newSubmissionStageLauncherAPI(t)
+	internal, err := newKubernetesLifecycleObservationStageLauncher(submissionStageLauncherClientConfig{
+		Endpoint: "http://127.0.0.1:12345", BearerToken: "short-lived-installer-token", AuthorityIdentity: "ok-mgmt",
+		Client: api.client(), Clock: func() time.Time { return time.Date(2026, 8, 16, 12, 16, 0, 0, time.UTC) },
+		ValidUntil: time.Date(2026, 8, 16, 12, 15, 0, 0, time.UTC),
+	}, material.packaged, material.credentials, material.runtime)
+	if err != nil {
+		t.Fatal(err)
+	}
+	launchReceipt, err := internal.Launch(context.Background())
+	if err == nil || launchReceipt.State != "STOPPED_ZERO_WRITE" || launchReceipt.MutationState != "NOT_ATTEMPTED" || len(api.requests) != 0 {
+		t.Fatalf("expired sealed material reached API: %#v %v", launchReceipt, err)
+	}
+}
+
+func lifecycleObservationStageLaunchMaterialConfig(t *testing.T) (LifecycleObservationStageLaunchMaterialConfig, []byte, []byte) {
+	t.Helper()
+	credentialConfig, ledgerToken, observerToken := lifecycleObservationCredentialConfig(t)
+	manifest := submissionStageRuntimeManifest(t)
+	return LifecycleObservationStageLaunchMaterialConfig{
+		Package: credentialConfig.PackageConfigForTest(t), MaterializationTime: credentialConfig.MaterializationTime,
+		Ledger: credentialConfig.Ledger, ManagementObserver: credentialConfig.ManagementObserver,
+		RuntimeManifest: manifest, RuntimeManifestDigest: digest.SHA256(manifest),
+		Candidate: submissionStageLaunchCandidateConfig(),
+	}, ledgerToken, observerToken
+}
+
+func (config LifecycleObservationStageCredentialPackageConfig) PackageConfigForTest(t *testing.T) LifecycleObservationStagePackageConfig {
+	t.Helper()
+	// Test helpers rebuild the deterministic package inputs; production code
+	// never extracts configuration from a verified package.
+	return lifecycleObservationStagePackageConfig(t)
+}


### PR DESCRIPTION
## What changed

- add sealed lifecycle-observation launch material
- retain the exact package, credential Secrets, runtime prerequisite and candidate privately as one verified unit
- expose only redaction-safe material and candidate receipts
- require the exact candidate digest again before opening the launcher

## Why

CLI prepare and execute paths must not reconstruct or substitute individual verified launch components between review and execution.

## Impact

- local bounded-file verification only
- no Kubernetes API request or infrastructure mutation
- no private object bytes, endpoint or installer-token identity in the material receipt

## Validation

- `go test -ldflags=-linkmode=external ./...`
- `go vet ./...`
- `go test -race -ldflags=-linkmode=external ./cmd/ok ./internal/runner ./internal/execution ./internal/ledger ./internal/observation`
- `python3 -m unittest discover -s tests -p '*_test.py'` (18 tests, 1 expected skip)
