### PR TITLE
feat(runner): add bounded enablement stage launcher (OK-147)

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,10 @@ Powered by [Cluster API (CAPI)](https://cluster-api.sigs.k8s.io/), [CAPK (KubeVi
   expiry-bound candidate then binds that plan to one exact management API,
   CA, installer-token identity and independent credential evidence. These
   public and private inputs can now be sealed as one verified launch material;
-  it deliberately has no open or execute method yet.
+  it deliberately has no open or execute method yet. A single-use Enablement
+  launcher now proves the six-GET global barrier and fixed six-POST create-only
+  sequence against a fake API; it is not yet reachable from the CLI or sealed
+  launch material.
 
 ---
 

--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -1288,6 +1288,15 @@ Post-verification changes to any retained component fail closed. At this
 checkpoint the material deliberately exposes neither private bytes nor an
 `Open`/execute method, so it cannot launch Kubernetes objects.
 
+`ok147-enablement-stage-launch-receipt/v1` is produced by a single-use bounded
+launcher that completes all six exact-name GETs before its first POST. It
+accepts only global absence, the already verified runtime alone, or all six
+objects matching exactly; every other partial state stops with zero writes.
+Creation is fixed to runtime, ConfigMap, NetworkPolicy, ledger Secret, writer
+Secret and Job. A failed create preserves the verified prefix and stops without
+retry. The launcher is currently exercised only through a fake Kubernetes API
+and is not exposed by the CLI or sealed launch material.
+
 ## Typed Contract-to-CAPI submission stages
 
 The existing bounded exact-create submission primitive now has a typed adapter

--- a/internal/runner/enablement_stage_launcher.go
+++ b/internal/runner/enablement_stage_launcher.go
@@ -1,0 +1,418 @@
+package runner
+
+import (
+	"bytes"
+	"context"
+	"crypto/subtle"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"gopkg.in/yaml.v3"
+)
+
+const EnablementStageLaunchReceiptFormat = "ok147-enablement-stage-launch-receipt/v1"
+
+type EnablementStageLauncherConfig struct {
+	Authority               KubernetesAuthorityConfig
+	Clock                   func() time.Time
+	Candidate               VerifiedEnablementStageLaunchCandidate
+	ExpectedCandidateDigest string
+}
+
+type EnablementStageLaunchReceipt struct {
+	Format                  string                        `json:"format"`
+	StageID                 string                        `json:"stageId"`
+	EnablementPackageDigest string                        `json:"enablementPackageDigest"`
+	CredentialPackageDigest string                        `json:"credentialPackageDigest"`
+	RuntimeManifestDigest   string                        `json:"runtimeManifestDigest"`
+	Authority               string                        `json:"authority"`
+	State                   string                        `json:"state"`
+	MutationState           string                        `json:"mutationState"`
+	Results                 []SubmissionStageLaunchResult `json:"results"`
+}
+
+// KubernetesEnablementStageLauncher is a single-use six-object create-only
+// operation. It completes the global preflight before its first POST and has
+// no update, patch, apply, delete, list, watch or retry path.
+type KubernetesEnablementStageLauncher struct {
+	mu          sync.Mutex
+	used        bool
+	endpoint    *url.URL
+	token       string
+	client      *http.Client
+	clock       func() time.Time
+	validUntil  time.Time
+	plan        EnablementStageLaunchPlan
+	runtime     VerifiedEnablementStageRuntimePrerequisite
+	credentials EnablementStageCredentialPackageReceipt
+	secrets     []submissionStageCredentialInstallObject
+	objects     []submissionStageInstallObject
+}
+
+// OpenKubernetesEnablementStageLauncher opens one exact client from the
+// prepared candidate and bounded installer credential. It performs no API
+// request.
+func OpenKubernetesEnablementStageLauncher(config EnablementStageLauncherConfig, packaged VerifiedEnablementStagePackage, credentials VerifiedEnablementStageCredentialPackage, runtime VerifiedEnablementStageRuntimePrerequisite) (*KubernetesEnablementStageLauncher, error) {
+	plan, err := PlanEnablementStageLaunch(packaged, credentials, runtime)
+	if err != nil {
+		return nil, err
+	}
+	if err := verifyEnablementStageLaunchCandidate(config.Candidate); err != nil {
+		return nil, err
+	}
+	candidate := config.Candidate.receipt
+	planRaw, err := json.Marshal(plan)
+	if err != nil {
+		return nil, errors.New("encode enablement launcher plan identity")
+	}
+	if config.ExpectedCandidateDigest != candidate.CandidateDigest || digest.SHA256(planRaw) != candidate.LaunchPlanDigest || plan.StageID != candidate.StageID || plan.Authority != candidate.Authority || plan.EnablementPackageDigest != candidate.EnablementPackageDigest || plan.CredentialPackageDigest != candidate.CredentialPackageDigest || plan.RuntimeManifestDigest != candidate.RuntimeManifestDigest {
+		return nil, errors.New("enablement launcher components differ from exact candidate")
+	}
+	if config.Authority.AuthorityIdentity == "" || config.Authority.AuthorityIdentity != plan.Authority {
+		return nil, errors.New("enablement launcher authority differs from verified management authority")
+	}
+	endpoint, err := normalizeSubmissionStageLaunchEndpoint(config.Authority.Endpoint)
+	if err != nil || endpoint != config.Candidate.authorityEndpoint || config.Authority.CABundleDigest != candidate.CABundleDigest {
+		return nil, errors.New("enablement launcher destination differs from exact candidate")
+	}
+	token, ca, client, err := openBoundedKubernetesMaterial(config.Authority.TokenFile, config.Authority.CAFile)
+	if err != nil {
+		return nil, errors.New("open bounded enablement launcher credential")
+	}
+	if digest.SHA256(ca) != config.Authority.CABundleDigest || digest.SHA256([]byte(token)) != config.Candidate.installerTokenDigest {
+		return nil, errors.New("enablement launcher credential differs from bound identity")
+	}
+	validUntil, err := time.Parse(time.RFC3339, candidate.ValidUntil)
+	if err != nil {
+		return nil, errors.New("enablement launch candidate validity is invalid")
+	}
+	return newKubernetesEnablementStageLauncher(submissionStageLauncherClientConfig{
+		Endpoint: config.Authority.Endpoint, BearerToken: token, AuthorityIdentity: config.Authority.AuthorityIdentity,
+		Client: client, Clock: config.Clock, ValidUntil: validUntil,
+	}, packaged, credentials, runtime)
+}
+
+func newKubernetesEnablementStageLauncher(config submissionStageLauncherClientConfig, packaged VerifiedEnablementStagePackage, credentials VerifiedEnablementStageCredentialPackage, runtime VerifiedEnablementStageRuntimePrerequisite) (*KubernetesEnablementStageLauncher, error) {
+	plan, err := PlanEnablementStageLaunch(packaged, credentials, runtime)
+	if err != nil {
+		return nil, err
+	}
+	credentialReceipt, secrets, err := prepareEnablementStageCredentialInstallation(credentials)
+	if err != nil {
+		return nil, err
+	}
+	_, objects, err := prepareEnablementStageInstallation(packaged)
+	if err != nil {
+		return nil, err
+	}
+	if config.AuthorityIdentity == "" || config.AuthorityIdentity != plan.Authority {
+		return nil, errors.New("enablement launcher authority differs from verified management authority")
+	}
+	endpoint, err := url.Parse(config.Endpoint)
+	if err != nil || endpoint.Host == "" || endpoint.User != nil || endpoint.RawQuery != "" || endpoint.Fragment != "" || endpoint.Path != "" && endpoint.Path != "/" || endpoint.Port() == "" || net.ParseIP(endpoint.Hostname()) == nil {
+		return nil, errors.New("enablement launcher Kubernetes endpoint is invalid")
+	}
+	if endpoint.Scheme != "https" && !(endpoint.Scheme == "http" && endpoint.Hostname() == "127.0.0.1") {
+		return nil, errors.New("enablement launcher Kubernetes endpoint must use HTTPS")
+	}
+	if config.BearerToken == "" || strings.TrimSpace(config.BearerToken) != config.BearerToken || strings.ContainsAny(config.BearerToken, "\r\n") || config.Client == nil || config.Clock == nil {
+		return nil, errors.New("enablement launcher credential, client, or clock is invalid")
+	}
+	for _, secret := range secrets {
+		if len(config.BearerToken) == len(secret.token) && subtle.ConstantTimeCompare([]byte(config.BearerToken), secret.token) == 1 {
+			return nil, errors.New("enablement launcher and Job credentials must be distinct")
+		}
+	}
+	client := *config.Client
+	client.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+	if client.Timeout == 0 {
+		client.Timeout = 15 * time.Second
+	}
+	endpoint.Path, endpoint.RawPath = "", ""
+	runtime.raw = append([]byte(nil), runtime.raw...)
+	return &KubernetesEnablementStageLauncher{
+		endpoint: endpoint, token: config.BearerToken, client: &client, clock: config.Clock, validUntil: config.ValidUntil,
+		plan: plan, runtime: runtime, credentials: credentialReceipt, secrets: secrets, objects: objects,
+	}, nil
+}
+
+func (launcher *KubernetesEnablementStageLauncher) Launch(ctx context.Context) (EnablementStageLaunchReceipt, error) {
+	receipt := launcher.newReceipt()
+	if launcher == nil || launcher.client == nil || launcher.clock == nil {
+		return receipt, errors.New("enablement launcher is required")
+	}
+	launcher.mu.Lock()
+	if launcher.used {
+		launcher.mu.Unlock()
+		return stopEnablementStageLaunch(receipt, "STOPPED_ZERO_WRITE", errors.New("enablement launcher is single-use"))
+	}
+	launcher.used = true
+	launcher.mu.Unlock()
+
+	now := launcher.clock().UTC()
+	if !launcher.validUntil.IsZero() && now.After(launcher.validUntil) {
+		return stopEnablementStageLaunch(receipt, "STOPPED_ZERO_WRITE", errors.New("enablement launch candidate validity has expired"))
+	}
+	materializedAt, err := time.Parse(time.RFC3339, launcher.credentials.MaterializedAt)
+	if err != nil || now.Before(materializedAt) {
+		return stopEnablementStageLaunch(receipt, "STOPPED_ZERO_WRITE", errors.New("enablement launch precedes credential materialization"))
+	}
+	for _, secret := range launcher.secrets {
+		if secret.expiresAt.Sub(now) < minimumStageCredentialRemaining {
+			return stopEnablementStageLaunch(receipt, "STOPPED_ZERO_WRITE", errors.New("enablement credential has insufficient remaining lifetime"))
+		}
+	}
+
+	existing := make(map[int]SubmissionStageLaunchResult, len(launcher.plan.Preflights))
+	for _, preflight := range launcher.plan.Preflights {
+		raw, status, err := launcher.request(ctx, http.MethodGet, preflight.ObjectPath, nil)
+		if err != nil {
+			return stopEnablementStageLaunch(receipt, "STOPPED_ZERO_WRITE", err)
+		}
+		switch status {
+		case http.StatusNotFound:
+		case http.StatusOK:
+			result, err := launcher.verifyExisting(preflight, raw)
+			if err != nil {
+				return stopEnablementStageLaunch(receipt, "STOPPED_ZERO_WRITE", err)
+			}
+			existing[preflight.Order] = result
+		default:
+			return stopEnablementStageLaunch(receipt, "STOPPED_ZERO_WRITE", submissionStageLaunchStatusError(http.MethodGet, status))
+		}
+	}
+	if len(existing) == len(launcher.plan.Preflights) {
+		receipt.State = "ALREADY_LAUNCHED"
+		for order := 1; order <= len(launcher.plan.Preflights); order++ {
+			receipt.Results = append(receipt.Results, existing[order])
+		}
+		return receipt, nil
+	}
+	runtimeResult, runtimeExists := existing[1]
+	if len(existing) != 0 && !(len(existing) == 1 && runtimeExists) {
+		return stopEnablementStageLaunch(receipt, "STOPPED_ZERO_WRITE", errors.New("enablement launch found exact partial state"))
+	}
+
+	receipt.State = "LAUNCHING"
+	if runtimeExists {
+		receipt.Results = append(receipt.Results, runtimeResult)
+	} else {
+		result, err := launcher.createRuntime(ctx)
+		if err != nil {
+			return launcher.stopAfterAttempt(receipt, err)
+		}
+		receipt.MutationState = "ATTEMPTED"
+		receipt.Results = append(receipt.Results, result)
+	}
+	for index := 0; index < 2; index++ {
+		result, err := launcher.createObject(ctx, index+2, "stage-prerequisites", launcher.objects[index])
+		if err != nil {
+			return launcher.stopAfterAttempt(receipt, err)
+		}
+		receipt.MutationState = "ATTEMPTED"
+		receipt.Results = append(receipt.Results, result)
+	}
+	for index, secret := range launcher.secrets {
+		result, err := launcher.createSecret(ctx, index+4, secret)
+		if err != nil {
+			return launcher.stopAfterAttempt(receipt, err)
+		}
+		receipt.MutationState = "ATTEMPTED"
+		receipt.Results = append(receipt.Results, result)
+	}
+	result, err := launcher.createObject(ctx, 6, "job", launcher.objects[2])
+	if err != nil {
+		return launcher.stopAfterAttempt(receipt, err)
+	}
+	receipt.MutationState = "ATTEMPTED"
+	receipt.Results = append(receipt.Results, result)
+	receipt.State = "LAUNCHED"
+	return receipt, nil
+}
+
+func (launcher *KubernetesEnablementStageLauncher) verifyExisting(preflight SubmissionStageLaunchPreflight, raw []byte) (SubmissionStageLaunchResult, error) {
+	var uid, resourceVersion string
+	var err error
+	switch preflight.Phase {
+	case "runtime":
+		uid, resourceVersion, err = verifySubmissionStageRuntimeObject(raw, launcher.runtime.raw)
+	case "stage-prerequisites":
+		uid, resourceVersion, err = verifySubmissionStageCreatedObject(raw, launcher.objects[preflight.Order-2])
+	case "credentials":
+		uid, resourceVersion, err = verifySubmissionStageCredentialCreatedObject(raw, launcher.secrets[preflight.Order-4])
+	case "job":
+		uid, resourceVersion, err = verifySubmissionStageCreatedObject(raw, launcher.objects[2])
+	default:
+		return SubmissionStageLaunchResult{}, errors.New("enablement preflight phase is invalid")
+	}
+	if err != nil {
+		return SubmissionStageLaunchResult{}, errors.New("existing enablement object differs from verified plan")
+	}
+	return enablementLaunchResult(preflight.Order, preflight.Phase, preflight.APIVersion, preflight.Kind, preflight.Namespace, preflight.Name, preflight.ObjectDigest, "EXISTING_VERIFIED", uid, resourceVersion), nil
+}
+
+func (launcher *KubernetesEnablementStageLauncher) createRuntime(ctx context.Context) (SubmissionStageLaunchResult, error) {
+	create := launcher.plan.Creates[0]
+	raw, status, err := launcher.request(ctx, http.MethodPost, create.CollectionPath, launcher.runtime.raw)
+	if err != nil || status != http.StatusCreated {
+		return SubmissionStageLaunchResult{}, submissionStageLaunchCreateError(status, err)
+	}
+	uid, resourceVersion, err := verifySubmissionStageRuntimeObject(raw, launcher.runtime.raw)
+	if err != nil {
+		return SubmissionStageLaunchResult{}, errors.New("created enablement runtime differs")
+	}
+	return enablementLaunchResult(1, "runtime", "v1", "ServiceAccount", create.Namespace, create.Name, create.ObjectDigest, "CREATED", uid, resourceVersion), nil
+}
+
+func (launcher *KubernetesEnablementStageLauncher) createSecret(ctx context.Context, order int, secret submissionStageCredentialInstallObject) (SubmissionStageLaunchResult, error) {
+	raw, status, err := launcher.request(ctx, http.MethodPost, secret.collectionPath, secret.raw)
+	if err != nil || status != http.StatusCreated {
+		return SubmissionStageLaunchResult{}, submissionStageLaunchCreateError(status, err)
+	}
+	uid, resourceVersion, err := verifySubmissionStageCredentialCreatedObject(raw, secret)
+	if err != nil {
+		return SubmissionStageLaunchResult{}, errors.New("created enablement credential differs")
+	}
+	return enablementLaunchResult(order, "credentials", "v1", "Secret", submissionStageInputNamespace, secret.name, secret.objectDigest, "CREATED", uid, resourceVersion), nil
+}
+
+func (launcher *KubernetesEnablementStageLauncher) createObject(ctx context.Context, order int, phase string, object submissionStageInstallObject) (SubmissionStageLaunchResult, error) {
+	raw, status, err := launcher.request(ctx, http.MethodPost, object.plan.CollectionPath, object.raw)
+	if err != nil || status != http.StatusCreated {
+		return SubmissionStageLaunchResult{}, submissionStageLaunchCreateError(status, err)
+	}
+	uid, resourceVersion, err := verifySubmissionStageCreatedObject(raw, object)
+	if err != nil {
+		return SubmissionStageLaunchResult{}, errors.New("created enablement object differs")
+	}
+	return enablementLaunchResult(order, phase, object.plan.APIVersion, object.plan.Kind, object.plan.Namespace, object.plan.Name, object.plan.ObjectDigest, "CREATED", uid, resourceVersion), nil
+}
+
+func (launcher *KubernetesEnablementStageLauncher) stopAfterAttempt(receipt EnablementStageLaunchReceipt, err error) (EnablementStageLaunchReceipt, error) {
+	receipt.MutationState = "ATTEMPTED_UNKNOWN"
+	return stopEnablementStageLaunch(receipt, "STOPPED_PARTIAL_OR_UNKNOWN", err)
+}
+
+func (launcher *KubernetesEnablementStageLauncher) request(ctx context.Context, method, path string, body []byte) ([]byte, int, error) {
+	endpoint := *launcher.endpoint
+	endpoint.Path = path
+	request, err := http.NewRequestWithContext(ctx, method, endpoint.String(), bytes.NewReader(body))
+	if err != nil {
+		return nil, 0, errors.New("construct bounded enablement launch request")
+	}
+	request.Header.Set("Accept", "application/json")
+	request.Header.Set("Authorization", "Bearer "+launcher.token)
+	if body != nil {
+		request.Header.Set("Content-Type", "application/json")
+	}
+	response, err := launcher.client.Do(request)
+	if err != nil {
+		return nil, 0, fmt.Errorf("bounded enablement launch %s failed", method)
+	}
+	defer response.Body.Close()
+	raw, readErr := io.ReadAll(io.LimitReader(response.Body, maximumStageInstallationResponseBytes+1))
+	if readErr != nil || len(raw) > maximumStageInstallationResponseBytes {
+		return nil, 0, errors.New("bounded enablement response exceeds accepted size")
+	}
+	if len(raw) > 0 {
+		mediaType, _, err := mime.ParseMediaType(response.Header.Get("Content-Type"))
+		if err != nil || mediaType != "application/json" {
+			return nil, 0, errors.New("bounded enablement response is not JSON")
+		}
+	}
+	return raw, response.StatusCode, nil
+}
+
+func (launcher *KubernetesEnablementStageLauncher) newReceipt() EnablementStageLaunchReceipt {
+	receipt := EnablementStageLaunchReceipt{Format: EnablementStageLaunchReceiptFormat, State: "PREFLIGHT", MutationState: "NOT_ATTEMPTED", Results: []SubmissionStageLaunchResult{}}
+	if launcher != nil {
+		receipt.StageID, receipt.Authority = launcher.plan.StageID, launcher.plan.Authority
+		receipt.EnablementPackageDigest, receipt.CredentialPackageDigest = launcher.plan.EnablementPackageDigest, launcher.plan.CredentialPackageDigest
+		receipt.RuntimeManifestDigest = launcher.plan.RuntimeManifestDigest
+	}
+	return receipt
+}
+
+func stopEnablementStageLaunch(receipt EnablementStageLaunchReceipt, state string, err error) (EnablementStageLaunchReceipt, error) {
+	receipt.State = state
+	return receipt, err
+}
+
+func enablementLaunchResult(order int, phase, apiVersion, kind, namespace, name, objectDigest, state, uid, resourceVersion string) SubmissionStageLaunchResult {
+	return SubmissionStageLaunchResult{
+		Order: order, Phase: phase, APIVersion: apiVersion, Kind: kind, Namespace: namespace, Name: name,
+		ObjectDigest: objectDigest, ObjectState: state, UIDDigest: digest.SHA256([]byte(uid)), ResourceVersionDigest: digest.SHA256([]byte(resourceVersion)),
+	}
+}
+
+func prepareEnablementStageInstallation(packaged VerifiedEnablementStagePackage) (EnablementStageInstallationPlan, []submissionStageInstallObject, error) {
+	plan, err := PlanEnablementStageInstallation(packaged)
+	if err != nil {
+		return EnablementStageInstallationPlan{}, nil, err
+	}
+	decoder := yaml.NewDecoder(bytes.NewReader(packaged.raw))
+	objects := make([]submissionStageInstallObject, 0, len(plan.Creates))
+	for index := range plan.Creates {
+		var value map[string]any
+		if err := decoder.Decode(&value); err != nil || len(value) == 0 {
+			return EnablementStageInstallationPlan{}, nil, errors.New("decode enablement installation object")
+		}
+		raw, err := json.Marshal(value)
+		if err != nil || digest.SHA256(raw) != plan.Creates[index].ObjectDigest {
+			return EnablementStageInstallationPlan{}, nil, errors.New("enablement installation object differs from plan")
+		}
+		objects = append(objects, submissionStageInstallObject{plan: plan.Creates[index], raw: raw})
+	}
+	var trailing map[string]any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		return EnablementStageInstallationPlan{}, nil, errors.New("enablement installation contains trailing object")
+	}
+	return plan, objects, nil
+}
+
+func prepareEnablementStageCredentialInstallation(packaged VerifiedEnablementStageCredentialPackage) (EnablementStageCredentialPackageReceipt, []submissionStageCredentialInstallObject, error) {
+	if err := verifyEnablementStageCredentialPackage(packaged); err != nil {
+		return EnablementStageCredentialPackageReceipt{}, nil, err
+	}
+	objects := make([]submissionStageCredentialInstallObject, 0, 2)
+	for index, private := range packaged.objects {
+		public := packaged.receipt.Credentials[index]
+		var secret map[string]any
+		if err := json.Unmarshal(private.raw, &secret); err != nil {
+			return EnablementStageCredentialPackageReceipt{}, nil, errors.New("enablement credential object is invalid JSON")
+		}
+		metadata, _ := secret["metadata"].(map[string]any)
+		labels, _ := metadata["labels"].(map[string]any)
+		annotations, _ := metadata["annotations"].(map[string]any)
+		data, _ := secret["data"].(map[string]any)
+		if secret["apiVersion"] != "v1" || secret["kind"] != "Secret" || secret["immutable"] != true || secret["type"] != "Opaque" || metadata["name"] != private.name || metadata["namespace"] != submissionStageInputNamespace || labels["openkubes.io/stage-id"] != packaged.receipt.StageID || labels["openkubes.io/credential-role"] != private.role || annotations["openkubes.io/authority-identity"] != private.authority || annotations["openkubes.io/expires-at"] != public.ExpiresAt || len(data) != 2 {
+			return EnablementStageCredentialPackageReceipt{}, nil, errors.New("enablement credential Secret semantics changed")
+		}
+		tokenEncoded, tokenOK := data["token"].(string)
+		caEncoded, caOK := data["ca.crt"].(string)
+		token, tokenErr := base64.StdEncoding.DecodeString(tokenEncoded)
+		ca, caErr := base64.StdEncoding.DecodeString(caEncoded)
+		expiresAt, timeErr := time.Parse(time.RFC3339, public.ExpiresAt)
+		if !tokenOK || !caOK || tokenErr != nil || caErr != nil || len(token) == 0 || len(ca) == 0 || timeErr != nil || digest.SHA256(ca) != public.CABundleDigest {
+			return EnablementStageCredentialPackageReceipt{}, nil, errors.New("enablement credential Secret data changed")
+		}
+		collection := "/api/v1/namespaces/" + submissionStageInputNamespace + "/secrets"
+		objects = append(objects, submissionStageCredentialInstallObject{
+			order: index + 4, role: private.role, authority: private.authority, name: private.name,
+			objectPath: collection + "/" + private.name, collectionPath: collection,
+			objectDigest: public.ObjectDigest, expiresAt: expiresAt, raw: append([]byte(nil), private.raw...), token: token,
+		})
+	}
+	return packaged.receipt, objects, nil
+}

