### PR TITLE
feat(runner): persist runtime binding immutably (OK-147)

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,10 @@ Powered by [Cluster API (CAPI)](https://cluster-api.sigs.k8s.io/), [CAPK (KubeVi
   composed with the runner-owned crash-safe stage operation and immutable
   ledger receipt. `ok cluster stage bind runtime --execute` is the first local,
   two-minute activation boundary and emits only its redaction-safe evidence;
-  Job activation and all target access remain separate.
+  Job activation and all target access remain separate. A Job-suitable store
+  candidate can create or verify one exact immutable runtime-binding Secret on
+  `ok-mgmt`; it has no update/delete/retry path and is not yet wired to the
+  stage or a live package.
   Stage 4 now has its first distinct path as well:
   `ok cluster stage run enablement --execute` binds the verified three-receipt
   prefix and signed `CreateEnablement` grant to exactly one externally rendered

--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -2200,6 +2200,41 @@ Ephemeral Job packaging and launch remain separate checkpoints. Target access
 is still unreachable: this command only captures the exact private authority
 material that a later target-access stage must consume.
 
+### Immutable Kubernetes runtime-binding store
+
+The first Job-suitable persistence candidate stores the same verified private
+runtime-binding material in one exact immutable `Secret` on `ok-mgmt`. This
+avoids both an `emptyDir`, which would lose the binding when the Job is
+recreated, and a new PVC/storage lifecycle owned by the runner.
+
+The store is bound before execution to the verified management authority,
+namespace `openkubes-execution-system` and one DNS-safe name prefixed with
+`ok147-runtime-binding-`. It permits only this sequence:
+
+```text
+POST exact Secret collection
+        |
+        +-- 201 -> verify exact immutable object and server identity
+        |
+        `-- 409 -> one exact GET-by-name
+                    `-- accept only byte-equivalent existing object
+```
+
+The Secret is `immutable: true`, contains exactly one data key and carries
+only the fixed runner labels plus content and plan digests. A conflicting
+object, uncertain response or altered metadata stops fail-closed. The client
+has no update, patch, delete, list, watch, discovery, redirect or retry path,
+and its public receipt contains only digests and categorical state—not the
+Secret identity, endpoint, token, CA, runtime UIDs or private material.
+
+This checkpoint is deliberately only a typed store capability. It is tested
+against a local fake TLS API and is not yet composed with the runtime-binding
+stage, packaged in a Job or invoked against a live cluster. The existing local
+exclusive-file path remains unchanged. A later composition checkpoint must
+select exactly one persistence implementation and bind a separately scoped
+management credential; adding this store does not create an OpenKubes
+reconciler or grant lifecycle mutation authority.
+
 ## Bounded convergence observation polling
 
 The aggregate observer can now be wrapped by a bounded polling observer before

--- a/internal/runner/runtime_binding_kubernetes_store.go
+++ b/internal/runner/runtime_binding_kubernetes_store.go
@@ -1,0 +1,234 @@
+package runner
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/jsonstrict"
+)
+
+const (
+	KubernetesRuntimeBindingPersistenceReceiptFormat = "ok147-kubernetes-runtime-binding-persistence-receipt/v1"
+	maximumRuntimeBindingSecretResponse              = 1024 * 1024
+	runtimeBindingSecretDataKey                      = "runtime-binding.json"
+)
+
+type KubernetesRuntimeBindingPersistenceReceipt struct {
+	Format                   string `json:"format"`
+	State                    string `json:"state"`
+	PrivateMaterialDigest    string `json:"privateMaterialDigest"`
+	ObjectIdentityDigest     string `json:"objectIdentityDigest"`
+	AuthorityIdentityDigest  string `json:"authorityIdentityDigest"`
+	PersistenceMutationState string `json:"persistenceMutationState"`
+	LifecycleMutationAllowed bool   `json:"lifecycleMutationAllowed"`
+}
+
+type KubernetesRuntimeBindingStore struct {
+	mu        sync.Mutex
+	used      bool
+	endpoint  *url.URL
+	token     string
+	client    *http.Client
+	namespace string
+	name      string
+	authority string
+}
+
+type runtimeBindingSecret struct {
+	APIVersion string                         `json:"apiVersion"`
+	Kind       string                         `json:"kind"`
+	Metadata   runtimeBindingSecretObjectMeta `json:"metadata"`
+	Immutable  bool                           `json:"immutable"`
+	Type       string                         `json:"type"`
+	Data       map[string][]byte              `json:"data"`
+}
+
+type runtimeBindingSecretObjectMeta struct {
+	Name            string            `json:"name"`
+	Namespace       string            `json:"namespace"`
+	UID             string            `json:"uid,omitempty"`
+	ResourceVersion string            `json:"resourceVersion,omitempty"`
+	Labels          map[string]string `json:"labels"`
+	Annotations     map[string]string `json:"annotations"`
+}
+
+// OpenKubernetesRuntimeBindingStore binds one management authority to one
+// exact immutable Secret identity. It reads bounded credentials but performs
+// no API request.
+func OpenKubernetesRuntimeBindingStore(authority KubernetesAuthorityConfig, expectedAuthority, namespace, name string) (*KubernetesRuntimeBindingStore, error) {
+	if authority.AuthorityIdentity == "" || authority.AuthorityIdentity != expectedAuthority {
+		return nil, errors.New("runtime binding persistence authority differs from management")
+	}
+	if namespace != submissionStageInputNamespace || !submissionStageInputNamePattern.MatchString(name) || len(name) > 63 || !strings.HasPrefix(name, "ok147-runtime-binding-") {
+		return nil, errors.New("runtime binding Secret identity is invalid")
+	}
+	endpoint, err := url.Parse(authority.Endpoint)
+	if err != nil || endpoint.Scheme != "https" || endpoint.Host == "" || endpoint.User != nil || endpoint.Path != "" || endpoint.RawQuery != "" || endpoint.Fragment != "" {
+		return nil, errors.New("runtime binding persistence endpoint is invalid")
+	}
+	token, _, client, err := openBoundedKubernetesMaterial(authority.TokenFile, authority.CAFile)
+	if err != nil {
+		return nil, errors.New("open bounded runtime binding persistence credential")
+	}
+	bounded := *client
+	bounded.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+	return &KubernetesRuntimeBindingStore{
+		endpoint: endpoint, token: token, client: &bounded, namespace: namespace, name: name, authority: authority.AuthorityIdentity,
+	}, nil
+}
+
+// Store performs one create-if-absent. A conflict is followed by exactly one
+// GET-by-name and succeeds only when the immutable Secret is byte-equivalent.
+// There is no update, patch, delete, list, watch or retry path.
+func (store *KubernetesRuntimeBindingStore) Store(ctx context.Context, material VerifiedRuntimeBindingMaterial) (KubernetesRuntimeBindingPersistenceReceipt, error) {
+	receipt := KubernetesRuntimeBindingPersistenceReceipt{
+		Format: KubernetesRuntimeBindingPersistenceReceiptFormat, State: "PREWRITE",
+		PersistenceMutationState: "NOT_ATTEMPTED", LifecycleMutationAllowed: false,
+	}
+	if store == nil || store.endpoint == nil || store.client == nil {
+		return receipt, errors.New("runtime binding Kubernetes store is required")
+	}
+	store.mu.Lock()
+	if store.used {
+		store.mu.Unlock()
+		return receipt, errors.New("runtime binding Kubernetes store is single-use")
+	}
+	store.used = true
+	store.mu.Unlock()
+	raw, err := material.Bytes()
+	if err != nil {
+		return receipt, errors.New("runtime binding material is not verified")
+	}
+	materialReceipt, err := material.Receipt()
+	if err != nil {
+		return receipt, errors.New("runtime binding material receipt is invalid")
+	}
+	receipt.PrivateMaterialDigest = digest.SHA256(raw)
+	receipt.ObjectIdentityDigest = digest.SHA256([]byte(store.namespace + "/" + store.name))
+	receipt.AuthorityIdentityDigest = digest.SHA256([]byte(store.authority))
+	secret := runtimeBindingSecret{
+		APIVersion: "v1", Kind: "Secret",
+		Metadata: runtimeBindingSecretObjectMeta{
+			Name: store.name, Namespace: store.namespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/managed-by": "ok-cluster-contract-executor", "openkubes.io/stage-id": "runtime-binding",
+			},
+			Annotations: map[string]string{
+				"openkubes.io/content-digest": receipt.PrivateMaterialDigest, "openkubes.io/plan-digest": materialReceipt.PlanDigest,
+			},
+		},
+		Immutable: true, Type: "Opaque", Data: map[string][]byte{runtimeBindingSecretDataKey: raw},
+	}
+	body, err := json.Marshal(secret)
+	if err != nil {
+		return receipt, errors.New("encode immutable runtime binding Secret")
+	}
+	response, status, err := store.request(ctx, http.MethodPost, store.collectionPath(), body)
+	receipt.PersistenceMutationState = "ATTEMPTED"
+	if err != nil {
+		receipt.State = "STOPPED_PARTIAL_OR_UNKNOWN"
+		return receipt, errors.New("create immutable runtime binding Secret failed")
+	}
+	if status == http.StatusCreated {
+		if err := verifyRuntimeBindingSecret(response, secret, true); err != nil {
+			receipt.State = "STOPPED_PARTIAL_OR_UNKNOWN"
+			return receipt, errors.New("created runtime binding Secret differs")
+		}
+		receipt.State = "CREATED_VERIFIED"
+		return receipt, nil
+	}
+	if status != http.StatusConflict {
+		receipt.State = "STOPPED_PARTIAL_OR_UNKNOWN"
+		return receipt, fmt.Errorf("create immutable runtime binding Secret returned HTTP %d", status)
+	}
+	existing, status, err := store.request(ctx, http.MethodGet, store.objectPath(), nil)
+	if err != nil || status != http.StatusOK || verifyRuntimeBindingSecret(existing, secret, true) != nil {
+		receipt.State = "STOPPED_CONFLICTING_EXISTING"
+		return receipt, errors.New("existing runtime binding Secret differs")
+	}
+	receipt.State = "EXISTING_VERIFIED"
+	receipt.PersistenceMutationState = "CONFLICT_OBSERVED"
+	return receipt, nil
+}
+
+func (store *KubernetesRuntimeBindingStore) request(ctx context.Context, method, path string, body []byte) ([]byte, int, error) {
+	endpoint := *store.endpoint
+	endpoint.Path = path
+	request, err := http.NewRequestWithContext(ctx, method, endpoint.String(), bytes.NewReader(body))
+	if err != nil {
+		return nil, 0, errors.New("construct bounded runtime binding persistence request")
+	}
+	request.Header.Set("Accept", "application/json")
+	request.Header.Set("Authorization", "Bearer "+store.token)
+	if body != nil {
+		request.Header.Set("Content-Type", "application/json")
+	}
+	response, err := store.client.Do(request)
+	if err != nil {
+		return nil, 0, errors.New("bounded runtime binding persistence request failed")
+	}
+	defer response.Body.Close()
+	raw, readErr := io.ReadAll(io.LimitReader(response.Body, maximumRuntimeBindingSecretResponse+1))
+	if readErr != nil || len(raw) > maximumRuntimeBindingSecretResponse {
+		return nil, 0, errors.New("runtime binding persistence response exceeds accepted size")
+	}
+	mediaType, _, mediaErr := mime.ParseMediaType(response.Header.Get("Content-Type"))
+	if len(raw) > 0 && (mediaErr != nil || mediaType != "application/json") {
+		return nil, 0, errors.New("runtime binding persistence response is not JSON")
+	}
+	return raw, response.StatusCode, nil
+}
+
+func (store *KubernetesRuntimeBindingStore) collectionPath() string {
+	return "/api/v1/namespaces/" + store.namespace + "/secrets"
+}
+
+func (store *KubernetesRuntimeBindingStore) objectPath() string {
+	return store.collectionPath() + "/" + store.name
+}
+
+func verifyRuntimeBindingSecret(raw []byte, expected runtimeBindingSecret, requireServerIdentity bool) error {
+	var generic map[string]any
+	if err := jsonstrict.Decode(raw, &generic); err != nil {
+		return err
+	}
+	var observed runtimeBindingSecret
+	if err := json.Unmarshal(raw, &observed); err != nil {
+		return err
+	}
+	if observed.APIVersion != expected.APIVersion || observed.Kind != expected.Kind || observed.Metadata.Name != expected.Metadata.Name || observed.Metadata.Namespace != expected.Metadata.Namespace || observed.Type != expected.Type || !observed.Immutable {
+		return errors.New("runtime binding Secret identity differs")
+	}
+	if requireServerIdentity && (!runtimeInputUIDPattern.MatchString(observed.Metadata.UID) || !runtimeInputUIDPattern.MatchString(observed.Metadata.ResourceVersion)) {
+		return errors.New("runtime binding Secret lacks server identity")
+	}
+	if len(observed.Data) != 1 || !bytes.Equal(observed.Data[runtimeBindingSecretDataKey], expected.Data[runtimeBindingSecretDataKey]) {
+		return errors.New("runtime binding Secret payload differs")
+	}
+	if !equalRuntimeBindingStringMap(observed.Metadata.Labels, expected.Metadata.Labels) || !equalRuntimeBindingStringMap(observed.Metadata.Annotations, expected.Metadata.Annotations) {
+		return errors.New("runtime binding Secret metadata differs")
+	}
+	return nil
+}
+
+func equalRuntimeBindingStringMap(left, right map[string]string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for key, value := range right {
+		if left[key] != value {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/runner/runtime_binding_kubernetes_store_test.go
+++ b/internal/runner/runtime_binding_kubernetes_store_test.go
@@ -1,0 +1,202 @@
+package runner
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestKubernetesRuntimeBindingStoreCreatesAndVerifiesExactlyOnce(t *testing.T) {
+	api := newRuntimeBindingSecretAPI(t)
+	defer api.Close()
+	store := openRuntimeBindingSecretStore(t, api.Server, "ok-mgmt", "short-lived-binding-token")
+	if api.RequestCount() != 0 {
+		t.Fatal("opening runtime binding store contacted Kubernetes")
+	}
+	material, err := BuildRuntimeBindingMaterial(runtimeBindingMaterialConfig(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := store.Store(context.Background(), material)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if receipt.Format != KubernetesRuntimeBindingPersistenceReceiptFormat || receipt.State != "CREATED_VERIFIED" || receipt.PersistenceMutationState != "ATTEMPTED" || receipt.LifecycleMutationAllowed || receipt.PrivateMaterialDigest == "" || receipt.ObjectIdentityDigest == "" || receipt.AuthorityIdentityDigest == "" {
+		t.Fatalf("runtime binding Secret receipt differs: %#v", receipt)
+	}
+	want := []string{"POST /api/v1/namespaces/openkubes-execution-system/secrets"}
+	if !reflect.DeepEqual(api.Requests(), want) {
+		t.Fatalf("runtime binding store request boundary differs: %v", api.Requests())
+	}
+	public, _ := json.Marshal(receipt)
+	private, _ := material.Bytes()
+	for _, forbidden := range []string{api.URL, "short-lived-binding-token", "ok147-runtime-binding-run-01", string(private)} {
+		if bytes.Contains(public, []byte(forbidden)) {
+			t.Fatalf("runtime binding persistence receipt exposed private value %q", forbidden)
+		}
+	}
+	if _, err := store.Store(context.Background(), material); err == nil {
+		t.Fatal("single-use runtime binding store wrote twice")
+	}
+}
+
+func TestKubernetesRuntimeBindingStoreAcceptsOnlyEquivalentConflict(t *testing.T) {
+	api := newRuntimeBindingSecretAPI(t)
+	defer api.Close()
+	material, err := BuildRuntimeBindingMaterial(runtimeBindingMaterialConfig(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	first := openRuntimeBindingSecretStore(t, api.Server, "ok-mgmt", "short-lived-binding-token")
+	if _, err := first.Store(context.Background(), material); err != nil {
+		t.Fatal(err)
+	}
+	api.ResetRequests()
+	replacement := openRuntimeBindingSecretStore(t, api.Server, "ok-mgmt", "replacement-binding-token")
+	receipt, err := replacement.Store(context.Background(), material)
+	if err != nil || receipt.State != "EXISTING_VERIFIED" || receipt.PersistenceMutationState != "CONFLICT_OBSERVED" {
+		t.Fatalf("equivalent immutable Secret was not resumed: %#v %v", receipt, err)
+	}
+	want := []string{
+		"POST /api/v1/namespaces/openkubes-execution-system/secrets",
+		"GET /api/v1/namespaces/openkubes-execution-system/secrets/ok147-runtime-binding-run-01",
+	}
+	if !reflect.DeepEqual(api.Requests(), want) {
+		t.Fatalf("conflict verification request boundary differs: %v", api.Requests())
+	}
+
+	api.TamperData()
+	conflicting := openRuntimeBindingSecretStore(t, api.Server, "ok-mgmt", "third-binding-token")
+	receipt, err = conflicting.Store(context.Background(), material)
+	if err == nil || receipt.State != "STOPPED_CONFLICTING_EXISTING" {
+		t.Fatalf("conflicting immutable Secret was accepted: %#v %v", receipt, err)
+	}
+}
+
+func TestKubernetesRuntimeBindingStoreFailsClosedBeforeRequest(t *testing.T) {
+	api := newRuntimeBindingSecretAPI(t)
+	defer api.Close()
+	root := t.TempDir()
+	caPath := writeRuntimeBindingServerCA(t, root, "management-ca.crt", api.Server)
+	tokenPath := filepath.Join(root, "token")
+	if err := os.WriteFile(tokenPath, []byte("short-lived-binding-token"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	base := KubernetesAuthorityConfig{Endpoint: api.URL, AuthorityIdentity: "ok-mgmt", TokenFile: tokenPath, CAFile: caPath}
+	for name, test := range map[string]struct {
+		authority KubernetesAuthorityConfig
+		expected  string
+		namespace string
+		secret    string
+	}{
+		"foreign authority": {authority: base, expected: "ok-infra", namespace: submissionStageInputNamespace, secret: "ok147-runtime-binding-run-01"},
+		"foreign namespace": {authority: base, expected: "ok-mgmt", namespace: "other", secret: "ok147-runtime-binding-run-01"},
+		"foreign name":      {authority: base, expected: "ok-mgmt", namespace: submissionStageInputNamespace, secret: "other-binding"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := OpenKubernetesRuntimeBindingStore(test.authority, test.expected, test.namespace, test.secret); err == nil {
+				t.Fatal("unsafe runtime binding persistence boundary was accepted")
+			}
+		})
+	}
+	if api.RequestCount() != 0 {
+		t.Fatal("invalid runtime binding store contacted Kubernetes")
+	}
+	store := openRuntimeBindingSecretStore(t, api.Server, "ok-mgmt", "short-lived-binding-token")
+	if _, err := store.Store(context.Background(), VerifiedRuntimeBindingMaterial{}); err == nil || api.RequestCount() != 0 {
+		t.Fatalf("unverified material reached Kubernetes: requests=%d err=%v", api.RequestCount(), err)
+	}
+}
+
+func openRuntimeBindingSecretStore(t *testing.T, server *httptest.Server, authority, token string) *KubernetesRuntimeBindingStore {
+	t.Helper()
+	root := t.TempDir()
+	caPath := writeRuntimeBindingServerCA(t, root, "management-ca.crt", server)
+	tokenPath := filepath.Join(root, "token")
+	if err := os.WriteFile(tokenPath, []byte(token), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	store, err := OpenKubernetesRuntimeBindingStore(KubernetesAuthorityConfig{
+		Endpoint: server.URL, AuthorityIdentity: authority, TokenFile: tokenPath, CAFile: caPath,
+	}, "ok-mgmt", submissionStageInputNamespace, "ok147-runtime-binding-run-01")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return store
+}
+
+type runtimeBindingSecretAPI struct {
+	*httptest.Server
+	mu       sync.Mutex
+	object   map[string]any
+	requests []string
+}
+
+func newRuntimeBindingSecretAPI(t *testing.T) *runtimeBindingSecretAPI {
+	t.Helper()
+	api := &runtimeBindingSecretAPI{}
+	api.Server = httptest.NewTLSServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		api.mu.Lock()
+		defer api.mu.Unlock()
+		api.requests = append(api.requests, request.Method+" "+request.URL.RequestURI())
+		response.Header().Set("Content-Type", "application/json")
+		if !strings.HasSuffix(request.Header.Get("Authorization"), "binding-token") {
+			response.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		collection := "/api/v1/namespaces/openkubes-execution-system/secrets"
+		switch {
+		case request.Method == http.MethodPost && request.URL.Path == collection:
+			if api.object != nil {
+				response.WriteHeader(http.StatusConflict)
+				return
+			}
+			if err := json.NewDecoder(request.Body).Decode(&api.object); err != nil {
+				response.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			metadata := api.object["metadata"].(map[string]any)
+			metadata["uid"], metadata["resourceVersion"] = "runtime-binding-secret-uid", "1"
+			response.WriteHeader(http.StatusCreated)
+			json.NewEncoder(response).Encode(api.object)
+		case request.Method == http.MethodGet && request.URL.Path == collection+"/ok147-runtime-binding-run-01":
+			if api.object == nil {
+				response.WriteHeader(http.StatusNotFound)
+				return
+			}
+			json.NewEncoder(response).Encode(api.object)
+		default:
+			response.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	return api
+}
+
+func (api *runtimeBindingSecretAPI) Requests() []string {
+	api.mu.Lock()
+	defer api.mu.Unlock()
+	return append([]string(nil), api.requests...)
+}
+
+func (api *runtimeBindingSecretAPI) RequestCount() int { return len(api.Requests()) }
+
+func (api *runtimeBindingSecretAPI) ResetRequests() {
+	api.mu.Lock()
+	defer api.mu.Unlock()
+	api.requests = nil
+}
+
+func (api *runtimeBindingSecretAPI) TamperData() {
+	api.mu.Lock()
+	defer api.mu.Unlock()
+	data := api.object["data"].(map[string]any)
+	data[runtimeBindingSecretDataKey] = "dGFtcGVyZWQ="
+}


### PR DESCRIPTION
## Outcome

Adds a Job-suitable persistence candidate for verified private runtime-binding material using one exact immutable Secret on ok-mgmt.

## Safety boundary

- exact create-if-absent plus one exact GET on conflict
- existing objects accepted only when byte-equivalent
- no update, patch, delete, list, watch, discovery, redirect, or retry
- redaction-safe receipt only
- not composed with the stage, not packaged, and no live cluster contact

## Verification

- go test -ldflags=-linkmode=external ./...
- go vet ./...
- go test -race -ldflags=-linkmode=external ./internal/runner/...

OK-147