### PR TITLE
feat(runner): plan enablement installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,9 @@ Powered by [Cluster API (CAPI)](https://cluster-api.sigs.k8s.io/), [CAPK (KubeVi
   short-lived management TokenRequest results for ledger and HCP writer roles;
   its public receipt exposes neither tokens, CA data, subjects nor paths. The
   shared tokenless runtime ServiceAccount is also bound offline to the exact
-  Enablement package and contains no RBAC or implicit Pod credential.
+  Enablement package and contains no RBAC or implicit Pod credential. A
+  read-only installation planner finally derives the fixed ConfigMap,
+  NetworkPolicy, Job GET/POST sequence without opening either credential.
 
 ---
 

--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -1255,6 +1255,14 @@ only: no Role, binding, Secret or implicit Pod credential. Its canonical object
 digest, source-manifest digest, `ok-mgmt` authority and package digest are
 retained in a redaction-safe receipt. This step is also entirely offline.
 
+`ok147-enablement-stage-installation-plan/v1` parses the sealed three-object
+package again and derives the exact create order `ConfigMap -> NetworkPolicy ->
+Job`. Every item carries an exact-name GET preflight path, collection-only POST
+path and canonical object digest. The planner verifies immutable input,
+NetworkPolicy/Job run identity, tokenless ServiceAccount, `ok-mgmt` authority
+and the two exact credential Secret names. It deliberately excludes the Secret
+objects themselves and grants no mutation authority.
+
 ## Typed Contract-to-CAPI submission stages
 
 The existing bounded exact-create submission primitive now has a typed adapter

--- a/internal/runner/enablement_stage_installation_plan.go
+++ b/internal/runner/enablement_stage_installation_plan.go
@@ -1,0 +1,125 @@
+package runner
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"gopkg.in/yaml.v3"
+)
+
+const EnablementStageInstallationPlanFormat = "ok147-enablement-stage-installation-plan/v1"
+
+// EnablementStageInstallationPlan is an offline exact-create description. It
+// grants no authority to perform any recorded request.
+type EnablementStageInstallationPlan struct {
+	Format                  string                      `json:"format"`
+	State                   string                      `json:"state"`
+	StageID                 string                      `json:"stageId"`
+	EnablementPackageDigest string                      `json:"enablementPackageDigest"`
+	Authority               string                      `json:"authority"`
+	Creates                 []SubmissionStageCreatePlan `json:"creates"`
+	MutationAllowed         bool                        `json:"mutationAllowed"`
+}
+
+// PlanEnablementStageInstallation verifies the immutable input,
+// NetworkPolicy and Job identities and derives their exact create order. It
+// performs no API request and opens no credential.
+func PlanEnablementStageInstallation(packaged VerifiedEnablementStagePackage) (EnablementStageInstallationPlan, error) {
+	receipt, err := packaged.Receipt()
+	if err != nil {
+		return EnablementStageInstallationPlan{}, err
+	}
+	expectedKinds := []string{"ConfigMap", "NetworkPolicy", "Job"}
+	if !equalStringList(receipt.ObjectKinds, expectedKinds) {
+		return EnablementStageInstallationPlan{}, errors.New("enablement package object inventory is invalid")
+	}
+	documents := bytes.Split(packaged.raw, []byte("\n---\n"))
+	if len(documents) != len(expectedKinds) || digest.SHA256(documents[0]) != receipt.InputConfigMapDigest || digest.SHA256(bytes.Join(documents[1:], []byte("\n---\n"))) != receipt.JobEnvelopeDigest {
+		return EnablementStageInstallationPlan{}, errors.New("enablement package component identity differs")
+	}
+	decoder := yaml.NewDecoder(bytes.NewReader(packaged.raw))
+	objects := make([]map[string]any, 0, len(expectedKinds))
+	for {
+		var object map[string]any
+		err := decoder.Decode(&object)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil || len(object) == 0 {
+			return EnablementStageInstallationPlan{}, errors.New("decode enablement package")
+		}
+		objects = append(objects, object)
+	}
+	if len(objects) != len(expectedKinds) {
+		return EnablementStageInstallationPlan{}, errors.New("enablement package object count is invalid")
+	}
+
+	configMapName, runID := "", ""
+	creates := make([]SubmissionStageCreatePlan, 0, len(objects))
+	for index, object := range objects {
+		apiVersion, _ := object["apiVersion"].(string)
+		kind, _ := object["kind"].(string)
+		if kind != expectedKinds[index] {
+			return EnablementStageInstallationPlan{}, errors.New("enablement package create order is invalid")
+		}
+		metadata, ok := object["metadata"].(map[string]any)
+		if !ok {
+			return EnablementStageInstallationPlan{}, errors.New("enablement package object metadata is invalid")
+		}
+		name, _ := metadata["name"].(string)
+		namespace, _ := metadata["namespace"].(string)
+		if !submissionStageInputNamePattern.MatchString(name) || len(name) > 63 || namespace != submissionStageInputNamespace || metadata["generateName"] != nil {
+			return EnablementStageInstallationPlan{}, errors.New("enablement package object identity is invalid")
+		}
+		collectionPath, objectPath, err := submissionStageCreatePaths(apiVersion, kind, namespace, name)
+		if err != nil {
+			return EnablementStageInstallationPlan{}, err
+		}
+		canonical, err := json.Marshal(object)
+		if err != nil {
+			return EnablementStageInstallationPlan{}, errors.New("encode enablement package object")
+		}
+		creates = append(creates, SubmissionStageCreatePlan{
+			Order: index + 1, APIVersion: apiVersion, Kind: kind, Namespace: namespace, Name: name,
+			PreflightMethod: "GET", ObjectPath: objectPath, CreateMethod: "POST", CollectionPath: collectionPath,
+			ObjectDigest: digest.SHA256(canonical),
+		})
+		switch kind {
+		case "ConfigMap":
+			labels, _ := metadata["labels"].(map[string]any)
+			if object["immutable"] != true || labels["openkubes.io/stage-id"] != receipt.StageID {
+				return EnablementStageInstallationPlan{}, errors.New("enablement input ConfigMap semantics differ")
+			}
+			configMapName = name
+		case "NetworkPolicy":
+			runID = name
+			spec, _ := object["spec"].(map[string]any)
+			selector, _ := spec["podSelector"].(map[string]any)
+			matchLabels, _ := selector["matchLabels"].(map[string]any)
+			if matchLabels["openkubes.io/execution-id"] != runID {
+				return EnablementStageInstallationPlan{}, errors.New("enablement NetworkPolicy selector differs from run identity")
+			}
+		case "Job":
+			if name != runID {
+				return EnablementStageInstallationPlan{}, errors.New("enablement Job and NetworkPolicy identities differ")
+			}
+			spec, _ := object["spec"].(map[string]any)
+			template, _ := spec["template"].(map[string]any)
+			podSpec, _ := template["spec"].(map[string]any)
+			if podSpec["serviceAccountName"] != "ok147-contract-executor-runtime" || podSpec["automountServiceAccountToken"] != false {
+				return EnablementStageInstallationPlan{}, errors.New("enablement Job runtime identity is invalid")
+			}
+			if !jobMountsInputConfigMap(podSpec, configMapName) || !jobUsesManagementAuthority(podSpec, packaged.managementAuthority) || !jobUsesLifecycleObservationCredentialSecrets(podSpec, packaged.ledgerCredential, packaged.managementCredential) {
+				return EnablementStageInstallationPlan{}, errors.New("enablement Job binding differs from verified package")
+			}
+		}
+	}
+	return EnablementStageInstallationPlan{
+		Format: EnablementStageInstallationPlanFormat, State: "VERIFIED", StageID: receipt.StageID,
+		EnablementPackageDigest: receipt.PackageDigest, Authority: packaged.managementAuthority,
+		Creates: creates, MutationAllowed: false,
+	}, nil
+}

