### PR TITLE
feat(ok): run bounded enablement stage

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,11 @@ Powered by [Cluster API (CAPI)](https://cluster-api.sigs.k8s.io/), [CAPK (KubeVi
   an expiry-bound installer candidate. Only `observe lifecycle launch execute`
   can open the installer credential and run the single-use six-object
   exact-create launcher; it requires the separately copied candidate digest
-  and explicit `--execute`.
+  and explicit `--execute`. Stage 4 now has its first distinct path as well:
+  `ok cluster stage run enablement --execute` binds the verified three-receipt
+  prefix and signed `CreateEnablement` grant to exactly one externally rendered
+  `HelmChartProxy`; it neither renders Helm nor writes the controller-owned
+  `HelmReleaseProxy`.
 
 ---
 

--- a/cmd/ok/main.go
+++ b/cmd/ok/main.go
@@ -400,6 +400,18 @@ var executeSubmissionStage = func(ctx context.Context, bundleConfig runner.Submi
 	return bound.Run(ctx)
 }
 
+var executeEnablementStage = func(ctx context.Context, bundleConfig runner.EnablementStageBundleConfig, runtimeConfig runner.SubmissionStageRuntimeConfig) (execution.StagedOperationReceipt, error) {
+	bundle, err := runner.LoadEnablementStageBundle(bundleConfig)
+	if err != nil {
+		return execution.StagedOperationReceipt{}, err
+	}
+	bound, err := bundle.Open(runtimeConfig)
+	if err != nil {
+		return execution.StagedOperationReceipt{}, err
+	}
+	return bound.Run(ctx)
+}
+
 var executeLifecycleObservationStage = func(ctx context.Context, bundleConfig runner.StageResumeConfig, runtimeConfig runner.LifecycleObservationStageRuntimeConfig) (execution.ObservationStageRunReceipt, error) {
 	bundle, err := runner.LoadLifecycleObservationStageBundle(bundleConfig)
 	if err != nil {
@@ -463,6 +475,9 @@ func runContext(ctx context.Context, arguments []string, stdout, stderr io.Write
 	if len(arguments) >= 4 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "observe" && arguments[3] == "lifecycle" {
 		return runClusterStageObserveLifecycle(ctx, arguments[4:], stdout, stderr)
 	}
+	if len(arguments) >= 4 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "run" && arguments[3] == "enablement" {
+		return runClusterStageRunEnablement(ctx, arguments[4:], stdout, stderr)
+	}
 	if len(arguments) >= 3 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "run" {
 		return runClusterStageRun(ctx, arguments[3:], stdout, stderr)
 	}
@@ -475,7 +490,7 @@ func runContext(ctx context.Context, arguments []string, stdout, stderr io.Write
 	if len(arguments) >= 4 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "launch" && arguments[3] == "execute" {
 		return runClusterStageLaunchExecute(ctx, arguments[4:], stdout, stderr)
 	}
-	return errors.New("usage: ok cluster create ... | ok cluster stage inspect ... | ok cluster stage resume ... | ok cluster stage observe lifecycle ... | ok cluster stage observe lifecycle package ... | ok cluster stage observe lifecycle launch prepare ... | ok cluster stage observe lifecycle launch execute ... | ok cluster stage run ... | ok cluster stage package ... | ok cluster stage launch prepare ... | ok cluster stage launch execute ...")
+	return errors.New("usage: ok cluster create ... | ok cluster stage inspect ... | ok cluster stage resume ... | ok cluster stage observe lifecycle ... | ok cluster stage observe lifecycle package ... | ok cluster stage observe lifecycle launch prepare ... | ok cluster stage observe lifecycle launch execute ... | ok cluster stage run ... | ok cluster stage run enablement ... | ok cluster stage package ... | ok cluster stage launch prepare ... | ok cluster stage launch execute ...")
 }
 
 func runClusterCreate(arguments []string, stdout, stderr io.Writer) error {
@@ -998,6 +1013,78 @@ func runClusterStageRun(ctx context.Context, arguments []string, stdout, stderr 
 		},
 		Authority: runner.KubernetesAuthorityConfig{
 			Endpoint: *authorityAPIEndpoint, TokenFile: *authorityTokenFile, CAFile: *authorityCAFile,
+		},
+		Clock: func() time.Time { return time.Now().UTC() },
+	})
+	if receipt.Format != "" {
+		encoder := json.NewEncoder(stdout)
+		encoder.SetEscapeHTML(false)
+		encoder.SetIndent("", "  ")
+		if err := encoder.Encode(receipt); err != nil {
+			return err
+		}
+	}
+	return runErr
+}
+
+func runClusterStageRunEnablement(ctx context.Context, arguments []string, stdout, stderr io.Writer) error {
+	flags := flag.NewFlagSet("ok cluster stage run enablement", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	resumeFlags := addStageResumeFlags(flags)
+	grantPath := flags.String("grant", "", "path to the signed single-stage grant")
+	grantKeyPath := flags.String("grant-key", "", "path to the trusted stage-authority public key")
+	evaluationTime := flags.String("evaluation-time", "", "explicit RFC3339 grant evaluation time")
+	artifactPath := flags.String("enablement-artifact", "", "path to the exact externally rendered HelmChartProxy")
+	objectName := flags.String("helmchartproxy-name", "", "independently expected HelmChartProxy name")
+	execute := flags.Bool("execute", false, "claim and execute exactly the selected enablement stage")
+	ledgerAPIEndpoint := flags.String("ledger-api-endpoint", "", "TLS Kubernetes API endpoint for the durable ledger")
+	ledgerTokenFile := flags.String("ledger-token-file", "", "path to the short-lived ledger token")
+	ledgerCAFile := flags.String("ledger-ca-file", "", "path to the ledger Kubernetes API CA bundle")
+	managementAPIEndpoint := flags.String("management-api-endpoint", "", "TLS Kubernetes API endpoint for the management writer")
+	managementTokenFile := flags.String("management-token-file", "", "path to the short-lived management writer token")
+	managementCAFile := flags.String("management-ca-file", "", "path to the management Kubernetes API CA bundle")
+	if err := flags.Parse(arguments); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return errors.New("positional arguments are not accepted")
+	}
+	if !*execute {
+		return errors.New("enablement mutation requires explicit --execute")
+	}
+	resume, err := resumeFlags.config()
+	if err != nil {
+		return err
+	}
+	for _, input := range []struct{ name, value string }{
+		{"--grant", *grantPath}, {"--grant-key", *grantKeyPath}, {"--evaluation-time", *evaluationTime},
+		{"--enablement-artifact", *artifactPath}, {"--helmchartproxy-name", *objectName},
+		{"--ledger-api-endpoint", *ledgerAPIEndpoint}, {"--ledger-token-file", *ledgerTokenFile}, {"--ledger-ca-file", *ledgerCAFile},
+		{"--management-api-endpoint", *managementAPIEndpoint}, {"--management-token-file", *managementTokenFile}, {"--management-ca-file", *managementCAFile},
+	} {
+		if input.value == "" {
+			return fmt.Errorf("%s is required", input.name)
+		}
+	}
+	at, err := time.Parse(time.RFC3339, *evaluationTime)
+	if err != nil {
+		return fmt.Errorf("parse evaluation time: %w", err)
+	}
+	bundleConfig := runner.EnablementStageBundleConfig{
+		PlanPath: resume.PlanPath, PlanExpected: resume.PlanExpected, Receipts: resume.Receipts,
+		GrantPath: *grantPath, GrantPublicKeyPath: *grantKeyPath, EvaluationTime: at, ArtifactPath: *artifactPath,
+		ExpectedObject: projection.ResourceIdentity{
+			APIVersion: "addons.cluster.x-k8s.io/v1alpha1", Kind: "HelmChartProxy",
+			Namespace: resume.PlanExpected.ContractIdentity.Namespace, Name: *objectName,
+		},
+	}
+	boundedContext, cancel := context.WithTimeout(ctx, stageRunTimeout)
+	defer cancel()
+	receipt, runErr := executeEnablementStage(boundedContext, bundleConfig, runner.SubmissionStageRuntimeConfig{
+		Ledger: runner.KubernetesLedgerConfig{Endpoint: *ledgerAPIEndpoint, Namespace: ledgerNamespace, TokenFile: *ledgerTokenFile, CAFile: *ledgerCAFile},
+		Authority: runner.KubernetesAuthorityConfig{
+			Endpoint: *managementAPIEndpoint, AuthorityIdentity: resume.PlanExpected.ManagementAuthority,
+			TokenFile: *managementTokenFile, CAFile: *managementCAFile,
 		},
 		Clock: func() time.Time { return time.Now().UTC() },
 	})

--- a/cmd/ok/main_test.go
+++ b/cmd/ok/main_test.go
@@ -482,6 +482,65 @@ func TestStageRunFailsClosedBeforeExecution(t *testing.T) {
 	}
 }
 
+func TestEnablementStageRunBindsExactHCPAndManagementRuntime(t *testing.T) {
+	previous := executeEnablementStage
+	defer func() { executeEnablementStage = previous }()
+	var calls int
+	executeEnablementStage = func(ctx context.Context, bundle runner.EnablementStageBundleConfig, runtime runner.SubmissionStageRuntimeConfig) (execution.StagedOperationReceipt, error) {
+		calls++
+		deadline, bounded := ctx.Deadline()
+		if !bounded || time.Until(deadline) > stageRunTimeout || time.Until(deadline) < stageRunTimeout-time.Minute {
+			t.Fatalf("enablement context is not bounded: %s %t", deadline, bounded)
+		}
+		if bundle.PlanPath != "/tmp/plan.json" || len(bundle.Receipts) != 3 || bundle.ArtifactPath != "/tmp/enablement.yaml" || bundle.ExpectedObject.Kind != "HelmChartProxy" || bundle.ExpectedObject.Name != "disposable-ok147-cilium" || bundle.ExpectedObject.Namespace != "disposable-ok147" {
+			t.Fatalf("enablement bundle differs: %#v", bundle)
+		}
+		if runtime.Ledger.Namespace != ledgerNamespace || runtime.Authority.AuthorityIdentity != "ok-mgmt" || runtime.Authority.TokenFile != "/tmp/management-token" || runtime.Clock == nil {
+			t.Fatalf("enablement runtime differs: %#v", runtime)
+		}
+		return execution.StagedOperationReceipt{Format: execution.StagedReceiptFormat, State: "COMPLETED_SUCCEEDED", StageID: "enablement", StageReceiptDigest: testSHA("8")}, nil
+	}
+	var stdout, stderr bytes.Buffer
+	if err := run(enablementStageRunArguments(), &stdout, &stderr); err != nil {
+		t.Fatalf("run: %v; stderr=%s", err, stderr.String())
+	}
+	if calls != 1 {
+		t.Fatalf("enablement runner calls = %d", calls)
+	}
+	var receipt execution.StagedOperationReceipt
+	if err := json.Unmarshal(stdout.Bytes(), &receipt); err != nil || receipt.StageID != "enablement" {
+		t.Fatalf("unexpected enablement receipt: %#v %v", receipt, err)
+	}
+}
+
+func TestEnablementStageRunFailsClosedBeforeExecution(t *testing.T) {
+	previous := executeEnablementStage
+	defer func() { executeEnablementStage = previous }()
+	calls := 0
+	executeEnablementStage = func(context.Context, runner.EnablementStageBundleConfig, runner.SubmissionStageRuntimeConfig) (execution.StagedOperationReceipt, error) {
+		calls++
+		return execution.StagedOperationReceipt{}, nil
+	}
+	valid := enablementStageRunArguments()
+	for name, arguments := range map[string][]string{
+		"missing execute":    removeArgument(valid, "--execute"),
+		"missing artifact":   removeArgumentWithValue(valid, "--enablement-artifact"),
+		"missing credential": removeArgumentWithValue(valid, "--management-token-file"),
+		"invalid time":       replaceArgument(valid, "--evaluation-time", "not-time"),
+		"positional":         append(append([]string{}, valid...), "unexpected"),
+	} {
+		t.Run(name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			if err := run(arguments, &stdout, &stderr); err == nil || stdout.Len() != 0 {
+				t.Fatalf("unsafe enablement run was accepted: %v %s", err, stdout.String())
+			}
+		})
+	}
+	if calls != 0 {
+		t.Fatalf("enablement runner reached %d times for invalid input", calls)
+	}
+}
+
 func TestSubmissionStageAuthorityIsDerivedFromVerifiedTopology(t *testing.T) {
 	expected := stageplan.Expected{InfrastructureAuthority: "ok-infra", ManagementAuthority: "ok-mgmt"}
 	for symbolic, want := range map[string]string{"infrastructure": "ok-infra", "management": "ok-mgmt"} {
@@ -899,6 +958,22 @@ func stageRunArguments() []string {
 		"--execute",
 		"--ledger-api-endpoint", "https://192.0.2.12:6443", "--ledger-token-file", "/tmp/ledger-token", "--ledger-ca-file", "/tmp/ledger-ca",
 		"--authority-api-endpoint", "https://192.0.2.11:6443", "--authority-token-file", "/tmp/authority-token", "--authority-ca-file", "/tmp/authority-ca",
+	)
+}
+
+func enablementStageRunArguments() []string {
+	resume := stageResumeArguments()
+	arguments := append([]string{"cluster", "stage", "run", "enablement"}, resume[3:]...)
+	return append(arguments,
+		"--receipt", "/tmp/provider.json@"+testSHA("1"),
+		"--receipt", "/tmp/lifecycle.json@"+testSHA("2"),
+		"--receipt", "/tmp/lifecycle-observation.json@"+testSHA("3"),
+		"--grant", "/tmp/enablement-grant.json", "--grant-key", "/tmp/enablement-grant.pub",
+		"--evaluation-time", "2026-08-16T21:00:00Z",
+		"--enablement-artifact", "/tmp/enablement.yaml", "--helmchartproxy-name", "disposable-ok147-cilium",
+		"--execute",
+		"--ledger-api-endpoint", "https://192.0.2.12:6443", "--ledger-token-file", "/tmp/ledger-token", "--ledger-ca-file", "/tmp/ledger-ca",
+		"--management-api-endpoint", "https://192.0.2.12:6443", "--management-token-file", "/tmp/management-token", "--management-ca-file", "/tmp/management-ca",
 	)
 }
 

--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -1194,6 +1194,27 @@ read, rejects symlinks and non-text input, and emits only artifact and ConfigMap
 digests. It remains an offline input package: no NetworkPolicy, Job, credential
 Secret or live launch exists at this checkpoint.
 
+The local binary can now activate the same typed boundary directly:
+
+```text
+ok cluster stage run enablement --execute
+  + exact plan and three-receipt prefix
+  + signed CreateEnablement grant and public key
+  + exact HCP artifact and independently expected name
+  + distinct short-lived ledger and management-writer credentials
+      -> durable single-use claim
+      -> at most one exact HCP create
+      -> immutable outcome and stage receipt
+```
+
+The command has a fixed ten-minute outer deadline. It derives the namespace,
+R, E, fixture and management authority from independently supplied plan
+expectations; the caller can choose neither another API kind nor a
+`HelmReleaseProxy`. Missing `--execute`, incomplete receipt or credential
+inputs, a malformed evaluation time or positional input fail before bundle
+execution. This CLI does not package or launch a Job and adds no retry,
+rollback or cleanup.
+
 ## Typed Contract-to-CAPI submission stages
 
 The existing bounded exact-create submission primitive now has a typed adapter


### PR DESCRIPTION
## Outcome

Expose the typed Stage 4 boundary as `ok cluster stage run enablement --execute`.

The command binds:

- the verified three-receipt prefix;
- a signed `CreateEnablement` grant;
- one externally rendered, independently named `HelmChartProxy`;
- distinct short-lived ledger and management-writer credentials; and
- a fixed ten-minute execution deadline.

## Ownership boundary

The CLI neither renders Helm nor writes `HelmReleaseProxy`. CAAPH retains release convergence ownership. This checkpoint adds no Job, live launch, retry, rollback, cleanup, infrastructure mutation, or public API.

## Fail-closed behavior

Missing `--execute`, incomplete artifact or credential inputs, malformed evaluation time, and positional input fail before the execution bundle is opened.

## Validation

- `GOCACHE=/private/tmp/ok147-go-build-cache go test -ldflags=-linkmode=external ./...`
- `GOCACHE=/private/tmp/ok147-go-build-cache go vet ./...`
- `GOCACHE=/private/tmp/ok147-go-build-cache go test -race -ldflags=-linkmode=external ./cmd/ok ./internal/execution ./internal/runner ./internal/submission`
- `git diff --check`

No live infrastructure action was performed.