--- a/internal/runner/enablement_stage_launcher_test.go
+++ b/internal/runner/enablement_stage_launcher_test.go
@@ -1,0 +1,152 @@
+package runner
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+func TestEnablementStageLauncherPreflightsThenCreatesJobLast(t *testing.T) {
+	stage, credentials, runtime, ledgerToken, writerToken := enablementStageLaunchFixture(t)
+	api := newSubmissionStageLauncherAPI(t)
+	launcher := newEnablementStageLauncher(t, stage, credentials, runtime, api, time.Date(2026, 8, 16, 12, 1, 0, 0, time.UTC))
+	receipt, err := launcher.Launch(context.Background())
+	if err != nil || receipt.State != "LAUNCHED" || receipt.MutationState != "ATTEMPTED" || len(receipt.Results) != 6 {
+		t.Fatalf("enablement launch failed: %#v %v", receipt, err)
+	}
+	if len(api.requests) != 12 || api.posts != 6 {
+		t.Fatalf("requests=%d posts=%d, want six GETs then six POSTs", len(api.requests), api.posts)
+	}
+	for index := 0; index < 6; index++ {
+		preflight, create := api.requests[index], api.requests[index+6]
+		if preflight.method != "GET" || preflight.path != launcher.plan.Preflights[index].ObjectPath || create.method != "POST" || create.path != launcher.plan.Creates[index].CollectionPath || digest.SHA256(create.body) != launcher.plan.Creates[index].ObjectDigest {
+			t.Fatalf("request order %d differs: %#v %#v", index+1, preflight, create)
+		}
+		if receipt.Results[index].Order != index+1 || receipt.Results[index].Kind != launcher.plan.Creates[index].Kind || receipt.Results[index].ObjectState != "CREATED" {
+			t.Fatalf("result %d differs: %#v", index+1, receipt.Results[index])
+		}
+	}
+	if launcher.plan.Creates[5].Kind != "Job" || launcher.plan.Creates[3].Kind != "Secret" || launcher.plan.Creates[4].Kind != "Secret" {
+		t.Fatalf("Job was not held behind both credentials: %#v", launcher.plan.Creates)
+	}
+	public, err := json.Marshal(receipt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range [][]byte{ledgerToken, writerToken, credentials.objects[0].raw, credentials.objects[1].raw, []byte("short-lived-installer-token"), []byte("created-uid")} {
+		if bytes.Contains(public, forbidden) {
+			t.Fatal("enablement receipt exposed private content")
+		}
+	}
+	requests := len(api.requests)
+	retry, retryErr := launcher.Launch(context.Background())
+	if retryErr == nil || retry.State != "STOPPED_ZERO_WRITE" || len(api.requests) != requests {
+		t.Fatalf("single-use launcher retried: %#v %v", retry, retryErr)
+	}
+}
+
+func TestEnablementStageLauncherAcceptsOnlyExactCompleteDuplicate(t *testing.T) {
+	stage, credentials, runtime, _, _ := enablementStageLaunchFixture(t)
+	api := newSubmissionStageLauncherAPI(t)
+	now := time.Date(2026, 8, 16, 12, 1, 0, 0, time.UTC)
+	first := newEnablementStageLauncher(t, stage, credentials, runtime, api, now)
+	if receipt, err := first.Launch(context.Background()); err != nil || receipt.State != "LAUNCHED" {
+		t.Fatalf("first launch failed: %#v %v", receipt, err)
+	}
+	requests := len(api.requests)
+	duplicate := newEnablementStageLauncher(t, stage, credentials, runtime, api, now)
+	receipt, err := duplicate.Launch(context.Background())
+	if err != nil || receipt.State != "ALREADY_LAUNCHED" || receipt.MutationState != "NOT_ATTEMPTED" || len(receipt.Results) != 6 || api.posts != 6 || len(api.requests) != requests+6 {
+		t.Fatalf("exact duplicate was not idempotent: %#v %v", receipt, err)
+	}
+
+	stage, credentials, runtime, _, _ = enablementStageLaunchFixture(t)
+	api = newSubmissionStageLauncherAPI(t)
+	partial := newEnablementStageLauncher(t, stage, credentials, runtime, api, now)
+	existing := decodeCapabilityJSONForTest(t, partial.objects[0].raw)
+	metadata := existing["metadata"].(map[string]any)
+	metadata["uid"], metadata["resourceVersion"] = "existing-input-uid", "9"
+	api.objects[partial.plan.Preflights[1].ObjectPath] = existing
+	receipt, err = partial.Launch(context.Background())
+	if err == nil || receipt.State != "STOPPED_ZERO_WRITE" || receipt.MutationState != "NOT_ATTEMPTED" || api.posts != 0 || len(api.requests) != 6 {
+		t.Fatalf("partial enablement state reached mutation: %#v %v", receipt, err)
+	}
+}
+
+func TestEnablementStageLauncherPreservesPartialPrefixAndStopsStaleLocally(t *testing.T) {
+	stage, credentials, runtime, _, _ := enablementStageLaunchFixture(t)
+	api := newSubmissionStageLauncherAPI(t)
+	api.failPost = 5
+	launcher := newEnablementStageLauncher(t, stage, credentials, runtime, api, time.Date(2026, 8, 16, 12, 1, 0, 0, time.UTC))
+	receipt, err := launcher.Launch(context.Background())
+	if err == nil || receipt.State != "STOPPED_PARTIAL_OR_UNKNOWN" || receipt.MutationState != "ATTEMPTED_UNKNOWN" || len(receipt.Results) != 4 || api.posts != 5 {
+		t.Fatalf("partial prefix differs: %#v %v", receipt, err)
+	}
+
+	stage, credentials, runtime, _, _ = enablementStageLaunchFixture(t)
+	api = newSubmissionStageLauncherAPI(t)
+	stale := newEnablementStageLauncher(t, stage, credentials, runtime, api, time.Date(2026, 8, 16, 12, 16, 0, 0, time.UTC))
+	receipt, err = stale.Launch(context.Background())
+	if err == nil || receipt.State != "STOPPED_ZERO_WRITE" || receipt.MutationState != "NOT_ATTEMPTED" || len(api.requests) != 0 {
+		t.Fatalf("stale enablement candidate reached API: %#v %v", receipt, err)
+	}
+}
+
+func TestOpenEnablementStageLauncherRequiresExactCandidate(t *testing.T) {
+	stage, credentials, runtime, _, _ := enablementStageLaunchFixture(t)
+	installerToken := []byte("installer-token-v1")
+	ca := testCA(t)
+	candidateConfig := submissionStageLaunchCandidateConfig()
+	candidateConfig.CABundleDigest = digest.SHA256(ca)
+	candidateConfig.InstallerTokenDigest = digest.SHA256(installerToken)
+	candidate, err := PrepareEnablementStageLaunchCandidate(candidateConfig, stage, credentials, runtime)
+	if err != nil {
+		t.Fatal(err)
+	}
+	candidateReceipt, _ := candidate.Receipt()
+	root := t.TempDir()
+	tokenPath, caPath := filepath.Join(root, "installer-token"), filepath.Join(root, "ca.crt")
+	if err := os.WriteFile(tokenPath, installerToken, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(caPath, ca, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	config := EnablementStageLauncherConfig{
+		Authority: KubernetesAuthorityConfig{
+			Endpoint: candidateConfig.AuthorityEndpoint, AuthorityIdentity: "ok-mgmt", TokenFile: tokenPath, CAFile: caPath, CABundleDigest: candidateConfig.CABundleDigest,
+		},
+		Clock:     func() time.Time { return time.Date(2026, 8, 16, 12, 16, 0, 0, time.UTC) },
+		Candidate: candidate, ExpectedCandidateDigest: candidateReceipt.CandidateDigest,
+	}
+	launcher, err := OpenKubernetesEnablementStageLauncher(config, stage, credentials, runtime)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := launcher.Launch(context.Background())
+	if err == nil || receipt.State != "STOPPED_ZERO_WRITE" || receipt.MutationState != "NOT_ATTEMPTED" {
+		t.Fatalf("expired candidate did not stop before API contact: %#v %v", receipt, err)
+	}
+	config.ExpectedCandidateDigest = digest.SHA256([]byte("foreign"))
+	if _, err := OpenKubernetesEnablementStageLauncher(config, stage, credentials, runtime); err == nil {
+		t.Fatal("foreign candidate digest accepted")
+	}
+}
+
+func newEnablementStageLauncher(t *testing.T, stage VerifiedEnablementStagePackage, credentials VerifiedEnablementStageCredentialPackage, runtime VerifiedEnablementStageRuntimePrerequisite, api *submissionStageLauncherAPI, now time.Time) *KubernetesEnablementStageLauncher {
+	t.Helper()
+	launcher, err := newKubernetesEnablementStageLauncher(submissionStageLauncherClientConfig{
+		Endpoint: "http://127.0.0.1:12345", BearerToken: "short-lived-installer-token", AuthorityIdentity: "ok-mgmt",
+		Client: api.client(), Clock: func() time.Time { return now }, ValidUntil: time.Date(2026, 8, 16, 12, 15, 0, 0, time.UTC),
+	}, stage, credentials, runtime)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return launcher
+}


### PR DESCRIPTION
## Outcome

Add the single-use bounded Enablement launcher for the exact six-object create-only sequence.

## Safety boundary

- all six exact-name GET preflights complete before the first POST
- only global absence, exact runtime-only state or exact complete state is accepted
- fixed order: ServiceAccount, ConfigMap, NetworkPolicy, ledger Secret, writer Secret, Job
- foreign partial state stops with zero writes
- create failure preserves the verified prefix and stops without retry
- candidate expiry and credential lifetime are checked before API contact
- no update, patch, apply, delete, list, watch or retry path
- tested only with a local fake API; not exposed by CLI or sealed material

## Validation

- `GOCACHE=/private/tmp/ok147-go-build-cache go test -ldflags=-linkmode=external ./...`
- `GOCACHE=/private/tmp/ok147-go-build-cache go vet ./...`
- `GOCACHE=/private/tmp/ok147-go-build-cache go test -race -ldflags=-linkmode=external ./internal/runner`
- `git diff --check`

Jira: OK-147
