### PR TITLE
feat(ok): execute bounded enablement launch (OK-147)

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,9 @@ Powered by [Cluster API (CAPI)](https://cluster-api.sigs.k8s.io/), [CAPK (KubeVi
   The material can open only its exact retained candidate. A single-use Enablement
   launcher now proves the six-GET global barrier and fixed six-POST create-only
   sequence against a fake API. `ok cluster stage run enablement launch prepare`
-  now emits the redaction-safe sealed-material and candidate receipts; launch
-  execution is not yet reachable from the CLI.
+  emits the redaction-safe sealed-material and candidate receipts. The separate
+  `... launch execute --execute` boundary requires that exact candidate digest
+  plus the bounded installer files before it can open the single-use launcher.
 
 ---
 

--- a/cmd/ok/enablement_launch.go
+++ b/cmd/ok/enablement_launch.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -29,6 +30,25 @@ var prepareEnablementStageLaunch = func(config runner.EnablementStageLaunchMater
 		Format: "ok147-enablement-stage-launch-preparation/v1", State: "PREPARED",
 		Material: materialReceipt, Candidate: candidateReceipt, MutationAllowed: false,
 	}, nil
+}
+
+var executeEnablementStageLaunch = func(ctx context.Context, config runner.EnablementStageLaunchMaterialConfig, authority runner.KubernetesAuthorityConfig, expectedCandidateDigest string) (runner.EnablementStageLaunchReceipt, error) {
+	material, err := runner.BuildEnablementStageLaunchMaterial(config)
+	if err != nil {
+		return runner.EnablementStageLaunchReceipt{}, err
+	}
+	candidate, err := material.CandidateReceipt()
+	if err != nil {
+		return runner.EnablementStageLaunchReceipt{}, err
+	}
+	authority.AuthorityIdentity = candidate.Authority
+	launcher, err := material.Open(runner.EnablementStageLaunchOpenConfig{
+		Authority: authority, Clock: func() time.Time { return time.Now().UTC() }, ExpectedCandidateDigest: expectedCandidateDigest,
+	})
+	if err != nil {
+		return runner.EnablementStageLaunchReceipt{}, err
+	}
+	return launcher.Launch(ctx)
 }
 
 type enablementLaunchPreparation struct {
@@ -178,4 +198,52 @@ func runClusterStageRunEnablementLaunchPrepare(arguments []string, stdout, stder
 	encoder.SetEscapeHTML(false)
 	encoder.SetIndent("", "  ")
 	return encoder.Encode(preparation)
+}
+
+func runClusterStageRunEnablementLaunchExecute(ctx context.Context, arguments []string, stdout, stderr io.Writer) error {
+	flags := flag.NewFlagSet("ok cluster stage run enablement launch execute", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	materialFlags := addEnablementLaunchMaterialFlags(flags)
+	execute := flags.Bool("execute", false, "perform the exact single-use six-object Enablement launch")
+	expectedCandidateDigest := flags.String("expected-candidate-digest", "", "exact digest emitted by Enablement launch prepare")
+	installerTokenFile := flags.String("installer-token-file", "", "bounded short-lived management installer token file")
+	installerCAFile := flags.String("installer-ca-file", "", "bounded management installer CA file")
+	if err := flags.Parse(arguments); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return errors.New("positional arguments are not accepted")
+	}
+	if !*execute {
+		return errors.New("enablement launch mutation requires explicit --execute")
+	}
+	for _, input := range []struct{ name, value string }{
+		{"--expected-candidate-digest", *expectedCandidateDigest}, {"--installer-token-file", *installerTokenFile}, {"--installer-ca-file", *installerCAFile},
+	} {
+		if input.value == "" {
+			return fmt.Errorf("%s is required", input.name)
+		}
+	}
+	if !sha256DigestPattern.MatchString(*expectedCandidateDigest) {
+		return errors.New("--expected-candidate-digest must be sha256:<64 lowercase hex>")
+	}
+	config, err := materialFlags.config()
+	if err != nil {
+		return err
+	}
+	boundedContext, cancel := context.WithTimeout(ctx, stageLaunchTimeout)
+	defer cancel()
+	receipt, launchErr := executeEnablementStageLaunch(boundedContext, config, runner.KubernetesAuthorityConfig{
+		Endpoint: config.Candidate.AuthorityEndpoint, TokenFile: *installerTokenFile,
+		CAFile: *installerCAFile, CABundleDigest: config.Candidate.CABundleDigest,
+	}, *expectedCandidateDigest)
+	if receipt.Format != "" {
+		encoder := json.NewEncoder(stdout)
+		encoder.SetEscapeHTML(false)
+		encoder.SetIndent("", "  ")
+		if err := encoder.Encode(receipt); err != nil {
+			return err
+		}
+	}
+	return launchErr
 }

--- a/cmd/ok/enablement_launch_test.go
+++ b/cmd/ok/enablement_launch_test.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/openkubes/ok-cluster/internal/digest"
 	"github.com/openkubes/ok-cluster/internal/runner"
@@ -68,6 +70,63 @@ func TestEnablementLaunchPrepareBuildsOneNonMutatingCandidate(t *testing.T) {
 	}
 }
 
