### PR TITLE
feat(runner): bind enablement stage

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -1166,6 +1166,23 @@ Kubernetes or write a `HelmReleaseProxy`; the latter remains exclusively owned
 by CAAPH. Cursor/grant composition and live exact-create execution are later
 boundaries.
 
+That projection can now be composed with the verified three-receipt prefix,
+the `enablement` resume cursor and one signed `CreateEnablement` grant. The
+bundle requires `stage.enablement` to bind exactly the raw renderer artifact;
+neither a caller nor the operation can replace the HCP after verification.
+
+Opening the bundle binds the management exact-create client and durable ledger
+with two distinct credentials but performs no API request. The resulting typed
+mutator can submit only the one HCP already retained by the bundle. It rejects
+a foreign R, E, fixture, authority, stage input, object kind or mutation
+request. A partial or ambiguous API result produces redacted stopped evidence;
+an exact no-write result cannot claim stage success. Grant claim and completion
+remain crash-safe in the existing staged ledger.
+
+This checkpoint is library composition exercised with in-memory submission
+transports. It adds no CLI command, Job envelope, credential materialization,
+live Kubernetes contact, retry, rollback or cleanup.
+
 ## Typed Contract-to-CAPI submission stages
 
 The existing bounded exact-create submission primitive now has a typed adapter

--- a/internal/execution/enablement_stage.go
+++ b/internal/execution/enablement_stage.go
@@ -1,0 +1,84 @@
+package execution
+
+import (
+	"context"
+	"errors"
+
+	"github.com/openkubes/ok-cluster/internal/contract"
+	"github.com/openkubes/ok-cluster/internal/stageplan"
+	"github.com/openkubes/ok-cluster/internal/submission"
+)
+
+// EnablementMutator is bound to one externally rendered HelmChartProxy and the
+// management writer. It never renders Helm content or writes HelmReleaseProxy.
+type EnablementMutator struct {
+	binding   StageMutationBinding
+	identity  contract.Identity
+	plane     submission.Plane
+	submitter PlaneSubmitter
+}
+
+var _ StageMutator = (*EnablementMutator)(nil)
+
+// NewEnablementMutator binds the fourth stage to its exact non-authorizing
+// projection. Authorization and durable single-use claim remain owned by the
+// surrounding StagedOperation.
+func NewEnablementMutator(plan stageplan.Binding, projected submission.EnablementPlan, submitter PlaneSubmitter) (*EnablementMutator, error) {
+	if submitter == nil {
+		return nil, errors.New("enablement stage requires a bounded plane submitter")
+	}
+	stage, stageDigest, err := plan.Stage("enablement")
+	if err != nil {
+		return nil, err
+	}
+	if projected.Format != submission.EnablementPlanFormat || projected.MutationAllowed || projected.IntentRevision != plan.IntentRevision || projected.EnablementRevision != plan.EnablementRevision || projected.ExecutionFixture != plan.ExecutionFixture {
+		return nil, errors.New("enablement projection differs from the verified staged plan")
+	}
+	if err := plan.RequireInput(stage.ID, "stage.enablement", projected.ArtifactDigest); err != nil {
+		return nil, err
+	}
+	plane := projected.Management
+	if plane.Identity != plan.Authorities.Management || plane.Role != "enablement-desired-state-writer" || len(plane.Objects) != 1 {
+		return nil, errors.New("enablement projection authority or content differs from the selected stage")
+	}
+	object := plane.Objects[0]
+	if object.Identity.APIVersion != "addons.cluster.x-k8s.io/v1alpha1" || object.Identity.Kind != "HelmChartProxy" || object.Identity.Namespace != plan.ContractIdentity.Namespace || len(object.Raw) == 0 {
+		return nil, errors.New("enablement projection lacks the exact HelmChartProxy")
+	}
+	return &EnablementMutator{
+		binding: StageMutationBinding{
+			PlanDigest: plan.PlanDigest, StageID: stage.ID, StageDigest: stageDigest,
+			Operation: stage.GrantOperation, Authority: stage.Authority, ContractRevision: plan.IntentRevision,
+		},
+		identity: plan.ContractIdentity, plane: cloneSubmissionPlane(plane), submitter: submitter,
+	}, nil
+}
+
+func (mutator *EnablementMutator) Binding() StageMutationBinding {
+	if mutator == nil {
+		return StageMutationBinding{}
+	}
+	return mutator.binding
+}
+
+func (mutator *EnablementMutator) Mutate(ctx context.Context, request StageMutationRequest) (StageMutationResult, error) {
+	if mutator == nil || request.StageMutationBinding != mutator.binding || request.ContractIdentity != mutator.identity || request.GrantID == "" || !stagedDigestPattern.MatchString(request.PredecessorDigest) {
+		return StageMutationResult{}, errors.New("enablement mutation request differs from the preconstructed stage")
+	}
+	receipt, submitErr := mutator.submitter.Submit(ctx, cloneSubmissionPlane(mutator.plane))
+	mutationState, err := validateSubmissionPlaneOutcome(receipt, mutator.plane, submitErr != nil)
+	if err != nil {
+		return StageMutationResult{}, err
+	}
+	evidenceDigest, err := canonicalDigest(receipt)
+	if err != nil {
+		return StageMutationResult{}, errors.New("derive bounded enablement evidence")
+	}
+	if submitErr != nil {
+		return StageMutationResult{Outcome: "STOPPED", MutationState: mutationState, EvidenceDigest: evidenceDigest}, errors.New("bounded enablement submission stopped")
+	}
+	if mutationState != "ATTEMPTED" {
+		return StageMutationResult{Outcome: "STOPPED", MutationState: mutationState, EvidenceDigest: evidenceDigest}, nil
+	}
+	return StageMutationResult{Outcome: "SUCCEEDED", MutationState: mutationState, EvidenceDigest: evidenceDigest}, nil
+}

