### PR TITLE
OK-147: expose lifecycle observation launch CLI

### DIFF
--- a/cmd/ok/main.go
+++ b/cmd/ok/main.go
@@ -84,6 +84,25 @@ var prepareSubmissionStageLaunch = func(config runner.SubmissionStageLaunchMater
 	}, nil
 }
 
+var prepareLifecycleObservationStageLaunch = func(config runner.LifecycleObservationStageLaunchMaterialConfig) (lifecycleObservationLaunchPreparation, error) {
+	material, err := runner.BuildLifecycleObservationStageLaunchMaterial(config)
+	if err != nil {
+		return lifecycleObservationLaunchPreparation{}, err
+	}
+	materialReceipt, err := material.Receipt()
+	if err != nil {
+		return lifecycleObservationLaunchPreparation{}, err
+	}
+	candidateReceipt, err := material.CandidateReceipt()
+	if err != nil {
+		return lifecycleObservationLaunchPreparation{}, err
+	}
+	return lifecycleObservationLaunchPreparation{
+		Format: "ok147-lifecycle-observation-stage-launch-preparation/v1", State: "PREPARED",
+		Material: materialReceipt, Candidate: candidateReceipt, MutationAllowed: false,
+	}, nil
+}
+
 var executeSubmissionStageLaunch = func(ctx context.Context, config runner.SubmissionStageLaunchMaterialConfig, authority runner.KubernetesAuthorityConfig, expectedCandidateDigest string) (runner.SubmissionStageLaunchReceipt, error) {
 	material, err := runner.BuildSubmissionStageLaunchMaterial(config)
 	if err != nil {
@@ -99,6 +118,25 @@ var executeSubmissionStageLaunch = func(ctx context.Context, config runner.Submi
 	})
 	if err != nil {
 		return runner.SubmissionStageLaunchReceipt{}, err
+	}
+	return launcher.Launch(ctx)
+}
+
+var executeLifecycleObservationStageLaunch = func(ctx context.Context, config runner.LifecycleObservationStageLaunchMaterialConfig, authority runner.KubernetesAuthorityConfig, expectedCandidateDigest string) (runner.LifecycleObservationStageLaunchReceipt, error) {
+	material, err := runner.BuildLifecycleObservationStageLaunchMaterial(config)
+	if err != nil {
+		return runner.LifecycleObservationStageLaunchReceipt{}, err
+	}
+	candidate, err := material.CandidateReceipt()
+	if err != nil {
+		return runner.LifecycleObservationStageLaunchReceipt{}, err
+	}
+	authority.AuthorityIdentity = candidate.Authority
+	launcher, err := material.Open(runner.LifecycleObservationStageLaunchOpenConfig{
+		Authority: authority, Clock: func() time.Time { return time.Now().UTC() }, ExpectedCandidateDigest: expectedCandidateDigest,
+	})
+	if err != nil {
+		return runner.LifecycleObservationStageLaunchReceipt{}, err
 	}
 	return launcher.Launch(ctx)
 }
@@ -138,6 +176,14 @@ type stageLaunchPreparation struct {
 	Material        runner.SubmissionStageLaunchMaterialReceipt  `json:"material"`
 	Candidate       runner.SubmissionStageLaunchCandidateReceipt `json:"candidate"`
 	MutationAllowed bool                                         `json:"mutationAllowed"`
+}
+
+type lifecycleObservationLaunchPreparation struct {
+	Format          string                                                 `json:"format"`
+	State           string                                                 `json:"state"`
+	Material        runner.LifecycleObservationStageLaunchMaterialReceipt  `json:"material"`
+	Candidate       runner.LifecycleObservationStageLaunchCandidateReceipt `json:"candidate"`
+	MutationAllowed bool                                                   `json:"mutationAllowed"`
 }
 
 type receiptFlags []string
