### PR TITLE
feat(runner): plan network observation installation (OK-147)

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -1992,6 +1992,14 @@ existing output path and validates all semantic digests and polling bounds
 before invoking the packager. Its tests inject package construction, so no
 private runtime file or Kubernetes API is read.
 
+The package now also produces a tokenless offline installation plan for its
+three public objects. It re-decodes the sealed package, verifies component and
+per-object digests, enforces ConfigMap → NetworkPolicy → Job order, checks the
+shared run identity, tokenless runtime ServiceAccount, management-authority
+argument and exact three-Secret volume geometry (including `binding.json`
+only on the workload credential). The plan exposes only GET/POST paths and
+object digests and grants no mutation or credential access.
+
 The next offline boundary materializes three pairwise-distinct, immutable
 credential Secrets from independently bound short-lived TokenRequest results:
 one ledger writer and one management reader from the management authority,

--- a/internal/runner/network_observation_stage_installation_plan.go
+++ b/internal/runner/network_observation_stage_installation_plan.go
@@ -1,0 +1,177 @@
+package runner
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"gopkg.in/yaml.v3"
+)
+
+const NetworkObservationStageInstallationPlanFormat = "ok147-network-observation-stage-installation-plan/v1"
+
+// NetworkObservationStageInstallationPlan is a tokenless offline description
+// of the three exact public objects. It grants no create authority.
+type NetworkObservationStageInstallationPlan struct {
+	Format                   string                      `json:"format"`
+	State                    string                      `json:"state"`
+	StageID                  string                      `json:"stageId"`
+	ObservationPackageDigest string                      `json:"observationPackageDigest"`
+	Authority                string                      `json:"authority"`
+	Creates                  []SubmissionStageCreatePlan `json:"creates"`
+	MutationAllowed          bool                        `json:"mutationAllowed"`
+}
+
+// PlanNetworkObservationStageInstallation verifies the immutable input,
+// NetworkPolicy and Job and derives their exact create order without opening
+// credentials or contacting Kubernetes.
+func PlanNetworkObservationStageInstallation(packaged VerifiedNetworkObservationStagePackage) (NetworkObservationStageInstallationPlan, error) {
+	receipt, err := packaged.Receipt()
+	if err != nil {
+		return NetworkObservationStageInstallationPlan{}, err
+	}
+	expectedKinds := []string{"ConfigMap", "NetworkPolicy", "Job"}
+	if !equalStringList(receipt.ObjectKinds, expectedKinds) {
+		return NetworkObservationStageInstallationPlan{}, errors.New("network observation package object inventory is invalid")
+	}
+	documents := bytes.Split(packaged.raw, []byte("\n---\n"))
+	if len(documents) != len(expectedKinds) || digest.SHA256(documents[0]) != receipt.InputConfigMapDigest || digest.SHA256(bytes.Join(documents[1:], []byte("\n---\n"))) != receipt.JobEnvelopeDigest {
+		return NetworkObservationStageInstallationPlan{}, errors.New("network observation package component identity differs")
+	}
+	decoder := yaml.NewDecoder(bytes.NewReader(packaged.raw))
+	objects := make([]map[string]any, 0, len(expectedKinds))
+	for {
+		var object map[string]any
+		err := decoder.Decode(&object)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil || len(object) == 0 {
+			return NetworkObservationStageInstallationPlan{}, errors.New("decode network observation package")
+		}
+		objects = append(objects, object)
+	}
+	if len(objects) != len(expectedKinds) {
+		return NetworkObservationStageInstallationPlan{}, errors.New("network observation package object count is invalid")
+	}
+
+	configMapName, runID := "", ""
+	creates := make([]SubmissionStageCreatePlan, 0, len(objects))
+	for index, object := range objects {
+		apiVersion, _ := object["apiVersion"].(string)
+		kind, _ := object["kind"].(string)
+		if kind != expectedKinds[index] {
+			return NetworkObservationStageInstallationPlan{}, errors.New("network observation package create order is invalid")
+		}
+		metadata, ok := object["metadata"].(map[string]any)
+		if !ok {
+			return NetworkObservationStageInstallationPlan{}, errors.New("network observation package object metadata is invalid")
+		}
+		name, _ := metadata["name"].(string)
+		namespace, _ := metadata["namespace"].(string)
+		if !submissionStageInputNamePattern.MatchString(name) || len(name) > 63 || namespace != submissionStageInputNamespace || metadata["generateName"] != nil {
+			return NetworkObservationStageInstallationPlan{}, errors.New("network observation package object identity is invalid")
+		}
+		collectionPath, objectPath, err := submissionStageCreatePaths(apiVersion, kind, namespace, name)
+		if err != nil {
+			return NetworkObservationStageInstallationPlan{}, err
+		}
+		canonical, err := json.Marshal(object)
+		if err != nil {
+			return NetworkObservationStageInstallationPlan{}, errors.New("encode network observation package object")
+		}
+		creates = append(creates, SubmissionStageCreatePlan{
+			Order: index + 1, APIVersion: apiVersion, Kind: kind, Namespace: namespace, Name: name,
+			PreflightMethod: "GET", ObjectPath: objectPath, CreateMethod: "POST", CollectionPath: collectionPath,
+			ObjectDigest: digest.SHA256(canonical),
+		})
+		switch kind {
+		case "ConfigMap":
+			labels, _ := metadata["labels"].(map[string]any)
+			if object["immutable"] != true || labels["openkubes.io/stage-id"] != receipt.StageID {
+				return NetworkObservationStageInstallationPlan{}, errors.New("network observation input ConfigMap semantics differ")
+			}
+			configMapName = name
+		case "NetworkPolicy":
+			runID = name
+			spec, _ := object["spec"].(map[string]any)
+			selector, _ := spec["podSelector"].(map[string]any)
+			matchLabels, _ := selector["matchLabels"].(map[string]any)
+			if matchLabels["openkubes.io/execution-id"] != runID {
+				return NetworkObservationStageInstallationPlan{}, errors.New("network observation NetworkPolicy selector differs from run identity")
+			}
+		case "Job":
+			if name != runID {
+				return NetworkObservationStageInstallationPlan{}, errors.New("network observation Job and NetworkPolicy identities differ")
+			}
+			spec, _ := object["spec"].(map[string]any)
+			template, _ := spec["template"].(map[string]any)
+			podSpec, _ := template["spec"].(map[string]any)
+			if podSpec["serviceAccountName"] != "ok147-contract-executor-runtime" || podSpec["automountServiceAccountToken"] != false {
+				return NetworkObservationStageInstallationPlan{}, errors.New("network observation Job runtime identity is invalid")
+			}
+			if !jobMountsInputConfigMap(podSpec, configMapName) || !jobUsesManagementAuthority(podSpec, packaged.managementAuthority) || !jobUsesNetworkObservationCredentialSecrets(podSpec, packaged.ledgerCredential, packaged.managementCredential, packaged.workloadCredential) {
+				return NetworkObservationStageInstallationPlan{}, errors.New("network observation Job binding differs from verified package")
+			}
+		}
+	}
+	return NetworkObservationStageInstallationPlan{
+		Format: NetworkObservationStageInstallationPlanFormat, State: "VERIFIED", StageID: receipt.StageID,
+		ObservationPackageDigest: receipt.PackageDigest, Authority: packaged.managementAuthority,
+		Creates: creates, MutationAllowed: false,
+	}, nil
+}
+
+func jobUsesNetworkObservationCredentialSecrets(podSpec map[string]any, ledger, management, workload string) bool {
+	volumes, ok := podSpec["volumes"].([]any)
+	if !ok {
+		return false
+	}
+	want := map[string]struct {
+		secret string
+		items  map[string]string
+	}{
+		"ledger-credential":     {secret: ledger, items: map[string]string{"token": "token", "ca.crt": "ca.crt"}},
+		"management-credential": {secret: management, items: map[string]string{"token": "token", "ca.crt": "ca.crt"}},
+		"workload-credential":   {secret: workload, items: map[string]string{"token": "token", "ca.crt": "ca.crt", "binding.json": "binding.json"}},
+	}
+	found := map[string]bool{}
+	for _, item := range volumes {
+		volume, _ := item.(map[string]any)
+		name, _ := volume["name"].(string)
+		expected, relevant := want[name]
+		if !relevant {
+			continue
+		}
+		secret, _ := volume["secret"].(map[string]any)
+		secretName, _ := secret["secretName"].(string)
+		items, _ := secret["items"].([]any)
+		if secretName != expected.secret || !exactCredentialSecretItems(items, expected.items) {
+			return false
+		}
+		found[name] = true
+	}
+	return len(found) == len(want)
+}
+
+func exactCredentialSecretItems(items []any, expected map[string]string) bool {
+	if len(items) != len(expected) {
+		return false
+	}
+	want := make(map[string]string, len(expected))
+	for key, value := range expected {
+		want[key] = value
+	}
+	for _, item := range items {
+		entry, _ := item.(map[string]any)
+		key, _ := entry["key"].(string)
+		path, _ := entry["path"].(string)
+		if want[key] != path {
+			return false
+		}
+		delete(want, key)
+	}
+	return len(want) == 0
+}