--- a/internal/execution/enablement_stage_test.go
+++ b/internal/execution/enablement_stage_test.go
@@ -1,0 +1,98 @@
+package execution
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/openkubes/ok-cluster/internal/projection"
+	"github.com/openkubes/ok-cluster/internal/submission"
+)
+
+func TestEnablementMutatorBindsOneHCPAndManagementWriter(t *testing.T) {
+	plan := stagedPlan(t)
+	projected := stagedEnablementPlan(plan.Authorities.Management, plan.IntentRevision, plan.EnablementRevision, plan.ExecutionFixture)
+	submitter := &fakePlaneSubmitter{receipt: successfulPlaneReceipt(projected.Management, "CREATED", "ATTEMPTED")}
+	mutator, err := NewEnablementMutator(plan, projected, submitter)
+	if err != nil {
+		t.Fatal(err)
+	}
+	projected.Management.Objects[0].Raw[0] = 'x'
+	result, err := mutator.Mutate(context.Background(), stagedMutationRequest(t, plan, mutator.Binding()))
+	if err != nil || result.Outcome != "SUCCEEDED" || result.MutationState != "ATTEMPTED" || result.EvidenceDigest == "" || submitter.calls != 1 {
+		t.Fatalf("enablement mutation did not complete: %#v calls=%d err=%v", result, submitter.calls, err)
+	}
+	if submitter.plane.Identity != plan.Authorities.Management || submitter.plane.Objects[0].Identity.Kind != "HelmChartProxy" || string(submitter.plane.Objects[0].Raw) != `{"apiVersion":"addons.cluster.x-k8s.io/v1alpha1","kind":"HelmChartProxy"}` {
+		t.Fatalf("mutator did not retain the verified HCP plane: %#v", submitter.plane)
+	}
+}
+
+func TestEnablementMutatorPreservesStoppedEvidence(t *testing.T) {
+	plan := stagedPlan(t)
+	projected := stagedEnablementPlan(plan.Authorities.Management, plan.IntentRevision, plan.EnablementRevision, plan.ExecutionFixture)
+	receipt := successfulPlaneReceipt(projected.Management, "CREATED", "ATTEMPTED")
+	receipt.State = "STOPPED_PARTIAL_OR_UNKNOWN"
+	mutator, err := NewEnablementMutator(plan, projected, &fakePlaneSubmitter{receipt: receipt, err: errors.New("sensitive API detail")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := mutator.Mutate(context.Background(), stagedMutationRequest(t, plan, mutator.Binding()))
+	if err == nil || err.Error() != "bounded enablement submission stopped" || result.Outcome != "STOPPED" || result.MutationState != "ATTEMPTED" || result.EvidenceDigest == "" {
+		t.Fatalf("enablement stop was not redacted and retained: %#v %v", result, err)
+	}
+}
+
+func TestEnablementMutatorRejectsForeignProjectionAndRequest(t *testing.T) {
+	plan := stagedPlan(t)
+	valid := stagedEnablementPlan(plan.Authorities.Management, plan.IntentRevision, plan.EnablementRevision, plan.ExecutionFixture)
+	tests := map[string]func(*submission.EnablementPlan){
+		"authorizing input": func(value *submission.EnablementPlan) { value.MutationAllowed = true },
+		"wrong E":           func(value *submission.EnablementPlan) { value.EnablementRevision = stagedSHA("0") },
+		"wrong artifact":    func(value *submission.EnablementPlan) { value.ArtifactDigest = stagedSHA("0") },
+		"wrong authority":   func(value *submission.EnablementPlan) { value.Management.Identity = plan.Authorities.Infrastructure },
+		"second object": func(value *submission.EnablementPlan) {
+			value.Management.Objects = append(value.Management.Objects, value.Management.Objects[0])
+		},
+		"wrong kind": func(value *submission.EnablementPlan) { value.Management.Objects[0].Identity.Kind = "HelmReleaseProxy" },
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			candidate := cloneEnablementPlan(valid)
+			mutate(&candidate)
+			if _, err := NewEnablementMutator(plan, candidate, &fakePlaneSubmitter{}); err == nil {
+				t.Fatal("foreign enablement projection was accepted")
+			}
+		})
+	}
+	mutator, _ := NewEnablementMutator(plan, valid, &fakePlaneSubmitter{})
+	request := stagedMutationRequest(t, plan, mutator.Binding())
+	request.ContractIdentity.Name = "other"
+	if _, err := mutator.Mutate(context.Background(), request); err == nil {
+		t.Fatal("foreign enablement request was accepted")
+	}
+}
+
+func stagedEnablementPlan(authority, r, e, fixture string) submission.EnablementPlan {
+	object := submission.Object{
+		Identity: projection.ResourceIdentity{APIVersion: "addons.cluster.x-k8s.io/v1alpha1", Kind: "HelmChartProxy", Namespace: "disposable-ok147", Name: "disposable-ok147-cilium"},
+		Digest:   stagedSHA("5"), CollectionPath: "/apis/addons.cluster.x-k8s.io/v1alpha1/namespaces/disposable-ok147/helmchartproxies",
+		ObjectPath: "/apis/addons.cluster.x-k8s.io/v1alpha1/namespaces/disposable-ok147/helmchartproxies/disposable-ok147-cilium",
+		Raw:        json.RawMessage(`{"apiVersion":"addons.cluster.x-k8s.io/v1alpha1","kind":"HelmChartProxy"}`),
+	}
+	return submission.EnablementPlan{
+		Format: submission.EnablementPlanFormat, IntentRevision: r, EnablementRevision: e, ExecutionFixture: fixture,
+		ArtifactDigest: stagedSHA("d"), MutationAllowed: false,
+		Management: submission.Plane{Identity: authority, Role: "enablement-desired-state-writer", Objects: []submission.Object{object}},
+	}
+}
+
+func cloneEnablementPlan(source submission.EnablementPlan) submission.EnablementPlan {
+	clone := source
+	clone.Management.Objects = make([]submission.Object, len(source.Management.Objects))
+	for index, object := range source.Management.Objects {
+		clone.Management.Objects[index] = object
+		clone.Management.Objects[index].Raw = append([]byte(nil), object.Raw...)
+	}
+	return clone
+}

