### PR TITLE
feat(execution): add runtime binding stage operation (OK-147)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,11 @@ Powered by [Cluster API (CAPI)](https://cluster-api.sigs.k8s.io/), [CAPK (KubeVi
   installer candidate offline, while `observe network launch execute` alone
   can open the installer authority and invoke the seven-object, Job-last
   launcher. It also requires the exact candidate digest and explicit
-  `--execute`. Stage 4 now has its first distinct path as well:
+  `--execute`. The following `runtime-binding` stage now has a separate
+  crash-safe local operation as well: it accepts only the exact runner-owned
+  cursor, invokes one prebound binder and persists an immutable receipt before
+  any later target-access stage can open. This primitive still has no concrete
+  Secret reader, cluster client or CLI activation. Stage 4 now has its first distinct path as well:
   `ok cluster stage run enablement --execute` binds the verified three-receipt
   prefix and signed `CreateEnablement` grant to exactly one externally rendered
   `HelmChartProxy`; it neither renders Helm nor writes the controller-owned

--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -2084,6 +2084,41 @@ stop before the launcher is invoked. A stopped live launch still emits its
 redaction-safe receipt so partial or uncertain state remains visible without
 creating an implicit retry path.
 
+## Crash-safe runtime-binding operation
+
+The stage immediately after successful NetworkReady observation now has a
+dedicated non-mutating execution primitive. `BindingStageOperation` accepts
+only a verified cursor selecting `runtime-binding` with runner authority and a
+preconstructed binder whose plan, stage, authority and R identities match that
+decision exactly:
+
+```text
+successful network-observation receipt
+                 |
+                 v
+       exact runtime-binding cursor
+                 |
+                 v
+     one prebound local binder call
+                 |
+                 v
+ immutable runtime-binding stage receipt
+```
+
+The binder's future private artifact, credentials and source reads remain
+encapsulated behind its single `Bind` method. Public orchestration retains only
+the result state, evidence digest, completion time and final receipt digest.
+Raw operational errors are never returned. A failed or stopped result is
+persisted as terminal evidence and cannot be replaced by success.
+
+Before invoking the binder, the operation inspects the deterministic receipt
+slot. A verified existing receipt is returned without rebinding, closing the
+process-termination window after receipt persistence. Observation, submission,
+credential and evaluation cursors are rejected before the binder is called.
+This checkpoint supplies only the execution composition: it does not yet read
+the workload-kubeconfig Secret, contact a cluster, create the private runtime
+binding file, activate a CLI/Job path or grant target access.
+
 ## Bounded convergence observation polling
 
 The aggregate observer can now be wrapped by a bounded polling observer before

--- a/internal/execution/staged_binding.go
+++ b/internal/execution/staged_binding.go
@@ -1,0 +1,127 @@
+package execution
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/ledger"
+	"github.com/openkubes/ok-cluster/internal/stagecursor"
+	"github.com/openkubes/ok-cluster/internal/stageplan"
+	"github.com/openkubes/ok-cluster/internal/stagereceipt"
+)
+
+const BindingStageReceiptFormat = "ok147-binding-stage-run-receipt/v1"
+
+// StageBinderBinding makes one preconstructed local binder specific to one
+// verified plan stage. It is not a dynamic operation dispatcher.
+type StageBinderBinding struct {
+	PlanDigest       string
+	StageID          string
+	StageDigest      string
+	Authority        string
+	ContractRevision string
+}
+
+// StageBindingResult is the redaction-safe result of producing one private,
+// digest-bound runtime correlation artifact.
+type StageBindingResult struct {
+	Outcome        string
+	EvidenceDigest string
+	CompletedAt    time.Time
+}
+
+// StageBinder is preconstructed for exactly one local binding stage. It has no
+// grant, Kubernetes mutation or general dispatcher method.
+type StageBinder interface {
+	Binding() StageBinderBinding
+	Bind(context.Context) (StageBindingResult, error)
+}
+
+// BindingStageOperation composes cursor verification, one local binding call
+// and immutable stage-receipt persistence.
+type BindingStageOperation struct {
+	Ledger *ledger.Ledger
+	Binder StageBinder
+}
+
+type BindingStageRunReceipt struct {
+	Format             string `json:"format"`
+	State              string `json:"state"`
+	PlanDigest         string `json:"planDigest,omitempty"`
+	StageID            string `json:"stageId,omitempty"`
+	StageReceiptDigest string `json:"stageReceiptDigest,omitempty"`
+}
+
+type BindingStageResultError struct{ State string }
+
+func (err *BindingStageResultError) Error() string {
+	return "binding stage completed with " + err.State
+}
+
+// Run invokes at most one prebound local binder. An already persisted receipt
+// is returned without opening the binder again, so a process restart cannot
+// silently regenerate a different runtime identity.
+func (operation BindingStageOperation) Run(ctx context.Context, plan stageplan.Binding, cursor stagecursor.Cursor) (BindingStageRunReceipt, error) {
+	receipt := BindingStageRunReceipt{Format: BindingStageReceiptFormat, State: "PREBINDING"}
+	if operation.Ledger == nil || operation.Binder == nil {
+		return receipt, errors.New("binding stage ledger and binder are required")
+	}
+	decision, err := cursor.Decision()
+	if err != nil {
+		return receipt, err
+	}
+	if decision.State != "NEXT" || decision.Kind != "Binding" || decision.Authority != "runner" || decision.RequiresAuthorization || decision.Operation != "" {
+		return receipt, errors.New("stage cursor does not select a local binding stage")
+	}
+	predecessors, err := cursor.Predecessors()
+	if err != nil {
+		return receipt, err
+	}
+	want := StageBinderBinding{
+		PlanDigest: plan.PlanDigest, StageID: decision.StageID, StageDigest: decision.StageDigest,
+		Authority: decision.Authority, ContractRevision: plan.IntentRevision,
+	}
+	if operation.Binder.Binding() != want {
+		return receipt, errors.New("preconstructed binder differs from the selected stage")
+	}
+	receipt.PlanDigest, receipt.StageID = plan.PlanDigest, decision.StageID
+	if existing, found, err := operation.Ledger.InspectStageReceipt(ctx, plan, decision.StageID, predecessors); err != nil {
+		return receipt, err
+	} else if found {
+		return finalizeBindingRunReceipt(receipt, existing)
+	}
+
+	result, bindErr := operation.Binder.Bind(ctx)
+	if bindErr != nil {
+		return receipt, errors.New("bounded runtime binding failed")
+	}
+	if !oneOf(result.Outcome, "SUCCEEDED", "FAILED", "STOPPED") || !stagedDigestPattern.MatchString(result.EvidenceDigest) || result.CompletedAt.IsZero() {
+		return receipt, errors.New("stage binder returned an invalid redaction-safe result")
+	}
+	verified, err := stagereceipt.New(plan, decision.StageID, predecessors, result.Outcome, "NOT_APPLICABLE", "", result.EvidenceDigest, result.CompletedAt)
+	if err != nil {
+		return receipt, err
+	}
+	if _, err := operation.Ledger.StoreStageReceipt(ctx, plan, verified, predecessors); err != nil {
+		return receipt, err
+	}
+	return finalizeBindingRunReceipt(receipt, verified)
+}
+
+func finalizeBindingRunReceipt(receipt BindingStageRunReceipt, verified stagereceipt.Verified) (BindingStageRunReceipt, error) {
+	stageReceipt, err := verified.Receipt()
+	if err != nil {
+		return receipt, err
+	}
+	digest, err := verified.Digest()
+	if err != nil {
+		return receipt, err
+	}
+	receipt.StageReceiptDigest = digest
+	receipt.State = "COMPLETED_" + stageReceipt.State
+	if stageReceipt.State != "SUCCEEDED" {
+		return receipt, &BindingStageResultError{State: receipt.State}
+	}
+	return receipt, nil
+}

