### PR TITLE
feat(runner): plan network observation launch (OK-147)

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -2011,6 +2011,15 @@ audiences, authority/digest identities and exact Secret-object digests; it
 contains no token, CA, endpoint, raw target UID, subject or source path. This
 primitive performs no TokenRequest, Secret installation or Kubernetes call.
 
+The tokenless runtime prerequisite and seven-object launch plan now close the
+offline launch geometry. One global preflight barrier covers the reusable
+runtime ServiceAccount, immutable input, NetworkPolicy, all three private
+Secrets and finally the Job. Only the runtime may already exist if its exact
+digest matches; every stage-specific object must be globally all absent or all
+exact before a later launcher may create anything. The Job is always last.
+The launch plan carries only package, credential and runtime digests plus exact
+GET/POST metadata and remains `MutationAllowed=false`.
+
 ## Bounded convergence observation polling
 
 The aggregate observer can now be wrapped by a bounded polling observer before

--- a/internal/runner/network_observation_stage_launch_plan.go
+++ b/internal/runner/network_observation_stage_launch_plan.go
@@ -1,0 +1,82 @@
+package runner
+
+import "errors"
+
+const NetworkObservationStageLaunchPlanFormat = "ok147-network-observation-stage-launch-plan/v1"
+
+// NetworkObservationStageLaunchPlan binds all seven exact objects needed for
+// one Job launch. It contains no object body or credential and grants no
+// mutation authority.
+type NetworkObservationStageLaunchPlan struct {
+	Format                   string                           `json:"format"`
+	State                    string                           `json:"state"`
+	StageID                  string                           `json:"stageId"`
+	Authority                string                           `json:"authority"`
+	ObservationPackageDigest string                           `json:"observationPackageDigest"`
+	CredentialPackageDigest  string                           `json:"credentialPackageDigest"`
+	RuntimeManifestDigest    string                           `json:"runtimeManifestDigest"`
+	PreflightBarrier         string                           `json:"preflightBarrier"`
+	Preflights               []SubmissionStageLaunchPreflight `json:"preflights"`
+	Creates                  []SubmissionStageLaunchCreate    `json:"creates"`
+	MutationAllowed          bool                             `json:"mutationAllowed"`
+}
+
+// PlanNetworkObservationStageLaunch accepts only a coherent package,
+// three-credential package and tokenless runtime prerequisite. Every GET must
+// pass before any create can be considered by a later launcher.
+func PlanNetworkObservationStageLaunch(packaged VerifiedNetworkObservationStagePackage, credentials VerifiedNetworkObservationStageCredentialPackage, runtime VerifiedNetworkObservationStageRuntimePrerequisite) (NetworkObservationStageLaunchPlan, error) {
+	stage, err := PlanNetworkObservationStageInstallation(packaged)
+	if err != nil {
+		return NetworkObservationStageLaunchPlan{}, err
+	}
+	if err := verifyNetworkObservationStageCredentialPackage(credentials); err != nil {
+		return NetworkObservationStageLaunchPlan{}, err
+	}
+	if err := verifyNetworkObservationStageRuntimePrerequisite(runtime); err != nil {
+		return NetworkObservationStageLaunchPlan{}, err
+	}
+	if stage.ObservationPackageDigest != credentials.receipt.ObservationPackageDigest || stage.ObservationPackageDigest != runtime.receipt.ObservationPackageDigest || stage.StageID != credentials.receipt.StageID || stage.Authority != credentials.installationAuthority || stage.Authority != runtime.receipt.Authority || credentials.receipt.WorkloadBindingDigest != packaged.receipt.WorkloadBindingDigest {
+		return NetworkObservationStageLaunchPlan{}, errors.New("network observation launch components do not share one verified identity")
+	}
+
+	preflights := make([]SubmissionStageLaunchPreflight, 0, 7)
+	creates := make([]SubmissionStageLaunchCreate, 0, 7)
+	appendObject := func(order int, phase, apiVersion, kind, namespace, name, objectPath, collectionPath, objectDigest, existingPolicy, createPolicy string) {
+		preflights = append(preflights, SubmissionStageLaunchPreflight{
+			Order: order, Phase: phase, APIVersion: apiVersion, Kind: kind, Namespace: namespace, Name: name,
+			Method: "GET", ObjectPath: objectPath, ResponseMode: "FULL_OBJECT", ExistingPolicy: existingPolicy,
+			ObjectDigest: objectDigest,
+		})
+		creates = append(creates, SubmissionStageLaunchCreate{
+			Order: order, Phase: phase, APIVersion: apiVersion, Kind: kind, Namespace: namespace, Name: name,
+			Method: "POST", CollectionPath: collectionPath, CreatePolicy: createPolicy, ObjectDigest: objectDigest,
+		})
+	}
+	runtimeCollection := "/api/v1/namespaces/" + runtime.receipt.Namespace + "/serviceaccounts"
+	appendObject(1, "runtime", "v1", "ServiceAccount", runtime.receipt.Namespace, runtime.receipt.Name,
+		runtimeCollection+"/"+runtime.receipt.Name, runtimeCollection, runtime.receipt.ObjectDigest,
+		"VERIFY_EXACT", "CREATE_IF_ABSENT_OR_VERIFY_EXISTING")
+	for index, object := range stage.Creates[:2] {
+		appendObject(index+2, "stage-prerequisites", object.APIVersion, object.Kind, object.Namespace, object.Name,
+			object.ObjectPath, object.CollectionPath, object.ObjectDigest,
+			"VERIFY_EXACT_GLOBAL_STATE", "CREATE_ONLY_AFTER_GLOBAL_ABSENCE")
+	}
+	for index, object := range credentials.objects {
+		collection := "/api/v1/namespaces/" + submissionStageInputNamespace + "/secrets"
+		appendObject(index+4, "credentials", "v1", "Secret", submissionStageInputNamespace, object.name,
+			collection+"/"+object.name, collection, credentials.receipt.Credentials[index].ObjectDigest,
+			"VERIFY_EXACT_GLOBAL_STATE", "CREATE_ONLY_AFTER_GLOBAL_ABSENCE")
+	}
+	job := stage.Creates[2]
+	appendObject(7, "job", job.APIVersion, job.Kind, job.Namespace, job.Name,
+		job.ObjectPath, job.CollectionPath, job.ObjectDigest,
+		"VERIFY_EXACT_GLOBAL_STATE", "CREATE_ONLY_AFTER_GLOBAL_ABSENCE")
+
+	return NetworkObservationStageLaunchPlan{
+		Format: NetworkObservationStageLaunchPlanFormat, State: "VERIFIED", StageID: stage.StageID,
+		Authority: stage.Authority, ObservationPackageDigest: stage.ObservationPackageDigest,
+		CredentialPackageDigest: credentials.receipt.PackageDigest, RuntimeManifestDigest: runtime.receipt.ManifestDigest,
+		PreflightBarrier: "ALL_ABSENT_OR_RUNTIME_ONLY_OR_ALL_EXACT", Preflights: preflights, Creates: creates,
+		MutationAllowed: false,
+	}, nil
+}