--- a/internal/runner/enablement_stage_bundle.go
+++ b/internal/runner/enablement_stage_bundle.go
@@ -1,0 +1,137 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/authorization"
+	"github.com/openkubes/ok-cluster/internal/execution"
+	"github.com/openkubes/ok-cluster/internal/projection"
+	"github.com/openkubes/ok-cluster/internal/stagecursor"
+	"github.com/openkubes/ok-cluster/internal/stageplan"
+	"github.com/openkubes/ok-cluster/internal/stagereceipt"
+	"github.com/openkubes/ok-cluster/internal/submission"
+)
+
+// EnablementStageBundleConfig binds the complete verified prefix, signed grant
+// and externally rendered HCP artifact. Loading is non-mutating.
+type EnablementStageBundleConfig struct {
+	PlanPath           string
+	PlanExpected       stageplan.Expected
+	Receipts           []StageReceiptSource
+	GrantPath          string
+	GrantPublicKeyPath string
+	EvaluationTime     time.Time
+	ArtifactPath       string
+	ExpectedObject     projection.ResourceIdentity
+}
+
+type VerifiedEnablementStageBundle struct {
+	plan       stageplan.Binding
+	cursor     stagecursor.Cursor
+	grant      authorization.VerifiedStageGrant
+	projection submission.EnablementPlan
+	verified   bool
+}
+
+type BoundEnablementStage struct {
+	operation execution.StagedOperation
+	plan      stageplan.Binding
+	cursor    stagecursor.Cursor
+	grant     authorization.VerifiedStageGrant
+	verified  bool
+}
+
+// LoadEnablementStageBundle verifies the fourth-stage preclaim chain without
+// reading a credential, opening the ledger or contacting Kubernetes.
+func LoadEnablementStageBundle(config EnablementStageBundleConfig) (VerifiedEnablementStageBundle, error) {
+	if config.Receipts == nil {
+		return VerifiedEnablementStageBundle{}, errors.New("enablement receipt prefix must be explicit")
+	}
+	if config.EvaluationTime.IsZero() {
+		return VerifiedEnablementStageBundle{}, errors.New("enablement authorization evaluation time is required")
+	}
+	plan, err := stageplan.Load(config.PlanPath, config.PlanExpected)
+	if err != nil {
+		return VerifiedEnablementStageBundle{}, err
+	}
+	prefix := make([]stagereceipt.Verified, 0, len(config.Receipts))
+	predecessors := []stagereceipt.Verified{}
+	for _, source := range config.Receipts {
+		verified, err := stagereceipt.Load(source.Path, source.Digest, plan, predecessors)
+		if err != nil {
+			return VerifiedEnablementStageBundle{}, err
+		}
+		prefix = append(prefix, verified)
+		predecessors = []stagereceipt.Verified{verified}
+	}
+	cursor, err := stagecursor.Evaluate(plan, prefix)
+	if err != nil {
+		return VerifiedEnablementStageBundle{}, err
+	}
+	decision, err := cursor.Decision()
+	if err != nil {
+		return VerifiedEnablementStageBundle{}, err
+	}
+	if decision.State != "NEXT" || decision.StageID != "enablement" || !decision.RequiresAuthorization || decision.Operation != "CreateEnablement" {
+		return VerifiedEnablementStageBundle{}, errors.New("artifact bundle does not select the enablement stage")
+	}
+	stage, _, err := plan.Stage("enablement")
+	if err != nil {
+		return VerifiedEnablementStageBundle{}, err
+	}
+	if len(stage.Inputs) != 1 || stage.Inputs[0].Name != "stage.enablement" {
+		return VerifiedEnablementStageBundle{}, errors.New("enablement stage must bind exactly one renderer artifact")
+	}
+	projected, err := submission.LoadEnablement(config.ArtifactPath, submission.EnablementExpected{
+		ArtifactDigest: stage.Inputs[0].Digest, ContractIdentity: plan.ContractIdentity,
+		IntentRevision: plan.IntentRevision, EnablementRevision: plan.EnablementRevision,
+		ExecutionFixture: plan.ExecutionFixture, ManagementAuthority: plan.Authorities.Management,
+		ObjectIdentity: config.ExpectedObject,
+	})
+	if err != nil {
+		return VerifiedEnablementStageBundle{}, err
+	}
+	directPredecessors, err := cursor.Predecessors()
+	if err != nil {
+		return VerifiedEnablementStageBundle{}, err
+	}
+	grant, err := authorization.LoadStage(config.GrantPath, config.GrantPublicKeyPath, plan, "enablement", directPredecessors, config.EvaluationTime)
+	if err != nil {
+		return VerifiedEnablementStageBundle{}, err
+	}
+	if _, err := authorization.BindStageGrant(grant, plan, "enablement", directPredecessors); err != nil {
+		return VerifiedEnablementStageBundle{}, err
+	}
+	return VerifiedEnablementStageBundle{plan: plan, cursor: cursor, grant: grant, projection: projected, verified: true}, nil
+}
+
+func (bundle VerifiedEnablementStageBundle) Decision() (stagecursor.Decision, error) {
+	if !bundle.verified {
+		return stagecursor.Decision{}, errors.New("enablement stage bundle was not produced by verification")
+	}
+	return bundle.cursor.Decision()
+}
+
+// Open binds verified artifacts to bounded credentials but performs no API
+// request. The returned operation owns the single-use durable claim.
+func (bundle VerifiedEnablementStageBundle) Open(config SubmissionStageRuntimeConfig) (BoundEnablementStage, error) {
+	if !bundle.verified {
+		return BoundEnablementStage{}, errors.New("enablement stage bundle was not produced by verification")
+	}
+	operation, err := OpenKubernetesEnablementStageOperation(KubernetesEnablementStageOperationConfig{
+		Ledger: config.Ledger, Authority: config.Authority, Plan: bundle.plan, Projection: bundle.projection, Clock: config.Clock,
+	})
+	if err != nil {
+		return BoundEnablementStage{}, err
+	}
+	return BoundEnablementStage{operation: operation, plan: bundle.plan, cursor: bundle.cursor, grant: bundle.grant, verified: true}, nil
+}
+
+func (stage BoundEnablementStage) Run(ctx context.Context) (execution.StagedOperationReceipt, error) {
+	if !stage.verified {
+		return execution.StagedOperationReceipt{}, errors.New("enablement stage runtime was not produced by verification")
+	}
+	return stage.operation.Run(ctx, stage.plan, stage.cursor, stage.grant)
+}

