### PR TITLE
feat(runner): define network observation job (OK-147)

### DIFF
--- a/deploy/contract-executor-network-observation-job.yaml.tpl
+++ b/deploy/contract-executor-network-observation-job.yaml.tpl
@@ -1,0 +1,174 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: "${OK147_RUN_ID}"
+  namespace: openkubes-execution-system
+spec:
+  podSelector:
+    matchLabels:
+      openkubes.io/execution-id: "${OK147_RUN_ID}"
+  policyTypes: ["Ingress", "Egress"]
+  ingress: []
+  egress:
+    - to: [{ipBlock: {cidr: "${OK147_LEDGER_API_CIDR}"}}]
+      ports: [{protocol: TCP, port: ${OK147_LEDGER_API_PORT}}]
+    - to: [{ipBlock: {cidr: "${OK147_WORKLOAD_API_CIDR}"}}]
+      ports: [{protocol: TCP, port: ${OK147_WORKLOAD_API_PORT}}]
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "${OK147_RUN_ID}"
+  namespace: openkubes-execution-system
+  labels:
+    app.kubernetes.io/name: ok-cluster-contract-executor
+    openkubes.io/execution-id: "${OK147_RUN_ID}"
+    openkubes.io/stage-id: network-observation
+spec:
+  backoffLimit: 0
+  completions: 1
+  parallelism: 1
+  activeDeadlineSeconds: ${OK147_ACTIVE_DEADLINE_SECONDS}
+  ttlSecondsAfterFinished: 3600
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ok-cluster-contract-executor
+        openkubes.io/execution-id: "${OK147_RUN_ID}"
+    spec:
+      serviceAccountName: ok147-contract-executor-runtime
+      automountServiceAccountToken: false
+      enableServiceLinks: false
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+        seccompProfile: {type: RuntimeDefault}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - {key: node-role.kubernetes.io/control-plane, operator: DoesNotExist}
+      containers:
+        - name: executor
+          image: "${OK147_IMAGE_DIGEST}"
+          imagePullPolicy: IfNotPresent
+          command: ["/ok"]
+          args:
+            - cluster
+            - stage
+            - observe
+            - network
+            - --execute
+            - --plan
+            - /var/run/openkubes/input/staged-plan.json
+            - --contract-namespace
+            - "${OK147_CONTRACT_NAMESPACE}"
+            - --contract-name
+            - "${OK147_CONTRACT_NAME}"
+            - --intent-revision
+            - "${OK147_R}"
+            - --enablement-revision
+            - "${OK147_E}"
+            - --platform-revision
+            - "${OK147_P}"
+            - --execution-fixture
+            - "${OK147_FIXTURE}"
+            - --infrastructure-authority
+            - "${OK147_INFRA_AUTHORITY}"
+            - --management-authority
+            - "${OK147_MGMT_AUTHORITY}"
+            - --gitops-authority
+            - "${OK147_GITOPS_AUTHORITY}"
+            - --receipt-prefix
+            - /var/run/openkubes/input/receipt-prefix.json
+            - --receipt-prefix-digest
+            - "${OK147_RECEIPT_PREFIX_DIGEST}"
+            - --ledger-api-endpoint
+            - "${OK147_LEDGER_API_URL}"
+            - --ledger-token-file
+            - /var/run/openkubes/ledger/token
+            - --ledger-ca-file
+            - /var/run/openkubes/ledger/ca.crt
+            - --management-api-endpoint
+            - "${OK147_MANAGEMENT_API_URL}"
+            - --management-token-file
+            - /var/run/openkubes/management/token
+            - --management-ca-file
+            - /var/run/openkubes/management/ca.crt
+            - --workload-binding
+            - /var/run/openkubes/workload/binding.json
+            - --workload-binding-digest
+            - "${OK147_WORKLOAD_BINDING_DIGEST}"
+            - --workload-token-file
+            - /var/run/openkubes/workload/token
+            - --workload-ca-file
+            - /var/run/openkubes/workload/ca.crt
+            - --network-profile
+            - /var/run/openkubes/input/network-profile.json
+            - --network-profile-digest
+            - "${OK147_NETWORK_PROFILE_DIGEST}"
+            - --poll-interval
+            - "${OK147_POLL_INTERVAL}"
+            - --poll-timeout
+            - "${OK147_POLL_TIMEOUT}"
+          resources:
+            requests: {cpu: 50m, memory: 64Mi, ephemeral-storage: 16Mi}
+            limits: {cpu: 250m, memory: 128Mi, ephemeral-storage: 32Mi}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities: {drop: ["ALL"]}
+          volumeMounts:
+            - {name: input, mountPath: /var/run/openkubes/input/staged-plan.json, subPath: staged-plan.json, readOnly: true}
+            - {name: input, mountPath: /var/run/openkubes/input/receipt-prefix.json, subPath: receipt-prefix.json, readOnly: true}
+            - {name: input, mountPath: /var/run/openkubes/input/provider-receipt.json, subPath: provider-receipt.json, readOnly: true}
+            - {name: input, mountPath: /var/run/openkubes/input/lifecycle-receipt.json, subPath: lifecycle-receipt.json, readOnly: true}
+            - {name: input, mountPath: /var/run/openkubes/input/lifecycle-observation-receipt.json, subPath: lifecycle-observation-receipt.json, readOnly: true}
+            - {name: input, mountPath: /var/run/openkubes/input/enablement-receipt.json, subPath: enablement-receipt.json, readOnly: true}
+            - {name: input, mountPath: /var/run/openkubes/input/network-profile.json, subPath: network-profile.json, readOnly: true}
+            - {name: ledger-credential, mountPath: /var/run/openkubes/ledger/token, subPath: token, readOnly: true}
+            - {name: ledger-credential, mountPath: /var/run/openkubes/ledger/ca.crt, subPath: ca.crt, readOnly: true}
+            - {name: management-credential, mountPath: /var/run/openkubes/management/token, subPath: token, readOnly: true}
+            - {name: management-credential, mountPath: /var/run/openkubes/management/ca.crt, subPath: ca.crt, readOnly: true}
+            - {name: workload-credential, mountPath: /var/run/openkubes/workload/token, subPath: token, readOnly: true}
+            - {name: workload-credential, mountPath: /var/run/openkubes/workload/ca.crt, subPath: ca.crt, readOnly: true}
+            - {name: workload-credential, mountPath: /var/run/openkubes/workload/binding.json, subPath: binding.json, readOnly: true}
+      volumes:
+        - name: input
+          configMap:
+            name: "${OK147_INPUT_CONFIGMAP}"
+            defaultMode: 0444
+            items:
+              - {key: staged-plan.json, path: staged-plan.json}
+              - {key: receipt-prefix.json, path: receipt-prefix.json}
+              - {key: provider-receipt.json, path: provider-receipt.json}
+              - {key: lifecycle-receipt.json, path: lifecycle-receipt.json}
+              - {key: lifecycle-observation-receipt.json, path: lifecycle-observation-receipt.json}
+              - {key: enablement-receipt.json, path: enablement-receipt.json}
+              - {key: network-profile.json, path: network-profile.json}
+        - name: ledger-credential
+          secret:
+            secretName: "${OK147_LEDGER_CREDENTIAL_SECRET}"
+            defaultMode: 0440
+            items:
+              - {key: token, path: token}
+              - {key: ca.crt, path: ca.crt}
+        - name: management-credential
+          secret:
+            secretName: "${OK147_MANAGEMENT_CREDENTIAL_SECRET}"
+            defaultMode: 0440
+            items:
+              - {key: token, path: token}
+              - {key: ca.crt, path: ca.crt}
+        - name: workload-credential
+          secret:
+            secretName: "${OK147_WORKLOAD_CREDENTIAL_SECRET}"
+            defaultMode: 0440
+            items:
+              - {key: token, path: token}
+              - {key: ca.crt, path: ca.crt}
+              - {key: binding.json, path: binding.json}

