### PR TITLE
feat(runner): seal network observation inputs (OK-147)

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -1948,6 +1948,14 @@ This checkpoint adds no Job, credential issuance, infrastructure mutation,
 repair or controller loop; command tests inject the execution boundary and
 make no Kubernetes request.
 
+The first packaging boundary now emits one immutable public input ConfigMap.
+It contains exactly the staged plan, the four canonical receipts, their
+digest-bound prefix manifest and the immutable Network profile. It is built
+only after the bundle and profile have been verified both before and after
+file capture. The private workload-authority binding, API endpoint, token and
+CA are intentionally absent and remain inputs to a later Secret/runtime
+boundary. This step creates no Kubernetes object and performs no API request.
+
 ## Bounded convergence observation polling
 
 The aggregate observer can now be wrapped by a bounded polling observer before

--- a/internal/runner/network_observation_bundle_test.go
+++ b/internal/runner/network_observation_bundle_test.go
@@ -97,13 +97,16 @@ func networkObservationBundleConfig(t *testing.T, withTargetDigest bool) StageRe
 		t.Fatal(err)
 	}
 	root := t.TempDir()
-	for name, receipt := range map[string]stagereceipt.Verified{
-		"lifecycle-observation.json": lifecycleObservation,
-		"enablement.json":            enablement,
+	for _, item := range []struct {
+		name    string
+		receipt stagereceipt.Verified
+	}{
+		{name: "lifecycle-observation.json", receipt: lifecycleObservation},
+		{name: "enablement.json", receipt: enablement},
 	} {
-		raw, _ := receipt.Bytes()
-		receiptDigest, _ := receipt.Digest()
-		base.Receipts = append(base.Receipts, StageReceiptSource{Path: writeBundleFile(t, root, name, raw), Digest: receiptDigest})
+		raw, _ := item.receipt.Bytes()
+		receiptDigest, _ := item.receipt.Digest()
+		base.Receipts = append(base.Receipts, StageReceiptSource{Path: writeBundleFile(t, root, item.name, raw), Digest: receiptDigest})
 	}
 	return base
 }