--- a/internal/runner/enablement_stage_bundle_test.go
+++ b/internal/runner/enablement_stage_bundle_test.go
@@ -1,0 +1,168 @@
+package runner
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/projection"
+	"github.com/openkubes/ok-cluster/internal/stageplan"
+	"github.com/openkubes/ok-cluster/internal/stagereceipt"
+)
+
+func TestLoadEnablementStageBundleBindsCursorGrantAndHCP(t *testing.T) {
+	fixture := enablementBundleFixture(t)
+	bundle, err := LoadEnablementStageBundle(fixture.config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decision, err := bundle.Decision()
+	if err != nil || decision.StageID != "enablement" || decision.Operation != "CreateEnablement" || !decision.RequiresAuthorization {
+		t.Fatalf("unexpected enablement decision: %#v %v", decision, err)
+	}
+	bound, err := bundle.Open(submissionBundleRuntime(t, fixture.plan, "cluster-lifecycle"))
+	if err != nil || !bound.verified {
+		t.Fatalf("enablement bundle did not open offline: %#v %v", bound, err)
+	}
+}
+
+func TestLoadEnablementStageBundleFailsClosed(t *testing.T) {
+	fixture := enablementBundleFixture(t)
+	fixture.config.Receipts = nil
+	if _, err := LoadEnablementStageBundle(fixture.config); err == nil {
+		t.Fatal("implicit enablement prefix was accepted")
+	}
+
+	fixture = enablementBundleFixture(t)
+	raw, err := os.ReadFile(fixture.config.ArtifactPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(fixture.config.ArtifactPath, append(raw, '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadEnablementStageBundle(fixture.config); err == nil {
+		t.Fatal("changed enablement artifact was accepted")
+	}
+
+	fixture = enablementBundleFixture(t)
+	fixture.config.ExpectedObject.Name = "other-cilium"
+	if _, err := LoadEnablementStageBundle(fixture.config); err == nil {
+		t.Fatal("foreign enablement object was accepted")
+	}
+
+	if _, err := (VerifiedEnablementStageBundle{}).Open(SubmissionStageRuntimeConfig{}); err == nil {
+		t.Fatal("unverified enablement bundle was opened")
+	}
+}
+
+type enablementBundleTestFixture struct {
+	config EnablementStageBundleConfig
+	plan   stageplan.Binding
+}
+
+func enablementBundleFixture(t *testing.T) enablementBundleTestFixture {
+	t.Helper()
+	root := t.TempDir()
+	at := time.Date(2026, 8, 16, 21, 0, 0, 0, time.UTC)
+	expected := stageplan.Expected{
+		ContractIdentity: runnerStagedPlan(t).ContractIdentity,
+		IntentRevision:   runnerStageSHA("a"), EnablementRevision: runnerStageSHA("b"), PlatformRevision: runnerStageSHA("c"), ExecutionFixture: runnerStageSHA("d"),
+		InfrastructureAuthority: "ok-infra", ManagementAuthority: "ok-mgmt", GitOpsAuthority: "ok-shared",
+	}
+	hcp := runnerEnablementYAML(expected)
+	planRaw := submissionBundlePlan(t, expected, runnerStageSHA("1"), runnerStageSHA("2"))
+	var document map[string]any
+	if err := json.Unmarshal(planRaw, &document); err != nil {
+		t.Fatal(err)
+	}
+	stages := document["stages"].([]any)
+	enablement := stages[3].(map[string]any)
+	enablement["inputs"] = []any{map[string]any{"name": "stage.enablement", "digest": digest.SHA256(hcp)}}
+	planPath := writeBundleFile(t, root, "staged-plan.json", mustJSON(t, document))
+	plan, err := stageplan.Load(planPath, expected)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	receipts := make([]StageReceiptSource, 0, 3)
+	predecessors := []stagereceipt.Verified{}
+	provider, err := stagereceipt.New(plan, "provider-prerequisites", predecessors, "SUCCEEDED", "ATTEMPTED", runnerStageSHA("4"), runnerStageSHA("5"), at.Add(-3*time.Minute))
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipts = appendStageReceipt(t, root, receipts, provider, "provider.json")
+	predecessors = []stagereceipt.Verified{provider}
+	lifecycle, err := stagereceipt.NewWithTargetClusterUIDDigest(plan, "cluster-lifecycle", predecessors, "SUCCEEDED", "ATTEMPTED", runnerStageSHA("6"), runnerStageSHA("7"), runnerStageSHA("8"), at.Add(-2*time.Minute))
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipts = appendStageReceipt(t, root, receipts, lifecycle, "lifecycle.json")
+	predecessors = []stagereceipt.Verified{lifecycle}
+	observed, err := stagereceipt.New(plan, "lifecycle-observation", predecessors, "SUCCEEDED", "NOT_APPLICABLE", "", runnerStageSHA("0"), at.Add(-time.Minute))
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipts = appendStageReceipt(t, root, receipts, observed, "observation.json")
+	grantPath, keyPath := writeSubmissionStageGrant(t, root, plan, "enablement", []stagereceipt.Verified{observed}, at)
+	return enablementBundleTestFixture{
+		config: EnablementStageBundleConfig{
+			PlanPath: planPath, PlanExpected: expected, Receipts: receipts,
+			GrantPath: grantPath, GrantPublicKeyPath: keyPath, EvaluationTime: at,
+			ArtifactPath:   writeBundleFile(t, root, "enablement.yaml", hcp),
+			ExpectedObject: projection.ResourceIdentity{APIVersion: "addons.cluster.x-k8s.io/v1alpha1", Kind: "HelmChartProxy", Namespace: expected.ContractIdentity.Namespace, Name: expected.ContractIdentity.Name + "-cilium"},
+		},
+		plan: plan,
+	}
+}
+
+func appendStageReceipt(t *testing.T, root string, sources []StageReceiptSource, receipt stagereceipt.Verified, name string) []StageReceiptSource {
+	t.Helper()
+	raw, err := receipt.Bytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	receiptDigest, err := receipt.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return append(sources, StageReceiptSource{Path: writeBundleFile(t, root, name, raw), Digest: receiptDigest})
+}
+
+func runnerEnablementYAML(expected stageplan.Expected) []byte {
+	return []byte(`apiVersion: addons.cluster.x-k8s.io/v1alpha1
+kind: HelmChartProxy
+metadata:
+  name: disposable-ok147-cilium
+  namespace: disposable-ok147
+  annotations:
+    openkubes.io/contract-name: disposable-ok147
+    openkubes.io/contract-namespace: disposable-ok147
+    openkubes.io/intent-revision: ` + expected.IntentRevision + `
+    openkubes.io/enablement-revision: ` + expected.EnablementRevision + `
+    openkubes.io/execution-fixture: ` + expected.ExecutionFixture + `
+    openkubes.io/oci-manifest-digest: ` + runnerStageSHA("4") + `
+    openkubes.io/chart-artifact-digest: ` + runnerStageSHA("5") + `
+    openkubes.io/values-digest: ` + runnerStageSHA("6") + `
+    openkubes.io/digest-enforcement: external-evidence-required
+spec:
+  clusterSelector:
+    matchLabels:
+      openkubes.io/type: talos
+  chartName: cilium
+  repoURL: oci://quay.io/cilium/charts
+  releaseName: cilium
+  namespace: kube-system
+  version: 1.19.6
+  reconcileStrategy: Continuous
+  valuesTemplate: |
+    operator:
+      replicas: 1
+  options:
+    atomic: true
+    wait: true
+    waitForJobs: true
+`)
+}

--- a/internal/runner/enablement_stage_operation.go
+++ b/internal/runner/enablement_stage_operation.go
@@ -1,0 +1,48 @@
+package runner
+
+import (
+	"crypto/subtle"
+	"errors"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/execution"
+	"github.com/openkubes/ok-cluster/internal/stageplan"
+	"github.com/openkubes/ok-cluster/internal/submission"
+)
+
+// KubernetesEnablementStageOperationConfig binds the exact HCP submission to
+// the management authority and durable stage ledger.
+type KubernetesEnablementStageOperationConfig struct {
+	Ledger     KubernetesLedgerConfig
+	Authority  KubernetesAuthorityConfig
+	Plan       stageplan.Binding
+	Projection submission.EnablementPlan
+	Clock      func() time.Time
+}
+
+// OpenKubernetesEnablementStageOperation reads bounded credentials and
+// constructs the shared operation without contacting Kubernetes.
+func OpenKubernetesEnablementStageOperation(config KubernetesEnablementStageOperationConfig) (execution.StagedOperation, error) {
+	if config.Clock == nil {
+		return execution.StagedOperation{}, errors.New("enablement operation clock is required")
+	}
+	if config.Authority.AuthorityIdentity != config.Plan.Authorities.Management {
+		return execution.StagedOperation{}, errors.New("enablement credential authority differs from management")
+	}
+	store, ledgerToken, err := openKubernetesLedger(config.Ledger)
+	if err != nil {
+		return execution.StagedOperation{}, errors.New("open enablement stage ledger")
+	}
+	submitter, authorityToken, err := openKubernetesSubmissionClient(config.Authority)
+	if err != nil {
+		return execution.StagedOperation{}, errors.New("open enablement submission authority")
+	}
+	if len(ledgerToken) == len(authorityToken) && subtle.ConstantTimeCompare([]byte(ledgerToken), []byte(authorityToken)) == 1 {
+		return execution.StagedOperation{}, errors.New("ledger and enablement credentials must be distinct")
+	}
+	mutator, err := execution.NewEnablementMutator(config.Plan, config.Projection, submitter)
+	if err != nil {
+		return execution.StagedOperation{}, err
+	}
+	return execution.StagedOperation{Ledger: store, Mutator: mutator, Clock: config.Clock}, nil
+}

--- a/internal/runner/enablement_stage_operation_test.go
+++ b/internal/runner/enablement_stage_operation_test.go
@@ -1,0 +1,96 @@
+package runner
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/projection"
+	"github.com/openkubes/ok-cluster/internal/stageplan"
+	"github.com/openkubes/ok-cluster/internal/submission"
+)
+
+func TestOpenKubernetesEnablementStageOperationBindsManagement(t *testing.T) {
+	plan := runnerStagedPlan(t)
+	config := runnerEnablementOperationConfig(t, plan)
+	operation, err := OpenKubernetesEnablementStageOperation(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if operation.Ledger == nil || operation.Mutator == nil || operation.Clock == nil {
+		t.Fatalf("incomplete enablement operation: %#v", operation)
+	}
+	binding := operation.Mutator.Binding()
+	if binding.StageID != "enablement" || binding.Operation != "CreateEnablement" || binding.PlanDigest != plan.PlanDigest {
+		t.Fatalf("operation bound a different stage: %#v", binding)
+	}
+}
+
+func TestOpenKubernetesEnablementStageOperationRejectsForeignInputs(t *testing.T) {
+	plan := runnerStagedPlan(t)
+	config := runnerEnablementOperationConfig(t, plan)
+	config.Authority.AuthorityIdentity = plan.Authorities.Infrastructure
+	if _, err := OpenKubernetesEnablementStageOperation(config); err == nil {
+		t.Fatal("foreign enablement authority was accepted")
+	}
+
+	config = runnerEnablementOperationConfig(t, plan)
+	ledgerToken, err := os.ReadFile(config.Ledger.TokenFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(config.Authority.TokenFile, ledgerToken, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := OpenKubernetesEnablementStageOperation(config); err == nil {
+		t.Fatal("shared ledger and enablement credential was accepted")
+	}
+
+	config = runnerEnablementOperationConfig(t, plan)
+	config.Projection.EnablementRevision = runnerStageSHA("0")
+	if _, err := OpenKubernetesEnablementStageOperation(config); err == nil {
+		t.Fatal("foreign enablement projection was accepted")
+	}
+
+	config = runnerEnablementOperationConfig(t, plan)
+	config.Clock = nil
+	if _, err := OpenKubernetesEnablementStageOperation(config); err == nil {
+		t.Fatal("missing enablement clock was accepted")
+	}
+}
+
+func runnerEnablementOperationConfig(t *testing.T, plan stageplan.Binding) KubernetesEnablementStageOperationConfig {
+	t.Helper()
+	root := t.TempDir()
+	caPath := filepath.Join(root, "ca.crt")
+	ledgerToken := filepath.Join(root, "ledger-token")
+	authorityToken := filepath.Join(root, "authority-token")
+	for path, value := range map[string][]byte{
+		caPath: testCA(t), ledgerToken: []byte("short-lived-ledger-token"), authorityToken: []byte("short-lived-enablement-token"),
+	} {
+		if err := os.WriteFile(path, value, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return KubernetesEnablementStageOperationConfig{
+		Ledger:    KubernetesLedgerConfig{Endpoint: "https://192.0.2.12:6443", Namespace: "openkubes-execution-system", TokenFile: ledgerToken, CAFile: caPath},
+		Authority: KubernetesAuthorityConfig{Endpoint: "https://192.0.2.12:6443", AuthorityIdentity: plan.Authorities.Management, TokenFile: authorityToken, CAFile: caPath},
+		Plan:      plan, Projection: runnerEnablementPlan(plan), Clock: func() time.Time { return time.Date(2026, 8, 16, 21, 0, 0, 0, time.UTC) },
+	}
+}
+
+func runnerEnablementPlan(plan stageplan.Binding) submission.EnablementPlan {
+	object := submission.Object{
+		Identity: projection.ResourceIdentity{APIVersion: "addons.cluster.x-k8s.io/v1alpha1", Kind: "HelmChartProxy", Namespace: plan.ContractIdentity.Namespace, Name: plan.ContractIdentity.Name + "-cilium"},
+		Digest:   runnerStageSHA("5"), CollectionPath: "/apis/addons.cluster.x-k8s.io/v1alpha1/namespaces/" + plan.ContractIdentity.Namespace + "/helmchartproxies",
+		ObjectPath: "/apis/addons.cluster.x-k8s.io/v1alpha1/namespaces/" + plan.ContractIdentity.Namespace + "/helmchartproxies/" + plan.ContractIdentity.Name + "-cilium",
+		Raw:        json.RawMessage(`{"apiVersion":"addons.cluster.x-k8s.io/v1alpha1","kind":"HelmChartProxy"}`),
+	}
+	return submission.EnablementPlan{
+		Format: submission.EnablementPlanFormat, IntentRevision: plan.IntentRevision, EnablementRevision: plan.EnablementRevision, ExecutionFixture: plan.ExecutionFixture,
+		ArtifactDigest: runnerStageSHA("d"), MutationAllowed: false,
+		Management: submission.Plane{Identity: plan.Authorities.Management, Role: "enablement-desired-state-writer", Objects: []submission.Object{object}},
+	}
+}


### PR DESCRIPTION
## Outcome

Binds OK-147 stage 4 (`enablement`) to the verified receipt cursor, one signed `CreateEnablement` grant, the immutable HCP projection, the management exact-create client, and the durable single-use ledger.

## Boundary

- requires the exact three-stage successful prefix
- requires one `stage.enablement` artifact and one HCP
- retains the externally rendered object after verification
- uses distinct ledger and management-writer credentials
- preserves redacted stopped evidence for partial/ambiguous submission
- never renders Helm or writes HelmReleaseProxy

Library composition only: no CLI, Job, live credentials, cluster contact, retry, rollback, or cleanup.

## Validation

- `go test -ldflags=-linkmode=external ./...`
- `go vet ./...`
- `go test -race -ldflags=-linkmode=external ./internal/execution ./internal/runner ./internal/submission`
- `git diff --check`