--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -1956,6 +1956,17 @@ file capture. The private workload-authority binding, API endpoint, token and
 CA are intentionally absent and remain inputs to a later Secret/runtime
 boundary. This step creates no Kubernetes object and performs no API request.
 
+The matching offline Job template now binds the remaining runtime geometry.
+It mounts the public ConfigMap plus three different external Secrets for the
+ledger, management reader and workload reader. Only the workload Secret may
+carry the private binding alongside its token and CA. Its NetworkPolicy permits
+exactly two single-address API destinations: the shared management/ledger API
+and the distinct workload API. The tokenless runtime ServiceAccount,
+`backoffLimit: 0`, `restartPolicy: Never`, fixed resource bounds, non-root
+security context and digest-pinned image prevent an implicit retry or broad
+ambient authority. Rendering is strict literal substitution and performs no
+cluster request or object creation.
+
 ## Bounded convergence observation polling
 
 The aggregate observer can now be wrapped by a bounded polling observer before

--- a/internal/runner/network_observation_stage_job.go
+++ b/internal/runner/network_observation_stage_job.go
@@ -1,0 +1,117 @@
+package runner
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/stageplan"
+)
+
+type NetworkObservationStageJobValues struct {
+	RunID                      string
+	ImageDigest                string
+	Expected                   stageplan.Expected
+	InputConfigMap             string
+	ReceiptPrefixDigest        string
+	NetworkProfileDigest       string
+	LedgerAPIURL               string
+	LedgerAPICIDR              string
+	LedgerCredentialSecret     string
+	ManagementAPIURL           string
+	ManagementAPICIDR          string
+	ManagementCredentialSecret string
+	WorkloadAPIURL             string
+	WorkloadAPICIDR            string
+	WorkloadCredentialSecret   string
+	WorkloadBindingDigest      string
+	PollInterval               time.Duration
+	PollTimeout                time.Duration
+}
+
+// RenderNetworkObservationStageJobTemplate performs validated literal
+// substitution for exactly one two-endpoint NetworkPolicy and one read-only
+// network-observation Job.
+func RenderNetworkObservationStageJobTemplate(template []byte, values NetworkObservationStageJobValues) ([]byte, error) {
+	if len(template) == 0 || len(template) > 1024*1024 {
+		return nil, errors.New("network observation Job template size is invalid")
+	}
+	dnsLabel := regexp.MustCompile(`^[a-z0-9](?:[-a-z0-9]*[a-z0-9])?$`)
+	if !dnsLabel.MatchString(values.RunID) || len(values.RunID) > 63 || !strings.HasPrefix(values.RunID, "ok147-") {
+		return nil, errors.New("network observation Job run ID is invalid")
+	}
+	names := []string{values.InputConfigMap, values.LedgerCredentialSecret, values.ManagementCredentialSecret, values.WorkloadCredentialSecret}
+	seen := map[string]struct{}{}
+	for _, value := range names {
+		if !dnsLabel.MatchString(value) || len(value) > 63 {
+			return nil, errors.New("network observation Job object name is invalid")
+		}
+		if _, duplicate := seen[value]; duplicate {
+			return nil, errors.New("network observation Job inputs and credentials must use distinct objects")
+		}
+		seen[value] = struct{}{}
+	}
+	if !regexp.MustCompile(`^[a-z0-9][a-z0-9./:_-]*@sha256:[0-9a-f]{64}$`).MatchString(values.ImageDigest) {
+		return nil, errors.New("network observation Job image is not digest-bound")
+	}
+	for _, value := range []string{values.ReceiptPrefixDigest, values.NetworkProfileDigest, values.WorkloadBindingDigest} {
+		if !stageReceiptPrefixDigestPattern.MatchString(value) {
+			return nil, errors.New("network observation Job semantic digest is invalid")
+		}
+	}
+	if err := stageplan.ValidateExpected(values.Expected); err != nil {
+		return nil, fmt.Errorf("network observation Job expected binding: %w", err)
+	}
+	if values.PollInterval < time.Second || values.PollInterval > 5*time.Minute || values.PollTimeout < values.PollInterval || values.PollTimeout > 6*time.Hour || values.PollInterval%time.Second != 0 || values.PollTimeout%time.Second != 0 {
+		return nil, errors.New("network observation Job polling window is invalid")
+	}
+	ledgerPort, ledgerEndpoint, err := exactAPIEndpoint(values.LedgerAPIURL, values.LedgerAPICIDR)
+	if err != nil {
+		return nil, fmt.Errorf("network observation Job ledger endpoint: %w", err)
+	}
+	managementPort, managementEndpoint, err := exactAPIEndpoint(values.ManagementAPIURL, values.ManagementAPICIDR)
+	if err != nil {
+		return nil, fmt.Errorf("network observation Job management endpoint: %w", err)
+	}
+	if ledgerEndpoint != managementEndpoint || ledgerPort != managementPort {
+		return nil, errors.New("network observation ledger and management source must use the same verified API")
+	}
+	workloadPort, workloadEndpoint, err := exactAPIEndpoint(values.WorkloadAPIURL, values.WorkloadAPICIDR)
+	if err != nil {
+		return nil, fmt.Errorf("network observation Job workload endpoint: %w", err)
+	}
+	if workloadEndpoint == managementEndpoint {
+		return nil, errors.New("network observation management and workload endpoints must differ")
+	}
+	replacements := map[string]string{
+		"${OK147_RUN_ID}": values.RunID, "${OK147_IMAGE_DIGEST}": values.ImageDigest,
+		"${OK147_CONTRACT_NAMESPACE}": values.Expected.ContractIdentity.Namespace, "${OK147_CONTRACT_NAME}": values.Expected.ContractIdentity.Name,
+		"${OK147_R}": values.Expected.IntentRevision, "${OK147_E}": values.Expected.EnablementRevision,
+		"${OK147_P}": values.Expected.PlatformRevision, "${OK147_FIXTURE}": values.Expected.ExecutionFixture,
+		"${OK147_INFRA_AUTHORITY}": values.Expected.InfrastructureAuthority, "${OK147_MGMT_AUTHORITY}": values.Expected.ManagementAuthority,
+		"${OK147_GITOPS_AUTHORITY}": values.Expected.GitOpsAuthority,
+		"${OK147_INPUT_CONFIGMAP}":  values.InputConfigMap, "${OK147_RECEIPT_PREFIX_DIGEST}": values.ReceiptPrefixDigest,
+		"${OK147_NETWORK_PROFILE_DIGEST}": values.NetworkProfileDigest,
+		"${OK147_LEDGER_API_URL}":         values.LedgerAPIURL, "${OK147_LEDGER_API_CIDR}": values.LedgerAPICIDR,
+		"${OK147_LEDGER_API_PORT}": ledgerPort, "${OK147_LEDGER_CREDENTIAL_SECRET}": values.LedgerCredentialSecret,
+		"${OK147_MANAGEMENT_API_URL}": values.ManagementAPIURL, "${OK147_MANAGEMENT_CREDENTIAL_SECRET}": values.ManagementCredentialSecret,
+		"${OK147_WORKLOAD_API_CIDR}": values.WorkloadAPICIDR, "${OK147_WORKLOAD_API_PORT}": workloadPort,
+		"${OK147_WORKLOAD_CREDENTIAL_SECRET}": values.WorkloadCredentialSecret, "${OK147_WORKLOAD_BINDING_DIGEST}": values.WorkloadBindingDigest,
+		"${OK147_POLL_INTERVAL}": values.PollInterval.String(), "${OK147_POLL_TIMEOUT}": values.PollTimeout.String(),
+		"${OK147_ACTIVE_DEADLINE_SECONDS}": strconv.FormatInt(int64((values.PollTimeout+lifecycleObservationJobOverhead)/time.Second), 10),
+	}
+	result := string(template)
+	for placeholder, value := range replacements {
+		if !strings.Contains(result, placeholder) {
+			return nil, fmt.Errorf("network observation Job template lacks %s", placeholder)
+		}
+		result = strings.ReplaceAll(result, placeholder, value)
+	}
+	if strings.Contains(result, "${") {
+		return nil, errors.New("network observation Job template contains an unknown placeholder")
+	}
+	return []byte(result), nil
+}

