### PR TITLE
feat(cli): launch network observation stage (OK-147)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,13 @@ Powered by [Cluster API (CAPI)](https://cluster-api.sigs.k8s.io/), [CAPK (KubeVi
   an expiry-bound installer candidate. Only `observe lifecycle launch execute`
   can open the installer credential and run the single-use six-object
   exact-create launcher; it requires the separately copied candidate digest
-  and explicit `--execute`. Stage 4 now has its first distinct path as well:
+  and explicit `--execute`. The NetworkReady observation follows the same
+  split boundary: `observe network launch prepare` correlates the immutable
+  package, three distinct Job credentials, runtime identity and expiring
+  installer candidate offline, while `observe network launch execute` alone
+  can open the installer authority and invoke the seven-object, Job-last
+  launcher. It also requires the exact candidate digest and explicit
+  `--execute`. Stage 4 now has its first distinct path as well:
   `ok cluster stage run enablement --execute` binds the verified three-receipt
   prefix and signed `CreateEnablement` grant to exactly one externally rendered
   `HelmChartProxy`; it neither renders Helm nor writes the controller-owned

--- a/cmd/ok/main.go
+++ b/cmd/ok/main.go
@@ -129,6 +129,25 @@ var prepareLifecycleObservationStageLaunch = func(config runner.LifecycleObserva
 	}, nil
 }
 
+var prepareNetworkObservationStageLaunch = func(config runner.NetworkObservationStageLaunchMaterialConfig) (networkObservationLaunchPreparation, error) {
+	material, err := runner.BuildNetworkObservationStageLaunchMaterial(config)
+	if err != nil {
+		return networkObservationLaunchPreparation{}, err
+	}
+	materialReceipt, err := material.Receipt()
+	if err != nil {
+		return networkObservationLaunchPreparation{}, err
+	}
+	candidateReceipt, err := material.CandidateReceipt()
+	if err != nil {
+		return networkObservationLaunchPreparation{}, err
+	}
+	return networkObservationLaunchPreparation{
+		Format: "ok147-network-observation-stage-launch-preparation/v1", State: "PREPARED",
+		Material: materialReceipt, Candidate: candidateReceipt, MutationAllowed: false,
+	}, nil
+}
+
 var executeSubmissionStageLaunch = func(ctx context.Context, config runner.SubmissionStageLaunchMaterialConfig, authority runner.KubernetesAuthorityConfig, expectedCandidateDigest string) (runner.SubmissionStageLaunchReceipt, error) {
 	material, err := runner.BuildSubmissionStageLaunchMaterial(config)
 	if err != nil {
@@ -163,6 +182,25 @@ var executeLifecycleObservationStageLaunch = func(ctx context.Context, config ru
 	})
 	if err != nil {
 		return runner.LifecycleObservationStageLaunchReceipt{}, err
+	}
+	return launcher.Launch(ctx)
+}
+
+var executeNetworkObservationStageLaunch = func(ctx context.Context, config runner.NetworkObservationStageLaunchMaterialConfig, authority runner.KubernetesAuthorityConfig, expectedCandidateDigest string) (runner.NetworkObservationStageLaunchReceipt, error) {
+	material, err := runner.BuildNetworkObservationStageLaunchMaterial(config)
+	if err != nil {
+		return runner.NetworkObservationStageLaunchReceipt{}, err
+	}
+	candidate, err := material.CandidateReceipt()
+	if err != nil {
+		return runner.NetworkObservationStageLaunchReceipt{}, err
+	}
+	authority.AuthorityIdentity = candidate.Authority
+	launcher, err := material.Open(runner.NetworkObservationStageLaunchOpenConfig{
+		Authority: authority, Clock: func() time.Time { return time.Now().UTC() }, ExpectedCandidateDigest: expectedCandidateDigest,
+	})
+	if err != nil {
+		return runner.NetworkObservationStageLaunchReceipt{}, err
 	}
 	return launcher.Launch(ctx)
 }
@@ -210,6 +248,14 @@ type lifecycleObservationLaunchPreparation struct {
 	Material        runner.LifecycleObservationStageLaunchMaterialReceipt  `json:"material"`
 	Candidate       runner.LifecycleObservationStageLaunchCandidateReceipt `json:"candidate"`
 	MutationAllowed bool                                                   `json:"mutationAllowed"`
+}
+
+type networkObservationLaunchPreparation struct {
+	Format          string                                               `json:"format"`
+	State           string                                               `json:"state"`
+	Material        runner.NetworkObservationStageLaunchMaterialReceipt  `json:"material"`
+	Candidate       runner.NetworkObservationStageLaunchCandidateReceipt `json:"candidate"`
+	MutationAllowed bool                                                 `json:"mutationAllowed"`
 }
 
 type receiptFlags []string
