### PR TITLE
feat(runner): package enablement stage input

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -1183,6 +1183,17 @@ This checkpoint is library composition exercised with in-memory submission
 transports. It adds no CLI command, Job envelope, credential materialization,
 live Kubernetes contact, retry, rollback or cleanup.
 
+The complete public preclaim chain can also be snapshotted into one immutable
+`ok147-enablement-stage-input/v1` ConfigMap. It contains only the staged plan,
+canonical three-receipt prefix, three receipt files, signed grant, public key
+and exact HCP artifact. It deliberately excludes tokens, CA bundles,
+kubeconfigs and the unrelated Contract-to-CAPI projection artifacts.
+
+Materialization verifies the bundle both before and after every bounded source
+read, rejects symlinks and non-text input, and emits only artifact and ConfigMap
+digests. It remains an offline input package: no NetworkPolicy, Job, credential
+Secret or live launch exists at this checkpoint.
+
 ## Typed Contract-to-CAPI submission stages
 
 The existing bounded exact-create submission primitive now has a typed adapter

--- a/internal/runner/enablement_stage_input.go
+++ b/internal/runner/enablement_stage_input.go
@@ -1,0 +1,125 @@
+package runner
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"sort"
+	"unicode/utf8"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+const EnablementStageInputFormat = "ok147-enablement-stage-input/v1"
+
+// EnablementStageInputReceipt exposes only the immutable public input
+// identities. The ConfigMap contains no credential or authorization decision.
+type EnablementStageInputReceipt struct {
+	Format              string   `json:"format"`
+	State               string   `json:"state"`
+	StageID             string   `json:"stageId"`
+	ConfigMapName       string   `json:"configMapName"`
+	ConfigMapDigest     string   `json:"configMapDigest"`
+	ReceiptPrefixDigest string   `json:"receiptPrefixDigest"`
+	EnablementDigest    string   `json:"enablementDigest"`
+	DataKeys            []string `json:"dataKeys"`
+}
+
+type VerifiedEnablementStageInput struct {
+	raw      []byte
+	receipt  EnablementStageInputReceipt
+	verified bool
+}
+
+// BuildEnablementStageInput snapshots the already verified fourth-stage
+// artifact chain into one immutable ConfigMap. It performs no API request.
+func BuildEnablementStageInput(config EnablementStageBundleConfig, configMapName string) (VerifiedEnablementStageInput, error) {
+	if !submissionStageInputNamePattern.MatchString(configMapName) || len(configMapName) > 63 || len(configMapName) < len("ok147-") || configMapName[:len("ok147-")] != "ok147-" {
+		return VerifiedEnablementStageInput{}, errors.New("enablement stage input ConfigMap name is invalid")
+	}
+	if len(config.Receipts) != 3 {
+		return VerifiedEnablementStageInput{}, errors.New("enablement stage input requires exactly three predecessor receipts")
+	}
+	if _, err := LoadEnablementStageBundle(config); err != nil {
+		return VerifiedEnablementStageInput{}, err
+	}
+
+	prefix := stageReceiptPrefixDocument{Format: StageReceiptPrefixFormat, Receipts: []stageReceiptPrefixEntry{
+		{File: "provider-receipt.json", Digest: config.Receipts[0].Digest},
+		{File: "lifecycle-receipt.json", Digest: config.Receipts[1].Digest},
+		{File: "lifecycle-observation-receipt.json", Digest: config.Receipts[2].Digest},
+	}}
+	prefixRaw, err := json.Marshal(prefix)
+	if err != nil {
+		return VerifiedEnablementStageInput{}, errors.New("encode enablement receipt prefix")
+	}
+	paths := map[string]string{
+		"staged-plan.json": config.PlanPath, "stage-grant.json": config.GrantPath,
+		"stage-authority.pub": config.GrantPublicKeyPath, "enablement.yaml": config.ArtifactPath,
+		"provider-receipt.json": config.Receipts[0].Path, "lifecycle-receipt.json": config.Receipts[1].Path,
+		"lifecycle-observation-receipt.json": config.Receipts[2].Path,
+	}
+	data := make(map[string]string, len(paths)+1)
+	data["receipt-prefix.json"] = string(prefixRaw)
+	for key, path := range paths {
+		raw, err := readBoundedRegular(path, maximumSubmissionStageInputBytes)
+		if err != nil {
+			return VerifiedEnablementStageInput{}, errors.New("read bounded enablement stage input " + key)
+		}
+		if !utf8.Valid(raw) || bytes.IndexByte(raw, 0) >= 0 {
+			return VerifiedEnablementStageInput{}, errors.New("enablement stage input is not valid ConfigMap text")
+		}
+		data[key] = string(raw)
+	}
+	if _, err := LoadEnablementStageBundle(config); err != nil {
+		return VerifiedEnablementStageInput{}, errors.New("enablement stage inputs changed during materialization")
+	}
+
+	configMap := submissionStageInputConfigMap{
+		APIVersion: "v1", Kind: "ConfigMap",
+		Metadata: submissionStageInputObjectMeta{
+			Name: configMapName, Namespace: submissionStageInputNamespace,
+			Labels: map[string]string{"app.kubernetes.io/name": "ok-cluster-contract-executor", "openkubes.io/stage-id": "enablement"},
+			Annotations: map[string]string{
+				"openkubes.io/input-format": EnablementStageInputFormat, "openkubes.io/receipt-prefix-digest": digest.SHA256(prefixRaw),
+			},
+		},
+		Immutable: true, Data: data,
+	}
+	raw, err := json.Marshal(configMap)
+	if err != nil {
+		return VerifiedEnablementStageInput{}, errors.New("encode enablement stage input ConfigMap")
+	}
+	if len(raw) > maximumSubmissionStageInputBytes {
+		return VerifiedEnablementStageInput{}, errors.New("enablement stage input ConfigMap exceeds size limit")
+	}
+	keys := make([]string, 0, len(data))
+	for key := range data {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return VerifiedEnablementStageInput{
+		raw: raw,
+		receipt: EnablementStageInputReceipt{
+			Format: EnablementStageInputFormat, State: "VERIFIED", StageID: "enablement", ConfigMapName: configMapName,
+			ConfigMapDigest: digest.SHA256(raw), ReceiptPrefixDigest: digest.SHA256(prefixRaw), EnablementDigest: digest.SHA256([]byte(data["enablement.yaml"])), DataKeys: keys,
+		},
+		verified: true,
+	}, nil
+}
+
+func (input VerifiedEnablementStageInput) Bytes() ([]byte, error) {
+	if !input.verified || len(input.raw) == 0 {
+		return nil, errors.New("enablement stage input was not produced by verification")
+	}
+	return append([]byte(nil), input.raw...), nil
+}
+
+func (input VerifiedEnablementStageInput) Receipt() (EnablementStageInputReceipt, error) {
+	if !input.verified || input.receipt.State != "VERIFIED" {
+		return EnablementStageInputReceipt{}, errors.New("enablement stage input was not produced by verification")
+	}
+	receipt := input.receipt
+	receipt.DataKeys = append([]string(nil), input.receipt.DataKeys...)
+	return receipt, nil
+}

--- a/internal/runner/enablement_stage_input_test.go
+++ b/internal/runner/enablement_stage_input_test.go
@@ -1,0 +1,62 @@
+package runner
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+func TestBuildEnablementStageInputCapturesOnlyPublicBoundArtifacts(t *testing.T) {
+	fixture := enablementBundleFixture(t)
+	input, err := BuildEnablementStageInput(fixture.config, "ok147-enablement-input")
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := input.Bytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := input.Receipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if receipt.Format != EnablementStageInputFormat || receipt.State != "VERIFIED" || receipt.StageID != "enablement" || receipt.ConfigMapDigest != digest.SHA256(raw) || receipt.EnablementDigest == "" || len(receipt.DataKeys) != 8 {
+		t.Fatalf("unexpected enablement input receipt: %#v", receipt)
+	}
+	var object submissionStageInputConfigMap
+	if err := json.Unmarshal(raw, &object); err != nil {
+		t.Fatal(err)
+	}
+	if !object.Immutable || object.Metadata.Namespace != submissionStageInputNamespace || object.Metadata.Labels["openkubes.io/stage-id"] != "enablement" || len(object.Data) != 8 {
+		t.Fatalf("unexpected enablement ConfigMap: %#v", object)
+	}
+	for _, forbidden := range []string{"token", "ca.crt", "kubeconfig", "projection-manifest.json", "authority-map.json", "ok-mgmt-lifecycle.yaml"} {
+		if _, exists := object.Data[forbidden]; exists {
+			t.Fatalf("private or foreign input %q was packaged", forbidden)
+		}
+	}
+}
+
+func TestBuildEnablementStageInputFailsClosed(t *testing.T) {
+	fixture := enablementBundleFixture(t)
+	if _, err := BuildEnablementStageInput(fixture.config, "not-ok147"); err == nil {
+		t.Fatal("foreign ConfigMap name was accepted")
+	}
+	fixture = enablementBundleFixture(t)
+	fixture.config.Receipts = fixture.config.Receipts[:2]
+	if _, err := BuildEnablementStageInput(fixture.config, "ok147-enablement-input"); err == nil {
+		t.Fatal("incomplete receipt prefix was accepted")
+	}
+	fixture = enablementBundleFixture(t)
+	if err := os.WriteFile(fixture.config.ArtifactPath, []byte("changed"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := BuildEnablementStageInput(fixture.config, "ok147-enablement-input"); err == nil {
+		t.Fatal("changed HCP input was accepted")
+	}
+	if _, err := (VerifiedEnablementStageInput{}).Bytes(); err == nil {
+		t.Fatal("unverified enablement input exposed bytes")
+	}
+}


### PR DESCRIPTION
## Outcome

Packages the verified OK-147 enablement preclaim chain into one immutable, credential-free ConfigMap.

## Contents

- staged plan and canonical receipt-prefix manifest
- provider, lifecycle, and lifecycle-observation receipts
- signed stage grant and public key
- exact externally rendered HelmChartProxy

Tokens, CA bundles, kubeconfigs, CAPI projection artifacts, and credentials are excluded.

## Validation

- `go test -ldflags=-linkmode=external ./...`
- `go vet ./...`
- `go test -race -ldflags=-linkmode=external ./internal/runner`
- `git diff --check`

Offline only; no Job, Secret, API contact, or mutation.
