### PR TITLE
feat(ok): package enablement stage offline

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,8 @@ Powered by [Cluster API (CAPI)](https://cluster-api.sigs.k8s.io/), [CAPK (KubeVi
   `HelmChartProxy`; it neither renders Helm nor writes the controller-owned
   `HelmReleaseProxy`. A distinct offline package now composes the immutable
   eight-key input ConfigMap with a tokenless, non-retrying Job and a deny-all
-  NetworkPolicy that permits only the exact management API endpoint.
+  NetworkPolicy that permits only the exact management API endpoint. The
+  package is emitted locally with `ok cluster stage run enablement package`.
 
 ---
 

--- a/cmd/ok/main.go
+++ b/cmd/ok/main.go
@@ -65,6 +65,19 @@ var materializeLifecycleObservationStagePackage = func(config runner.LifecycleOb
 	return raw, receipt, err
 }
 
+var materializeEnablementStagePackage = func(config runner.EnablementStagePackageConfig) ([]byte, runner.EnablementStagePackageReceipt, error) {
+	packaged, err := runner.BuildEnablementStagePackage(config)
+	if err != nil {
+		return nil, runner.EnablementStagePackageReceipt{}, err
+	}
+	raw, err := packaged.Bytes()
+	if err != nil {
+		return nil, runner.EnablementStagePackageReceipt{}, err
+	}
+	receipt, err := packaged.Receipt()
+	return raw, receipt, err
+}
+
 var prepareSubmissionStageLaunch = func(config runner.SubmissionStageLaunchMaterialConfig) (stageLaunchPreparation, error) {
 	material, err := runner.BuildSubmissionStageLaunchMaterial(config)
 	if err != nil {
@@ -475,6 +488,9 @@ func runContext(ctx context.Context, arguments []string, stdout, stderr io.Write
 	if len(arguments) >= 4 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "observe" && arguments[3] == "lifecycle" {
 		return runClusterStageObserveLifecycle(ctx, arguments[4:], stdout, stderr)
 	}
+	if len(arguments) >= 5 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "run" && arguments[3] == "enablement" && arguments[4] == "package" {
+		return runClusterStageRunEnablementPackage(arguments[5:], stdout, stderr)
+	}
 	if len(arguments) >= 4 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "run" && arguments[3] == "enablement" {
 		return runClusterStageRunEnablement(ctx, arguments[4:], stdout, stderr)
 	}
@@ -490,7 +506,7 @@ func runContext(ctx context.Context, arguments []string, stdout, stderr io.Write
 	if len(arguments) >= 4 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "launch" && arguments[3] == "execute" {
 		return runClusterStageLaunchExecute(ctx, arguments[4:], stdout, stderr)
 	}
-	return errors.New("usage: ok cluster create ... | ok cluster stage inspect ... | ok cluster stage resume ... | ok cluster stage observe lifecycle ... | ok cluster stage observe lifecycle package ... | ok cluster stage observe lifecycle launch prepare ... | ok cluster stage observe lifecycle launch execute ... | ok cluster stage run ... | ok cluster stage run enablement ... | ok cluster stage package ... | ok cluster stage launch prepare ... | ok cluster stage launch execute ...")
+	return errors.New("usage: ok cluster create ... | ok cluster stage inspect ... | ok cluster stage resume ... | ok cluster stage observe lifecycle ... | ok cluster stage observe lifecycle package ... | ok cluster stage observe lifecycle launch prepare ... | ok cluster stage observe lifecycle launch execute ... | ok cluster stage run ... | ok cluster stage run enablement ... | ok cluster stage run enablement package ... | ok cluster stage package ... | ok cluster stage launch prepare ... | ok cluster stage launch execute ...")
 }
 
 func runClusterCreate(arguments []string, stdout, stderr io.Writer) error {
@@ -1097,6 +1113,83 @@ func runClusterStageRunEnablement(ctx context.Context, arguments []string, stdou
 		}
 	}
 	return runErr
+}
+
+func runClusterStageRunEnablementPackage(arguments []string, stdout, stderr io.Writer) error {
+	flags := flag.NewFlagSet("ok cluster stage run enablement package", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	resumeFlags := addStageResumeFlags(flags)
+	grantPath := flags.String("grant", "", "path to the signed single-stage grant")
+	grantKeyPath := flags.String("grant-key", "", "path to the trusted stage-authority public key")
+	evaluationTime := flags.String("evaluation-time", "", "explicit RFC3339 grant evaluation time")
+	artifactPath := flags.String("enablement-artifact", "", "path to the exact externally rendered HelmChartProxy")
+	objectName := flags.String("helmchartproxy-name", "", "independently expected HelmChartProxy name")
+	jobTemplate := flags.String("job-template", "", "path to the bounded enablement Job template")
+	jobTemplateDigest := flags.String("job-template-digest", "", "expected SHA-256 identity of the Job template")
+	output := flags.String("output", "", "new local file for the verified enablement package")
+	runID := flags.String("run-id", "", "bounded OK-147 enablement Job identity")
+	imageDigest := flags.String("image", "", "digest-pinned ok image")
+	inputConfigMap := flags.String("input-configmap", "", "immutable enablement input ConfigMap name")
+	ledgerAPIURL := flags.String("ledger-api-url", "", "exact management-ledger HTTPS IP endpoint")
+	ledgerAPICIDR := flags.String("ledger-api-cidr", "", "single-address management-ledger CIDR")
+	ledgerCredentialSecret := flags.String("ledger-credential-secret", "", "externally materialized ledger credential Secret name")
+	managementAPIURL := flags.String("management-api-url", "", "exact management-writer HTTPS IP endpoint")
+	managementAPICIDR := flags.String("management-api-cidr", "", "single-address management-writer CIDR")
+	managementCredentialSecret := flags.String("management-credential-secret", "", "externally materialized management-writer credential Secret name")
+	if err := flags.Parse(arguments); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return errors.New("positional arguments are not accepted")
+	}
+	resume, err := resumeFlags.config()
+	if err != nil {
+		return err
+	}
+	for _, input := range []struct{ name, value string }{
+		{"--grant", *grantPath}, {"--grant-key", *grantKeyPath}, {"--evaluation-time", *evaluationTime},
+		{"--enablement-artifact", *artifactPath}, {"--helmchartproxy-name", *objectName},
+		{"--job-template", *jobTemplate}, {"--job-template-digest", *jobTemplateDigest}, {"--output", *output},
+		{"--run-id", *runID}, {"--image", *imageDigest}, {"--input-configmap", *inputConfigMap},
+		{"--ledger-api-url", *ledgerAPIURL}, {"--ledger-api-cidr", *ledgerAPICIDR}, {"--ledger-credential-secret", *ledgerCredentialSecret},
+		{"--management-api-url", *managementAPIURL}, {"--management-api-cidr", *managementAPICIDR}, {"--management-credential-secret", *managementCredentialSecret},
+	} {
+		if input.value == "" {
+			return fmt.Errorf("%s is required", input.name)
+		}
+	}
+	at, err := time.Parse(time.RFC3339, *evaluationTime)
+	if err != nil {
+		return fmt.Errorf("parse evaluation time: %w", err)
+	}
+	template, err := readBoundedLocalFile(*jobTemplate, 1024*1024)
+	if err != nil {
+		return fmt.Errorf("read enablement Job template: %w", err)
+	}
+	raw, receipt, err := materializeEnablementStagePackage(runner.EnablementStagePackageConfig{
+		Bundle: runner.EnablementStageBundleConfig{
+			PlanPath: resume.PlanPath, PlanExpected: resume.PlanExpected, Receipts: resume.Receipts,
+			GrantPath: *grantPath, GrantPublicKeyPath: *grantKeyPath, EvaluationTime: at, ArtifactPath: *artifactPath,
+			ExpectedObject: projection.ResourceIdentity{
+				APIVersion: "addons.cluster.x-k8s.io/v1alpha1", Kind: "HelmChartProxy",
+				Namespace: resume.PlanExpected.ContractIdentity.Namespace, Name: *objectName,
+			},
+		},
+		JobTemplate: template, JobTemplateDigest: *jobTemplateDigest,
+		RunID: *runID, ImageDigest: *imageDigest, InputConfigMap: *inputConfigMap, HelmChartProxyName: *objectName,
+		LedgerAPIURL: *ledgerAPIURL, LedgerAPICIDR: *ledgerAPICIDR, LedgerCredentialSecret: *ledgerCredentialSecret,
+		ManagementAPIURL: *managementAPIURL, ManagementAPICIDR: *managementAPICIDR, ManagementCredentialSecret: *managementCredentialSecret,
+	})
+	if err != nil {
+		return err
+	}
+	if err := writeNewLocalFile(*output, raw); err != nil {
+		return fmt.Errorf("write enablement stage package: %w", err)
+	}
+	encoder := json.NewEncoder(stdout)
+	encoder.SetEscapeHTML(false)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(receipt)
 }
 
 func runClusterStagePackage(arguments []string, stdout, stderr io.Writer) error {

--- a/cmd/ok/main_test.go
+++ b/cmd/ok/main_test.go
@@ -541,6 +541,81 @@ func TestEnablementStageRunFailsClosedBeforeExecution(t *testing.T) {
 	}
 }
 
+func TestEnablementStagePackageWritesVerifiedOfflineArtifact(t *testing.T) {
+	previous := materializeEnablementStagePackage
+	defer func() { materializeEnablementStagePackage = previous }()
+	var captured runner.EnablementStagePackageConfig
+	materializeEnablementStagePackage = func(config runner.EnablementStagePackageConfig) ([]byte, runner.EnablementStagePackageReceipt, error) {
+		captured = config
+		return []byte("verified-enablement-package\n"), runner.EnablementStagePackageReceipt{
+			Format: runner.EnablementStagePackageFormat, State: "VERIFIED", StageID: "enablement",
+			PackageDigest: testSHA("1"), InputConfigMapDigest: testSHA("2"), ReceiptPrefixDigest: testSHA("3"), EnablementDigest: testSHA("4"),
+			JobTemplateDigest: testSHA("5"), JobEnvelopeDigest: testSHA("6"), ObjectKinds: []string{"ConfigMap", "NetworkPolicy", "Job"},
+			AuthorizationState: "VERIFIED", MutationAllowed: false,
+		}, nil
+	}
+	root := t.TempDir()
+	template := filepath.Join(root, "enablement-job.yaml.tpl")
+	if err := os.WriteFile(template, []byte("bounded-enablement-template"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	output := filepath.Join(root, "enablement-package.yaml")
+	arguments := enablementStagePackageArguments(template, output)
+	var stdout, stderr bytes.Buffer
+	if err := run(arguments, &stdout, &stderr); err != nil {
+		t.Fatalf("run: %v; stderr=%s", err, stderr.String())
+	}
+	if captured.Bundle.PlanPath != "/tmp/plan.json" || len(captured.Bundle.Receipts) != 3 || captured.RunID != "ok147-enablement-20260816-01" || captured.HelmChartProxyName != "disposable-ok147-cilium" {
+		t.Fatalf("unexpected enablement package config: %#v", captured)
+	}
+	if string(captured.JobTemplate) != "bounded-enablement-template" || captured.JobTemplateDigest != digest.SHA256([]byte("bounded-enablement-template")) || captured.LedgerCredentialSecret == captured.ManagementCredentialSecret {
+		t.Fatalf("enablement template or credentials were not bound: %#v", captured)
+	}
+	written, err := os.ReadFile(output)
+	if err != nil || string(written) != "verified-enablement-package\n" {
+		t.Fatalf("unexpected enablement package: %q %v", written, err)
+	}
+	info, err := os.Stat(output)
+	if err != nil || info.Mode().Perm() != 0o600 {
+		t.Fatalf("enablement package mode is not 0600: %v %v", info, err)
+	}
+	var receipt runner.EnablementStagePackageReceipt
+	if err := json.Unmarshal(stdout.Bytes(), &receipt); err != nil {
+		t.Fatal(err)
+	}
+	if receipt.AuthorizationState != "VERIFIED" || receipt.MutationAllowed {
+		t.Fatalf("unsafe enablement package receipt: %#v", receipt)
+	}
+	stdout.Reset()
+	if err := run(arguments, &stdout, &stderr); err == nil || stdout.Len() != 0 {
+		t.Fatal("existing enablement package was overwritten")
+	}
+}
+
+func TestEnablementStagePackageRejectsIncompleteInputs(t *testing.T) {
+	root := t.TempDir()
+	template := filepath.Join(root, "enablement-job.yaml.tpl")
+	if err := os.WriteFile(template, []byte("bounded-enablement-template"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	output := filepath.Join(root, "enablement-package.yaml")
+	valid := enablementStagePackageArguments(template, output)
+	for name, arguments := range map[string][]string{
+		"execute":                   append(append([]string{}, valid...), "--execute"),
+		"missing template digest":   removeArgumentWithValue(valid, "--job-template-digest"),
+		"missing management secret": removeArgumentWithValue(valid, "--management-credential-secret"),
+		"invalid time":              replaceArgument(valid, "--evaluation-time", "not-time"),
+		"positional":                append(append([]string{}, valid...), "unexpected"),
+	} {
+		t.Run(name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			if err := run(arguments, &stdout, &stderr); err == nil || stdout.Len() != 0 {
+				t.Fatalf("unsafe enablement package input was accepted: %v %s", err, stdout.String())
+			}
+		})
+	}
+}
+
 func TestSubmissionStageAuthorityIsDerivedFromVerifiedTopology(t *testing.T) {
 	expected := stageplan.Expected{InfrastructureAuthority: "ok-infra", ManagementAuthority: "ok-mgmt"}
 	for symbolic, want := range map[string]string{"infrastructure": "ok-infra", "management": "ok-mgmt"} {
@@ -974,6 +1049,22 @@ func enablementStageRunArguments() []string {
 		"--execute",
 		"--ledger-api-endpoint", "https://192.0.2.12:6443", "--ledger-token-file", "/tmp/ledger-token", "--ledger-ca-file", "/tmp/ledger-ca",
 		"--management-api-endpoint", "https://192.0.2.12:6443", "--management-token-file", "/tmp/management-token", "--management-ca-file", "/tmp/management-ca",
+	)
+}
+
+func enablementStagePackageArguments(template, output string) []string {
+	arguments := enablementStageRunArguments()
+	arguments = removeArgument(arguments, "--execute")
+	for _, name := range []string{"--ledger-api-endpoint", "--ledger-token-file", "--ledger-ca-file", "--management-api-endpoint", "--management-token-file", "--management-ca-file"} {
+		arguments = removeArgumentWithValue(arguments, name)
+	}
+	arguments = append(arguments[:4], append([]string{"package"}, arguments[4:]...)...)
+	return append(arguments,
+		"--job-template", template, "--job-template-digest", digest.SHA256([]byte("bounded-enablement-template")),
+		"--output", output, "--run-id", "ok147-enablement-20260816-01",
+		"--image", "ghcr.io/openkubes/ok-cluster@"+testSHA("a"), "--input-configmap", "ok147-enablement-input",
+		"--ledger-api-url", "https://192.0.2.12:6443", "--ledger-api-cidr", "192.0.2.12/32", "--ledger-credential-secret", "ok147-ledger-enablement",
+		"--management-api-url", "https://192.0.2.12:6443", "--management-api-cidr", "192.0.2.12/32", "--management-credential-secret", "ok147-management-enablement",
 	)
 }
 

--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -1231,6 +1231,11 @@ must address the same exact management API IP and port; the NetworkPolicy has
 only that one egress rule. The Job submits the bound `HelmChartProxy` and never
 renders Helm or writes a `HelmReleaseProxy`. Package construction remains
 offline: no Secret, ServiceAccount, ConfigMap, NetworkPolicy or Job is created.
+`ok cluster stage run enablement package` exposes that composer as a local
+fail-closed command. It reads a digest-bound Job template, writes one new 0600
+package file without overwrite, and emits only the redaction-safe package
+receipt on stdout. It has no `--execute` flag and accepts no credential
+contents.
 
 ## Typed Contract-to-CAPI submission stages
 


### PR DESCRIPTION
## Outcome

Expose the deterministic Enablement package composer through `ok cluster stage run enablement package`.

The command binds the exact three-receipt prefix, signed grant, externally rendered `HelmChartProxy`, digest-pinned Job template and public runtime identities. It writes one new 0600 package file without overwrite and prints a redaction-safe receipt.

## Boundary

- no `--execute` path;
- no credential contents;
- no API contact;
- no Helm rendering or `HelmReleaseProxy` write;
- no ServiceAccount, Secret, ConfigMap, NetworkPolicy, or Job creation.

## Validation

- `GOCACHE=/private/tmp/ok147-go-build-cache go test -ldflags=-linkmode=external ./...`
- `GOCACHE=/private/tmp/ok147-go-build-cache go vet ./...`
- `GOCACHE=/private/tmp/ok147-go-build-cache go test -race -ldflags=-linkmode=external ./cmd/ok ./internal/runner`
- `git diff --check`

No live infrastructure action was performed.