@@ -408,6 +454,12 @@ func runContext(ctx context.Context, arguments []string, stdout, stderr io.Write
 	if len(arguments) >= 5 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "observe" && arguments[3] == "lifecycle" && arguments[4] == "package" {
 		return runClusterStageObserveLifecyclePackage(arguments[5:], stdout, stderr)
 	}
+	if len(arguments) >= 6 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "observe" && arguments[3] == "lifecycle" && arguments[4] == "launch" && arguments[5] == "prepare" {
+		return runClusterStageObserveLifecycleLaunchPrepare(arguments[6:], stdout, stderr)
+	}
+	if len(arguments) >= 6 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "observe" && arguments[3] == "lifecycle" && arguments[4] == "launch" && arguments[5] == "execute" {
+		return runClusterStageObserveLifecycleLaunchExecute(ctx, arguments[6:], stdout, stderr)
+	}
 	if len(arguments) >= 4 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "observe" && arguments[3] == "lifecycle" {
 		return runClusterStageObserveLifecycle(ctx, arguments[4:], stdout, stderr)
 	}
@@ -423,7 +475,7 @@ func runContext(ctx context.Context, arguments []string, stdout, stderr io.Write
 	if len(arguments) >= 4 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "launch" && arguments[3] == "execute" {
 		return runClusterStageLaunchExecute(ctx, arguments[4:], stdout, stderr)
 	}
-	return errors.New("usage: ok cluster create ... | ok cluster stage inspect ... | ok cluster stage resume ... | ok cluster stage observe lifecycle ... | ok cluster stage observe lifecycle package ... | ok cluster stage run ... | ok cluster stage package ... | ok cluster stage launch prepare ... | ok cluster stage launch execute ...")
+	return errors.New("usage: ok cluster create ... | ok cluster stage inspect ... | ok cluster stage resume ... | ok cluster stage observe lifecycle ... | ok cluster stage observe lifecycle package ... | ok cluster stage observe lifecycle launch prepare ... | ok cluster stage observe lifecycle launch execute ... | ok cluster stage run ... | ok cluster stage package ... | ok cluster stage launch prepare ... | ok cluster stage launch execute ...")
 }
 
 func runClusterCreate(arguments []string, stdout, stderr io.Writer) error {
@@ -727,6 +779,181 @@ func runClusterStageObserveLifecyclePackage(arguments []string, stdout, stderr i
 	encoder.SetEscapeHTML(false)
 	encoder.SetIndent("", "  ")
 	return encoder.Encode(receipt)
+}
+
+type lifecycleObservationLaunchMaterialFlags struct {
+	resume                                                                                       *stageResumeFlags
+	jobTemplate, jobTemplateDigest, runID, imageDigest, inputConfigMap                           *string
+	ledgerAPIURL, ledgerAPICIDR, ledgerCredentialSecret                                          *string
+	managementAPIURL, managementAPICIDR, managementCredentialSecret                              *string
+	pollInterval, pollTimeout                                                                    *time.Duration
+	materializedAt, runtimeManifest, runtimeManifestDigest                                       *string
+	installerAPIEndpoint, installerCADigest, installerTokenDigest, installerEvidence, preparedAt *string
+	ledgerCredential, managementCredential                                                       *stageLaunchCredentialFlags
+}
+
+func addLifecycleObservationLaunchMaterialFlags(flags *flag.FlagSet) *lifecycleObservationLaunchMaterialFlags {
+	values := &lifecycleObservationLaunchMaterialFlags{resume: addStageResumeFlags(flags)}
+	values.jobTemplate = flags.String("job-template", "", "path to the bounded lifecycle-observation Job template")
+	values.jobTemplateDigest = flags.String("job-template-digest", "", "expected SHA-256 identity of the Job template")
+	values.runID = flags.String("run-id", "", "bounded OK-147 observation Job identity")
+	values.imageDigest = flags.String("image", "", "digest-pinned ok image")
+	values.inputConfigMap = flags.String("input-configmap", "", "immutable observation input ConfigMap name")
+	values.ledgerAPIURL = flags.String("ledger-api-url", "", "exact management-ledger HTTPS IP endpoint")
+	values.ledgerAPICIDR = flags.String("ledger-api-cidr", "", "single-address management-ledger CIDR")
+	values.ledgerCredentialSecret = flags.String("ledger-credential-secret", "", "ledger credential Secret name")
+	values.managementAPIURL = flags.String("management-api-url", "", "exact management-observer HTTPS IP endpoint")
+	values.managementAPICIDR = flags.String("management-api-cidr", "", "single-address management-observer CIDR")
+	values.managementCredentialSecret = flags.String("management-credential-secret", "", "read-only management credential Secret name")
+	values.pollInterval = flags.Duration("poll-interval", 0, "bounded interval between Unknown observations")
+	values.pollTimeout = flags.Duration("poll-timeout", 0, "maximum bounded lifecycle observation duration")
+	values.materializedAt = flags.String("credential-materialized-at", "", "exact credential materialization time")
+	values.ledgerCredential = addStageLaunchCredentialFlags(flags, "ledger-job", "ledger Job credential")
+	values.managementCredential = addStageLaunchCredentialFlags(flags, "management-observer-job", "read-only management observer Job credential")
+	values.runtimeManifest = flags.String("runtime-manifest", "", "path to the tokenless runtime ServiceAccount manifest")
+	values.runtimeManifestDigest = flags.String("runtime-manifest-digest", "", "expected runtime manifest digest")
+	values.installerAPIEndpoint = flags.String("installer-api-endpoint", "", "exact management installer HTTPS IP endpoint")
+	values.installerCADigest = flags.String("installer-ca-digest", "", "expected management installer CA digest")
+	values.installerTokenDigest = flags.String("installer-token-digest", "", "private expected management installer token digest")
+	values.installerEvidence = flags.String("installer-tokenrequest-evidence-digest", "", "management installer TokenRequest evidence digest")
+	values.preparedAt = flags.String("prepared-at", "", "exact launch candidate preparation time")
+	return values
+}
+
+func (values *lifecycleObservationLaunchMaterialFlags) config() (runner.LifecycleObservationStageLaunchMaterialConfig, error) {
+	resumeConfig, err := values.resume.config()
+	if err != nil {
+		return runner.LifecycleObservationStageLaunchMaterialConfig{}, err
+	}
+	for _, input := range []struct{ name, value string }{
+		{"--job-template", *values.jobTemplate}, {"--job-template-digest", *values.jobTemplateDigest}, {"--run-id", *values.runID}, {"--image", *values.imageDigest},
+		{"--input-configmap", *values.inputConfigMap}, {"--ledger-api-url", *values.ledgerAPIURL}, {"--ledger-api-cidr", *values.ledgerAPICIDR},
+		{"--ledger-credential-secret", *values.ledgerCredentialSecret}, {"--management-api-url", *values.managementAPIURL},
+		{"--management-api-cidr", *values.managementAPICIDR}, {"--management-credential-secret", *values.managementCredentialSecret},
+		{"--credential-materialized-at", *values.materializedAt}, {"--runtime-manifest", *values.runtimeManifest},
+		{"--runtime-manifest-digest", *values.runtimeManifestDigest}, {"--installer-api-endpoint", *values.installerAPIEndpoint},
+		{"--installer-ca-digest", *values.installerCADigest}, {"--installer-token-digest", *values.installerTokenDigest},
+		{"--installer-tokenrequest-evidence-digest", *values.installerEvidence}, {"--prepared-at", *values.preparedAt},
+	} {
+		if input.value == "" {
+			return runner.LifecycleObservationStageLaunchMaterialConfig{}, fmt.Errorf("%s is required", input.name)
+		}
+	}
+	if *values.pollInterval < time.Second || *values.pollInterval > 5*time.Minute || *values.pollTimeout < *values.pollInterval || *values.pollTimeout > 6*time.Hour {
+		return runner.LifecycleObservationStageLaunchMaterialConfig{}, errors.New("--poll-interval and --poll-timeout must define a valid bounded observation of at most 6h")
+	}
+	materializedAt, err := time.Parse(time.RFC3339, *values.materializedAt)
+	if err != nil {
+		return runner.LifecycleObservationStageLaunchMaterialConfig{}, fmt.Errorf("parse credential materialization time: %w", err)
+	}
+	preparedAt, err := time.Parse(time.RFC3339, *values.preparedAt)
+	if err != nil {
+		return runner.LifecycleObservationStageLaunchMaterialConfig{}, fmt.Errorf("parse candidate preparation time: %w", err)
+	}
+	ledgerSource, err := values.ledgerCredential.source("ledger-job")
+	if err != nil {
+		return runner.LifecycleObservationStageLaunchMaterialConfig{}, err
+	}
+	managementSource, err := values.managementCredential.source("management-observer-job")
+	if err != nil {
+		return runner.LifecycleObservationStageLaunchMaterialConfig{}, err
+	}
+	template, err := readBoundedLocalFile(*values.jobTemplate, 1024*1024)
+	if err != nil {
+		return runner.LifecycleObservationStageLaunchMaterialConfig{}, fmt.Errorf("read lifecycle observation Job template: %w", err)
+	}
+	runtimeRaw, err := readBoundedLocalFile(*values.runtimeManifest, 128*1024)
+	if err != nil {
+		return runner.LifecycleObservationStageLaunchMaterialConfig{}, fmt.Errorf("read runtime manifest: %w", err)
+	}
+	return runner.LifecycleObservationStageLaunchMaterialConfig{
+		Package: runner.LifecycleObservationStagePackageConfig{
+			Bundle: resumeConfig, JobTemplate: template, JobTemplateDigest: *values.jobTemplateDigest,
+			RunID: *values.runID, ImageDigest: *values.imageDigest, InputConfigMap: *values.inputConfigMap,
+			LedgerAPIURL: *values.ledgerAPIURL, LedgerAPICIDR: *values.ledgerAPICIDR, LedgerCredentialSecret: *values.ledgerCredentialSecret,
+			ManagementAPIURL: *values.managementAPIURL, ManagementAPICIDR: *values.managementAPICIDR, ManagementCredentialSecret: *values.managementCredentialSecret,
+			PollInterval: *values.pollInterval, PollTimeout: *values.pollTimeout,
+		},
+		MaterializationTime: materializedAt, Ledger: ledgerSource, ManagementObserver: managementSource,
+		RuntimeManifest: runtimeRaw, RuntimeManifestDigest: *values.runtimeManifestDigest,
+		Candidate: runner.SubmissionStageLaunchCandidateConfig{
+			AuthorityEndpoint: *values.installerAPIEndpoint, CABundleDigest: *values.installerCADigest,
+			InstallerTokenDigest: *values.installerTokenDigest, InstallerCredentialEvidenceDigest: *values.installerEvidence,
+			PreparedAt: preparedAt,
+		},
+	}, nil
+}
+
+func runClusterStageObserveLifecycleLaunchPrepare(arguments []string, stdout, stderr io.Writer) error {
+	flags := flag.NewFlagSet("ok cluster stage observe lifecycle launch prepare", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	materialFlags := addLifecycleObservationLaunchMaterialFlags(flags)
+	if err := flags.Parse(arguments); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return errors.New("positional arguments are not accepted")
+	}
+	config, err := materialFlags.config()
+	if err != nil {
+		return err
+	}
+	preparation, err := prepareLifecycleObservationStageLaunch(config)
+	if err != nil {
+		return err
+	}
+	encoder := json.NewEncoder(stdout)
+	encoder.SetEscapeHTML(false)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(preparation)
+}
+
+func runClusterStageObserveLifecycleLaunchExecute(ctx context.Context, arguments []string, stdout, stderr io.Writer) error {
+	flags := flag.NewFlagSet("ok cluster stage observe lifecycle launch execute", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	materialFlags := addLifecycleObservationLaunchMaterialFlags(flags)
+	execute := flags.Bool("execute", false, "perform the exact single-use lifecycle observation launch")
+	expectedCandidateDigest := flags.String("expected-candidate-digest", "", "exact digest emitted by lifecycle observation launch prepare")
+	installerTokenFile := flags.String("installer-token-file", "", "bounded short-lived management installer token file")
+	installerCAFile := flags.String("installer-ca-file", "", "bounded management installer CA file")
+	if err := flags.Parse(arguments); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return errors.New("positional arguments are not accepted")
+	}
+	if !*execute {
+		return errors.New("lifecycle observation launch mutation requires explicit --execute")
+	}
+	for _, input := range []struct{ name, value string }{
+		{"--expected-candidate-digest", *expectedCandidateDigest}, {"--installer-token-file", *installerTokenFile}, {"--installer-ca-file", *installerCAFile},
+	} {
+		if input.value == "" {
+			return fmt.Errorf("%s is required", input.name)
+		}
+	}
+	if !sha256DigestPattern.MatchString(*expectedCandidateDigest) {
+		return errors.New("--expected-candidate-digest must be sha256:<64 lowercase hex>")
+	}
+	config, err := materialFlags.config()
+	if err != nil {
+		return err
+	}
+	boundedContext, cancel := context.WithTimeout(ctx, stageLaunchTimeout)
+	defer cancel()
+	receipt, launchErr := executeLifecycleObservationStageLaunch(boundedContext, config, runner.KubernetesAuthorityConfig{
+		Endpoint: config.Candidate.AuthorityEndpoint, TokenFile: *installerTokenFile,
+		CAFile: *installerCAFile, CABundleDigest: config.Candidate.CABundleDigest,
+	}, *expectedCandidateDigest)
+	if receipt.Format != "" {
+		encoder := json.NewEncoder(stdout)
+		encoder.SetEscapeHTML(false)
+		encoder.SetIndent("", "  ")
+		if err := encoder.Encode(receipt); err != nil {
+			return err
+		}
+	}
+	return launchErr
 }
 
 func runClusterStageRun(ctx context.Context, arguments []string, stdout, stderr io.Writer) error {

--- a/cmd/ok/main_test.go
+++ b/cmd/ok/main_test.go
@@ -769,6 +769,108 @@ func TestStageLaunchExecuteEmitsStoppedReceipt(t *testing.T) {
 	}
 }
 
+func TestLifecycleObservationLaunchPrepareBuildsOneNonMutatingCandidate(t *testing.T) {
+	previous := prepareLifecycleObservationStageLaunch
+	defer func() { prepareLifecycleObservationStageLaunch = previous }()
+	var captured runner.LifecycleObservationStageLaunchMaterialConfig
+	prepareLifecycleObservationStageLaunch = func(config runner.LifecycleObservationStageLaunchMaterialConfig) (lifecycleObservationLaunchPreparation, error) {
+		captured = config
+		return lifecycleObservationLaunchPreparation{
+			Format: "ok147-lifecycle-observation-stage-launch-preparation/v1", State: "PREPARED",
+			Material: runner.LifecycleObservationStageLaunchMaterialReceipt{
+				Format: runner.LifecycleObservationStageLaunchMaterialFormat, State: "VERIFIED", StageID: "lifecycle-observation",
+				Authority: "ok-mgmt", CandidateDigest: testSHA("1"), MutationAllowed: false,
+			},
+			Candidate: runner.LifecycleObservationStageLaunchCandidateReceipt{
+				Format: runner.LifecycleObservationStageLaunchCandidateFormat, State: "PREPARED", CandidateDigest: testSHA("1"), MutationAllowed: false,
+			},
+			MutationAllowed: false,
+		}, nil
+	}
+	root := t.TempDir()
+	template, runtimeManifest := filepath.Join(root, "observation.yaml.tpl"), filepath.Join(root, "runtime.yaml")
+	if err := os.WriteFile(template, []byte("bounded-observation-template"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(runtimeManifest, []byte("bounded-runtime"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	if err := run(lifecycleObservationLaunchPrepareArguments(template, runtimeManifest), &stdout, &stderr); err != nil {
+		t.Fatalf("run: %v; stderr=%s", err, stderr.String())
+	}
+	if captured.Package.Bundle.PlanExpected.ManagementAuthority != "ok-mgmt" || captured.Package.RunID != "ok147-lifecycle-observation-01" || captured.Package.PollInterval != 15*time.Second || captured.Package.PollTimeout != 5*time.Minute || string(captured.Package.JobTemplate) != "bounded-observation-template" || string(captured.RuntimeManifest) != "bounded-runtime" {
+		t.Fatalf("lifecycle observation launch material differs: %#v", captured)
+	}
+	if captured.Ledger.AuthorityIdentity != "ok-mgmt" || captured.ManagementObserver.AuthorityIdentity != "ok-mgmt" || captured.Ledger.TokenFile == captured.ManagementObserver.TokenFile {
+		t.Fatalf("observation credential boundary differs: %#v %#v", captured.Ledger, captured.ManagementObserver)
+	}
+	var preparation lifecycleObservationLaunchPreparation
+	if err := json.Unmarshal(stdout.Bytes(), &preparation); err != nil {
+		t.Fatal(err)
+	}
+	if preparation.State != "PREPARED" || preparation.MutationAllowed || preparation.Material.MutationAllowed || preparation.Candidate.MutationAllowed {
+		t.Fatalf("unsafe lifecycle observation preparation: %#v", preparation)
+	}
+}
+
+func TestLifecycleObservationLaunchExecuteUsesExactBoundary(t *testing.T) {
+	previous := executeLifecycleObservationStageLaunch
+	defer func() { executeLifecycleObservationStageLaunch = previous }()
+	var calls int
+	var candidate string
+	executeLifecycleObservationStageLaunch = func(ctx context.Context, config runner.LifecycleObservationStageLaunchMaterialConfig, authority runner.KubernetesAuthorityConfig, expectedCandidateDigest string) (runner.LifecycleObservationStageLaunchReceipt, error) {
+		calls++
+		candidate = expectedCandidateDigest
+		deadline, ok := ctx.Deadline()
+		if !ok || time.Until(deadline) <= 0 || time.Until(deadline) > stageLaunchTimeout {
+			t.Fatal("lifecycle observation launch context is not bounded")
+		}
+		if config.Package.RunID != "ok147-lifecycle-observation-01" || authority.Endpoint != "https://192.0.2.12:6443" || authority.TokenFile != "/private/tmp/installer-token" {
+			t.Fatalf("execute boundary differs: %#v %#v", config, authority)
+		}
+		return runner.LifecycleObservationStageLaunchReceipt{
+			Format: runner.LifecycleObservationStageLaunchReceiptFormat, StageID: "lifecycle-observation", Authority: "ok-mgmt",
+			State: "LAUNCHED", MutationState: "ATTEMPTED", Results: []runner.SubmissionStageLaunchResult{},
+		}, nil
+	}
+	root := t.TempDir()
+	template, runtimeManifest := filepath.Join(root, "observation.yaml.tpl"), filepath.Join(root, "runtime.yaml")
+	if err := os.WriteFile(template, []byte("bounded-observation-template"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(runtimeManifest, []byte("bounded-runtime"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	if err := run(lifecycleObservationLaunchExecuteArguments(template, runtimeManifest), &stdout, &stderr); err != nil {
+		t.Fatalf("run: %v; stderr=%s", err, stderr.String())
+	}
+	if calls != 1 || candidate != testSHA("9") {
+		t.Fatalf("exact observation candidate not used: calls=%d digest=%q", calls, candidate)
+	}
+	var receipt runner.LifecycleObservationStageLaunchReceipt
+	if err := json.Unmarshal(stdout.Bytes(), &receipt); err != nil || receipt.State != "LAUNCHED" {
+		t.Fatalf("unexpected observation launch receipt: %#v %v", receipt, err)
+	}
+
+	valid := lifecycleObservationLaunchExecuteArguments(template, runtimeManifest)
+	for name, arguments := range map[string][]string{
+		"missing execute":         removeArgument(valid, "--execute"),
+		"missing candidate":       removeArgumentWithValue(valid, "--expected-candidate-digest"),
+		"malformed candidate":     replaceArgument(valid, "--expected-candidate-digest", "sha256:ABC"),
+		"missing installer token": removeArgumentWithValue(valid, "--installer-token-file"),
+	} {
+		t.Run(name, func(t *testing.T) {
+			before := calls
+			stdout.Reset()
+			if err := run(arguments, &stdout, &stderr); err == nil || stdout.Len() != 0 || calls != before {
+				t.Fatal("unsafe observation launch input reached executor")
+			}
+		})
+	}
+}
+
 func stageInspectArguments() []string {
 	return []string{
 		"cluster", "stage", "inspect",
@@ -879,6 +981,42 @@ func stageLaunchPrepareArguments(template, runtimeManifest string) []string {
 func stageLaunchExecuteArguments(template, runtimeManifest string) []string {
 	arguments := stageLaunchPrepareArguments(template, runtimeManifest)
 	arguments[3] = "execute"
+	return append(arguments,
+		"--execute", "--expected-candidate-digest", testSHA("9"),
+		"--installer-token-file", "/private/tmp/installer-token", "--installer-ca-file", "/private/tmp/installer-ca",
+	)
+}
+
+func lifecycleObservationLaunchPrepareArguments(template, runtimeManifest string) []string {
+	packaged := stageObserveLifecyclePackageArguments(template, "/private/tmp/not-used-package")
+	packaged = removeArgumentWithValue(packaged, "--output")
+	arguments := append([]string{"cluster", "stage", "observe", "lifecycle", "launch", "prepare"}, packaged[5:]...)
+	arguments = append(arguments, "--credential-materialized-at", "2026-08-16T12:00:00Z")
+	for _, credential := range []struct{ prefix, tokenFile, tokenDigest, caFile, caDigest, evidence, subject string }{
+		{"ledger-job", "/private/tmp/ledger-observation-token", testSHA("1"), "/private/tmp/ledger-observation-ca", testSHA("2"), testSHA("3"), "system:serviceaccount:openkubes-execution-system:ok147-ledger-writer"},
+		{"management-observer-job", "/private/tmp/management-observer-token", testSHA("4"), "/private/tmp/management-observer-ca", testSHA("2"), testSHA("5"), "system:serviceaccount:openkubes-execution-system:ok147-lifecycle-observer"},
+	} {
+		arguments = append(arguments,
+			"--"+credential.prefix+"-authority", "ok-mgmt",
+			"--"+credential.prefix+"-token-file", credential.tokenFile, "--"+credential.prefix+"-token-digest", credential.tokenDigest,
+			"--"+credential.prefix+"-ca-file", credential.caFile, "--"+credential.prefix+"-ca-digest", credential.caDigest,
+			"--"+credential.prefix+"-tokenrequest-evidence-digest", credential.evidence,
+			"--"+credential.prefix+"-issuer", "https://kubernetes.default.svc.cluster.local", "--"+credential.prefix+"-subject", credential.subject,
+			"--"+credential.prefix+"-audiences", "https://kubernetes.default.svc",
+			"--"+credential.prefix+"-issued-at", "2026-08-16T11:59:00Z", "--"+credential.prefix+"-expires-at", "2026-08-16T12:30:00Z",
+		)
+	}
+	return append(arguments,
+		"--runtime-manifest", runtimeManifest, "--runtime-manifest-digest", digest.SHA256([]byte("bounded-runtime")),
+		"--installer-api-endpoint", "https://192.0.2.12:6443", "--installer-ca-digest", testSHA("2"),
+		"--installer-token-digest", testSHA("7"), "--installer-tokenrequest-evidence-digest", testSHA("8"),
+		"--prepared-at", "2026-08-16T12:01:00Z",
+	)
+}
+
+func lifecycleObservationLaunchExecuteArguments(template, runtimeManifest string) []string {
+	arguments := lifecycleObservationLaunchPrepareArguments(template, runtimeManifest)
+	arguments[5] = "execute"
 	return append(arguments,
 		"--execute", "--expected-candidate-digest", testSHA("9"),
 		"--installer-token-file", "/private/tmp/installer-token", "--installer-ca-file", "/private/tmp/installer-ca",


### PR DESCRIPTION
## What changed

- add `ok cluster stage observe lifecycle launch prepare`
- add `ok cluster stage observe lifecycle launch execute`
- parse and bind the full observation package, two distinct Job credentials, runtime prerequisite and launch candidate
- require explicit `--execute`, exact candidate digest and separate installer credential files for the mutating path
- emit stopped receipts even when the bounded launcher returns an error

## Why

The verified lifecycle-observation launcher is only useful operationally if the CLI preserves its sealed prepare/execute boundary rather than reconstructing private components ad hoc.

## Impact

- no command was executed against Kubernetes in this checkpoint
- prepare remains non-mutating
- invalid or incomplete execute input never reaches the launcher
- live execution still requires explicit caller-provided, digest-bound material

## Validation

- `go test -ldflags=-linkmode=external ./...`
- `go vet ./...`
- `go test -race -ldflags=-linkmode=external ./cmd/ok ./internal/runner ./internal/execution ./internal/ledger ./internal/observation`
- `python3 -m unittest discover -s tests -p '*_test.py'` (18 tests, 1 expected skip)
