### PR TITLE
feat(ok): package network observation stage (OK-147)

### DIFF
--- a/cmd/ok/main.go
+++ b/cmd/ok/main.go
@@ -65,6 +65,19 @@ var materializeLifecycleObservationStagePackage = func(config runner.LifecycleOb
 	return raw, receipt, err
 }
 
+var materializeNetworkObservationStagePackage = func(config runner.NetworkObservationStagePackageConfig) ([]byte, runner.NetworkObservationStagePackageReceipt, error) {
+	packaged, err := runner.BuildNetworkObservationStagePackage(config)
+	if err != nil {
+		return nil, runner.NetworkObservationStagePackageReceipt{}, err
+	}
+	raw, err := packaged.Bytes()
+	if err != nil {
+		return nil, runner.NetworkObservationStagePackageReceipt{}, err
+	}
+	receipt, err := packaged.Receipt()
+	return raw, receipt, err
+}
+
 var materializeEnablementStagePackage = func(config runner.EnablementStagePackageConfig) ([]byte, runner.EnablementStagePackageReceipt, error) {
 	packaged, err := runner.BuildEnablementStagePackage(config)
 	if err != nil {
@@ -501,6 +514,9 @@ func runContext(ctx context.Context, arguments []string, stdout, stderr io.Write
 	if len(arguments) >= 4 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "observe" && arguments[3] == "lifecycle" {
 		return runClusterStageObserveLifecycle(ctx, arguments[4:], stdout, stderr)
 	}
+	if len(arguments) >= 5 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "observe" && arguments[3] == "network" && arguments[4] == "package" {
+		return runClusterStageObserveNetworkPackage(arguments[5:], stdout, stderr)
+	}
 	if len(arguments) >= 4 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "observe" && arguments[3] == "network" {
 		return runClusterStageObserveNetwork(ctx, arguments[4:], stdout, stderr)
 	}
@@ -528,7 +544,7 @@ func runContext(ctx context.Context, arguments []string, stdout, stderr io.Write
 	if len(arguments) >= 4 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "launch" && arguments[3] == "execute" {
 		return runClusterStageLaunchExecute(ctx, arguments[4:], stdout, stderr)
 	}
-	return errors.New("usage: ok cluster create ... | ok cluster stage inspect ... | ok cluster stage resume ... | ok cluster stage observe lifecycle ... | ok cluster stage observe network ... | ok cluster stage observe lifecycle package ... | ok cluster stage observe lifecycle launch prepare ... | ok cluster stage observe lifecycle launch execute ... | ok cluster stage run ... | ok cluster stage run enablement ... | ok cluster stage run enablement package ... | ok cluster stage run enablement launch prepare ... | ok cluster stage run enablement launch execute ... | ok cluster stage package ... | ok cluster stage launch prepare ... | ok cluster stage launch execute ...")
+	return errors.New("usage: ok cluster create ... | ok cluster stage inspect ... | ok cluster stage resume ... | ok cluster stage observe lifecycle ... | ok cluster stage observe network ... | ok cluster stage observe network package ... | ok cluster stage observe lifecycle package ... | ok cluster stage observe lifecycle launch prepare ... | ok cluster stage observe lifecycle launch execute ... | ok cluster stage run ... | ok cluster stage run enablement ... | ok cluster stage run enablement package ... | ok cluster stage run enablement launch prepare ... | ok cluster stage run enablement launch execute ... | ok cluster stage package ... | ok cluster stage launch prepare ... | ok cluster stage launch execute ...")
 }
 
 func runClusterCreate(arguments []string, stdout, stderr io.Writer) error {
@@ -845,6 +861,91 @@ func runClusterStageObserveNetwork(ctx context.Context, arguments []string, stdo
 		}
 	}
 	return runErr
+}
+
+func runClusterStageObserveNetworkPackage(arguments []string, stdout, stderr io.Writer) error {
+	flags := flag.NewFlagSet("ok cluster stage observe network package", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	resumeFlags := addStageResumeFlags(flags)
+	jobTemplate := flags.String("job-template", "", "path to the bounded network-observation Job template")
+	jobTemplateDigest := flags.String("job-template-digest", "", "expected SHA-256 identity of the Job template")
+	output := flags.String("output", "", "new local file for the verified ConfigMap/Job/NetworkPolicy package")
+	runID := flags.String("run-id", "", "bounded OK-147 network observation Job identity")
+	imageDigest := flags.String("image", "", "digest-pinned ok image")
+	inputConfigMap := flags.String("input-configmap", "", "immutable network observation input ConfigMap name")
+	networkProfile := flags.String("network-profile", "", "path to the immutable NetworkReady profile")
+	networkProfileDigest := flags.String("network-profile-digest", "", "expected NetworkReady profile digest")
+	ledgerAPIURL := flags.String("ledger-api-url", "", "exact management-ledger HTTPS IP endpoint")
+	ledgerAPICIDR := flags.String("ledger-api-cidr", "", "single-address management-ledger CIDR")
+	ledgerCredentialSecret := flags.String("ledger-credential-secret", "", "externally materialized ledger credential Secret name")
+	managementAPIURL := flags.String("management-api-url", "", "exact management-observer HTTPS IP endpoint")
+	managementAPICIDR := flags.String("management-api-cidr", "", "single-address management-observer CIDR")
+	managementCredentialSecret := flags.String("management-credential-secret", "", "externally materialized management credential Secret name")
+	workloadAPIURL := flags.String("workload-api-url", "", "exact workload-observer HTTPS IP endpoint")
+	workloadAPICIDR := flags.String("workload-api-cidr", "", "single-address workload-observer CIDR")
+	workloadCredentialSecret := flags.String("workload-credential-secret", "", "externally materialized workload credential Secret name")
+	workloadBinding := flags.String("workload-binding", "", "path to the private workload-authority binding")
+	workloadBindingDigest := flags.String("workload-binding-digest", "", "expected workload-authority binding digest")
+	pollInterval := flags.Duration("poll-interval", 0, "bounded interval between verified Unknown observations")
+	pollTimeout := flags.Duration("poll-timeout", 0, "maximum bounded network observation duration")
+	if err := flags.Parse(arguments); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return errors.New("positional arguments are not accepted")
+	}
+	bundleConfig, err := resumeFlags.config()
+	if err != nil {
+		return err
+	}
+	for _, input := range []struct{ name, value string }{
+		{"--job-template", *jobTemplate}, {"--job-template-digest", *jobTemplateDigest}, {"--output", *output},
+		{"--run-id", *runID}, {"--image", *imageDigest}, {"--input-configmap", *inputConfigMap},
+		{"--network-profile", *networkProfile}, {"--network-profile-digest", *networkProfileDigest},
+		{"--ledger-api-url", *ledgerAPIURL}, {"--ledger-api-cidr", *ledgerAPICIDR}, {"--ledger-credential-secret", *ledgerCredentialSecret},
+		{"--management-api-url", *managementAPIURL}, {"--management-api-cidr", *managementAPICIDR}, {"--management-credential-secret", *managementCredentialSecret},
+		{"--workload-api-url", *workloadAPIURL}, {"--workload-api-cidr", *workloadAPICIDR}, {"--workload-credential-secret", *workloadCredentialSecret},
+		{"--workload-binding", *workloadBinding}, {"--workload-binding-digest", *workloadBindingDigest},
+	} {
+		if input.value == "" {
+			return fmt.Errorf("%s is required", input.name)
+		}
+	}
+	for _, value := range []string{*jobTemplateDigest, *networkProfileDigest, *workloadBindingDigest} {
+		if !sha256DigestPattern.MatchString(value) {
+			return errors.New("template, network profile, and workload binding digests must be lowercase SHA-256 identities")
+		}
+	}
+	if *pollInterval < time.Second || *pollInterval > 5*time.Minute || *pollTimeout < *pollInterval || *pollTimeout > 6*time.Hour {
+		return errors.New("--poll-interval and --poll-timeout must define a valid bounded observation of at most 6h")
+	}
+	template, err := readBoundedLocalFile(*jobTemplate, 1024*1024)
+	if err != nil {
+		return fmt.Errorf("read network observation Job template: %w", err)
+	}
+	raw, receipt, err := materializeNetworkObservationStagePackage(runner.NetworkObservationStagePackageConfig{
+		Input: runner.NetworkObservationStageInputConfig{
+			Bundle: bundleConfig, NetworkProfilePath: *networkProfile,
+			ExpectedNetworkProfileDigest: *networkProfileDigest, ConfigMapName: *inputConfigMap,
+		},
+		JobTemplate: template, JobTemplateDigest: *jobTemplateDigest,
+		RunID: *runID, ImageDigest: *imageDigest,
+		LedgerAPIURL: *ledgerAPIURL, LedgerAPICIDR: *ledgerAPICIDR, LedgerCredentialSecret: *ledgerCredentialSecret,
+		ManagementAPIURL: *managementAPIURL, ManagementAPICIDR: *managementAPICIDR, ManagementCredentialSecret: *managementCredentialSecret,
+		WorkloadAPIURL: *workloadAPIURL, WorkloadAPICIDR: *workloadAPICIDR, WorkloadCredentialSecret: *workloadCredentialSecret,
+		WorkloadBindingPath: *workloadBinding, ExpectedWorkloadBindingDigest: *workloadBindingDigest,
+		PollInterval: *pollInterval, PollTimeout: *pollTimeout,
+	})
+	if err != nil {
+		return err
+	}
+	if err := writeNewLocalFile(*output, raw); err != nil {
+		return fmt.Errorf("write network observation stage package: %w", err)
+	}
+	encoder := json.NewEncoder(stdout)
+	encoder.SetEscapeHTML(false)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(receipt)
 }
 
 func runClusterStageObserveLifecyclePackage(arguments []string, stdout, stderr io.Writer) error {

--- a/cmd/ok/main_test.go
+++ b/cmd/ok/main_test.go
@@ -518,6 +518,88 @@ func TestStageObserveLifecyclePackageRejectsIncompleteInputs(t *testing.T) {
 	}
 }
 
+func TestStageObserveNetworkPackageWritesVerifiedOfflineArtifact(t *testing.T) {
+	previous := materializeNetworkObservationStagePackage
+	defer func() { materializeNetworkObservationStagePackage = previous }()
+	var captured runner.NetworkObservationStagePackageConfig
+	materializeNetworkObservationStagePackage = func(config runner.NetworkObservationStagePackageConfig) ([]byte, runner.NetworkObservationStagePackageReceipt, error) {
+		captured = config
+		return []byte("verified-network-package\n"), runner.NetworkObservationStagePackageReceipt{
+			Format: runner.NetworkObservationStagePackageFormat, State: "VERIFIED", StageID: "network-observation",
+			PackageDigest: testSHA("1"), InputConfigMapDigest: testSHA("2"), ReceiptPrefixDigest: testSHA("3"),
+			NetworkProfileDigest: testSHA("4"), WorkloadBindingDigest: testSHA("5"),
+			JobTemplateDigest: testSHA("6"), JobEnvelopeDigest: testSHA("7"), ObjectKinds: []string{"ConfigMap", "NetworkPolicy", "Job"},
+			AuthorizationState: "NOT_REQUIRED", MutationAllowed: false,
+		}, nil
+	}
+	root := t.TempDir()
+	template := filepath.Join(root, "network-job.yaml.tpl")
+	if err := os.WriteFile(template, []byte("bounded-network-template"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	output := filepath.Join(root, "network-package.yaml")
+	arguments := stageObserveNetworkPackageArguments(template, output)
+	var stdout, stderr bytes.Buffer
+	if err := run(arguments, &stdout, &stderr); err != nil {
+		t.Fatalf("run: %v; stderr=%s", err, stderr.String())
+	}
+	if captured.Input.Bundle.PlanPath != "/tmp/plan.json" || len(captured.Input.Bundle.Receipts) != 4 || captured.RunID != "ok147-network-observation-01" || captured.PollTimeout != 5*time.Minute {
+		t.Fatalf("unexpected network package config: %#v", captured)
+	}
+	if string(captured.JobTemplate) != "bounded-network-template" || captured.JobTemplateDigest != digest.SHA256([]byte("bounded-network-template")) || captured.Input.ExpectedNetworkProfileDigest != testSHA("5") || captured.ExpectedWorkloadBindingDigest != testSHA("4") {
+		t.Fatalf("network semantic package inputs were not bound: %#v", captured)
+	}
+	if captured.LedgerCredentialSecret == captured.ManagementCredentialSecret || captured.LedgerCredentialSecret == captured.WorkloadCredentialSecret || captured.ManagementCredentialSecret == captured.WorkloadCredentialSecret {
+		t.Fatalf("network credential identities are not distinct: %#v", captured)
+	}
+	written, err := os.ReadFile(output)
+	if err != nil || string(written) != "verified-network-package\n" {
+		t.Fatalf("unexpected network package: %q %v", written, err)
+	}
+	info, err := os.Stat(output)
+	if err != nil || info.Mode().Perm() != 0o600 {
+		t.Fatalf("network package mode is not 0600: %v %v", info, err)
+	}
+	var receipt runner.NetworkObservationStagePackageReceipt
+	if err := json.Unmarshal(stdout.Bytes(), &receipt); err != nil {
+		t.Fatal(err)
+	}
+	if receipt.AuthorizationState != "NOT_REQUIRED" || receipt.MutationAllowed {
+		t.Fatalf("unsafe network package receipt: %#v", receipt)
+	}
+	stdout.Reset()
+	if err := run(arguments, &stdout, &stderr); err == nil || stdout.Len() != 0 {
+		t.Fatal("existing network package was overwritten")
+	}
+}
+
+func TestStageObserveNetworkPackageRejectsIncompleteInputs(t *testing.T) {
+	root := t.TempDir()
+	template := filepath.Join(root, "network-job.yaml.tpl")
+	if err := os.WriteFile(template, []byte("bounded-network-template"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	valid := stageObserveNetworkPackageArguments(template, filepath.Join(root, "network-package.yaml"))
+	for name, arguments := range map[string][]string{
+		"execute":                  append(append([]string{}, valid...), "--execute"),
+		"missing template digest":  removeArgumentWithValue(valid, "--job-template-digest"),
+		"missing profile digest":   removeArgumentWithValue(valid, "--network-profile-digest"),
+		"missing binding digest":   removeArgumentWithValue(valid, "--workload-binding-digest"),
+		"missing workload secret":  removeArgumentWithValue(valid, "--workload-credential-secret"),
+		"invalid workload binding": replaceArgument(valid, "--workload-binding-digest", "sha256:bad"),
+		"missing poll timeout":     removeArgumentWithValue(valid, "--poll-timeout"),
+		"interval exceeds timeout": replaceArgument(valid, "--poll-interval", "6m"),
+		"positional":               append(append([]string{}, valid...), "unexpected"),
+	} {
+		t.Run(name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			if err := run(arguments, &stdout, &stderr); err == nil || stdout.Len() != 0 {
+				t.Fatalf("unsafe network package input was accepted: %v %s", err, stdout.String())
+			}
+		})
+	}
+}
+
 func TestStageRunRequiresExplicitExecutionAndBindsOneRuntime(t *testing.T) {
 	previous := executeSubmissionStage
 	defer func() { executeSubmissionStage = previous }()
@@ -1190,6 +1272,26 @@ func stageObserveNetworkArguments() []string {
 		"--workload-binding", "/tmp/workload-binding.json", "--workload-binding-digest", testSHA("4"),
 		"--workload-token-file", "/tmp/workload-observer-token", "--workload-ca-file", "/tmp/workload-ca",
 		"--network-profile", "/tmp/network-profile.json", "--network-profile-digest", testSHA("5"),
+		"--poll-interval", "15s", "--poll-timeout", "5m",
+	)
+}
+
+func stageObserveNetworkPackageArguments(template, output string) []string {
+	resume := stageResumeArguments()
+	arguments := append([]string{"cluster", "stage", "observe", "network", "package"}, resume[3:]...)
+	return append(arguments,
+		"--receipt", "/tmp/provider.json@"+testSHA("1"),
+		"--receipt", "/tmp/lifecycle.json@"+testSHA("2"),
+		"--receipt", "/tmp/lifecycle-observation.json@"+testSHA("3"),
+		"--receipt", "/tmp/enablement.json@"+testSHA("4"),
+		"--job-template", template, "--job-template-digest", digest.SHA256([]byte("bounded-network-template")),
+		"--output", output, "--run-id", "ok147-network-observation-01",
+		"--image", "ghcr.io/openkubes/ok-cluster@"+testSHA("a"), "--input-configmap", "ok147-network-observation-input",
+		"--network-profile", "/tmp/network-profile.json", "--network-profile-digest", testSHA("5"),
+		"--ledger-api-url", "https://192.0.2.12:6443", "--ledger-api-cidr", "192.0.2.12/32", "--ledger-credential-secret", "ok147-ledger-network",
+		"--management-api-url", "https://192.0.2.12:6443", "--management-api-cidr", "192.0.2.12/32", "--management-credential-secret", "ok147-management-network",
+		"--workload-api-url", "https://192.0.2.20:6443", "--workload-api-cidr", "192.0.2.20/32", "--workload-credential-secret", "ok147-workload-network",
+		"--workload-binding", "/tmp/workload-binding.json", "--workload-binding-digest", testSHA("4"),
 		"--poll-interval", "15s", "--poll-timeout", "5m",
 	)
 }

--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -1975,6 +1975,23 @@ redaction-safe package receipt retains only the binding digest plus the public
 input, prefix, profile, template, envelope and complete package digests. This
 is package coherence, not credential materialization or launch authority.
 
+The package is now exposed through an offline CLI boundary:
+
+```text
+ok cluster stage observe network package
+  + exact plan and four-receipt prefix
+  + immutable Network profile and private workload-binding digests
+  + reviewed Job-template digest and two exact API destinations
+  + three distinct external credential Secret names
+      -> new 0600 ConfigMap/NetworkPolicy/Job package
+      -> redaction-safe package receipt
+```
+
+The command accepts no `--execute`, credential bytes or grant, refuses an
+existing output path and validates all semantic digests and polling bounds
+before invoking the packager. Its tests inject package construction, so no
+private runtime file or Kubernetes API is read.
+
 ## Bounded convergence observation polling
 
 The aggregate observer can now be wrapped by a bounded polling observer before


### PR DESCRIPTION
## Summary

- add `ok cluster stage observe network package` for sealed offline package materialization
- bind the exact resume/receipt chain, template, R/E identities, network profile, workload authority binding, and three credential authorities
- validate all referenced SHA-256 digests and reject incomplete or execution-bearing input fail-closed

## Boundaries

- offline only; no cluster contact or credential reads
- no grant, launch, Job creation, or `--execute` path
- writes only a new local package artifact and receipt

## Validation

- `git diff --check`
- `GOCACHE=/private/tmp/ok147-go-build-cache go test -ldflags=-linkmode=external ./...`
- `GOCACHE=/private/tmp/ok147-go-build-cache go vet ./...`
- `GOCACHE=/private/tmp/ok147-go-build-cache go test -race -ldflags=-linkmode=external ./cmd/ok ./internal/runner`

Jira: OK-147
