### PR TITLE
feat(runner): open sealed enablement launch material (OK-147)

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,11 +99,10 @@ Powered by [Cluster API (CAPI)](https://cluster-api.sigs.k8s.io/), [CAPK (KubeVi
   the final Job behind one global six-object preflight barrier. A prepared,
   expiry-bound candidate then binds that plan to one exact management API,
   CA, installer-token identity and independent credential evidence. These
-  public and private inputs can now be sealed as one verified launch material;
-  it deliberately has no open or execute method yet. A single-use Enablement
+  public and private inputs can now be sealed as one verified launch material.
+  The material can open only its exact retained candidate. A single-use Enablement
   launcher now proves the six-GET global barrier and fixed six-POST create-only
-  sequence against a fake API; it is not yet reachable from the CLI or sealed
-  launch material.
+  sequence against a fake API; it is not yet reachable from the CLI.
 
 ---
 

--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -1285,8 +1285,9 @@ private credentials, tokenless runtime and expiry-bound candidate as one
 coherent private value. Its public receipt contains only the correlated
 package, credential, runtime, launch-plan and candidate digests plus validity.
 Post-verification changes to any retained component fail closed. At this
-checkpoint the material deliberately exposes neither private bytes nor an
-`Open`/execute method, so it cannot launch Kubernetes objects.
+checkpoint the material exposes no private bytes. Its `Open` boundary requires
+the exact candidate digest and reuses only retained verified components;
+opening validates the bounded local installer credential without API contact.
 
 `ok147-enablement-stage-launch-receipt/v1` is produced by a single-use bounded
 launcher that completes all six exact-name GETs before its first POST. It
@@ -1295,7 +1296,7 @@ objects matching exactly; every other partial state stops with zero writes.
 Creation is fixed to runtime, ConfigMap, NetworkPolicy, ledger Secret, writer
 Secret and Job. A failed create preserves the verified prefix and stops without
 retry. The launcher is currently exercised only through a fake Kubernetes API
-and is not exposed by the CLI or sealed launch material.
+and is not exposed by the CLI.
 
 ## Typed Contract-to-CAPI submission stages
 

--- a/internal/runner/enablement_stage_launch_material.go
+++ b/internal/runner/enablement_stage_launch_material.go
@@ -31,8 +31,8 @@ type EnablementStageLaunchMaterialReceipt struct {
 	MutationAllowed         bool   `json:"mutationAllowed"`
 }
 
-// VerifiedEnablementStageLaunchMaterial retains every private component but
-// deliberately provides no Open or execution method at this checkpoint.
+// VerifiedEnablementStageLaunchMaterial retains every private component and
+// permits only the exact retained candidate to open a bounded launcher.
 type VerifiedEnablementStageLaunchMaterial struct {
 	packaged    VerifiedEnablementStagePackage
 	credentials VerifiedEnablementStageCredentialPackage
@@ -40,6 +40,12 @@ type VerifiedEnablementStageLaunchMaterial struct {
 	candidate   VerifiedEnablementStageLaunchCandidate
 	receipt     EnablementStageLaunchMaterialReceipt
 	verified    bool
+}
+
+type EnablementStageLaunchOpenConfig struct {
+	Authority               KubernetesAuthorityConfig
+	Clock                   func() time.Time
+	ExpectedCandidateDigest string
 }
 
 // BuildEnablementStageLaunchMaterial constructs the complete private launch
@@ -94,6 +100,22 @@ func (material VerifiedEnablementStageLaunchMaterial) CandidateReceipt() (Enable
 		return EnablementStageLaunchCandidateReceipt{}, err
 	}
 	return material.candidate.Receipt()
+}
+
+// Open requires the exact prepared candidate digest and never permits callers
+// to replace any private verified component retained by the material. Opening
+// validates local credentials but performs no Kubernetes request.
+func (material VerifiedEnablementStageLaunchMaterial) Open(config EnablementStageLaunchOpenConfig) (*KubernetesEnablementStageLauncher, error) {
+	if err := verifyEnablementStageLaunchMaterial(material); err != nil {
+		return nil, err
+	}
+	if config.ExpectedCandidateDigest == "" || config.ExpectedCandidateDigest != material.receipt.CandidateDigest {
+		return nil, errors.New("enablement launch open requires the exact candidate digest")
+	}
+	return OpenKubernetesEnablementStageLauncher(EnablementStageLauncherConfig{
+		Authority: config.Authority, Clock: config.Clock, Candidate: material.candidate,
+		ExpectedCandidateDigest: config.ExpectedCandidateDigest,
+	}, material.packaged, material.credentials, material.runtime)
 }
 
 func verifyEnablementStageLaunchMaterial(material VerifiedEnablementStageLaunchMaterial) error {

--- a/internal/runner/enablement_stage_launch_material_test.go
+++ b/internal/runner/enablement_stage_launch_material_test.go
@@ -2,6 +2,7 @@ package runner
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"testing"
 	"time"
@@ -47,6 +48,44 @@ func TestBuildEnablementStageLaunchMaterialSealsPrivateComponents(t *testing.T) 
 	tampered.receipt.CandidateDigest = digest.SHA256([]byte("foreign"))
 	if _, err := tampered.Receipt(); err == nil {
 		t.Fatal("changed enablement launch material identity accepted")
+	}
+}
+
+func TestEnablementStageLaunchMaterialOpenRetainsExactComponents(t *testing.T) {
+	config, _, _, _ := enablementStageLaunchMaterialConfig(t)
+	material, err := BuildEnablementStageLaunchMaterial(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, _ := material.Receipt()
+	launcher, err := material.Open(EnablementStageLaunchOpenConfig{
+		Authority: KubernetesAuthorityConfig{
+			Endpoint: "http://127.0.0.1:12345", AuthorityIdentity: "ok-mgmt",
+		},
+		Clock:                   func() time.Time { return time.Date(2026, 8, 16, 12, 16, 0, 0, time.UTC) },
+		ExpectedCandidateDigest: receipt.CandidateDigest,
+	})
+	if err == nil || launcher != nil {
+		// Public Open requires the bound endpoint and credential files; the
+		// in-memory client path is intentionally unavailable here.
+		t.Fatalf("unbound public launcher was opened: %v", err)
+	}
+	if _, err := material.Open(EnablementStageLaunchOpenConfig{ExpectedCandidateDigest: digest.SHA256([]byte("foreign"))}); err == nil {
+		t.Fatal("wrong exact candidate digest accepted")
+	}
+
+	api := newSubmissionStageLauncherAPI(t)
+	internal, err := newKubernetesEnablementStageLauncher(submissionStageLauncherClientConfig{
+		Endpoint: "http://127.0.0.1:12345", BearerToken: "short-lived-installer-token", AuthorityIdentity: "ok-mgmt",
+		Client: api.client(), Clock: func() time.Time { return time.Date(2026, 8, 16, 12, 16, 0, 0, time.UTC) },
+		ValidUntil: time.Date(2026, 8, 16, 12, 15, 0, 0, time.UTC),
+	}, material.packaged, material.credentials, material.runtime)
+	if err != nil {
+		t.Fatal(err)
+	}
+	launchReceipt, err := internal.Launch(context.Background())
+	if err == nil || launchReceipt.State != "STOPPED_ZERO_WRITE" || launchReceipt.MutationState != "NOT_ATTEMPTED" || len(api.requests) != 0 {
+		t.Fatalf("expired sealed material reached API: %#v %v", launchReceipt, err)
 	}
 }
 


### PR DESCRIPTION
## Outcome

Connect the sealed Enablement launch material to the bounded launcher without exposing or replacing retained private components.

## Safety boundary

- `Open` requires the exact prepared candidate digest
- only retained verified package, credentials, runtime and candidate are used
- opening validates bounded local installer material but performs no API request
- expired material stops before fake API contact
- still no CLI exposure or live infrastructure action

## Validation

- `GOCACHE=/private/tmp/ok147-go-build-cache go test -ldflags=-linkmode=external ./...`
- `GOCACHE=/private/tmp/ok147-go-build-cache go vet ./...`
- `GOCACHE=/private/tmp/ok147-go-build-cache go test -race -ldflags=-linkmode=external ./internal/runner`
- `git diff --check`

Jira: OK-147
