### PR TITLE
feat(runner): bind runtime source and private writer (OK-147)

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,11 @@ Powered by [Cluster API (CAPI)](https://cluster-api.sigs.k8s.io/), [CAPK (KubeVi
   cursor, invokes one prebound binder and persists an immutable receipt before
   any later target-access stage can open. Its offline materializer now binds
   the private target endpoint, CA and raw runtime UIDs to the five-receipt
-  prefix while exposing only digest identities publicly. The exact workload
-  reads, exclusive private-file writer and CLI activation remain separate.
+  prefix while exposing only digest identities publicly. A bounded source now
+  performs only the exact `kube-system` and `local-path` GETs after proving the
+  workload authority, and an exclusive private writer creates and verifies one
+  `0600` binding file without overwrite or cleanup. Composition with the stage
+  operation and CLI/Job activation remains separate.
   Stage 4 now has its first distinct path as well:
   `ok cluster stage run enablement --execute` binds the verified three-receipt
   prefix and signed `CreateEnablement` grant to exactly one externally rendered

--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -2146,9 +2146,36 @@ UIDs with digests. A same-name replacement target, changed CA, incomplete
 prefix, missing namespace identity or unexpected provisioner fails closed.
 
 Materialization is deterministic and returns defensive copies. It performs no
-Kubernetes request and no file write. The bounded exact-GET source, exclusive
-private-file persistence and composition with `BindingStageOperation` remain
-separate later checkpoints; target access is still unreachable here.
+Kubernetes request and no file write.
+
+The bounded workload source and private writer now implement those two side
+effects independently. The source proves that endpoint, target Cluster UID and
+CA digest still match the verified workload-authority binding before it opens
+one short-lived token. It then permits exactly these ordered requests:
+
+```text
+GET /api/v1/namespaces/kube-system
+GET /apis/storage.k8s.io/v1/storageclasses/local-path
+```
+
+There is no arbitrary path, list, watch, discovery or mutation. Responses are
+size bounded, duplicate-key rejecting and reduced to the Namespace UID plus
+StorageClass UID and exact `rancher.io/local-path` provisioner. Redirects,
+non-JSON responses, replacement identities and any request error stop without
+retry and expose no endpoint, token or raw response in the returned error.
+
+The writer accepts only verified private material and one absent absolute path
+inside an existing private, non-symlink directory. It creates exactly one
+`0600` file with `O_EXCL`, syncs, closes and digest-verifies the stored bytes.
+There is no overwrite, rename, retry, cleanup or delete path. A write-side
+failure remains `STOPPED_PARTIAL_OR_UNKNOWN`; the public persistence receipt
+contains only the material digest, size and mode and explicitly denies
+Kubernetes mutation.
+
+The source, materializer, writer and `BindingStageOperation` are not yet
+composed into one CLI/Job boundary. Therefore this checkpoint still performs
+no live request or file write in production, and target access remains
+unreachable.
 
 ## Bounded convergence observation polling
 

--- a/internal/runner/runtime_binding_source.go
+++ b/internal/runner/runtime_binding_source.go
@@ -1,0 +1,154 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/jsonstrict"
+)
+
+const (
+	runtimeBindingKubeSystemPath = "/api/v1/namespaces/kube-system"
+	runtimeBindingLocalPathPath  = "/apis/storage.k8s.io/v1/storageclasses/local-path"
+	maximumRuntimeBindingSource  = 1024 * 1024
+)
+
+type KubernetesRuntimeBindingSource struct {
+	endpoint *url.URL
+	token    string
+	client   *http.Client
+}
+
+// OpenKubernetesRuntimeBindingSource opens one short-lived, read-only workload
+// authority and fixes its request surface to the two runtime-binding GETs. It
+// reads credential files but performs no API request.
+func OpenKubernetesRuntimeBindingSource(authority KubernetesAuthorityConfig, binding WorkloadAuthorityBinding) (*KubernetesRuntimeBindingSource, error) {
+	if err := validateWorkloadAuthorityBinding(binding); err != nil {
+		return nil, errors.New("runtime binding workload authority is invalid")
+	}
+	if authority.Endpoint != binding.Endpoint || authority.AuthorityIdentity != binding.TargetClusterUID || authority.CABundleDigest != binding.CABundleDigest {
+		return nil, errors.New("runtime binding source differs from workload authority")
+	}
+	token, ca, client, err := openBoundedKubernetesMaterial(authority.TokenFile, authority.CAFile)
+	if err != nil {
+		return nil, errors.New("open bounded runtime binding credential")
+	}
+	if digest.SHA256(ca) != binding.CABundleDigest {
+		return nil, errors.New("runtime binding source CA differs from workload authority")
+	}
+	return newKubernetesRuntimeBindingSource(authority.Endpoint, token, client)
+}
+
+func newKubernetesRuntimeBindingSource(endpoint, token string, client *http.Client) (*KubernetesRuntimeBindingSource, error) {
+	parsed, err := url.Parse(endpoint)
+	if err != nil || parsed.Host == "" || parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" || parsed.Path != "" && parsed.Path != "/" {
+		return nil, errors.New("runtime binding Kubernetes endpoint is invalid")
+	}
+	host := parsed.Hostname()
+	if parsed.Scheme != "https" && !(parsed.Scheme == "http" && (host == "127.0.0.1" || host == "::1" || host == "localhost")) {
+		return nil, errors.New("runtime binding Kubernetes endpoint must use HTTPS")
+	}
+	if token == "" || strings.TrimSpace(token) != token || strings.ContainsAny(token, "\r\n") || client == nil {
+		return nil, errors.New("runtime binding credential or client is invalid")
+	}
+	bounded := *client
+	bounded.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+	if bounded.Timeout == 0 {
+		bounded.Timeout = 15 * time.Second
+	}
+	parsed.Path, parsed.RawPath = "", ""
+	return &KubernetesRuntimeBindingSource{endpoint: parsed, token: token, client: &bounded}, nil
+}
+
+// Observe performs exactly the namespace GET followed by the StorageClass GET.
+// It exposes only the immutable fields consumed by runtime materialization.
+func (source *KubernetesRuntimeBindingSource) Observe(ctx context.Context) (RuntimeBindingObservation, error) {
+	if source == nil || source.endpoint == nil || source.client == nil {
+		return RuntimeBindingObservation{}, errors.New("runtime binding source is required")
+	}
+	namespaceRaw, err := source.get(ctx, runtimeBindingKubeSystemPath)
+	if err != nil {
+		return RuntimeBindingObservation{}, errors.New("read bounded kube-system identity")
+	}
+	namespace, err := decodeRuntimeBindingObject(namespaceRaw)
+	if err != nil || namespace.kind != "Namespace" || !runtimeInputUIDPattern.MatchString(namespace.uid) {
+		return RuntimeBindingObservation{}, errors.New("kube-system identity is invalid")
+	}
+	storageRaw, err := source.get(ctx, runtimeBindingLocalPathPath)
+	if err != nil {
+		return RuntimeBindingObservation{}, errors.New("read bounded local-path identity")
+	}
+	storage, err := decodeRuntimeBindingObject(storageRaw)
+	if err != nil || storage.kind != "StorageClass" || !runtimeInputUIDPattern.MatchString(storage.uid) || storage.provisioner != "rancher.io/local-path" {
+		return RuntimeBindingObservation{}, errors.New("local-path identity is invalid")
+	}
+	return RuntimeBindingObservation{
+		KubeSystemUID: namespace.uid, LocalPathStorageClassUID: storage.uid, LocalPathProvisioner: storage.provisioner,
+	}, nil
+}
+
+func (source *KubernetesRuntimeBindingSource) get(ctx context.Context, path string) ([]byte, error) {
+	if path != runtimeBindingKubeSystemPath && path != runtimeBindingLocalPathPath {
+		return nil, errors.New("runtime binding path is outside the fixed allowlist")
+	}
+	endpoint := *source.endpoint
+	endpoint.Path = path
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint.String(), nil)
+	if err != nil {
+		return nil, errors.New("construct bounded runtime binding request")
+	}
+	request.Header.Set("Accept", "application/json")
+	request.Header.Set("Authorization", "Bearer "+source.token)
+	response, err := source.client.Do(request)
+	if err != nil {
+		return nil, errors.New("bounded runtime binding request failed")
+	}
+	defer response.Body.Close()
+	raw, readErr := io.ReadAll(io.LimitReader(response.Body, maximumRuntimeBindingSource+1))
+	if readErr != nil || len(raw) > maximumRuntimeBindingSource {
+		return nil, errors.New("bounded runtime binding response exceeds accepted size")
+	}
+	if response.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("bounded runtime binding request returned HTTP %d", response.StatusCode)
+	}
+	mediaType, _, err := mime.ParseMediaType(response.Header.Get("Content-Type"))
+	if err != nil || mediaType != "application/json" {
+		return nil, errors.New("bounded runtime binding response is not JSON")
+	}
+	return raw, nil
+}
+
+type runtimeBindingObject struct {
+	kind        string
+	uid         string
+	provisioner string
+}
+
+func decodeRuntimeBindingObject(raw []byte) (runtimeBindingObject, error) {
+	var value map[string]any
+	if err := jsonstrict.Decode(raw, &value); err != nil {
+		return runtimeBindingObject{}, err
+	}
+	kind, ok := value["kind"].(string)
+	if !ok {
+		return runtimeBindingObject{}, errors.New("runtime object kind is missing")
+	}
+	metadata, ok := value["metadata"].(map[string]any)
+	if !ok {
+		return runtimeBindingObject{}, errors.New("runtime object metadata is missing")
+	}
+	uid, ok := metadata["uid"].(string)
+	if !ok {
+		return runtimeBindingObject{}, errors.New("runtime object UID is missing")
+	}
+	provisioner, _ := value["provisioner"].(string)
+	return runtimeBindingObject{kind: kind, uid: uid, provisioner: provisioner}, nil
+}

