### PR TITLE
feat(runner): seal network observation launch material (OK-147)

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -2028,6 +2028,14 @@ private; the public candidate exposes only their digests and remains
 `MutationAllowed=false`. Candidate preparation reads no credential and makes
 no API request.
 
+The complete launch material now reconstructs and re-verifies the package,
+three private credentials, tokenless runtime and time-bounded candidate from
+their independently bound local sources. The resulting value retains all
+private bytes internally but exposes only a redaction-safe receipt and the
+candidate receipt. Any changed package, credential, runtime, candidate or
+cross-component digest invalidates the material. Construction remains offline
+and grants no launch authority.
+
 ## Bounded convergence observation polling
 
 The aggregate observer can now be wrapped by a bounded polling observer before

--- a/internal/runner/network_observation_stage_credentials_test.go
+++ b/internal/runner/network_observation_stage_credentials_test.go
@@ -131,6 +131,12 @@ func TestBuildNetworkObservationStageCredentialPackageFailsClosed(t *testing.T) 
 
 func networkObservationCredentialConfig(t *testing.T) (NetworkObservationStageCredentialPackageConfig, [][]byte) {
 	t.Helper()
+	config, _, tokens := networkObservationCredentialInputs(t)
+	return config, tokens
+}
+
+func networkObservationCredentialInputs(t *testing.T) (NetworkObservationStageCredentialPackageConfig, NetworkObservationStagePackageConfig, [][]byte) {
+	t.Helper()
 	now := time.Date(2026, 8, 16, 12, 0, 0, 0, time.UTC)
 	issuedAt, expiresAt := now.Add(-time.Minute), now.Add(30*time.Minute)
 	audiences := []string{"https://kubernetes.default.svc"}
@@ -193,5 +199,5 @@ func networkObservationCredentialConfig(t *testing.T) (NetworkObservationStageCr
 		Ledger:             source("ok-mgmt", tokenPaths[0], subjects[0], "1", managementCAPath, tokens[0], managementCA),
 		ManagementObserver: source("ok-mgmt", tokenPaths[1], subjects[1], "2", managementCAPath, tokens[1], managementCA),
 		WorkloadObserver:   source(digest.SHA256([]byte(binding.TargetClusterUID)), tokenPaths[2], subjects[2], "3", workloadCAPath, tokens[2], workloadCA),
-	}, tokens
+	}, packageConfig, tokens
 }