--- a/internal/runner/enablement_stage_installation_plan_test.go
+++ b/internal/runner/enablement_stage_installation_plan_test.go
@@ -1,0 +1,83 @@
+package runner
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+func TestPlanEnablementStageInstallationProducesExactSafeOrder(t *testing.T) {
+	packaged, err := BuildEnablementStagePackage(enablementStagePackageConfig(t, enablementBundleFixture(t)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan, err := PlanEnablementStageInstallation(packaged)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, _ := packaged.Receipt()
+	if plan.Format != EnablementStageInstallationPlanFormat || plan.State != "VERIFIED" || plan.StageID != "enablement" || plan.EnablementPackageDigest != receipt.PackageDigest || plan.Authority != "ok-mgmt" || plan.MutationAllowed {
+		t.Fatalf("unexpected enablement installation plan: %#v", plan)
+	}
+	wantKinds := []string{"ConfigMap", "NetworkPolicy", "Job"}
+	wantCollections := []string{
+		"/api/v1/namespaces/openkubes-execution-system/configmaps",
+		"/apis/networking.k8s.io/v1/namespaces/openkubes-execution-system/networkpolicies",
+		"/apis/batch/v1/namespaces/openkubes-execution-system/jobs",
+	}
+	if len(plan.Creates) != len(wantKinds) {
+		t.Fatalf("creates=%d, want 3", len(plan.Creates))
+	}
+	for index, create := range plan.Creates {
+		if create.Order != index+1 || create.Kind != wantKinds[index] || create.Namespace != submissionStageInputNamespace || create.PreflightMethod != "GET" || create.CreateMethod != "POST" || create.CollectionPath != wantCollections[index] || create.ObjectPath != create.CollectionPath+"/"+create.Name || !stageReceiptPrefixDigestPattern.MatchString(create.ObjectDigest) {
+			t.Fatalf("unexpected enablement create %d: %#v", index, create)
+		}
+		if strings.Contains(strings.ToLower(create.ObjectPath), "secret") {
+			t.Fatalf("installation plan unexpectedly contains credential path: %#v", create)
+		}
+	}
+	if plan.Creates[1].Name != plan.Creates[2].Name {
+		t.Fatal("enablement NetworkPolicy and Job run identities differ")
+	}
+}
+
+func TestPlanEnablementStageInstallationFailsClosed(t *testing.T) {
+	valid, err := BuildEnablementStagePackage(enablementStagePackageConfig(t, enablementBundleFixture(t)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := PlanEnablementStageInstallation(VerifiedEnablementStagePackage{}); err == nil {
+		t.Fatal("unverified enablement package was planned")
+	}
+	tests := map[string]func(*VerifiedEnablementStagePackage){
+		"wrong inventory": func(packaged *VerifiedEnablementStagePackage) {
+			packaged.receipt.ObjectKinds = []string{"ConfigMap", "Job", "NetworkPolicy"}
+		},
+		"foreign authority": func(packaged *VerifiedEnablementStagePackage) { packaged.managementAuthority = "ok-infra" },
+		"changed runtime": func(packaged *VerifiedEnablementStagePackage) {
+			packaged.raw = bytes.Replace(packaged.raw, []byte("ok147-contract-executor-runtime"), []byte("ok147-foreign-runtime"), 1)
+			packaged.receipt.PackageDigest = digest.SHA256(packaged.raw)
+		},
+		"changed credential": func(packaged *VerifiedEnablementStagePackage) {
+			packaged.raw = bytes.Replace(packaged.raw, []byte(packaged.managementCredential), []byte("ok147-foreign-writer"), 1)
+			packaged.receipt.PackageDigest = digest.SHA256(packaged.raw)
+		},
+		"extra object": func(packaged *VerifiedEnablementStagePackage) {
+			packaged.raw = append(packaged.raw, []byte("\n---\napiVersion: v1\nkind: Secret\nmetadata: {name: forbidden}\n")...)
+			packaged.receipt.PackageDigest = digest.SHA256(packaged.raw)
+		},
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			packaged := valid
+			packaged.raw = append([]byte(nil), valid.raw...)
+			packaged.receipt.ObjectKinds = append([]string(nil), valid.receipt.ObjectKinds...)
+			mutate(&packaged)
+			if _, err := PlanEnablementStageInstallation(packaged); err == nil {
+				t.Fatal("changed enablement package was planned")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Outcome

Derive the exact offline installation plan for the sealed Stage 4 package.

## Boundary

- fixed `ConfigMap -> NetworkPolicy -> Job` order;
- exact-name GET preflight and collection-only POST path per object;
- canonical object digest per request;
- immutable input, run identity, tokenless ServiceAccount, `ok-mgmt` authority, and exact credential Secret-name verification;
- credential objects excluded from this public plan;
- no credential open, API request, or mutation authority.

## Validation

- `GOCACHE=/private/tmp/ok147-go-build-cache go test -ldflags=-linkmode=external ./...`
- `GOCACHE=/private/tmp/ok147-go-build-cache go vet ./...`
- `GOCACHE=/private/tmp/ok147-go-build-cache go test -race -ldflags=-linkmode=external ./internal/runner`
- `git diff --check`

No live infrastructure action was performed.
