### PR TITLE
feat(ok): execute bounded network observation (OK-147)

### DIFF
--- a/cmd/ok/main.go
+++ b/cmd/ok/main.go
@@ -438,6 +438,19 @@ var executeLifecycleObservationStage = func(ctx context.Context, bundleConfig ru
 	return opened.Run(ctx)
 }
 
+var executeNetworkObservationStage = func(ctx context.Context, bundleConfig runner.StageResumeConfig, runtimeConfig runner.NetworkObservationStageRuntimeConfig) (execution.ObservationStageRunReceipt, error) {
+	bundle, err := runner.LoadNetworkObservationStageBundle(bundleConfig)
+	if err != nil {
+		return execution.ObservationStageRunReceipt{}, err
+	}
+	runtimeConfig.Management.AuthorityIdentity = bundleConfig.PlanExpected.ManagementAuthority
+	opened, err := bundle.Open(runtimeConfig)
+	if err != nil {
+		return execution.ObservationStageRunReceipt{}, err
+	}
+	return opened.Run(ctx)
+}
+
 func submissionStageAuthority(decision stagecursor.Decision, expected stageplan.Expected) (string, error) {
 	switch decision.Authority {
 	case "infrastructure":
@@ -488,6 +501,9 @@ func runContext(ctx context.Context, arguments []string, stdout, stderr io.Write
 	if len(arguments) >= 4 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "observe" && arguments[3] == "lifecycle" {
 		return runClusterStageObserveLifecycle(ctx, arguments[4:], stdout, stderr)
 	}
+	if len(arguments) >= 4 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "observe" && arguments[3] == "network" {
+		return runClusterStageObserveNetwork(ctx, arguments[4:], stdout, stderr)
+	}
 	if len(arguments) >= 5 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "run" && arguments[3] == "enablement" && arguments[4] == "package" {
 		return runClusterStageRunEnablementPackage(arguments[5:], stdout, stderr)
 	}
@@ -512,7 +528,7 @@ func runContext(ctx context.Context, arguments []string, stdout, stderr io.Write
 	if len(arguments) >= 4 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "launch" && arguments[3] == "execute" {
 		return runClusterStageLaunchExecute(ctx, arguments[4:], stdout, stderr)
 	}
-	return errors.New("usage: ok cluster create ... | ok cluster stage inspect ... | ok cluster stage resume ... | ok cluster stage observe lifecycle ... | ok cluster stage observe lifecycle package ... | ok cluster stage observe lifecycle launch prepare ... | ok cluster stage observe lifecycle launch execute ... | ok cluster stage run ... | ok cluster stage run enablement ... | ok cluster stage run enablement package ... | ok cluster stage run enablement launch prepare ... | ok cluster stage run enablement launch execute ... | ok cluster stage package ... | ok cluster stage launch prepare ... | ok cluster stage launch execute ...")
+	return errors.New("usage: ok cluster create ... | ok cluster stage inspect ... | ok cluster stage resume ... | ok cluster stage observe lifecycle ... | ok cluster stage observe network ... | ok cluster stage observe lifecycle package ... | ok cluster stage observe lifecycle launch prepare ... | ok cluster stage observe lifecycle launch execute ... | ok cluster stage run ... | ok cluster stage run enablement ... | ok cluster stage run enablement package ... | ok cluster stage run enablement launch prepare ... | ok cluster stage run enablement launch execute ... | ok cluster stage package ... | ok cluster stage launch prepare ... | ok cluster stage launch execute ...")
 }
 
 func runClusterCreate(arguments []string, stdout, stderr io.Writer) error {
@@ -740,6 +756,83 @@ func runClusterStageObserveLifecycle(ctx context.Context, arguments []string, st
 		Management: runner.KubernetesAuthorityConfig{
 			Endpoint: *managementAPIEndpoint, TokenFile: *managementTokenFile, CAFile: *managementCAFile,
 		},
+		PollInterval: *pollInterval, PollTimeout: *pollTimeout,
+		Clock: func() time.Time { return time.Now().UTC() }, Wait: runner.WaitWithTimer,
+	})
+	if receipt.Format != "" {
+		encoder := json.NewEncoder(stdout)
+		encoder.SetEscapeHTML(false)
+		encoder.SetIndent("", "  ")
+		if err := encoder.Encode(receipt); err != nil {
+			return err
+		}
+	}
+	return runErr
+}
+
+func runClusterStageObserveNetwork(ctx context.Context, arguments []string, stdout, stderr io.Writer) error {
+	flags := flag.NewFlagSet("ok cluster stage observe network", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	resumeFlags := addStageResumeFlags(flags)
+	execute := flags.Bool("execute", false, "perform exactly the selected read-only network observation and persist its receipt")
+	ledgerAPIEndpoint := flags.String("ledger-api-endpoint", "", "TLS Kubernetes API endpoint for the durable ledger")
+	ledgerTokenFile := flags.String("ledger-token-file", "", "path to the short-lived ledger token")
+	ledgerCAFile := flags.String("ledger-ca-file", "", "path to the ledger Kubernetes API CA bundle")
+	managementAPIEndpoint := flags.String("management-api-endpoint", "", "TLS Kubernetes API endpoint for exact HCP/HRP observation")
+	managementTokenFile := flags.String("management-token-file", "", "path to the short-lived read-only management token")
+	managementCAFile := flags.String("management-ca-file", "", "path to the management Kubernetes API CA bundle")
+	workloadBinding := flags.String("workload-binding", "", "path to the private runtime workload-authority binding")
+	workloadBindingDigest := flags.String("workload-binding-digest", "", "expected workload-authority binding digest")
+	workloadTokenFile := flags.String("workload-token-file", "", "path to the short-lived read-only workload token")
+	workloadCAFile := flags.String("workload-ca-file", "", "path to the workload Kubernetes API CA bundle")
+	networkProfile := flags.String("network-profile", "", "path to the immutable NetworkReady profile")
+	networkProfileDigest := flags.String("network-profile-digest", "", "expected NetworkReady profile digest")
+	pollInterval := flags.Duration("poll-interval", 0, "bounded interval between verified Unknown observations")
+	pollTimeout := flags.Duration("poll-timeout", 0, "maximum bounded network observation duration")
+	if err := flags.Parse(arguments); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return errors.New("positional arguments are not accepted")
+	}
+	if !*execute {
+		return errors.New("network observation requires explicit --execute")
+	}
+	bundleConfig, err := resumeFlags.config()
+	if err != nil {
+		return err
+	}
+	for _, input := range []struct{ name, value string }{
+		{"--ledger-api-endpoint", *ledgerAPIEndpoint}, {"--ledger-token-file", *ledgerTokenFile}, {"--ledger-ca-file", *ledgerCAFile},
+		{"--management-api-endpoint", *managementAPIEndpoint}, {"--management-token-file", *managementTokenFile}, {"--management-ca-file", *managementCAFile},
+		{"--workload-binding", *workloadBinding}, {"--workload-binding-digest", *workloadBindingDigest},
+		{"--workload-token-file", *workloadTokenFile}, {"--workload-ca-file", *workloadCAFile},
+		{"--network-profile", *networkProfile}, {"--network-profile-digest", *networkProfileDigest},
+	} {
+		if input.value == "" {
+			return fmt.Errorf("%s is required", input.name)
+		}
+	}
+	if !sha256DigestPattern.MatchString(*workloadBindingDigest) || !sha256DigestPattern.MatchString(*networkProfileDigest) {
+		return errors.New("workload binding and network profile digests must be lowercase SHA-256 identities")
+	}
+	if *pollInterval < time.Second || *pollInterval > 5*time.Minute || *pollTimeout < *pollInterval || *pollTimeout > 6*time.Hour {
+		return errors.New("--poll-interval and --poll-timeout must define a valid bounded observation of at most 6h")
+	}
+	boundedContext, cancel := context.WithTimeout(ctx, *pollTimeout+lifecycleObservationRunOverhead)
+	defer cancel()
+	receipt, runErr := executeNetworkObservationStage(boundedContext, bundleConfig, runner.NetworkObservationStageRuntimeConfig{
+		Ledger: runner.KubernetesLedgerConfig{
+			Endpoint: *ledgerAPIEndpoint, Namespace: ledgerNamespace, TokenFile: *ledgerTokenFile, CAFile: *ledgerCAFile,
+		},
+		Management: runner.KubernetesAuthorityConfig{
+			Endpoint: *managementAPIEndpoint, TokenFile: *managementTokenFile, CAFile: *managementCAFile,
+		},
+		Workload: runner.WorkloadAuthorityFileResolverConfig{
+			Path: *workloadBinding, ExpectedBindingDigest: *workloadBindingDigest,
+			TokenFile: *workloadTokenFile, CAFile: *workloadCAFile,
+		},
+		NetworkProfilePath: *networkProfile, ExpectedNetworkProfileDigest: *networkProfileDigest,
 		PollInterval: *pollInterval, PollTimeout: *pollTimeout,
 		Clock: func() time.Time { return time.Now().UTC() }, Wait: runner.WaitWithTimer,
 	})

--- a/cmd/ok/main_test.go
+++ b/cmd/ok/main_test.go
@@ -348,6 +348,101 @@ func TestStageObserveLifecycleEmitsPersistedTerminalReceipt(t *testing.T) {
 	}
 }
 
+func TestStageObserveNetworkRequiresExplicitExecutionAndBindsRuntime(t *testing.T) {
+	previous := executeNetworkObservationStage
+	defer func() { executeNetworkObservationStage = previous }()
+	var capturedBundle runner.StageResumeConfig
+	var capturedRuntime runner.NetworkObservationStageRuntimeConfig
+	var capturedContext context.Context
+	executeNetworkObservationStage = func(ctx context.Context, bundle runner.StageResumeConfig, runtime runner.NetworkObservationStageRuntimeConfig) (execution.ObservationStageRunReceipt, error) {
+		capturedContext, capturedBundle, capturedRuntime = ctx, bundle, runtime
+		return execution.ObservationStageRunReceipt{
+			Format: execution.ObservationStageReceiptFormat, State: "COMPLETED_SUCCEEDED",
+			PlanDigest: testSHA("9"), StageID: "network-observation", StageReceiptDigest: testSHA("8"),
+		}, nil
+	}
+	var stdout, stderr bytes.Buffer
+	if err := run(stageObserveNetworkArguments(), &stdout, &stderr); err != nil {
+		t.Fatalf("run: %v; stderr=%s", err, stderr.String())
+	}
+	if capturedBundle.PlanPath != "/tmp/plan.json" || len(capturedBundle.Receipts) != 4 {
+		t.Fatalf("unexpected network observation bundle: %#v", capturedBundle)
+	}
+	if capturedRuntime.Ledger.Namespace != ledgerNamespace || capturedRuntime.Management.AuthorityIdentity != "" || capturedRuntime.Workload.ExpectedBindingDigest != testSHA("4") || capturedRuntime.ExpectedNetworkProfileDigest != testSHA("5") {
+		t.Fatalf("unexpected network observation runtime: %#v", capturedRuntime)
+	}
+	if capturedRuntime.PollInterval != 15*time.Second || capturedRuntime.PollTimeout != 5*time.Minute || capturedRuntime.Clock == nil || capturedRuntime.Wait == nil {
+		t.Fatalf("bounded network observation timing differs: %#v", capturedRuntime)
+	}
+	deadline, bounded := capturedContext.Deadline()
+	remaining := time.Until(deadline)
+	if !bounded || remaining > 6*time.Minute || remaining < 5*time.Minute {
+		t.Fatalf("network observation context is not bounded: %s %t", deadline, bounded)
+	}
+	var receipt execution.ObservationStageRunReceipt
+	if err := json.Unmarshal(stdout.Bytes(), &receipt); err != nil {
+		t.Fatal(err)
+	}
+	if receipt.State != "COMPLETED_SUCCEEDED" || receipt.StageID != "network-observation" {
+		t.Fatalf("unexpected network observation receipt: %#v", receipt)
+	}
+}
+
+func TestStageObserveNetworkFailsClosedBeforeExecution(t *testing.T) {
+	previous := executeNetworkObservationStage
+	defer func() { executeNetworkObservationStage = previous }()
+	calls := 0
+	executeNetworkObservationStage = func(context.Context, runner.StageResumeConfig, runner.NetworkObservationStageRuntimeConfig) (execution.ObservationStageRunReceipt, error) {
+		calls++
+		return execution.ObservationStageRunReceipt{}, nil
+	}
+	valid := stageObserveNetworkArguments()
+	for name, arguments := range map[string][]string{
+		"missing execute":          removeArgument(valid, "--execute"),
+		"missing workload binding": removeArgumentWithValue(valid, "--workload-binding"),
+		"bad binding digest":       replaceArgument(valid, "--workload-binding-digest", "sha256:bad"),
+		"missing profile":          removeArgumentWithValue(valid, "--network-profile"),
+		"bad profile digest":       replaceArgument(valid, "--network-profile-digest", "sha256:bad"),
+		"missing poll timeout":     removeArgumentWithValue(valid, "--poll-timeout"),
+		"too frequent":             replaceArgument(valid, "--poll-interval", "500ms"),
+		"interval exceeds timeout": replaceArgument(valid, "--poll-interval", "6m"),
+		"too long":                 replaceArgument(valid, "--poll-timeout", "7h"),
+		"positional":               append(append([]string{}, valid...), "unexpected"),
+	} {
+		t.Run(name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			if err := run(arguments, &stdout, &stderr); err == nil || stdout.Len() != 0 {
+				t.Fatalf("unsafe network observation input was accepted: err=%v stdout=%s", err, stdout.String())
+			}
+		})
+	}
+	if calls != 0 {
+		t.Fatalf("network observation execution was reached %d times for invalid input", calls)
+	}
+}
+
+func TestStageObserveNetworkEmitsPersistedTerminalReceipt(t *testing.T) {
+	previous := executeNetworkObservationStage
+	defer func() { executeNetworkObservationStage = previous }()
+	executeNetworkObservationStage = func(context.Context, runner.StageResumeConfig, runner.NetworkObservationStageRuntimeConfig) (execution.ObservationStageRunReceipt, error) {
+		return execution.ObservationStageRunReceipt{
+			Format: execution.ObservationStageReceiptFormat, State: "COMPLETED_STOPPED",
+			PlanDigest: testSHA("9"), StageID: "network-observation", StageReceiptDigest: testSHA("8"),
+		}, errors.New("bounded observation stopped")
+	}
+	var stdout, stderr bytes.Buffer
+	if err := run(stageObserveNetworkArguments(), &stdout, &stderr); err == nil {
+		t.Fatal("terminal network observation returned success")
+	}
+	var receipt execution.ObservationStageRunReceipt
+	if err := json.Unmarshal(stdout.Bytes(), &receipt); err != nil {
+		t.Fatal(err)
+	}
+	if receipt.State != "COMPLETED_STOPPED" || receipt.StageReceiptDigest == "" {
+		t.Fatalf("persisted terminal network observation receipt was lost: %#v", receipt)
+	}
+}
+
 func TestStageObserveLifecyclePackageWritesVerifiedOfflineArtifact(t *testing.T) {
 	previous := materializeLifecycleObservationStagePackage
 	defer func() { materializeLifecycleObservationStagePackage = previous }()
@@ -1077,6 +1172,24 @@ func stageObserveLifecycleArguments() []string {
 		"--execute",
 		"--ledger-api-endpoint", "https://192.0.2.12:6443", "--ledger-token-file", "/tmp/ledger-token", "--ledger-ca-file", "/tmp/ledger-ca",
 		"--management-api-endpoint", "https://192.0.2.12:6443", "--management-token-file", "/tmp/management-observer-token", "--management-ca-file", "/tmp/management-ca",
+		"--poll-interval", "15s", "--poll-timeout", "5m",
+	)
+}
+
+func stageObserveNetworkArguments() []string {
+	arguments := stageResumeArguments()
+	arguments = append([]string{"cluster", "stage", "observe", "network"}, arguments[3:]...)
+	return append(arguments,
+		"--receipt", "/tmp/provider.json@"+testSHA("1"),
+		"--receipt", "/tmp/lifecycle.json@"+testSHA("2"),
+		"--receipt", "/tmp/lifecycle-observation.json@"+testSHA("3"),
+		"--receipt", "/tmp/enablement.json@"+testSHA("4"),
+		"--execute",
+		"--ledger-api-endpoint", "https://192.0.2.12:6443", "--ledger-token-file", "/tmp/ledger-token", "--ledger-ca-file", "/tmp/ledger-ca",
+		"--management-api-endpoint", "https://192.0.2.12:6443", "--management-token-file", "/tmp/management-observer-token", "--management-ca-file", "/tmp/management-ca",
+		"--workload-binding", "/tmp/workload-binding.json", "--workload-binding-digest", testSHA("4"),
+		"--workload-token-file", "/tmp/workload-observer-token", "--workload-ca-file", "/tmp/workload-ca",
+		"--network-profile", "/tmp/network-profile.json", "--network-profile-digest", testSHA("5"),
 		"--poll-interval", "15s", "--poll-timeout", "5m",
 	)
 }

--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -1927,9 +1927,26 @@ input. Opening reads bounded local files and constructs TLS clients but makes
 no API request; only the resulting private `Run` method can invoke the existing
 crash-safe observation-stage operation.
 
-This bundle remains library-only. No CLI, Job, credential issuance, cluster
-request, persistence call or infrastructure mutation was activated by its
-construction or tests.
+The local CLI can now activate exactly this bundle:
+
+```text
+ok cluster stage observe network --execute
+  + exact plan identity and four-receipt prefix
+  + distinct ledger, management and workload credentials
+  + digest-bound private workload binding and Network profile
+  + bounded poll interval and timeout
+      -> existing NetworkReady source and evaluator
+      -> immutable network-observation receipt
+```
+
+It accepts no grant, renderer, arbitrary target UID, HCP name, command or
+mutation input. `--execute` is mandatory because the command performs bounded
+reads and persists the stage receipt. The outer context is limited to the poll
+timeout plus one minute of completion overhead, and terminal `FAILED` or
+`STOPPED` receipts remain visible even though the command returns an error.
+This checkpoint adds no Job, credential issuance, infrastructure mutation,
+repair or controller loop; command tests inject the execution boundary and
+make no Kubernetes request.
 
 ## Bounded convergence observation polling
 


### PR DESCRIPTION
## Summary

- add `ok cluster stage observe network --execute`
- bind the exact four-receipt prefix, private workload authority, immutable Network profile, and three distinct credentials
- enforce a bounded poll timeout plus fixed receipt-completion overhead
- preserve terminal FAILED/STOPPED receipts while returning an error
- reject missing execution intent, malformed digests, incomplete inputs, positional arguments, and unsafe timing before execution

## Boundaries

- no grant, caller-supplied target UID, arbitrary HCP name, probe command, renderer, or mutation input
- no Job, credential issuance, infrastructure mutation, repair, or reconciliation loop
- CLI tests inject the execution boundary and make no Kubernetes request

## Validation

- `go test -ldflags=-linkmode=external ./...`
- `go vet ./...`
- `go test -race -ldflags=-linkmode=external ./cmd/ok ./internal/runner`
- `git diff --check`

OK-147
