### PR TITLE
feat(runner): add bounded network stage observer (OK-147)

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -1881,6 +1881,40 @@ object to delete.
 The concrete service checks are still injected typed implementations in this
 checkpoint; no live Kubernetes request or capability mutation was performed.
 
+## Receipt-correlated network-observation stage
+
+The `network-observation` stage now has a narrow typed adapter around the
+existing NetworkReady source and evaluator. It does not introduce another
+network evaluator or an OpenKubes reconciliation loop. The adapter verifies
+the full four-receipt prefix through `enablement` and correlates the private
+workload Cluster UID to the digest retained by `cluster-lifecycle`:
+
+```text
+verified receipt prefix
+  cluster-lifecycle.targetClusterUidDigest
+                    |
+ SHA-256(private workload Cluster UID)
+                    |
+              exact equality
+                    v
+ existing bounded NetworkReady source + immutable E profile
+                    v
+ deterministic one-condition evaluation and bounded Unknown polling
+                    v
+ SUCCEEDED | FAILED | STOPPED stage result
+```
+
+This deliberately reaches past the direct `enablement` predecessor for
+identity correlation without weakening the direct receipt chain. A same-name
+replacement, missing historical UID digest, foreign profile, reordered prefix
+or prefix selecting another stage fails before observation. Only verified
+`Unknown` evidence is polled; terminal `True` and `False` return immediately,
+and operational source details are redacted.
+
+This checkpoint is the stage observer only. It adds no Kubernetes bundle, CLI,
+Job, credential opening, cluster request or infrastructure mutation. Those
+activation boundaries remain separate reviewable steps.
+
 ## Bounded convergence observation polling
 
 The aggregate observer can now be wrapped by a bounded polling observer before

