### PR TITLE
feat(runner): package enablement stage job

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,9 @@ Powered by [Cluster API (CAPI)](https://cluster-api.sigs.k8s.io/), [CAPK (KubeVi
   `ok cluster stage run enablement --execute` binds the verified three-receipt
   prefix and signed `CreateEnablement` grant to exactly one externally rendered
   `HelmChartProxy`; it neither renders Helm nor writes the controller-owned
-  `HelmReleaseProxy`.
+  `HelmReleaseProxy`. A distinct offline package now composes the immutable
+  eight-key input ConfigMap with a tokenless, non-retrying Job and a deny-all
+  NetworkPolicy that permits only the exact management API endpoint.
 
 ---
 

--- a/deploy/contract-executor-enablement-job.yaml.tpl
+++ b/deploy/contract-executor-enablement-job.yaml.tpl
@@ -1,0 +1,161 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: "${OK147_RUN_ID}"
+  namespace: openkubes-execution-system
+spec:
+  podSelector:
+    matchLabels:
+      openkubes.io/execution-id: "${OK147_RUN_ID}"
+  policyTypes: ["Ingress", "Egress"]
+  ingress: []
+  egress:
+    - to: [{ipBlock: {cidr: "${OK147_LEDGER_API_CIDR}"}}]
+      ports: [{protocol: TCP, port: ${OK147_LEDGER_API_PORT}}]
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "${OK147_RUN_ID}"
+  namespace: openkubes-execution-system
+  annotations:
+    openkubes.io/receipt-prefix-digest: "${OK147_RECEIPT_PREFIX_DIGEST}"
+  labels:
+    app.kubernetes.io/name: ok-cluster-contract-executor
+    openkubes.io/execution-id: "${OK147_RUN_ID}"
+    openkubes.io/stage-id: enablement
+spec:
+  backoffLimit: 0
+  completions: 1
+  parallelism: 1
+  activeDeadlineSeconds: 660
+  ttlSecondsAfterFinished: 3600
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ok-cluster-contract-executor
+        openkubes.io/execution-id: "${OK147_RUN_ID}"
+    spec:
+      serviceAccountName: ok147-contract-executor-runtime
+      automountServiceAccountToken: false
+      enableServiceLinks: false
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+        seccompProfile: {type: RuntimeDefault}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - {key: node-role.kubernetes.io/control-plane, operator: DoesNotExist}
+      containers:
+        - name: executor
+          image: "${OK147_IMAGE_DIGEST}"
+          imagePullPolicy: IfNotPresent
+          command: ["/ok"]
+          args:
+            - cluster
+            - stage
+            - run
+            - enablement
+            - --execute
+            - --plan
+            - /var/run/openkubes/input/staged-plan.json
+            - --contract-namespace
+            - "${OK147_CONTRACT_NAMESPACE}"
+            - --contract-name
+            - "${OK147_CONTRACT_NAME}"
+            - --intent-revision
+            - "${OK147_R}"
+            - --enablement-revision
+            - "${OK147_E}"
+            - --platform-revision
+            - "${OK147_P}"
+            - --execution-fixture
+            - "${OK147_FIXTURE}"
+            - --infrastructure-authority
+            - "${OK147_INFRA_AUTHORITY}"
+            - --management-authority
+            - "${OK147_MGMT_AUTHORITY}"
+            - --gitops-authority
+            - "${OK147_GITOPS_AUTHORITY}"
+            - --receipt
+            - /var/run/openkubes/input/provider-receipt.json
+            - --receipt
+            - /var/run/openkubes/input/lifecycle-receipt.json
+            - --receipt
+            - /var/run/openkubes/input/lifecycle-observation-receipt.json
+            - --grant
+            - /var/run/openkubes/input/stage-grant.json
+            - --grant-key
+            - /var/run/openkubes/input/stage-authority.pub
+            - --evaluation-time
+            - "${OK147_EVALUATION_TIME}"
+            - --enablement-artifact
+            - /var/run/openkubes/input/enablement.yaml
+            - --helmchartproxy-name
+            - "${OK147_HELMCHARTPROXY_NAME}"
+            - --ledger-api-endpoint
+            - "${OK147_LEDGER_API_URL}"
+            - --ledger-token-file
+            - /var/run/openkubes/ledger/token
+            - --ledger-ca-file
+            - /var/run/openkubes/ledger/ca.crt
+            - --management-api-endpoint
+            - "${OK147_MANAGEMENT_API_URL}"
+            - --management-token-file
+            - /var/run/openkubes/management/token
+            - --management-ca-file
+            - /var/run/openkubes/management/ca.crt
+          resources:
+            requests: {cpu: 25m, memory: 48Mi, ephemeral-storage: 16Mi}
+            limits: {cpu: 200m, memory: 96Mi, ephemeral-storage: 32Mi}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities: {drop: ["ALL"]}
+          volumeMounts:
+            - {name: input, mountPath: /var/run/openkubes/input/staged-plan.json, subPath: staged-plan.json, readOnly: true}
+            - {name: input, mountPath: /var/run/openkubes/input/receipt-prefix.json, subPath: receipt-prefix.json, readOnly: true}
+            - {name: input, mountPath: /var/run/openkubes/input/provider-receipt.json, subPath: provider-receipt.json, readOnly: true}
+            - {name: input, mountPath: /var/run/openkubes/input/lifecycle-receipt.json, subPath: lifecycle-receipt.json, readOnly: true}
+            - {name: input, mountPath: /var/run/openkubes/input/lifecycle-observation-receipt.json, subPath: lifecycle-observation-receipt.json, readOnly: true}
+            - {name: input, mountPath: /var/run/openkubes/input/stage-grant.json, subPath: stage-grant.json, readOnly: true}
+            - {name: input, mountPath: /var/run/openkubes/input/stage-authority.pub, subPath: stage-authority.pub, readOnly: true}
+            - {name: input, mountPath: /var/run/openkubes/input/enablement.yaml, subPath: enablement.yaml, readOnly: true}
+            - {name: ledger-credential, mountPath: /var/run/openkubes/ledger/token, subPath: token, readOnly: true}
+            - {name: ledger-credential, mountPath: /var/run/openkubes/ledger/ca.crt, subPath: ca.crt, readOnly: true}
+            - {name: management-credential, mountPath: /var/run/openkubes/management/token, subPath: token, readOnly: true}
+            - {name: management-credential, mountPath: /var/run/openkubes/management/ca.crt, subPath: ca.crt, readOnly: true}
+      volumes:
+        - name: input
+          configMap:
+            name: "${OK147_INPUT_CONFIGMAP}"
+            defaultMode: 0444
+            items:
+              - {key: staged-plan.json, path: staged-plan.json}
+              - {key: receipt-prefix.json, path: receipt-prefix.json}
+              - {key: provider-receipt.json, path: provider-receipt.json}
+              - {key: lifecycle-receipt.json, path: lifecycle-receipt.json}
+              - {key: lifecycle-observation-receipt.json, path: lifecycle-observation-receipt.json}
+              - {key: stage-grant.json, path: stage-grant.json}
+              - {key: stage-authority.pub, path: stage-authority.pub}
+              - {key: enablement.yaml, path: enablement.yaml}
+        - name: ledger-credential
+          secret:
+            secretName: "${OK147_LEDGER_CREDENTIAL_SECRET}"
+            defaultMode: 0440
+            items:
+              - {key: token, path: token}
+              - {key: ca.crt, path: ca.crt}
+        - name: management-credential
+          secret:
+            secretName: "${OK147_MANAGEMENT_CREDENTIAL_SECRET}"
+            defaultMode: 0440
+            items:
+              - {key: token, path: token}
+              - {key: ca.crt, path: ca.crt}

--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -1215,6 +1215,23 @@ inputs, a malformed evaluation time or positional input fail before bundle
 execution. This CLI does not package or launch a Job and adds no retry,
 rollback or cleanup.
 
+The separate `ok147-enablement-stage-package/v1` composer can materialize the
+same boundary as a deterministic three-object stream:
+
+```text
+immutable eight-key ConfigMap
+        -> single-endpoint deny-all NetworkPolicy
+        -> backoffLimit: 0 Enablement Job
+```
+
+The Job is tokenless and non-root, mounts the public input and the ledger and
+management-writer credentials from three distinct objects, and has a fixed
+660-second deadline around the command's ten-minute context. Both credentials
+must address the same exact management API IP and port; the NetworkPolicy has
+only that one egress rule. The Job submits the bound `HelmChartProxy` and never
+renders Helm or writes a `HelmReleaseProxy`. Package construction remains
+offline: no Secret, ServiceAccount, ConfigMap, NetworkPolicy or Job is created.
+
 ## Typed Contract-to-CAPI submission stages
 
 The existing bounded exact-create submission primitive now has a typed adapter

--- a/internal/runner/enablement_stage_job.go
+++ b/internal/runner/enablement_stage_job.go
@@ -1,0 +1,97 @@
+package runner
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/stageplan"
+)
+
+// EnablementStageJobValues bind one non-retrying Job to the exact verified
+// HelmChartProxy input and the management API used by the ledger and writer.
+type EnablementStageJobValues struct {
+	RunID                      string
+	ImageDigest                string
+	EvaluationTime             string
+	Expected                   stageplan.Expected
+	InputConfigMap             string
+	ReceiptPrefixDigest        string
+	HelmChartProxyName         string
+	LedgerAPIURL               string
+	LedgerAPICIDR              string
+	LedgerCredentialSecret     string
+	ManagementAPIURL           string
+	ManagementAPICIDR          string
+	ManagementCredentialSecret string
+}
+
+// RenderEnablementStageJobTemplate performs validated literal substitution for
+// exactly one enablement NetworkPolicy and Job. It never renders Helm content.
+func RenderEnablementStageJobTemplate(template []byte, values EnablementStageJobValues) ([]byte, error) {
+	if len(template) == 0 || len(template) > 1024*1024 {
+		return nil, errors.New("enablement stage Job template size is invalid")
+	}
+	dnsLabel := regexp.MustCompile(`^[a-z0-9](?:[-a-z0-9]*[a-z0-9])?$`)
+	if !dnsLabel.MatchString(values.RunID) || len(values.RunID) > 63 || !strings.HasPrefix(values.RunID, "ok147-") {
+		return nil, errors.New("enablement stage Job run ID is invalid")
+	}
+	for _, value := range []string{values.InputConfigMap, values.HelmChartProxyName, values.LedgerCredentialSecret, values.ManagementCredentialSecret} {
+		if !dnsLabel.MatchString(value) || len(value) > 63 {
+			return nil, errors.New("enablement stage Job object name is invalid")
+		}
+	}
+	if values.InputConfigMap == values.LedgerCredentialSecret || values.InputConfigMap == values.ManagementCredentialSecret || values.LedgerCredentialSecret == values.ManagementCredentialSecret {
+		return nil, errors.New("enablement stage Job input and credentials must use distinct objects")
+	}
+	if !regexp.MustCompile(`^[a-z0-9][a-z0-9./:_-]*@sha256:[0-9a-f]{64}$`).MatchString(values.ImageDigest) {
+		return nil, errors.New("enablement stage Job image is not digest-bound")
+	}
+	if !stageReceiptPrefixDigestPattern.MatchString(values.ReceiptPrefixDigest) {
+		return nil, errors.New("enablement stage Job receipt-prefix digest is invalid")
+	}
+	if _, err := time.Parse(time.RFC3339, values.EvaluationTime); err != nil {
+		return nil, errors.New("enablement stage Job evaluation time is not RFC3339")
+	}
+	if err := stageplan.ValidateExpected(values.Expected); err != nil {
+		return nil, fmt.Errorf("enablement stage Job expected binding: %w", err)
+	}
+	ledgerPort, ledgerEndpoint, err := exactAPIEndpoint(values.LedgerAPIURL, values.LedgerAPICIDR)
+	if err != nil {
+		return nil, fmt.Errorf("enablement stage Job ledger endpoint: %w", err)
+	}
+	managementPort, managementEndpoint, err := exactAPIEndpoint(values.ManagementAPIURL, values.ManagementAPICIDR)
+	if err != nil {
+		return nil, fmt.Errorf("enablement stage Job management endpoint: %w", err)
+	}
+	if ledgerEndpoint != managementEndpoint || ledgerPort != managementPort {
+		return nil, errors.New("enablement ledger and writer must use the same verified management API")
+	}
+	replacements := map[string]string{
+		"${OK147_RUN_ID}": values.RunID, "${OK147_IMAGE_DIGEST}": values.ImageDigest,
+		"${OK147_EVALUATION_TIME}":    values.EvaluationTime,
+		"${OK147_CONTRACT_NAMESPACE}": values.Expected.ContractIdentity.Namespace, "${OK147_CONTRACT_NAME}": values.Expected.ContractIdentity.Name,
+		"${OK147_R}": values.Expected.IntentRevision, "${OK147_E}": values.Expected.EnablementRevision,
+		"${OK147_P}": values.Expected.PlatformRevision, "${OK147_FIXTURE}": values.Expected.ExecutionFixture,
+		"${OK147_INFRA_AUTHORITY}": values.Expected.InfrastructureAuthority, "${OK147_MGMT_AUTHORITY}": values.Expected.ManagementAuthority,
+		"${OK147_GITOPS_AUTHORITY}": values.Expected.GitOpsAuthority,
+		"${OK147_INPUT_CONFIGMAP}":  values.InputConfigMap, "${OK147_RECEIPT_PREFIX_DIGEST}": values.ReceiptPrefixDigest,
+		"${OK147_HELMCHARTPROXY_NAME}": values.HelmChartProxyName,
+		"${OK147_LEDGER_API_URL}":      values.LedgerAPIURL, "${OK147_LEDGER_API_CIDR}": values.LedgerAPICIDR,
+		"${OK147_LEDGER_API_PORT}": ledgerPort, "${OK147_LEDGER_CREDENTIAL_SECRET}": values.LedgerCredentialSecret,
+		"${OK147_MANAGEMENT_API_URL}": values.ManagementAPIURL, "${OK147_MANAGEMENT_CREDENTIAL_SECRET}": values.ManagementCredentialSecret,
+	}
+	result := string(template)
+	for placeholder, value := range replacements {
+		if !strings.Contains(result, placeholder) {
+			return nil, fmt.Errorf("enablement stage Job template lacks %s", placeholder)
+		}
+		result = strings.ReplaceAll(result, placeholder, value)
+	}
+	if strings.Contains(result, "${") {
+		return nil, errors.New("enablement stage Job template contains an unknown placeholder")
+	}
+	return []byte(result), nil
+}