--- a/internal/execution/staged_binding_test.go
+++ b/internal/execution/staged_binding_test.go
@@ -1,0 +1,133 @@
+package execution
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/ledger"
+	"github.com/openkubes/ok-cluster/internal/stagecursor"
+	"github.com/openkubes/ok-cluster/internal/stageplan"
+	"github.com/openkubes/ok-cluster/internal/stagereceipt"
+)
+
+func TestBindingStagePersistsAndResumesWithoutRebinding(t *testing.T) {
+	plan, cursor, at := runtimeBindingCursor(t)
+	store, _ := ledger.Open(filepath.Join(t.TempDir(), "ledger"))
+	binder := &fakeStageBinder{
+		binding: binderBinding(t, plan, "runtime-binding"),
+		result:  StageBindingResult{Outcome: "SUCCEEDED", EvidenceDigest: stagedSHA("e"), CompletedAt: at},
+	}
+	operation := BindingStageOperation{Ledger: store, Binder: binder}
+	first, err := operation.Run(context.Background(), plan, cursor)
+	if err != nil || first.State != "COMPLETED_SUCCEEDED" || first.StageReceiptDigest == "" || binder.calls != 1 {
+		t.Fatalf("unexpected binding run: %#v calls=%d err=%v", first, binder.calls, err)
+	}
+	replayed, err := operation.Run(context.Background(), plan, cursor)
+	if err != nil || replayed != first || binder.calls != 1 {
+		t.Fatalf("persisted binding was executed again: %#v calls=%d err=%v", replayed, binder.calls, err)
+	}
+}
+
+func TestBindingStagePersistsTerminalResultWithoutRawError(t *testing.T) {
+	plan, cursor, at := runtimeBindingCursor(t)
+	store, _ := ledger.Open(filepath.Join(t.TempDir(), "ledger"))
+	binder := &fakeStageBinder{
+		binding: binderBinding(t, plan, "runtime-binding"),
+		result:  StageBindingResult{Outcome: "STOPPED", EvidenceDigest: stagedSHA("f"), CompletedAt: at},
+	}
+	receipt, err := (BindingStageOperation{Ledger: store, Binder: binder}).Run(context.Background(), plan, cursor)
+	var resultErr *BindingStageResultError
+	if !errors.As(err, &resultErr) || receipt.State != "COMPLETED_STOPPED" || receipt.StageReceiptDigest == "" {
+		t.Fatalf("terminal binding was not retained: %#v %v", receipt, err)
+	}
+}
+
+func TestBindingStageFailsClosedBeforePersistence(t *testing.T) {
+	plan, cursor, at := runtimeBindingCursor(t)
+	for name, mutate := range map[string]func(*fakeStageBinder){
+		"foreign binding": func(binder *fakeStageBinder) { binder.binding.Authority = "workload" },
+		"raw failure":     func(binder *fakeStageBinder) { binder.err = errors.New("sensitive endpoint detail") },
+		"bad evidence":    func(binder *fakeStageBinder) { binder.result.EvidenceDigest = "invalid" },
+		"missing time":    func(binder *fakeStageBinder) { binder.result.CompletedAt = time.Time{} },
+	} {
+		t.Run(name, func(t *testing.T) {
+			store, _ := ledger.Open(filepath.Join(t.TempDir(), "ledger"))
+			binder := &fakeStageBinder{
+				binding: binderBinding(t, plan, "runtime-binding"),
+				result:  StageBindingResult{Outcome: "SUCCEEDED", EvidenceDigest: stagedSHA("e"), CompletedAt: at},
+			}
+			mutate(binder)
+			receipt, err := (BindingStageOperation{Ledger: store, Binder: binder}).Run(context.Background(), plan, cursor)
+			if err == nil || strings.Contains(err.Error(), "sensitive") || receipt.StageReceiptDigest != "" {
+				t.Fatalf("unsafe binding result was accepted: %#v %v", receipt, err)
+			}
+		})
+	}
+}
+
+func TestBindingStageRejectsObservationCursor(t *testing.T) {
+	plan, cursor, _ := lifecycleObservationCursor(t)
+	store, _ := ledger.Open(filepath.Join(t.TempDir(), "ledger"))
+	binder := &fakeStageBinder{}
+	if _, err := (BindingStageOperation{Ledger: store, Binder: binder}).Run(context.Background(), plan, cursor); err == nil || binder.calls != 0 {
+		t.Fatalf("observation cursor reached binder: calls=%d err=%v", binder.calls, err)
+	}
+}
+
+type fakeStageBinder struct {
+	binding StageBinderBinding
+	result  StageBindingResult
+	err     error
+	calls   int
+}
+
+func (binder *fakeStageBinder) Binding() StageBinderBinding { return binder.binding }
+
+func (binder *fakeStageBinder) Bind(context.Context) (StageBindingResult, error) {
+	binder.calls++
+	return binder.result, binder.err
+}
+
+func runtimeBindingCursor(t *testing.T) (stageplan.Binding, stagecursor.Cursor, time.Time) {
+	t.Helper()
+	plan := stagedPlan(t)
+	at := time.Date(2026, 8, 17, 8, 0, 0, 0, time.UTC)
+	provider, err := stagereceipt.New(plan, "provider-prerequisites", []stagereceipt.Verified{}, "SUCCEEDED", "ATTEMPTED", stagedSHA("1"), stagedSHA("a"), at.Add(-5*time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	lifecycle, err := stagereceipt.NewWithTargetClusterUIDDigest(plan, "cluster-lifecycle", []stagereceipt.Verified{provider}, "SUCCEEDED", "ATTEMPTED", stagedSHA("2"), stagedSHA("b"), stagedSHA("7"), at.Add(-4*time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	lifecycleObservation, err := stagereceipt.New(plan, "lifecycle-observation", []stagereceipt.Verified{lifecycle}, "SUCCEEDED", "NOT_APPLICABLE", "", stagedSHA("c"), at.Add(-3*time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	enablement, err := stagereceipt.New(plan, "enablement", []stagereceipt.Verified{lifecycleObservation}, "SUCCEEDED", "ATTEMPTED", stagedSHA("3"), stagedSHA("d"), at.Add(-2*time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	network, err := stagereceipt.New(plan, "network-observation", []stagereceipt.Verified{enablement}, "SUCCEEDED", "NOT_APPLICABLE", "", stagedSHA("e"), at.Add(-time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	cursor, err := stagecursor.Evaluate(plan, []stagereceipt.Verified{provider, lifecycle, lifecycleObservation, enablement, network})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return plan, cursor, at
+}
+
+func binderBinding(t *testing.T, plan stageplan.Binding, stageID string) StageBinderBinding {
+	t.Helper()
+	stage, stageDigest, err := plan.Stage(stageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return StageBinderBinding{PlanDigest: plan.PlanDigest, StageID: stageID, StageDigest: stageDigest, Authority: stage.Authority, ContractRevision: plan.IntentRevision}
+}


### PR DESCRIPTION
## Summary
- add a dedicated non-mutating operation for the runner-owned runtime-binding stage
- require an exact prebound binder identity and reject observation, submission, credential, and evaluation cursors
- persist terminal redaction-safe receipts and resume without reopening the binder
- keep the concrete Secret reader, workload client, private binding writer, and CLI activation out of this checkpoint

## Verification
- go test -ldflags=-linkmode=external ./...
- go vet ./...
- go test -race -ldflags=-linkmode=external ./internal/execution

No cluster was contacted and no infrastructure was changed.