--- a/internal/runner/network_observation_stage_input.go
+++ b/internal/runner/network_observation_stage_input.go
@@ -1,0 +1,145 @@
+package runner
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"sort"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+const NetworkObservationStageInputFormat = "ok147-network-observation-stage-input/v1"
+
+type NetworkObservationStageInputConfig struct {
+	Bundle                       StageResumeConfig
+	NetworkProfilePath           string
+	ExpectedNetworkProfileDigest string
+	ConfigMapName                string
+}
+
+type NetworkObservationStageInputReceipt struct {
+	Format               string   `json:"format"`
+	State                string   `json:"state"`
+	StageID              string   `json:"stageId"`
+	ConfigMapName        string   `json:"configMapName"`
+	ConfigMapDigest      string   `json:"configMapDigest"`
+	ReceiptPrefixDigest  string   `json:"receiptPrefixDigest"`
+	NetworkProfileDigest string   `json:"networkProfileDigest"`
+	DataKeys             []string `json:"dataKeys"`
+}
+
+type VerifiedNetworkObservationStageInput struct {
+	raw      []byte
+	receipt  NetworkObservationStageInputReceipt
+	verified bool
+}
+
+// BuildNetworkObservationStageInput packages only public immutable semantic
+// inputs. The private workload binding, endpoint, credentials and CA material
+// are deliberately excluded.
+func BuildNetworkObservationStageInput(config NetworkObservationStageInputConfig) (VerifiedNetworkObservationStageInput, error) {
+	if !submissionStageInputNamePattern.MatchString(config.ConfigMapName) || len(config.ConfigMapName) > 63 || !strings.HasPrefix(config.ConfigMapName, "ok147-") {
+		return VerifiedNetworkObservationStageInput{}, errors.New("network observation input ConfigMap name is invalid")
+	}
+	bundle, err := LoadNetworkObservationStageBundle(config.Bundle)
+	if err != nil {
+		return VerifiedNetworkObservationStageInput{}, err
+	}
+	if len(config.Bundle.Receipts) != 4 {
+		return VerifiedNetworkObservationStageInput{}, errors.New("network observation input requires the exact four-receipt prefix")
+	}
+	profile, err := LoadNetworkProfileFile(NetworkProfileFileConfig{
+		Path: config.NetworkProfilePath, ExpectedProfileDigest: config.ExpectedNetworkProfileDigest,
+		ExpectedIntentRevision: bundle.plan.IntentRevision, ExpectedEnablementRevision: bundle.plan.EnablementRevision,
+	})
+	if err != nil {
+		return VerifiedNetworkObservationStageInput{}, errors.New("load public network observation profile")
+	}
+	keys := []string{"provider-receipt.json", "lifecycle-receipt.json", "lifecycle-observation-receipt.json", "enablement-receipt.json"}
+	prefix := stageReceiptPrefixDocument{Format: StageReceiptPrefixFormat, Receipts: make([]stageReceiptPrefixEntry, len(keys))}
+	paths := map[string]string{"staged-plan.json": config.Bundle.PlanPath, "network-profile.json": config.NetworkProfilePath}
+	for index, key := range keys {
+		paths[key] = config.Bundle.Receipts[index].Path
+		prefix.Receipts[index] = stageReceiptPrefixEntry{File: key, Digest: config.Bundle.Receipts[index].Digest}
+	}
+	prefixRaw, err := json.Marshal(prefix)
+	if err != nil {
+		return VerifiedNetworkObservationStageInput{}, errors.New("encode network observation receipt prefix")
+	}
+	data := make(map[string]string, len(paths)+1)
+	data["receipt-prefix.json"] = string(prefixRaw)
+	for key, path := range paths {
+		raw, err := readBoundedRegular(path, maximumSubmissionStageInputBytes)
+		if err != nil {
+			return VerifiedNetworkObservationStageInput{}, errors.New("read bounded network observation input " + key)
+		}
+		if !utf8.Valid(raw) || bytes.IndexByte(raw, 0) >= 0 {
+			return VerifiedNetworkObservationStageInput{}, errors.New("network observation input is not valid ConfigMap text")
+		}
+		data[key] = string(raw)
+	}
+	if _, err := LoadNetworkObservationStageBundle(config.Bundle); err != nil {
+		return VerifiedNetworkObservationStageInput{}, errors.New("network observation receipts changed during materialization")
+	}
+	if _, err := LoadNetworkProfileFile(NetworkProfileFileConfig{
+		Path: config.NetworkProfilePath, ExpectedProfileDigest: profile.Digest,
+		ExpectedIntentRevision: bundle.plan.IntentRevision, ExpectedEnablementRevision: bundle.plan.EnablementRevision,
+	}); err != nil {
+		return VerifiedNetworkObservationStageInput{}, errors.New("network observation profile changed during materialization")
+	}
+	configMap := submissionStageInputConfigMap{
+		APIVersion: "v1", Kind: "ConfigMap",
+		Metadata: submissionStageInputObjectMeta{
+			Name: config.ConfigMapName, Namespace: submissionStageInputNamespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/name": "ok-cluster-contract-executor", "openkubes.io/stage-id": "network-observation",
+			},
+			Annotations: map[string]string{
+				"openkubes.io/input-format":           NetworkObservationStageInputFormat,
+				"openkubes.io/receipt-prefix-digest":  digest.SHA256(prefixRaw),
+				"openkubes.io/network-profile-digest": profile.Digest,
+			},
+		},
+		Immutable: true, Data: data,
+	}
+	raw, err := json.Marshal(configMap)
+	if err != nil {
+		return VerifiedNetworkObservationStageInput{}, errors.New("encode network observation input ConfigMap")
+	}
+	if len(raw) > maximumSubmissionStageInputBytes {
+		return VerifiedNetworkObservationStageInput{}, errors.New("network observation input ConfigMap exceeds size limit")
+	}
+	dataKeys := make([]string, 0, len(data))
+	for key := range data {
+		dataKeys = append(dataKeys, key)
+	}
+	sort.Strings(dataKeys)
+	return VerifiedNetworkObservationStageInput{
+		raw: raw,
+		receipt: NetworkObservationStageInputReceipt{
+			Format: NetworkObservationStageInputFormat, State: "VERIFIED", StageID: "network-observation",
+			ConfigMapName: config.ConfigMapName, ConfigMapDigest: digest.SHA256(raw),
+			ReceiptPrefixDigest: digest.SHA256(prefixRaw), NetworkProfileDigest: profile.Digest, DataKeys: dataKeys,
+		},
+		verified: true,
+	}, nil
+}
+
+func (input VerifiedNetworkObservationStageInput) Bytes() ([]byte, error) {
+	if !input.verified || len(input.raw) == 0 {
+		return nil, errors.New("network observation input was not produced by verification")
+	}
+	return append([]byte(nil), input.raw...), nil
+}
+
+func (input VerifiedNetworkObservationStageInput) Receipt() (NetworkObservationStageInputReceipt, error) {
+	if !input.verified || input.receipt.State != "VERIFIED" || digest.SHA256(input.raw) != input.receipt.ConfigMapDigest {
+		return NetworkObservationStageInputReceipt{}, errors.New("network observation input was not produced by verification")
+	}
+	receipt := input.receipt
+	receipt.DataKeys = append([]string(nil), input.receipt.DataKeys...)
+	return receipt, nil
+}

