### PR TITLE
feat(runner): plan enablement launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,9 @@ Powered by [Cluster API (CAPI)](https://cluster-api.sigs.k8s.io/), [CAPK (KubeVi
   shared tokenless runtime ServiceAccount is also bound offline to the exact
   Enablement package and contains no RBAC or implicit Pod credential. A
   read-only installation planner finally derives the fixed ConfigMap,
-  NetworkPolicy, Job GET/POST sequence without opening either credential.
+  NetworkPolicy, Job GET/POST sequence without opening either credential. A
+  private launch planner correlates runtime, prerequisites, both Secrets and
+  the final Job behind one global six-object preflight barrier.
 
 ---
 

--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -1263,6 +1263,15 @@ NetworkPolicy/Job run identity, tokenless ServiceAccount, `ok-mgmt` authority
 and the two exact credential Secret names. It deliberately excludes the Secret
 objects themselves and grants no mutation authority.
 
+`ok147-enablement-stage-launch-plan/v1` then correlates the verified package,
+private credential package and tokenless runtime prerequisite into six exact
+objects: runtime ServiceAccount, input ConfigMap, NetworkPolicy, ledger Secret,
+writer Secret and finally the Job. Every GET must establish the single global
+state `ALL_ABSENT_OR_RUNTIME_ONLY_OR_ALL_EXACT` before any POST may start. The
+runtime alone may already exist if it matches exactly; every other object is
+create-only after global absence. The redaction-safe plan contains no object
+body or credential content and still grants no mutation authority.
+
 ## Typed Contract-to-CAPI submission stages
 
 The existing bounded exact-create submission primitive now has a typed adapter

--- a/internal/runner/enablement_stage_launch_plan.go
+++ b/internal/runner/enablement_stage_launch_plan.go
@@ -1,0 +1,82 @@
+package runner
+
+import "errors"
+
+const EnablementStageLaunchPlanFormat = "ok147-enablement-stage-launch-plan/v1"
+
+// EnablementStageLaunchPlan correlates every exact object needed to start one
+// Enablement Job. It contains no object body or credential content and grants
+// no mutation authority.
+type EnablementStageLaunchPlan struct {
+	Format                  string                           `json:"format"`
+	State                   string                           `json:"state"`
+	StageID                 string                           `json:"stageId"`
+	Authority               string                           `json:"authority"`
+	EnablementPackageDigest string                           `json:"enablementPackageDigest"`
+	CredentialPackageDigest string                           `json:"credentialPackageDigest"`
+	RuntimeManifestDigest   string                           `json:"runtimeManifestDigest"`
+	PreflightBarrier        string                           `json:"preflightBarrier"`
+	Preflights              []SubmissionStageLaunchPreflight `json:"preflights"`
+	Creates                 []SubmissionStageLaunchCreate    `json:"creates"`
+	MutationAllowed         bool                             `json:"mutationAllowed"`
+}
+
+// PlanEnablementStageLaunch requires one coherent package, credential package
+// and runtime prerequisite. Every preflight must pass before any create.
+func PlanEnablementStageLaunch(packaged VerifiedEnablementStagePackage, credentials VerifiedEnablementStageCredentialPackage, runtime VerifiedEnablementStageRuntimePrerequisite) (EnablementStageLaunchPlan, error) {
+	stage, err := PlanEnablementStageInstallation(packaged)
+	if err != nil {
+		return EnablementStageLaunchPlan{}, err
+	}
+	if err := verifyEnablementStageCredentialPackage(credentials); err != nil {
+		return EnablementStageLaunchPlan{}, err
+	}
+	if err := verifyEnablementStageRuntimePrerequisite(runtime); err != nil {
+		return EnablementStageLaunchPlan{}, err
+	}
+	if stage.EnablementPackageDigest != credentials.receipt.EnablementPackageDigest || stage.EnablementPackageDigest != runtime.receipt.EnablementPackageDigest || stage.StageID != credentials.receipt.StageID || stage.Authority != credentials.installationAuthority || stage.Authority != runtime.receipt.Authority {
+		return EnablementStageLaunchPlan{}, errors.New("enablement launch components do not share one verified identity")
+	}
+
+	preflights := make([]SubmissionStageLaunchPreflight, 0, 6)
+	creates := make([]SubmissionStageLaunchCreate, 0, 6)
+	appendObject := func(order int, phase, apiVersion, kind, namespace, name, objectPath, collectionPath, objectDigest, existingPolicy, createPolicy string) {
+		preflights = append(preflights, SubmissionStageLaunchPreflight{
+			Order: order, Phase: phase, APIVersion: apiVersion, Kind: kind, Namespace: namespace, Name: name,
+			Method: "GET", ObjectPath: objectPath, ResponseMode: "FULL_OBJECT", ExistingPolicy: existingPolicy, ObjectDigest: objectDigest,
+		})
+		creates = append(creates, SubmissionStageLaunchCreate{
+			Order: order, Phase: phase, APIVersion: apiVersion, Kind: kind, Namespace: namespace, Name: name,
+			Method: "POST", CollectionPath: collectionPath, CreatePolicy: createPolicy, ObjectDigest: objectDigest,
+		})
+	}
+	runtimeCollection := "/api/v1/namespaces/" + runtime.receipt.Namespace + "/serviceaccounts"
+	appendObject(1, "runtime", "v1", "ServiceAccount", runtime.receipt.Namespace, runtime.receipt.Name,
+		runtimeCollection+"/"+runtime.receipt.Name, runtimeCollection, runtime.receipt.ObjectDigest,
+		"VERIFY_EXACT", "CREATE_IF_ABSENT_OR_VERIFY_EXISTING")
+
+	// The executable Job is held until input, policy and both credentials exist.
+	for index, object := range stage.Creates[:2] {
+		appendObject(index+2, "stage-prerequisites", object.APIVersion, object.Kind, object.Namespace, object.Name,
+			object.ObjectPath, object.CollectionPath, object.ObjectDigest,
+			"VERIFY_EXACT_GLOBAL_STATE", "CREATE_ONLY_AFTER_GLOBAL_ABSENCE")
+	}
+	for index, object := range credentials.objects {
+		collection := "/api/v1/namespaces/" + submissionStageInputNamespace + "/secrets"
+		appendObject(index+4, "credentials", "v1", "Secret", submissionStageInputNamespace, object.name,
+			collection+"/"+object.name, collection, credentials.receipt.Credentials[index].ObjectDigest,
+			"VERIFY_EXACT_GLOBAL_STATE", "CREATE_ONLY_AFTER_GLOBAL_ABSENCE")
+	}
+	job := stage.Creates[2]
+	appendObject(6, "job", job.APIVersion, job.Kind, job.Namespace, job.Name,
+		job.ObjectPath, job.CollectionPath, job.ObjectDigest,
+		"VERIFY_EXACT_GLOBAL_STATE", "CREATE_ONLY_AFTER_GLOBAL_ABSENCE")
+
+	return EnablementStageLaunchPlan{
+		Format: EnablementStageLaunchPlanFormat, State: "VERIFIED", StageID: stage.StageID,
+		Authority: stage.Authority, EnablementPackageDigest: stage.EnablementPackageDigest,
+		CredentialPackageDigest: credentials.receipt.PackageDigest, RuntimeManifestDigest: runtime.receipt.ManifestDigest,
+		PreflightBarrier: "ALL_ABSENT_OR_RUNTIME_ONLY_OR_ALL_EXACT", Preflights: preflights, Creates: creates,
+		MutationAllowed: false,
+	}, nil
+}

--- a/internal/runner/enablement_stage_launch_plan_test.go
+++ b/internal/runner/enablement_stage_launch_plan_test.go
@@ -1,0 +1,99 @@
+package runner
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+func TestPlanEnablementStageLaunchBindsSixObjectsBehindOneBarrier(t *testing.T) {
+	stage, credentials, runtime, ledgerToken, writerToken := enablementStageLaunchFixture(t)
+	plan, err := PlanEnablementStageLaunch(stage, credentials, runtime)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stageReceipt, _ := stage.Receipt()
+	credentialReceipt, _ := credentials.Receipt()
+	runtimeReceipt, _ := runtime.Receipt()
+	if plan.Format != EnablementStageLaunchPlanFormat || plan.State != "VERIFIED" || plan.StageID != "enablement" || plan.Authority != "ok-mgmt" || plan.EnablementPackageDigest != stageReceipt.PackageDigest || plan.CredentialPackageDigest != credentialReceipt.PackageDigest || plan.RuntimeManifestDigest != runtimeReceipt.ManifestDigest || plan.PreflightBarrier != "ALL_ABSENT_OR_RUNTIME_ONLY_OR_ALL_EXACT" || plan.MutationAllowed {
+		t.Fatalf("unexpected enablement launch identity: %#v", plan)
+	}
+	wantKinds := []string{"ServiceAccount", "ConfigMap", "NetworkPolicy", "Secret", "Secret", "Job"}
+	wantPhases := []string{"runtime", "stage-prerequisites", "stage-prerequisites", "credentials", "credentials", "job"}
+	if len(plan.Preflights) != len(wantKinds) || len(plan.Creates) != len(wantKinds) {
+		t.Fatalf("unexpected enablement launch object count: %d %d", len(plan.Preflights), len(plan.Creates))
+	}
+	for index := range wantKinds {
+		preflight, create := plan.Preflights[index], plan.Creates[index]
+		if preflight.Order != index+1 || create.Order != index+1 || preflight.Phase != wantPhases[index] || create.Phase != wantPhases[index] || preflight.Kind != wantKinds[index] || create.Kind != wantKinds[index] || preflight.Name != create.Name || preflight.Namespace != create.Namespace || preflight.ObjectDigest != create.ObjectDigest || preflight.Method != "GET" || create.Method != "POST" || preflight.ResponseMode != "FULL_OBJECT" {
+			t.Fatalf("enablement launch step %d differs: %#v %#v", index+1, preflight, create)
+		}
+		if index == 0 {
+			if preflight.ExistingPolicy != "VERIFY_EXACT" || create.CreatePolicy != "CREATE_IF_ABSENT_OR_VERIFY_EXISTING" {
+				t.Fatalf("runtime policy differs: %#v %#v", preflight, create)
+			}
+		} else if preflight.ExistingPolicy != "VERIFY_EXACT_GLOBAL_STATE" || create.CreatePolicy != "CREATE_ONLY_AFTER_GLOBAL_ABSENCE" {
+			t.Fatalf("global policy differs at %d: %#v %#v", index+1, preflight, create)
+		}
+	}
+	public, err := json.Marshal(plan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range [][]byte{ledgerToken, writerToken, credentials.objects[0].raw, credentials.objects[1].raw, runtime.raw, stage.raw} {
+		if bytes.Contains(public, forbidden) {
+			t.Fatal("enablement launch plan exposed private object content")
+		}
+	}
+}
+
+func TestPlanEnablementStageLaunchRejectsMismatchedComponents(t *testing.T) {
+	stage, credentials, runtime, _, _ := enablementStageLaunchFixture(t)
+	tests := map[string]func() (VerifiedEnablementStagePackage, VerifiedEnablementStageCredentialPackage, VerifiedEnablementStageRuntimePrerequisite){
+		"empty stage": func() (VerifiedEnablementStagePackage, VerifiedEnablementStageCredentialPackage, VerifiedEnablementStageRuntimePrerequisite) {
+			return VerifiedEnablementStagePackage{}, credentials, runtime
+		},
+		"empty credentials": func() (VerifiedEnablementStagePackage, VerifiedEnablementStageCredentialPackage, VerifiedEnablementStageRuntimePrerequisite) {
+			return stage, VerifiedEnablementStageCredentialPackage{}, runtime
+		},
+		"empty runtime": func() (VerifiedEnablementStagePackage, VerifiedEnablementStageCredentialPackage, VerifiedEnablementStageRuntimePrerequisite) {
+			return stage, credentials, VerifiedEnablementStageRuntimePrerequisite{}
+		},
+		"foreign credential package": func() (VerifiedEnablementStagePackage, VerifiedEnablementStageCredentialPackage, VerifiedEnablementStageRuntimePrerequisite) {
+			changed := credentials
+			changed.receipt.EnablementPackageDigest = digest.SHA256([]byte("foreign"))
+			return stage, changed, runtime
+		},
+		"foreign runtime package": func() (VerifiedEnablementStagePackage, VerifiedEnablementStageCredentialPackage, VerifiedEnablementStageRuntimePrerequisite) {
+			changed := runtime
+			changed.receipt.EnablementPackageDigest = digest.SHA256([]byte("foreign"))
+			return stage, credentials, changed
+		},
+	}
+	for name, values := range tests {
+		t.Run(name, func(t *testing.T) {
+			candidateStage, candidateCredentials, candidateRuntime := values()
+			if _, err := PlanEnablementStageLaunch(candidateStage, candidateCredentials, candidateRuntime); err == nil {
+				t.Fatal("mismatched enablement launch components accepted")
+			}
+		})
+	}
+}
+
+func enablementStageLaunchFixture(t *testing.T) (VerifiedEnablementStagePackage, VerifiedEnablementStageCredentialPackage, VerifiedEnablementStageRuntimePrerequisite, []byte, []byte) {
+	t.Helper()
+	credentialConfig, ledgerToken, writerToken := enablementCredentialConfig(t)
+	stage := credentialConfig.Package
+	credentials, err := BuildEnablementStageCredentialPackage(credentialConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest := submissionStageRuntimeManifest(t)
+	runtime, err := BuildEnablementStageRuntimePrerequisite(stage, manifest, digest.SHA256(manifest))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return stage, credentials, runtime, ledgerToken, writerToken
+}


### PR DESCRIPTION
## Outcome

Correlate the verified Stage 4 package, private credentials, and tokenless runtime behind one six-object global preflight barrier.

## Exact order

1. runtime ServiceAccount
2. immutable input ConfigMap
3. NetworkPolicy
4. ledger Secret
5. management-writer Secret
6. Job

The runtime alone may already exist if exact. Every other object is create-only after global absence. The redaction-safe plan contains no object body or credential content and grants no mutation authority.

## Validation

- `GOCACHE=/private/tmp/ok147-go-build-cache go test -ldflags=-linkmode=external ./...`
- `GOCACHE=/private/tmp/ok147-go-build-cache go vet ./...`
- `GOCACHE=/private/tmp/ok147-go-build-cache go test -race -ldflags=-linkmode=external ./internal/runner`
- `git diff --check`

No live infrastructure action was performed.