--- a/internal/runner/network_stage_observer.go
+++ b/internal/runner/network_stage_observer.go
@@ -1,0 +1,147 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/execution"
+	"github.com/openkubes/ok-cluster/internal/observation"
+	"github.com/openkubes/ok-cluster/internal/stagecursor"
+	"github.com/openkubes/ok-cluster/internal/stageplan"
+	"github.com/openkubes/ok-cluster/internal/stagereceipt"
+)
+
+type NetworkStageObserverConfig struct {
+	Plan             stageplan.Binding
+	ReceiptPrefix    []stagereceipt.Verified
+	TargetClusterUID string
+	Source           observation.NetworkEvidenceSource
+	Profile          observation.NetworkProfile
+	PollInterval     time.Duration
+	PollTimeout      time.Duration
+	Clock            func() time.Time
+	Wait             ObservationWaiter
+}
+
+// NetworkStageObserver is the stage-specific adapter around the existing
+// bounded NetworkReady source and deterministic observation evaluator. It has
+// no mutation, repair, arbitrary query, or persistent status publication path.
+type NetworkStageObserver struct {
+	binding      execution.StageObservationBinding
+	source       observation.NetworkEvidenceSource
+	profile      observation.NetworkProfile
+	policy       observation.Policy
+	pollInterval time.Duration
+	pollLimit    time.Duration
+	clock        func() time.Time
+	wait         ObservationWaiter
+}
+
+var _ execution.StageObserver = (*NetworkStageObserver)(nil)
+
+// NewNetworkStageObserver derives stage selection from the complete verified
+// receipt prefix and correlates the private raw target UID to the durable
+// digest emitted by cluster-lifecycle. A same-name replacement is rejected.
+func NewNetworkStageObserver(config NetworkStageObserverConfig) (*NetworkStageObserver, error) {
+	if config.Source == nil || config.Clock == nil || config.Wait == nil {
+		return nil, errors.New("network stage observer source, clock, and waiter are required")
+	}
+	cursor, err := stagecursor.Evaluate(config.Plan, config.ReceiptPrefix)
+	if err != nil {
+		return nil, errors.New("verify network observation receipt prefix")
+	}
+	decision, err := cursor.Decision()
+	if err != nil || decision.State != "NEXT" || decision.StageID != "network-observation" || decision.Kind != "Observation" || decision.Authority != "workload" || decision.RequiresAuthorization || decision.Operation != "" {
+		return nil, errors.New("stage receipt prefix does not select network observation")
+	}
+	if len(config.ReceiptPrefix) != 4 {
+		return nil, errors.New("network observation receipt prefix is incomplete")
+	}
+	lifecycle, err := config.ReceiptPrefix[1].Receipt()
+	if err != nil || lifecycle.StageID != "cluster-lifecycle" || !platformInputDigestPattern.MatchString(lifecycle.TargetClusterUIDDigest) || digest.SHA256([]byte(config.TargetClusterUID)) != lifecycle.TargetClusterUIDDigest {
+		return nil, errors.New("network observation target differs from durable lifecycle correlation")
+	}
+	if err := observation.ValidateNetworkProfile(config.Profile); err != nil || config.Profile.IntentRevision != config.Plan.IntentRevision || config.Profile.EnablementRevision != config.Plan.EnablementRevision {
+		return nil, errors.New("network profile differs from the verified execution plan")
+	}
+	stage, stageDigest, err := config.Plan.Stage(decision.StageID)
+	if err != nil || stageDigest != decision.StageDigest {
+		return nil, errors.New("network observation stage differs from verified plan")
+	}
+	return &NetworkStageObserver{
+		binding: execution.StageObservationBinding{
+			PlanDigest: config.Plan.PlanDigest, StageID: stage.ID, StageDigest: stageDigest,
+			Authority: stage.Authority, ContractRevision: config.Plan.IntentRevision,
+		},
+		source: config.Source, profile: config.Profile,
+		policy: observation.Policy{
+			Format: observation.PolicyFormat, IntentRevision: config.Plan.IntentRevision,
+			EnablementRevision: config.Plan.EnablementRevision, PlatformRevision: config.Plan.PlatformRevision,
+			TargetClusterUID: config.TargetClusterUID, Required: []string{"NetworkReady"},
+		},
+		pollInterval: config.PollInterval, pollLimit: config.PollTimeout,
+		clock: config.Clock, wait: config.Wait,
+	}, nil
+}
+
+func (observer *NetworkStageObserver) Binding() execution.StageObservationBinding {
+	if observer == nil {
+		return execution.StageObservationBinding{}
+	}
+	return observer.binding
+}
+
+func (observer *NetworkStageObserver) Observe(ctx context.Context) (execution.StageObservationResult, error) {
+	if observer == nil {
+		return execution.StageObservationResult{}, errors.New("network stage observer is required")
+	}
+	polling, err := NewBoundedPollingObserver(BoundedPollingObserverConfig{
+		Source:   &networkPollingSource{source: observer.source, profile: observer.profile, clock: observer.clock},
+		Interval: observer.pollInterval, Timeout: observer.pollLimit, Clock: observer.clock, Wait: observer.wait,
+	})
+	if err != nil {
+		return execution.StageObservationResult{}, err
+	}
+	result, err := polling.Observe(ctx, observer.policy)
+	if err != nil {
+		return execution.StageObservationResult{}, errors.New("bounded network convergence observation failed")
+	}
+	receipt, err := result.Receipt()
+	if err != nil {
+		return execution.StageObservationResult{}, err
+	}
+	evidenceDigest, err := result.EvidenceDigest()
+	if err != nil {
+		return execution.StageObservationResult{}, err
+	}
+	completedAt, err := time.Parse(time.RFC3339Nano, receipt.EvaluatedAt)
+	if err != nil {
+		return execution.StageObservationResult{}, errors.New("network observation completion time is invalid")
+	}
+	outcome := "STOPPED"
+	if receipt.Ready == "True" {
+		outcome = "SUCCEEDED"
+	} else if receipt.Ready == "False" {
+		outcome = "FAILED"
+	}
+	return execution.StageObservationResult{Outcome: outcome, EvidenceDigest: evidenceDigest, CompletedAt: completedAt}, nil
+}
+
+type networkPollingSource struct {
+	source  observation.NetworkEvidenceSource
+	profile observation.NetworkProfile
+	clock   func() time.Time
+}
+
+func (source *networkPollingSource) Observe(ctx context.Context, policy observation.Policy) (observation.VerifiedResult, error) {
+	evidence, err := source.source.Observe(ctx, policy, source.profile)
+	if err != nil {
+		return observation.VerifiedResult{}, err
+	}
+	return observation.Evaluate(policy, observation.Bundle{
+		Format: observation.BundleFormat, IntentRevision: policy.IntentRevision,
+		EvaluatedAt: source.clock().UTC().Format(time.RFC3339Nano), Evidence: []observation.Evidence{evidence},
+	})
+}