--- a/internal/runner/enablement_stage_job_test.go
+++ b/internal/runner/enablement_stage_job_test.go
@@ -1,0 +1,121 @@
+package runner
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/openkubes/ok-cluster/internal/contract"
+	"github.com/openkubes/ok-cluster/internal/stageplan"
+)
+
+func TestRenderEnablementStageJobBindsExactEnvelope(t *testing.T) {
+	values := validEnablementStageJobValues()
+	raw, err := RenderEnablementStageJobTemplate(enablementStageJobTemplate(t), values)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(raw, []byte("${")) || bytes.Contains(raw, []byte("system:masters")) || bytes.Contains(raw, []byte("privileged: true")) {
+		t.Fatal("materialized enablement Job contains an unresolved or privileged boundary")
+	}
+	objects := decodeJobObjects(t, raw)
+	job, policy := objects["Job"], objects["NetworkPolicy"]
+	if len(objects) != 2 || job == nil || policy == nil {
+		t.Fatalf("unexpected enablement envelope: %#v", objects)
+	}
+	jobSpec := objectAt(t, job, "spec")
+	if jobSpec["backoffLimit"] != 0 || jobSpec["parallelism"] != 1 || jobSpec["completions"] != 1 || jobSpec["activeDeadlineSeconds"] != 660 {
+		t.Fatalf("enablement Job boundary differs: %#v", jobSpec)
+	}
+	podSpec := objectAt(t, objectAt(t, jobSpec, "template"), "spec")
+	if podSpec["serviceAccountName"] != "ok147-contract-executor-runtime" || podSpec["automountServiceAccountToken"] != false || podSpec["restartPolicy"] != "Never" {
+		t.Fatalf("unexpected enablement Pod identity: %#v", podSpec)
+	}
+	container := arrayAt(t, podSpec, "containers")[0].(map[string]any)
+	args := stringArray(t, container, "args")
+	for _, required := range []string{"cluster", "stage", "run", "enablement", "--execute", "--grant", "--enablement-artifact", "--helmchartproxy-name", "--ledger-token-file", "--management-token-file"} {
+		if !contains(args, required) {
+			t.Fatalf("enablement Job args do not bind %s: %v", required, args)
+		}
+	}
+	if argumentValue(args, "--helmchartproxy-name") != values.HelmChartProxyName {
+		t.Fatal("enablement Job does not bind independently expected HCP name")
+	}
+	receiptCount := 0
+	for _, argument := range args {
+		if argument == "--receipt" {
+			receiptCount++
+		}
+	}
+	if receiptCount != 3 {
+		t.Fatalf("receipt arguments=%d, want 3", receiptCount)
+	}
+	if mounts := arrayAt(t, container, "volumeMounts"); len(mounts) != 12 {
+		t.Fatalf("enablement volumeMounts=%d, want 12", len(mounts))
+	}
+	policySpec := objectAt(t, policy, "spec")
+	if len(arrayAt(t, policySpec, "ingress")) != 0 || len(arrayAt(t, policySpec, "egress")) != 1 {
+		t.Fatalf("enablement NetworkPolicy is not single-endpoint deny-all: %#v", policySpec)
+	}
+}
+
+func TestRenderEnablementStageJobFailsClosed(t *testing.T) {
+	template := enablementStageJobTemplate(t)
+	for name, mutate := range map[string]func(*EnablementStageJobValues){
+		"mutable image": func(values *EnablementStageJobValues) { values.ImageDigest = "ghcr.io/openkubes/ok-cluster:latest" },
+		"shared credential": func(values *EnablementStageJobValues) {
+			values.ManagementCredentialSecret = values.LedgerCredentialSecret
+		},
+		"foreign management endpoint": func(values *EnablementStageJobValues) { values.ManagementAPIURL = "https://192.0.2.13:6443" },
+		"broad management CIDR":       func(values *EnablementStageJobValues) { values.ManagementAPICIDR = "192.0.2.0/24" },
+		"DNS endpoint": func(values *EnablementStageJobValues) {
+			values.ManagementAPIURL = "https://kubernetes.default.svc:6443"
+		},
+		"invalid HCP name": func(values *EnablementStageJobValues) { values.HelmChartProxyName = "Bad_Name" },
+		"foreign authority": func(values *EnablementStageJobValues) {
+			values.Expected.ManagementAuthority = values.Expected.InfrastructureAuthority
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			values := validEnablementStageJobValues()
+			mutate(&values)
+			if _, err := RenderEnablementStageJobTemplate(template, values); err == nil {
+				t.Fatal("unsafe enablement stage Job was accepted")
+			}
+		})
+	}
+	if _, err := RenderEnablementStageJobTemplate(append(template, []byte("\n${UNKNOWN}")...), validEnablementStageJobValues()); err == nil {
+		t.Fatal("unknown enablement placeholder was accepted")
+	}
+}
+
+func validEnablementStageJobValues() EnablementStageJobValues {
+	return EnablementStageJobValues{
+		RunID: "ok147-enablement-20260816-01", ImageDigest: "ghcr.io/openkubes/ok-cluster@sha256:" + strings.Repeat("a", 64),
+		EvaluationTime: "2026-08-16T21:00:00Z",
+		Expected: stageplan.Expected{
+			ContractIdentity: contract.Identity{Namespace: "disposable-ok147", Name: "disposable-ok147"},
+			IntentRevision:   prefixSHA("a"), EnablementRevision: prefixSHA("b"), PlatformRevision: prefixSHA("c"), ExecutionFixture: prefixSHA("d"),
+			InfrastructureAuthority: "ok-infra", ManagementAuthority: "ok-mgmt", GitOpsAuthority: "ok-shared",
+		},
+		InputConfigMap: "ok147-enablement-input", ReceiptPrefixDigest: prefixSHA("e"), HelmChartProxyName: "disposable-ok147-cilium",
+		LedgerAPIURL: "https://192.0.2.12:6443", LedgerAPICIDR: "192.0.2.12/32", LedgerCredentialSecret: "ok147-ledger-credential",
+		ManagementAPIURL: "https://192.0.2.12:6443", ManagementAPICIDR: "192.0.2.12/32", ManagementCredentialSecret: "ok147-management-credential",
+	}
+}
+
+func enablementStageJobTemplate(t *testing.T) []byte {
+	t.Helper()
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("cannot resolve test path")
+	}
+	raw, err := os.ReadFile(filepath.Join(filepath.Dir(filename), "..", "..", "deploy", "contract-executor-enablement-job.yaml.tpl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return raw
+}

--- a/internal/runner/enablement_stage_package.go
+++ b/internal/runner/enablement_stage_package.go
@@ -1,0 +1,112 @@
+package runner
+
+import (
+	"errors"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+const EnablementStagePackageFormat = "ok147-enablement-stage-package/v1"
+
+// EnablementStagePackageConfig contains only public package identities and the
+// names of separately materialized credential Secrets.
+type EnablementStagePackageConfig struct {
+	Bundle                     EnablementStageBundleConfig
+	JobTemplate                []byte
+	JobTemplateDigest          string
+	RunID                      string
+	ImageDigest                string
+	InputConfigMap             string
+	HelmChartProxyName         string
+	LedgerAPIURL               string
+	LedgerAPICIDR              string
+	LedgerCredentialSecret     string
+	ManagementAPIURL           string
+	ManagementAPICIDR          string
+	ManagementCredentialSecret string
+}
+
+// EnablementStagePackageReceipt is redaction-safe offline composition proof.
+type EnablementStagePackageReceipt struct {
+	Format               string   `json:"format"`
+	State                string   `json:"state"`
+	StageID              string   `json:"stageId"`
+	PackageDigest        string   `json:"packageDigest"`
+	InputConfigMapDigest string   `json:"inputConfigMapDigest"`
+	ReceiptPrefixDigest  string   `json:"receiptPrefixDigest"`
+	EnablementDigest     string   `json:"enablementDigest"`
+	JobTemplateDigest    string   `json:"jobTemplateDigest"`
+	JobEnvelopeDigest    string   `json:"jobEnvelopeDigest"`
+	ObjectKinds          []string `json:"objectKinds"`
+	AuthorizationState   string   `json:"authorizationState"`
+	MutationAllowed      bool     `json:"mutationAllowed"`
+}
+
+type VerifiedEnablementStagePackage struct {
+	raw      []byte
+	receipt  EnablementStagePackageReceipt
+	verified bool
+}
+
+// BuildEnablementStagePackage composes an immutable input ConfigMap with one
+// bounded NetworkPolicy/Job envelope. It performs no API request.
+func BuildEnablementStagePackage(config EnablementStagePackageConfig) (VerifiedEnablementStagePackage, error) {
+	if !stageReceiptPrefixDigestPattern.MatchString(config.JobTemplateDigest) || digest.SHA256(config.JobTemplate) != config.JobTemplateDigest {
+		return VerifiedEnablementStagePackage{}, errors.New("enablement stage Job template digest differs from expected identity")
+	}
+	if config.InputConfigMap == config.LedgerCredentialSecret || config.InputConfigMap == config.ManagementCredentialSecret {
+		return VerifiedEnablementStagePackage{}, errors.New("enablement stage input and credential object names must be distinct")
+	}
+	input, err := BuildEnablementStageInput(config.Bundle, config.InputConfigMap)
+	if err != nil {
+		return VerifiedEnablementStagePackage{}, err
+	}
+	inputRaw, err := input.Bytes()
+	if err != nil {
+		return VerifiedEnablementStagePackage{}, err
+	}
+	inputReceipt, err := input.Receipt()
+	if err != nil {
+		return VerifiedEnablementStagePackage{}, err
+	}
+	jobRaw, err := RenderEnablementStageJobTemplate(config.JobTemplate, EnablementStageJobValues{
+		RunID: config.RunID, ImageDigest: config.ImageDigest,
+		EvaluationTime: config.Bundle.EvaluationTime.UTC().Format(time.RFC3339), Expected: config.Bundle.PlanExpected,
+		InputConfigMap: config.InputConfigMap, ReceiptPrefixDigest: inputReceipt.ReceiptPrefixDigest,
+		HelmChartProxyName: config.HelmChartProxyName,
+		LedgerAPIURL:       config.LedgerAPIURL, LedgerAPICIDR: config.LedgerAPICIDR, LedgerCredentialSecret: config.LedgerCredentialSecret,
+		ManagementAPIURL: config.ManagementAPIURL, ManagementAPICIDR: config.ManagementAPICIDR, ManagementCredentialSecret: config.ManagementCredentialSecret,
+	})
+	if err != nil {
+		return VerifiedEnablementStagePackage{}, err
+	}
+	packageRaw := make([]byte, 0, len(inputRaw)+len(jobRaw)+6)
+	packageRaw = append(packageRaw, inputRaw...)
+	packageRaw = append(packageRaw, '\n', '-', '-', '-', '\n')
+	packageRaw = append(packageRaw, jobRaw...)
+	receipt := EnablementStagePackageReceipt{
+		Format: EnablementStagePackageFormat, State: "VERIFIED", StageID: "enablement",
+		PackageDigest: digest.SHA256(packageRaw), InputConfigMapDigest: inputReceipt.ConfigMapDigest,
+		ReceiptPrefixDigest: inputReceipt.ReceiptPrefixDigest, EnablementDigest: inputReceipt.EnablementDigest,
+		JobTemplateDigest: config.JobTemplateDigest, JobEnvelopeDigest: digest.SHA256(jobRaw),
+		ObjectKinds: []string{"ConfigMap", "NetworkPolicy", "Job"}, AuthorizationState: "VERIFIED", MutationAllowed: false,
+	}
+	return VerifiedEnablementStagePackage{raw: packageRaw, receipt: receipt, verified: true}, nil
+}
+
+func (packaged VerifiedEnablementStagePackage) Bytes() ([]byte, error) {
+	if !packaged.verified || len(packaged.raw) == 0 {
+		return nil, errors.New("enablement stage package was not produced by verification")
+	}
+	return append([]byte(nil), packaged.raw...), nil
+}
+
+func (packaged VerifiedEnablementStagePackage) Receipt() (EnablementStagePackageReceipt, error) {
+	if !packaged.verified || packaged.receipt.State != "VERIFIED" {
+		return EnablementStagePackageReceipt{}, errors.New("enablement stage package was not produced by verification")
+	}
+	receipt := packaged.receipt
+	receipt.ObjectKinds = append([]string(nil), packaged.receipt.ObjectKinds...)
+	return receipt, nil
+}

--- a/internal/runner/enablement_stage_package_test.go
+++ b/internal/runner/enablement_stage_package_test.go
@@ -1,0 +1,109 @@
+package runner
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+func TestBuildEnablementStagePackageBindsInputAndJobEnvelope(t *testing.T) {
+	fixture := enablementBundleFixture(t)
+	config := enablementStagePackageConfig(t, fixture)
+	packaged, err := BuildEnablementStagePackage(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := packaged.Bytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := packaged.Receipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	objects := decodeJobObjects(t, raw)
+	if len(objects) != 3 || objects["ConfigMap"] == nil || objects["NetworkPolicy"] == nil || objects["Job"] == nil {
+		t.Fatalf("unexpected enablement package object set: %#v", objects)
+	}
+	configMap := objects["ConfigMap"]
+	if configMap["immutable"] != true || objectAt(t, configMap, "metadata")["name"] != config.InputConfigMap {
+		t.Fatalf("unexpected enablement input ConfigMap: %#v", configMap)
+	}
+	job := objects["Job"]
+	container := arrayAt(t, objectAt(t, objectAt(t, objectAt(t, job, "spec"), "template"), "spec"), "containers")[0].(map[string]any)
+	args := stringArray(t, container, "args")
+	if argumentValue(args, "--helmchartproxy-name") != config.HelmChartProxyName || argumentValue(args, "--evaluation-time") != fixture.config.EvaluationTime.UTC().Format("2006-01-02T15:04:05Z07:00") {
+		t.Fatalf("enablement Job and package bindings differ: %v %#v", args, receipt)
+	}
+	if receipt.Format != EnablementStagePackageFormat || receipt.State != "VERIFIED" || receipt.StageID != "enablement" || receipt.PackageDigest != digest.SHA256(raw) || receipt.MutationAllowed {
+		t.Fatalf("unexpected enablement package receipt: %#v", receipt)
+	}
+	parts := bytes.SplitN(raw, []byte("\n---\n"), 2)
+	if len(parts) != 2 || receipt.InputConfigMapDigest != digest.SHA256(parts[0]) || receipt.JobEnvelopeDigest != digest.SHA256(parts[1]) {
+		t.Fatal("enablement package component digests do not match emitted bytes")
+	}
+	if receipt.JobTemplateDigest != digest.SHA256(config.JobTemplate) || receipt.EnablementDigest == "" || !reflect.DeepEqual(receipt.ObjectKinds, []string{"ConfigMap", "NetworkPolicy", "Job"}) {
+		t.Fatalf("enablement package identities differ: %#v", receipt)
+	}
+	policyPosition := bytes.Index(raw, []byte("\nkind: NetworkPolicy\n"))
+	jobPosition := bytes.Index(raw, []byte("\nkind: Job\n"))
+	if policyPosition < 0 || jobPosition < 0 || policyPosition >= jobPosition {
+		t.Fatal("enablement executable Job appears before its NetworkPolicy boundary")
+	}
+
+	raw[0] = 'x'
+	again, err := packaged.Bytes()
+	if err != nil || again[0] != '{' {
+		t.Fatal("caller mutated retained enablement package")
+	}
+	receipt.ObjectKinds[0] = "Changed"
+	againReceipt, err := packaged.Receipt()
+	if err != nil || againReceipt.ObjectKinds[0] != "ConfigMap" {
+		t.Fatal("caller mutated retained enablement package receipt")
+	}
+}
+
+func TestBuildEnablementStagePackageFailsClosed(t *testing.T) {
+	fixture := enablementBundleFixture(t)
+	valid := enablementStagePackageConfig(t, fixture)
+	for name, mutate := range map[string]func(*EnablementStagePackageConfig){
+		"input reuses ledger Secret":     func(config *EnablementStagePackageConfig) { config.InputConfigMap = config.LedgerCredentialSecret },
+		"input reuses management Secret": func(config *EnablementStagePackageConfig) { config.InputConfigMap = config.ManagementCredentialSecret },
+		"mutable image":                  func(config *EnablementStagePackageConfig) { config.ImageDigest = "ghcr.io/openkubes/ok-cluster:latest" },
+		"foreign endpoint":               func(config *EnablementStagePackageConfig) { config.ManagementAPIURL = "https://192.0.2.13:6443" },
+		"changed template": func(config *EnablementStagePackageConfig) {
+			config.JobTemplate = append(config.JobTemplate, []byte("\n${UNKNOWN}")...)
+		},
+		"wrong template digest": func(config *EnablementStagePackageConfig) { config.JobTemplateDigest = prefixSHA("f") },
+	} {
+		t.Run(name, func(t *testing.T) {
+			config := valid
+			config.JobTemplate = append([]byte(nil), valid.JobTemplate...)
+			mutate(&config)
+			if _, err := BuildEnablementStagePackage(config); err == nil {
+				t.Fatal("incoherent enablement stage package was accepted")
+			}
+		})
+	}
+	if _, err := (VerifiedEnablementStagePackage{}).Bytes(); err == nil {
+		t.Fatal("unverified enablement package bytes were exposed")
+	}
+	if _, err := (VerifiedEnablementStagePackage{}).Receipt(); err == nil {
+		t.Fatal("unverified enablement package receipt was exposed")
+	}
+}
+
+func enablementStagePackageConfig(t *testing.T, fixture enablementBundleTestFixture) EnablementStagePackageConfig {
+	t.Helper()
+	values := validEnablementStageJobValues()
+	config := EnablementStagePackageConfig{
+		Bundle: fixture.config, JobTemplate: enablementStageJobTemplate(t),
+		RunID: values.RunID, ImageDigest: values.ImageDigest, InputConfigMap: values.InputConfigMap, HelmChartProxyName: values.HelmChartProxyName,
+		LedgerAPIURL: values.LedgerAPIURL, LedgerAPICIDR: values.LedgerAPICIDR, LedgerCredentialSecret: values.LedgerCredentialSecret,
+		ManagementAPIURL: values.ManagementAPIURL, ManagementAPICIDR: values.ManagementAPICIDR, ManagementCredentialSecret: values.ManagementCredentialSecret,
+	}
+	config.JobTemplateDigest = digest.SHA256(config.JobTemplate)
+	return config
+}


### PR DESCRIPTION
## Outcome

Package Stage 4 as a deterministic, offline `ConfigMap -> NetworkPolicy -> Job` stream.

## Boundaries

- immutable eight-key public input ConfigMap;
- digest-pinned runner image;
- distinct ledger and management-writer credential Secret names;
- both credentials bound to the same exact management API IP and port;
- deny-all ingress and exactly one API egress rule;
- tokenless, non-root Job with `backoffLimit: 0` and a 660-second deadline;
- exactly one externally rendered `HelmChartProxy` input.

The package neither renders Helm nor writes `HelmReleaseProxy`. Construction performs no API request and creates no ServiceAccount, Secret, ConfigMap, NetworkPolicy, or Job.

## Validation

- `GOCACHE=/private/tmp/ok147-go-build-cache go test -ldflags=-linkmode=external ./...`
- `GOCACHE=/private/tmp/ok147-go-build-cache go vet ./...`
- `GOCACHE=/private/tmp/ok147-go-build-cache go test -race -ldflags=-linkmode=external ./internal/runner`
- `git diff --check`

No live infrastructure action was performed.
