### PR TITLE
feat(runner): verify enablement projection

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -1144,6 +1144,28 @@ tested with fake mutators only: no concrete Kubernetes stage implementation,
 credential resolver, dispatcher, cluster contact or CLI/Job activation exists
 at this checkpoint.
 
+## Externally rendered Enablement projection
+
+The next submission stage begins with a separate offline verifier for exactly
+one `addons.cluster.x-k8s.io/v1alpha1` `HelmChartProxy`. The object remains an
+output of an authoritative external profile/renderer; the runner does not
+construct Helm values, choose a chart or translate Contract intent.
+
+The verifier binds the raw artifact digest from `stage.enablement`, the exact
+management authority and object identity, R, E, the execution fixture, the OCI
+manifest digest, chart-content digest and values digest. It also requires
+explicit Contract name/namespace carriers, an OCI repository, a fixed chart
+version, `Continuous` reconciliation and the bounded atomic/wait Helm options.
+YAML aliases, multiple objects, status, runtime metadata, mutable chart
+versions and non-OCI sources fail closed.
+
+The resulting `ok147-bounded-enablement-plan/v1` contains one exact canonical
+create candidate for the management plane and reports
+`mutationAllowed: false`. It does not submit the object, install CAAPH, contact
+Kubernetes or write a `HelmReleaseProxy`; the latter remains exclusively owned
+by CAAPH. Cursor/grant composition and live exact-create execution are later
+boundaries.
+
 ## Typed Contract-to-CAPI submission stages
 
 The existing bounded exact-create submission primitive now has a typed adapter