--- a/internal/runner/network_observation_stage_launch_material.go
+++ b/internal/runner/network_observation_stage_launch_material.go
@@ -1,0 +1,118 @@
+package runner
+
+import (
+	"errors"
+	"time"
+)
+
+const NetworkObservationStageLaunchMaterialFormat = "ok147-network-observation-stage-launch-material/v1"
+
+type NetworkObservationStageLaunchMaterialConfig struct {
+	Package               NetworkObservationStagePackageConfig
+	MaterializationTime   time.Time
+	Ledger                SubmissionStageCredentialSource
+	ManagementObserver    SubmissionStageCredentialSource
+	WorkloadObserver      SubmissionStageCredentialSource
+	RuntimeManifest       []byte
+	RuntimeManifestDigest string
+	Candidate             SubmissionStageLaunchCandidateConfig
+}
+
+type NetworkObservationStageLaunchMaterialReceipt struct {
+	Format                   string `json:"format"`
+	State                    string `json:"state"`
+	StageID                  string `json:"stageId"`
+	Authority                string `json:"authority"`
+	ObservationPackageDigest string `json:"observationPackageDigest"`
+	CredentialPackageDigest  string `json:"credentialPackageDigest"`
+	RuntimeManifestDigest    string `json:"runtimeManifestDigest"`
+	LaunchPlanDigest         string `json:"launchPlanDigest"`
+	CandidateDigest          string `json:"candidateDigest"`
+	ValidUntil               string `json:"validUntil"`
+	MutationAllowed          bool   `json:"mutationAllowed"`
+}
+
+// VerifiedNetworkObservationStageLaunchMaterial retains every exact private
+// object, credential and candidate needed by a later launcher while exposing
+// only redaction-safe receipts.
+type VerifiedNetworkObservationStageLaunchMaterial struct {
+	packaged    VerifiedNetworkObservationStagePackage
+	credentials VerifiedNetworkObservationStageCredentialPackage
+	runtime     VerifiedNetworkObservationStageRuntimePrerequisite
+	candidate   VerifiedNetworkObservationStageLaunchCandidate
+	receipt     NetworkObservationStageLaunchMaterialReceipt
+	verified    bool
+}
+
+// BuildNetworkObservationStageLaunchMaterial reconstructs and re-verifies the
+// complete private launch input from bounded local sources. It performs no API
+// request and grants no launch authority.
+func BuildNetworkObservationStageLaunchMaterial(config NetworkObservationStageLaunchMaterialConfig) (VerifiedNetworkObservationStageLaunchMaterial, error) {
+	packaged, err := BuildNetworkObservationStagePackage(config.Package)
+	if err != nil {
+		return VerifiedNetworkObservationStageLaunchMaterial{}, err
+	}
+	credentials, err := BuildNetworkObservationStageCredentialPackage(NetworkObservationStageCredentialPackageConfig{
+		Package: packaged, MaterializationTime: config.MaterializationTime,
+		WorkloadBindingPath: config.Package.WorkloadBindingPath,
+		Ledger:              config.Ledger, ManagementObserver: config.ManagementObserver, WorkloadObserver: config.WorkloadObserver,
+	})
+	if err != nil {
+		return VerifiedNetworkObservationStageLaunchMaterial{}, err
+	}
+	runtime, err := BuildNetworkObservationStageRuntimePrerequisite(packaged, config.RuntimeManifest, config.RuntimeManifestDigest)
+	if err != nil {
+		return VerifiedNetworkObservationStageLaunchMaterial{}, err
+	}
+	candidate, err := PrepareNetworkObservationStageLaunchCandidate(config.Candidate, packaged, credentials, runtime)
+	if err != nil {
+		return VerifiedNetworkObservationStageLaunchMaterial{}, err
+	}
+	candidateReceipt, err := candidate.Receipt()
+	if err != nil {
+		return VerifiedNetworkObservationStageLaunchMaterial{}, err
+	}
+	receipt := NetworkObservationStageLaunchMaterialReceipt{
+		Format: NetworkObservationStageLaunchMaterialFormat, State: "VERIFIED", StageID: candidateReceipt.StageID,
+		Authority: candidateReceipt.Authority, ObservationPackageDigest: candidateReceipt.ObservationPackageDigest,
+		CredentialPackageDigest: candidateReceipt.CredentialPackageDigest, RuntimeManifestDigest: candidateReceipt.RuntimeManifestDigest,
+		LaunchPlanDigest: candidateReceipt.LaunchPlanDigest, CandidateDigest: candidateReceipt.CandidateDigest,
+		ValidUntil: candidateReceipt.ValidUntil, MutationAllowed: false,
+	}
+	return VerifiedNetworkObservationStageLaunchMaterial{
+		packaged: packaged, credentials: credentials, runtime: runtime, candidate: candidate,
+		receipt: receipt, verified: true,
+	}, nil
+}
+
+func (material VerifiedNetworkObservationStageLaunchMaterial) Receipt() (NetworkObservationStageLaunchMaterialReceipt, error) {
+	if err := verifyNetworkObservationStageLaunchMaterial(material); err != nil {
+		return NetworkObservationStageLaunchMaterialReceipt{}, err
+	}
+	return material.receipt, nil
+}
+
+func (material VerifiedNetworkObservationStageLaunchMaterial) CandidateReceipt() (NetworkObservationStageLaunchCandidateReceipt, error) {
+	if err := verifyNetworkObservationStageLaunchMaterial(material); err != nil {
+		return NetworkObservationStageLaunchCandidateReceipt{}, err
+	}
+	return material.candidate.Receipt()
+}
+
+func verifyNetworkObservationStageLaunchMaterial(material VerifiedNetworkObservationStageLaunchMaterial) error {
+	if !material.verified || material.receipt.Format != NetworkObservationStageLaunchMaterialFormat || material.receipt.State != "VERIFIED" || material.receipt.MutationAllowed {
+		return errors.New("network observation launch material was not produced by verification")
+	}
+	plan, err := PlanNetworkObservationStageLaunch(material.packaged, material.credentials, material.runtime)
+	if err != nil {
+		return err
+	}
+	candidateReceipt, err := material.candidate.Receipt()
+	if err != nil {
+		return err
+	}
+	if material.receipt.StageID != plan.StageID || material.receipt.Authority != plan.Authority || material.receipt.ObservationPackageDigest != plan.ObservationPackageDigest || material.receipt.CredentialPackageDigest != plan.CredentialPackageDigest || material.receipt.RuntimeManifestDigest != plan.RuntimeManifestDigest || material.receipt.StageID != candidateReceipt.StageID || material.receipt.Authority != candidateReceipt.Authority || material.receipt.ObservationPackageDigest != candidateReceipt.ObservationPackageDigest || material.receipt.CredentialPackageDigest != candidateReceipt.CredentialPackageDigest || material.receipt.RuntimeManifestDigest != candidateReceipt.RuntimeManifestDigest || material.receipt.LaunchPlanDigest != candidateReceipt.LaunchPlanDigest || material.receipt.CandidateDigest != candidateReceipt.CandidateDigest || material.receipt.ValidUntil != candidateReceipt.ValidUntil {
+		return errors.New("network observation launch material identity changed after verification")
+	}
+	return nil
+}