--- a/internal/runner/network_observation_stage_input_test.go
+++ b/internal/runner/network_observation_stage_input_test.go
@@ -1,0 +1,123 @@
+package runner
+
+import (
+	"encoding/json"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/observation"
+	"github.com/openkubes/ok-cluster/internal/stageplan"
+)
+
+func TestBuildNetworkObservationStageInputContainsOnlyPublicBoundInputs(t *testing.T) {
+	config := networkObservationStageInputConfig(t)
+	input, err := BuildNetworkObservationStageInput(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := input.Bytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := input.Receipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var object map[string]any
+	if err := json.Unmarshal(raw, &object); err != nil {
+		t.Fatal(err)
+	}
+	if object["kind"] != "ConfigMap" || object["immutable"] != true || objectAt(t, object, "metadata")["name"] != config.ConfigMapName {
+		t.Fatalf("unexpected network observation input: %#v", object)
+	}
+	data := objectAt(t, object, "data")
+	wantKeys := []string{
+		"enablement-receipt.json", "lifecycle-observation-receipt.json", "lifecycle-receipt.json",
+		"network-profile.json", "provider-receipt.json", "receipt-prefix.json", "staged-plan.json",
+	}
+	gotKeys := make([]string, 0, len(data))
+	for key := range data {
+		gotKeys = append(gotKeys, key)
+	}
+	sort.Strings(gotKeys)
+	if !reflect.DeepEqual(gotKeys, wantKeys) || data["workload-binding.json"] != nil || data["token"] != nil || data["ca.crt"] != nil {
+		t.Fatalf("network observation public input boundary differs: %v", gotKeys)
+	}
+	if receipt.Format != NetworkObservationStageInputFormat || receipt.StageID != "network-observation" || receipt.ConfigMapDigest != digest.SHA256(raw) || !reflect.DeepEqual(receipt.DataKeys, wantKeys) {
+		t.Fatalf("unexpected network observation input receipt: %#v", receipt)
+	}
+	profile := networkStageProfile(loadNetworkInputPlan(t, config))
+	profileDigest, _ := observation.NetworkProfileDigest(profile)
+	if receipt.NetworkProfileDigest != profileDigest || !stageReceiptPrefixDigestPattern.MatchString(receipt.ReceiptPrefixDigest) {
+		t.Fatalf("input semantic identities differ: %#v", receipt)
+	}
+	raw[0] = 'x'
+	again, _ := input.Bytes()
+	if again[0] != '{' {
+		t.Fatal("caller mutated retained network observation input")
+	}
+	receipt.DataKeys[0] = "changed"
+	againReceipt, _ := input.Receipt()
+	if againReceipt.DataKeys[0] != wantKeys[0] {
+		t.Fatal("caller mutated retained input receipt")
+	}
+}
+
+func TestBuildNetworkObservationStageInputFailsClosed(t *testing.T) {
+	valid := networkObservationStageInputConfig(t)
+	for name, mutate := range map[string]func(*NetworkObservationStageInputConfig){
+		"missing receipt": func(config *NetworkObservationStageInputConfig) {
+			config.Bundle.Receipts = config.Bundle.Receipts[:3]
+		},
+		"foreign profile digest": func(config *NetworkObservationStageInputConfig) {
+			config.ExpectedNetworkProfileDigest = bundleSHA("f")
+		},
+		"invalid ConfigMap name": func(config *NetworkObservationStageInputConfig) {
+			config.ConfigMapName = "network-input"
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			config := valid
+			mutate(&config)
+			if _, err := BuildNetworkObservationStageInput(config); err == nil {
+				t.Fatal("unsafe network observation input was accepted")
+			}
+		})
+	}
+	if _, err := (VerifiedNetworkObservationStageInput{}).Bytes(); err == nil {
+		t.Fatal("unverified network input bytes were exposed")
+	}
+	if _, err := (VerifiedNetworkObservationStageInput{}).Receipt(); err == nil {
+		t.Fatal("unverified network input receipt was exposed")
+	}
+}
+
+func networkObservationStageInputConfig(t *testing.T) NetworkObservationStageInputConfig {
+	t.Helper()
+	bundleConfig := networkObservationBundleConfig(t, true)
+	plan, _, _, err := loadStageResumeWithPrefix(bundleConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	profile := networkStageProfile(plan)
+	profilePath := writeBundleFile(t, t.TempDir(), "network-profile.json", mustJSON(t, profile))
+	profileDigest, err := observation.NetworkProfileDigest(profile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return NetworkObservationStageInputConfig{
+		Bundle: bundleConfig, NetworkProfilePath: profilePath,
+		ExpectedNetworkProfileDigest: profileDigest, ConfigMapName: "ok147-network-observation-input",
+	}
+}
+
+func loadNetworkInputPlan(t *testing.T, config NetworkObservationStageInputConfig) stageplan.Binding {
+	t.Helper()
+	plan, _, _, err := loadStageResumeWithPrefix(config.Bundle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return plan
+}


### PR DESCRIPTION
## Summary

- build an immutable public ConfigMap for `network-observation`
- include exactly the staged plan, four canonical receipts, digest-bound prefix manifest, and immutable Network profile
- reverify the receipt chain and profile before and after source capture
- retain canonical ConfigMap, receipt-prefix, and profile digests
- fix nondeterministic receipt ordering in the Network bundle test fixture

## Boundaries

- private workload binding, endpoint, token, and CA are excluded
- no Job, Secret, cluster request, persistence call, or infrastructure mutation

## Validation

- `go test -count=3 -ldflags=-linkmode=external ./internal/runner`
- `go test -ldflags=-linkmode=external ./...`
- `go vet ./...`
- `go test -race -ldflags=-linkmode=external ./internal/runner`
- `git diff --check`

OK-147
