### PR TITLE
feat(runner): bind network observation credentials (OK-147)

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -1992,6 +1992,17 @@ existing output path and validates all semantic digests and polling bounds
 before invoking the packager. Its tests inject package construction, so no
 private runtime file or Kubernetes API is read.
 
+The next offline boundary materializes three pairwise-distinct, immutable
+credential Secrets from independently bound short-lived TokenRequest results:
+one ledger writer and one management reader from the management authority,
+plus one workload reader from the digest-bound workload authority. Only the
+workload Secret contains the canonical private workload binding alongside its
+token and CA. Its CA, R, endpoint and target-UID digest must still equal the
+verified observation package. The public receipt exposes only expiry,
+audiences, authority/digest identities and exact Secret-object digests; it
+contains no token, CA, endpoint, raw target UID, subject or source path. This
+primitive performs no TokenRequest, Secret installation or Kubernetes call.
+
 ## Bounded convergence observation polling
 
 The aggregate observer can now be wrapped by a bounded polling observer before

--- a/internal/runner/network_observation_stage_credentials.go
+++ b/internal/runner/network_observation_stage_credentials.go
@@ -1,0 +1,210 @@
+package runner
+
+import (
+	"crypto/subtle"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/jsonstrict"
+)
+
+const NetworkObservationStageCredentialPackageFormat = "ok147-network-observation-stage-credential-package/v1"
+
+type NetworkObservationStageCredentialPackageConfig struct {
+	Package             VerifiedNetworkObservationStagePackage
+	MaterializationTime time.Time
+	WorkloadBindingPath string
+	Ledger              SubmissionStageCredentialSource
+	ManagementObserver  SubmissionStageCredentialSource
+	WorkloadObserver    SubmissionStageCredentialSource
+}
+
+type NetworkObservationStageCredentialPackageReceipt struct {
+	Format                   string                                   `json:"format"`
+	State                    string                                   `json:"state"`
+	StageID                  string                                   `json:"stageId"`
+	ObservationPackageDigest string                                   `json:"observationPackageDigest"`
+	WorkloadBindingDigest    string                                   `json:"workloadBindingDigest"`
+	InstallationAuthority    string                                   `json:"installationAuthority"`
+	MaterializedAt           string                                   `json:"materializedAt"`
+	PackageDigest            string                                   `json:"packageDigest"`
+	Credentials              []SubmissionStageCredentialObjectReceipt `json:"credentials"`
+	MutationAllowed          bool                                     `json:"mutationAllowed"`
+}
+
+type networkObservationStageCredentialPackageIdentity struct {
+	ObservationPackageDigest string                                   `json:"observationPackageDigest"`
+	WorkloadBindingDigest    string                                   `json:"workloadBindingDigest"`
+	InstallationAuthority    string                                   `json:"installationAuthority"`
+	MaterializedAt           string                                   `json:"materializedAt"`
+	Credentials              []SubmissionStageCredentialObjectReceipt `json:"credentials"`
+}
+
+// VerifiedNetworkObservationStageCredentialPackage retains three exact
+// immutable Secrets privately. The workload Secret additionally carries the
+// private workload binding; no private bytes or source paths enter its receipt.
+type VerifiedNetworkObservationStageCredentialPackage struct {
+	objects               []submissionStageCredentialObject
+	receipt               NetworkObservationStageCredentialPackageReceipt
+	installationAuthority string
+	workloadAuthority     string
+	verified              bool
+}
+
+// BuildNetworkObservationStageCredentialPackage verifies three independent,
+// short-lived TokenRequest results and the package-bound workload identity.
+// It creates private Secret bytes entirely offline and performs no API call.
+func BuildNetworkObservationStageCredentialPackage(config NetworkObservationStageCredentialPackageConfig) (VerifiedNetworkObservationStageCredentialPackage, error) {
+	packageReceipt, err := config.Package.Receipt()
+	if err != nil || packageReceipt.StageID != "network-observation" {
+		return VerifiedNetworkObservationStageCredentialPackage{}, errors.New("verified network observation package is required")
+	}
+	if config.MaterializationTime.IsZero() || !config.MaterializationTime.Equal(config.MaterializationTime.Truncate(time.Second)) {
+		return VerifiedNetworkObservationStageCredentialPackage{}, errors.New("network observation credential materialization time is required")
+	}
+	binding, err := loadWorkloadAuthorityBinding(config.WorkloadBindingPath, packageReceipt.WorkloadBindingDigest)
+	if err != nil {
+		return VerifiedNetworkObservationStageCredentialPackage{}, errors.New("verify private network observation workload binding")
+	}
+	if binding.IntentRevision != config.Package.intentRevision || binding.Endpoint != config.Package.workloadEndpoint || binding.CABundleDigest != config.Package.workloadCABundle || digest.SHA256([]byte(binding.TargetClusterUID)) != config.Package.workloadAuthority {
+		return VerifiedNetworkObservationStageCredentialPackage{}, errors.New("network observation workload binding differs from verified package")
+	}
+	bindings := []struct {
+		role      string
+		name      string
+		authority string
+		source    SubmissionStageCredentialSource
+	}{
+		{role: "ledger", name: config.Package.ledgerCredential, authority: config.Package.managementAuthority, source: config.Ledger},
+		{role: "management-observer", name: config.Package.managementCredential, authority: config.Package.managementAuthority, source: config.ManagementObserver},
+		{role: "workload-observer", name: config.Package.workloadCredential, authority: config.Package.workloadAuthority, source: config.WorkloadObserver},
+	}
+	objects := make([]submissionStageCredentialObject, 0, len(bindings))
+	receipts := make([]SubmissionStageCredentialObjectReceipt, 0, len(bindings))
+	tokens := make([][]byte, 0, len(bindings))
+	for _, credential := range bindings {
+		object, receipt, token, err := buildSubmissionStageCredentialObject(
+			packageReceipt.StageID, config.MaterializationTime.UTC(), credential.role,
+			credential.name, credential.authority, credential.source,
+		)
+		if err != nil {
+			return VerifiedNetworkObservationStageCredentialPackage{}, err
+		}
+		objects = append(objects, object)
+		receipts = append(receipts, receipt)
+		tokens = append(tokens, token)
+	}
+	for left := range tokens {
+		for right := left + 1; right < len(tokens); right++ {
+			if len(tokens[left]) == len(tokens[right]) && subtle.ConstantTimeCompare(tokens[left], tokens[right]) == 1 {
+				return VerifiedNetworkObservationStageCredentialPackage{}, errors.New("network observation credentials must be pairwise distinct")
+			}
+		}
+	}
+	bindingRaw, err := json.Marshal(binding)
+	if err != nil {
+		return VerifiedNetworkObservationStageCredentialPackage{}, errors.New("encode private network observation workload binding")
+	}
+	var workloadSecret map[string]any
+	if err := jsonstrict.Decode(objects[2].raw, &workloadSecret); err != nil {
+		return VerifiedNetworkObservationStageCredentialPackage{}, errors.New("decode private workload credential Secret")
+	}
+	data, ok := workloadSecret["data"].(map[string]any)
+	if !ok {
+		return VerifiedNetworkObservationStageCredentialPackage{}, errors.New("private workload credential Secret data is missing")
+	}
+	data["binding.json"] = base64.StdEncoding.EncodeToString(bindingRaw)
+	objects[2].raw, err = json.Marshal(workloadSecret)
+	if err != nil || len(objects[2].raw) > maximumStageCredentialObjectBytes {
+		return VerifiedNetworkObservationStageCredentialPackage{}, errors.New("network observation workload credential Secret exceeds accepted size")
+	}
+	receipts[2].ObjectDigest = digest.SHA256(objects[2].raw)
+
+	materializedAt := config.MaterializationTime.UTC().Format(time.RFC3339)
+	identity, err := json.Marshal(networkObservationStageCredentialPackageIdentity{
+		ObservationPackageDigest: packageReceipt.PackageDigest,
+		WorkloadBindingDigest:    packageReceipt.WorkloadBindingDigest,
+		InstallationAuthority:    config.Package.managementAuthority,
+		MaterializedAt:           materializedAt, Credentials: receipts,
+	})
+	if err != nil {
+		return VerifiedNetworkObservationStageCredentialPackage{}, errors.New("encode network observation credential package identity")
+	}
+	receipt := NetworkObservationStageCredentialPackageReceipt{
+		Format: NetworkObservationStageCredentialPackageFormat, State: "VERIFIED", StageID: packageReceipt.StageID,
+		ObservationPackageDigest: packageReceipt.PackageDigest, WorkloadBindingDigest: packageReceipt.WorkloadBindingDigest,
+		InstallationAuthority: config.Package.managementAuthority, MaterializedAt: materializedAt,
+		PackageDigest: digest.SHA256(identity), Credentials: receipts, MutationAllowed: false,
+	}
+	return VerifiedNetworkObservationStageCredentialPackage{
+		objects: cloneStageCredentialObjects(objects), receipt: receipt,
+		installationAuthority: config.Package.managementAuthority,
+		workloadAuthority:     config.Package.workloadAuthority, verified: true,
+	}, nil
+}
+
+func (packaged VerifiedNetworkObservationStageCredentialPackage) Receipt() (NetworkObservationStageCredentialPackageReceipt, error) {
+	if err := verifyNetworkObservationStageCredentialPackage(packaged); err != nil {
+		return NetworkObservationStageCredentialPackageReceipt{}, errors.New("network observation credential package was not produced by verification")
+	}
+	receipt := packaged.receipt
+	receipt.Credentials = append([]SubmissionStageCredentialObjectReceipt(nil), packaged.receipt.Credentials...)
+	for index := range receipt.Credentials {
+		receipt.Credentials[index].Audiences = append([]string(nil), packaged.receipt.Credentials[index].Audiences...)
+	}
+	return receipt, nil
+}
+
+func verifyNetworkObservationStageCredentialPackage(packaged VerifiedNetworkObservationStageCredentialPackage) error {
+	if !packaged.verified || packaged.receipt.Format != NetworkObservationStageCredentialPackageFormat || packaged.receipt.State != "VERIFIED" || packaged.receipt.StageID != "network-observation" || packaged.installationAuthority == "" || packaged.receipt.InstallationAuthority != packaged.installationAuthority || !stageReceiptPrefixDigestPattern.MatchString(packaged.workloadAuthority) || len(packaged.objects) != 3 || len(packaged.receipt.Credentials) != 3 {
+		return errors.New("network observation credential package identity is incomplete")
+	}
+	identity, err := json.Marshal(networkObservationStageCredentialPackageIdentity{
+		ObservationPackageDigest: packaged.receipt.ObservationPackageDigest,
+		WorkloadBindingDigest:    packaged.receipt.WorkloadBindingDigest,
+		InstallationAuthority:    packaged.receipt.InstallationAuthority,
+		MaterializedAt:           packaged.receipt.MaterializedAt, Credentials: packaged.receipt.Credentials,
+	})
+	if err != nil || digest.SHA256(identity) != packaged.receipt.PackageDigest {
+		return errors.New("network observation credential package identity changed after verification")
+	}
+	if _, err := time.Parse(time.RFC3339, packaged.receipt.MaterializedAt); err != nil {
+		return errors.New("network observation credential materialization time is invalid")
+	}
+	expectedRoles := []string{"ledger", "management-observer", "workload-observer"}
+	expectedAuthorities := []string{packaged.installationAuthority, packaged.installationAuthority, packaged.workloadAuthority}
+	for index, object := range packaged.objects {
+		receipt := packaged.receipt.Credentials[index]
+		if object.role != expectedRoles[index] || receipt.Role != expectedRoles[index] || object.authority != expectedAuthorities[index] || receipt.Authority != expectedAuthorities[index] || object.name != receipt.Name || receipt.Namespace != submissionStageInputNamespace || digest.SHA256(object.raw) != receipt.ObjectDigest {
+			return errors.New("network observation credential object identity changed after verification")
+		}
+	}
+	var workloadSecret map[string]any
+	if err := jsonstrict.Decode(packaged.objects[2].raw, &workloadSecret); err != nil {
+		return errors.New("network observation workload credential is invalid")
+	}
+	data, ok := workloadSecret["data"].(map[string]any)
+	if !ok {
+		return errors.New("network observation workload credential data is missing")
+	}
+	bindingEncoded, ok := data["binding.json"].(string)
+	if !ok {
+		return errors.New("network observation workload binding is missing")
+	}
+	bindingRaw, err := base64.StdEncoding.DecodeString(bindingEncoded)
+	if err != nil {
+		return errors.New("network observation workload binding encoding is invalid")
+	}
+	var binding WorkloadAuthorityBinding
+	if err := jsonstrict.Decode(bindingRaw, &binding); err != nil {
+		return errors.New("network observation workload binding is invalid")
+	}
+	bindingDigest, err := WorkloadAuthorityBindingDigest(binding)
+	if err != nil || bindingDigest != packaged.receipt.WorkloadBindingDigest || digest.SHA256([]byte(binding.TargetClusterUID)) != packaged.workloadAuthority {
+		return errors.New("network observation workload binding identity changed after verification")
+	}
+	return nil
+}

