### PR TITLE
feat(runner): materialize runtime binding identity (OK-147)

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,11 @@ Powered by [Cluster API (CAPI)](https://cluster-api.sigs.k8s.io/), [CAPK (KubeVi
   `--execute`. The following `runtime-binding` stage now has a separate
   crash-safe local operation as well: it accepts only the exact runner-owned
   cursor, invokes one prebound binder and persists an immutable receipt before
-  any later target-access stage can open. This primitive still has no concrete
-  Secret reader, cluster client or CLI activation. Stage 4 now has its first distinct path as well:
+  any later target-access stage can open. Its offline materializer now binds
+  the private target endpoint, CA and raw runtime UIDs to the five-receipt
+  prefix while exposing only digest identities publicly. The exact workload
+  reads, exclusive private-file writer and CLI activation remain separate.
+  Stage 4 now has its first distinct path as well:
   `ok cluster stage run enablement --execute` binds the verified three-receipt
   prefix and signed `CreateEnablement` grant to exactly one externally rendered
   `HelmChartProxy`; it neither renders Helm nor writes the controller-owned

--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -2119,6 +2119,37 @@ This checkpoint supplies only the execution composition: it does not yet read
 the workload-kubeconfig Secret, contact a cluster, create the private runtime
 binding file, activate a CLI/Job path or grant target access.
 
+The first concrete runtime-binding materializer now defines what that binder
+must retain. It accepts only the exact successful five-receipt prefix, the
+previously verified private workload-authority binding, the matching CA file
+and explicit results of the two bounded workload reads:
+
+```text
+cluster-lifecycle target UID digest
+        + NetworkReady receipt
+        + workload authority binding
+        + matching workload API CA
+        + kube-system UID
+        + local-path StorageClass UID/provisioner
+                         |
+                         v
+        canonical private runtime-binding material
+                         +
+        redaction-safe public material receipt
+```
+
+The private material binds the exact CAPI Cluster UID, target identity scheme,
+workload API endpoint, CA payload and digest, `kube-system` UID, `local-path`
+StorageClass UID and provisioner, R/E/P/Fixture and the lifecycle/network
+evidence digests. The public receipt replaces the endpoint, CA payload and raw
+UIDs with digests. A same-name replacement target, changed CA, incomplete
+prefix, missing namespace identity or unexpected provisioner fails closed.
+
+Materialization is deterministic and returns defensive copies. It performs no
+Kubernetes request and no file write. The bounded exact-GET source, exclusive
+private-file persistence and composition with `BindingStageOperation` remain
+separate later checkpoints; target access is still unreachable here.
+
 ## Bounded convergence observation polling
 
 The aggregate observer can now be wrapped by a bounded polling observer before

--- a/internal/runner/runtime_binding_material.go
+++ b/internal/runner/runtime_binding_material.go
@@ -1,0 +1,193 @@
+package runner
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+
+	"github.com/openkubes/ok-cluster/internal/contract"
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+const RuntimeBindingMaterialFormat = "ok147-runtime-binding-material/v1"
+
+type RuntimeBindingObservation struct {
+	KubeSystemUID            string
+	LocalPathStorageClassUID string
+	LocalPathProvisioner     string
+}
+
+type RuntimeBindingMaterialConfig struct {
+	Bundle                        StageResumeConfig
+	WorkloadBindingPath           string
+	ExpectedWorkloadBindingDigest string
+	WorkloadCAFile                string
+	Observation                   RuntimeBindingObservation
+}
+
+type RuntimeBindingTarget struct {
+	Name                 string `json:"name"`
+	CAPIClusterUID       string `json:"capiClusterUid"`
+	TargetIdentityScheme string `json:"targetIdentityScheme"`
+	WorkloadAPIEndpoint  string `json:"workloadApiEndpoint"`
+	WorkloadAPICAData    string `json:"workloadApiCaData"`
+	WorkloadAPICADigest  string `json:"workloadApiCaDigest"`
+	KubeSystemUID        string `json:"kubeSystemUid"`
+}
+
+type RuntimeBindingStorage struct {
+	Name        string `json:"name"`
+	UID         string `json:"uid"`
+	Provisioner string `json:"provisioner"`
+}
+
+type RuntimeBindingEvidence struct {
+	LifecycleEvidenceDigest string `json:"lifecycleEvidenceDigest"`
+	NetworkEvidenceDigest   string `json:"networkEvidenceDigest"`
+}
+
+// RuntimeBindingMaterial is private runtime data. Its endpoint, raw UIDs and
+// public CA payload must not be copied into public evidence.
+type RuntimeBindingMaterial struct {
+	Format             string                 `json:"format"`
+	State              string                 `json:"state"`
+	PlanDigest         string                 `json:"planDigest"`
+	IntentRevision     string                 `json:"intentRevision"`
+	EnablementRevision string                 `json:"enablementRevision"`
+	PlatformRevision   string                 `json:"platformRevision"`
+	ExecutionFixture   string                 `json:"executionFixture"`
+	Target             RuntimeBindingTarget   `json:"target"`
+	Storage            RuntimeBindingStorage  `json:"storage"`
+	Evidence           RuntimeBindingEvidence `json:"evidence"`
+}
+
+type RuntimeBindingMaterialReceipt struct {
+	Format                    string `json:"format"`
+	State                     string `json:"state"`
+	StageID                   string `json:"stageId"`
+	PlanDigest                string `json:"planDigest"`
+	IntentRevision            string `json:"intentRevision"`
+	TargetClusterUIDDigest    string `json:"targetClusterUidDigest"`
+	WorkloadAPICADigest       string `json:"workloadApiCaDigest"`
+	KubeSystemUIDDigest       string `json:"kubeSystemUidDigest"`
+	LocalPathStorageUIDDigest string `json:"localPathStorageUidDigest"`
+	LifecycleEvidenceDigest   string `json:"lifecycleEvidenceDigest"`
+	NetworkEvidenceDigest     string `json:"networkEvidenceDigest"`
+	PrivateMaterialDigest     string `json:"privateMaterialDigest"`
+	PersistentMutationAllowed bool   `json:"persistentMutationAllowed"`
+}
+
+type VerifiedRuntimeBindingMaterial struct {
+	material RuntimeBindingMaterial
+	raw      []byte
+	receipt  RuntimeBindingMaterialReceipt
+	verified bool
+}
+
+// BuildRuntimeBindingMaterial correlates the exact successful five-receipt
+// prefix with the already verified workload authority, current read-only
+// workload observations and the actual CA bytes. It performs no API request
+// and writes no file.
+func BuildRuntimeBindingMaterial(config RuntimeBindingMaterialConfig) (VerifiedRuntimeBindingMaterial, error) {
+	plan, cursor, prefix, err := loadStageResumeWithPrefix(config.Bundle)
+	if err != nil {
+		return VerifiedRuntimeBindingMaterial{}, err
+	}
+	decision, err := cursor.Decision()
+	if err != nil || decision.State != "NEXT" || decision.StageID != "runtime-binding" || decision.Kind != "Binding" || decision.Authority != "runner" || decision.RequiresAuthorization || decision.Operation != "" {
+		return VerifiedRuntimeBindingMaterial{}, errors.New("verified prefix does not select runtime binding")
+	}
+	if len(prefix) != 5 {
+		return VerifiedRuntimeBindingMaterial{}, errors.New("runtime binding requires the exact five-receipt prefix")
+	}
+	lifecycle, err := prefix[1].Receipt()
+	if err != nil || lifecycle.StageID != "cluster-lifecycle" || !platformInputDigestPattern.MatchString(lifecycle.TargetClusterUIDDigest) {
+		return VerifiedRuntimeBindingMaterial{}, errors.New("runtime binding history lacks durable target correlation")
+	}
+	network, err := prefix[4].Receipt()
+	if err != nil || network.StageID != "network-observation" || network.State != "SUCCEEDED" {
+		return VerifiedRuntimeBindingMaterial{}, errors.New("runtime binding history lacks successful NetworkReady evidence")
+	}
+	binding, err := loadWorkloadAuthorityBinding(config.WorkloadBindingPath, config.ExpectedWorkloadBindingDigest)
+	if err != nil {
+		return VerifiedRuntimeBindingMaterial{}, errors.New("load verified workload authority binding")
+	}
+	if binding.IntentRevision != plan.IntentRevision || digest.SHA256([]byte(binding.TargetClusterUID)) != lifecycle.TargetClusterUIDDigest {
+		return VerifiedRuntimeBindingMaterial{}, errors.New("workload authority differs from durable lifecycle target")
+	}
+	ca, err := readBoundedRegular(config.WorkloadCAFile, maximumCABytes)
+	if err != nil || digest.SHA256(ca) != binding.CABundleDigest {
+		return VerifiedRuntimeBindingMaterial{}, errors.New("workload API CA differs from runtime authority")
+	}
+	if !runtimeInputUIDPattern.MatchString(config.Observation.KubeSystemUID) || !runtimeInputUIDPattern.MatchString(config.Observation.LocalPathStorageClassUID) || config.Observation.LocalPathProvisioner != "rancher.io/local-path" {
+		return VerifiedRuntimeBindingMaterial{}, errors.New("runtime workload observation is invalid")
+	}
+	material := RuntimeBindingMaterial{
+		Format: RuntimeBindingMaterialFormat, State: "CURRENT_RUNTIME_BOUND",
+		PlanDigest: plan.PlanDigest, IntentRevision: plan.IntentRevision, EnablementRevision: plan.EnablementRevision,
+		PlatformRevision: plan.PlatformRevision, ExecutionFixture: plan.ExecutionFixture,
+		Target: RuntimeBindingTarget{
+			Name: plan.ContractIdentity.Name, CAPIClusterUID: binding.TargetClusterUID, TargetIdentityScheme: binding.TargetIdentityScheme,
+			WorkloadAPIEndpoint: binding.Endpoint, WorkloadAPICAData: base64.StdEncoding.EncodeToString(ca),
+			WorkloadAPICADigest: binding.CABundleDigest, KubeSystemUID: config.Observation.KubeSystemUID,
+		},
+		Storage:  RuntimeBindingStorage{Name: "local-path", UID: config.Observation.LocalPathStorageClassUID, Provisioner: config.Observation.LocalPathProvisioner},
+		Evidence: RuntimeBindingEvidence{LifecycleEvidenceDigest: lifecycle.EvidenceDigest, NetworkEvidenceDigest: network.EvidenceDigest},
+	}
+	raw, err := canonicalRuntimeBinding(material)
+	if err != nil {
+		return VerifiedRuntimeBindingMaterial{}, errors.New("encode private runtime binding material")
+	}
+	receipt := RuntimeBindingMaterialReceipt{
+		Format: RuntimeBindingMaterialFormat, State: "VERIFIED", StageID: "runtime-binding", PlanDigest: plan.PlanDigest,
+		IntentRevision: plan.IntentRevision, TargetClusterUIDDigest: lifecycle.TargetClusterUIDDigest,
+		WorkloadAPICADigest: binding.CABundleDigest, KubeSystemUIDDigest: digest.SHA256([]byte(config.Observation.KubeSystemUID)),
+		LocalPathStorageUIDDigest: digest.SHA256([]byte(config.Observation.LocalPathStorageClassUID)),
+		LifecycleEvidenceDigest:   lifecycle.EvidenceDigest, NetworkEvidenceDigest: network.EvidenceDigest,
+		PrivateMaterialDigest: digest.SHA256(raw), PersistentMutationAllowed: false,
+	}
+	return VerifiedRuntimeBindingMaterial{material: material, raw: raw, receipt: receipt, verified: true}, nil
+}
+
+func (material VerifiedRuntimeBindingMaterial) Bytes() ([]byte, error) {
+	if err := verifyRuntimeBindingMaterial(material); err != nil {
+		return nil, err
+	}
+	return append([]byte(nil), material.raw...), nil
+}
+
+func (material VerifiedRuntimeBindingMaterial) Receipt() (RuntimeBindingMaterialReceipt, error) {
+	if err := verifyRuntimeBindingMaterial(material); err != nil {
+		return RuntimeBindingMaterialReceipt{}, err
+	}
+	return material.receipt, nil
+}
+
+func verifyRuntimeBindingMaterial(material VerifiedRuntimeBindingMaterial) error {
+	if !material.verified || material.receipt.Format != RuntimeBindingMaterialFormat || material.receipt.State != "VERIFIED" || material.receipt.StageID != "runtime-binding" || material.receipt.PersistentMutationAllowed {
+		return errors.New("runtime binding material was not produced by verification")
+	}
+	raw, err := canonicalRuntimeBinding(material.material)
+	if err != nil || !bytes.Equal(raw, material.raw) || digest.SHA256(raw) != material.receipt.PrivateMaterialDigest {
+		return errors.New("runtime binding material changed after verification")
+	}
+	if digest.SHA256([]byte(material.material.Target.CAPIClusterUID)) != material.receipt.TargetClusterUIDDigest || material.material.Target.WorkloadAPICADigest != material.receipt.WorkloadAPICADigest || digest.SHA256([]byte(material.material.Target.KubeSystemUID)) != material.receipt.KubeSystemUIDDigest || digest.SHA256([]byte(material.material.Storage.UID)) != material.receipt.LocalPathStorageUIDDigest || material.material.Evidence.LifecycleEvidenceDigest != material.receipt.LifecycleEvidenceDigest || material.material.Evidence.NetworkEvidenceDigest != material.receipt.NetworkEvidenceDigest {
+		return errors.New("runtime binding receipt differs from private material")
+	}
+	return nil
+}
+
+func canonicalRuntimeBinding(binding RuntimeBindingMaterial) ([]byte, error) {
+	raw, err := json.Marshal(binding)
+	if err != nil {
+		return nil, err
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	var value any
+	if err := decoder.Decode(&value); err != nil {
+		return nil, err
+	}
+	return contract.JCS(value)
+}

--- a/internal/runner/runtime_binding_material_test.go
+++ b/internal/runner/runtime_binding_material_test.go
@@ -1,0 +1,175 @@
+package runner
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/stagereceipt"
+)
+
+func TestRuntimeBindingMaterialCorrelatesPrivateRuntimeIdentity(t *testing.T) {
+	config := runtimeBindingMaterialConfig(t)
+	material, err := BuildRuntimeBindingMaterial(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := material.Receipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := material.Bytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if receipt.Format != RuntimeBindingMaterialFormat || receipt.State != "VERIFIED" || receipt.StageID != "runtime-binding" || receipt.PersistentMutationAllowed || receipt.PrivateMaterialDigest != digest.SHA256(raw) || receipt.TargetClusterUIDDigest != digest.SHA256([]byte("cluster-runtime-uid-147")) {
+		t.Fatalf("unexpected runtime binding receipt: %#v", receipt)
+	}
+	var private RuntimeBindingMaterial
+	if err := json.Unmarshal(raw, &private); err != nil {
+		t.Fatal(err)
+	}
+	if private.State != "CURRENT_RUNTIME_BOUND" || private.Target.CAPIClusterUID != "cluster-runtime-uid-147" || private.Target.WorkloadAPIEndpoint != "https://192.0.2.20:6443" || private.Target.WorkloadAPICAData == "" || private.Storage.Provisioner != "rancher.io/local-path" {
+		t.Fatalf("private runtime identity differs: %#v", private)
+	}
+	public, _ := json.Marshal(receipt)
+	for _, forbidden := range []string{"cluster-runtime-uid-147", "192.0.2.20", private.Target.WorkloadAPICAData, "kube-system-runtime-uid", "local-path-runtime-uid"} {
+		if strings.Contains(string(public), forbidden) {
+			t.Fatalf("public receipt leaked private runtime value %q", forbidden)
+		}
+	}
+
+	copyBytes, _ := material.Bytes()
+	copyBytes[0] ^= 0xff
+	again, _ := material.Bytes()
+	if copyBytes[0] == again[0] {
+		t.Fatal("runtime binding bytes are not defensive copies")
+	}
+	if _, err := (VerifiedRuntimeBindingMaterial{}).Receipt(); err == nil {
+		t.Fatal("unverified runtime binding material exposed a receipt")
+	}
+}
+
+func TestRuntimeBindingMaterialFailsClosed(t *testing.T) {
+	valid := runtimeBindingMaterialConfig(t)
+	for name, mutate := range map[string]func(*RuntimeBindingMaterialConfig){
+		"wrong receipt prefix": func(config *RuntimeBindingMaterialConfig) { config.Bundle.Receipts = config.Bundle.Receipts[:4] },
+		"replacement target": func(config *RuntimeBindingMaterialConfig) {
+			binding, _ := loadWorkloadAuthorityBinding(config.WorkloadBindingPath, config.ExpectedWorkloadBindingDigest)
+			binding.TargetClusterUID = "replacement-runtime-uid"
+			writePlatformJSON(t, config.WorkloadBindingPath, binding)
+			config.ExpectedWorkloadBindingDigest, _ = WorkloadAuthorityBindingDigest(binding)
+		},
+		"wrong CA": func(config *RuntimeBindingMaterialConfig) {
+			os.WriteFile(config.WorkloadCAFile, []byte("foreign-ca"), 0o600)
+		},
+		"missing namespace": func(config *RuntimeBindingMaterialConfig) { config.Observation.KubeSystemUID = "" },
+		"wrong provisioner": func(config *RuntimeBindingMaterialConfig) {
+			config.Observation.LocalPathProvisioner = "foreign.example/storage"
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			config := cloneRuntimeBindingMaterialConfig(t, valid)
+			mutate(&config)
+			if _, err := BuildRuntimeBindingMaterial(config); err == nil {
+				t.Fatal("unsafe runtime binding input was accepted")
+			}
+		})
+	}
+}
+
+func runtimeBindingMaterialConfig(t *testing.T) RuntimeBindingMaterialConfig {
+	t.Helper()
+	bundle := runtimeBindingBundleConfig(t)
+	plan, _, prefix, err := loadStageResumeWithPrefix(bundle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root := t.TempDir()
+	ca := testCA(t)
+	caPath, bindingPath := filepath.Join(root, "workload-ca.crt"), filepath.Join(root, "workload-binding.json")
+	if err := os.WriteFile(caPath, ca, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	lifecycle, _ := prefix[1].Receipt()
+	binding := WorkloadAuthorityBinding{
+		Format: WorkloadAuthorityBindingFormat, IntentRevision: plan.IntentRevision,
+		TargetClusterUID: "cluster-runtime-uid-147", TargetIdentityScheme: "capi-cluster-uid/v1",
+		Endpoint: "https://192.0.2.20:6443", CABundleDigest: digest.SHA256(ca),
+	}
+	if digest.SHA256([]byte(binding.TargetClusterUID)) != lifecycle.TargetClusterUIDDigest {
+		t.Fatal("test lifecycle target differs from workload binding")
+	}
+	writePlatformJSON(t, bindingPath, binding)
+	bindingDigest, err := WorkloadAuthorityBindingDigest(binding)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return RuntimeBindingMaterialConfig{
+		Bundle: bundle, WorkloadBindingPath: bindingPath, ExpectedWorkloadBindingDigest: bindingDigest, WorkloadCAFile: caPath,
+		Observation: RuntimeBindingObservation{KubeSystemUID: "kube-system-runtime-uid", LocalPathStorageClassUID: "local-path-runtime-uid", LocalPathProvisioner: "rancher.io/local-path"},
+	}
+}
+
+func runtimeBindingBundleConfig(t *testing.T) StageResumeConfig {
+	t.Helper()
+	base := networkObservationBundleConfig(t, true)
+	plan, _, prefix, err := loadStageResumeWithPrefix(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Rebuild the lifecycle receipt's private target identity to match the
+	// explicit runtime UID used by this materialization fixture.
+	at := time.Date(2026, 8, 17, 9, 0, 0, 0, time.UTC)
+	provider := prefix[0]
+	lifecycle, err := stagereceipt.NewWithTargetClusterUIDDigest(plan, "cluster-lifecycle", []stagereceipt.Verified{provider}, "SUCCEEDED", "ATTEMPTED", bundleSHA("3"), bundleSHA("4"), digest.SHA256([]byte("cluster-runtime-uid-147")), at.Add(-4*time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	lifecycleObservation, err := stagereceipt.New(plan, "lifecycle-observation", []stagereceipt.Verified{lifecycle}, "SUCCEEDED", "NOT_APPLICABLE", "", bundleSHA("5"), at.Add(-3*time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	enablement, err := stagereceipt.New(plan, "enablement", []stagereceipt.Verified{lifecycleObservation}, "SUCCEEDED", "ATTEMPTED", bundleSHA("6"), bundleSHA("7"), at.Add(-2*time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	network, err := stagereceipt.New(plan, "network-observation", []stagereceipt.Verified{enablement}, "SUCCEEDED", "NOT_APPLICABLE", "", bundleSHA("8"), at.Add(-time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	root := t.TempDir()
+	base.Receipts = nil
+	for index, item := range []stagereceipt.Verified{provider, lifecycle, lifecycleObservation, enablement, network} {
+		raw, _ := item.Bytes()
+		receiptDigest, _ := item.Digest()
+		base.Receipts = append(base.Receipts, StageReceiptSource{Path: writeBundleFile(t, root, "receipt-"+string(rune('0'+index))+".json", raw), Digest: receiptDigest})
+	}
+	return base
+}
+
+func cloneRuntimeBindingMaterialConfig(t *testing.T, source RuntimeBindingMaterialConfig) RuntimeBindingMaterialConfig {
+	t.Helper()
+	root := t.TempDir()
+	clone := source
+	clone.Bundle.Receipts = append([]StageReceiptSource(nil), source.Bundle.Receipts...)
+	for _, item := range []struct {
+		source string
+		target *string
+	}{{source.WorkloadBindingPath, &clone.WorkloadBindingPath}, {source.WorkloadCAFile, &clone.WorkloadCAFile}} {
+		raw, err := os.ReadFile(item.source)
+		if err != nil {
+			t.Fatal(err)
+		}
+		path := filepath.Join(root, filepath.Base(item.source))
+		if err := os.WriteFile(path, raw, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		*item.target = path
+	}
+	return clone
+}


### PR DESCRIPTION
## Summary
- define deterministic private runtime-binding material for the stage after NetworkReady
- correlate the exact five-receipt prefix, lifecycle target UID, workload authority, CA, kube-system identity, and local-path identity
- expose only redaction-safe digest identities publicly
- fail closed on replacement targets, CA drift, incomplete history, missing namespace identity, or foreign storage provisioners

## Verification
- go test -ldflags=-linkmode=external ./...
- go vet ./...
- go test -race -ldflags=-linkmode=external ./internal/runner

This checkpoint performs no API request, file write, credential issuance, target-access mutation, or infrastructure change.