### PR TITLE
feat(runner): prepare enablement launch candidate

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,9 @@ Powered by [Cluster API (CAPI)](https://cluster-api.sigs.k8s.io/), [CAPK (KubeVi
   read-only installation planner finally derives the fixed ConfigMap,
   NetworkPolicy, Job GET/POST sequence without opening either credential. A
   private launch planner correlates runtime, prerequisites, both Secrets and
-  the final Job behind one global six-object preflight barrier.
+  the final Job behind one global six-object preflight barrier. A prepared,
+  expiry-bound candidate then binds that plan to one exact management API,
+  CA, installer-token identity and independent credential evidence.
 
 ---
 

--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -1272,6 +1272,14 @@ runtime alone may already exist if it matches exactly; every other object is
 create-only after global absence. The redaction-safe plan contains no object
 body or credential content and still grants no mutation authority.
 
+`ok147-enablement-stage-launch-candidate/v1` binds that plan to one normalized
+IP-literal HTTPS management endpoint, exact CA digest and independently
+evidenced installer-token identity. Its validity ends fifteen minutes before
+the earliest Job credential expires; a preparation time before credential
+materialization or after that boundary fails closed. The public receipt exposes
+only digests and times, not the endpoint or installer token, and remains
+non-mutating.
+
 ## Typed Contract-to-CAPI submission stages
 
 The existing bounded exact-create submission primitive now has a typed adapter

--- a/internal/runner/enablement_stage_launch_candidate.go
+++ b/internal/runner/enablement_stage_launch_candidate.go
@@ -1,0 +1,173 @@
+package runner
+
+import (
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+const EnablementStageLaunchCandidateFormat = "ok147-enablement-stage-launch-candidate/v1"
+
+type EnablementStageLaunchCandidateReceipt struct {
+	Format                            string `json:"format"`
+	State                             string `json:"state"`
+	StageID                           string `json:"stageId"`
+	Authority                         string `json:"authority"`
+	EnablementPackageDigest           string `json:"enablementPackageDigest"`
+	CredentialPackageDigest           string `json:"credentialPackageDigest"`
+	RuntimeManifestDigest             string `json:"runtimeManifestDigest"`
+	LaunchPlanDigest                  string `json:"launchPlanDigest"`
+	AuthorityEndpointDigest           string `json:"authorityEndpointDigest"`
+	CABundleDigest                    string `json:"caBundleDigest"`
+	InstallerCredentialBindingDigest  string `json:"installerCredentialBindingDigest"`
+	InstallerCredentialEvidenceDigest string `json:"installerCredentialEvidenceDigest"`
+	PreparedAt                        string `json:"preparedAt"`
+	ValidUntil                        string `json:"validUntil"`
+	CandidateDigest                   string `json:"candidateDigest"`
+	MutationAllowed                   bool   `json:"mutationAllowed"`
+}
+
+type enablementStageLaunchCandidateIdentity struct {
+	StageID                           string `json:"stageId"`
+	Authority                         string `json:"authority"`
+	EnablementPackageDigest           string `json:"enablementPackageDigest"`
+	CredentialPackageDigest           string `json:"credentialPackageDigest"`
+	RuntimeManifestDigest             string `json:"runtimeManifestDigest"`
+	LaunchPlanDigest                  string `json:"launchPlanDigest"`
+	AuthorityEndpointDigest           string `json:"authorityEndpointDigest"`
+	CABundleDigest                    string `json:"caBundleDigest"`
+	InstallerCredentialBindingDigest  string `json:"installerCredentialBindingDigest"`
+	InstallerCredentialEvidenceDigest string `json:"installerCredentialEvidenceDigest"`
+	PreparedAt                        string `json:"preparedAt"`
+	ValidUntil                        string `json:"validUntil"`
+}
+
+// VerifiedEnablementStageLaunchCandidate retains the exact endpoint and
+// installer-token identity that are absent from its redaction-safe receipt.
+type VerifiedEnablementStageLaunchCandidate struct {
+	receipt              EnablementStageLaunchCandidateReceipt
+	authorityEndpoint    string
+	installerTokenDigest string
+	verified             bool
+}
+
+// PrepareEnablementStageLaunchCandidate binds one coherent launch plan to one
+// API destination, CA and independently evidenced installer credential. It
+// opens no credential and performs no API request.
+func PrepareEnablementStageLaunchCandidate(config SubmissionStageLaunchCandidateConfig, packaged VerifiedEnablementStagePackage, credentials VerifiedEnablementStageCredentialPackage, runtime VerifiedEnablementStageRuntimePrerequisite) (VerifiedEnablementStageLaunchCandidate, error) {
+	plan, err := PlanEnablementStageLaunch(packaged, credentials, runtime)
+	if err != nil {
+		return VerifiedEnablementStageLaunchCandidate{}, err
+	}
+	if err := verifyEnablementStageCredentialPackage(credentials); err != nil {
+		return VerifiedEnablementStageLaunchCandidate{}, err
+	}
+	endpoint, err := normalizeSubmissionStageLaunchEndpoint(config.AuthorityEndpoint)
+	if err != nil {
+		return VerifiedEnablementStageLaunchCandidate{}, err
+	}
+	if !stageReceiptPrefixDigestPattern.MatchString(config.CABundleDigest) || !stageReceiptPrefixDigestPattern.MatchString(config.InstallerTokenDigest) || !stageReceiptPrefixDigestPattern.MatchString(config.InstallerCredentialEvidenceDigest) {
+		return VerifiedEnablementStageLaunchCandidate{}, errors.New("enablement launch candidate credential identities are invalid")
+	}
+	if config.PreparedAt.IsZero() || !config.PreparedAt.Equal(config.PreparedAt.Truncate(time.Second)) {
+		return VerifiedEnablementStageLaunchCandidate{}, errors.New("enablement launch candidate preparation time is required")
+	}
+	materializedAt, err := time.Parse(time.RFC3339, credentials.receipt.MaterializedAt)
+	if err != nil || config.PreparedAt.Before(materializedAt) {
+		return VerifiedEnablementStageLaunchCandidate{}, errors.New("enablement launch candidate predates credential materialization")
+	}
+	validUntil := time.Time{}
+	for _, credential := range credentials.receipt.Credentials {
+		expiresAt, err := time.Parse(time.RFC3339, credential.ExpiresAt)
+		if err != nil {
+			return VerifiedEnablementStageLaunchCandidate{}, errors.New("enablement credential expiration is invalid")
+		}
+		candidate := expiresAt.Add(-minimumStageCredentialRemaining)
+		if validUntil.IsZero() || candidate.Before(validUntil) {
+			validUntil = candidate
+		}
+	}
+	if validUntil.IsZero() || config.PreparedAt.After(validUntil) {
+		return VerifiedEnablementStageLaunchCandidate{}, errors.New("enablement credentials cannot retain minimum lifetime")
+	}
+	planRaw, err := json.Marshal(plan)
+	if err != nil {
+		return VerifiedEnablementStageLaunchCandidate{}, errors.New("encode enablement launch plan identity")
+	}
+	credentialBindingRaw, err := json.Marshal(submissionStageInstallerCredentialIdentity{TokenDigest: config.InstallerTokenDigest, EvidenceDigest: config.InstallerCredentialEvidenceDigest})
+	if err != nil {
+		return VerifiedEnablementStageLaunchCandidate{}, errors.New("encode enablement installer credential identity")
+	}
+	identity := enablementStageLaunchCandidateIdentity{
+		StageID: plan.StageID, Authority: plan.Authority, EnablementPackageDigest: plan.EnablementPackageDigest,
+		CredentialPackageDigest: plan.CredentialPackageDigest, RuntimeManifestDigest: plan.RuntimeManifestDigest,
+		LaunchPlanDigest: digest.SHA256(planRaw), AuthorityEndpointDigest: digest.SHA256([]byte(endpoint)),
+		CABundleDigest: config.CABundleDigest, InstallerCredentialBindingDigest: digest.SHA256(credentialBindingRaw),
+		InstallerCredentialEvidenceDigest: config.InstallerCredentialEvidenceDigest,
+		PreparedAt:                        config.PreparedAt.UTC().Format(time.RFC3339), ValidUntil: validUntil.UTC().Format(time.RFC3339),
+	}
+	identityRaw, err := json.Marshal(identity)
+	if err != nil {
+		return VerifiedEnablementStageLaunchCandidate{}, errors.New("encode enablement launch candidate identity")
+	}
+	receipt := EnablementStageLaunchCandidateReceipt{
+		Format: EnablementStageLaunchCandidateFormat, State: "PREPARED", StageID: identity.StageID, Authority: identity.Authority,
+		EnablementPackageDigest: identity.EnablementPackageDigest, CredentialPackageDigest: identity.CredentialPackageDigest,
+		RuntimeManifestDigest: identity.RuntimeManifestDigest, LaunchPlanDigest: identity.LaunchPlanDigest,
+		AuthorityEndpointDigest: identity.AuthorityEndpointDigest, CABundleDigest: identity.CABundleDigest,
+		InstallerCredentialBindingDigest:  identity.InstallerCredentialBindingDigest,
+		InstallerCredentialEvidenceDigest: identity.InstallerCredentialEvidenceDigest,
+		PreparedAt:                        identity.PreparedAt, ValidUntil: identity.ValidUntil, CandidateDigest: digest.SHA256(identityRaw), MutationAllowed: false,
+	}
+	return VerifiedEnablementStageLaunchCandidate{receipt: receipt, authorityEndpoint: endpoint, installerTokenDigest: config.InstallerTokenDigest, verified: true}, nil
+}
+
+func (candidate VerifiedEnablementStageLaunchCandidate) Receipt() (EnablementStageLaunchCandidateReceipt, error) {
+	if err := verifyEnablementStageLaunchCandidate(candidate); err != nil {
+		return EnablementStageLaunchCandidateReceipt{}, err
+	}
+	return candidate.receipt, nil
+}
+
+func verifyEnablementStageLaunchCandidate(candidate VerifiedEnablementStageLaunchCandidate) error {
+	if !candidate.verified || candidate.receipt.Format != EnablementStageLaunchCandidateFormat || candidate.receipt.State != "PREPARED" || candidate.receipt.StageID != "enablement" || candidate.receipt.Authority == "" || candidate.receipt.MutationAllowed || candidate.authorityEndpoint == "" || !stageReceiptPrefixDigestPattern.MatchString(candidate.installerTokenDigest) {
+		return errors.New("enablement launch candidate was not produced by verification")
+	}
+	for _, value := range []string{
+		candidate.receipt.EnablementPackageDigest, candidate.receipt.CredentialPackageDigest, candidate.receipt.RuntimeManifestDigest,
+		candidate.receipt.LaunchPlanDigest, candidate.receipt.AuthorityEndpointDigest, candidate.receipt.CABundleDigest,
+		candidate.receipt.InstallerCredentialBindingDigest, candidate.receipt.InstallerCredentialEvidenceDigest, candidate.receipt.CandidateDigest,
+	} {
+		if !stageReceiptPrefixDigestPattern.MatchString(value) {
+			return errors.New("enablement launch candidate contains an invalid digest")
+		}
+	}
+	credentialBindingRaw, err := json.Marshal(submissionStageInstallerCredentialIdentity{TokenDigest: candidate.installerTokenDigest, EvidenceDigest: candidate.receipt.InstallerCredentialEvidenceDigest})
+	if err != nil || digest.SHA256(credentialBindingRaw) != candidate.receipt.InstallerCredentialBindingDigest {
+		return errors.New("enablement installer credential identity changed after verification")
+	}
+	identity := enablementStageLaunchCandidateIdentity{
+		StageID: candidate.receipt.StageID, Authority: candidate.receipt.Authority,
+		EnablementPackageDigest: candidate.receipt.EnablementPackageDigest, CredentialPackageDigest: candidate.receipt.CredentialPackageDigest,
+		RuntimeManifestDigest: candidate.receipt.RuntimeManifestDigest, LaunchPlanDigest: candidate.receipt.LaunchPlanDigest,
+		AuthorityEndpointDigest: candidate.receipt.AuthorityEndpointDigest, CABundleDigest: candidate.receipt.CABundleDigest,
+		InstallerCredentialBindingDigest:  candidate.receipt.InstallerCredentialBindingDigest,
+		InstallerCredentialEvidenceDigest: candidate.receipt.InstallerCredentialEvidenceDigest,
+		PreparedAt:                        candidate.receipt.PreparedAt, ValidUntil: candidate.receipt.ValidUntil,
+	}
+	raw, err := json.Marshal(identity)
+	if err != nil || digest.SHA256(raw) != candidate.receipt.CandidateDigest || digest.SHA256([]byte(candidate.authorityEndpoint)) != candidate.receipt.AuthorityEndpointDigest {
+		return errors.New("enablement launch candidate identity changed after verification")
+	}
+	preparedAt, err := time.Parse(time.RFC3339, candidate.receipt.PreparedAt)
+	if err != nil {
+		return errors.New("enablement launch candidate preparation time is invalid")
+	}
+	validUntil, err := time.Parse(time.RFC3339, candidate.receipt.ValidUntil)
+	if err != nil || validUntil.Before(preparedAt) {
+		return errors.New("enablement launch candidate validity is invalid")
+	}
+	return nil
+}

--- a/internal/runner/enablement_stage_launch_candidate_test.go
+++ b/internal/runner/enablement_stage_launch_candidate_test.go
@@ -1,0 +1,79 @@
+package runner
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+func TestPrepareEnablementStageLaunchCandidateBindsDestinationAndCredential(t *testing.T) {
+	stage, credentials, runtime, _, _ := enablementStageLaunchFixture(t)
+	config := submissionStageLaunchCandidateConfig()
+	candidate, err := PrepareEnablementStageLaunchCandidate(config, stage, credentials, runtime)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := candidate.Receipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	again, err := PrepareEnablementStageLaunchCandidate(config, stage, credentials, runtime)
+	if err != nil {
+		t.Fatal(err)
+	}
+	againReceipt, _ := again.Receipt()
+	if receipt.Format != EnablementStageLaunchCandidateFormat || receipt.State != "PREPARED" || receipt.StageID != "enablement" || receipt.Authority != "ok-mgmt" || receipt.PreparedAt != "2026-08-16T12:01:00Z" || receipt.ValidUntil != "2026-08-16T12:15:00Z" || receipt.MutationAllowed || receipt.CandidateDigest != againReceipt.CandidateDigest {
+		t.Fatalf("unexpected enablement candidate: %#v", receipt)
+	}
+	public, err := json.Marshal(receipt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range []string{config.AuthorityEndpoint, config.InstallerTokenDigest, "installer-token-v1"} {
+		if bytes.Contains(public, []byte(forbidden)) {
+			t.Fatalf("enablement candidate receipt exposed private input %q", forbidden)
+		}
+	}
+	changed := candidate
+	changed.receipt.ValidUntil = "2026-08-16T12:16:00Z"
+	if _, err := changed.Receipt(); err == nil {
+		t.Fatal("changed enablement candidate receipt accepted")
+	}
+	changed = candidate
+	changed.installerTokenDigest = digest.SHA256([]byte("foreign-token"))
+	if _, err := changed.Receipt(); err == nil {
+		t.Fatal("changed private enablement installer binding accepted")
+	}
+}
+
+func TestPrepareEnablementStageLaunchCandidateFailsClosed(t *testing.T) {
+	stage, credentials, runtime, _, _ := enablementStageLaunchFixture(t)
+	valid := submissionStageLaunchCandidateConfig()
+	for name, mutate := range map[string]func(*SubmissionStageLaunchCandidateConfig){
+		"DNS endpoint": func(config *SubmissionStageLaunchCandidateConfig) {
+			config.AuthorityEndpoint = "https://ok-mgmt.example:6443"
+		},
+		"HTTP endpoint": func(config *SubmissionStageLaunchCandidateConfig) {
+			config.AuthorityEndpoint = "http://192.0.2.10:6443"
+		},
+		"missing CA":       func(config *SubmissionStageLaunchCandidateConfig) { config.CABundleDigest = "" },
+		"missing evidence": func(config *SubmissionStageLaunchCandidateConfig) { config.InstallerCredentialEvidenceDigest = "" },
+		"fractional time": func(config *SubmissionStageLaunchCandidateConfig) {
+			config.PreparedAt = config.PreparedAt.Add(time.Nanosecond)
+		},
+		"expired credentials": func(config *SubmissionStageLaunchCandidateConfig) {
+			config.PreparedAt = time.Date(2026, 8, 16, 12, 15, 1, 0, time.UTC)
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			config := valid
+			mutate(&config)
+			if _, err := PrepareEnablementStageLaunchCandidate(config, stage, credentials, runtime); err == nil {
+				t.Fatal("invalid enablement launch candidate accepted")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Outcome

Prepare an expiry-bound Stage 4 launch candidate from one coherent Enablement launch plan.

## Boundary

- exact normalized IP-literal HTTPS `ok-mgmt` endpoint;
- exact CA digest;
- independently evidenced installer-token identity;
- candidate expires fifteen minutes before the earliest Job credential;
- public receipt excludes endpoint and installer token;
- no credential open, API request, or mutation authority.

## Validation

- `GOCACHE=/private/tmp/ok147-go-build-cache go test -ldflags=-linkmode=external ./...`
- `GOCACHE=/private/tmp/ok147-go-build-cache go vet ./...`
- `GOCACHE=/private/tmp/ok147-go-build-cache go test -race -ldflags=-linkmode=external ./internal/runner`
- `git diff --check`

No live infrastructure action was performed.
