### PR TITLE
feat(cli): activate runtime binding stage (OK-147)

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,9 @@ Powered by [Cluster API (CAPI)](https://cluster-api.sigs.k8s.io/), [CAPK (KubeVi
   workload authority, and an exclusive private writer creates and verifies one
   `0600` binding file without overwrite or cleanup. These capabilities are now
   composed with the runner-owned crash-safe stage operation and immutable
-  ledger receipt; CLI/Job activation remains separate.
+  ledger receipt. `ok cluster stage bind runtime --execute` is the first local,
+  two-minute activation boundary and emits only its redaction-safe evidence;
+  Job activation and all target access remain separate.
   Stage 4 now has its first distinct path as well:
   `ok cluster stage run enablement --execute` binds the verified three-receipt
   prefix and signed `CreateEnablement` grant to exactly one externally rendered

--- a/cmd/ok/main.go
+++ b/cmd/ok/main.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"syscall"
@@ -30,6 +31,7 @@ const (
 	stageRunTimeout                 = 10 * time.Minute
 	stageLaunchTimeout              = 5 * time.Minute
 	lifecycleObservationRunOverhead = time.Minute
+	runtimeBindingRunTimeout        = 2 * time.Minute
 )
 
 var (
@@ -256,6 +258,12 @@ type networkObservationLaunchPreparation struct {
 	Material        runner.NetworkObservationStageLaunchMaterialReceipt  `json:"material"`
 	Candidate       runner.NetworkObservationStageLaunchCandidateReceipt `json:"candidate"`
 	MutationAllowed bool                                                 `json:"mutationAllowed"`
+}
+
+type runtimeBindingExecution struct {
+	Format   string                                     `json:"format"`
+	Receipt  execution.BindingStageRunReceipt           `json:"receipt"`
+	Evidence *runner.RuntimeBindingStageEvidenceReceipt `json:"evidence,omitempty"`
 }
 
 type receiptFlags []string
@@ -510,6 +518,23 @@ var executeNetworkObservationStage = func(ctx context.Context, bundleConfig runn
 	return opened.Run(ctx)
 }
 
+var executeRuntimeBindingStage = func(ctx context.Context, bundleConfig runner.StageResumeConfig, runtimeConfig runner.RuntimeBindingStageRuntimeConfig) (execution.BindingStageRunReceipt, *runner.RuntimeBindingStageEvidenceReceipt, error) {
+	bundle, err := runner.LoadRuntimeBindingStageBundle(bundleConfig)
+	if err != nil {
+		return execution.BindingStageRunReceipt{}, nil, err
+	}
+	opened, err := bundle.Open(runtimeConfig)
+	if err != nil {
+		return execution.BindingStageRunReceipt{}, nil, err
+	}
+	receipt, runErr := opened.Run(ctx)
+	evidence, evidenceErr := opened.EvidenceReceipt()
+	if evidenceErr == nil {
+		return receipt, &evidence, runErr
+	}
+	return receipt, nil, runErr
+}
+
 func submissionStageAuthority(decision stagecursor.Decision, expected stageplan.Expected) (string, error) {
 	switch decision.Authority {
 	case "infrastructure":
@@ -572,6 +597,9 @@ func runContext(ctx context.Context, arguments []string, stdout, stderr io.Write
 	if len(arguments) >= 4 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "observe" && arguments[3] == "network" {
 		return runClusterStageObserveNetwork(ctx, arguments[4:], stdout, stderr)
 	}
+	if len(arguments) >= 4 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "bind" && arguments[3] == "runtime" {
+		return runClusterStageBindRuntime(ctx, arguments[4:], stdout, stderr)
+	}
 	if len(arguments) >= 5 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "run" && arguments[3] == "enablement" && arguments[4] == "package" {
 		return runClusterStageRunEnablementPackage(arguments[5:], stdout, stderr)
 	}
@@ -596,7 +624,7 @@ func runContext(ctx context.Context, arguments []string, stdout, stderr io.Write
 	if len(arguments) >= 4 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "launch" && arguments[3] == "execute" {
 		return runClusterStageLaunchExecute(ctx, arguments[4:], stdout, stderr)
 	}
-	return errors.New("usage: ok cluster create ... | ok cluster stage inspect ... | ok cluster stage resume ... | ok cluster stage observe lifecycle ... | ok cluster stage observe network ... | ok cluster stage observe network package ... | ok cluster stage observe network launch prepare ... | ok cluster stage observe network launch execute ... | ok cluster stage observe lifecycle package ... | ok cluster stage observe lifecycle launch prepare ... | ok cluster stage observe lifecycle launch execute ... | ok cluster stage run ... | ok cluster stage run enablement ... | ok cluster stage run enablement package ... | ok cluster stage run enablement launch prepare ... | ok cluster stage run enablement launch execute ... | ok cluster stage package ... | ok cluster stage launch prepare ... | ok cluster stage launch execute ...")
+	return errors.New("usage: ok cluster create ... | ok cluster stage inspect ... | ok cluster stage resume ... | ok cluster stage observe lifecycle ... | ok cluster stage observe network ... | ok cluster stage bind runtime ... | ok cluster stage observe network package ... | ok cluster stage observe network launch prepare ... | ok cluster stage observe network launch execute ... | ok cluster stage observe lifecycle package ... | ok cluster stage observe lifecycle launch prepare ... | ok cluster stage observe lifecycle launch execute ... | ok cluster stage run ... | ok cluster stage run enablement ... | ok cluster stage run enablement package ... | ok cluster stage run enablement launch prepare ... | ok cluster stage run enablement launch execute ... | ok cluster stage package ... | ok cluster stage launch prepare ... | ok cluster stage launch execute ...")
 }
 
 func runClusterCreate(arguments []string, stdout, stderr io.Writer) error {
@@ -909,6 +937,70 @@ func runClusterStageObserveNetwork(ctx context.Context, arguments []string, stdo
 		encoder.SetEscapeHTML(false)
 		encoder.SetIndent("", "  ")
 		if err := encoder.Encode(receipt); err != nil {
+			return err
+		}
+	}
+	return runErr
+}
+
+func runClusterStageBindRuntime(ctx context.Context, arguments []string, stdout, stderr io.Writer) error {
+	flags := flag.NewFlagSet("ok cluster stage bind runtime", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	resumeFlags := addStageResumeFlags(flags)
+	execute := flags.Bool("execute", false, "perform exactly the selected runtime binding and persist its receipts")
+	ledgerAPIEndpoint := flags.String("ledger-api-endpoint", "", "TLS Kubernetes API endpoint for the durable management ledger")
+	ledgerTokenFile := flags.String("ledger-token-file", "", "path to the short-lived ledger token")
+	ledgerCAFile := flags.String("ledger-ca-file", "", "path to the ledger Kubernetes API CA bundle")
+	workloadBinding := flags.String("workload-binding", "", "path to the private workload-authority binding")
+	workloadBindingDigest := flags.String("workload-binding-digest", "", "expected workload-authority binding digest")
+	workloadTokenFile := flags.String("workload-token-file", "", "path to the short-lived read-only workload token")
+	workloadCAFile := flags.String("workload-ca-file", "", "path to the workload Kubernetes API CA bundle")
+	output := flags.String("output", "", "absent absolute path in a private directory for the runtime binding")
+	if err := flags.Parse(arguments); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return errors.New("positional arguments are not accepted")
+	}
+	if !*execute {
+		return errors.New("runtime binding requires explicit --execute")
+	}
+	bundleConfig, err := resumeFlags.config()
+	if err != nil {
+		return err
+	}
+	for _, input := range []struct{ name, value string }{
+		{"--ledger-api-endpoint", *ledgerAPIEndpoint}, {"--ledger-token-file", *ledgerTokenFile}, {"--ledger-ca-file", *ledgerCAFile},
+		{"--workload-binding", *workloadBinding}, {"--workload-binding-digest", *workloadBindingDigest},
+		{"--workload-token-file", *workloadTokenFile}, {"--workload-ca-file", *workloadCAFile}, {"--output", *output},
+	} {
+		if input.value == "" {
+			return fmt.Errorf("%s is required", input.name)
+		}
+	}
+	if !sha256DigestPattern.MatchString(*workloadBindingDigest) {
+		return errors.New("workload binding digest must be a lowercase SHA-256 identity")
+	}
+	if !filepath.IsAbs(*output) || filepath.Clean(*output) != *output {
+		return errors.New("--output must be a clean absolute path")
+	}
+	boundedContext, cancel := context.WithTimeout(ctx, runtimeBindingRunTimeout)
+	defer cancel()
+	receipt, evidence, runErr := executeRuntimeBindingStage(boundedContext, bundleConfig, runner.RuntimeBindingStageRuntimeConfig{
+		Ledger: runner.KubernetesLedgerConfig{
+			Endpoint: *ledgerAPIEndpoint, Namespace: ledgerNamespace, TokenFile: *ledgerTokenFile, CAFile: *ledgerCAFile,
+		},
+		Workload: runner.WorkloadAuthorityFileResolverConfig{
+			Path: *workloadBinding, ExpectedBindingDigest: *workloadBindingDigest,
+			TokenFile: *workloadTokenFile, CAFile: *workloadCAFile,
+		},
+		OutputPath: *output, Clock: func() time.Time { return time.Now().UTC() },
+	})
+	if receipt.Format != "" {
+		encoder := json.NewEncoder(stdout)
+		encoder.SetEscapeHTML(false)
+		encoder.SetIndent("", "  ")
+		if err := encoder.Encode(runtimeBindingExecution{Format: "ok147-runtime-binding-execution/v1", Receipt: receipt, Evidence: evidence}); err != nil {
 			return err
 		}
 	}

--- a/cmd/ok/main_test.go
+++ b/cmd/ok/main_test.go
@@ -443,6 +443,104 @@ func TestStageObserveNetworkEmitsPersistedTerminalReceipt(t *testing.T) {
 	}
 }
 
+func TestStageBindRuntimeRequiresExplicitExecutionAndBindsRuntime(t *testing.T) {
+	previous := executeRuntimeBindingStage
+	defer func() { executeRuntimeBindingStage = previous }()
+	var capturedBundle runner.StageResumeConfig
+	var capturedRuntime runner.RuntimeBindingStageRuntimeConfig
+	var capturedContext context.Context
+	executeRuntimeBindingStage = func(ctx context.Context, bundle runner.StageResumeConfig, runtime runner.RuntimeBindingStageRuntimeConfig) (execution.BindingStageRunReceipt, *runner.RuntimeBindingStageEvidenceReceipt, error) {
+		capturedContext, capturedBundle, capturedRuntime = ctx, bundle, runtime
+		evidence := &runner.RuntimeBindingStageEvidenceReceipt{
+			Format: runner.RuntimeBindingStageEvidenceFormat, State: "SUCCEEDED", PlanDigest: testSHA("9"), StageID: "runtime-binding",
+			KubernetesMutationAllowed: false,
+		}
+		return execution.BindingStageRunReceipt{
+			Format: execution.BindingStageReceiptFormat, State: "COMPLETED_SUCCEEDED",
+			PlanDigest: testSHA("9"), StageID: "runtime-binding", StageReceiptDigest: testSHA("8"),
+		}, evidence, nil
+	}
+	var stdout, stderr bytes.Buffer
+	if err := run(stageBindRuntimeArguments(), &stdout, &stderr); err != nil {
+		t.Fatalf("run: %v; stderr=%s", err, stderr.String())
+	}
+	if capturedBundle.PlanPath != "/tmp/plan.json" || len(capturedBundle.Receipts) != 5 {
+		t.Fatalf("unexpected runtime binding bundle: %#v", capturedBundle)
+	}
+	if capturedRuntime.Ledger.Namespace != ledgerNamespace || capturedRuntime.Workload.ExpectedBindingDigest != testSHA("5") || capturedRuntime.OutputPath != "/private/tmp/ok147-runtime-binding.json" || capturedRuntime.Clock == nil {
+		t.Fatalf("unexpected runtime binding config: %#v", capturedRuntime)
+	}
+	deadline, bounded := capturedContext.Deadline()
+	remaining := time.Until(deadline)
+	if !bounded || remaining > runtimeBindingRunTimeout || remaining < runtimeBindingRunTimeout-time.Second {
+		t.Fatalf("runtime binding context is not bounded: %s %t", deadline, bounded)
+	}
+	var result runtimeBindingExecution
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatal(err)
+	}
+	if result.Format != "ok147-runtime-binding-execution/v1" || result.Receipt.State != "COMPLETED_SUCCEEDED" || result.Evidence == nil || result.Evidence.State != "SUCCEEDED" {
+		t.Fatalf("unexpected runtime binding output: %#v", result)
+	}
+}
+
+func TestStageBindRuntimeFailsClosedBeforeExecution(t *testing.T) {
+	previous := executeRuntimeBindingStage
+	defer func() { executeRuntimeBindingStage = previous }()
+	calls := 0
+	executeRuntimeBindingStage = func(context.Context, runner.StageResumeConfig, runner.RuntimeBindingStageRuntimeConfig) (execution.BindingStageRunReceipt, *runner.RuntimeBindingStageEvidenceReceipt, error) {
+		calls++
+		return execution.BindingStageRunReceipt{}, nil, nil
+	}
+	valid := stageBindRuntimeArguments()
+	for name, arguments := range map[string][]string{
+		"missing execute":          removeArgument(valid, "--execute"),
+		"missing ledger token":     removeArgumentWithValue(valid, "--ledger-token-file"),
+		"missing workload binding": removeArgumentWithValue(valid, "--workload-binding"),
+		"bad binding digest":       replaceArgument(valid, "--workload-binding-digest", "sha256:bad"),
+		"missing workload token":   removeArgumentWithValue(valid, "--workload-token-file"),
+		"relative output":          replaceArgument(valid, "--output", "runtime-binding.json"),
+		"unclean output":           replaceArgument(valid, "--output", "/private/tmp/../tmp/runtime-binding.json"),
+		"positional":               append(append([]string{}, valid...), "unexpected"),
+	} {
+		t.Run(name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			if err := run(arguments, &stdout, &stderr); err == nil || stdout.Len() != 0 {
+				t.Fatalf("unsafe runtime binding input was accepted: err=%v stdout=%s", err, stdout.String())
+			}
+		})
+	}
+	if calls != 0 {
+		t.Fatalf("runtime binding execution was reached %d times for invalid input", calls)
+	}
+}
+
+func TestStageBindRuntimeEmitsPersistedTerminalReceipt(t *testing.T) {
+	previous := executeRuntimeBindingStage
+	defer func() { executeRuntimeBindingStage = previous }()
+	executeRuntimeBindingStage = func(context.Context, runner.StageResumeConfig, runner.RuntimeBindingStageRuntimeConfig) (execution.BindingStageRunReceipt, *runner.RuntimeBindingStageEvidenceReceipt, error) {
+		evidence := &runner.RuntimeBindingStageEvidenceReceipt{
+			Format: runner.RuntimeBindingStageEvidenceFormat, State: "STOPPED", PlanDigest: testSHA("9"), StageID: "runtime-binding",
+			FailureCategory: "SOURCE_STOPPED", KubernetesMutationAllowed: false,
+		}
+		return execution.BindingStageRunReceipt{
+			Format: execution.BindingStageReceiptFormat, State: "COMPLETED_STOPPED",
+			PlanDigest: testSHA("9"), StageID: "runtime-binding", StageReceiptDigest: testSHA("8"),
+		}, evidence, errors.New("bounded runtime binding stopped")
+	}
+	var stdout, stderr bytes.Buffer
+	if err := run(stageBindRuntimeArguments(), &stdout, &stderr); err == nil {
+		t.Fatal("terminal runtime binding returned success")
+	}
+	var result runtimeBindingExecution
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatal(err)
+	}
+	if result.Receipt.State != "COMPLETED_STOPPED" || result.Receipt.StageReceiptDigest == "" || result.Evidence == nil || result.Evidence.FailureCategory != "SOURCE_STOPPED" {
+		t.Fatalf("persisted terminal runtime binding was lost: %#v", result)
+	}
+}
+
 func TestStageObserveLifecyclePackageWritesVerifiedOfflineArtifact(t *testing.T) {
 	previous := materializeLifecycleObservationStagePackage
 	defer func() { materializeLifecycleObservationStagePackage = previous }()
@@ -1376,6 +1474,23 @@ func stageObserveNetworkArguments() []string {
 		"--workload-token-file", "/tmp/workload-observer-token", "--workload-ca-file", "/tmp/workload-ca",
 		"--network-profile", "/tmp/network-profile.json", "--network-profile-digest", testSHA("5"),
 		"--poll-interval", "15s", "--poll-timeout", "5m",
+	)
+}
+
+func stageBindRuntimeArguments() []string {
+	arguments := stageResumeArguments()
+	arguments = append([]string{"cluster", "stage", "bind", "runtime"}, arguments[3:]...)
+	return append(arguments,
+		"--receipt", "/tmp/provider.json@"+testSHA("1"),
+		"--receipt", "/tmp/lifecycle.json@"+testSHA("2"),
+		"--receipt", "/tmp/lifecycle-observation.json@"+testSHA("3"),
+		"--receipt", "/tmp/enablement.json@"+testSHA("4"),
+		"--receipt", "/tmp/network-observation.json@"+testSHA("5"),
+		"--execute",
+		"--ledger-api-endpoint", "https://192.0.2.12:6443", "--ledger-token-file", "/tmp/ledger-token", "--ledger-ca-file", "/tmp/ledger-ca",
+		"--workload-binding", "/tmp/workload-binding.json", "--workload-binding-digest", testSHA("5"),
+		"--workload-token-file", "/tmp/workload-observer-token", "--workload-ca-file", "/tmp/workload-ca",
+		"--output", "/private/tmp/ok147-runtime-binding.json",
 	)
 }
 

--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -2182,9 +2182,23 @@ in the ledger. A source or persistence failure becomes a redaction-safe,
 terminal `STOPPED` receipt; a restart returns an existing receipt without
 re-reading or rewriting the workload binding.
 
-CLI/Job activation remains a separate checkpoint. Therefore the composition
-is not reachable from the product command surface yet, and target access
-remains unreachable.
+The first product activation is deliberately local and explicit:
+
+```text
+ok cluster stage bind runtime --execute ...
+```
+
+The command requires the exact five-receipt prefix, immutable plan identities,
+separate short-lived ledger and workload credentials, the digest-bound private
+workload-authority binding and one clean absolute output path. It has a fixed
+two-minute context and accepts no grant, projection, arbitrary API path, retry,
+overwrite or cleanup option. Output combines the immutable stage receipt with
+the redaction-safe binding evidence; endpoint, CA payload, tokens, local paths
+and raw runtime UIDs stay private.
+
+Ephemeral Job packaging and launch remain separate checkpoints. Target access
+is still unreachable: this command only captures the exact private authority
+material that a later target-access stage must consume.
 
 ## Bounded convergence observation polling
 


### PR DESCRIPTION
## Summary
- add `ok cluster stage bind runtime --execute` as an explicit two-minute local activation boundary
- require the exact five-receipt prefix, distinct short-lived ledger/workload credentials and one clean private output path
- emit only immutable stage receipt plus redaction-safe binding evidence
- retain no grant, retry, overwrite, cleanup, arbitrary API or target-access surface

## Verification
- `go test -ldflags=-linkmode=external ./...`
- `go vet ./...`
- `go test -race -ldflags=-linkmode=external ./cmd/ok ./internal/runner`

No live cluster contact or infrastructure mutation was performed.