### PR TITLE
feat(ok): prepare sealed enablement launch (OK-147)

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,9 @@ Powered by [Cluster API (CAPI)](https://cluster-api.sigs.k8s.io/), [CAPK (KubeVi
   public and private inputs can now be sealed as one verified launch material.
   The material can open only its exact retained candidate. A single-use Enablement
   launcher now proves the six-GET global barrier and fixed six-POST create-only
-  sequence against a fake API; it is not yet reachable from the CLI.
+  sequence against a fake API. `ok cluster stage run enablement launch prepare`
+  now emits the redaction-safe sealed-material and candidate receipts; launch
+  execution is not yet reachable from the CLI.
 
 ---
 

--- a/cmd/ok/enablement_launch.go
+++ b/cmd/ok/enablement_launch.go
@@ -1,0 +1,181 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/projection"
+	"github.com/openkubes/ok-cluster/internal/runner"
+)
+
+var prepareEnablementStageLaunch = func(config runner.EnablementStageLaunchMaterialConfig) (enablementLaunchPreparation, error) {
+	material, err := runner.BuildEnablementStageLaunchMaterial(config)
+	if err != nil {
+		return enablementLaunchPreparation{}, err
+	}
+	materialReceipt, err := material.Receipt()
+	if err != nil {
+		return enablementLaunchPreparation{}, err
+	}
+	candidateReceipt, err := material.CandidateReceipt()
+	if err != nil {
+		return enablementLaunchPreparation{}, err
+	}
+	return enablementLaunchPreparation{
+		Format: "ok147-enablement-stage-launch-preparation/v1", State: "PREPARED",
+		Material: materialReceipt, Candidate: candidateReceipt, MutationAllowed: false,
+	}, nil
+}
+
+type enablementLaunchPreparation struct {
+	Format          string                                       `json:"format"`
+	State           string                                       `json:"state"`
+	Material        runner.EnablementStageLaunchMaterialReceipt  `json:"material"`
+	Candidate       runner.EnablementStageLaunchCandidateReceipt `json:"candidate"`
+	MutationAllowed bool                                         `json:"mutationAllowed"`
+}
+
+type enablementLaunchMaterialFlags struct {
+	resume                                                                                       *stageResumeFlags
+	grantPath, grantKeyPath, evaluationTime, artifactPath, objectName                            *string
+	jobTemplate, jobTemplateDigest, runID, imageDigest, inputConfigMap                           *string
+	ledgerAPIURL, ledgerAPICIDR, ledgerCredentialSecret                                          *string
+	managementAPIURL, managementAPICIDR, managementCredentialSecret                              *string
+	materializedAt, runtimeManifest, runtimeManifestDigest                                       *string
+	installerAPIEndpoint, installerCADigest, installerTokenDigest, installerEvidence, preparedAt *string
+	ledgerCredential, managementCredential                                                       *stageLaunchCredentialFlags
+}
+
+func addEnablementLaunchMaterialFlags(flags *flag.FlagSet) *enablementLaunchMaterialFlags {
+	values := &enablementLaunchMaterialFlags{resume: addStageResumeFlags(flags)}
+	values.grantPath = flags.String("grant", "", "path to the signed single-stage grant")
+	values.grantKeyPath = flags.String("grant-key", "", "path to the trusted stage-authority public key")
+	values.evaluationTime = flags.String("evaluation-time", "", "explicit RFC3339 grant evaluation time")
+	values.artifactPath = flags.String("enablement-artifact", "", "path to the exact externally rendered HelmChartProxy")
+	values.objectName = flags.String("helmchartproxy-name", "", "independently expected HelmChartProxy name")
+	values.jobTemplate = flags.String("job-template", "", "path to the bounded enablement Job template")
+	values.jobTemplateDigest = flags.String("job-template-digest", "", "expected SHA-256 identity of the Job template")
+	values.runID = flags.String("run-id", "", "bounded OK-147 enablement Job identity")
+	values.imageDigest = flags.String("image", "", "digest-pinned ok image")
+	values.inputConfigMap = flags.String("input-configmap", "", "immutable enablement input ConfigMap name")
+	values.ledgerAPIURL = flags.String("ledger-api-url", "", "exact management-ledger HTTPS IP endpoint")
+	values.ledgerAPICIDR = flags.String("ledger-api-cidr", "", "single-address management-ledger CIDR")
+	values.ledgerCredentialSecret = flags.String("ledger-credential-secret", "", "ledger credential Secret name")
+	values.managementAPIURL = flags.String("management-api-url", "", "exact management-writer HTTPS IP endpoint")
+	values.managementAPICIDR = flags.String("management-api-cidr", "", "single-address management-writer CIDR")
+	values.managementCredentialSecret = flags.String("management-credential-secret", "", "management writer credential Secret name")
+	values.materializedAt = flags.String("credential-materialized-at", "", "exact credential materialization time")
+	values.ledgerCredential = addStageLaunchCredentialFlags(flags, "ledger-job", "ledger Job credential")
+	values.managementCredential = addStageLaunchCredentialFlags(flags, "management-writer-job", "management writer Job credential")
+	values.runtimeManifest = flags.String("runtime-manifest", "", "path to the tokenless runtime ServiceAccount manifest")
+	values.runtimeManifestDigest = flags.String("runtime-manifest-digest", "", "expected runtime manifest digest")
+	values.installerAPIEndpoint = flags.String("installer-api-endpoint", "", "exact management installer HTTPS IP endpoint")
+	values.installerCADigest = flags.String("installer-ca-digest", "", "expected management installer CA digest")
+	values.installerTokenDigest = flags.String("installer-token-digest", "", "private expected management installer token digest")
+	values.installerEvidence = flags.String("installer-tokenrequest-evidence-digest", "", "management installer TokenRequest evidence digest")
+	values.preparedAt = flags.String("prepared-at", "", "exact launch candidate preparation time")
+	return values
+}
+
+func (values *enablementLaunchMaterialFlags) config() (runner.EnablementStageLaunchMaterialConfig, error) {
+	resume, err := values.resume.config()
+	if err != nil {
+		return runner.EnablementStageLaunchMaterialConfig{}, err
+	}
+	for _, input := range []struct{ name, value string }{
+		{"--grant", *values.grantPath}, {"--grant-key", *values.grantKeyPath}, {"--evaluation-time", *values.evaluationTime},
+		{"--enablement-artifact", *values.artifactPath}, {"--helmchartproxy-name", *values.objectName},
+		{"--job-template", *values.jobTemplate}, {"--job-template-digest", *values.jobTemplateDigest}, {"--run-id", *values.runID}, {"--image", *values.imageDigest},
+		{"--input-configmap", *values.inputConfigMap}, {"--ledger-api-url", *values.ledgerAPIURL}, {"--ledger-api-cidr", *values.ledgerAPICIDR},
+		{"--ledger-credential-secret", *values.ledgerCredentialSecret}, {"--management-api-url", *values.managementAPIURL},
+		{"--management-api-cidr", *values.managementAPICIDR}, {"--management-credential-secret", *values.managementCredentialSecret},
+		{"--credential-materialized-at", *values.materializedAt}, {"--runtime-manifest", *values.runtimeManifest},
+		{"--runtime-manifest-digest", *values.runtimeManifestDigest}, {"--installer-api-endpoint", *values.installerAPIEndpoint},
+		{"--installer-ca-digest", *values.installerCADigest}, {"--installer-token-digest", *values.installerTokenDigest},
+		{"--installer-tokenrequest-evidence-digest", *values.installerEvidence}, {"--prepared-at", *values.preparedAt},
+	} {
+		if input.value == "" {
+			return runner.EnablementStageLaunchMaterialConfig{}, fmt.Errorf("%s is required", input.name)
+		}
+	}
+	evaluatedAt, err := time.Parse(time.RFC3339, *values.evaluationTime)
+	if err != nil {
+		return runner.EnablementStageLaunchMaterialConfig{}, fmt.Errorf("parse evaluation time: %w", err)
+	}
+	materializedAt, err := time.Parse(time.RFC3339, *values.materializedAt)
+	if err != nil {
+		return runner.EnablementStageLaunchMaterialConfig{}, fmt.Errorf("parse credential materialization time: %w", err)
+	}
+	preparedAt, err := time.Parse(time.RFC3339, *values.preparedAt)
+	if err != nil {
+		return runner.EnablementStageLaunchMaterialConfig{}, fmt.Errorf("parse candidate preparation time: %w", err)
+	}
+	ledgerSource, err := values.ledgerCredential.source("ledger-job")
+	if err != nil {
+		return runner.EnablementStageLaunchMaterialConfig{}, err
+	}
+	managementSource, err := values.managementCredential.source("management-writer-job")
+	if err != nil {
+		return runner.EnablementStageLaunchMaterialConfig{}, err
+	}
+	template, err := readBoundedLocalFile(*values.jobTemplate, 1024*1024)
+	if err != nil {
+		return runner.EnablementStageLaunchMaterialConfig{}, fmt.Errorf("read enablement Job template: %w", err)
+	}
+	runtimeRaw, err := readBoundedLocalFile(*values.runtimeManifest, 128*1024)
+	if err != nil {
+		return runner.EnablementStageLaunchMaterialConfig{}, fmt.Errorf("read runtime manifest: %w", err)
+	}
+	return runner.EnablementStageLaunchMaterialConfig{
+		Package: runner.EnablementStagePackageConfig{
+			Bundle: runner.EnablementStageBundleConfig{
+				PlanPath: resume.PlanPath, PlanExpected: resume.PlanExpected, Receipts: resume.Receipts,
+				GrantPath: *values.grantPath, GrantPublicKeyPath: *values.grantKeyPath, EvaluationTime: evaluatedAt,
+				ArtifactPath: *values.artifactPath,
+				ExpectedObject: projection.ResourceIdentity{
+					APIVersion: "addons.cluster.x-k8s.io/v1alpha1", Kind: "HelmChartProxy",
+					Namespace: resume.PlanExpected.ContractIdentity.Namespace, Name: *values.objectName,
+				},
+			},
+			JobTemplate: template, JobTemplateDigest: *values.jobTemplateDigest,
+			RunID: *values.runID, ImageDigest: *values.imageDigest, InputConfigMap: *values.inputConfigMap, HelmChartProxyName: *values.objectName,
+			LedgerAPIURL: *values.ledgerAPIURL, LedgerAPICIDR: *values.ledgerAPICIDR, LedgerCredentialSecret: *values.ledgerCredentialSecret,
+			ManagementAPIURL: *values.managementAPIURL, ManagementAPICIDR: *values.managementAPICIDR, ManagementCredentialSecret: *values.managementCredentialSecret,
+		},
+		MaterializationTime: materializedAt, Ledger: ledgerSource, ManagementWriter: managementSource,
+		RuntimeManifest: runtimeRaw, RuntimeManifestDigest: *values.runtimeManifestDigest,
+		Candidate: runner.SubmissionStageLaunchCandidateConfig{
+			AuthorityEndpoint: *values.installerAPIEndpoint, CABundleDigest: *values.installerCADigest,
+			InstallerTokenDigest: *values.installerTokenDigest, InstallerCredentialEvidenceDigest: *values.installerEvidence,
+			PreparedAt: preparedAt,
+		},
+	}, nil
+}
+
+func runClusterStageRunEnablementLaunchPrepare(arguments []string, stdout, stderr io.Writer) error {
+	flags := flag.NewFlagSet("ok cluster stage run enablement launch prepare", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	materialFlags := addEnablementLaunchMaterialFlags(flags)
+	if err := flags.Parse(arguments); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return errors.New("positional arguments are not accepted")
+	}
+	config, err := materialFlags.config()
+	if err != nil {
+		return err
+	}
+	preparation, err := prepareEnablementStageLaunch(config)
+	if err != nil {
+		return err
+	}
+	encoder := json.NewEncoder(stdout)
+	encoder.SetEscapeHTML(false)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(preparation)
+}

