### PR TITLE
feat(runner): bind enablement runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,9 @@ Powered by [Cluster API (CAPI)](https://cluster-api.sigs.k8s.io/), [CAPK (KubeVi
   package is emitted locally with `ok cluster stage run enablement package`.
   A private offline credential packager separately verifies two distinct,
   short-lived management TokenRequest results for ledger and HCP writer roles;
-  its public receipt exposes neither tokens, CA data, subjects nor paths.
+  its public receipt exposes neither tokens, CA data, subjects nor paths. The
+  shared tokenless runtime ServiceAccount is also bound offline to the exact
+  Enablement package and contains no RBAC or implicit Pod credential.
 
 ---
 

--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -1248,6 +1248,13 @@ receipt contains only authority, expiry, CA/evidence/object digests and object
 names. Changing the previously verified Enablement package identity fails
 closed. No credential or Job is installed by this checkpoint.
 
+`ok147-enablement-stage-runtime-prerequisite/v1` independently binds the exact
+shared `ok147-contract-executor-runtime` ServiceAccount manifest to the same
+Enablement package. The accepted manifest contains one tokenless ServiceAccount
+only: no Role, binding, Secret or implicit Pod credential. Its canonical object
+digest, source-manifest digest, `ok-mgmt` authority and package digest are
+retained in a redaction-safe receipt. This step is also entirely offline.
+
 ## Typed Contract-to-CAPI submission stages
 
 The existing bounded exact-create submission primitive now has a typed adapter

--- a/internal/runner/enablement_stage_runtime.go
+++ b/internal/runner/enablement_stage_runtime.go
@@ -1,0 +1,61 @@
+package runner
+
+import (
+	"errors"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+const EnablementStageRuntimePrerequisiteFormat = "ok147-enablement-stage-runtime-prerequisite/v1"
+
+type EnablementStageRuntimePrerequisiteReceipt struct {
+	Format                  string `json:"format"`
+	State                   string `json:"state"`
+	EnablementPackageDigest string `json:"enablementPackageDigest"`
+	ManifestDigest          string `json:"manifestDigest"`
+	ObjectDigest            string `json:"objectDigest"`
+	Authority               string `json:"authority"`
+	Namespace               string `json:"namespace"`
+	Name                    string `json:"name"`
+	MutationAllowed         bool   `json:"mutationAllowed"`
+}
+
+type VerifiedEnablementStageRuntimePrerequisite struct {
+	raw      []byte
+	receipt  EnablementStageRuntimePrerequisiteReceipt
+	verified bool
+}
+
+// BuildEnablementStageRuntimePrerequisite binds the shared tokenless runtime
+// ServiceAccount to one exact Enablement package entirely offline.
+func BuildEnablementStageRuntimePrerequisite(packaged VerifiedEnablementStagePackage, manifest []byte, expectedDigest string) (VerifiedEnablementStageRuntimePrerequisite, error) {
+	packageReceipt, err := packaged.Receipt()
+	if err != nil || packaged.managementAuthority == "" {
+		return VerifiedEnablementStageRuntimePrerequisite{}, errors.New("verified enablement package is required")
+	}
+	raw, objectDigest, err := buildStageRuntimePrerequisiteObject(manifest, expectedDigest)
+	if err != nil {
+		return VerifiedEnablementStageRuntimePrerequisite{}, err
+	}
+	receipt := EnablementStageRuntimePrerequisiteReceipt{
+		Format: EnablementStageRuntimePrerequisiteFormat, State: "VERIFIED",
+		EnablementPackageDigest: packageReceipt.PackageDigest, ManifestDigest: expectedDigest,
+		ObjectDigest: objectDigest, Authority: packaged.managementAuthority,
+		Namespace: submissionStageInputNamespace, Name: "ok147-contract-executor-runtime", MutationAllowed: false,
+	}
+	return VerifiedEnablementStageRuntimePrerequisite{raw: raw, receipt: receipt, verified: true}, nil
+}
+
+func (runtime VerifiedEnablementStageRuntimePrerequisite) Receipt() (EnablementStageRuntimePrerequisiteReceipt, error) {
+	if err := verifyEnablementStageRuntimePrerequisite(runtime); err != nil {
+		return EnablementStageRuntimePrerequisiteReceipt{}, err
+	}
+	return runtime.receipt, nil
+}
+
+func verifyEnablementStageRuntimePrerequisite(runtime VerifiedEnablementStageRuntimePrerequisite) error {
+	if !runtime.verified || runtime.receipt.Format != EnablementStageRuntimePrerequisiteFormat || runtime.receipt.State != "VERIFIED" || runtime.receipt.Authority == "" || runtime.receipt.Namespace != submissionStageInputNamespace || runtime.receipt.Name != "ok147-contract-executor-runtime" || runtime.receipt.MutationAllowed || !stageReceiptPrefixDigestPattern.MatchString(runtime.receipt.EnablementPackageDigest) || !stageReceiptPrefixDigestPattern.MatchString(runtime.receipt.ManifestDigest) || digest.SHA256(runtime.raw) != runtime.receipt.ObjectDigest {
+		return errors.New("enablement runtime prerequisite was not produced by verification")
+	}
+	return nil
+}

--- a/internal/runner/enablement_stage_runtime_test.go
+++ b/internal/runner/enablement_stage_runtime_test.go
@@ -1,0 +1,49 @@
+package runner
+
+import (
+	"testing"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+func TestBuildEnablementStageRuntimePrerequisiteBindsExactPackage(t *testing.T) {
+	packaged, err := BuildEnablementStagePackage(enablementStagePackageConfig(t, enablementBundleFixture(t)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest := submissionStageRuntimeManifest(t)
+	runtime, err := BuildEnablementStageRuntimePrerequisite(packaged, manifest, digest.SHA256(manifest))
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := runtime.Receipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	packageReceipt, _ := packaged.Receipt()
+	if receipt.Format != EnablementStageRuntimePrerequisiteFormat || receipt.State != "VERIFIED" || receipt.EnablementPackageDigest != packageReceipt.PackageDigest || receipt.Authority != "ok-mgmt" || receipt.Namespace != submissionStageInputNamespace || receipt.Name != "ok147-contract-executor-runtime" || receipt.ManifestDigest != digest.SHA256(manifest) || receipt.ObjectDigest != digest.SHA256(runtime.raw) || receipt.MutationAllowed {
+		t.Fatalf("unexpected enablement runtime receipt: %#v", receipt)
+	}
+}
+
+func TestBuildEnablementStageRuntimePrerequisiteFailsClosed(t *testing.T) {
+	packaged, err := BuildEnablementStagePackage(enablementStagePackageConfig(t, enablementBundleFixture(t)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest := submissionStageRuntimeManifest(t)
+	if _, err := BuildEnablementStageRuntimePrerequisite(VerifiedEnablementStagePackage{}, manifest, digest.SHA256(manifest)); err == nil {
+		t.Fatal("unverified enablement package accepted")
+	}
+	if _, err := BuildEnablementStageRuntimePrerequisite(packaged, append(manifest, '\n'), digest.SHA256(manifest)); err == nil {
+		t.Fatal("changed enablement runtime manifest accepted")
+	}
+	runtime, err := BuildEnablementStageRuntimePrerequisite(packaged, manifest, digest.SHA256(manifest))
+	if err != nil {
+		t.Fatal(err)
+	}
+	runtime.raw[0] = 'x'
+	if _, err := runtime.Receipt(); err == nil {
+		t.Fatal("changed enablement runtime object accepted")
+	}
+}


### PR DESCRIPTION
## Outcome

Bind the shared tokenless runtime ServiceAccount to one exact verified Enablement package.

## Boundary

- exactly one `ServiceAccount/ok147-contract-executor-runtime`;
- `automountServiceAccountToken: false`;
- no Role, binding, Secret, or implicit Pod credential;
- exact source manifest, canonical object, Enablement package, and `ok-mgmt` authority digests;
- no API request or Kubernetes mutation.

## Validation

- `GOCACHE=/private/tmp/ok147-go-build-cache go test -ldflags=-linkmode=external ./...`
- `GOCACHE=/private/tmp/ok147-go-build-cache go vet ./...`
- `GOCACHE=/private/tmp/ok147-go-build-cache go test -race -ldflags=-linkmode=external ./internal/runner`
- `git diff --check`

No live infrastructure action was performed.