--- a/internal/runner/runtime_binding_source_test.go
+++ b/internal/runner/runtime_binding_source_test.go
@@ -1,0 +1,121 @@
+package runner
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+func TestOpenKubernetesRuntimeBindingSourceBindsExactAuthority(t *testing.T) {
+	root := t.TempDir()
+	ca := testCA(t)
+	tokenPath, caPath := filepath.Join(root, "token"), filepath.Join(root, "ca.crt")
+	if err := os.WriteFile(tokenPath, []byte("short-lived-runtime-token"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(caPath, ca, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	binding := WorkloadAuthorityBinding{
+		Format: WorkloadAuthorityBindingFormat, IntentRevision: digestOf("a"),
+		TargetClusterUID: "cluster-runtime-uid-147", TargetIdentityScheme: "capi-cluster-uid/v1",
+		Endpoint: "https://192.0.2.20:6443", CABundleDigest: digest.SHA256(ca),
+	}
+	authority := KubernetesAuthorityConfig{
+		Endpoint: binding.Endpoint, AuthorityIdentity: binding.TargetClusterUID,
+		TokenFile: tokenPath, CAFile: caPath, CABundleDigest: binding.CABundleDigest,
+	}
+	if _, err := OpenKubernetesRuntimeBindingSource(authority, binding); err != nil {
+		t.Fatal(err)
+	}
+	for name, mutate := range map[string]func(*KubernetesAuthorityConfig){
+		"endpoint":  func(config *KubernetesAuthorityConfig) { config.Endpoint = "https://192.0.2.21:6443" },
+		"identity":  func(config *KubernetesAuthorityConfig) { config.AuthorityIdentity = "replacement-cluster-uid" },
+		"CA digest": func(config *KubernetesAuthorityConfig) { config.CABundleDigest = digestOf("b") },
+	} {
+		t.Run(name, func(t *testing.T) {
+			changed := authority
+			mutate(&changed)
+			if _, err := OpenKubernetesRuntimeBindingSource(changed, binding); err == nil {
+				t.Fatal("mismatched runtime authority was accepted")
+			}
+		})
+	}
+}
+
+func TestRuntimeBindingSourceUsesExactlyTwoGETs(t *testing.T) {
+	var requests []string
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		requests = append(requests, request.Method+" "+request.URL.RequestURI())
+		if request.Header.Get("Authorization") != "Bearer runtime-token" || request.Header.Get("Accept") != "application/json" {
+			t.Error("runtime source credential headers differ")
+		}
+		response.Header().Set("Content-Type", "application/json")
+		switch request.URL.Path {
+		case runtimeBindingKubeSystemPath:
+			fmt.Fprint(response, `{"apiVersion":"v1","kind":"Namespace","metadata":{"name":"kube-system","uid":"kube-system-runtime-uid","resourceVersion":"1"}}`)
+		case runtimeBindingLocalPathPath:
+			fmt.Fprint(response, `{"apiVersion":"storage.k8s.io/v1","kind":"StorageClass","metadata":{"name":"local-path","uid":"local-path-runtime-uid"},"provisioner":"rancher.io/local-path"}`)
+		default:
+			response.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+	source, err := newKubernetesRuntimeBindingSource(server.URL, "runtime-token", server.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	observed, err := source.Observe(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if observed.KubeSystemUID != "kube-system-runtime-uid" || observed.LocalPathStorageClassUID != "local-path-runtime-uid" || observed.LocalPathProvisioner != "rancher.io/local-path" {
+		t.Fatalf("runtime observation differs: %#v", observed)
+	}
+	want := []string{"GET " + runtimeBindingKubeSystemPath, "GET " + runtimeBindingLocalPathPath}
+	if !reflect.DeepEqual(requests, want) {
+		t.Fatalf("runtime request boundary differs: got=%v want=%v", requests, want)
+	}
+}
+
+func TestRuntimeBindingSourceFailsClosed(t *testing.T) {
+	for name, handler := range map[string]http.HandlerFunc{
+		"first request fails": func(response http.ResponseWriter, _ *http.Request) { response.WriteHeader(http.StatusForbidden) },
+		"replacement namespace": func(response http.ResponseWriter, request *http.Request) {
+			response.Header().Set("Content-Type", "application/json")
+			if request.URL.Path == runtimeBindingKubeSystemPath {
+				fmt.Fprint(response, `{"kind":"Namespace","metadata":{"uid":""}}`)
+			}
+		},
+		"foreign provisioner": func(response http.ResponseWriter, request *http.Request) {
+			response.Header().Set("Content-Type", "application/json")
+			if request.URL.Path == runtimeBindingKubeSystemPath {
+				fmt.Fprint(response, `{"kind":"Namespace","metadata":{"uid":"kube-system-runtime-uid"}}`)
+				return
+			}
+			fmt.Fprint(response, `{"kind":"StorageClass","metadata":{"uid":"local-path-runtime-uid"},"provisioner":"foreign.example/storage"}`)
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			server := httptest.NewServer(handler)
+			defer server.Close()
+			source, err := newKubernetesRuntimeBindingSource(server.URL, "runtime-token", server.Client())
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := source.Observe(context.Background()); err == nil {
+				t.Fatal("unsafe runtime source response was accepted")
+			}
+		})
+	}
+	if _, err := (&KubernetesRuntimeBindingSource{}).Observe(context.Background()); err == nil {
+		t.Fatal("unopened runtime binding source could observe")
+	}
+}

--- a/internal/runner/runtime_binding_writer.go
+++ b/internal/runner/runtime_binding_writer.go
@@ -1,0 +1,96 @@
+package runner
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+const RuntimeBindingPersistenceReceiptFormat = "ok147-runtime-binding-persistence-receipt/v1"
+
+type RuntimeBindingPersistenceReceipt struct {
+	Format                    string `json:"format"`
+	State                     string `json:"state"`
+	PrivateMaterialDigest     string `json:"privateMaterialDigest"`
+	FileSize                  int    `json:"fileSize,omitempty"`
+	FileMode                  string `json:"fileMode,omitempty"`
+	KubernetesMutationAllowed bool   `json:"kubernetesMutationAllowed"`
+}
+
+type RuntimeBindingWriter struct {
+	mu       sync.Mutex
+	used     bool
+	material VerifiedRuntimeBindingMaterial
+	path     string
+}
+
+// OpenRuntimeBindingWriter validates one absolute path below an existing
+// private directory. It performs no write.
+func OpenRuntimeBindingWriter(material VerifiedRuntimeBindingMaterial, path string) (*RuntimeBindingWriter, error) {
+	if err := verifyRuntimeBindingMaterial(material); err != nil {
+		return nil, err
+	}
+	if path == "" || !filepath.IsAbs(path) || filepath.Clean(path) != path || filepath.Base(path) == "." || filepath.Base(path) == string(filepath.Separator) {
+		return nil, errors.New("runtime binding output path is invalid")
+	}
+	parent := filepath.Dir(path)
+	info, err := os.Lstat(parent)
+	if err != nil || !info.IsDir() || info.Mode()&os.ModeSymlink != 0 || info.Mode().Perm()&0o077 != 0 {
+		return nil, errors.New("runtime binding output directory is not private")
+	}
+	if _, err := os.Lstat(path); err == nil || !errors.Is(err, os.ErrNotExist) {
+		return nil, errors.New("runtime binding output must be absent")
+	}
+	return &RuntimeBindingWriter{material: material, path: path}, nil
+}
+
+// Write creates exactly one 0600 file with O_EXCL, syncs it, and re-verifies
+// the bytes. It has no overwrite, retry, rename, cleanup or delete path.
+func (writer *RuntimeBindingWriter) Write() (RuntimeBindingPersistenceReceipt, error) {
+	receipt := RuntimeBindingPersistenceReceipt{Format: RuntimeBindingPersistenceReceiptFormat, State: "PREWRITE", KubernetesMutationAllowed: false}
+	if writer == nil {
+		return receipt, errors.New("runtime binding writer is required")
+	}
+	writer.mu.Lock()
+	if writer.used {
+		writer.mu.Unlock()
+		return receipt, errors.New("runtime binding writer is single-use")
+	}
+	writer.used = true
+	writer.mu.Unlock()
+	raw, err := writer.material.Bytes()
+	if err != nil {
+		return receipt, err
+	}
+	receipt.PrivateMaterialDigest = digest.SHA256(raw)
+	file, err := os.OpenFile(writer.path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		receipt.State = "STOPPED_ZERO_WRITE"
+		return receipt, errors.New("create exclusive runtime binding output")
+	}
+	receipt.State = "STOPPED_PARTIAL_OR_UNKNOWN"
+	if _, err := file.Write(raw); err != nil {
+		file.Close()
+		return receipt, errors.New("write private runtime binding")
+	}
+	if err := file.Sync(); err != nil {
+		file.Close()
+		return receipt, errors.New("sync private runtime binding")
+	}
+	if err := file.Close(); err != nil {
+		return receipt, errors.New("close private runtime binding")
+	}
+	info, err := os.Lstat(writer.path)
+	if err != nil || !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 || info.Mode().Perm() != 0o600 || info.Size() != int64(len(raw)) {
+		return receipt, errors.New("private runtime binding metadata differs after write")
+	}
+	stored, err := readBoundedRegular(writer.path, int64(len(raw)))
+	if err != nil || digest.SHA256(stored) != receipt.PrivateMaterialDigest {
+		return receipt, errors.New("private runtime binding differs after write")
+	}
+	receipt.State, receipt.FileSize, receipt.FileMode = "WRITTEN_VERIFIED", len(raw), "0600"
+	return receipt, nil
+}

--- a/internal/runner/runtime_binding_writer_test.go
+++ b/internal/runner/runtime_binding_writer_test.go
@@ -1,0 +1,67 @@
+package runner
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRuntimeBindingWriterCreatesOneVerifiedPrivateFile(t *testing.T) {
+	material, err := BuildRuntimeBindingMaterial(runtimeBindingMaterialConfig(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	root := t.TempDir()
+	if err := os.Chmod(root, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(root, "runtime-binding.json")
+	writer, err := OpenRuntimeBindingWriter(material, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := writer.Write()
+	if err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Lstat(path)
+	if err != nil || receipt.State != "WRITTEN_VERIFIED" || receipt.FileMode != "0600" || receipt.FileSize <= 0 || receipt.KubernetesMutationAllowed || info.Mode().Perm() != 0o600 {
+		t.Fatalf("runtime binding persistence differs: %#v mode=%v err=%v", receipt, info.Mode(), err)
+	}
+	if _, err := writer.Write(); err == nil {
+		t.Fatal("single-use runtime binding writer wrote twice")
+	}
+}
+
+func TestRuntimeBindingWriterFailsClosedOnUnsafeOutput(t *testing.T) {
+	material, err := BuildRuntimeBindingMaterial(runtimeBindingMaterialConfig(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	root := t.TempDir()
+	if err := os.Chmod(root, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	existing := filepath.Join(root, "existing.json")
+	if err := os.WriteFile(existing, []byte("existing"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	public := filepath.Join(t.TempDir(), "public")
+	if err := os.Chmod(filepath.Dir(public), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for name, path := range map[string]string{
+		"relative":      "runtime-binding.json",
+		"existing":      existing,
+		"public parent": public,
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := OpenRuntimeBindingWriter(material, path); err == nil {
+				t.Fatal("unsafe runtime binding output was accepted")
+			}
+		})
+	}
+	if _, err := OpenRuntimeBindingWriter(VerifiedRuntimeBindingMaterial{}, filepath.Join(root, "invalid.json")); err == nil {
+		t.Fatal("unverified runtime binding material opened a writer")
+	}
+}


### PR DESCRIPTION
## Summary
- bind the exact workload authority before opening the runtime source
- permit only kube-system and local-path exact GETs and reduce responses to immutable runtime identities
- persist verified runtime material once with O_EXCL, mode 0600 and digest pullback
- keep stage composition and CLI/Job activation unreachable

## Verification
- `go test -ldflags=-linkmode=external ./...`
- `go vet ./...`
- `go test -race -ldflags=-linkmode=external ./internal/runner`

No live cluster contact or infrastructure mutation was performed.