--- a/internal/runner/network_observation_stage_credentials_test.go
+++ b/internal/runner/network_observation_stage_credentials_test.go
@@ -1,0 +1,197 @@
+package runner
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+func TestBuildNetworkObservationStageCredentialPackageBindsThreePrivateSecrets(t *testing.T) {
+	config, tokens := networkObservationCredentialConfig(t)
+	packaged, err := BuildNetworkObservationStageCredentialPackage(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := packaged.Receipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	observationReceipt, _ := config.Package.Receipt()
+	if receipt.Format != NetworkObservationStageCredentialPackageFormat || receipt.State != "VERIFIED" || receipt.StageID != "network-observation" || receipt.ObservationPackageDigest != observationReceipt.PackageDigest || receipt.WorkloadBindingDigest != observationReceipt.WorkloadBindingDigest || receipt.InstallationAuthority != "ok-mgmt" || receipt.MaterializedAt != config.MaterializationTime.Format(time.RFC3339) || !stageReceiptPrefixDigestPattern.MatchString(receipt.PackageDigest) || receipt.MutationAllowed || len(receipt.Credentials) != 3 {
+		t.Fatalf("unexpected network observation credential receipt: %#v", receipt)
+	}
+	want := []struct {
+		role      string
+		name      string
+		authority string
+	}{
+		{role: "ledger", name: config.Package.ledgerCredential, authority: "ok-mgmt"},
+		{role: "management-observer", name: config.Package.managementCredential, authority: "ok-mgmt"},
+		{role: "workload-observer", name: config.Package.workloadCredential, authority: config.Package.workloadAuthority},
+	}
+	for index, expected := range want {
+		object := packaged.objects[index]
+		objectReceipt := receipt.Credentials[index]
+		if object.role != expected.role || object.authority != expected.authority || object.name != expected.name || digest.SHA256(object.raw) != objectReceipt.ObjectDigest {
+			t.Fatalf("private network credential %d differs: %#v %#v", index, object, objectReceipt)
+		}
+		var secret map[string]any
+		if err := json.Unmarshal(object.raw, &secret); err != nil {
+			t.Fatal(err)
+		}
+		data := secret["data"].(map[string]any)
+		decodedToken, err := base64.StdEncoding.DecodeString(data["token"].(string))
+		if err != nil || !bytes.Equal(decodedToken, tokens[index]) {
+			t.Fatalf("private network token %d differs", index)
+		}
+		_, hasBinding := data["binding.json"]
+		if hasBinding != (index == 2) {
+			t.Fatalf("credential %d workload-binding presence differs", index)
+		}
+	}
+	public, err := json.Marshal(receipt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range []string{
+		string(tokens[0]), string(tokens[1]), string(tokens[2]), config.WorkloadBindingPath,
+		config.Ledger.TokenFile, config.ManagementObserver.TokenFile, config.WorkloadObserver.TokenFile,
+		config.Ledger.ExpectedSubject, config.ManagementObserver.ExpectedSubject, config.WorkloadObserver.ExpectedSubject,
+	} {
+		if bytes.Contains(public, []byte(forbidden)) {
+			t.Fatalf("network observation credential receipt exposed private value %q", forbidden)
+		}
+	}
+	receipt.Credentials[0].Audiences[0] = "changed"
+	again, err := packaged.Receipt()
+	if err != nil || again.Credentials[0].Audiences[0] == "changed" {
+		t.Fatal("caller mutated retained network observation credential receipt")
+	}
+}
+
+func TestBuildNetworkObservationStageCredentialPackageFailsClosed(t *testing.T) {
+	for name, mutate := range map[string]func(*NetworkObservationStageCredentialPackageConfig){
+		"foreign management authority": func(config *NetworkObservationStageCredentialPackageConfig) {
+			config.ManagementObserver.AuthorityIdentity = "ok-infra"
+		},
+		"foreign workload authority": func(config *NetworkObservationStageCredentialPackageConfig) {
+			config.WorkloadObserver.AuthorityIdentity = prefixSHA("f")
+		},
+		"workload CA differs from binding": func(config *NetworkObservationStageCredentialPackageConfig) {
+			config.WorkloadObserver.CABundleDigest = prefixSHA("e")
+		},
+		"shared token": func(config *NetworkObservationStageCredentialPackageConfig) {
+			config.WorkloadObserver.TokenFile = config.ManagementObserver.TokenFile
+			config.WorkloadObserver.TokenDigest = config.ManagementObserver.TokenDigest
+			config.WorkloadObserver.ExpectedIssuer = config.ManagementObserver.ExpectedIssuer
+			config.WorkloadObserver.ExpectedSubject = config.ManagementObserver.ExpectedSubject
+			config.WorkloadObserver.ExpectedAudiences = append([]string(nil), config.ManagementObserver.ExpectedAudiences...)
+			config.WorkloadObserver.IssuedAt = config.ManagementObserver.IssuedAt
+			config.WorkloadObserver.ExpiresAt = config.ManagementObserver.ExpiresAt
+		},
+		"missing TokenRequest evidence": func(config *NetworkObservationStageCredentialPackageConfig) {
+			config.Ledger.TokenRequestEvidenceDigest = ""
+		},
+		"unverified package": func(config *NetworkObservationStageCredentialPackageConfig) {
+			config.Package = VerifiedNetworkObservationStagePackage{}
+		},
+		"changed package identity": func(config *NetworkObservationStageCredentialPackageConfig) {
+			config.Package.receipt.PackageDigest = prefixSHA("d")
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			config, _ := networkObservationCredentialConfig(t)
+			mutate(&config)
+			_, err := BuildNetworkObservationStageCredentialPackage(config)
+			if err == nil || strings.Contains(err.Error(), config.WorkloadBindingPath) || strings.Contains(err.Error(), config.WorkloadObserver.TokenFile) {
+				t.Fatalf("unsafe network observation credential package accepted: %v", err)
+			}
+		})
+	}
+	if _, err := (VerifiedNetworkObservationStageCredentialPackage{}).Receipt(); err == nil {
+		t.Fatal("unverified network observation credential receipt was exposed")
+	}
+	config, _ := networkObservationCredentialConfig(t)
+	packaged, err := BuildNetworkObservationStageCredentialPackage(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	packaged.objects[2].raw = append(packaged.objects[2].raw, '\n')
+	if _, err := packaged.Receipt(); err == nil {
+		t.Fatal("changed private network observation credential was accepted")
+	}
+}
+
+func networkObservationCredentialConfig(t *testing.T) (NetworkObservationStageCredentialPackageConfig, [][]byte) {
+	t.Helper()
+	now := time.Date(2026, 8, 16, 12, 0, 0, 0, time.UTC)
+	issuedAt, expiresAt := now.Add(-time.Minute), now.Add(30*time.Minute)
+	audiences := []string{"https://kubernetes.default.svc"}
+	issuer := "https://kubernetes.default.svc.cluster.local"
+	root := t.TempDir()
+	managementCA, workloadCA := testCA(t), testCA(t)
+	managementCAPath, workloadCAPath := filepath.Join(root, "management-ca.crt"), filepath.Join(root, "workload-ca.crt")
+	if err := os.WriteFile(managementCAPath, managementCA, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(workloadCAPath, workloadCA, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	packageConfig := networkObservationStagePackageConfig(t)
+	binding, err := loadWorkloadAuthorityBinding(packageConfig.WorkloadBindingPath, packageConfig.ExpectedWorkloadBindingDigest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	binding.CABundleDigest = digest.SHA256(workloadCA)
+	bindingRaw := mustJSON(t, binding)
+	if err := os.WriteFile(packageConfig.WorkloadBindingPath, bindingRaw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	packageConfig.ExpectedWorkloadBindingDigest, err = WorkloadAuthorityBindingDigest(binding)
+	if err != nil {
+		t.Fatal(err)
+	}
+	packaged, err := BuildNetworkObservationStagePackage(packageConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	subjects := []string{
+		"system:serviceaccount:openkubes-execution-system:ok147-ledger-writer",
+		"system:serviceaccount:openkubes-execution-system:ok147-network-management-observer",
+		"system:serviceaccount:openkubes-execution-system:ok147-network-workload-observer",
+	}
+	tokens := [][]byte{
+		stageCredentialJWT(t, issuer, subjects[0], audiences, issuedAt, expiresAt, 'e'),
+		stageCredentialJWT(t, issuer, subjects[1], audiences, issuedAt, expiresAt, 'f'),
+		stageCredentialJWT(t, issuer, subjects[2], audiences, issuedAt, expiresAt, 'a'),
+	}
+	tokenPaths := make([]string, len(tokens))
+	for index, token := range tokens {
+		tokenPaths[index] = filepath.Join(root, "token-"+string(rune('0'+index)))
+		if err := os.WriteFile(tokenPaths[index], token, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	source := func(authority, tokenPath, subject, evidence, caPath string, token, ca []byte) SubmissionStageCredentialSource {
+		return SubmissionStageCredentialSource{
+			AuthorityIdentity: authority, TokenFile: tokenPath, TokenDigest: digest.SHA256(token),
+			CAFile: caPath, CABundleDigest: digest.SHA256(ca), TokenRequestEvidenceDigest: prefixSHA(evidence),
+			ExpectedIssuer: issuer, ExpectedSubject: subject, ExpectedAudiences: audiences,
+			IssuedAt: issuedAt, ExpiresAt: expiresAt,
+		}
+	}
+	return NetworkObservationStageCredentialPackageConfig{
+		Package: packaged, MaterializationTime: now, WorkloadBindingPath: packageConfig.WorkloadBindingPath,
+		Ledger:             source("ok-mgmt", tokenPaths[0], subjects[0], "1", managementCAPath, tokens[0], managementCA),
+		ManagementObserver: source("ok-mgmt", tokenPaths[1], subjects[1], "2", managementCAPath, tokens[1], managementCA),
+		WorkloadObserver:   source(digest.SHA256([]byte(binding.TargetClusterUID)), tokenPaths[2], subjects[2], "3", workloadCAPath, tokens[2], workloadCA),
+	}, tokens
+}

--- a/internal/runner/network_observation_stage_package.go
+++ b/internal/runner/network_observation_stage_package.go
@@ -52,6 +52,11 @@ type VerifiedNetworkObservationStagePackage struct {
 	ledgerCredential     string
 	managementCredential string
 	workloadCredential   string
+	managementAuthority  string
+	workloadAuthority    string
+	intentRevision       string
+	workloadEndpoint     string
+	workloadCABundle     string
 	verified             bool
 }
 
@@ -117,7 +122,11 @@ func BuildNetworkObservationStagePackage(config NetworkObservationStagePackageCo
 	return VerifiedNetworkObservationStagePackage{
 		raw: packageRaw, receipt: receipt, ledgerCredential: config.LedgerCredentialSecret,
 		managementCredential: config.ManagementCredentialSecret, workloadCredential: config.WorkloadCredentialSecret,
-		verified: true,
+		managementAuthority: bundle.plan.Authorities.Management,
+		workloadAuthority:   digest.SHA256([]byte(binding.TargetClusterUID)),
+		intentRevision:      binding.IntentRevision, workloadEndpoint: binding.Endpoint,
+		workloadCABundle: binding.CABundleDigest,
+		verified:         true,
 	}, nil
 }
 
@@ -129,7 +138,7 @@ func (packaged VerifiedNetworkObservationStagePackage) Bytes() ([]byte, error) {
 }
 
 func (packaged VerifiedNetworkObservationStagePackage) Receipt() (NetworkObservationStagePackageReceipt, error) {
-	if !packaged.verified || packaged.receipt.State != "VERIFIED" || digest.SHA256(packaged.raw) != packaged.receipt.PackageDigest || packaged.ledgerCredential == "" || packaged.managementCredential == "" || packaged.workloadCredential == "" || packaged.ledgerCredential == packaged.managementCredential || packaged.ledgerCredential == packaged.workloadCredential || packaged.managementCredential == packaged.workloadCredential {
+	if !packaged.verified || packaged.receipt.State != "VERIFIED" || digest.SHA256(packaged.raw) != packaged.receipt.PackageDigest || packaged.ledgerCredential == "" || packaged.managementCredential == "" || packaged.workloadCredential == "" || packaged.ledgerCredential == packaged.managementCredential || packaged.ledgerCredential == packaged.workloadCredential || packaged.managementCredential == packaged.workloadCredential || packaged.managementAuthority == "" || !stageReceiptPrefixDigestPattern.MatchString(packaged.workloadAuthority) || !stageReceiptPrefixDigestPattern.MatchString(packaged.intentRevision) || packaged.workloadEndpoint == "" || !stageReceiptPrefixDigestPattern.MatchString(packaged.workloadCABundle) {
 		return NetworkObservationStagePackageReceipt{}, errors.New("network observation package was not produced by verification")
 	}
 	receipt := packaged.receipt


### PR DESCRIPTION
## Summary

- add an offline credential package for the network-observation stage
- bind pairwise-distinct ledger, management-reader, and workload-reader TokenRequest results
- place the canonical private workload binding only in the workload Secret while retaining redaction-safe public receipts

## Boundaries

- no TokenRequest, Secret installation, Job launch, or Kubernetes API contact
- public receipt contains no token, CA, endpoint, raw target UID, subject, or local source path
- workload authority is represented publicly only by its SHA-256 identity

## Validation

- `git diff --check`
- `GOCACHE=/private/tmp/ok147-go-build-cache go test -ldflags=-linkmode=external ./...`
- `GOCACHE=/private/tmp/ok147-go-build-cache go vet ./...`
- `GOCACHE=/private/tmp/ok147-go-build-cache go test -race -ldflags=-linkmode=external ./internal/runner`

Jira: OK-147
