### PR TITLE
feat(runner): seal enablement credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ Powered by [Cluster API (CAPI)](https://cluster-api.sigs.k8s.io/), [CAPK (KubeVi
   eight-key input ConfigMap with a tokenless, non-retrying Job and a deny-all
   NetworkPolicy that permits only the exact management API endpoint. The
   package is emitted locally with `ok cluster stage run enablement package`.
+  A private offline credential packager separately verifies two distinct,
+  short-lived management TokenRequest results for ledger and HCP writer roles;
+  its public receipt exposes neither tokens, CA data, subjects nor paths.
 
 ---
 

--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -1237,6 +1237,17 @@ package file without overwrite, and emits only the redaction-safe package
 receipt on stdout. It has no `--execute` flag and accepts no credential
 contents.
 
+`ok147-enablement-stage-credential-package/v1` adds the private credential
+boundary without contacting Kubernetes. It accepts two independently obtained,
+digest-bound and short-lived TokenRequest results for the ledger and management
+writer. Both must prove the verified `ok-mgmt` authority, use different Secret
+names and different token bytes, carry exact issuer/subject/audience/time
+claims, retain at least fifteen minutes, and expire within one hour. The two
+immutable Secret objects remain private inside the verified package; its public
+receipt contains only authority, expiry, CA/evidence/object digests and object
+names. Changing the previously verified Enablement package identity fails
+closed. No credential or Job is installed by this checkpoint.
+
 ## Typed Contract-to-CAPI submission stages
 
 The existing bounded exact-create submission primitive now has a typed adapter

--- a/internal/runner/enablement_stage_credentials.go
+++ b/internal/runner/enablement_stage_credentials.go
@@ -1,0 +1,146 @@
+package runner
+
+import (
+	"crypto/subtle"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+const EnablementStageCredentialPackageFormat = "ok147-enablement-stage-credential-package/v1"
+
+type EnablementStageCredentialPackageConfig struct {
+	Package             VerifiedEnablementStagePackage
+	MaterializationTime time.Time
+	Ledger              SubmissionStageCredentialSource
+	ManagementWriter    SubmissionStageCredentialSource
+}
+
+type EnablementStageCredentialPackageReceipt struct {
+	Format                  string                                   `json:"format"`
+	State                   string                                   `json:"state"`
+	StageID                 string                                   `json:"stageId"`
+	EnablementPackageDigest string                                   `json:"enablementPackageDigest"`
+	InstallationAuthority   string                                   `json:"installationAuthority"`
+	MaterializedAt          string                                   `json:"materializedAt"`
+	PackageDigest           string                                   `json:"packageDigest"`
+	Credentials             []SubmissionStageCredentialObjectReceipt `json:"credentials"`
+	MutationAllowed         bool                                     `json:"mutationAllowed"`
+}
+
+type enablementStageCredentialPackageIdentity struct {
+	EnablementPackageDigest string                                   `json:"enablementPackageDigest"`
+	InstallationAuthority   string                                   `json:"installationAuthority"`
+	MaterializedAt          string                                   `json:"materializedAt"`
+	Credentials             []SubmissionStageCredentialObjectReceipt `json:"credentials"`
+}
+
+// VerifiedEnablementStageCredentialPackage retains the two exact immutable
+// Secret objects privately for a later installer boundary.
+type VerifiedEnablementStageCredentialPackage struct {
+	objects               []submissionStageCredentialObject
+	receipt               EnablementStageCredentialPackageReceipt
+	installationAuthority string
+	verified              bool
+}
+
+// BuildEnablementStageCredentialPackage verifies two independently obtained
+// short-lived TokenRequest results entirely offline. It exposes no Secret
+// bytes, token, CA, subject or source path.
+func BuildEnablementStageCredentialPackage(config EnablementStageCredentialPackageConfig) (VerifiedEnablementStageCredentialPackage, error) {
+	packageReceipt, err := config.Package.Receipt()
+	if err != nil || config.Package.managementAuthority == "" || config.Package.ledgerCredential == "" || config.Package.managementCredential == "" {
+		return VerifiedEnablementStageCredentialPackage{}, errors.New("verified enablement package is required")
+	}
+	if config.Package.ledgerCredential == config.Package.managementCredential {
+		return VerifiedEnablementStageCredentialPackage{}, errors.New("enablement credential names must be distinct")
+	}
+	if config.MaterializationTime.IsZero() || !config.MaterializationTime.Equal(config.MaterializationTime.Truncate(time.Second)) {
+		return VerifiedEnablementStageCredentialPackage{}, errors.New("enablement credential materialization time is required")
+	}
+	bindings := []struct {
+		role   string
+		name   string
+		source SubmissionStageCredentialSource
+	}{
+		{role: "ledger", name: config.Package.ledgerCredential, source: config.Ledger},
+		{role: "writer", name: config.Package.managementCredential, source: config.ManagementWriter},
+	}
+	objects := make([]submissionStageCredentialObject, 0, len(bindings))
+	receipts := make([]SubmissionStageCredentialObjectReceipt, 0, len(bindings))
+	tokens := make([][]byte, 0, len(bindings))
+	for _, binding := range bindings {
+		object, receipt, token, err := buildSubmissionStageCredentialObject(
+			packageReceipt.StageID, config.MaterializationTime.UTC(), binding.role, binding.name,
+			config.Package.managementAuthority, binding.source,
+		)
+		if err != nil {
+			return VerifiedEnablementStageCredentialPackage{}, err
+		}
+		objects = append(objects, object)
+		receipts = append(receipts, receipt)
+		tokens = append(tokens, token)
+	}
+	if len(tokens[0]) == len(tokens[1]) && subtle.ConstantTimeCompare(tokens[0], tokens[1]) == 1 {
+		return VerifiedEnablementStageCredentialPackage{}, errors.New("enablement ledger and writer credentials must be distinct")
+	}
+	materializedAt := config.MaterializationTime.UTC().Format(time.RFC3339)
+	identity, err := json.Marshal(enablementStageCredentialPackageIdentity{
+		EnablementPackageDigest: packageReceipt.PackageDigest, InstallationAuthority: config.Package.managementAuthority,
+		MaterializedAt: materializedAt, Credentials: receipts,
+	})
+	if err != nil {
+		return VerifiedEnablementStageCredentialPackage{}, errors.New("encode enablement credential package identity")
+	}
+	receipt := EnablementStageCredentialPackageReceipt{
+		Format: EnablementStageCredentialPackageFormat, State: "VERIFIED", StageID: packageReceipt.StageID,
+		EnablementPackageDigest: packageReceipt.PackageDigest, InstallationAuthority: config.Package.managementAuthority,
+		MaterializedAt: materializedAt, PackageDigest: digest.SHA256(identity), Credentials: receipts, MutationAllowed: false,
+	}
+	return VerifiedEnablementStageCredentialPackage{
+		objects: cloneStageCredentialObjects(objects), receipt: receipt,
+		installationAuthority: config.Package.managementAuthority, verified: true,
+	}, nil
+}
+
+func (packaged VerifiedEnablementStageCredentialPackage) Receipt() (EnablementStageCredentialPackageReceipt, error) {
+	if err := verifyEnablementStageCredentialPackage(packaged); err != nil {
+		return EnablementStageCredentialPackageReceipt{}, errors.New("enablement credential package was not produced by verification")
+	}
+	receipt := packaged.receipt
+	receipt.Credentials = append([]SubmissionStageCredentialObjectReceipt(nil), packaged.receipt.Credentials...)
+	for index := range receipt.Credentials {
+		receipt.Credentials[index].Audiences = append([]string(nil), packaged.receipt.Credentials[index].Audiences...)
+	}
+	return receipt, nil
+}
+
+func verifyEnablementStageCredentialPackage(packaged VerifiedEnablementStageCredentialPackage) error {
+	if !packaged.verified || packaged.receipt.Format != EnablementStageCredentialPackageFormat || packaged.receipt.State != "VERIFIED" || packaged.receipt.StageID != "enablement" || packaged.installationAuthority == "" || packaged.receipt.InstallationAuthority != packaged.installationAuthority || len(packaged.objects) != 2 || len(packaged.receipt.Credentials) != 2 {
+		return errors.New("enablement credential package identity is incomplete")
+	}
+	if !stageReceiptPrefixDigestPattern.MatchString(packaged.receipt.EnablementPackageDigest) {
+		return errors.New("enablement package digest is invalid")
+	}
+	identity, err := json.Marshal(enablementStageCredentialPackageIdentity{
+		EnablementPackageDigest: packaged.receipt.EnablementPackageDigest,
+		InstallationAuthority:   packaged.receipt.InstallationAuthority,
+		MaterializedAt:          packaged.receipt.MaterializedAt, Credentials: packaged.receipt.Credentials,
+	})
+	if err != nil || digest.SHA256(identity) != packaged.receipt.PackageDigest {
+		return errors.New("enablement credential package identity changed after verification")
+	}
+	if _, err := time.Parse(time.RFC3339, packaged.receipt.MaterializedAt); err != nil {
+		return errors.New("enablement credential materialization time is invalid")
+	}
+	expectedRoles := []string{"ledger", "writer"}
+	for index, object := range packaged.objects {
+		receipt := packaged.receipt.Credentials[index]
+		if object.role != expectedRoles[index] || receipt.Role != expectedRoles[index] || object.role != receipt.Role || object.authority != packaged.installationAuthority || receipt.Authority != packaged.installationAuthority || object.name != receipt.Name || receipt.Namespace != submissionStageInputNamespace || digest.SHA256(object.raw) != receipt.ObjectDigest {
+			return errors.New("enablement credential object identity changed after verification")
+		}
+	}
+	return nil
+}

--- a/internal/runner/enablement_stage_credentials_test.go
+++ b/internal/runner/enablement_stage_credentials_test.go
@@ -1,0 +1,161 @@
+package runner
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+func TestBuildEnablementStageCredentialPackageBindsDistinctPrivateSecrets(t *testing.T) {
+	config, ledgerToken, writerToken := enablementCredentialConfig(t)
+	packaged, err := BuildEnablementStageCredentialPackage(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := packaged.Receipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	packageReceipt, _ := config.Package.Receipt()
+	if receipt.Format != EnablementStageCredentialPackageFormat || receipt.State != "VERIFIED" || receipt.StageID != "enablement" || receipt.EnablementPackageDigest != packageReceipt.PackageDigest || receipt.InstallationAuthority != "ok-mgmt" || receipt.MaterializedAt != config.MaterializationTime.Format(time.RFC3339) || !stageReceiptPrefixDigestPattern.MatchString(receipt.PackageDigest) || receipt.MutationAllowed || len(receipt.Credentials) != 2 {
+		t.Fatalf("unexpected enablement credential receipt: %#v", receipt)
+	}
+	want := []struct {
+		role  string
+		name  string
+		token []byte
+	}{
+		{role: "ledger", name: config.Package.ledgerCredential, token: ledgerToken},
+		{role: "writer", name: config.Package.managementCredential, token: writerToken},
+	}
+	for index, expected := range want {
+		object := packaged.objects[index]
+		objectReceipt := receipt.Credentials[index]
+		if object.role != expected.role || object.authority != "ok-mgmt" || object.name != expected.name || digest.SHA256(object.raw) != objectReceipt.ObjectDigest {
+			t.Fatalf("private enablement credential %d differs: %#v %#v", index, object, objectReceipt)
+		}
+		var secret map[string]any
+		if err := json.Unmarshal(object.raw, &secret); err != nil {
+			t.Fatal(err)
+		}
+		metadata := secret["metadata"].(map[string]any)
+		labels := metadata["labels"].(map[string]any)
+		annotations := metadata["annotations"].(map[string]any)
+		data := secret["data"].(map[string]any)
+		decodedToken, err := base64.StdEncoding.DecodeString(data["token"].(string))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if secret["immutable"] != true || metadata["namespace"] != submissionStageInputNamespace || labels["openkubes.io/stage-id"] != "enablement" || labels["openkubes.io/credential-role"] != expected.role || annotations["openkubes.io/authority-identity"] != "ok-mgmt" || !bytes.Equal(decodedToken, expected.token) {
+			t.Fatalf("enablement credential Secret %d differs: %#v", index, secret)
+		}
+	}
+	public, err := json.Marshal(receipt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range []string{string(ledgerToken), string(writerToken), config.Ledger.TokenFile, config.Ledger.CAFile, config.Ledger.ExpectedSubject, config.ManagementWriter.ExpectedSubject} {
+		if bytes.Contains(public, []byte(forbidden)) {
+			t.Fatalf("enablement credential receipt exposed private value %q", forbidden)
+		}
+	}
+	receipt.Credentials[0].Audiences[0] = "changed"
+	again, err := packaged.Receipt()
+	if err != nil || again.Credentials[0].Audiences[0] == "changed" {
+		t.Fatal("caller mutated retained enablement credential receipt")
+	}
+}
+
+func TestBuildEnablementStageCredentialPackageFailsClosed(t *testing.T) {
+	for name, mutate := range map[string]func(*EnablementStageCredentialPackageConfig){
+		"foreign writer authority": func(config *EnablementStageCredentialPackageConfig) {
+			config.ManagementWriter.AuthorityIdentity = "ok-infra"
+		},
+		"shared token": func(config *EnablementStageCredentialPackageConfig) {
+			config.ManagementWriter.TokenFile = config.Ledger.TokenFile
+			config.ManagementWriter.TokenDigest = config.Ledger.TokenDigest
+			config.ManagementWriter.ExpectedIssuer = config.Ledger.ExpectedIssuer
+			config.ManagementWriter.ExpectedSubject = config.Ledger.ExpectedSubject
+			config.ManagementWriter.ExpectedAudiences = append([]string(nil), config.Ledger.ExpectedAudiences...)
+			config.ManagementWriter.IssuedAt = config.Ledger.IssuedAt
+			config.ManagementWriter.ExpiresAt = config.Ledger.ExpiresAt
+		},
+		"wrong token digest": func(config *EnablementStageCredentialPackageConfig) {
+			config.ManagementWriter.TokenDigest = prefixSHA("1")
+		},
+		"missing evidence": func(config *EnablementStageCredentialPackageConfig) { config.Ledger.TokenRequestEvidenceDigest = "" },
+		"unverified package": func(config *EnablementStageCredentialPackageConfig) {
+			config.Package = VerifiedEnablementStagePackage{}
+		},
+		"changed package identity": func(config *EnablementStageCredentialPackageConfig) {
+			config.Package.receipt.PackageDigest = prefixSHA("2")
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			config, _, _ := enablementCredentialConfig(t)
+			mutate(&config)
+			_, err := BuildEnablementStageCredentialPackage(config)
+			if err == nil || strings.Contains(err.Error(), config.Ledger.TokenFile) || strings.Contains(err.Error(), config.ManagementWriter.TokenFile) {
+				t.Fatalf("unsafe enablement credential package accepted: %v", err)
+			}
+		})
+	}
+	if _, err := (VerifiedEnablementStageCredentialPackage{}).Receipt(); err == nil {
+		t.Fatal("unverified enablement credential receipt was exposed")
+	}
+	config, _, _ := enablementCredentialConfig(t)
+	packaged, err := BuildEnablementStageCredentialPackage(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	packaged.objects[1].raw = append(packaged.objects[1].raw, '\n')
+	if _, err := packaged.Receipt(); err == nil {
+		t.Fatal("changed private enablement credential was accepted")
+	}
+}
+
+func enablementCredentialConfig(t *testing.T) (EnablementStageCredentialPackageConfig, []byte, []byte) {
+	t.Helper()
+	now := time.Date(2026, 8, 16, 12, 0, 0, 0, time.UTC)
+	issuedAt, expiresAt := now.Add(-time.Minute), now.Add(30*time.Minute)
+	audiences := []string{"https://kubernetes.default.svc"}
+	issuer := "https://kubernetes.default.svc.cluster.local"
+	ledgerSubject := "system:serviceaccount:openkubes-execution-system:ok147-ledger-writer"
+	writerSubject := "system:serviceaccount:openkubes-execution-system:ok147-enablement-writer"
+	ledgerToken := stageCredentialJWT(t, issuer, ledgerSubject, audiences, issuedAt, expiresAt, 'e')
+	writerToken := stageCredentialJWT(t, issuer, writerSubject, audiences, issuedAt, expiresAt, 'f')
+	root := t.TempDir()
+	ca := testCA(t)
+	caPath := filepath.Join(root, "ca.crt")
+	ledgerPath := filepath.Join(root, "ledger-token")
+	writerPath := filepath.Join(root, "writer-token")
+	for path, raw := range map[string][]byte{caPath: ca, ledgerPath: ledgerToken, writerPath: writerToken} {
+		if err := os.WriteFile(path, raw, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	fixture := enablementBundleFixture(t)
+	enablementPackage, err := BuildEnablementStagePackage(enablementStagePackageConfig(t, fixture))
+	if err != nil {
+		t.Fatal(err)
+	}
+	source := func(tokenPath, subject, evidence string, token []byte) SubmissionStageCredentialSource {
+		return SubmissionStageCredentialSource{
+			AuthorityIdentity: "ok-mgmt", TokenFile: tokenPath, TokenDigest: digest.SHA256(token),
+			CAFile: caPath, CABundleDigest: digest.SHA256(ca), TokenRequestEvidenceDigest: prefixSHA(evidence),
+			ExpectedIssuer: issuer, ExpectedSubject: subject, ExpectedAudiences: audiences,
+			IssuedAt: issuedAt, ExpiresAt: expiresAt,
+		}
+	}
+	return EnablementStageCredentialPackageConfig{
+		Package: enablementPackage, MaterializationTime: now,
+		Ledger: source(ledgerPath, ledgerSubject, "a", ledgerToken), ManagementWriter: source(writerPath, writerSubject, "b", writerToken),
+	}, ledgerToken, writerToken
+}

--- a/internal/runner/enablement_stage_package.go
+++ b/internal/runner/enablement_stage_package.go
@@ -44,9 +44,12 @@ type EnablementStagePackageReceipt struct {
 }
 
 type VerifiedEnablementStagePackage struct {
-	raw      []byte
-	receipt  EnablementStagePackageReceipt
-	verified bool
+	raw                  []byte
+	receipt              EnablementStagePackageReceipt
+	managementAuthority  string
+	ledgerCredential     string
+	managementCredential string
+	verified             bool
 }
 
 // BuildEnablementStagePackage composes an immutable input ConfigMap with one
@@ -92,21 +95,39 @@ func BuildEnablementStagePackage(config EnablementStagePackageConfig) (VerifiedE
 		JobTemplateDigest: config.JobTemplateDigest, JobEnvelopeDigest: digest.SHA256(jobRaw),
 		ObjectKinds: []string{"ConfigMap", "NetworkPolicy", "Job"}, AuthorizationState: "VERIFIED", MutationAllowed: false,
 	}
-	return VerifiedEnablementStagePackage{raw: packageRaw, receipt: receipt, verified: true}, nil
+	return VerifiedEnablementStagePackage{
+		raw: packageRaw, receipt: receipt,
+		managementAuthority: config.Bundle.PlanExpected.ManagementAuthority,
+		ledgerCredential:    config.LedgerCredentialSecret, managementCredential: config.ManagementCredentialSecret,
+		verified: true,
+	}, nil
 }
 
 func (packaged VerifiedEnablementStagePackage) Bytes() ([]byte, error) {
-	if !packaged.verified || len(packaged.raw) == 0 {
+	if err := verifyEnablementStagePackage(packaged); err != nil {
 		return nil, errors.New("enablement stage package was not produced by verification")
 	}
 	return append([]byte(nil), packaged.raw...), nil
 }
 
 func (packaged VerifiedEnablementStagePackage) Receipt() (EnablementStagePackageReceipt, error) {
-	if !packaged.verified || packaged.receipt.State != "VERIFIED" {
+	if err := verifyEnablementStagePackage(packaged); err != nil {
 		return EnablementStagePackageReceipt{}, errors.New("enablement stage package was not produced by verification")
 	}
 	receipt := packaged.receipt
 	receipt.ObjectKinds = append([]string(nil), packaged.receipt.ObjectKinds...)
 	return receipt, nil
+}
+
+func verifyEnablementStagePackage(packaged VerifiedEnablementStagePackage) error {
+	if !packaged.verified || packaged.receipt.Format != EnablementStagePackageFormat || packaged.receipt.State != "VERIFIED" || packaged.receipt.StageID != "enablement" || packaged.receipt.MutationAllowed || len(packaged.raw) == 0 || packaged.managementAuthority == "" || packaged.ledgerCredential == "" || packaged.managementCredential == "" || packaged.ledgerCredential == packaged.managementCredential {
+		return errors.New("enablement stage package identity is incomplete")
+	}
+	if digest.SHA256(packaged.raw) != packaged.receipt.PackageDigest || !stageReceiptPrefixDigestPattern.MatchString(packaged.receipt.InputConfigMapDigest) || !stageReceiptPrefixDigestPattern.MatchString(packaged.receipt.ReceiptPrefixDigest) || !stageReceiptPrefixDigestPattern.MatchString(packaged.receipt.EnablementDigest) || !stageReceiptPrefixDigestPattern.MatchString(packaged.receipt.JobTemplateDigest) || !stageReceiptPrefixDigestPattern.MatchString(packaged.receipt.JobEnvelopeDigest) {
+		return errors.New("enablement stage package digest identity changed after verification")
+	}
+	if len(packaged.receipt.ObjectKinds) != 3 || packaged.receipt.ObjectKinds[0] != "ConfigMap" || packaged.receipt.ObjectKinds[1] != "NetworkPolicy" || packaged.receipt.ObjectKinds[2] != "Job" || packaged.receipt.AuthorizationState != "VERIFIED" {
+		return errors.New("enablement stage package object inventory changed after verification")
+	}
+	return nil
 }


### PR DESCRIPTION
## Outcome

Seal the private Stage 4 ledger and management-writer credentials behind an offline verified package.

## Boundary

- two independently obtained TokenRequest results;
- exact `ok-mgmt` authority, issuer, subject, audience, issued-at and expiry claims;
- distinct Secret names and token bytes;
- at least fifteen minutes remaining and at most one hour lifetime;
- immutable private Secret objects retained inside the verified package;
- public receipt excludes tokens, CA payloads, subjects and source paths.

Changing the verified Enablement package identity fails closed. This checkpoint performs no API request and installs no Secret or Job.

## Validation

- `GOCACHE=/private/tmp/ok147-go-build-cache go test -ldflags=-linkmode=external ./...`
- `GOCACHE=/private/tmp/ok147-go-build-cache go vet ./...`
- `GOCACHE=/private/tmp/ok147-go-build-cache go test -race -ldflags=-linkmode=external ./internal/runner`
- `git diff --check`

No live infrastructure action was performed.