--- a/internal/runner/network_stage_observer_test.go
+++ b/internal/runner/network_stage_observer_test.go
@@ -1,0 +1,188 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/observation"
+	"github.com/openkubes/ok-cluster/internal/stageplan"
+	"github.com/openkubes/ok-cluster/internal/stagereceipt"
+)
+
+func TestNetworkStageObserverBindsHistoricalTargetAndConverges(t *testing.T) {
+	plan, prefix, runtimeUID := networkObserverPrefix(t, true)
+	current := time.Date(2026, 8, 16, 21, 0, 0, 0, time.UTC)
+	source := &fakeNetworkStageSource{statuses: []string{"Unknown", "True"}}
+	observer, err := NewNetworkStageObserver(NetworkStageObserverConfig{
+		Plan: plan, ReceiptPrefix: prefix, TargetClusterUID: runtimeUID, Source: source,
+		Profile: networkStageProfile(plan), PollInterval: time.Second, PollTimeout: time.Minute,
+		Clock: func() time.Time { return current },
+		Wait:  func(_ context.Context, wait time.Duration) error { current = current.Add(wait); return nil },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := observer.Observe(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	binding := observer.Binding()
+	if binding.StageID != "network-observation" || binding.Authority != "workload" || binding.PlanDigest != plan.PlanDigest {
+		t.Fatalf("unexpected network stage binding: %#v", binding)
+	}
+	if result.Outcome != "SUCCEEDED" || !platformInputDigestPattern.MatchString(result.EvidenceDigest) || source.calls != 2 {
+		t.Fatalf("unexpected network observation: %#v calls=%d", result, source.calls)
+	}
+	if source.policy.TargetClusterUID != runtimeUID || source.policy.IntentRevision != plan.IntentRevision || source.policy.EnablementRevision != plan.EnablementRevision || len(source.policy.Required) != 1 || source.policy.Required[0] != "NetworkReady" {
+		t.Fatalf("network source received an unbound policy: %#v", source.policy)
+	}
+}
+
+func TestNetworkStageObserverReturnsTerminalFalseAndBoundedUnknown(t *testing.T) {
+	for name, testCase := range map[string]struct {
+		statuses []string
+		want     string
+		calls    int
+	}{
+		"terminal false":  {statuses: []string{"False"}, want: "FAILED", calls: 1},
+		"bounded unknown": {statuses: []string{"Unknown"}, want: "STOPPED", calls: 3},
+	} {
+		t.Run(name, func(t *testing.T) {
+			plan, prefix, runtimeUID := networkObserverPrefix(t, true)
+			current := time.Date(2026, 8, 16, 21, 0, 0, 0, time.UTC)
+			source := &fakeNetworkStageSource{statuses: testCase.statuses}
+			observer, err := NewNetworkStageObserver(NetworkStageObserverConfig{
+				Plan: plan, ReceiptPrefix: prefix, TargetClusterUID: runtimeUID, Source: source,
+				Profile: networkStageProfile(plan), PollInterval: time.Second, PollTimeout: 2 * time.Second,
+				Clock: func() time.Time { return current },
+				Wait:  func(_ context.Context, wait time.Duration) error { current = current.Add(wait); return nil },
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			result, err := observer.Observe(context.Background())
+			if err != nil || result.Outcome != testCase.want || source.calls != testCase.calls {
+				t.Fatalf("unexpected terminal network result: %#v calls=%d err=%v", result, source.calls, err)
+			}
+		})
+	}
+}
+
+func TestNetworkStageObserverRejectsForeignTargetAndIncompleteHistory(t *testing.T) {
+	plan, prefix, runtimeUID := networkObserverPrefix(t, true)
+	base := NetworkStageObserverConfig{
+		Plan: plan, ReceiptPrefix: prefix, TargetClusterUID: runtimeUID,
+		Source: &fakeNetworkStageSource{statuses: []string{"True"}}, Profile: networkStageProfile(plan),
+		PollInterval: time.Second, PollTimeout: time.Minute, Clock: time.Now,
+		Wait: func(context.Context, time.Duration) error { return nil },
+	}
+	for name, mutate := range map[string]func(*NetworkStageObserverConfig){
+		"same-name replacement": func(config *NetworkStageObserverConfig) { config.TargetClusterUID = "replacement-cluster-uid" },
+		"incomplete prefix":     func(config *NetworkStageObserverConfig) { config.ReceiptPrefix = config.ReceiptPrefix[:3] },
+		"foreign profile": func(config *NetworkStageObserverConfig) {
+			config.Profile.EnablementRevision = bundleSHA("9")
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			config := base
+			mutate(&config)
+			if _, err := NewNetworkStageObserver(config); err == nil {
+				t.Fatal("unsafe network stage boundary was accepted")
+			}
+		})
+	}
+
+	plan, prefix, runtimeUID = networkObserverPrefix(t, false)
+	base.Plan, base.ReceiptPrefix, base.TargetClusterUID, base.Profile = plan, prefix, runtimeUID, networkStageProfile(plan)
+	if _, err := NewNetworkStageObserver(base); err == nil {
+		t.Fatal("historical lifecycle receipt without target UID digest was accepted")
+	}
+}
+
+func TestNetworkStageObserverRedactsSourceFailure(t *testing.T) {
+	plan, prefix, runtimeUID := networkObserverPrefix(t, true)
+	observer, err := NewNetworkStageObserver(NetworkStageObserverConfig{
+		Plan: plan, ReceiptPrefix: prefix, TargetClusterUID: runtimeUID,
+		Source: &fakeNetworkStageSource{err: errors.New("sensitive target endpoint")}, Profile: networkStageProfile(plan),
+		PollInterval: time.Second, PollTimeout: time.Minute, Clock: time.Now,
+		Wait: func(context.Context, time.Duration) error { return nil },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = observer.Observe(context.Background())
+	if err == nil || strings.Contains(err.Error(), "sensitive") || strings.Contains(err.Error(), "endpoint") {
+		t.Fatalf("network source failure leaked detail or was accepted: %v", err)
+	}
+}
+
+type fakeNetworkStageSource struct {
+	statuses []string
+	err      error
+	calls    int
+	policy   observation.Policy
+	profile  observation.NetworkProfile
+}
+
+func (source *fakeNetworkStageSource) Observe(_ context.Context, policy observation.Policy, profile observation.NetworkProfile) (observation.Evidence, error) {
+	source.calls++
+	source.policy, source.profile = policy, profile
+	if source.err != nil {
+		return observation.Evidence{}, source.err
+	}
+	status := source.statuses[len(source.statuses)-1]
+	if source.calls <= len(source.statuses) {
+		status = source.statuses[source.calls-1]
+	}
+	reason := "NetworkConverged"
+	if status == "False" {
+		reason = "NetworkInvariantFailed"
+	} else if status == "Unknown" {
+		reason = "NetworkEvidencePending"
+	}
+	return observation.Evidence{
+		Type: "NetworkReady", Source: "BoundedNetworkEvaluator", SourceUID: "network-evidence-ok147",
+		TargetClusterUID: policy.TargetClusterUID, Status: status, Reason: reason,
+		DesiredRevision: policy.EnablementRevision, ObservedRevision: policy.EnablementRevision,
+		EvidenceDigest: bundleSHA("7"),
+	}, nil
+}
+
+func networkObserverPrefix(t *testing.T, withTargetDigest bool) (stageplan.Binding, []stagereceipt.Verified, string) {
+	t.Helper()
+	plan := submissionBundleFixture(t, false, "").plan
+	at := time.Date(2026, 8, 16, 19, 0, 0, 0, time.UTC)
+	const runtimeUID = "cluster-runtime-uid-147"
+	provider, err := stagereceipt.New(plan, "provider-prerequisites", []stagereceipt.Verified{}, "SUCCEEDED", "ATTEMPTED", bundleSHA("1"), bundleSHA("2"), at)
+	if err != nil {
+		t.Fatal(err)
+	}
+	targetDigest := ""
+	if withTargetDigest {
+		targetDigest = digest.SHA256([]byte(runtimeUID))
+	}
+	lifecycle, err := stagereceipt.NewWithTargetClusterUIDDigest(plan, "cluster-lifecycle", []stagereceipt.Verified{provider}, "SUCCEEDED", "ATTEMPTED", bundleSHA("3"), bundleSHA("4"), targetDigest, at.Add(time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	lifecycleObservation, err := stagereceipt.New(plan, "lifecycle-observation", []stagereceipt.Verified{lifecycle}, "SUCCEEDED", "NOT_APPLICABLE", "", bundleSHA("5"), at.Add(2*time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	enablement, err := stagereceipt.New(plan, "enablement", []stagereceipt.Verified{lifecycleObservation}, "SUCCEEDED", "ATTEMPTED", bundleSHA("6"), bundleSHA("7"), at.Add(3*time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return plan, []stagereceipt.Verified{provider, lifecycle, lifecycleObservation, enablement}, runtimeUID
+}
+
+func networkStageProfile(plan stageplan.Binding) observation.NetworkProfile {
+	profile := runnerNetworkProfile()
+	profile.IntentRevision = plan.IntentRevision
+	profile.EnablementRevision = plan.EnablementRevision
+	return profile
+}


### PR DESCRIPTION
## Summary

- add a typed `network-observation` stage adapter around the existing bounded NetworkReady source and evaluator
- derive target correlation from the complete verified receipt prefix and the historical `cluster-lifecycle` target UID digest
- poll only verified `Unknown` results within fixed bounds; map `True`, `False`, and timeout to durable stage outcomes
- reject replacement targets, incomplete history, foreign profiles, and source-detail leakage

## Boundaries

- no new evaluator or reconciliation loop
- no Kubernetes bundle, CLI, Job, credential opening, cluster request, or infrastructure mutation
- activation remains a separate checkpoint

## Validation

- `go test -ldflags=-linkmode=external ./...`
- `go vet ./...`
- `go test -race -ldflags=-linkmode=external ./internal/runner`
- `git diff --check`

OK-147