--- a/internal/submission/enablement.go
+++ b/internal/submission/enablement.go
@@ -1,0 +1,222 @@
+package submission
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/openkubes/ok-cluster/internal/contract"
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/projection"
+	"gopkg.in/yaml.v3"
+)
+
+const EnablementPlanFormat = "ok147-bounded-enablement-plan/v1"
+
+var immutableDigestPattern = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
+
+// EnablementExpected is independently supplied from the verified execution
+// fixture and staged plan. The renderer remains responsible for the object.
+type EnablementExpected struct {
+	ArtifactDigest      string
+	ContractIdentity    contract.Identity
+	IntentRevision      string
+	EnablementRevision  string
+	ExecutionFixture    string
+	ManagementAuthority string
+	ObjectIdentity      projection.ResourceIdentity
+}
+
+// EnablementPlan contains exactly one externally rendered HelmChartProxy.
+// It is a verified desired-state projection, not authorization to submit it.
+type EnablementPlan struct {
+	Format             string `json:"format"`
+	IntentRevision     string `json:"intentRevision"`
+	EnablementRevision string `json:"enablementRevision"`
+	ExecutionFixture   string `json:"executionFixture"`
+	ArtifactDigest     string `json:"artifactDigest"`
+	MutationAllowed    bool   `json:"mutationAllowed"`
+	Management         Plane  `json:"management"`
+}
+
+// LoadEnablement verifies one bounded renderer artifact without rendering,
+// contacting Kubernetes or granting mutation authority.
+func LoadEnablement(path string, expected EnablementExpected) (EnablementPlan, error) {
+	if err := validateEnablementExpected(expected); err != nil {
+		return EnablementPlan{}, err
+	}
+	info, err := os.Lstat(path)
+	if err != nil {
+		return EnablementPlan{}, fmt.Errorf("inspect enablement artifact: %w", err)
+	}
+	if !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 || info.Size() <= 0 || info.Size() > maximumProjectionArtifactBytes {
+		return EnablementPlan{}, errors.New("enablement artifact metadata is invalid")
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return EnablementPlan{}, fmt.Errorf("open enablement artifact: %w", err)
+	}
+	defer file.Close()
+	raw, err := io.ReadAll(io.LimitReader(file, maximumProjectionArtifactBytes+1))
+	if err != nil || len(raw) > maximumProjectionArtifactBytes {
+		return EnablementPlan{}, errors.New("read bounded enablement artifact")
+	}
+	if actual := digest.SHA256(raw); actual != expected.ArtifactDigest {
+		return EnablementPlan{}, errors.New("enablement artifact digest differs from staged input")
+	}
+	object, err := decodeEnablementObject(raw, expected)
+	if err != nil {
+		return EnablementPlan{}, err
+	}
+	return EnablementPlan{
+		Format: EnablementPlanFormat, IntentRevision: expected.IntentRevision,
+		EnablementRevision: expected.EnablementRevision, ExecutionFixture: expected.ExecutionFixture,
+		ArtifactDigest: expected.ArtifactDigest, MutationAllowed: false,
+		Management: Plane{Identity: expected.ManagementAuthority, Role: "enablement-desired-state-writer", Objects: []Object{object}},
+	}, nil
+}
+
+func validateEnablementExpected(expected EnablementExpected) error {
+	for _, value := range []string{expected.ArtifactDigest, expected.IntentRevision, expected.EnablementRevision, expected.ExecutionFixture} {
+		if !immutableDigestPattern.MatchString(value) {
+			return errors.New("enablement expected digest identity is invalid")
+		}
+	}
+	if !validName(expected.ContractIdentity.Namespace, 63) || strings.Contains(expected.ContractIdentity.Namespace, ".") || !validName(expected.ContractIdentity.Name, 253) {
+		return errors.New("enablement Contract identity is invalid")
+	}
+	if !validName(expected.ManagementAuthority, 63) || strings.Contains(expected.ManagementAuthority, ".") {
+		return errors.New("enablement management authority is invalid")
+	}
+	identity := expected.ObjectIdentity
+	if identity.APIVersion != "addons.cluster.x-k8s.io/v1alpha1" || identity.Kind != "HelmChartProxy" || identity.Namespace != expected.ContractIdentity.Namespace || !validName(identity.Name, 253) {
+		return errors.New("enablement object identity is invalid")
+	}
+	return nil
+}
+
+func decodeEnablementObject(raw []byte, expected EnablementExpected) (Object, error) {
+	decoder := yaml.NewDecoder(bytes.NewReader(raw))
+	var document yaml.Node
+	if err := decoder.Decode(&document); err != nil {
+		return Object{}, fmt.Errorf("decode enablement YAML: %w", err)
+	}
+	if len(document.Content) == 0 {
+		return Object{}, errors.New("enablement artifact is empty")
+	}
+	if err := rejectAliases(document.Content[0]); err != nil {
+		return Object{}, err
+	}
+	var decoded any
+	if err := document.Content[0].Decode(&decoded); err != nil {
+		return Object{}, fmt.Errorf("decode enablement object: %w", err)
+	}
+	value, err := jsonValue(decoded)
+	if err != nil {
+		return Object{}, err
+	}
+	object, ok := value.(map[string]any)
+	if !ok {
+		return Object{}, errors.New("enablement document is not a Kubernetes object")
+	}
+	var trailing yaml.Node
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		if err != nil {
+			return Object{}, fmt.Errorf("decode trailing enablement YAML: %w", err)
+		}
+		if len(trailing.Content) != 0 {
+			return Object{}, errors.New("enablement artifact must contain exactly one object")
+		}
+	}
+	return validateEnablementObject(object, expected)
+}
+
+func validateEnablementObject(value map[string]any, expected EnablementExpected) (Object, error) {
+	if _, exists := value["status"]; exists {
+		return Object{}, errors.New("enablement object must not contain status")
+	}
+	metadata, _ := value["metadata"].(map[string]any)
+	identity := projection.ResourceIdentity{
+		APIVersion: text(value["apiVersion"]), Kind: text(value["kind"]),
+		Name: text(metadata["name"]), Namespace: text(metadata["namespace"]),
+	}
+	if identity != expected.ObjectIdentity {
+		return Object{}, errors.New("enablement object identity differs from the staged input")
+	}
+	for _, forbidden := range []string{"generateName", "uid", "resourceVersion", "generation", "creationTimestamp", "deletionTimestamp", "deletionGracePeriodSeconds", "managedFields", "ownerReferences", "finalizers"} {
+		if _, exists := metadata[forbidden]; exists {
+			return Object{}, fmt.Errorf("enablement metadata.%s is not accepted", forbidden)
+		}
+	}
+	annotations, _ := metadata["annotations"].(map[string]any)
+	required := map[string]string{
+		"openkubes.io/contract-name":       expected.ContractIdentity.Name,
+		"openkubes.io/contract-namespace":  expected.ContractIdentity.Namespace,
+		"openkubes.io/intent-revision":     expected.IntentRevision,
+		"openkubes.io/enablement-revision": expected.EnablementRevision,
+		"openkubes.io/execution-fixture":   expected.ExecutionFixture,
+		"openkubes.io/digest-enforcement":  "external-evidence-required",
+	}
+	for key, want := range required {
+		if text(annotations[key]) != want {
+			return Object{}, fmt.Errorf("enablement object lacks exact %s carrier", key)
+		}
+	}
+	for _, key := range []string{"openkubes.io/oci-manifest-digest", "openkubes.io/chart-artifact-digest", "openkubes.io/values-digest"} {
+		if !immutableDigestPattern.MatchString(text(annotations[key])) {
+			return Object{}, fmt.Errorf("enablement object lacks immutable %s", key)
+		}
+	}
+	if err := validateHelmChartProxySpec(value["spec"]); err != nil {
+		return Object{}, err
+	}
+	collection := "/apis/addons.cluster.x-k8s.io/v1alpha1/namespaces/" + identity.Namespace + "/helmchartproxies"
+	canonical, err := canonicalJSON(value)
+	if err != nil {
+		return Object{}, err
+	}
+	return Object{Identity: identity, Digest: digest.SHA256(canonical), CollectionPath: collection, ObjectPath: collection + "/" + identity.Name, Raw: canonical}, nil
+}
+
+func validateHelmChartProxySpec(raw any) error {
+	spec, ok := raw.(map[string]any)
+	if !ok {
+		return errors.New("enablement HelmChartProxy spec is missing")
+	}
+	selector, _ := spec["clusterSelector"].(map[string]any)
+	labels, _ := selector["matchLabels"].(map[string]any)
+	if len(labels) == 0 || len(selector) != 1 {
+		return errors.New("enablement cluster selector must use non-empty matchLabels only")
+	}
+	for key, value := range labels {
+		if key == "" || text(value) == "" {
+			return errors.New("enablement cluster selector label is invalid")
+		}
+	}
+	for _, key := range []string{"chartName", "releaseName", "namespace", "version", "valuesTemplate"} {
+		if strings.TrimSpace(text(spec[key])) == "" {
+			return fmt.Errorf("enablement HelmChartProxy spec.%s is required", key)
+		}
+	}
+	repo := text(spec["repoURL"])
+	if len(repo) <= len("oci://") || !strings.HasPrefix(repo, "oci://") || strings.ContainsAny(repo, " \t\r\n") {
+		return errors.New("enablement chart repository must be an explicit OCI source")
+	}
+	if strings.EqualFold(text(spec["version"]), "latest") {
+		return errors.New("enablement chart version must be immutable")
+	}
+	if text(spec["reconcileStrategy"]) != "Continuous" {
+		return errors.New("enablement reconcile strategy must be Continuous")
+	}
+	options, _ := spec["options"].(map[string]any)
+	for _, key := range []string{"atomic", "wait", "waitForJobs"} {
+		if enabled, _ := options[key].(bool); !enabled {
+			return fmt.Errorf("enablement Helm option %s must be true", key)
+		}
+	}
+	return nil
+}