+func TestEnablementLaunchExecuteUsesExactBoundary(t *testing.T) {
+	previous := executeEnablementStageLaunch
+	defer func() { executeEnablementStageLaunch = previous }()
+	var calls int
+	var candidate string
+	executeEnablementStageLaunch = func(ctx context.Context, config runner.EnablementStageLaunchMaterialConfig, authority runner.KubernetesAuthorityConfig, expectedCandidateDigest string) (runner.EnablementStageLaunchReceipt, error) {
+		calls++
+		candidate = expectedCandidateDigest
+		deadline, ok := ctx.Deadline()
+		if !ok || time.Until(deadline) <= 0 || time.Until(deadline) > stageLaunchTimeout {
+			t.Fatal("enablement launch context is not bounded")
+		}
+		if config.Package.RunID != "ok147-enablement-20260816-01" || authority.Endpoint != "https://192.0.2.12:6443" || authority.TokenFile != "/private/tmp/installer-token" {
+			t.Fatalf("execute boundary differs: %#v %#v", config, authority)
+		}
+		return runner.EnablementStageLaunchReceipt{
+			Format: runner.EnablementStageLaunchReceiptFormat, StageID: "enablement", Authority: "ok-mgmt",
+			State: "LAUNCHED", MutationState: "ATTEMPTED", Results: []runner.SubmissionStageLaunchResult{},
+		}, nil
+	}
+	root := t.TempDir()
+	template, runtimeManifest := filepath.Join(root, "enablement.yaml.tpl"), filepath.Join(root, "runtime.yaml")
+	if err := os.WriteFile(template, []byte("bounded-enablement-template"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(runtimeManifest, []byte("bounded-runtime"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	if err := run(enablementLaunchExecuteArguments(template, runtimeManifest), &stdout, &stderr); err != nil {
+		t.Fatalf("run: %v; stderr=%s", err, stderr.String())
+	}
+	if calls != 1 || candidate != testSHA("9") {
+		t.Fatalf("exact enablement candidate not used: calls=%d digest=%q", calls, candidate)
+	}
+	var receipt runner.EnablementStageLaunchReceipt
+	if err := json.Unmarshal(stdout.Bytes(), &receipt); err != nil || receipt.State != "LAUNCHED" {
+		t.Fatalf("unexpected enablement launch receipt: %#v %v", receipt, err)
+	}
+
+	valid := enablementLaunchExecuteArguments(template, runtimeManifest)
+	for name, arguments := range map[string][]string{
+		"missing execute":         removeArgument(valid, "--execute"),
+		"missing candidate":       removeArgumentWithValue(valid, "--expected-candidate-digest"),
+		"malformed candidate":     replaceArgument(valid, "--expected-candidate-digest", "sha256:ABC"),
+		"missing installer token": removeArgumentWithValue(valid, "--installer-token-file"),
+	} {
+		t.Run(name, func(t *testing.T) {
+			before := calls
+			stdout.Reset()
+			if err := run(arguments, &stdout, &stderr); err == nil || stdout.Len() != 0 || calls != before {
+				t.Fatal("unsafe enablement launch input reached executor")
+			}
+		})
+	}
+}
+
 func enablementLaunchPrepareArguments(template, runtimeManifest string) []string {
 	packaged := enablementStagePackageArguments(template, "/private/tmp/not-used-package")
 	packaged = removeArgumentWithValue(packaged, "--output")
@@ -92,5 +151,14 @@ func enablementLaunchPrepareArguments(template, runtimeManifest string) []string
 		"--installer-api-endpoint", "https://192.0.2.12:6443", "--installer-ca-digest", testSHA("2"),
 		"--installer-token-digest", testSHA("7"), "--installer-tokenrequest-evidence-digest", testSHA("8"),
 		"--prepared-at", "2026-08-16T12:01:00Z",
+	)
+}
+
+func enablementLaunchExecuteArguments(template, runtimeManifest string) []string {
+	arguments := enablementLaunchPrepareArguments(template, runtimeManifest)
+	arguments[5] = "execute"
+	return append(arguments,
+		"--execute", "--expected-candidate-digest", testSHA("9"),
+		"--installer-token-file", "/private/tmp/installer-token", "--installer-ca-file", "/private/tmp/installer-ca",
 	)
 }

--- a/cmd/ok/main.go
+++ b/cmd/ok/main.go
@@ -494,6 +494,9 @@ func runContext(ctx context.Context, arguments []string, stdout, stderr io.Write
 	if len(arguments) >= 6 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "run" && arguments[3] == "enablement" && arguments[4] == "launch" && arguments[5] == "prepare" {
 		return runClusterStageRunEnablementLaunchPrepare(arguments[6:], stdout, stderr)
 	}
+	if len(arguments) >= 6 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "run" && arguments[3] == "enablement" && arguments[4] == "launch" && arguments[5] == "execute" {
+		return runClusterStageRunEnablementLaunchExecute(ctx, arguments[6:], stdout, stderr)
+	}
 	if len(arguments) >= 4 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "run" && arguments[3] == "enablement" {
 		return runClusterStageRunEnablement(ctx, arguments[4:], stdout, stderr)
 	}
@@ -509,7 +512,7 @@ func runContext(ctx context.Context, arguments []string, stdout, stderr io.Write
 	if len(arguments) >= 4 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "launch" && arguments[3] == "execute" {
 		return runClusterStageLaunchExecute(ctx, arguments[4:], stdout, stderr)
 	}
-	return errors.New("usage: ok cluster create ... | ok cluster stage inspect ... | ok cluster stage resume ... | ok cluster stage observe lifecycle ... | ok cluster stage observe lifecycle package ... | ok cluster stage observe lifecycle launch prepare ... | ok cluster stage observe lifecycle launch execute ... | ok cluster stage run ... | ok cluster stage run enablement ... | ok cluster stage run enablement package ... | ok cluster stage run enablement launch prepare ... | ok cluster stage package ... | ok cluster stage launch prepare ... | ok cluster stage launch execute ...")
+	return errors.New("usage: ok cluster create ... | ok cluster stage inspect ... | ok cluster stage resume ... | ok cluster stage observe lifecycle ... | ok cluster stage observe lifecycle package ... | ok cluster stage observe lifecycle launch prepare ... | ok cluster stage observe lifecycle launch execute ... | ok cluster stage run ... | ok cluster stage run enablement ... | ok cluster stage run enablement package ... | ok cluster stage run enablement launch prepare ... | ok cluster stage run enablement launch execute ... | ok cluster stage package ... | ok cluster stage launch prepare ... | ok cluster stage launch execute ...")
 }
 
 func runClusterCreate(arguments []string, stdout, stderr io.Writer) error {

--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -1296,7 +1296,15 @@ ok cluster stage run enablement launch prepare
 
 It requires the complete package, private two-credential, tokenless-runtime
 and installer-candidate inputs and emits only the material and candidate
-receipts. It has no execute flag and cannot contact Kubernetes.
+receipts. The separately gated execution boundary is:
+
+```text
+ok cluster stage run enablement launch execute --execute
+```
+
+It rebuilds the same material and additionally requires the exact prepared
+candidate digest and bounded installer token/CA files. Missing `--execute`, a
+foreign digest or incomplete installer input stops before opening a launcher.
 
 `ok147-enablement-stage-launch-receipt/v1` is produced by a single-use bounded
 launcher that completes all six exact-name GETs before its first POST. It
@@ -1305,7 +1313,7 @@ objects matching exactly; every other partial state stops with zero writes.
 Creation is fixed to runtime, ConfigMap, NetworkPolicy, ledger Secret, writer
 Secret and Job. A failed create preserves the verified prefix and stops without
 retry. The launcher is currently exercised only through a fake Kubernetes API
-and launch execution is not exposed by the CLI.
+in tests; no live Enablement launch is performed by the repository suite.
 
 ## Typed Contract-to-CAPI submission stages
 


### PR DESCRIPTION
## Outcome

Expose the bounded Enablement launcher through the separately gated `ok cluster stage run enablement launch execute --execute` command.

## Safety boundary

- rebuilds the same sealed material as `prepare`
- requires explicit `--execute`, exact candidate digest and bounded installer token/CA files
- uses a five-minute context and the single-use create-only launcher
- malformed or missing execution inputs stop before the executor is called
- receipts remain redaction-safe
- tests inject a stub/fake API only; no live infrastructure action

## Validation

- `GOCACHE=/private/tmp/ok147-go-build-cache go test -ldflags=-linkmode=external ./...`
- `GOCACHE=/private/tmp/ok147-go-build-cache go vet ./...`
- `GOCACHE=/private/tmp/ok147-go-build-cache go test -race -ldflags=-linkmode=external ./internal/runner ./cmd/ok`
- `git diff --check`

Jira: OK-147