--- a/internal/runner/network_observation_stage_installation_plan_test.go
+++ b/internal/runner/network_observation_stage_installation_plan_test.go
@@ -1,0 +1,85 @@
+package runner
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+func TestPlanNetworkObservationStageInstallationProducesExactSafeOrder(t *testing.T) {
+	packaged, err := BuildNetworkObservationStagePackage(networkObservationStagePackageConfig(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan, err := PlanNetworkObservationStageInstallation(packaged)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, _ := packaged.Receipt()
+	if plan.Format != NetworkObservationStageInstallationPlanFormat || plan.State != "VERIFIED" || plan.StageID != "network-observation" || plan.ObservationPackageDigest != receipt.PackageDigest || plan.Authority != "ok-mgmt" || plan.MutationAllowed {
+		t.Fatalf("unexpected network observation installation plan: %#v", plan)
+	}
+	wantKinds := []string{"ConfigMap", "NetworkPolicy", "Job"}
+	wantCollections := []string{
+		"/api/v1/namespaces/openkubes-execution-system/configmaps",
+		"/apis/networking.k8s.io/v1/namespaces/openkubes-execution-system/networkpolicies",
+		"/apis/batch/v1/namespaces/openkubes-execution-system/jobs",
+	}
+	if len(plan.Creates) != len(wantKinds) {
+		t.Fatalf("creates=%d, want 3", len(plan.Creates))
+	}
+	for index, create := range plan.Creates {
+		if create.Order != index+1 || create.Kind != wantKinds[index] || create.Namespace != submissionStageInputNamespace || create.PreflightMethod != "GET" || create.CreateMethod != "POST" || create.CollectionPath != wantCollections[index] || create.ObjectPath != create.CollectionPath+"/"+create.Name || !stageReceiptPrefixDigestPattern.MatchString(create.ObjectDigest) {
+			t.Fatalf("unexpected network observation create %d: %#v", index, create)
+		}
+		if strings.Contains(strings.ToLower(create.ObjectPath), "secret") {
+			t.Fatalf("installation plan unexpectedly contains credential path: %#v", create)
+		}
+	}
+	if plan.Creates[1].Name != plan.Creates[2].Name {
+		t.Fatal("NetworkPolicy and Job run identities differ")
+	}
+}
+
+func TestPlanNetworkObservationStageInstallationFailsClosed(t *testing.T) {
+	valid, err := BuildNetworkObservationStagePackage(networkObservationStagePackageConfig(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := PlanNetworkObservationStageInstallation(VerifiedNetworkObservationStagePackage{}); err == nil {
+		t.Fatal("unverified network observation package was planned")
+	}
+	tests := map[string]func(*VerifiedNetworkObservationStagePackage){
+		"wrong inventory": func(packaged *VerifiedNetworkObservationStagePackage) {
+			packaged.receipt.ObjectKinds = []string{"ConfigMap", "Job", "NetworkPolicy"}
+		},
+		"foreign authority": func(packaged *VerifiedNetworkObservationStagePackage) {
+			packaged.managementAuthority = "ok-infra"
+		},
+		"changed runtime": func(packaged *VerifiedNetworkObservationStagePackage) {
+			packaged.raw = bytes.Replace(packaged.raw, []byte("ok147-contract-executor-runtime"), []byte("ok147-foreign-runtime"), 1)
+			packaged.receipt.PackageDigest = digest.SHA256(packaged.raw)
+		},
+		"changed workload credential": func(packaged *VerifiedNetworkObservationStagePackage) {
+			packaged.raw = bytes.Replace(packaged.raw, []byte(packaged.workloadCredential), []byte("ok147-foreign-workload"), 1)
+			packaged.receipt.PackageDigest = digest.SHA256(packaged.raw)
+		},
+		"extra object": func(packaged *VerifiedNetworkObservationStagePackage) {
+			packaged.raw = append(packaged.raw, []byte("\n---\napiVersion: v1\nkind: Secret\nmetadata: {name: forbidden}\n")...)
+			packaged.receipt.PackageDigest = digest.SHA256(packaged.raw)
+		},
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			packaged := valid
+			packaged.raw = append([]byte(nil), valid.raw...)
+			packaged.receipt.ObjectKinds = append([]string(nil), valid.receipt.ObjectKinds...)
+			mutate(&packaged)
+			if _, err := PlanNetworkObservationStageInstallation(packaged); err == nil {
+				t.Fatal("changed network observation package was planned")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- add an offline exact-create installation plan for the sealed network-observation package
- verify package decomposition, per-object digests, create order, run identity, tokenless runtime, authority, and all three Secret mounts
- expose only exact GET/POST paths and object digests

## Boundaries

- no credentials are opened
- no Kubernetes request or object creation
- no mutation authority is represented by the plan

## Validation

- `git diff --check`
- `GOCACHE=/private/tmp/ok147-go-build-cache go test -ldflags=-linkmode=external ./...`
- `GOCACHE=/private/tmp/ok147-go-build-cache go vet ./...`
- `GOCACHE=/private/tmp/ok147-go-build-cache go test -race -ldflags=-linkmode=external ./internal/runner`

Jira: OK-147