--- a/internal/submission/enablement_test.go
+++ b/internal/submission/enablement_test.go
@@ -1,0 +1,129 @@
+package submission
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/openkubes/ok-cluster/internal/contract"
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/projection"
+)
+
+func TestLoadEnablementVerifiesOneExternallyRenderedHCP(t *testing.T) {
+	raw := enablementYAML()
+	path := writeEnablement(t, raw)
+	plan, err := LoadEnablement(path, enablementExpected(raw))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plan.Format != EnablementPlanFormat || plan.MutationAllowed || plan.IntentRevision != enablementSHA("1") || plan.EnablementRevision != enablementSHA("2") || plan.ExecutionFixture != enablementSHA("3") || plan.ArtifactDigest != digest.SHA256(raw) {
+		t.Fatalf("unexpected enablement plan: %#v", plan)
+	}
+	if plan.Management.Identity != "ok-mgmt" || plan.Management.Role != "enablement-desired-state-writer" || len(plan.Management.Objects) != 1 {
+		t.Fatalf("unexpected enablement plane: %#v", plan.Management)
+	}
+	object := plan.Management.Objects[0]
+	if object.Identity.Kind != "HelmChartProxy" || object.CollectionPath != "/apis/addons.cluster.x-k8s.io/v1alpha1/namespaces/disposable-ok147/helmchartproxies" || !immutableDigestPattern.MatchString(object.Digest) || len(object.Raw) == 0 {
+		t.Fatalf("unexpected enablement object: %#v", object)
+	}
+}
+
+func TestLoadEnablementFailsClosed(t *testing.T) {
+	valid := enablementYAML()
+	tests := map[string]struct {
+		raw     []byte
+		mutate  func(*EnablementExpected)
+		symlink bool
+	}{
+		"artifact digest":          {raw: append(append([]byte{}, valid...), '\n'), mutate: func(expected *EnablementExpected) { expected.ArtifactDigest = digest.SHA256(valid) }},
+		"wrong E":                  {raw: []byte(strings.Replace(string(valid), enablementSHA("2"), enablementSHA("4"), 1))},
+		"wrong fixture":            {raw: []byte(strings.Replace(string(valid), enablementSHA("3"), enablementSHA("4"), 1))},
+		"missing contract carrier": {raw: []byte(strings.Replace(string(valid), "    openkubes.io/contract-name: disposable-ok147\n", "", 1))},
+		"mutable repository":       {raw: []byte(strings.Replace(string(valid), "oci://quay.io/cilium/charts", "https://example.invalid/charts", 1))},
+		"mutable version":          {raw: []byte(strings.Replace(string(valid), "version: 1.19.6", "version: latest", 1))},
+		"non-continuous":           {raw: []byte(strings.Replace(string(valid), "reconcileStrategy: Continuous", "reconcileStrategy: Once", 1))},
+		"status":                   {raw: append(append([]byte{}, valid...), []byte("status: {}\n")...)},
+		"multiple objects":         {raw: append(append(append([]byte{}, valid...), []byte("---\n")...), valid...)},
+		"foreign identity":         {raw: valid, mutate: func(expected *EnablementExpected) { expected.ObjectIdentity.Name = "other-cilium" }},
+		"symlink":                  {raw: valid, symlink: true},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			path := writeEnablement(t, test.raw)
+			if test.symlink {
+				link := filepath.Join(t.TempDir(), "enablement.yaml")
+				if err := os.Symlink(path, link); err != nil {
+					t.Fatal(err)
+				}
+				path = link
+			}
+			expected := enablementExpected(test.raw)
+			if test.mutate != nil {
+				test.mutate(&expected)
+			}
+			if _, err := LoadEnablement(path, expected); err == nil {
+				t.Fatal("unsafe enablement artifact was accepted")
+			}
+		})
+	}
+}
+
+func enablementExpected(raw []byte) EnablementExpected {
+	return EnablementExpected{
+		ArtifactDigest: digest.SHA256(raw), ContractIdentity: contract.Identity{Namespace: "disposable-ok147", Name: "disposable-ok147"},
+		IntentRevision: enablementSHA("1"), EnablementRevision: enablementSHA("2"), ExecutionFixture: enablementSHA("3"),
+		ManagementAuthority: "ok-mgmt", ObjectIdentity: projection.ResourceIdentity{
+			APIVersion: "addons.cluster.x-k8s.io/v1alpha1", Kind: "HelmChartProxy", Namespace: "disposable-ok147", Name: "disposable-ok147-cilium",
+		},
+	}
+}
+
+func enablementYAML() []byte {
+	return []byte(`apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: disposable-ok147-cilium
+  namespace: disposable-ok147
+  annotations:
+    openkubes.io/contract-name: disposable-ok147
+    openkubes.io/contract-namespace: disposable-ok147
+    openkubes.io/intent-revision: ` + enablementSHA("1") + `
+    openkubes.io/enablement-revision: ` + enablementSHA("2") + `
+    openkubes.io/execution-fixture: ` + enablementSHA("3") + `
+    openkubes.io/oci-manifest-digest: ` + enablementSHA("4") + `
+    openkubes.io/chart-artifact-digest: ` + enablementSHA("5") + `
+    openkubes.io/values-digest: ` + enablementSHA("6") + `
+    openkubes.io/digest-enforcement: external-evidence-required
+spec:
+  clusterSelector:
+    matchLabels:
+      openkubes.io/type: talos
+      openkubes.io/provider: kubevirt
+  chartName: cilium
+  repoURL: oci://quay.io/cilium/charts
+  releaseName: cilium
+  namespace: kube-system
+  version: 1.19.6
+  reconcileStrategy: Continuous
+  valuesTemplate: |
+    operator:
+      replicas: 1
+  options:
+    atomic: true
+    wait: true
+    waitForJobs: true
+`)
+}
+
+func writeEnablement(t *testing.T, raw []byte) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "enablement.yaml")
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func enablementSHA(value string) string { return "sha256:" + strings.Repeat(value, 64) }