--- a/cmd/ok/enablement_launch_test.go
+++ b/cmd/ok/enablement_launch_test.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/runner"
+)
+
+func TestEnablementLaunchPrepareBuildsOneNonMutatingCandidate(t *testing.T) {
+	previous := prepareEnablementStageLaunch
+	defer func() { prepareEnablementStageLaunch = previous }()
+	var captured runner.EnablementStageLaunchMaterialConfig
+	prepareEnablementStageLaunch = func(config runner.EnablementStageLaunchMaterialConfig) (enablementLaunchPreparation, error) {
+		captured = config
+		return enablementLaunchPreparation{
+			Format: "ok147-enablement-stage-launch-preparation/v1", State: "PREPARED",
+			Material: runner.EnablementStageLaunchMaterialReceipt{
+				Format: runner.EnablementStageLaunchMaterialFormat, State: "VERIFIED", StageID: "enablement",
+				Authority: "ok-mgmt", CandidateDigest: testSHA("1"), MutationAllowed: false,
+			},
+			Candidate: runner.EnablementStageLaunchCandidateReceipt{
+				Format: runner.EnablementStageLaunchCandidateFormat, State: "PREPARED", CandidateDigest: testSHA("1"), MutationAllowed: false,
+			},
+			MutationAllowed: false,
+		}, nil
+	}
+	root := t.TempDir()
+	template, runtimeManifest := filepath.Join(root, "enablement.yaml.tpl"), filepath.Join(root, "runtime.yaml")
+	if err := os.WriteFile(template, []byte("bounded-enablement-template"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(runtimeManifest, []byte("bounded-runtime"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	if err := run(enablementLaunchPrepareArguments(template, runtimeManifest), &stdout, &stderr); err != nil {
+		t.Fatalf("run: %v; stderr=%s", err, stderr.String())
+	}
+	if captured.Package.Bundle.PlanExpected.ManagementAuthority != "ok-mgmt" {
+		t.Fatalf("management authority differs: %q", captured.Package.Bundle.PlanExpected.ManagementAuthority)
+	}
+	if captured.Package.RunID != "ok147-enablement-20260816-01" || captured.Package.HelmChartProxyName != "disposable-ok147-cilium" {
+		t.Fatalf("enablement object identity differs: %q %q", captured.Package.RunID, captured.Package.HelmChartProxyName)
+	}
+	if string(captured.Package.JobTemplate) != "bounded-enablement-template" || string(captured.RuntimeManifest) != "bounded-runtime" {
+		t.Fatalf("enablement private templates differ: %q %q", captured.Package.JobTemplate, captured.RuntimeManifest)
+	}
+	if captured.Ledger.AuthorityIdentity != "ok-mgmt" || captured.ManagementWriter.AuthorityIdentity != "ok-mgmt" || captured.Ledger.TokenFile == captured.ManagementWriter.TokenFile {
+		t.Fatalf("enablement credential boundary differs: %#v %#v", captured.Ledger, captured.ManagementWriter)
+	}
+	var preparation enablementLaunchPreparation
+	if err := json.Unmarshal(stdout.Bytes(), &preparation); err != nil {
+		t.Fatal(err)
+	}
+	if preparation.State != "PREPARED" || preparation.MutationAllowed || preparation.Material.MutationAllowed || preparation.Candidate.MutationAllowed {
+		t.Fatalf("unsafe enablement launch preparation: %#v", preparation)
+	}
+
+	invalid := removeArgumentWithValue(enablementLaunchPrepareArguments(template, runtimeManifest), "--management-writer-job-token-file")
+	stdout.Reset()
+	if err := run(invalid, &stdout, &stderr); err == nil || stdout.Len() != 0 {
+		t.Fatal("incomplete private material reached preparation")
+	}
+}
+
+func enablementLaunchPrepareArguments(template, runtimeManifest string) []string {
+	packaged := enablementStagePackageArguments(template, "/private/tmp/not-used-package")
+	packaged = removeArgumentWithValue(packaged, "--output")
+	arguments := append([]string{"cluster", "stage", "run", "enablement", "launch", "prepare"}, packaged[5:]...)
+	arguments = append(arguments, "--credential-materialized-at", "2026-08-16T12:00:00Z")
+	for _, credential := range []struct{ prefix, tokenFile, tokenDigest, caFile, caDigest, evidence, subject string }{
+		{"ledger-job", "/private/tmp/ledger-enablement-token", testSHA("1"), "/private/tmp/ledger-enablement-ca", testSHA("2"), testSHA("3"), "system:serviceaccount:openkubes-execution-system:ok147-ledger-writer"},
+		{"management-writer-job", "/private/tmp/management-writer-token", testSHA("4"), "/private/tmp/management-writer-ca", testSHA("2"), testSHA("5"), "system:serviceaccount:openkubes-execution-system:ok147-enablement-writer"},
+	} {
+		arguments = append(arguments,
+			"--"+credential.prefix+"-authority", "ok-mgmt",
+			"--"+credential.prefix+"-token-file", credential.tokenFile, "--"+credential.prefix+"-token-digest", credential.tokenDigest,
+			"--"+credential.prefix+"-ca-file", credential.caFile, "--"+credential.prefix+"-ca-digest", credential.caDigest,
+			"--"+credential.prefix+"-tokenrequest-evidence-digest", credential.evidence,
+			"--"+credential.prefix+"-issuer", "https://kubernetes.default.svc.cluster.local", "--"+credential.prefix+"-subject", credential.subject,
+			"--"+credential.prefix+"-audiences", "https://kubernetes.default.svc",
+			"--"+credential.prefix+"-issued-at", "2026-08-16T11:59:00Z", "--"+credential.prefix+"-expires-at", "2026-08-16T12:30:00Z",
+		)
+	}
+	return append(arguments,
+		"--runtime-manifest", runtimeManifest, "--runtime-manifest-digest", digest.SHA256([]byte("bounded-runtime")),
+		"--installer-api-endpoint", "https://192.0.2.12:6443", "--installer-ca-digest", testSHA("2"),
+		"--installer-token-digest", testSHA("7"), "--installer-tokenrequest-evidence-digest", testSHA("8"),
+		"--prepared-at", "2026-08-16T12:01:00Z",
+	)
+}

--- a/cmd/ok/main.go
+++ b/cmd/ok/main.go
@@ -491,6 +491,9 @@ func runContext(ctx context.Context, arguments []string, stdout, stderr io.Write
 	if len(arguments) >= 5 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "run" && arguments[3] == "enablement" && arguments[4] == "package" {
 		return runClusterStageRunEnablementPackage(arguments[5:], stdout, stderr)
 	}
+	if len(arguments) >= 6 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "run" && arguments[3] == "enablement" && arguments[4] == "launch" && arguments[5] == "prepare" {
+		return runClusterStageRunEnablementLaunchPrepare(arguments[6:], stdout, stderr)
+	}
 	if len(arguments) >= 4 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "run" && arguments[3] == "enablement" {
 		return runClusterStageRunEnablement(ctx, arguments[4:], stdout, stderr)
 	}
@@ -506,7 +509,7 @@ func runContext(ctx context.Context, arguments []string, stdout, stderr io.Write
 	if len(arguments) >= 4 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "launch" && arguments[3] == "execute" {
 		return runClusterStageLaunchExecute(ctx, arguments[4:], stdout, stderr)
 	}
-	return errors.New("usage: ok cluster create ... | ok cluster stage inspect ... | ok cluster stage resume ... | ok cluster stage observe lifecycle ... | ok cluster stage observe lifecycle package ... | ok cluster stage observe lifecycle launch prepare ... | ok cluster stage observe lifecycle launch execute ... | ok cluster stage run ... | ok cluster stage run enablement ... | ok cluster stage run enablement package ... | ok cluster stage package ... | ok cluster stage launch prepare ... | ok cluster stage launch execute ...")
+	return errors.New("usage: ok cluster create ... | ok cluster stage inspect ... | ok cluster stage resume ... | ok cluster stage observe lifecycle ... | ok cluster stage observe lifecycle package ... | ok cluster stage observe lifecycle launch prepare ... | ok cluster stage observe lifecycle launch execute ... | ok cluster stage run ... | ok cluster stage run enablement ... | ok cluster stage run enablement package ... | ok cluster stage run enablement launch prepare ... | ok cluster stage package ... | ok cluster stage launch prepare ... | ok cluster stage launch execute ...")
 }
 
 func runClusterCreate(arguments []string, stdout, stderr io.Writer) error {

--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -1288,6 +1288,15 @@ Post-verification changes to any retained component fail closed. At this
 checkpoint the material exposes no private bytes. Its `Open` boundary requires
 the exact candidate digest and reuses only retained verified components;
 opening validates the bounded local installer credential without API contact.
+The offline CLI boundary is:
+
+```text
+ok cluster stage run enablement launch prepare
+```
+
+It requires the complete package, private two-credential, tokenless-runtime
+and installer-candidate inputs and emits only the material and candidate
+receipts. It has no execute flag and cannot contact Kubernetes.
 
 `ok147-enablement-stage-launch-receipt/v1` is produced by a single-use bounded
 launcher that completes all six exact-name GETs before its first POST. It
@@ -1296,7 +1305,7 @@ objects matching exactly; every other partial state stops with zero writes.
 Creation is fixed to runtime, ConfigMap, NetworkPolicy, ledger Secret, writer
 Secret and Job. A failed create preserves the verified prefix and stops without
 retry. The launcher is currently exercised only through a fake Kubernetes API
-and is not exposed by the CLI.
+and launch execution is not exposed by the CLI.
 
 ## Typed Contract-to-CAPI submission stages
 


### PR DESCRIPTION
## Outcome

Expose the offline Enablement launch-material composition as `ok cluster stage run enablement launch prepare`.

## Boundary

- requires the complete package, two private credential, tokenless runtime and installer-candidate inputs
- emits only redaction-safe material and candidate receipts
- missing or malformed private bindings fail before preparation
- no execute flag, Kubernetes client or API contact exists in this command
- no infrastructure mutation

## Validation

- `GOCACHE=/private/tmp/ok147-go-build-cache go test -ldflags=-linkmode=external ./...`
- `GOCACHE=/private/tmp/ok147-go-build-cache go vet ./...`
- `GOCACHE=/private/tmp/ok147-go-build-cache go test -race -ldflags=-linkmode=external ./internal/runner ./cmd/ok`
- `git diff --check`

Jira: OK-147