--- a/internal/runner/network_observation_stage_launch_material_test.go
+++ b/internal/runner/network_observation_stage_launch_material_test.go
@@ -1,0 +1,87 @@
+package runner
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+func TestBuildNetworkObservationStageLaunchMaterialSealsPrivateComponents(t *testing.T) {
+	config, tokens := networkObservationStageLaunchMaterialConfig(t)
+	material, err := BuildNetworkObservationStageLaunchMaterial(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := material.Receipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	candidate, err := material.CandidateReceipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if receipt.Format != NetworkObservationStageLaunchMaterialFormat || receipt.State != "VERIFIED" || receipt.StageID != "network-observation" || receipt.Authority != "ok-mgmt" || receipt.ObservationPackageDigest != candidate.ObservationPackageDigest || receipt.CandidateDigest != candidate.CandidateDigest || receipt.ValidUntil != candidate.ValidUntil || receipt.MutationAllowed {
+		t.Fatalf("unexpected network observation launch material: %#v", receipt)
+	}
+	public, err := json.Marshal(receipt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range append(tokens, material.packaged.raw, material.credentials.objects[0].raw, material.credentials.objects[1].raw, material.credentials.objects[2].raw, material.runtime.raw, []byte(config.Candidate.AuthorityEndpoint), []byte(config.Candidate.InstallerTokenDigest)) {
+		if bytes.Contains(public, forbidden) {
+			t.Fatal("network launch material receipt exposed private source content")
+		}
+	}
+	changed := material
+	changed.receipt.CandidateDigest = digest.SHA256([]byte("foreign"))
+	if _, err := changed.Receipt(); err == nil {
+		t.Fatal("changed network launch material identity accepted")
+	}
+	changed = material
+	changed.credentials.objects[2].raw = append(changed.credentials.objects[2].raw, '\n')
+	if _, err := changed.Receipt(); err == nil {
+		t.Fatal("changed private workload credential accepted")
+	}
+}
+
+func TestBuildNetworkObservationStageLaunchMaterialFailsClosed(t *testing.T) {
+	valid, _ := networkObservationStageLaunchMaterialConfig(t)
+	for name, mutate := range map[string]func(*NetworkObservationStageLaunchMaterialConfig){
+		"wrong runtime digest": func(config *NetworkObservationStageLaunchMaterialConfig) {
+			config.RuntimeManifestDigest = digest.SHA256([]byte("foreign"))
+		},
+		"foreign workload token": func(config *NetworkObservationStageLaunchMaterialConfig) {
+			config.WorkloadObserver.AuthorityIdentity = digest.SHA256([]byte("foreign"))
+		},
+		"expired candidate": func(config *NetworkObservationStageLaunchMaterialConfig) {
+			config.Candidate.PreparedAt = config.MaterializationTime.Add(16 * time.Minute)
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			config := valid
+			mutate(&config)
+			if _, err := BuildNetworkObservationStageLaunchMaterial(config); err == nil {
+				t.Fatal("invalid network observation launch material accepted")
+			}
+		})
+	}
+	if _, err := (VerifiedNetworkObservationStageLaunchMaterial{}).Receipt(); err == nil {
+		t.Fatal("unverified network launch material receipt exposed")
+	}
+}
+
+func networkObservationStageLaunchMaterialConfig(t *testing.T) (NetworkObservationStageLaunchMaterialConfig, [][]byte) {
+	t.Helper()
+	credentialConfig, packageConfig, tokens := networkObservationCredentialInputs(t)
+	manifest := submissionStageRuntimeManifest(t)
+	return NetworkObservationStageLaunchMaterialConfig{
+		Package: packageConfig, MaterializationTime: credentialConfig.MaterializationTime,
+		Ledger: credentialConfig.Ledger, ManagementObserver: credentialConfig.ManagementObserver,
+		WorkloadObserver: credentialConfig.WorkloadObserver,
+		RuntimeManifest:  manifest, RuntimeManifestDigest: digest.SHA256(manifest),
+		Candidate: submissionStageLaunchCandidateConfig(),
+	}, tokens
+}


### PR DESCRIPTION
## Summary

- add sealed private launch material for the network-observation stage
- reconstruct and reverify the package, three credentials, tokenless runtime, launch plan, and time-bounded candidate
- expose only redaction-safe material and candidate receipts

## Boundaries

- bounded local file reads only
- no Kubernetes request, credential exposure, or launch authority
- any cross-component identity change invalidates the material

## Validation

- `git diff --check`
- `GOCACHE=/private/tmp/ok147-go-build-cache go test -ldflags=-linkmode=external ./...`
- `GOCACHE=/private/tmp/ok147-go-build-cache go vet ./...`
- `GOCACHE=/private/tmp/ok147-go-build-cache go test -race -ldflags=-linkmode=external ./internal/runner`

Jira: OK-147