@@ -517,6 +563,12 @@ func runContext(ctx context.Context, arguments []string, stdout, stderr io.Write
 	if len(arguments) >= 5 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "observe" && arguments[3] == "network" && arguments[4] == "package" {
 		return runClusterStageObserveNetworkPackage(arguments[5:], stdout, stderr)
 	}
+	if len(arguments) >= 6 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "observe" && arguments[3] == "network" && arguments[4] == "launch" && arguments[5] == "prepare" {
+		return runClusterStageObserveNetworkLaunchPrepare(arguments[6:], stdout, stderr)
+	}
+	if len(arguments) >= 6 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "observe" && arguments[3] == "network" && arguments[4] == "launch" && arguments[5] == "execute" {
+		return runClusterStageObserveNetworkLaunchExecute(ctx, arguments[6:], stdout, stderr)
+	}
 	if len(arguments) >= 4 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "observe" && arguments[3] == "network" {
 		return runClusterStageObserveNetwork(ctx, arguments[4:], stdout, stderr)
 	}
@@ -544,7 +596,7 @@ func runContext(ctx context.Context, arguments []string, stdout, stderr io.Write
 	if len(arguments) >= 4 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "launch" && arguments[3] == "execute" {
 		return runClusterStageLaunchExecute(ctx, arguments[4:], stdout, stderr)
 	}
-	return errors.New("usage: ok cluster create ... | ok cluster stage inspect ... | ok cluster stage resume ... | ok cluster stage observe lifecycle ... | ok cluster stage observe network ... | ok cluster stage observe network package ... | ok cluster stage observe lifecycle package ... | ok cluster stage observe lifecycle launch prepare ... | ok cluster stage observe lifecycle launch execute ... | ok cluster stage run ... | ok cluster stage run enablement ... | ok cluster stage run enablement package ... | ok cluster stage run enablement launch prepare ... | ok cluster stage run enablement launch execute ... | ok cluster stage package ... | ok cluster stage launch prepare ... | ok cluster stage launch execute ...")
+	return errors.New("usage: ok cluster create ... | ok cluster stage inspect ... | ok cluster stage resume ... | ok cluster stage observe lifecycle ... | ok cluster stage observe network ... | ok cluster stage observe network package ... | ok cluster stage observe network launch prepare ... | ok cluster stage observe network launch execute ... | ok cluster stage observe lifecycle package ... | ok cluster stage observe lifecycle launch prepare ... | ok cluster stage observe lifecycle launch execute ... | ok cluster stage run ... | ok cluster stage run enablement ... | ok cluster stage run enablement package ... | ok cluster stage run enablement launch prepare ... | ok cluster stage run enablement launch execute ... | ok cluster stage package ... | ok cluster stage launch prepare ... | ok cluster stage launch execute ...")
 }
 
 func runClusterCreate(arguments []string, stdout, stderr io.Writer) error {
@@ -1173,6 +1225,204 @@ func runClusterStageObserveLifecycleLaunchExecute(ctx context.Context, arguments
 	boundedContext, cancel := context.WithTimeout(ctx, stageLaunchTimeout)
 	defer cancel()
 	receipt, launchErr := executeLifecycleObservationStageLaunch(boundedContext, config, runner.KubernetesAuthorityConfig{
+		Endpoint: config.Candidate.AuthorityEndpoint, TokenFile: *installerTokenFile,
+		CAFile: *installerCAFile, CABundleDigest: config.Candidate.CABundleDigest,
+	}, *expectedCandidateDigest)
+	if receipt.Format != "" {
+		encoder := json.NewEncoder(stdout)
+		encoder.SetEscapeHTML(false)
+		encoder.SetIndent("", "  ")
+		if err := encoder.Encode(receipt); err != nil {
+			return err
+		}
+	}
+	return launchErr
+}
+
+type networkObservationLaunchMaterialFlags struct {
+	resume                                                                                       *stageResumeFlags
+	jobTemplate, jobTemplateDigest, runID, imageDigest, inputConfigMap                           *string
+	networkProfile, networkProfileDigest                                                         *string
+	ledgerAPIURL, ledgerAPICIDR, ledgerCredentialSecret                                          *string
+	managementAPIURL, managementAPICIDR, managementCredentialSecret                              *string
+	workloadAPIURL, workloadAPICIDR, workloadCredentialSecret                                    *string
+	workloadBinding, workloadBindingDigest                                                       *string
+	pollInterval, pollTimeout                                                                    *time.Duration
+	materializedAt, runtimeManifest, runtimeManifestDigest                                       *string
+	installerAPIEndpoint, installerCADigest, installerTokenDigest, installerEvidence, preparedAt *string
+	ledgerCredential, managementCredential, workloadCredential                                   *stageLaunchCredentialFlags
+}
+
+func addNetworkObservationLaunchMaterialFlags(flags *flag.FlagSet) *networkObservationLaunchMaterialFlags {
+	values := &networkObservationLaunchMaterialFlags{resume: addStageResumeFlags(flags)}
+	values.jobTemplate = flags.String("job-template", "", "path to the bounded network-observation Job template")
+	values.jobTemplateDigest = flags.String("job-template-digest", "", "expected SHA-256 identity of the Job template")
+	values.runID = flags.String("run-id", "", "bounded OK-147 network observation Job identity")
+	values.imageDigest = flags.String("image", "", "digest-pinned ok image")
+	values.inputConfigMap = flags.String("input-configmap", "", "immutable network observation input ConfigMap name")
+	values.networkProfile = flags.String("network-profile", "", "path to the immutable NetworkReady profile")
+	values.networkProfileDigest = flags.String("network-profile-digest", "", "expected NetworkReady profile digest")
+	values.ledgerAPIURL = flags.String("ledger-api-url", "", "exact management-ledger HTTPS IP endpoint")
+	values.ledgerAPICIDR = flags.String("ledger-api-cidr", "", "single-address management-ledger CIDR")
+	values.ledgerCredentialSecret = flags.String("ledger-credential-secret", "", "ledger credential Secret name")
+	values.managementAPIURL = flags.String("management-api-url", "", "exact management-observer HTTPS IP endpoint")
+	values.managementAPICIDR = flags.String("management-api-cidr", "", "single-address management-observer CIDR")
+	values.managementCredentialSecret = flags.String("management-credential-secret", "", "read-only management credential Secret name")
+	values.workloadAPIURL = flags.String("workload-api-url", "", "exact workload-observer HTTPS IP endpoint")
+	values.workloadAPICIDR = flags.String("workload-api-cidr", "", "single-address workload-observer CIDR")
+	values.workloadCredentialSecret = flags.String("workload-credential-secret", "", "read-only workload credential Secret name")
+	values.workloadBinding = flags.String("workload-binding", "", "path to the private workload-authority binding")
+	values.workloadBindingDigest = flags.String("workload-binding-digest", "", "expected workload-authority binding digest")
+	values.pollInterval = flags.Duration("poll-interval", 0, "bounded interval between Unknown observations")
+	values.pollTimeout = flags.Duration("poll-timeout", 0, "maximum bounded network observation duration")
+	values.materializedAt = flags.String("credential-materialized-at", "", "exact credential materialization time")
+	values.ledgerCredential = addStageLaunchCredentialFlags(flags, "ledger-job", "ledger Job credential")
+	values.managementCredential = addStageLaunchCredentialFlags(flags, "management-observer-job", "read-only management observer Job credential")
+	values.workloadCredential = addStageLaunchCredentialFlags(flags, "workload-observer-job", "read-only workload observer Job credential")
+	values.runtimeManifest = flags.String("runtime-manifest", "", "path to the tokenless runtime ServiceAccount manifest")
+	values.runtimeManifestDigest = flags.String("runtime-manifest-digest", "", "expected runtime manifest digest")
+	values.installerAPIEndpoint = flags.String("installer-api-endpoint", "", "exact management installer HTTPS IP endpoint")
+	values.installerCADigest = flags.String("installer-ca-digest", "", "expected management installer CA digest")
+	values.installerTokenDigest = flags.String("installer-token-digest", "", "private expected management installer token digest")
+	values.installerEvidence = flags.String("installer-tokenrequest-evidence-digest", "", "management installer TokenRequest evidence digest")
+	values.preparedAt = flags.String("prepared-at", "", "exact launch candidate preparation time")
+	return values
+}
+
+func (values *networkObservationLaunchMaterialFlags) config() (runner.NetworkObservationStageLaunchMaterialConfig, error) {
+	resumeConfig, err := values.resume.config()
+	if err != nil {
+		return runner.NetworkObservationStageLaunchMaterialConfig{}, err
+	}
+	for _, input := range []struct{ name, value string }{
+		{"--job-template", *values.jobTemplate}, {"--job-template-digest", *values.jobTemplateDigest}, {"--run-id", *values.runID}, {"--image", *values.imageDigest},
+		{"--input-configmap", *values.inputConfigMap}, {"--network-profile", *values.networkProfile}, {"--network-profile-digest", *values.networkProfileDigest},
+		{"--ledger-api-url", *values.ledgerAPIURL}, {"--ledger-api-cidr", *values.ledgerAPICIDR}, {"--ledger-credential-secret", *values.ledgerCredentialSecret},
+		{"--management-api-url", *values.managementAPIURL}, {"--management-api-cidr", *values.managementAPICIDR}, {"--management-credential-secret", *values.managementCredentialSecret},
+		{"--workload-api-url", *values.workloadAPIURL}, {"--workload-api-cidr", *values.workloadAPICIDR}, {"--workload-credential-secret", *values.workloadCredentialSecret},
+		{"--workload-binding", *values.workloadBinding}, {"--workload-binding-digest", *values.workloadBindingDigest},
+		{"--credential-materialized-at", *values.materializedAt}, {"--runtime-manifest", *values.runtimeManifest},
+		{"--runtime-manifest-digest", *values.runtimeManifestDigest}, {"--installer-api-endpoint", *values.installerAPIEndpoint},
+		{"--installer-ca-digest", *values.installerCADigest}, {"--installer-token-digest", *values.installerTokenDigest},
+		{"--installer-tokenrequest-evidence-digest", *values.installerEvidence}, {"--prepared-at", *values.preparedAt},
+	} {
+		if input.value == "" {
+			return runner.NetworkObservationStageLaunchMaterialConfig{}, fmt.Errorf("%s is required", input.name)
+		}
+	}
+	for _, value := range []string{*values.jobTemplateDigest, *values.networkProfileDigest, *values.workloadBindingDigest, *values.runtimeManifestDigest, *values.installerCADigest, *values.installerTokenDigest, *values.installerEvidence} {
+		if !sha256DigestPattern.MatchString(value) {
+			return runner.NetworkObservationStageLaunchMaterialConfig{}, errors.New("network observation launch digests must be lowercase SHA-256 identities")
+		}
+	}
+	if *values.pollInterval < time.Second || *values.pollInterval > 5*time.Minute || *values.pollTimeout < *values.pollInterval || *values.pollTimeout > 6*time.Hour {
+		return runner.NetworkObservationStageLaunchMaterialConfig{}, errors.New("--poll-interval and --poll-timeout must define a valid bounded observation of at most 6h")
+	}
+	materializedAt, err := time.Parse(time.RFC3339, *values.materializedAt)
+	if err != nil {
+		return runner.NetworkObservationStageLaunchMaterialConfig{}, fmt.Errorf("parse credential materialization time: %w", err)
+	}
+	preparedAt, err := time.Parse(time.RFC3339, *values.preparedAt)
+	if err != nil {
+		return runner.NetworkObservationStageLaunchMaterialConfig{}, fmt.Errorf("parse candidate preparation time: %w", err)
+	}
+	ledgerSource, err := values.ledgerCredential.source("ledger-job")
+	if err != nil {
+		return runner.NetworkObservationStageLaunchMaterialConfig{}, err
+	}
+	managementSource, err := values.managementCredential.source("management-observer-job")
+	if err != nil {
+		return runner.NetworkObservationStageLaunchMaterialConfig{}, err
+	}
+	workloadSource, err := values.workloadCredential.source("workload-observer-job")
+	if err != nil {
+		return runner.NetworkObservationStageLaunchMaterialConfig{}, err
+	}
+	template, err := readBoundedLocalFile(*values.jobTemplate, 1024*1024)
+	if err != nil {
+		return runner.NetworkObservationStageLaunchMaterialConfig{}, fmt.Errorf("read network observation Job template: %w", err)
+	}
+	runtimeRaw, err := readBoundedLocalFile(*values.runtimeManifest, 128*1024)
+	if err != nil {
+		return runner.NetworkObservationStageLaunchMaterialConfig{}, fmt.Errorf("read runtime manifest: %w", err)
+	}
+	return runner.NetworkObservationStageLaunchMaterialConfig{
+		Package: runner.NetworkObservationStagePackageConfig{
+			Input:       runner.NetworkObservationStageInputConfig{Bundle: resumeConfig, NetworkProfilePath: *values.networkProfile, ExpectedNetworkProfileDigest: *values.networkProfileDigest, ConfigMapName: *values.inputConfigMap},
+			JobTemplate: template, JobTemplateDigest: *values.jobTemplateDigest, RunID: *values.runID, ImageDigest: *values.imageDigest,
+			LedgerAPIURL: *values.ledgerAPIURL, LedgerAPICIDR: *values.ledgerAPICIDR, LedgerCredentialSecret: *values.ledgerCredentialSecret,
+			ManagementAPIURL: *values.managementAPIURL, ManagementAPICIDR: *values.managementAPICIDR, ManagementCredentialSecret: *values.managementCredentialSecret,
+			WorkloadAPIURL: *values.workloadAPIURL, WorkloadAPICIDR: *values.workloadAPICIDR, WorkloadCredentialSecret: *values.workloadCredentialSecret,
+			WorkloadBindingPath: *values.workloadBinding, ExpectedWorkloadBindingDigest: *values.workloadBindingDigest,
+			PollInterval: *values.pollInterval, PollTimeout: *values.pollTimeout,
+		},
+		MaterializationTime: materializedAt, Ledger: ledgerSource, ManagementObserver: managementSource, WorkloadObserver: workloadSource,
+		RuntimeManifest: runtimeRaw, RuntimeManifestDigest: *values.runtimeManifestDigest,
+		Candidate: runner.SubmissionStageLaunchCandidateConfig{
+			AuthorityEndpoint: *values.installerAPIEndpoint, CABundleDigest: *values.installerCADigest,
+			InstallerTokenDigest: *values.installerTokenDigest, InstallerCredentialEvidenceDigest: *values.installerEvidence, PreparedAt: preparedAt,
+		},
+	}, nil
+}
+
+func runClusterStageObserveNetworkLaunchPrepare(arguments []string, stdout, stderr io.Writer) error {
+	flags := flag.NewFlagSet("ok cluster stage observe network launch prepare", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	materialFlags := addNetworkObservationLaunchMaterialFlags(flags)
+	if err := flags.Parse(arguments); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return errors.New("positional arguments are not accepted")
+	}
+	config, err := materialFlags.config()
+	if err != nil {
+		return err
+	}
+	preparation, err := prepareNetworkObservationStageLaunch(config)
+	if err != nil {
+		return err
+	}
+	encoder := json.NewEncoder(stdout)
+	encoder.SetEscapeHTML(false)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(preparation)
+}
+
+func runClusterStageObserveNetworkLaunchExecute(ctx context.Context, arguments []string, stdout, stderr io.Writer) error {
+	flags := flag.NewFlagSet("ok cluster stage observe network launch execute", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	materialFlags := addNetworkObservationLaunchMaterialFlags(flags)
+	execute := flags.Bool("execute", false, "perform the exact single-use network observation launch")
+	expectedCandidateDigest := flags.String("expected-candidate-digest", "", "exact digest emitted by network observation launch prepare")
+	installerTokenFile := flags.String("installer-token-file", "", "bounded short-lived management installer token file")
+	installerCAFile := flags.String("installer-ca-file", "", "bounded management installer CA file")
+	if err := flags.Parse(arguments); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return errors.New("positional arguments are not accepted")
+	}
+	if !*execute {
+		return errors.New("network observation launch mutation requires explicit --execute")
+	}
+	for _, input := range []struct{ name, value string }{
+		{"--expected-candidate-digest", *expectedCandidateDigest}, {"--installer-token-file", *installerTokenFile}, {"--installer-ca-file", *installerCAFile},
+	} {
+		if input.value == "" {
+			return fmt.Errorf("%s is required", input.name)
+		}
+	}
+	if !sha256DigestPattern.MatchString(*expectedCandidateDigest) {
+		return errors.New("--expected-candidate-digest must be sha256:<64 lowercase hex>")
+	}
+	config, err := materialFlags.config()
+	if err != nil {
+		return err
+	}
+	boundedContext, cancel := context.WithTimeout(ctx, stageLaunchTimeout)
+	defer cancel()
+	receipt, launchErr := executeNetworkObservationStageLaunch(boundedContext, config, runner.KubernetesAuthorityConfig{
 		Endpoint: config.Candidate.AuthorityEndpoint, TokenFile: *installerTokenFile,
 		CAFile: *installerCAFile, CABundleDigest: config.Candidate.CABundleDigest,
 	}, *expectedCandidateDigest)

--- a/cmd/ok/main_test.go
+++ b/cmd/ok/main_test.go
@@ -1182,6 +1182,109 @@ func TestLifecycleObservationLaunchExecuteUsesExactBoundary(t *testing.T) {
 	}
 }
 
+func TestNetworkObservationLaunchPrepareBuildsOneNonMutatingCandidate(t *testing.T) {
+	previous := prepareNetworkObservationStageLaunch
+	defer func() { prepareNetworkObservationStageLaunch = previous }()
+	var captured runner.NetworkObservationStageLaunchMaterialConfig
+	prepareNetworkObservationStageLaunch = func(config runner.NetworkObservationStageLaunchMaterialConfig) (networkObservationLaunchPreparation, error) {
+		captured = config
+		return networkObservationLaunchPreparation{
+			Format: "ok147-network-observation-stage-launch-preparation/v1", State: "PREPARED",
+			Material: runner.NetworkObservationStageLaunchMaterialReceipt{
+				Format: runner.NetworkObservationStageLaunchMaterialFormat, State: "VERIFIED", StageID: "network-observation",
+				Authority: "ok-mgmt", CandidateDigest: testSHA("1"), MutationAllowed: false,
+			},
+			Candidate: runner.NetworkObservationStageLaunchCandidateReceipt{
+				Format: runner.NetworkObservationStageLaunchCandidateFormat, State: "PREPARED", CandidateDigest: testSHA("1"), MutationAllowed: false,
+			},
+			MutationAllowed: false,
+		}, nil
+	}
+	root := t.TempDir()
+	template, runtimeManifest := filepath.Join(root, "network.yaml.tpl"), filepath.Join(root, "runtime.yaml")
+	if err := os.WriteFile(template, []byte("bounded-network-template"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(runtimeManifest, []byte("bounded-runtime"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	if err := run(networkObservationLaunchPrepareArguments(template, runtimeManifest), &stdout, &stderr); err != nil {
+		t.Fatalf("run: %v; stderr=%s", err, stderr.String())
+	}
+	if captured.Package.Input.Bundle.PlanExpected.ManagementAuthority != "ok-mgmt" || captured.Package.RunID != "ok147-network-observation-01" || captured.Package.PollInterval != 15*time.Second || captured.Package.PollTimeout != 5*time.Minute || string(captured.Package.JobTemplate) != "bounded-network-template" || string(captured.RuntimeManifest) != "bounded-runtime" {
+		t.Fatalf("network observation launch material differs: %#v", captured)
+	}
+	if captured.Ledger.AuthorityIdentity != "ok-mgmt" || captured.ManagementObserver.AuthorityIdentity != "ok-mgmt" || captured.WorkloadObserver.AuthorityIdentity != testSHA("b") || captured.Ledger.TokenFile == captured.ManagementObserver.TokenFile || captured.ManagementObserver.TokenFile == captured.WorkloadObserver.TokenFile {
+		t.Fatalf("network credential boundary differs: %#v %#v %#v", captured.Ledger, captured.ManagementObserver, captured.WorkloadObserver)
+	}
+	var preparation networkObservationLaunchPreparation
+	if err := json.Unmarshal(stdout.Bytes(), &preparation); err != nil {
+		t.Fatal(err)
+	}
+	if preparation.State != "PREPARED" || preparation.MutationAllowed || preparation.Material.MutationAllowed || preparation.Candidate.MutationAllowed {
+		t.Fatalf("unsafe network observation preparation: %#v", preparation)
+	}
+}
+
+func TestNetworkObservationLaunchExecuteUsesExactBoundary(t *testing.T) {
+	previous := executeNetworkObservationStageLaunch
+	defer func() { executeNetworkObservationStageLaunch = previous }()
+	var calls int
+	var candidate string
+	executeNetworkObservationStageLaunch = func(ctx context.Context, config runner.NetworkObservationStageLaunchMaterialConfig, authority runner.KubernetesAuthorityConfig, expectedCandidateDigest string) (runner.NetworkObservationStageLaunchReceipt, error) {
+		calls++
+		candidate = expectedCandidateDigest
+		deadline, ok := ctx.Deadline()
+		if !ok || time.Until(deadline) <= 0 || time.Until(deadline) > stageLaunchTimeout {
+			t.Fatal("network observation launch context is not bounded")
+		}
+		if config.Package.RunID != "ok147-network-observation-01" || authority.Endpoint != "https://192.0.2.12:6443" || authority.TokenFile != "/private/tmp/installer-token" {
+			t.Fatalf("execute boundary differs: %#v %#v", config, authority)
+		}
+		return runner.NetworkObservationStageLaunchReceipt{
+			Format: runner.NetworkObservationStageLaunchReceiptFormat, StageID: "network-observation", Authority: "ok-mgmt",
+			State: "LAUNCHED", MutationState: "ATTEMPTED", Results: []runner.SubmissionStageLaunchResult{},
+		}, nil
+	}
+	root := t.TempDir()
+	template, runtimeManifest := filepath.Join(root, "network.yaml.tpl"), filepath.Join(root, "runtime.yaml")
+	if err := os.WriteFile(template, []byte("bounded-network-template"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(runtimeManifest, []byte("bounded-runtime"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	if err := run(networkObservationLaunchExecuteArguments(template, runtimeManifest), &stdout, &stderr); err != nil {
+		t.Fatalf("run: %v; stderr=%s", err, stderr.String())
+	}
+	if calls != 1 || candidate != testSHA("9") {
+		t.Fatalf("exact network candidate not used: calls=%d digest=%q", calls, candidate)
+	}
+	var receipt runner.NetworkObservationStageLaunchReceipt
+	if err := json.Unmarshal(stdout.Bytes(), &receipt); err != nil || receipt.State != "LAUNCHED" {
+		t.Fatalf("unexpected network launch receipt: %#v %v", receipt, err)
+	}
+
+	valid := networkObservationLaunchExecuteArguments(template, runtimeManifest)
+	for name, arguments := range map[string][]string{
+		"missing execute":         removeArgument(valid, "--execute"),
+		"missing candidate":       removeArgumentWithValue(valid, "--expected-candidate-digest"),
+		"malformed candidate":     replaceArgument(valid, "--expected-candidate-digest", "sha256:ABC"),
+		"missing installer token": removeArgumentWithValue(valid, "--installer-token-file"),
+		"missing workload source": removeArgumentWithValue(valid, "--workload-observer-job-authority"),
+	} {
+		t.Run(name, func(t *testing.T) {
+			before := calls
+			stdout.Reset()
+			if err := run(arguments, &stdout, &stderr); err == nil || stdout.Len() != 0 || calls != before {
+				t.Fatal("unsafe network launch input reached executor")
+			}
+		})
+	}
+}
+
 func stageInspectArguments() []string {
 	return []string{
 		"cluster", "stage", "inspect",
@@ -1397,6 +1500,43 @@ func lifecycleObservationLaunchPrepareArguments(template, runtimeManifest string
 
 func lifecycleObservationLaunchExecuteArguments(template, runtimeManifest string) []string {
 	arguments := lifecycleObservationLaunchPrepareArguments(template, runtimeManifest)
+	arguments[5] = "execute"
+	return append(arguments,
+		"--execute", "--expected-candidate-digest", testSHA("9"),
+		"--installer-token-file", "/private/tmp/installer-token", "--installer-ca-file", "/private/tmp/installer-ca",
+	)
+}
+
+func networkObservationLaunchPrepareArguments(template, runtimeManifest string) []string {
+	packaged := stageObserveNetworkPackageArguments(template, "/private/tmp/not-used-network-package")
+	packaged = removeArgumentWithValue(packaged, "--output")
+	arguments := append([]string{"cluster", "stage", "observe", "network", "launch", "prepare"}, packaged[5:]...)
+	arguments = append(arguments, "--credential-materialized-at", "2026-08-16T12:00:00Z")
+	for _, credential := range []struct{ prefix, authority, tokenFile, tokenDigest, caFile, caDigest, evidence, subject string }{
+		{"ledger-job", "ok-mgmt", "/private/tmp/ledger-network-token", testSHA("1"), "/private/tmp/ledger-network-ca", testSHA("2"), testSHA("3"), "system:serviceaccount:openkubes-execution-system:ok147-ledger-writer"},
+		{"management-observer-job", "ok-mgmt", "/private/tmp/management-network-token", testSHA("4"), "/private/tmp/management-network-ca", testSHA("2"), testSHA("5"), "system:serviceaccount:openkubes-execution-system:ok147-network-management-observer"},
+		{"workload-observer-job", testSHA("b"), "/private/tmp/workload-network-token", testSHA("6"), "/private/tmp/workload-network-ca", testSHA("7"), testSHA("8"), "system:serviceaccount:openkubes-execution-system:ok147-network-workload-observer"},
+	} {
+		arguments = append(arguments,
+			"--"+credential.prefix+"-authority", credential.authority,
+			"--"+credential.prefix+"-token-file", credential.tokenFile, "--"+credential.prefix+"-token-digest", credential.tokenDigest,
+			"--"+credential.prefix+"-ca-file", credential.caFile, "--"+credential.prefix+"-ca-digest", credential.caDigest,
+			"--"+credential.prefix+"-tokenrequest-evidence-digest", credential.evidence,
+			"--"+credential.prefix+"-issuer", "https://kubernetes.default.svc.cluster.local", "--"+credential.prefix+"-subject", credential.subject,
+			"--"+credential.prefix+"-audiences", "https://kubernetes.default.svc",
+			"--"+credential.prefix+"-issued-at", "2026-08-16T11:59:00Z", "--"+credential.prefix+"-expires-at", "2026-08-16T12:30:00Z",
+		)
+	}
+	return append(arguments,
+		"--runtime-manifest", runtimeManifest, "--runtime-manifest-digest", digest.SHA256([]byte("bounded-runtime")),
+		"--installer-api-endpoint", "https://192.0.2.12:6443", "--installer-ca-digest", testSHA("2"),
+		"--installer-token-digest", testSHA("7"), "--installer-tokenrequest-evidence-digest", testSHA("8"),
+		"--prepared-at", "2026-08-16T12:01:00Z",
+	)
+}
+
+func networkObservationLaunchExecuteArguments(template, runtimeManifest string) []string {
+	arguments := networkObservationLaunchPrepareArguments(template, runtimeManifest)
 	arguments[5] = "execute"
 	return append(arguments,
 		"--execute", "--expected-candidate-digest", testSHA("9"),

--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -2054,6 +2054,36 @@ been verified as created. Any response or partial-state ambiguity stops with
 no retry, rollback or cleanup path, and public results retain only UID and
 resourceVersion digests.
 
+The same boundary is now exposed through two explicit CLI commands. Preparation
+reconstructs every private component, emits only redaction-safe material and
+candidate receipts and performs no Kubernetes request:
+
+```text
+ok cluster stage observe network launch prepare
+      -> verified seven-object material receipt
+      -> expiry-bound candidate receipt
+      -> mutationAllowed: false
+```
+
+Execution accepts the complete identical input set and additionally requires
+`--execute`, the separately copied candidate digest and bounded installer token
+and CA files:
+
+```text
+ok cluster stage observe network launch execute
+  + --execute
+  + --expected-candidate-digest sha256:...
+  + --installer-token-file PATH
+  + --installer-ca-file PATH
+```
+
+The command rebuilds the material before opening the installer authority and
+applies a five-minute outer deadline. Missing execution intent, a changed or
+malformed candidate, incomplete credential sources or missing installer files
+stop before the launcher is invoked. A stopped live launch still emits its
+redaction-safe receipt so partial or uncertain state remains visible without
+creating an implicit retry path.
+
 ## Bounded convergence observation polling
 
 The aggregate observer can now be wrapped by a bounded polling observer before


### PR DESCRIPTION
## Summary
- expose offline NetworkReady observation launch preparation through the ok CLI
- require the exact separately supplied candidate digest and explicit --execute before opening installer authority
- preserve the seven-object global preflight, Job-last creation order, bounded context, and redaction-safe stopped receipt
- document the CLI boundary and cover positive plus fail-closed argument paths

## Verification
- go test -ldflags=-linkmode=external ./...
- go vet ./...
- go test -race -ldflags=-linkmode=external ./cmd/ok ./internal/runner

No live infrastructure was contacted or changed.