### PR TITLE
feat(runner): compose runtime binding stage (OK-147)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,9 @@ Powered by [Cluster API (CAPI)](https://cluster-api.sigs.k8s.io/), [CAPK (KubeVi
   prefix while exposing only digest identities publicly. A bounded source now
   performs only the exact `kube-system` and `local-path` GETs after proving the
   workload authority, and an exclusive private writer creates and verifies one
-  `0600` binding file without overwrite or cleanup. Composition with the stage
-  operation and CLI/Job activation remains separate.
+  `0600` binding file without overwrite or cleanup. These capabilities are now
+  composed with the runner-owned crash-safe stage operation and immutable
+  ledger receipt; CLI/Job activation remains separate.
   Stage 4 now has its first distinct path as well:
   `ok cluster stage run enablement --execute` binds the verified three-receipt
   prefix and signed `CreateEnablement` grant to exactly one externally rendered

--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -2172,10 +2172,19 @@ failure remains `STOPPED_PARTIAL_OR_UNKNOWN`; the public persistence receipt
 contains only the material digest, size and mode and explicitly denies
 Kubernetes mutation.
 
-The source, materializer, writer and `BindingStageOperation` are not yet
-composed into one CLI/Job boundary. Therefore this checkpoint still performs
-no live request or file write in production, and target access remains
-unreachable.
+The verified stage bundle now composes that source, materializer and writer
+with `BindingStageOperation`. Opening the bundle re-verifies the five-receipt
+prefix, lifecycle target, private workload binding, distinct management-ledger
+and workload credentials, distinct API endpoints and safe output path without
+contacting either API. Running it performs the two workload GETs, creates and
+verifies the private file, then stores one immutable runner-owned stage receipt
+in the ledger. A source or persistence failure becomes a redaction-safe,
+terminal `STOPPED` receipt; a restart returns an existing receipt without
+re-reading or rewriting the workload binding.
+
+CLI/Job activation remains a separate checkpoint. Therefore the composition
+is not reachable from the product command surface yet, and target access
+remains unreachable.
 
 ## Bounded convergence observation polling
 

--- a/internal/runner/runtime_binding_source.go
+++ b/internal/runner/runtime_binding_source.go
@@ -31,20 +31,32 @@ type KubernetesRuntimeBindingSource struct {
 // authority and fixes its request surface to the two runtime-binding GETs. It
 // reads credential files but performs no API request.
 func OpenKubernetesRuntimeBindingSource(authority KubernetesAuthorityConfig, binding WorkloadAuthorityBinding) (*KubernetesRuntimeBindingSource, error) {
+	source, _, err := openKubernetesRuntimeBindingSource(authority, binding)
+	return source, err
+}
+
+// openKubernetesRuntimeBindingSource also returns the bounded token so stage
+// composition can prove that workload reads and ledger writes use distinct
+// credentials. The token never leaves this package or enters evidence.
+func openKubernetesRuntimeBindingSource(authority KubernetesAuthorityConfig, binding WorkloadAuthorityBinding) (*KubernetesRuntimeBindingSource, string, error) {
 	if err := validateWorkloadAuthorityBinding(binding); err != nil {
-		return nil, errors.New("runtime binding workload authority is invalid")
+		return nil, "", errors.New("runtime binding workload authority is invalid")
 	}
 	if authority.Endpoint != binding.Endpoint || authority.AuthorityIdentity != binding.TargetClusterUID || authority.CABundleDigest != binding.CABundleDigest {
-		return nil, errors.New("runtime binding source differs from workload authority")
+		return nil, "", errors.New("runtime binding source differs from workload authority")
 	}
 	token, ca, client, err := openBoundedKubernetesMaterial(authority.TokenFile, authority.CAFile)
 	if err != nil {
-		return nil, errors.New("open bounded runtime binding credential")
+		return nil, "", errors.New("open bounded runtime binding credential")
 	}
 	if digest.SHA256(ca) != binding.CABundleDigest {
-		return nil, errors.New("runtime binding source CA differs from workload authority")
+		return nil, "", errors.New("runtime binding source CA differs from workload authority")
 	}
-	return newKubernetesRuntimeBindingSource(authority.Endpoint, token, client)
+	source, err := newKubernetesRuntimeBindingSource(authority.Endpoint, token, client)
+	if err != nil {
+		return nil, "", err
+	}
+	return source, token, nil
 }
 
 func newKubernetesRuntimeBindingSource(endpoint, token string, client *http.Client) (*KubernetesRuntimeBindingSource, error) {

--- a/internal/runner/runtime_binding_stage.go
+++ b/internal/runner/runtime_binding_stage.go
@@ -1,0 +1,276 @@
+package runner
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/contract"
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/execution"
+	"github.com/openkubes/ok-cluster/internal/stagecursor"
+	"github.com/openkubes/ok-cluster/internal/stageplan"
+	"github.com/openkubes/ok-cluster/internal/stagereceipt"
+)
+
+const RuntimeBindingStageEvidenceFormat = "ok147-runtime-binding-stage-evidence/v1"
+
+type VerifiedRuntimeBindingStageBundle struct {
+	config   StageResumeConfig
+	plan     stageplan.Binding
+	cursor   stagecursor.Cursor
+	prefix   []stagereceipt.Verified
+	verified bool
+}
+
+type RuntimeBindingStageRuntimeConfig struct {
+	Ledger     KubernetesLedgerConfig
+	Workload   WorkloadAuthorityFileResolverConfig
+	OutputPath string
+	Clock      func() time.Time
+}
+
+type RuntimeBindingStageEvidenceReceipt struct {
+	Format                    string                            `json:"format"`
+	State                     string                            `json:"state"`
+	PlanDigest                string                            `json:"planDigest"`
+	StageID                   string                            `json:"stageId"`
+	FailureCategory           string                            `json:"failureCategory,omitempty"`
+	Material                  *RuntimeBindingMaterialReceipt    `json:"material,omitempty"`
+	Persistence               *RuntimeBindingPersistenceReceipt `json:"persistence,omitempty"`
+	KubernetesMutationAllowed bool                              `json:"kubernetesMutationAllowed"`
+}
+
+type OpenedRuntimeBindingStage struct {
+	operation execution.BindingStageOperation
+	plan      stageplan.Binding
+	cursor    stagecursor.Cursor
+	binder    *runtimeBindingStageBinder
+	verified  bool
+}
+
+// LoadRuntimeBindingStageBundle verifies the exact five-receipt prefix and
+// retains the runner-owned local binding cursor without opening credentials.
+func LoadRuntimeBindingStageBundle(config StageResumeConfig) (VerifiedRuntimeBindingStageBundle, error) {
+	plan, cursor, prefix, err := loadStageResumeWithPrefix(config)
+	if err != nil {
+		return VerifiedRuntimeBindingStageBundle{}, err
+	}
+	decision, err := cursor.Decision()
+	if err != nil || decision.State != "NEXT" || decision.StageID != "runtime-binding" || decision.Kind != "Binding" || decision.Authority != "runner" || decision.RequiresAuthorization || decision.Operation != "" {
+		return VerifiedRuntimeBindingStageBundle{}, errors.New("verified prefix does not select runtime binding")
+	}
+	if len(prefix) != 5 {
+		return VerifiedRuntimeBindingStageBundle{}, errors.New("runtime binding receipt prefix is incomplete")
+	}
+	retained := config
+	retained.Receipts = append([]StageReceiptSource(nil), config.Receipts...)
+	return VerifiedRuntimeBindingStageBundle{config: retained, plan: plan, cursor: cursor, prefix: prefix, verified: true}, nil
+}
+
+func (bundle VerifiedRuntimeBindingStageBundle) Decision() (stagecursor.Decision, error) {
+	if !bundle.verified {
+		return stagecursor.Decision{}, errors.New("runtime binding stage bundle is not verified")
+	}
+	return bundle.cursor.Decision()
+}
+
+// Open binds the exact ledger, workload source and private output path. It
+// reads bounded credential material but performs neither API requests nor file
+// creation.
+func (bundle VerifiedRuntimeBindingStageBundle) Open(config RuntimeBindingStageRuntimeConfig) (OpenedRuntimeBindingStage, error) {
+	if !bundle.verified || config.Clock == nil {
+		return OpenedRuntimeBindingStage{}, errors.New("verified runtime binding bundle and clock are required")
+	}
+	if err := validateRuntimeBindingOutputPath(config.OutputPath); err != nil {
+		return OpenedRuntimeBindingStage{}, err
+	}
+	lifecycle, err := bundle.prefix[1].Receipt()
+	if err != nil {
+		return OpenedRuntimeBindingStage{}, errors.New("read durable runtime target correlation")
+	}
+	binding, authority, err := loadWorkloadAuthorityFiles(config.Workload)
+	if err != nil {
+		return OpenedRuntimeBindingStage{}, errors.New("open runtime binding workload authority")
+	}
+	if binding.IntentRevision != bundle.plan.IntentRevision || digest.SHA256([]byte(binding.TargetClusterUID)) != lifecycle.TargetClusterUIDDigest {
+		return OpenedRuntimeBindingStage{}, errors.New("runtime binding workload authority differs from durable lifecycle target")
+	}
+	if sameRuntimeBindingEndpoint(config.Ledger.Endpoint, binding.Endpoint) {
+		return OpenedRuntimeBindingStage{}, errors.New("ledger and runtime observation endpoints must be distinct")
+	}
+	store, ledgerToken, err := openKubernetesLedger(config.Ledger)
+	if err != nil {
+		return OpenedRuntimeBindingStage{}, errors.New("open runtime binding ledger")
+	}
+	source, workloadToken, err := openKubernetesRuntimeBindingSource(authority, binding)
+	if err != nil {
+		return OpenedRuntimeBindingStage{}, errors.New("open bounded runtime binding source")
+	}
+	if sameSecret(ledgerToken, workloadToken) {
+		return OpenedRuntimeBindingStage{}, errors.New("ledger and runtime observation credentials must be distinct")
+	}
+	decision, _ := bundle.cursor.Decision()
+	binder := &runtimeBindingStageBinder{
+		binding: execution.StageBinderBinding{
+			PlanDigest: bundle.plan.PlanDigest, StageID: decision.StageID, StageDigest: decision.StageDigest,
+			Authority: decision.Authority, ContractRevision: bundle.plan.IntentRevision,
+		},
+		bundle: bundle.config, workload: config.Workload, outputPath: config.OutputPath,
+		source: source, clock: config.Clock,
+	}
+	return OpenedRuntimeBindingStage{
+		operation: execution.BindingStageOperation{Ledger: store, Binder: binder},
+		plan:      bundle.plan, cursor: bundle.cursor, binder: binder, verified: true,
+	}, nil
+}
+
+func (stage OpenedRuntimeBindingStage) Run(ctx context.Context) (execution.BindingStageRunReceipt, error) {
+	if !stage.verified {
+		return execution.BindingStageRunReceipt{}, errors.New("runtime binding stage is not opened")
+	}
+	return stage.operation.Run(ctx, stage.plan, stage.cursor)
+}
+
+// EvidenceReceipt exposes only the redaction-safe receipt from a binding call
+// made by this opened stage. Private material and runtime identities remain in
+// the exclusive output file.
+func (stage OpenedRuntimeBindingStage) EvidenceReceipt() (RuntimeBindingStageEvidenceReceipt, error) {
+	if !stage.verified || stage.binder == nil {
+		return RuntimeBindingStageEvidenceReceipt{}, errors.New("runtime binding stage is not opened")
+	}
+	return stage.binder.evidenceReceipt()
+}
+
+type runtimeBindingStageBinder struct {
+	mu          sync.Mutex
+	binding     execution.StageBinderBinding
+	bundle      StageResumeConfig
+	workload    WorkloadAuthorityFileResolverConfig
+	outputPath  string
+	source      *KubernetesRuntimeBindingSource
+	clock       func() time.Time
+	evidence    RuntimeBindingStageEvidenceReceipt
+	hasEvidence bool
+}
+
+func (binder *runtimeBindingStageBinder) Binding() execution.StageBinderBinding {
+	return binder.binding
+}
+
+func (binder *runtimeBindingStageBinder) Bind(ctx context.Context) (execution.StageBindingResult, error) {
+	if binder == nil || binder.source == nil || binder.clock == nil {
+		return execution.StageBindingResult{}, errors.New("runtime binding stage binder is invalid")
+	}
+	at := binder.clock().UTC()
+	if at.IsZero() {
+		return execution.StageBindingResult{}, errors.New("runtime binding completion time is invalid")
+	}
+	observation, err := binder.source.Observe(ctx)
+	if err != nil {
+		return binder.stop("SOURCE_STOPPED", nil, nil, at)
+	}
+	material, err := BuildRuntimeBindingMaterial(RuntimeBindingMaterialConfig{
+		Bundle: binder.bundle, WorkloadBindingPath: binder.workload.Path,
+		ExpectedWorkloadBindingDigest: binder.workload.ExpectedBindingDigest,
+		WorkloadCAFile:                binder.workload.CAFile, Observation: observation,
+	})
+	if err != nil {
+		return binder.stop("MATERIALIZATION_STOPPED", nil, nil, at)
+	}
+	materialReceipt, err := material.Receipt()
+	if err != nil || materialReceipt.PlanDigest != binder.binding.PlanDigest {
+		return binder.stop("MATERIAL_VERIFICATION_STOPPED", nil, nil, at)
+	}
+	writer, err := OpenRuntimeBindingWriter(material, binder.outputPath)
+	if err != nil {
+		return binder.stop("WRITER_OPEN_STOPPED", &materialReceipt, nil, at)
+	}
+	persistence, writeErr := writer.Write()
+	if writeErr != nil {
+		return binder.stop("PERSISTENCE_STOPPED", &materialReceipt, &persistence, at)
+	}
+	evidence := RuntimeBindingStageEvidenceReceipt{
+		Format: RuntimeBindingStageEvidenceFormat, State: "SUCCEEDED", PlanDigest: binder.binding.PlanDigest,
+		StageID: binder.binding.StageID, Material: &materialReceipt, Persistence: &persistence,
+		KubernetesMutationAllowed: false,
+	}
+	return binder.finish(evidence, "SUCCEEDED", at)
+}
+
+func (binder *runtimeBindingStageBinder) stop(category string, material *RuntimeBindingMaterialReceipt, persistence *RuntimeBindingPersistenceReceipt, at time.Time) (execution.StageBindingResult, error) {
+	evidence := RuntimeBindingStageEvidenceReceipt{
+		Format: RuntimeBindingStageEvidenceFormat, State: "STOPPED", PlanDigest: binder.binding.PlanDigest,
+		StageID: binder.binding.StageID, FailureCategory: category, Material: material, Persistence: persistence,
+		KubernetesMutationAllowed: false,
+	}
+	return binder.finish(evidence, "STOPPED", at)
+}
+
+func (binder *runtimeBindingStageBinder) finish(evidence RuntimeBindingStageEvidenceReceipt, outcome string, at time.Time) (execution.StageBindingResult, error) {
+	evidenceDigest, err := runtimeBindingStageEvidenceDigest(evidence)
+	if err != nil {
+		return execution.StageBindingResult{}, errors.New("encode runtime binding stage evidence")
+	}
+	binder.mu.Lock()
+	binder.evidence, binder.hasEvidence = evidence, true
+	binder.mu.Unlock()
+	return execution.StageBindingResult{Outcome: outcome, EvidenceDigest: evidenceDigest, CompletedAt: at}, nil
+}
+
+func (binder *runtimeBindingStageBinder) evidenceReceipt() (RuntimeBindingStageEvidenceReceipt, error) {
+	binder.mu.Lock()
+	defer binder.mu.Unlock()
+	if !binder.hasEvidence {
+		return RuntimeBindingStageEvidenceReceipt{}, errors.New("runtime binding evidence is not available")
+	}
+	return cloneRuntimeBindingStageEvidence(binder.evidence), nil
+}
+
+func runtimeBindingStageEvidenceDigest(evidence RuntimeBindingStageEvidenceReceipt) (string, error) {
+	raw, err := json.Marshal(evidence)
+	if err != nil {
+		return "", err
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	var value any
+	if err := decoder.Decode(&value); err != nil {
+		return "", err
+	}
+	canonical, err := contract.JCS(value)
+	if err != nil {
+		return "", err
+	}
+	return digest.SHA256(canonical), nil
+}
+
+func cloneRuntimeBindingStageEvidence(evidence RuntimeBindingStageEvidenceReceipt) RuntimeBindingStageEvidenceReceipt {
+	clone := evidence
+	if evidence.Material != nil {
+		value := *evidence.Material
+		clone.Material = &value
+	}
+	if evidence.Persistence != nil {
+		value := *evidence.Persistence
+		clone.Persistence = &value
+	}
+	return clone
+}
+
+func sameRuntimeBindingEndpoint(first, second string) bool {
+	left, leftErr := url.Parse(first)
+	right, rightErr := url.Parse(second)
+	if leftErr != nil || rightErr != nil {
+		return false
+	}
+	leftPath, rightPath := strings.TrimSuffix(left.Path, "/"), strings.TrimSuffix(right.Path, "/")
+	return strings.EqualFold(left.Scheme, right.Scheme) && strings.EqualFold(left.Host, right.Host) && leftPath == rightPath
+}
+
+var _ execution.StageBinder = (*runtimeBindingStageBinder)(nil)

--- a/internal/runner/runtime_binding_stage_test.go
+++ b/internal/runner/runtime_binding_stage_test.go
@@ -1,0 +1,300 @@
+package runner
+
+import (
+	"context"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/execution"
+)
+
+func TestRuntimeBindingStageComposesAndResumesWithoutRebinding(t *testing.T) {
+	config := runtimeBindingBundleConfig(t)
+	bundle, err := LoadRuntimeBindingStageBundle(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decision, err := bundle.Decision()
+	if err != nil || decision.StageID != "runtime-binding" || decision.Authority != "runner" {
+		t.Fatalf("runtime binding decision differs: %#v %v", decision, err)
+	}
+	ledgerAPI := newRuntimeBindingLedgerAPI(t)
+	defer ledgerAPI.Close()
+	workloadAPI := newRuntimeBindingWorkloadAPI(t, false)
+	defer workloadAPI.Close()
+	runtime := runtimeBindingStageRuntime(t, bundle, ledgerAPI.Server, workloadAPI.Server, "ledger-token", "workload-token")
+	opened, err := bundle.Open(runtime)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ledgerAPI.RequestCount() != 0 || workloadAPI.RequestCount() != 0 {
+		t.Fatal("opening runtime binding stage contacted Kubernetes")
+	}
+	receipt, err := opened.Run(context.Background())
+	if err != nil || receipt.State != "COMPLETED_SUCCEEDED" || receipt.StageReceiptDigest == "" {
+		t.Fatalf("runtime binding stage did not complete: %#v %v", receipt, err)
+	}
+	evidence, err := opened.EvidenceReceipt()
+	if err != nil || evidence.State != "SUCCEEDED" || evidence.Material == nil || evidence.Persistence == nil || evidence.Persistence.State != "WRITTEN_VERIFIED" || evidence.KubernetesMutationAllowed {
+		t.Fatalf("runtime binding evidence differs: %#v %v", evidence, err)
+	}
+	public, _ := json.Marshal(evidence)
+	for _, forbidden := range []string{workloadAPI.URL, "kube-system-runtime-uid", "local-path-runtime-uid", "ledger-token", "workload-token", runtime.OutputPath} {
+		if strings.Contains(string(public), forbidden) {
+			t.Fatalf("runtime binding evidence exposed private value %q", forbidden)
+		}
+	}
+	stored, err := os.ReadFile(runtime.OutputPath)
+	if err != nil || digest.SHA256(stored) != evidence.Material.PrivateMaterialDigest {
+		t.Fatalf("private runtime binding differs: %v", err)
+	}
+	wantRequests := []string{"GET " + runtimeBindingKubeSystemPath, "GET " + runtimeBindingLocalPathPath}
+	if !reflect.DeepEqual(workloadAPI.Requests(), wantRequests) {
+		t.Fatalf("workload request boundary differs: %v", workloadAPI.Requests())
+	}
+	evidence.Material.State = "CHANGED"
+	retained, err := opened.EvidenceReceipt()
+	if err != nil || retained.Material.State != "VERIFIED" {
+		t.Fatal("caller mutated retained runtime binding evidence")
+	}
+	if _, err := opened.Run(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(workloadAPI.Requests(), wantRequests) {
+		t.Fatal("persisted runtime binding stage rebound the workload")
+	}
+}
+
+func TestRuntimeBindingStagePersistsRedactedStop(t *testing.T) {
+	bundle, err := LoadRuntimeBindingStageBundle(runtimeBindingBundleConfig(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ledgerAPI := newRuntimeBindingLedgerAPI(t)
+	defer ledgerAPI.Close()
+	workloadAPI := newRuntimeBindingWorkloadAPI(t, true)
+	defer workloadAPI.Close()
+	runtime := runtimeBindingStageRuntime(t, bundle, ledgerAPI.Server, workloadAPI.Server, "ledger-token", "workload-token")
+	opened, err := bundle.Open(runtime)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, runErr := opened.Run(context.Background())
+	var resultErr *execution.BindingStageResultError
+	if !errors.As(runErr, &resultErr) || receipt.State != "COMPLETED_STOPPED" || receipt.StageReceiptDigest == "" {
+		t.Fatalf("runtime source failure was not retained: %#v %v", receipt, runErr)
+	}
+	evidence, err := opened.EvidenceReceipt()
+	if err != nil || evidence.State != "STOPPED" || evidence.FailureCategory != "SOURCE_STOPPED" || evidence.Material != nil || evidence.Persistence != nil {
+		t.Fatalf("stopped evidence differs: %#v %v", evidence, err)
+	}
+	if _, err := os.Lstat(runtime.OutputPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatal("source failure created private runtime material")
+	}
+}
+
+func TestRuntimeBindingStageOpenFailsClosedWithoutContact(t *testing.T) {
+	config := runtimeBindingBundleConfig(t)
+	bundle, err := LoadRuntimeBindingStageBundle(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ledgerAPI := newRuntimeBindingLedgerAPI(t)
+	defer ledgerAPI.Close()
+	workloadAPI := newRuntimeBindingWorkloadAPI(t, false)
+	defer workloadAPI.Close()
+	runtime := runtimeBindingStageRuntime(t, bundle, ledgerAPI.Server, workloadAPI.Server, "shared-token", "shared-token")
+	if _, err := bundle.Open(runtime); err == nil {
+		t.Fatal("shared ledger and workload credential was accepted")
+	}
+	if ledgerAPI.RequestCount() != 0 || workloadAPI.RequestCount() != 0 {
+		t.Fatal("failed runtime binding open contacted Kubernetes")
+	}
+	runtime = runtimeBindingStageRuntime(t, bundle, ledgerAPI.Server, workloadAPI.Server, "ledger-token", "workload-token")
+	runtime.Ledger.Endpoint = runtime.WorkloadEndpointForTest(t) + "/"
+	if _, err := bundle.Open(runtime); err == nil {
+		t.Fatal("shared ledger and workload endpoint was accepted")
+	}
+	if _, err := (VerifiedRuntimeBindingStageBundle{}).Open(runtime); err == nil {
+		t.Fatal("unverified runtime binding bundle opened credentials")
+	}
+	if _, err := (OpenedRuntimeBindingStage{}).Run(context.Background()); err == nil {
+		t.Fatal("unopened runtime binding stage could run")
+	}
+}
+
+func runtimeBindingStageRuntime(t *testing.T, bundle VerifiedRuntimeBindingStageBundle, ledgerServer, workloadServer *httptest.Server, ledgerToken, workloadToken string) RuntimeBindingStageRuntimeConfig {
+	t.Helper()
+	root := t.TempDir()
+	if err := os.Chmod(root, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	ledgerCA := writeRuntimeBindingServerCA(t, root, "ledger-ca.crt", ledgerServer)
+	workloadCA := writeRuntimeBindingServerCA(t, root, "workload-ca.crt", workloadServer)
+	workloadCARaw, err := os.ReadFile(workloadCA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ledgerTokenPath, workloadTokenPath := filepath.Join(root, "ledger-token"), filepath.Join(root, "workload-token")
+	for path, raw := range map[string][]byte{ledgerTokenPath: []byte(ledgerToken), workloadTokenPath: []byte(workloadToken)} {
+		if err := os.WriteFile(path, raw, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	lifecycle, _ := bundle.prefix[1].Receipt()
+	targetUID := "cluster-runtime-uid-147"
+	if digest.SHA256([]byte(targetUID)) != lifecycle.TargetClusterUIDDigest {
+		t.Fatal("test runtime target differs from lifecycle receipt")
+	}
+	binding := WorkloadAuthorityBinding{
+		Format: WorkloadAuthorityBindingFormat, IntentRevision: bundle.plan.IntentRevision,
+		TargetClusterUID: targetUID, TargetIdentityScheme: "capi-cluster-uid/v1",
+		Endpoint: workloadServer.URL, CABundleDigest: digest.SHA256(workloadCARaw),
+	}
+	bindingPath := filepath.Join(root, "workload-binding.json")
+	writePlatformJSON(t, bindingPath, binding)
+	bindingDigest, err := WorkloadAuthorityBindingDigest(binding)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return RuntimeBindingStageRuntimeConfig{
+		Ledger:     KubernetesLedgerConfig{Endpoint: ledgerServer.URL, Namespace: "openkubes-execution-system", TokenFile: ledgerTokenPath, CAFile: ledgerCA},
+		Workload:   WorkloadAuthorityFileResolverConfig{Path: bindingPath, ExpectedBindingDigest: bindingDigest, TokenFile: workloadTokenPath, CAFile: workloadCA},
+		OutputPath: filepath.Join(root, "runtime-binding.json"),
+		Clock:      func() time.Time { return time.Date(2026, 8, 17, 9, 0, 0, 0, time.UTC) },
+	}
+}
+
+// WorkloadEndpointForTest reloads only the strict semantic binding used by the
+// fixture; it exists to keep the unsafe shared-endpoint case explicit.
+func (config RuntimeBindingStageRuntimeConfig) WorkloadEndpointForTest(t *testing.T) string {
+	t.Helper()
+	binding, err := loadWorkloadAuthorityBinding(config.Workload.Path, config.Workload.ExpectedBindingDigest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return binding.Endpoint
+}
+
+func writeRuntimeBindingServerCA(t *testing.T, root, name string, server *httptest.Server) string {
+	t.Helper()
+	raw := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: server.Certificate().Raw})
+	path := filepath.Join(root, name)
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+type runtimeBindingWorkloadAPI struct {
+	*httptest.Server
+	mu       sync.Mutex
+	requests []string
+}
+
+func newRuntimeBindingWorkloadAPI(t *testing.T, fail bool) *runtimeBindingWorkloadAPI {
+	t.Helper()
+	api := &runtimeBindingWorkloadAPI{}
+	api.Server = httptest.NewTLSServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		api.mu.Lock()
+		api.requests = append(api.requests, request.Method+" "+request.URL.RequestURI())
+		api.mu.Unlock()
+		response.Header().Set("Content-Type", "application/json")
+		if request.Header.Get("Authorization") != "Bearer workload-token" {
+			response.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		if fail {
+			response.WriteHeader(http.StatusForbidden)
+			return
+		}
+		switch request.URL.Path {
+		case runtimeBindingKubeSystemPath:
+			fmt.Fprint(response, `{"kind":"Namespace","metadata":{"uid":"kube-system-runtime-uid"}}`)
+		case runtimeBindingLocalPathPath:
+			fmt.Fprint(response, `{"kind":"StorageClass","metadata":{"uid":"local-path-runtime-uid"},"provisioner":"rancher.io/local-path"}`)
+		default:
+			response.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	return api
+}
+
+func (api *runtimeBindingWorkloadAPI) Requests() []string {
+	api.mu.Lock()
+	defer api.mu.Unlock()
+	return append([]string(nil), api.requests...)
+}
+
+func (api *runtimeBindingWorkloadAPI) RequestCount() int { return len(api.Requests()) }
+
+type runtimeBindingLedgerAPI struct {
+	*httptest.Server
+	mu       sync.Mutex
+	objects  map[string]map[string]any
+	requests int
+}
+
+func newRuntimeBindingLedgerAPI(t *testing.T) *runtimeBindingLedgerAPI {
+	t.Helper()
+	api := &runtimeBindingLedgerAPI{objects: map[string]map[string]any{}}
+	api.Server = httptest.NewTLSServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		api.mu.Lock()
+		defer api.mu.Unlock()
+		api.requests++
+		response.Header().Set("Content-Type", "application/json")
+		if request.Header.Get("Authorization") != "Bearer ledger-token" {
+			response.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		prefix := "/api/v1/namespaces/openkubes-execution-system/configmaps"
+		if request.Method == http.MethodGet && strings.HasPrefix(request.URL.Path, prefix+"/") {
+			name := strings.TrimPrefix(request.URL.Path, prefix+"/")
+			object, ok := api.objects[name]
+			if !ok {
+				response.WriteHeader(http.StatusNotFound)
+				return
+			}
+			json.NewEncoder(response).Encode(object)
+			return
+		}
+		if request.Method == http.MethodPost && request.URL.Path == prefix {
+			var object map[string]any
+			if err := json.NewDecoder(request.Body).Decode(&object); err != nil {
+				response.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			metadata := object["metadata"].(map[string]any)
+			name := metadata["name"].(string)
+			if _, exists := api.objects[name]; exists {
+				response.WriteHeader(http.StatusConflict)
+				return
+			}
+			metadata["uid"], metadata["resourceVersion"] = "ledger-runtime-uid", "1"
+			api.objects[name] = object
+			response.WriteHeader(http.StatusCreated)
+			json.NewEncoder(response).Encode(object)
+			return
+		}
+		response.WriteHeader(http.StatusMethodNotAllowed)
+	}))
+	return api
+}
+
+func (api *runtimeBindingLedgerAPI) RequestCount() int {
+	api.mu.Lock()
+	defer api.mu.Unlock()
+	return api.requests
+}

--- a/internal/runner/runtime_binding_writer.go
+++ b/internal/runner/runtime_binding_writer.go
@@ -33,18 +33,25 @@ func OpenRuntimeBindingWriter(material VerifiedRuntimeBindingMaterial, path stri
 	if err := verifyRuntimeBindingMaterial(material); err != nil {
 		return nil, err
 	}
+	if err := validateRuntimeBindingOutputPath(path); err != nil {
+		return nil, err
+	}
+	return &RuntimeBindingWriter{material: material, path: path}, nil
+}
+
+func validateRuntimeBindingOutputPath(path string) error {
 	if path == "" || !filepath.IsAbs(path) || filepath.Clean(path) != path || filepath.Base(path) == "." || filepath.Base(path) == string(filepath.Separator) {
-		return nil, errors.New("runtime binding output path is invalid")
+		return errors.New("runtime binding output path is invalid")
 	}
 	parent := filepath.Dir(path)
 	info, err := os.Lstat(parent)
 	if err != nil || !info.IsDir() || info.Mode()&os.ModeSymlink != 0 || info.Mode().Perm()&0o077 != 0 {
-		return nil, errors.New("runtime binding output directory is not private")
+		return errors.New("runtime binding output directory is not private")
 	}
 	if _, err := os.Lstat(path); err == nil || !errors.Is(err, os.ErrNotExist) {
-		return nil, errors.New("runtime binding output must be absent")
+		return errors.New("runtime binding output must be absent")
 	}
-	return &RuntimeBindingWriter{material: material, path: path}, nil
+	return nil
 }
 
 // Write creates exactly one 0600 file with O_EXCL, syncs it, and re-verifies


### PR DESCRIPTION
## Summary
- compose the verified five-receipt prefix with distinct ledger and workload authorities
- execute only the two bounded runtime identity GETs, materialize the private binding and persist one immutable stage receipt
- retain redaction-safe terminal STOPPED evidence and resume without rebinding
- keep the composition unreachable from CLI and Job activation

## Verification
- `go test -ldflags=-linkmode=external ./...`
- `go vet ./...`
- `go test -race -ldflags=-linkmode=external ./internal/runner`

All API interactions were exercised against in-process fake TLS servers. No live cluster contact or infrastructure mutation was performed.