### PR TITLE
feat(runner): verify network observation install material (OK-147)

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -2036,6 +2036,14 @@ candidate receipt. Any changed package, credential, runtime, candidate or
 cross-component digest invalidates the material. Construction remains offline
 and grants no launch authority.
 
+Before HTTP execution, a private installation-material boundary re-decodes the
+three public YAML objects and all three Secret objects and proves that their
+canonical bodies still match the launch-plan digests. It additionally enforces
+that only the workload credential contains `binding.json` and rechecks that
+binding's semantic digest, target-UID digest and CA identity. Callers receive
+defensive copies only. No API is contacted and no installer credential is
+opened at this boundary.
+
 ## Bounded convergence observation polling
 
 The aggregate observer can now be wrapped by a bounded polling observer before

--- a/internal/runner/network_observation_stage_install_material.go
+++ b/internal/runner/network_observation_stage_install_material.go
@@ -1,0 +1,111 @@
+package runner
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"io"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/jsonstrict"
+	"gopkg.in/yaml.v3"
+)
+
+// prepareNetworkObservationStageInstallation recovers the exact three public
+// object bodies retained by a verified package and rechecks every plan digest.
+func prepareNetworkObservationStageInstallation(packaged VerifiedNetworkObservationStagePackage) (NetworkObservationStageInstallationPlan, []submissionStageInstallObject, error) {
+	plan, err := PlanNetworkObservationStageInstallation(packaged)
+	if err != nil {
+		return NetworkObservationStageInstallationPlan{}, nil, err
+	}
+	decoder := yaml.NewDecoder(bytes.NewReader(packaged.raw))
+	objects := make([]submissionStageInstallObject, 0, len(plan.Creates))
+	for index := range plan.Creates {
+		var value map[string]any
+		if err := decoder.Decode(&value); err != nil || len(value) == 0 {
+			return NetworkObservationStageInstallationPlan{}, nil, errors.New("decode network observation installation object")
+		}
+		raw, err := json.Marshal(value)
+		if err != nil || digest.SHA256(raw) != plan.Creates[index].ObjectDigest {
+			return NetworkObservationStageInstallationPlan{}, nil, errors.New("network observation installation object differs from plan")
+		}
+		objects = append(objects, submissionStageInstallObject{plan: plan.Creates[index], raw: raw})
+	}
+	var trailing map[string]any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		return NetworkObservationStageInstallationPlan{}, nil, errors.New("network observation installation contains trailing object")
+	}
+	return plan, objects, nil
+}
+
+// prepareNetworkObservationStageCredentialInstallation recovers the exact
+// private Secret bodies and validates their semantic data once more. Only the
+// workload Secret may contain the package-bound private binding.
+func prepareNetworkObservationStageCredentialInstallation(packaged VerifiedNetworkObservationStageCredentialPackage) (NetworkObservationStageCredentialPackageReceipt, []submissionStageCredentialInstallObject, error) {
+	if err := verifyNetworkObservationStageCredentialPackage(packaged); err != nil {
+		return NetworkObservationStageCredentialPackageReceipt{}, nil, err
+	}
+	objects := make([]submissionStageCredentialInstallObject, 0, 3)
+	for index, private := range packaged.objects {
+		public := packaged.receipt.Credentials[index]
+		var secret map[string]any
+		if err := jsonstrict.Decode(private.raw, &secret); err != nil {
+			return NetworkObservationStageCredentialPackageReceipt{}, nil, errors.New("network observation credential object is invalid JSON")
+		}
+		metadata, _ := secret["metadata"].(map[string]any)
+		labels, _ := metadata["labels"].(map[string]any)
+		annotations, _ := metadata["annotations"].(map[string]any)
+		data, _ := secret["data"].(map[string]any)
+		expectedDataCount := 2
+		if index == 2 {
+			expectedDataCount = 3
+		}
+		if secret["apiVersion"] != "v1" || secret["kind"] != "Secret" || secret["immutable"] != true || secret["type"] != "Opaque" || metadata["name"] != private.name || metadata["namespace"] != submissionStageInputNamespace || labels["openkubes.io/stage-id"] != packaged.receipt.StageID || labels["openkubes.io/credential-role"] != private.role || annotations["openkubes.io/authority-identity"] != private.authority || annotations["openkubes.io/expires-at"] != public.ExpiresAt || len(data) != expectedDataCount {
+			return NetworkObservationStageCredentialPackageReceipt{}, nil, errors.New("network observation credential Secret semantics changed")
+		}
+		tokenEncoded, tokenOK := data["token"].(string)
+		caEncoded, caOK := data["ca.crt"].(string)
+		token, tokenErr := base64.StdEncoding.DecodeString(tokenEncoded)
+		ca, caErr := base64.StdEncoding.DecodeString(caEncoded)
+		expiresAt, timeErr := time.Parse(time.RFC3339, public.ExpiresAt)
+		if !tokenOK || !caOK || tokenErr != nil || caErr != nil || len(token) == 0 || len(ca) == 0 || timeErr != nil || digest.SHA256(ca) != public.CABundleDigest {
+			return NetworkObservationStageCredentialPackageReceipt{}, nil, errors.New("network observation credential Secret data changed")
+		}
+		if index < 2 {
+			if data["binding.json"] != nil {
+				return NetworkObservationStageCredentialPackageReceipt{}, nil, errors.New("management-side network credential contains a workload binding")
+			}
+		} else if err := verifyNetworkObservationCredentialBinding(data, packaged.receipt.WorkloadBindingDigest, packaged.workloadAuthority, public.CABundleDigest); err != nil {
+			return NetworkObservationStageCredentialPackageReceipt{}, nil, err
+		}
+		collection := "/api/v1/namespaces/" + submissionStageInputNamespace + "/secrets"
+		objects = append(objects, submissionStageCredentialInstallObject{
+			order: index + 4, role: private.role, authority: private.authority, name: private.name,
+			objectPath: collection + "/" + private.name, collectionPath: collection,
+			objectDigest: public.ObjectDigest, expiresAt: expiresAt, raw: append([]byte(nil), private.raw...), token: token,
+		})
+	}
+	return packaged.receipt, objects, nil
+}
+
+func verifyNetworkObservationCredentialBinding(data map[string]any, expectedDigest, expectedAuthority, expectedCA string) error {
+	bindingEncoded, ok := data["binding.json"].(string)
+	if !ok {
+		return errors.New("network observation workload credential binding is missing")
+	}
+	bindingRaw, err := base64.StdEncoding.DecodeString(bindingEncoded)
+	if err != nil {
+		return errors.New("network observation workload credential binding encoding is invalid")
+	}
+	var binding WorkloadAuthorityBinding
+	if err := jsonstrict.Decode(bindingRaw, &binding); err != nil {
+		return errors.New("network observation workload credential binding is invalid")
+	}
+	bindingDigest, err := WorkloadAuthorityBindingDigest(binding)
+	if err != nil || bindingDigest != expectedDigest || digest.SHA256([]byte(binding.TargetClusterUID)) != expectedAuthority || binding.CABundleDigest != expectedCA {
+		return errors.New("network observation workload credential binding identity changed")
+	}
+	return nil
+}