--- a/internal/runner/network_observation_stage_launch_plan_test.go
+++ b/internal/runner/network_observation_stage_launch_plan_test.go
@@ -1,0 +1,99 @@
+package runner
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+func TestPlanNetworkObservationStageLaunchBindsSevenObjectsBehindOneBarrier(t *testing.T) {
+	stage, credentials, runtime, tokens := networkObservationStageLaunchFixture(t)
+	plan, err := PlanNetworkObservationStageLaunch(stage, credentials, runtime)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stageReceipt, _ := stage.Receipt()
+	credentialReceipt, _ := credentials.Receipt()
+	runtimeReceipt, _ := runtime.Receipt()
+	if plan.Format != NetworkObservationStageLaunchPlanFormat || plan.State != "VERIFIED" || plan.StageID != "network-observation" || plan.Authority != "ok-mgmt" || plan.ObservationPackageDigest != stageReceipt.PackageDigest || plan.CredentialPackageDigest != credentialReceipt.PackageDigest || plan.RuntimeManifestDigest != runtimeReceipt.ManifestDigest || plan.PreflightBarrier != "ALL_ABSENT_OR_RUNTIME_ONLY_OR_ALL_EXACT" || plan.MutationAllowed {
+		t.Fatalf("unexpected network observation launch identity: %#v", plan)
+	}
+	wantKinds := []string{"ServiceAccount", "ConfigMap", "NetworkPolicy", "Secret", "Secret", "Secret", "Job"}
+	wantPhases := []string{"runtime", "stage-prerequisites", "stage-prerequisites", "credentials", "credentials", "credentials", "job"}
+	if len(plan.Preflights) != len(wantKinds) || len(plan.Creates) != len(wantKinds) {
+		t.Fatalf("unexpected launch object count: %d %d", len(plan.Preflights), len(plan.Creates))
+	}
+	for index := range wantKinds {
+		preflight, create := plan.Preflights[index], plan.Creates[index]
+		if preflight.Order != index+1 || create.Order != index+1 || preflight.Phase != wantPhases[index] || create.Phase != wantPhases[index] || preflight.Kind != wantKinds[index] || create.Kind != wantKinds[index] || preflight.Name != create.Name || preflight.Namespace != create.Namespace || preflight.ObjectDigest != create.ObjectDigest || preflight.Method != "GET" || create.Method != "POST" || preflight.ResponseMode != "FULL_OBJECT" {
+			t.Fatalf("network observation launch step %d differs: %#v %#v", index+1, preflight, create)
+		}
+		if index == 0 {
+			if preflight.ExistingPolicy != "VERIFY_EXACT" || create.CreatePolicy != "CREATE_IF_ABSENT_OR_VERIFY_EXISTING" {
+				t.Fatalf("runtime policy differs: %#v %#v", preflight, create)
+			}
+		} else if preflight.ExistingPolicy != "VERIFY_EXACT_GLOBAL_STATE" || create.CreatePolicy != "CREATE_ONLY_AFTER_GLOBAL_ABSENCE" {
+			t.Fatalf("global policy differs at %d: %#v %#v", index+1, preflight, create)
+		}
+	}
+	public, err := json.Marshal(plan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range append(tokens, credentials.objects[0].raw, credentials.objects[1].raw, credentials.objects[2].raw, runtime.raw, stage.raw) {
+		if bytes.Contains(public, forbidden) {
+			t.Fatal("network observation launch plan exposed private object content")
+		}
+	}
+}
+
+func TestPlanNetworkObservationStageLaunchRejectsMismatchedComponents(t *testing.T) {
+	stage, credentials, runtime, _ := networkObservationStageLaunchFixture(t)
+	tests := map[string]func() (VerifiedNetworkObservationStagePackage, VerifiedNetworkObservationStageCredentialPackage, VerifiedNetworkObservationStageRuntimePrerequisite){
+		"empty stage": func() (VerifiedNetworkObservationStagePackage, VerifiedNetworkObservationStageCredentialPackage, VerifiedNetworkObservationStageRuntimePrerequisite) {
+			return VerifiedNetworkObservationStagePackage{}, credentials, runtime
+		},
+		"empty credentials": func() (VerifiedNetworkObservationStagePackage, VerifiedNetworkObservationStageCredentialPackage, VerifiedNetworkObservationStageRuntimePrerequisite) {
+			return stage, VerifiedNetworkObservationStageCredentialPackage{}, runtime
+		},
+		"empty runtime": func() (VerifiedNetworkObservationStagePackage, VerifiedNetworkObservationStageCredentialPackage, VerifiedNetworkObservationStageRuntimePrerequisite) {
+			return stage, credentials, VerifiedNetworkObservationStageRuntimePrerequisite{}
+		},
+		"foreign credential package": func() (VerifiedNetworkObservationStagePackage, VerifiedNetworkObservationStageCredentialPackage, VerifiedNetworkObservationStageRuntimePrerequisite) {
+			changed := credentials
+			changed.receipt.ObservationPackageDigest = digest.SHA256([]byte("foreign"))
+			return stage, changed, runtime
+		},
+		"foreign runtime package": func() (VerifiedNetworkObservationStagePackage, VerifiedNetworkObservationStageCredentialPackage, VerifiedNetworkObservationStageRuntimePrerequisite) {
+			changed := runtime
+			changed.receipt.ObservationPackageDigest = digest.SHA256([]byte("foreign"))
+			return stage, credentials, changed
+		},
+	}
+	for name, values := range tests {
+		t.Run(name, func(t *testing.T) {
+			candidateStage, candidateCredentials, candidateRuntime := values()
+			if _, err := PlanNetworkObservationStageLaunch(candidateStage, candidateCredentials, candidateRuntime); err == nil {
+				t.Fatal("mismatched network observation launch components accepted")
+			}
+		})
+	}
+}
+
+func networkObservationStageLaunchFixture(t *testing.T) (VerifiedNetworkObservationStagePackage, VerifiedNetworkObservationStageCredentialPackage, VerifiedNetworkObservationStageRuntimePrerequisite, [][]byte) {
+	t.Helper()
+	credentialConfig, tokens := networkObservationCredentialConfig(t)
+	stage := credentialConfig.Package
+	credentials, err := BuildNetworkObservationStageCredentialPackage(credentialConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest := submissionStageRuntimeManifest(t)
+	runtime, err := BuildNetworkObservationStageRuntimePrerequisite(stage, manifest, digest.SHA256(manifest))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return stage, credentials, runtime, tokens
+}

--- a/internal/runner/network_observation_stage_runtime.go
+++ b/internal/runner/network_observation_stage_runtime.go
@@ -1,0 +1,61 @@
+package runner
+
+import (
+	"errors"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+const NetworkObservationStageRuntimePrerequisiteFormat = "ok147-network-observation-stage-runtime-prerequisite/v1"
+
+type NetworkObservationStageRuntimePrerequisiteReceipt struct {
+	Format                   string `json:"format"`
+	State                    string `json:"state"`
+	ObservationPackageDigest string `json:"observationPackageDigest"`
+	ManifestDigest           string `json:"manifestDigest"`
+	ObjectDigest             string `json:"objectDigest"`
+	Authority                string `json:"authority"`
+	Namespace                string `json:"namespace"`
+	Name                     string `json:"name"`
+	MutationAllowed          bool   `json:"mutationAllowed"`
+}
+
+type VerifiedNetworkObservationStageRuntimePrerequisite struct {
+	raw      []byte
+	receipt  NetworkObservationStageRuntimePrerequisiteReceipt
+	verified bool
+}
+
+// BuildNetworkObservationStageRuntimePrerequisite binds the shared tokenless
+// runtime ServiceAccount to one exact network-observation package offline.
+func BuildNetworkObservationStageRuntimePrerequisite(packaged VerifiedNetworkObservationStagePackage, manifest []byte, expectedDigest string) (VerifiedNetworkObservationStageRuntimePrerequisite, error) {
+	plan, err := PlanNetworkObservationStageInstallation(packaged)
+	if err != nil {
+		return VerifiedNetworkObservationStageRuntimePrerequisite{}, err
+	}
+	raw, objectDigest, err := buildStageRuntimePrerequisiteObject(manifest, expectedDigest)
+	if err != nil {
+		return VerifiedNetworkObservationStageRuntimePrerequisite{}, err
+	}
+	receipt := NetworkObservationStageRuntimePrerequisiteReceipt{
+		Format: NetworkObservationStageRuntimePrerequisiteFormat, State: "VERIFIED",
+		ObservationPackageDigest: plan.ObservationPackageDigest, ManifestDigest: expectedDigest,
+		ObjectDigest: objectDigest, Authority: plan.Authority,
+		Namespace: submissionStageInputNamespace, Name: "ok147-contract-executor-runtime", MutationAllowed: false,
+	}
+	return VerifiedNetworkObservationStageRuntimePrerequisite{raw: raw, receipt: receipt, verified: true}, nil
+}
+
+func (runtime VerifiedNetworkObservationStageRuntimePrerequisite) Receipt() (NetworkObservationStageRuntimePrerequisiteReceipt, error) {
+	if err := verifyNetworkObservationStageRuntimePrerequisite(runtime); err != nil {
+		return NetworkObservationStageRuntimePrerequisiteReceipt{}, err
+	}
+	return runtime.receipt, nil
+}
+
+func verifyNetworkObservationStageRuntimePrerequisite(runtime VerifiedNetworkObservationStageRuntimePrerequisite) error {
+	if !runtime.verified || runtime.receipt.Format != NetworkObservationStageRuntimePrerequisiteFormat || runtime.receipt.State != "VERIFIED" || runtime.receipt.Authority == "" || runtime.receipt.Namespace != submissionStageInputNamespace || runtime.receipt.Name != "ok147-contract-executor-runtime" || runtime.receipt.MutationAllowed || !stageReceiptPrefixDigestPattern.MatchString(runtime.receipt.ObservationPackageDigest) || !stageReceiptPrefixDigestPattern.MatchString(runtime.receipt.ManifestDigest) || digest.SHA256(runtime.raw) != runtime.receipt.ObjectDigest {
+		return errors.New("network observation runtime prerequisite was not produced by verification")
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

- bind the shared tokenless runtime ServiceAccount to the exact network-observation package
- add a seven-object launch plan covering runtime, public prerequisites, three private credentials, and Job-last ordering
- require one global absence/exactness barrier before a later launcher may create anything

## Boundaries

- offline planning only
- no object bodies, credential bytes, Kubernetes contact, or mutation authority in the plan
- `MutationAllowed=false`

## Validation

- `git diff --check`
- `GOCACHE=/private/tmp/ok147-go-build-cache go test -ldflags=-linkmode=external ./...`
- `GOCACHE=/private/tmp/ok147-go-build-cache go vet ./...`
- `GOCACHE=/private/tmp/ok147-go-build-cache go test -race -ldflags=-linkmode=external ./internal/runner`

Jira: OK-147