--- a/internal/submission/plan.go
+++ b/internal/submission/plan.go
@@ -1,6 +1,6 @@
-// Package submission turns an already verified renderer projection into a
-// bounded exact-create plan. It never renders Contract intent and accepts only
-// the resource kinds required by the OK-141 CreateCluster reference path.
+// Package submission turns already verified renderer projections into bounded
+// exact-create plans. It never renders Contract intent. Every projection path
+// has its own explicit resource-kind and authority allow-list.
 package submission
 
 import (


### PR DESCRIPTION
## Outcome

Adds the first offline boundary for OK-147 stage 4 (`enablement`): exactly one externally rendered, immutable `HelmChartProxy` projection.

## Boundary

- binds raw artifact identity, Contract identity, R, E, execution fixture, management authority, and exact HCP identity
- requires immutable OCI/chart/values carriers and continuous bounded Helm semantics
- rejects aliases, multiple objects, status/runtime metadata, mutable chart source/version, and foreign identity
- produces a non-authorizing exact-create plan
- does not render Helm, contact Kubernetes, install CAAPH, submit HCP, or write HRP

## Validation

- `go test -ldflags=-linkmode=external ./...`
- `go vet ./...`
- `go test -race -ldflags=-linkmode=external ./internal/submission`
- `git diff --check`

No live infrastructure access or mutation.