--- a/internal/runner/network_observation_stage_install_material_test.go
+++ b/internal/runner/network_observation_stage_install_material_test.go
@@ -1,0 +1,91 @@
+package runner
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+func TestPrepareNetworkObservationStageInstallationRecoversExactObjects(t *testing.T) {
+	stage, _, _, _ := networkObservationStageLaunchFixture(t)
+	plan, objects, err := prepareNetworkObservationStageInstallation(stage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(objects) != 3 || len(plan.Creates) != 3 {
+		t.Fatalf("unexpected network installation material count: %d %d", len(objects), len(plan.Creates))
+	}
+	for index, object := range objects {
+		if object.plan != plan.Creates[index] || digest.SHA256(object.raw) != plan.Creates[index].ObjectDigest {
+			t.Fatalf("network installation object %d differs", index)
+		}
+	}
+	objects[0].raw[0] = 'x'
+	_, again, err := prepareNetworkObservationStageInstallation(stage)
+	if err != nil || again[0].raw[0] == 'x' {
+		t.Fatal("caller mutated retained network installation material")
+	}
+}
+
+func TestPrepareNetworkObservationStageCredentialInstallationRecoversThreeSecrets(t *testing.T) {
+	_, credentials, _, tokens := networkObservationStageLaunchFixture(t)
+	receipt, objects, err := prepareNetworkObservationStageCredentialInstallation(credentials)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(objects) != 3 || len(receipt.Credentials) != 3 {
+		t.Fatalf("unexpected network credential material count: %d %d", len(objects), len(receipt.Credentials))
+	}
+	for index, object := range objects {
+		if object.order != index+4 || object.role != receipt.Credentials[index].Role || object.authority != receipt.Credentials[index].Authority || object.name != receipt.Credentials[index].Name || object.objectDigest != receipt.Credentials[index].ObjectDigest || digest.SHA256(object.raw) != object.objectDigest || string(object.token) != string(tokens[index]) {
+			t.Fatalf("network credential installation object %d differs: %#v", index, object)
+		}
+		var secret map[string]any
+		if err := json.Unmarshal(object.raw, &secret); err != nil {
+			t.Fatal(err)
+		}
+		data := secret["data"].(map[string]any)
+		_, hasBinding := data["binding.json"]
+		if hasBinding != (index == 2) {
+			t.Fatalf("network credential %d binding presence differs", index)
+		}
+	}
+	objects[2].raw[0] = 'x'
+	_, again, err := prepareNetworkObservationStageCredentialInstallation(credentials)
+	if err != nil || again[2].raw[0] == 'x' {
+		t.Fatal("caller mutated retained private network credentials")
+	}
+}
+
+func TestPrepareNetworkObservationStageCredentialInstallationRejectsChangedBinding(t *testing.T) {
+	_, credentials, _, _ := networkObservationStageLaunchFixture(t)
+	var secret map[string]any
+	if err := json.Unmarshal(credentials.objects[2].raw, &secret); err != nil {
+		t.Fatal(err)
+	}
+	data := secret["data"].(map[string]any)
+	bindingRaw, err := base64.StdEncoding.DecodeString(data["binding.json"].(string))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var binding WorkloadAuthorityBinding
+	if err := json.Unmarshal(bindingRaw, &binding); err != nil {
+		t.Fatal(err)
+	}
+	binding.Endpoint = "https://192.0.2.99:6443"
+	changed, err := json.Marshal(binding)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data["binding.json"] = base64.StdEncoding.EncodeToString(changed)
+	credentials.objects[2].raw, err = json.Marshal(secret)
+	if err != nil {
+		t.Fatal(err)
+	}
+	credentials.receipt.Credentials[2].ObjectDigest = digest.SHA256(credentials.objects[2].raw)
+	if _, _, err := prepareNetworkObservationStageCredentialInstallation(credentials); err == nil {
+		t.Fatal("changed private workload binding was accepted")
+	}
+}


### PR DESCRIPTION
## Summary

- re-materialize the exact public and private object bodies behind the network-observation launch plan
- verify canonical object digests and the three-Secret semantic boundary
- recheck the private workload binding digest, target identity, and CA correlation

## Boundaries

- offline re-verification only
- no installer credential read, API request, or mutation
- returns defensive private copies for a later launcher

## Validation

- `git diff --check`
- `GOCACHE=/private/tmp/ok147-go-build-cache go test -ldflags=-linkmode=external ./...`
- `GOCACHE=/private/tmp/ok147-go-build-cache go vet ./...`
- `GOCACHE=/private/tmp/ok147-go-build-cache go test -race -ldflags=-linkmode=external ./internal/runner`

Jira: OK-147
