### PR TITLE
feat(runner): seal enablement launch material (OK-147)

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,9 @@ Powered by [Cluster API (CAPI)](https://cluster-api.sigs.k8s.io/), [CAPK (KubeVi
   private launch planner correlates runtime, prerequisites, both Secrets and
   the final Job behind one global six-object preflight barrier. A prepared,
   expiry-bound candidate then binds that plan to one exact management API,
-  CA, installer-token identity and independent credential evidence.
+  CA, installer-token identity and independent credential evidence. These
+  public and private inputs can now be sealed as one verified launch material;
+  it deliberately has no open or execute method yet.
 
 ---
 

--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -1280,6 +1280,14 @@ materialization or after that boundary fails closed. The public receipt exposes
 only digests and times, not the endpoint or installer token, and remains
 non-mutating.
 
+`ok147-enablement-stage-launch-material/v1` rebuilds and seals the package,
+private credentials, tokenless runtime and expiry-bound candidate as one
+coherent private value. Its public receipt contains only the correlated
+package, credential, runtime, launch-plan and candidate digests plus validity.
+Post-verification changes to any retained component fail closed. At this
+checkpoint the material deliberately exposes neither private bytes nor an
+`Open`/execute method, so it cannot launch Kubernetes objects.
+
 ## Typed Contract-to-CAPI submission stages
 
 The existing bounded exact-create submission primitive now has a typed adapter

--- a/internal/runner/enablement_stage_launch_material.go
+++ b/internal/runner/enablement_stage_launch_material.go
@@ -1,0 +1,115 @@
+package runner
+
+import (
+	"errors"
+	"time"
+)
+
+const EnablementStageLaunchMaterialFormat = "ok147-enablement-stage-launch-material/v1"
+
+type EnablementStageLaunchMaterialConfig struct {
+	Package               EnablementStagePackageConfig
+	MaterializationTime   time.Time
+	Ledger                SubmissionStageCredentialSource
+	ManagementWriter      SubmissionStageCredentialSource
+	RuntimeManifest       []byte
+	RuntimeManifestDigest string
+	Candidate             SubmissionStageLaunchCandidateConfig
+}
+
+type EnablementStageLaunchMaterialReceipt struct {
+	Format                  string `json:"format"`
+	State                   string `json:"state"`
+	StageID                 string `json:"stageId"`
+	Authority               string `json:"authority"`
+	EnablementPackageDigest string `json:"enablementPackageDigest"`
+	CredentialPackageDigest string `json:"credentialPackageDigest"`
+	RuntimeManifestDigest   string `json:"runtimeManifestDigest"`
+	LaunchPlanDigest        string `json:"launchPlanDigest"`
+	CandidateDigest         string `json:"candidateDigest"`
+	ValidUntil              string `json:"validUntil"`
+	MutationAllowed         bool   `json:"mutationAllowed"`
+}
+
+// VerifiedEnablementStageLaunchMaterial retains every private component but
+// deliberately provides no Open or execution method at this checkpoint.
+type VerifiedEnablementStageLaunchMaterial struct {
+	packaged    VerifiedEnablementStagePackage
+	credentials VerifiedEnablementStageCredentialPackage
+	runtime     VerifiedEnablementStageRuntimePrerequisite
+	candidate   VerifiedEnablementStageLaunchCandidate
+	receipt     EnablementStageLaunchMaterialReceipt
+	verified    bool
+}
+
+// BuildEnablementStageLaunchMaterial constructs the complete private launch
+// input from independently bound sources. It opens only bounded local files,
+// performs no API request and grants no launch authority.
+func BuildEnablementStageLaunchMaterial(config EnablementStageLaunchMaterialConfig) (VerifiedEnablementStageLaunchMaterial, error) {
+	packaged, err := BuildEnablementStagePackage(config.Package)
+	if err != nil {
+		return VerifiedEnablementStageLaunchMaterial{}, err
+	}
+	credentials, err := BuildEnablementStageCredentialPackage(EnablementStageCredentialPackageConfig{
+		Package: packaged, MaterializationTime: config.MaterializationTime,
+		Ledger: config.Ledger, ManagementWriter: config.ManagementWriter,
+	})
+	if err != nil {
+		return VerifiedEnablementStageLaunchMaterial{}, err
+	}
+	runtime, err := BuildEnablementStageRuntimePrerequisite(packaged, config.RuntimeManifest, config.RuntimeManifestDigest)
+	if err != nil {
+		return VerifiedEnablementStageLaunchMaterial{}, err
+	}
+	candidate, err := PrepareEnablementStageLaunchCandidate(config.Candidate, packaged, credentials, runtime)
+	if err != nil {
+		return VerifiedEnablementStageLaunchMaterial{}, err
+	}
+	candidateReceipt, err := candidate.Receipt()
+	if err != nil {
+		return VerifiedEnablementStageLaunchMaterial{}, err
+	}
+	receipt := EnablementStageLaunchMaterialReceipt{
+		Format: EnablementStageLaunchMaterialFormat, State: "VERIFIED", StageID: candidateReceipt.StageID,
+		Authority: candidateReceipt.Authority, EnablementPackageDigest: candidateReceipt.EnablementPackageDigest,
+		CredentialPackageDigest: candidateReceipt.CredentialPackageDigest, RuntimeManifestDigest: candidateReceipt.RuntimeManifestDigest,
+		LaunchPlanDigest: candidateReceipt.LaunchPlanDigest, CandidateDigest: candidateReceipt.CandidateDigest,
+		ValidUntil: candidateReceipt.ValidUntil, MutationAllowed: false,
+	}
+	return VerifiedEnablementStageLaunchMaterial{
+		packaged: packaged, credentials: credentials, runtime: runtime, candidate: candidate,
+		receipt: receipt, verified: true,
+	}, nil
+}
+
+func (material VerifiedEnablementStageLaunchMaterial) Receipt() (EnablementStageLaunchMaterialReceipt, error) {
+	if err := verifyEnablementStageLaunchMaterial(material); err != nil {
+		return EnablementStageLaunchMaterialReceipt{}, err
+	}
+	return material.receipt, nil
+}
+
+func (material VerifiedEnablementStageLaunchMaterial) CandidateReceipt() (EnablementStageLaunchCandidateReceipt, error) {
+	if err := verifyEnablementStageLaunchMaterial(material); err != nil {
+		return EnablementStageLaunchCandidateReceipt{}, err
+	}
+	return material.candidate.Receipt()
+}
+
+func verifyEnablementStageLaunchMaterial(material VerifiedEnablementStageLaunchMaterial) error {
+	if !material.verified || material.receipt.Format != EnablementStageLaunchMaterialFormat || material.receipt.State != "VERIFIED" || material.receipt.MutationAllowed {
+		return errors.New("enablement launch material was not produced by verification")
+	}
+	plan, err := PlanEnablementStageLaunch(material.packaged, material.credentials, material.runtime)
+	if err != nil {
+		return err
+	}
+	candidateReceipt, err := material.candidate.Receipt()
+	if err != nil {
+		return err
+	}
+	if material.receipt.StageID != plan.StageID || material.receipt.Authority != plan.Authority || material.receipt.EnablementPackageDigest != plan.EnablementPackageDigest || material.receipt.CredentialPackageDigest != plan.CredentialPackageDigest || material.receipt.RuntimeManifestDigest != plan.RuntimeManifestDigest || material.receipt.StageID != candidateReceipt.StageID || material.receipt.Authority != candidateReceipt.Authority || material.receipt.EnablementPackageDigest != candidateReceipt.EnablementPackageDigest || material.receipt.CredentialPackageDigest != candidateReceipt.CredentialPackageDigest || material.receipt.RuntimeManifestDigest != candidateReceipt.RuntimeManifestDigest || material.receipt.LaunchPlanDigest != candidateReceipt.LaunchPlanDigest || material.receipt.CandidateDigest != candidateReceipt.CandidateDigest || material.receipt.ValidUntil != candidateReceipt.ValidUntil {
+		return errors.New("enablement launch material identity changed after verification")
+	}
+	return nil
+}

--- a/internal/runner/enablement_stage_launch_material_test.go
+++ b/internal/runner/enablement_stage_launch_material_test.go
@@ -1,0 +1,85 @@
+package runner
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+func TestBuildEnablementStageLaunchMaterialSealsPrivateComponents(t *testing.T) {
+	config, installerToken, ledgerToken, writerToken := enablementStageLaunchMaterialConfig(t)
+	material, err := BuildEnablementStageLaunchMaterial(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := material.Receipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	candidate, err := material.CandidateReceipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	again, err := BuildEnablementStageLaunchMaterial(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	againReceipt, _ := again.Receipt()
+	if receipt.Format != EnablementStageLaunchMaterialFormat || receipt.State != "VERIFIED" || receipt.StageID != "enablement" || receipt.Authority != "ok-mgmt" || receipt.EnablementPackageDigest != candidate.EnablementPackageDigest || receipt.CandidateDigest != candidate.CandidateDigest || receipt.ValidUntil != candidate.ValidUntil || receipt.MutationAllowed || receipt.CandidateDigest != againReceipt.CandidateDigest {
+		t.Fatalf("unexpected enablement launch material: %#v", receipt)
+	}
+	public, err := json.Marshal(receipt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range [][]byte{
+		installerToken, ledgerToken, writerToken, material.packaged.raw, material.credentials.objects[0].raw,
+		material.credentials.objects[1].raw, material.runtime.raw, []byte(config.Candidate.AuthorityEndpoint), []byte(config.Candidate.InstallerTokenDigest),
+	} {
+		if bytes.Contains(public, forbidden) {
+			t.Fatal("enablement launch material receipt exposed private source content")
+		}
+	}
+	tampered := material
+	tampered.receipt.CandidateDigest = digest.SHA256([]byte("foreign"))
+	if _, err := tampered.Receipt(); err == nil {
+		t.Fatal("changed enablement launch material identity accepted")
+	}
+}
+
+func TestBuildEnablementStageLaunchMaterialRejectsChangedSources(t *testing.T) {
+	config, _, _, _ := enablementStageLaunchMaterialConfig(t)
+	config.RuntimeManifestDigest = digest.SHA256([]byte("other-runtime"))
+	if _, err := BuildEnablementStageLaunchMaterial(config); err == nil {
+		t.Fatal("changed enablement runtime source was accepted")
+	}
+	config, _, _, _ = enablementStageLaunchMaterialConfig(t)
+	config.Candidate.PreparedAt = time.Date(2026, 8, 16, 12, 16, 0, 0, time.UTC)
+	if _, err := BuildEnablementStageLaunchMaterial(config); err == nil {
+		t.Fatal("expired enablement candidate input was accepted")
+	}
+	if _, err := (VerifiedEnablementStageLaunchMaterial{}).Receipt(); err == nil {
+		t.Fatal("unverified enablement launch material receipt was exposed")
+	}
+}
+
+func enablementStageLaunchMaterialConfig(t *testing.T) (EnablementStageLaunchMaterialConfig, []byte, []byte, []byte) {
+	t.Helper()
+	credentialConfig, ledgerToken, writerToken := enablementCredentialConfig(t)
+	manifest := submissionStageRuntimeManifest(t)
+	installerToken := []byte("enablement-installer-token-v1")
+	return EnablementStageLaunchMaterialConfig{
+		Package:             enablementStagePackageConfig(t, enablementBundleFixture(t)),
+		MaterializationTime: credentialConfig.MaterializationTime,
+		Ledger:              credentialConfig.Ledger, ManagementWriter: credentialConfig.ManagementWriter,
+		RuntimeManifest: manifest, RuntimeManifestDigest: digest.SHA256(manifest),
+		Candidate: SubmissionStageLaunchCandidateConfig{
+			AuthorityEndpoint: "https://192.0.2.10:6443", CABundleDigest: credentialConfig.Ledger.CABundleDigest,
+			InstallerTokenDigest: digest.SHA256(installerToken), InstallerCredentialEvidenceDigest: digest.SHA256([]byte("enablement-installer-evidence")),
+			PreparedAt: time.Date(2026, 8, 16, 12, 1, 0, 0, time.UTC),
+		},
+	}, installerToken, ledgerToken, writerToken
+}


### PR DESCRIPTION
## Outcome

Seal the verified Enablement package, two private short-lived credentials, tokenless runtime prerequisite and expiry-bound launch candidate as one immutable private launch material.

## Boundary

- public receipt contains only correlated digests and the validity boundary
- retained component changes fail closed
- no private bytes, endpoint, token or credential path are published
- no `Open` or execute method exists yet
- no Kubernetes API contact or infrastructure mutation

## Validation

- `GOCACHE=/private/tmp/ok147-go-build-cache go test -ldflags=-linkmode=external ./...`
- `GOCACHE=/private/tmp/ok147-go-build-cache go vet ./...`
- `GOCACHE=/private/tmp/ok147-go-build-cache go test -race -ldflags=-linkmode=external ./internal/runner`
- `git diff --check`

Jira: OK-147
