### PR TITLE
feat(runner): compose network observation stage (OK-147)

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -1915,6 +1915,22 @@ This checkpoint is the stage observer only. It adds no Kubernetes bundle, CLI,
 Job, credential opening, cluster request or infrastructure mutation. Those
 activation boundaries remain separate reviewable steps.
 
+The subsequent private bundle now supplies that environment-neutral
+composition boundary. It retains the complete reverified prefix, loads the
+strict workload-authority binding and immutable Network profile, and proves
+that the binding's raw Cluster UID hashes to the historical lifecycle digest.
+It then opens three distinct bounded capabilities: ledger writer, management
+network reader and workload network reader/probe. Management and workload
+endpoints must differ, all three bearer-token values must remain separate, and
+the HCP identity is derived from the Contract identity rather than caller
+input. Opening reads bounded local files and constructs TLS clients but makes
+no API request; only the resulting private `Run` method can invoke the existing
+crash-safe observation-stage operation.
+
+This bundle remains library-only. No CLI, Job, credential issuance, cluster
+request, persistence call or infrastructure mutation was activated by its
+construction or tests.
+
 ## Bounded convergence observation polling
 
 The aggregate observer can now be wrapped by a bounded polling observer before

--- a/internal/runner/kubernetes.go
+++ b/internal/runner/kubernetes.go
@@ -182,53 +182,64 @@ func openKubernetesCAPILifecycleObserver(config KubernetesAuthorityConfig, expec
 // one for HCP/HRP reads on the management authority and one for runtime reads
 // on the immutable workload Cluster UID. It performs no API request itself.
 func OpenKubernetesNetworkSourceCollector(config KubernetesNetworkObserverConfig) (*observation.NetworkSourceCollector, error) {
+	collector, _, _, err := openKubernetesNetworkSourceCollector(config)
+	return collector, err
+}
+
+// openKubernetesNetworkSourceCollector returns token values only to private
+// stage composition so it can prove that capabilities remain separate.
+func openKubernetesNetworkSourceCollector(config KubernetesNetworkObserverConfig) (*observation.NetworkSourceCollector, string, string, error) {
 	if config.ExpectedManagementAuthority == "" || config.Management.AuthorityIdentity != config.ExpectedManagementAuthority {
-		return nil, errors.New("network observer management authority differs from the verified management plane")
+		return nil, "", "", errors.New("network observer management authority differs from the verified management plane")
 	}
 	if config.TargetClusterUID == "" || config.Workload.AuthorityIdentity != config.TargetClusterUID {
-		return nil, errors.New("network observer workload authority differs from the runtime-bound target Cluster")
+		return nil, "", "", errors.New("network observer workload authority differs from the runtime-bound target Cluster")
 	}
 	if config.Management.Endpoint == config.Workload.Endpoint {
-		return nil, errors.New("network observer management and workload endpoints must be distinct")
+		return nil, "", "", errors.New("network observer management and workload endpoints must be distinct")
 	}
 	managementToken, _, managementClient, err := openBoundedKubernetesMaterial(config.Management.TokenFile, config.Management.CAFile)
 	if err != nil {
-		return nil, errors.New("open bounded management network credential")
+		return nil, "", "", errors.New("open bounded management network credential")
 	}
 	workloadToken, workloadCA, workloadClient, err := openBoundedKubernetesMaterial(config.Workload.TokenFile, config.Workload.CAFile)
 	if err != nil {
-		return nil, errors.New("open bounded workload network credential")
+		return nil, "", "", errors.New("open bounded workload network credential")
 	}
 	if !platformInputDigestPattern.MatchString(config.Workload.CABundleDigest) || digest.SHA256(workloadCA) != config.Workload.CABundleDigest {
-		return nil, errors.New("workload network CA differs from the runtime-bound authority")
+		return nil, "", "", errors.New("workload network CA differs from the runtime-bound authority")
 	}
 	if len(managementToken) == len(workloadToken) && subtle.ConstantTimeCompare([]byte(managementToken), []byte(workloadToken)) == 1 {
-		return nil, errors.New("network observer management and workload credentials must be distinct")
+		return nil, "", "", errors.New("network observer management and workload credentials must be distinct")
 	}
 	management, err := observation.NewKubernetesManagementNetworkReader(observation.KubernetesNetworkReaderConfig{
 		Endpoint: config.Management.Endpoint, BearerToken: managementToken, Client: managementClient,
 	}, config.Namespace, config.Name, config.HCPName)
 	if err != nil {
-		return nil, err
+		return nil, "", "", err
 	}
 	workload, err := observation.NewKubernetesWorkloadNetworkReader(observation.KubernetesNetworkReaderConfig{
 		Endpoint: config.Workload.Endpoint, BearerToken: workloadToken, Client: workloadClient,
 	})
 	if err != nil {
-		return nil, err
+		return nil, "", "", err
 	}
 	podExecutor, err := newKubernetesCiliumWebSocketExecutor(config.Workload.Endpoint, workloadToken, workloadCA, workloadClient)
 	if err != nil {
-		return nil, err
+		return nil, "", "", err
 	}
 	probe, err := observation.NewKubernetesFixedCiliumProbe(podExecutor)
 	if err != nil {
-		return nil, err
+		return nil, "", "", err
 	}
-	return observation.NewNetworkSourceCollector(management, workload, probe, observation.NetworkCollectorConfig{
+	collector, err := observation.NewNetworkSourceCollector(management, workload, probe, observation.NetworkCollectorConfig{
 		Namespace: config.Namespace, Name: config.Name, HCPName: config.HCPName,
 		TargetClusterUID: config.TargetClusterUID, Clock: config.Clock,
 	})
+	if err != nil {
+		return nil, "", "", err
+	}
+	return collector, managementToken, workloadToken, nil
 }
 
 // OpenKubernetesPlatformSourceCollector materializes one TLS client restricted

--- a/internal/runner/network_observation_bundle.go
+++ b/internal/runner/network_observation_bundle.go
@@ -1,0 +1,134 @@
+package runner
+
+import (
+	"context"
+	"crypto/subtle"
+	"errors"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/execution"
+	"github.com/openkubes/ok-cluster/internal/stagecursor"
+	"github.com/openkubes/ok-cluster/internal/stageplan"
+	"github.com/openkubes/ok-cluster/internal/stagereceipt"
+)
+
+type VerifiedNetworkObservationStageBundle struct {
+	plan     stageplan.Binding
+	cursor   stagecursor.Cursor
+	prefix   []stagereceipt.Verified
+	verified bool
+}
+
+type NetworkObservationStageRuntimeConfig struct {
+	Ledger                       KubernetesLedgerConfig
+	Management                   KubernetesAuthorityConfig
+	Workload                     WorkloadAuthorityFileResolverConfig
+	NetworkProfilePath           string
+	ExpectedNetworkProfileDigest string
+	PollInterval                 time.Duration
+	PollTimeout                  time.Duration
+	Clock                        func() time.Time
+	Wait                         ObservationWaiter
+}
+
+type OpenedNetworkObservationStage struct {
+	operation execution.ObservationStageOperation
+	plan      stageplan.Binding
+	cursor    stagecursor.Cursor
+	verified  bool
+}
+
+// LoadNetworkObservationStageBundle retains the complete verified receipt
+// prefix because target correlation originates at cluster-lifecycle rather
+// than the direct enablement predecessor.
+func LoadNetworkObservationStageBundle(config StageResumeConfig) (VerifiedNetworkObservationStageBundle, error) {
+	plan, cursor, prefix, err := loadStageResumeWithPrefix(config)
+	if err != nil {
+		return VerifiedNetworkObservationStageBundle{}, err
+	}
+	decision, err := cursor.Decision()
+	if err != nil || decision.State != "NEXT" || decision.StageID != "network-observation" || decision.Kind != "Observation" || decision.Authority != "workload" || decision.RequiresAuthorization || decision.Operation != "" {
+		return VerifiedNetworkObservationStageBundle{}, errors.New("verified prefix does not select network observation")
+	}
+	if len(prefix) != 4 {
+		return VerifiedNetworkObservationStageBundle{}, errors.New("network observation receipt prefix is incomplete")
+	}
+	lifecycle, err := prefix[1].Receipt()
+	if err != nil || lifecycle.StageID != "cluster-lifecycle" || !platformInputDigestPattern.MatchString(lifecycle.TargetClusterUIDDigest) {
+		return VerifiedNetworkObservationStageBundle{}, errors.New("network observation history lacks durable target correlation")
+	}
+	return VerifiedNetworkObservationStageBundle{plan: plan, cursor: cursor, prefix: prefix, verified: true}, nil
+}
+
+func (bundle VerifiedNetworkObservationStageBundle) Decision() (stagecursor.Decision, error) {
+	if !bundle.verified {
+		return stagecursor.Decision{}, errors.New("network observation stage bundle is not verified")
+	}
+	return bundle.cursor.Decision()
+}
+
+// Open reads each bounded local input and credential once, builds isolated TLS
+// clients, and performs no Kubernetes request.
+func (bundle VerifiedNetworkObservationStageBundle) Open(config NetworkObservationStageRuntimeConfig) (OpenedNetworkObservationStage, error) {
+	if !bundle.verified || config.Clock == nil || config.Wait == nil {
+		return OpenedNetworkObservationStage{}, errors.New("verified network observation bundle, clock, and waiter are required")
+	}
+	lifecycle, err := bundle.prefix[1].Receipt()
+	if err != nil {
+		return OpenedNetworkObservationStage{}, errors.New("read durable network target correlation")
+	}
+	binding, workload, err := loadWorkloadAuthorityFiles(config.Workload)
+	if err != nil {
+		return OpenedNetworkObservationStage{}, errors.New("open network workload authority binding")
+	}
+	if binding.IntentRevision != bundle.plan.IntentRevision || digest.SHA256([]byte(binding.TargetClusterUID)) != lifecycle.TargetClusterUIDDigest {
+		return OpenedNetworkObservationStage{}, errors.New("network workload authority differs from durable lifecycle target")
+	}
+	loadedProfile, err := LoadNetworkProfileFile(NetworkProfileFileConfig{
+		Path: config.NetworkProfilePath, ExpectedProfileDigest: config.ExpectedNetworkProfileDigest,
+		ExpectedIntentRevision: bundle.plan.IntentRevision, ExpectedEnablementRevision: bundle.plan.EnablementRevision,
+	})
+	if err != nil {
+		return OpenedNetworkObservationStage{}, errors.New("open verified network profile")
+	}
+	store, ledgerToken, err := openKubernetesLedger(config.Ledger)
+	if err != nil {
+		return OpenedNetworkObservationStage{}, errors.New("open network observation ledger")
+	}
+	source, managementToken, workloadToken, err := openKubernetesNetworkSourceCollector(KubernetesNetworkObserverConfig{
+		Management: config.Management, Workload: workload,
+		ExpectedManagementAuthority: bundle.plan.Authorities.Management,
+		TargetClusterUID:            binding.TargetClusterUID, Namespace: bundle.plan.ContractIdentity.Namespace,
+		Name: bundle.plan.ContractIdentity.Name, HCPName: bundle.plan.ContractIdentity.Name + "-cilium", Clock: config.Clock,
+	})
+	if err != nil {
+		return OpenedNetworkObservationStage{}, errors.New("open bounded network observation source")
+	}
+	if sameSecret(ledgerToken, managementToken) || sameSecret(ledgerToken, workloadToken) {
+		return OpenedNetworkObservationStage{}, errors.New("ledger and network observation credentials must be distinct")
+	}
+	observer, err := NewNetworkStageObserver(NetworkStageObserverConfig{
+		Plan: bundle.plan, ReceiptPrefix: bundle.prefix, TargetClusterUID: binding.TargetClusterUID,
+		Source: source, Profile: loadedProfile.Profile,
+		PollInterval: config.PollInterval, PollTimeout: config.PollTimeout, Clock: config.Clock, Wait: config.Wait,
+	})
+	if err != nil {
+		return OpenedNetworkObservationStage{}, err
+	}
+	return OpenedNetworkObservationStage{
+		operation: execution.ObservationStageOperation{Ledger: store, Observer: observer},
+		plan:      bundle.plan, cursor: bundle.cursor, verified: true,
+	}, nil
+}
+
+func (stage OpenedNetworkObservationStage) Run(ctx context.Context) (execution.ObservationStageRunReceipt, error) {
+	if !stage.verified {
+		return execution.ObservationStageRunReceipt{}, errors.New("network observation stage is not opened")
+	}
+	return stage.operation.Run(ctx, stage.plan, stage.cursor)
+}
+
+func sameSecret(first, second string) bool {
+	return len(first) == len(second) && subtle.ConstantTimeCompare([]byte(first), []byte(second)) == 1
+}

--- a/internal/runner/network_observation_bundle_test.go
+++ b/internal/runner/network_observation_bundle_test.go
@@ -1,0 +1,165 @@
+package runner
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/observation"
+	"github.com/openkubes/ok-cluster/internal/stagereceipt"
+)
+
+func TestNetworkObservationStageBundleLoadsExactReadOnlyCursor(t *testing.T) {
+	bundle, err := LoadNetworkObservationStageBundle(networkObservationBundleConfig(t, true))
+	if err != nil {
+		t.Fatal(err)
+	}
+	decision, err := bundle.Decision()
+	if err != nil || decision.StageID != "network-observation" || decision.Authority != "workload" || decision.RequiresAuthorization || decision.Operation != "" {
+		t.Fatalf("unexpected network bundle decision: %#v %v", decision, err)
+	}
+	if _, err := (VerifiedNetworkObservationStageBundle{}).Decision(); err == nil {
+		t.Fatal("unverified network bundle exposed a decision")
+	}
+}
+
+func TestNetworkObservationStageBundleRejectsWrongStageOrMissingCorrelation(t *testing.T) {
+	if _, err := LoadNetworkObservationStageBundle(lifecycleObservationBundleConfig(t, true)); err == nil || !strings.Contains(err.Error(), "does not select") {
+		t.Fatalf("lifecycle observation cursor was accepted: %v", err)
+	}
+	if _, err := LoadNetworkObservationStageBundle(networkObservationBundleConfig(t, false)); err == nil || !strings.Contains(err.Error(), "durable target") {
+		t.Fatalf("history without target correlation was accepted: %v", err)
+	}
+}
+
+func TestNetworkObservationStageBundleOpensWithoutClusterContact(t *testing.T) {
+	bundle, err := LoadNetworkObservationStageBundle(networkObservationBundleConfig(t, true))
+	if err != nil {
+		t.Fatal(err)
+	}
+	runtime := networkObservationRuntime(t, bundle, "ledger-token", "management-token", "workload-token", "cluster-runtime-uid-147")
+	opened, err := bundle.Open(runtime)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !opened.verified {
+		t.Fatal("opened network observation stage is not verified")
+	}
+	if _, err := (OpenedNetworkObservationStage{}).Run(context.Background()); err == nil {
+		t.Fatal("unopened network observation stage could run")
+	}
+}
+
+func TestNetworkObservationStageBundleRequiresDistinctCorrelatedInputs(t *testing.T) {
+	bundle, err := LoadNetworkObservationStageBundle(networkObservationBundleConfig(t, true))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for name, runtime := range map[string]NetworkObservationStageRuntimeConfig{
+		"shared ledger management token": networkObservationRuntime(t, bundle, "shared-token", "shared-token", "workload-token", "cluster-runtime-uid-147"),
+		"shared ledger workload token":   networkObservationRuntime(t, bundle, "shared-token", "management-token", "shared-token", "cluster-runtime-uid-147"),
+		"replacement target":             networkObservationRuntime(t, bundle, "ledger-token", "management-token", "workload-token", "replacement-runtime-uid"),
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := bundle.Open(runtime); err == nil {
+				t.Fatal("unsafe network runtime composition was accepted")
+			}
+		})
+	}
+	runtime := networkObservationRuntime(t, bundle, "ledger-token", "management-token", "workload-token", "cluster-runtime-uid-147")
+	runtime.Management.AuthorityIdentity = "foreign-management"
+	if _, err := bundle.Open(runtime); err == nil {
+		t.Fatal("foreign management authority was accepted")
+	}
+	if _, err := (VerifiedNetworkObservationStageBundle{}).Open(runtime); err == nil {
+		t.Fatal("unverified bundle opened network credentials")
+	}
+}
+
+func networkObservationBundleConfig(t *testing.T, withTargetDigest bool) StageResumeConfig {
+	t.Helper()
+	base := lifecycleObservationBundleConfig(t, withTargetDigest)
+	plan, _, prefix, err := loadStageResumeWithPrefix(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	at := time.Date(2026, 8, 16, 21, 0, 0, 0, time.UTC)
+	lifecycleObservation, err := stagereceipt.New(plan, "lifecycle-observation", []stagereceipt.Verified{prefix[1]}, "SUCCEEDED", "NOT_APPLICABLE", "", bundleSHA("5"), at)
+	if err != nil {
+		t.Fatal(err)
+	}
+	enablement, err := stagereceipt.New(plan, "enablement", []stagereceipt.Verified{lifecycleObservation}, "SUCCEEDED", "ATTEMPTED", bundleSHA("6"), bundleSHA("7"), at.Add(time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	root := t.TempDir()
+	for name, receipt := range map[string]stagereceipt.Verified{
+		"lifecycle-observation.json": lifecycleObservation,
+		"enablement.json":            enablement,
+	} {
+		raw, _ := receipt.Bytes()
+		receiptDigest, _ := receipt.Digest()
+		base.Receipts = append(base.Receipts, StageReceiptSource{Path: writeBundleFile(t, root, name, raw), Digest: receiptDigest})
+	}
+	return base
+}
+
+func networkObservationRuntime(t *testing.T, bundle VerifiedNetworkObservationStageBundle, ledgerToken, managementToken, workloadToken, targetUID string) NetworkObservationStageRuntimeConfig {
+	t.Helper()
+	root := t.TempDir()
+	managementCA, workloadCA := testCA(t), testCA(t)
+	paths := map[string]string{
+		"management-ca":    filepath.Join(root, "management-ca.crt"),
+		"workload-ca":      filepath.Join(root, "workload-ca.crt"),
+		"ledger-token":     filepath.Join(root, "ledger-token"),
+		"management-token": filepath.Join(root, "management-token"),
+		"workload-token":   filepath.Join(root, "workload-token"),
+		"binding":          filepath.Join(root, "workload-binding.json"),
+		"profile":          filepath.Join(root, "network-profile.json"),
+	}
+	for path, content := range map[string][]byte{
+		paths["management-ca"]: managementCA, paths["workload-ca"]: workloadCA,
+		paths["ledger-token"]: []byte(ledgerToken), paths["management-token"]: []byte(managementToken), paths["workload-token"]: []byte(workloadToken),
+	} {
+		if err := os.WriteFile(path, content, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	binding := WorkloadAuthorityBinding{
+		Format: WorkloadAuthorityBindingFormat, IntentRevision: bundle.plan.IntentRevision,
+		TargetClusterUID: targetUID, TargetIdentityScheme: "capi-cluster-uid/v1",
+		Endpoint: "https://192.0.2.20:6443", CABundleDigest: digest.SHA256(workloadCA),
+	}
+	writePlatformJSON(t, paths["binding"], binding)
+	bindingDigest, err := WorkloadAuthorityBindingDigest(binding)
+	if err != nil {
+		t.Fatal(err)
+	}
+	profile := networkStageProfile(bundle.plan)
+	writePlatformJSON(t, paths["profile"], profile)
+	profileDigest, err := observation.NetworkProfileDigest(profile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return NetworkObservationStageRuntimeConfig{
+		Ledger: KubernetesLedgerConfig{
+			Endpoint: "https://192.0.2.10:6443", Namespace: "openkubes-execution-system",
+			TokenFile: paths["ledger-token"], CAFile: paths["management-ca"],
+		},
+		Management: KubernetesAuthorityConfig{
+			Endpoint: "https://192.0.2.10:6443", AuthorityIdentity: bundle.plan.Authorities.Management,
+			TokenFile: paths["management-token"], CAFile: paths["management-ca"],
+		},
+		Workload: WorkloadAuthorityFileResolverConfig{
+			Path: paths["binding"], ExpectedBindingDigest: bindingDigest,
+			TokenFile: paths["workload-token"], CAFile: paths["workload-ca"],
+		},
+		NetworkProfilePath: paths["profile"], ExpectedNetworkProfileDigest: profileDigest,
+		PollInterval: time.Second, PollTimeout: time.Minute, Clock: time.Now,
+		Wait: func(context.Context, time.Duration) error { return nil },
+	}
+}

--- a/internal/runner/runtime_resolvers.go
+++ b/internal/runner/runtime_resolvers.go
@@ -69,32 +69,47 @@ func (resolver *WorkloadAuthorityFileResolver) ResolveWorkloadAuthority(ctx cont
 	if _, err := observation.PolicyDigest(policy); err != nil {
 		return KubernetesAuthorityConfig{}, errors.New("runtime-bound observation policy is invalid")
 	}
-	raw, err := readBoundedRegular(resolver.config.Path, maximumWorkloadBindingBytes)
+	binding, authority, err := loadWorkloadAuthorityFiles(resolver.config)
 	if err != nil {
-		return KubernetesAuthorityConfig{}, errors.New("read bounded workload authority binding")
+		return KubernetesAuthorityConfig{}, err
+	}
+	if binding.IntentRevision != policy.IntentRevision || binding.TargetClusterUID != policy.TargetClusterUID {
+		return KubernetesAuthorityConfig{}, errors.New("workload authority binding differs from runtime-bound observation policy")
+	}
+	return authority, nil
+}
+
+// loadWorkloadAuthorityFiles reads one strict private binding and its CA. It
+// does not read the bearer token or contact either API authority.
+func loadWorkloadAuthorityFiles(config WorkloadAuthorityFileResolverConfig) (WorkloadAuthorityBinding, KubernetesAuthorityConfig, error) {
+	if config.Path == "" || config.TokenFile == "" || config.CAFile == "" || !platformInputDigestPattern.MatchString(config.ExpectedBindingDigest) {
+		return WorkloadAuthorityBinding{}, KubernetesAuthorityConfig{}, errors.New("workload authority file resolver binding is invalid")
+	}
+	raw, err := readBoundedRegular(config.Path, maximumWorkloadBindingBytes)
+	if err != nil {
+		return WorkloadAuthorityBinding{}, KubernetesAuthorityConfig{}, errors.New("read bounded workload authority binding")
 	}
 	var binding WorkloadAuthorityBinding
 	if err := jsonstrict.Decode(raw, &binding); err != nil {
-		return KubernetesAuthorityConfig{}, errors.New("decode strict workload authority binding")
+		return WorkloadAuthorityBinding{}, KubernetesAuthorityConfig{}, errors.New("decode strict workload authority binding")
 	}
 	bindingDigest, err := WorkloadAuthorityBindingDigest(binding)
 	if err != nil {
-		return KubernetesAuthorityConfig{}, errors.New("validate workload authority binding")
+		return WorkloadAuthorityBinding{}, KubernetesAuthorityConfig{}, errors.New("validate workload authority binding")
 	}
-	if bindingDigest != resolver.config.ExpectedBindingDigest || binding.IntentRevision != policy.IntentRevision || binding.TargetClusterUID != policy.TargetClusterUID {
-		return KubernetesAuthorityConfig{}, errors.New("workload authority binding differs from runtime-bound observation policy")
+	if bindingDigest != config.ExpectedBindingDigest {
+		return WorkloadAuthorityBinding{}, KubernetesAuthorityConfig{}, errors.New("workload authority binding differs from expected identity")
 	}
-	ca, err := readBoundedRegular(resolver.config.CAFile, maximumCABytes)
+	ca, err := readBoundedRegular(config.CAFile, maximumCABytes)
 	if err != nil {
-		return KubernetesAuthorityConfig{}, errors.New("read bounded workload API CA")
+		return WorkloadAuthorityBinding{}, KubernetesAuthorityConfig{}, errors.New("read bounded workload API CA")
 	}
 	if digest.SHA256(ca) != binding.CABundleDigest {
-		return KubernetesAuthorityConfig{}, errors.New("workload API CA differs from runtime binding")
+		return WorkloadAuthorityBinding{}, KubernetesAuthorityConfig{}, errors.New("workload API CA differs from runtime binding")
 	}
-	return KubernetesAuthorityConfig{
-		Endpoint: binding.Endpoint, AuthorityIdentity: policy.TargetClusterUID,
-		TokenFile: resolver.config.TokenFile, CAFile: resolver.config.CAFile,
-		CABundleDigest: binding.CABundleDigest,
+	return binding, KubernetesAuthorityConfig{
+		Endpoint: binding.Endpoint, AuthorityIdentity: binding.TargetClusterUID,
+		TokenFile: config.TokenFile, CAFile: config.CAFile, CABundleDigest: binding.CABundleDigest,
 	}, nil
 }
 

--- a/internal/runner/stage_resume.go
+++ b/internal/runner/stage_resume.go
@@ -29,26 +29,31 @@ func InspectStageResume(config StageResumeConfig) (stagecursor.Decision, error) 
 }
 
 func loadStageResume(config StageResumeConfig) (stageplan.Binding, stagecursor.Cursor, error) {
+	plan, cursor, _, err := loadStageResumeWithPrefix(config)
+	return plan, cursor, err
+}
+
+func loadStageResumeWithPrefix(config StageResumeConfig) (stageplan.Binding, stagecursor.Cursor, []stagereceipt.Verified, error) {
 	if config.Receipts == nil {
-		return stageplan.Binding{}, stagecursor.Cursor{}, errors.New("stage receipt prefix must be explicit")
+		return stageplan.Binding{}, stagecursor.Cursor{}, nil, errors.New("stage receipt prefix must be explicit")
 	}
 	plan, err := stageplan.Load(config.PlanPath, config.PlanExpected)
 	if err != nil {
-		return stageplan.Binding{}, stagecursor.Cursor{}, err
+		return stageplan.Binding{}, stagecursor.Cursor{}, nil, err
 	}
 	prefix := make([]stagereceipt.Verified, 0, len(config.Receipts))
 	predecessors := []stagereceipt.Verified{}
 	for _, source := range config.Receipts {
 		verified, err := stagereceipt.Load(source.Path, source.Digest, plan, predecessors)
 		if err != nil {
-			return stageplan.Binding{}, stagecursor.Cursor{}, err
+			return stageplan.Binding{}, stagecursor.Cursor{}, nil, err
 		}
 		prefix = append(prefix, verified)
 		predecessors = []stagereceipt.Verified{verified}
 	}
 	cursor, err := stagecursor.Evaluate(plan, prefix)
 	if err != nil {
-		return stageplan.Binding{}, stagecursor.Cursor{}, err
+		return stageplan.Binding{}, stagecursor.Cursor{}, nil, err
 	}
-	return plan, cursor, nil
+	return plan, cursor, prefix, nil
 }


### PR DESCRIPTION
## Summary

- retain the complete verified receipt prefix for the `network-observation` stage
- load and correlate the private workload-authority binding to the historical lifecycle target digest
- load the strict digest-bound Network profile and derive HCP identity from the Contract
- compose distinct ledger, management-reader, and workload-reader credentials around the existing NetworkReady source
- expose only the bounded crash-safe stage `Run` operation

## Boundaries

- opening reads bounded local files and builds TLS clients but performs no Kubernetes request
- no CLI, Job, credential issuance, mutation, repair, or reconciliation loop
- raw target UID and bearer tokens remain private

## Validation

- `go test -ldflags=-linkmode=external ./...`
- `go vet ./...`
- `go test -race -ldflags=-linkmode=external ./internal/runner`
- `git diff --check`

OK-147