--- a/internal/runner/network_observation_stage_job_test.go
+++ b/internal/runner/network_observation_stage_job_test.go
@@ -1,0 +1,122 @@
+package runner
+
+import (
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRenderNetworkObservationStageJobTemplateBindsExactEnvelope(t *testing.T) {
+	values := validNetworkObservationStageJobValues()
+	raw, err := RenderNetworkObservationStageJobTemplate(networkObservationJobTemplate(t), values)
+	if err != nil {
+		t.Fatal(err)
+	}
+	objects := decodeJobObjects(t, raw)
+	if len(objects) != 2 || objects["NetworkPolicy"] == nil || objects["Job"] == nil {
+		t.Fatalf("unexpected network observation object set: %#v", objects)
+	}
+	job := objects["Job"]
+	spec := objectAt(t, job, "spec")
+	if spec["backoffLimit"] != 0 || spec["activeDeadlineSeconds"] != 360 {
+		t.Fatalf("network Job retry or deadline differs: %#v", spec)
+	}
+	podSpec := objectAt(t, objectAt(t, spec, "template"), "spec")
+	if podSpec["automountServiceAccountToken"] != false || podSpec["restartPolicy"] != "Never" || podSpec["serviceAccountName"] != "ok147-contract-executor-runtime" {
+		t.Fatalf("unsafe network Pod identity or restart policy: %#v", podSpec)
+	}
+	container := arrayAt(t, podSpec, "containers")[0].(map[string]any)
+	args := stringArray(t, container, "args")
+	if !reflect.DeepEqual(args[:5], []string{"cluster", "stage", "observe", "network", "--execute"}) {
+		t.Fatalf("unexpected network command: %v", args)
+	}
+	for flag, want := range map[string]string{
+		"--receipt-prefix-digest":   values.ReceiptPrefixDigest,
+		"--workload-binding":        "/var/run/openkubes/workload/binding.json",
+		"--workload-binding-digest": values.WorkloadBindingDigest,
+		"--network-profile":         "/var/run/openkubes/input/network-profile.json",
+		"--network-profile-digest":  values.NetworkProfileDigest,
+		"--poll-timeout":            "5m0s",
+	} {
+		if got := argumentValue(args, flag); got != want {
+			t.Fatalf("%s=%q, want %q", flag, got, want)
+		}
+	}
+	volumes := arrayAt(t, podSpec, "volumes")
+	if len(volumes) != 4 {
+		t.Fatalf("network Job volume count differs: %#v", volumes)
+	}
+	policy := objects["NetworkPolicy"]
+	egress := arrayAt(t, objectAt(t, policy, "spec"), "egress")
+	if len(egress) != 2 {
+		t.Fatalf("network Job must have exact management and workload egress: %#v", egress)
+	}
+	text := string(raw)
+	for _, forbidden := range []string{"stage-grant", "projection-manifest", "authority-map", "system:masters", "privileged: true"} {
+		if strings.Contains(text, forbidden) {
+			t.Fatalf("network observation Job contains forbidden input %q", forbidden)
+		}
+	}
+}
+
+func TestRenderNetworkObservationStageJobTemplateFailsClosed(t *testing.T) {
+	valid := validNetworkObservationStageJobValues()
+	for name, mutate := range map[string]func(*NetworkObservationStageJobValues){
+		"mutable image": func(values *NetworkObservationStageJobValues) {
+			values.ImageDigest = "ghcr.io/openkubes/ok-cluster:latest"
+		},
+		"shared credential": func(values *NetworkObservationStageJobValues) {
+			values.WorkloadCredentialSecret = values.ManagementCredentialSecret
+		},
+		"foreign management endpoint": func(values *NetworkObservationStageJobValues) {
+			values.ManagementAPIURL, values.ManagementAPICIDR = "https://192.0.2.13:6443", "192.0.2.13/32"
+		},
+		"shared authority endpoint": func(values *NetworkObservationStageJobValues) {
+			values.WorkloadAPIURL, values.WorkloadAPICIDR = values.ManagementAPIURL, values.ManagementAPICIDR
+		},
+		"broad workload CIDR": func(values *NetworkObservationStageJobValues) {
+			values.WorkloadAPICIDR = "192.0.2.0/24"
+		},
+		"bad binding digest": func(values *NetworkObservationStageJobValues) {
+			values.WorkloadBindingDigest = "sha256:bad"
+		},
+		"subsecond polling": func(values *NetworkObservationStageJobValues) {
+			values.PollInterval = 500 * time.Millisecond
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			candidate := valid
+			mutate(&candidate)
+			if _, err := RenderNetworkObservationStageJobTemplate(networkObservationJobTemplate(t), candidate); err == nil {
+				t.Fatal("unsafe network observation Job values were accepted")
+			}
+		})
+	}
+	template := append(networkObservationJobTemplate(t), []byte("\n${UNKNOWN}")...)
+	if _, err := RenderNetworkObservationStageJobTemplate(template, valid); err == nil {
+		t.Fatal("unknown network observation placeholder was accepted")
+	}
+}
+
+func validNetworkObservationStageJobValues() NetworkObservationStageJobValues {
+	return NetworkObservationStageJobValues{
+		RunID: "ok147-network-observation-01", ImageDigest: "ghcr.io/openkubes/ok-cluster@" + bundleSHA("a"),
+		Expected: validSubmissionStageJobValues().Expected, InputConfigMap: "ok147-network-observation-input",
+		ReceiptPrefixDigest: bundleSHA("b"), NetworkProfileDigest: bundleSHA("c"),
+		LedgerAPIURL: "https://192.0.2.12:6443", LedgerAPICIDR: "192.0.2.12/32", LedgerCredentialSecret: "ok147-ledger-network",
+		ManagementAPIURL: "https://192.0.2.12:6443", ManagementAPICIDR: "192.0.2.12/32", ManagementCredentialSecret: "ok147-management-network",
+		WorkloadAPIURL: "https://192.0.2.20:6443", WorkloadAPICIDR: "192.0.2.20/32", WorkloadCredentialSecret: "ok147-workload-network",
+		WorkloadBindingDigest: bundleSHA("d"), PollInterval: 15 * time.Second, PollTimeout: 5 * time.Minute,
+	}
+}
+
+func networkObservationJobTemplate(t *testing.T) []byte {
+	t.Helper()
+	raw, err := os.ReadFile("../../deploy/contract-executor-network-observation-job.yaml.tpl")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return raw
+}


### PR DESCRIPTION
## Summary

- add a strict offline renderer and template for the `network-observation` Job
- bind the public ConfigMap plus separate ledger, management, and workload Secrets
- permit exactly the management/ledger API and distinct workload API as single-address egress targets
- mount the private workload binding only from the workload Secret
- enforce digest-pinned image, tokenless runtime identity, `backoffLimit: 0`, fixed deadline/resources, and hardened Pod security

## Boundaries

- no credential materialization, Job creation, API request, mutation, retry, or reconciliation loop
- no grants, arbitrary commands, wildcards, or ambient ServiceAccount token

## Validation

- `go test -ldflags=-linkmode=external ./...`
- `go vet ./...`
- `go test -race -ldflags=-linkmode=external ./internal/runner`
- `git diff --check`

OK-147
