### PR TITLE
feat(runner): seal network observation package (OK-147)

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -1967,6 +1967,14 @@ security context and digest-pinned image prevent an implicit retry or broad
 ambient authority. Rendering is strict literal substitution and performs no
 cluster request or object creation.
 
+The complete offline package now combines that envelope with the immutable
+public ConfigMap. Before rendering, it reads the private workload binding only
+long enough to prove its digest, R, target-UID correlation and exact workload
+API endpoint. Binding bytes are not copied into the package or receipt. The
+redaction-safe package receipt retains only the binding digest plus the public
+input, prefix, profile, template, envelope and complete package digests. This
+is package coherence, not credential materialization or launch authority.
+
 ## Bounded convergence observation polling
 
 The aggregate observer can now be wrapped by a bounded polling observer before

--- a/internal/runner/network_observation_stage_package.go
+++ b/internal/runner/network_observation_stage_package.go
@@ -1,0 +1,138 @@
+package runner
+
+import (
+	"errors"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+const NetworkObservationStagePackageFormat = "ok147-network-observation-stage-package/v1"
+
+type NetworkObservationStagePackageConfig struct {
+	Input                         NetworkObservationStageInputConfig
+	JobTemplate                   []byte
+	JobTemplateDigest             string
+	RunID                         string
+	ImageDigest                   string
+	LedgerAPIURL                  string
+	LedgerAPICIDR                 string
+	LedgerCredentialSecret        string
+	ManagementAPIURL              string
+	ManagementAPICIDR             string
+	ManagementCredentialSecret    string
+	WorkloadAPIURL                string
+	WorkloadAPICIDR               string
+	WorkloadCredentialSecret      string
+	WorkloadBindingPath           string
+	ExpectedWorkloadBindingDigest string
+	PollInterval                  time.Duration
+	PollTimeout                   time.Duration
+}
+
+type NetworkObservationStagePackageReceipt struct {
+	Format                string   `json:"format"`
+	State                 string   `json:"state"`
+	StageID               string   `json:"stageId"`
+	PackageDigest         string   `json:"packageDigest"`
+	InputConfigMapDigest  string   `json:"inputConfigMapDigest"`
+	ReceiptPrefixDigest   string   `json:"receiptPrefixDigest"`
+	NetworkProfileDigest  string   `json:"networkProfileDigest"`
+	WorkloadBindingDigest string   `json:"workloadBindingDigest"`
+	JobTemplateDigest     string   `json:"jobTemplateDigest"`
+	JobEnvelopeDigest     string   `json:"jobEnvelopeDigest"`
+	ObjectKinds           []string `json:"objectKinds"`
+	AuthorizationState    string   `json:"authorizationState"`
+	MutationAllowed       bool     `json:"mutationAllowed"`
+}
+
+type VerifiedNetworkObservationStagePackage struct {
+	raw                  []byte
+	receipt              NetworkObservationStagePackageReceipt
+	ledgerCredential     string
+	managementCredential string
+	workloadCredential   string
+	verified             bool
+}
+
+// BuildNetworkObservationStagePackage verifies the public input, the private
+// binding identity, and the two-endpoint Job envelope entirely offline. The
+// private binding bytes are never copied into package output.
+func BuildNetworkObservationStagePackage(config NetworkObservationStagePackageConfig) (VerifiedNetworkObservationStagePackage, error) {
+	if !stageReceiptPrefixDigestPattern.MatchString(config.JobTemplateDigest) || digest.SHA256(config.JobTemplate) != config.JobTemplateDigest {
+		return VerifiedNetworkObservationStagePackage{}, errors.New("network observation Job template digest differs from expected identity")
+	}
+	input, err := BuildNetworkObservationStageInput(config.Input)
+	if err != nil {
+		return VerifiedNetworkObservationStagePackage{}, err
+	}
+	inputRaw, err := input.Bytes()
+	if err != nil {
+		return VerifiedNetworkObservationStagePackage{}, err
+	}
+	inputReceipt, err := input.Receipt()
+	if err != nil {
+		return VerifiedNetworkObservationStagePackage{}, err
+	}
+	bundle, err := LoadNetworkObservationStageBundle(config.Input.Bundle)
+	if err != nil {
+		return VerifiedNetworkObservationStagePackage{}, err
+	}
+	lifecycle, err := bundle.prefix[1].Receipt()
+	if err != nil {
+		return VerifiedNetworkObservationStagePackage{}, errors.New("read package target correlation")
+	}
+	binding, err := loadWorkloadAuthorityBinding(config.WorkloadBindingPath, config.ExpectedWorkloadBindingDigest)
+	if err != nil {
+		return VerifiedNetworkObservationStagePackage{}, errors.New("verify private package workload binding")
+	}
+	if binding.IntentRevision != bundle.plan.IntentRevision || digest.SHA256([]byte(binding.TargetClusterUID)) != lifecycle.TargetClusterUIDDigest || binding.Endpoint != config.WorkloadAPIURL {
+		return VerifiedNetworkObservationStagePackage{}, errors.New("private workload binding differs from package target")
+	}
+	jobRaw, err := RenderNetworkObservationStageJobTemplate(config.JobTemplate, NetworkObservationStageJobValues{
+		RunID: config.RunID, ImageDigest: config.ImageDigest, Expected: config.Input.Bundle.PlanExpected,
+		InputConfigMap: config.Input.ConfigMapName, ReceiptPrefixDigest: inputReceipt.ReceiptPrefixDigest,
+		NetworkProfileDigest: inputReceipt.NetworkProfileDigest,
+		LedgerAPIURL:         config.LedgerAPIURL, LedgerAPICIDR: config.LedgerAPICIDR, LedgerCredentialSecret: config.LedgerCredentialSecret,
+		ManagementAPIURL: config.ManagementAPIURL, ManagementAPICIDR: config.ManagementAPICIDR, ManagementCredentialSecret: config.ManagementCredentialSecret,
+		WorkloadAPIURL: config.WorkloadAPIURL, WorkloadAPICIDR: config.WorkloadAPICIDR,
+		WorkloadCredentialSecret: config.WorkloadCredentialSecret, WorkloadBindingDigest: config.ExpectedWorkloadBindingDigest,
+		PollInterval: config.PollInterval, PollTimeout: config.PollTimeout,
+	})
+	if err != nil {
+		return VerifiedNetworkObservationStagePackage{}, err
+	}
+	packageRaw := make([]byte, 0, len(inputRaw)+len(jobRaw)+6)
+	packageRaw = append(packageRaw, inputRaw...)
+	packageRaw = append(packageRaw, '\n', '-', '-', '-', '\n')
+	packageRaw = append(packageRaw, jobRaw...)
+	receipt := NetworkObservationStagePackageReceipt{
+		Format: NetworkObservationStagePackageFormat, State: "VERIFIED", StageID: "network-observation",
+		PackageDigest: digest.SHA256(packageRaw), InputConfigMapDigest: inputReceipt.ConfigMapDigest,
+		ReceiptPrefixDigest: inputReceipt.ReceiptPrefixDigest, NetworkProfileDigest: inputReceipt.NetworkProfileDigest,
+		WorkloadBindingDigest: config.ExpectedWorkloadBindingDigest, JobTemplateDigest: config.JobTemplateDigest,
+		JobEnvelopeDigest: digest.SHA256(jobRaw), ObjectKinds: []string{"ConfigMap", "NetworkPolicy", "Job"},
+		AuthorizationState: "NOT_REQUIRED", MutationAllowed: false,
+	}
+	return VerifiedNetworkObservationStagePackage{
+		raw: packageRaw, receipt: receipt, ledgerCredential: config.LedgerCredentialSecret,
+		managementCredential: config.ManagementCredentialSecret, workloadCredential: config.WorkloadCredentialSecret,
+		verified: true,
+	}, nil
+}
+
+func (packaged VerifiedNetworkObservationStagePackage) Bytes() ([]byte, error) {
+	if !packaged.verified || len(packaged.raw) == 0 {
+		return nil, errors.New("network observation package was not produced by verification")
+	}
+	return append([]byte(nil), packaged.raw...), nil
+}
+
+func (packaged VerifiedNetworkObservationStagePackage) Receipt() (NetworkObservationStagePackageReceipt, error) {
+	if !packaged.verified || packaged.receipt.State != "VERIFIED" || digest.SHA256(packaged.raw) != packaged.receipt.PackageDigest || packaged.ledgerCredential == "" || packaged.managementCredential == "" || packaged.workloadCredential == "" || packaged.ledgerCredential == packaged.managementCredential || packaged.ledgerCredential == packaged.workloadCredential || packaged.managementCredential == packaged.workloadCredential {
+		return NetworkObservationStagePackageReceipt{}, errors.New("network observation package was not produced by verification")
+	}
+	receipt := packaged.receipt
+	receipt.ObjectKinds = append([]string(nil), packaged.receipt.ObjectKinds...)
+	return receipt, nil
+}

--- a/internal/runner/network_observation_stage_package_test.go
+++ b/internal/runner/network_observation_stage_package_test.go
@@ -1,0 +1,119 @@
+package runner
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+func TestBuildNetworkObservationStagePackageBindsPublicAndPrivateIdentities(t *testing.T) {
+	config := networkObservationStagePackageConfig(t)
+	packaged, err := BuildNetworkObservationStagePackage(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := packaged.Bytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := packaged.Receipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	objects := decodeJobObjects(t, raw)
+	if len(objects) != 3 || objects["ConfigMap"] == nil || objects["NetworkPolicy"] == nil || objects["Job"] == nil {
+		t.Fatalf("unexpected network observation package: %#v", objects)
+	}
+	if bytes.Contains(raw, []byte(`"targetClusterUid"`)) || bytes.Contains(raw, []byte(`"targetIdentityScheme"`)) || bytes.Contains(raw, []byte(`"caBundleDigest"`)) {
+		t.Fatal("private workload binding was copied into public package output")
+	}
+	if receipt.Format != NetworkObservationStagePackageFormat || receipt.StageID != "network-observation" || receipt.PackageDigest != digest.SHA256(raw) || receipt.AuthorizationState != "NOT_REQUIRED" || receipt.MutationAllowed {
+		t.Fatalf("unexpected network observation package receipt: %#v", receipt)
+	}
+	parts := bytes.SplitN(raw, []byte("\n---\n"), 2)
+	if len(parts) != 2 || receipt.InputConfigMapDigest != digest.SHA256(parts[0]) || receipt.JobEnvelopeDigest != digest.SHA256(parts[1]) {
+		t.Fatal("network observation package component digests differ")
+	}
+	if !reflect.DeepEqual(receipt.ObjectKinds, []string{"ConfigMap", "NetworkPolicy", "Job"}) || receipt.WorkloadBindingDigest != config.ExpectedWorkloadBindingDigest {
+		t.Fatalf("network observation package identities differ: %#v", receipt)
+	}
+	raw[0] = 'x'
+	again, _ := packaged.Bytes()
+	if again[0] != '{' {
+		t.Fatal("caller mutated retained network package")
+	}
+}
+
+func TestBuildNetworkObservationStagePackageFailsClosed(t *testing.T) {
+	valid := networkObservationStagePackageConfig(t)
+	for name, mutate := range map[string]func(*NetworkObservationStagePackageConfig){
+		"changed template": func(config *NetworkObservationStagePackageConfig) {
+			config.JobTemplate = append(config.JobTemplate, '\n')
+		},
+		"wrong template digest": func(config *NetworkObservationStagePackageConfig) {
+			config.JobTemplateDigest = bundleSHA("f")
+		},
+		"shared credentials": func(config *NetworkObservationStagePackageConfig) {
+			config.WorkloadCredentialSecret = config.ManagementCredentialSecret
+		},
+		"binding endpoint differs": func(config *NetworkObservationStagePackageConfig) {
+			config.WorkloadAPIURL = "https://192.0.2.21:6443"
+			config.WorkloadAPICIDR = "192.0.2.21/32"
+		},
+		"foreign binding digest": func(config *NetworkObservationStagePackageConfig) {
+			config.ExpectedWorkloadBindingDigest = bundleSHA("e")
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			config := valid
+			config.JobTemplate = append([]byte(nil), valid.JobTemplate...)
+			mutate(&config)
+			if _, err := BuildNetworkObservationStagePackage(config); err == nil {
+				t.Fatal("unsafe network observation package was accepted")
+			}
+		})
+	}
+	if _, err := (VerifiedNetworkObservationStagePackage{}).Bytes(); err == nil {
+		t.Fatal("unverified network package bytes were exposed")
+	}
+	if _, err := (VerifiedNetworkObservationStagePackage{}).Receipt(); err == nil {
+		t.Fatal("unverified network package receipt was exposed")
+	}
+}
+
+func networkObservationStagePackageConfig(t *testing.T) NetworkObservationStagePackageConfig {
+	t.Helper()
+	input := networkObservationStageInputConfig(t)
+	plan, _, prefix, err := loadStageResumeWithPrefix(input.Bundle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lifecycle, _ := prefix[1].Receipt()
+	const targetUID = "cluster-runtime-uid-147"
+	if digest.SHA256([]byte(targetUID)) != lifecycle.TargetClusterUIDDigest {
+		t.Fatal("test target differs from lifecycle receipt")
+	}
+	binding := WorkloadAuthorityBinding{
+		Format: WorkloadAuthorityBindingFormat, IntentRevision: plan.IntentRevision,
+		TargetClusterUID: targetUID, TargetIdentityScheme: "capi-cluster-uid/v1",
+		Endpoint: "https://192.0.2.20:6443", CABundleDigest: bundleSHA("9"),
+	}
+	bindingPath := writeBundleFile(t, t.TempDir(), "binding.json", mustJSON(t, binding))
+	bindingDigest, err := WorkloadAuthorityBindingDigest(binding)
+	if err != nil {
+		t.Fatal(err)
+	}
+	template := networkObservationJobTemplate(t)
+	return NetworkObservationStagePackageConfig{
+		Input: input, JobTemplate: template, JobTemplateDigest: digest.SHA256(template),
+		RunID: "ok147-network-observation-01", ImageDigest: "ghcr.io/openkubes/ok-cluster@" + bundleSHA("a"),
+		LedgerAPIURL: "https://192.0.2.12:6443", LedgerAPICIDR: "192.0.2.12/32", LedgerCredentialSecret: "ok147-ledger-network",
+		ManagementAPIURL: "https://192.0.2.12:6443", ManagementAPICIDR: "192.0.2.12/32", ManagementCredentialSecret: "ok147-management-network",
+		WorkloadAPIURL: binding.Endpoint, WorkloadAPICIDR: "192.0.2.20/32", WorkloadCredentialSecret: "ok147-workload-network",
+		WorkloadBindingPath: bindingPath, ExpectedWorkloadBindingDigest: bindingDigest,
+		PollInterval: 15 * time.Second, PollTimeout: 5 * time.Minute,
+	}
+}

--- a/internal/runner/runtime_resolvers.go
+++ b/internal/runner/runtime_resolvers.go
@@ -85,20 +85,9 @@ func loadWorkloadAuthorityFiles(config WorkloadAuthorityFileResolverConfig) (Wor
 	if config.Path == "" || config.TokenFile == "" || config.CAFile == "" || !platformInputDigestPattern.MatchString(config.ExpectedBindingDigest) {
 		return WorkloadAuthorityBinding{}, KubernetesAuthorityConfig{}, errors.New("workload authority file resolver binding is invalid")
 	}
-	raw, err := readBoundedRegular(config.Path, maximumWorkloadBindingBytes)
+	binding, err := loadWorkloadAuthorityBinding(config.Path, config.ExpectedBindingDigest)
 	if err != nil {
-		return WorkloadAuthorityBinding{}, KubernetesAuthorityConfig{}, errors.New("read bounded workload authority binding")
-	}
-	var binding WorkloadAuthorityBinding
-	if err := jsonstrict.Decode(raw, &binding); err != nil {
-		return WorkloadAuthorityBinding{}, KubernetesAuthorityConfig{}, errors.New("decode strict workload authority binding")
-	}
-	bindingDigest, err := WorkloadAuthorityBindingDigest(binding)
-	if err != nil {
-		return WorkloadAuthorityBinding{}, KubernetesAuthorityConfig{}, errors.New("validate workload authority binding")
-	}
-	if bindingDigest != config.ExpectedBindingDigest {
-		return WorkloadAuthorityBinding{}, KubernetesAuthorityConfig{}, errors.New("workload authority binding differs from expected identity")
+		return WorkloadAuthorityBinding{}, KubernetesAuthorityConfig{}, err
 	}
 	ca, err := readBoundedRegular(config.CAFile, maximumCABytes)
 	if err != nil {
@@ -111,6 +100,30 @@ func loadWorkloadAuthorityFiles(config WorkloadAuthorityFileResolverConfig) (Wor
 		Endpoint: binding.Endpoint, AuthorityIdentity: binding.TargetClusterUID,
 		TokenFile: config.TokenFile, CAFile: config.CAFile, CABundleDigest: binding.CABundleDigest,
 	}, nil
+}
+
+// loadWorkloadAuthorityBinding verifies only the strict private semantic
+// record. It reads no token or CA and performs no network request.
+func loadWorkloadAuthorityBinding(path, expectedDigest string) (WorkloadAuthorityBinding, error) {
+	if path == "" || !platformInputDigestPattern.MatchString(expectedDigest) {
+		return WorkloadAuthorityBinding{}, errors.New("workload authority binding source is invalid")
+	}
+	raw, err := readBoundedRegular(path, maximumWorkloadBindingBytes)
+	if err != nil {
+		return WorkloadAuthorityBinding{}, errors.New("read bounded workload authority binding")
+	}
+	var binding WorkloadAuthorityBinding
+	if err := jsonstrict.Decode(raw, &binding); err != nil {
+		return WorkloadAuthorityBinding{}, errors.New("decode strict workload authority binding")
+	}
+	bindingDigest, err := WorkloadAuthorityBindingDigest(binding)
+	if err != nil {
+		return WorkloadAuthorityBinding{}, errors.New("validate workload authority binding")
+	}
+	if bindingDigest != expectedDigest {
+		return WorkloadAuthorityBinding{}, errors.New("workload authority binding differs from expected identity")
+	}
+	return binding, nil
 }
 
 // WorkloadAuthorityBindingDigest identifies the canonical, secret-free


### PR DESCRIPTION
## Summary

- combine the immutable public ConfigMap and bounded Network Job envelope into one verified offline package
- verify the private workload binding digest, R, historical target correlation, and exact workload API endpoint before rendering
- retain only the private binding digest in redaction-safe package evidence
- bind input, receipt-prefix, profile, template, envelope, and complete package digests

## Boundaries

- private workload binding bytes are not copied into package output or receipt
- no Secret materialization, launch authority, API request, mutation, retry, or controller loop

## Validation

- `go test -ldflags=-linkmode=external ./...`
- `go vet ./...`
- `go test -race -ldflags=-linkmode=external ./internal/runner`
- `git diff --check`

OK-147
