### PR TITLE
feat(runner): compose Kubernetes runtime binding persistence (OK-147)

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,9 @@ Powered by [Cluster API (CAPI)](https://cluster-api.sigs.k8s.io/), [CAPK (KubeVi
   two-minute activation boundary and emits only its redaction-safe evidence;
   Job activation and all target access remain separate. A Job-suitable store
   candidate can create or verify one exact immutable runtime-binding Secret on
-  `ok-mgmt`; it has no update/delete/retry path and is not yet wired to the
-  stage or a live package.
+  `ok-mgmt`; it has no update/delete/retry path. A distinct library opener now
+  composes that store with pairwise-separate ledger, persistence and workload
+  credentials, but neither the CLI nor a Job package activates it yet.
   Stage 4 now has its first distinct path as well:
   `ok cluster stage run enablement --execute` binds the verified three-receipt
   prefix and signed `CreateEnablement` grant to exactly one externally rendered

--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -2235,6 +2235,28 @@ select exactly one persistence implementation and bind a separately scoped
 management credential; adding this store does not create an OpenKubes
 reconciler or grant lifecycle mutation authority.
 
+The following composition checkpoint now provides that exact selection in the
+runner library. The existing `Open` method remains file-only; a distinct
+`OpenKubernetes` method selects only the immutable Secret path. Its Secret name
+is derived from the verified plan digest rather than accepted from a caller.
+The Secret store must use the same exact management API and namespace as the
+ledger, while ledger writer, persistence writer and workload observer tokens
+must all differ. Opening reads those bounded credentials but performs no API
+request.
+
+The Kubernetes-persisted stage emits evidence format
+`ok147-runtime-binding-stage-evidence/v2`. It truthfully records that the exact
+persistence mutation was allowed while separately denying lifecycle mutation;
+the local file path retains the historical v1 evidence semantics. After a
+successful or byte-equivalent Secret result, the same crash-safe stage
+operation stores the immutable ledger receipt. A later process can therefore
+verify an equivalent pre-existing Secret if it stopped between those two
+writes, without gaining an update or generic retry path.
+
+This remains library-only composition tested against local fake TLS APIs. The
+CLI still selects the exclusive local file, no Job package selects
+`OpenKubernetes`, and no live Kubernetes API was contacted.
+
 ## Bounded convergence observation polling
 
 The aggregate observer can now be wrapped by a bounded polling observer before

--- a/internal/runner/runtime_binding_kubernetes_store.go
+++ b/internal/runner/runtime_binding_kubernetes_store.go
@@ -66,25 +66,33 @@ type runtimeBindingSecretObjectMeta struct {
 // exact immutable Secret identity. It reads bounded credentials but performs
 // no API request.
 func OpenKubernetesRuntimeBindingStore(authority KubernetesAuthorityConfig, expectedAuthority, namespace, name string) (*KubernetesRuntimeBindingStore, error) {
+	store, _, err := openKubernetesRuntimeBindingStore(authority, expectedAuthority, namespace, name)
+	return store, err
+}
+
+// openKubernetesRuntimeBindingStore additionally returns the bounded token so
+// stage composition can prove that ledger, persistence and workload roles use
+// distinct credentials. The token never enters a receipt or returned error.
+func openKubernetesRuntimeBindingStore(authority KubernetesAuthorityConfig, expectedAuthority, namespace, name string) (*KubernetesRuntimeBindingStore, string, error) {
 	if authority.AuthorityIdentity == "" || authority.AuthorityIdentity != expectedAuthority {
-		return nil, errors.New("runtime binding persistence authority differs from management")
+		return nil, "", errors.New("runtime binding persistence authority differs from management")
 	}
 	if namespace != submissionStageInputNamespace || !submissionStageInputNamePattern.MatchString(name) || len(name) > 63 || !strings.HasPrefix(name, "ok147-runtime-binding-") {
-		return nil, errors.New("runtime binding Secret identity is invalid")
+		return nil, "", errors.New("runtime binding Secret identity is invalid")
 	}
 	endpoint, err := url.Parse(authority.Endpoint)
 	if err != nil || endpoint.Scheme != "https" || endpoint.Host == "" || endpoint.User != nil || endpoint.Path != "" || endpoint.RawQuery != "" || endpoint.Fragment != "" {
-		return nil, errors.New("runtime binding persistence endpoint is invalid")
+		return nil, "", errors.New("runtime binding persistence endpoint is invalid")
 	}
 	token, _, client, err := openBoundedKubernetesMaterial(authority.TokenFile, authority.CAFile)
 	if err != nil {
-		return nil, errors.New("open bounded runtime binding persistence credential")
+		return nil, "", errors.New("open bounded runtime binding persistence credential")
 	}
 	bounded := *client
 	bounded.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
 	return &KubernetesRuntimeBindingStore{
 		endpoint: endpoint, token: token, client: &bounded, namespace: namespace, name: name, authority: authority.AuthorityIdentity,
-	}, nil
+	}, token, nil
 }
 
 // Store performs one create-if-absent. A conflict is followed by exactly one

--- a/internal/runner/runtime_binding_stage.go
+++ b/internal/runner/runtime_binding_stage.go
@@ -20,6 +20,8 @@ import (
 
 const RuntimeBindingStageEvidenceFormat = "ok147-runtime-binding-stage-evidence/v1"
 
+const RuntimeBindingStageKubernetesEvidenceFormat = "ok147-runtime-binding-stage-evidence/v2"
+
 type VerifiedRuntimeBindingStageBundle struct {
 	config   StageResumeConfig
 	plan     stageplan.Binding
@@ -35,15 +37,27 @@ type RuntimeBindingStageRuntimeConfig struct {
 	Clock      func() time.Time
 }
 
+// RuntimeBindingStageKubernetesRuntimeConfig selects the durable immutable
+// Secret persistence path. Its credential is distinct from both ledger and
+// workload credentials and carries no lifecycle authority.
+type RuntimeBindingStageKubernetesRuntimeConfig struct {
+	Ledger      KubernetesLedgerConfig
+	Workload    WorkloadAuthorityFileResolverConfig
+	Persistence KubernetesAuthorityConfig
+	Clock       func() time.Time
+}
+
 type RuntimeBindingStageEvidenceReceipt struct {
-	Format                    string                            `json:"format"`
-	State                     string                            `json:"state"`
-	PlanDigest                string                            `json:"planDigest"`
-	StageID                   string                            `json:"stageId"`
-	FailureCategory           string                            `json:"failureCategory,omitempty"`
-	Material                  *RuntimeBindingMaterialReceipt    `json:"material,omitempty"`
-	Persistence               *RuntimeBindingPersistenceReceipt `json:"persistence,omitempty"`
-	KubernetesMutationAllowed bool                              `json:"kubernetesMutationAllowed"`
+	Format                    string                                      `json:"format"`
+	State                     string                                      `json:"state"`
+	PlanDigest                string                                      `json:"planDigest"`
+	StageID                   string                                      `json:"stageId"`
+	FailureCategory           string                                      `json:"failureCategory,omitempty"`
+	Material                  *RuntimeBindingMaterialReceipt              `json:"material,omitempty"`
+	Persistence               *RuntimeBindingPersistenceReceipt           `json:"persistence,omitempty"`
+	KubernetesPersistence     *KubernetesRuntimeBindingPersistenceReceipt `json:"kubernetesPersistence,omitempty"`
+	KubernetesMutationAllowed bool                                        `json:"kubernetesMutationAllowed"`
+	LifecycleMutationAllowed  *bool                                       `json:"lifecycleMutationAllowed,omitempty"`
 }
 
 type OpenedRuntimeBindingStage struct {
@@ -90,21 +104,47 @@ func (bundle VerifiedRuntimeBindingStageBundle) Open(config RuntimeBindingStageR
 	if err := validateRuntimeBindingOutputPath(config.OutputPath); err != nil {
 		return OpenedRuntimeBindingStage{}, err
 	}
+	return bundle.open(config.Ledger, config.Workload, config.Clock, config.OutputPath, nil, "")
+}
+
+// OpenKubernetes binds the exact immutable Secret persistence capability. It
+// reads three bounded credentials but performs no API request.
+func (bundle VerifiedRuntimeBindingStageBundle) OpenKubernetes(config RuntimeBindingStageKubernetesRuntimeConfig) (OpenedRuntimeBindingStage, error) {
+	if !bundle.verified || config.Clock == nil {
+		return OpenedRuntimeBindingStage{}, errors.New("verified runtime binding bundle and clock are required")
+	}
+	if config.Ledger.Namespace != submissionStageInputNamespace || !sameRuntimeBindingEndpoint(config.Ledger.Endpoint, config.Persistence.Endpoint) {
+		return OpenedRuntimeBindingStage{}, errors.New("runtime binding persistence must share the exact management API and namespace")
+	}
+	name, err := runtimeBindingSecretName(bundle.plan.PlanDigest)
+	if err != nil {
+		return OpenedRuntimeBindingStage{}, err
+	}
+	store, persistenceToken, err := openKubernetesRuntimeBindingStore(
+		config.Persistence, bundle.plan.Authorities.Management, submissionStageInputNamespace, name,
+	)
+	if err != nil {
+		return OpenedRuntimeBindingStage{}, errors.New("open runtime binding Kubernetes persistence")
+	}
+	return bundle.open(config.Ledger, config.Workload, config.Clock, "", store, persistenceToken)
+}
+
+func (bundle VerifiedRuntimeBindingStageBundle) open(ledgerConfig KubernetesLedgerConfig, workloadConfig WorkloadAuthorityFileResolverConfig, clock func() time.Time, outputPath string, kubernetesStore *KubernetesRuntimeBindingStore, persistenceToken string) (OpenedRuntimeBindingStage, error) {
 	lifecycle, err := bundle.prefix[1].Receipt()
 	if err != nil {
 		return OpenedRuntimeBindingStage{}, errors.New("read durable runtime target correlation")
 	}
-	binding, authority, err := loadWorkloadAuthorityFiles(config.Workload)
+	binding, authority, err := loadWorkloadAuthorityFiles(workloadConfig)
 	if err != nil {
 		return OpenedRuntimeBindingStage{}, errors.New("open runtime binding workload authority")
 	}
 	if binding.IntentRevision != bundle.plan.IntentRevision || digest.SHA256([]byte(binding.TargetClusterUID)) != lifecycle.TargetClusterUIDDigest {
 		return OpenedRuntimeBindingStage{}, errors.New("runtime binding workload authority differs from durable lifecycle target")
 	}
-	if sameRuntimeBindingEndpoint(config.Ledger.Endpoint, binding.Endpoint) {
+	if sameRuntimeBindingEndpoint(ledgerConfig.Endpoint, binding.Endpoint) {
 		return OpenedRuntimeBindingStage{}, errors.New("ledger and runtime observation endpoints must be distinct")
 	}
-	store, ledgerToken, err := openKubernetesLedger(config.Ledger)
+	store, ledgerToken, err := openKubernetesLedger(ledgerConfig)
 	if err != nil {
 		return OpenedRuntimeBindingStage{}, errors.New("open runtime binding ledger")
 	}
@@ -112,8 +152,8 @@ func (bundle VerifiedRuntimeBindingStageBundle) Open(config RuntimeBindingStageR
 	if err != nil {
 		return OpenedRuntimeBindingStage{}, errors.New("open bounded runtime binding source")
 	}
-	if sameSecret(ledgerToken, workloadToken) {
-		return OpenedRuntimeBindingStage{}, errors.New("ledger and runtime observation credentials must be distinct")
+	if sameSecret(ledgerToken, workloadToken) || persistenceToken != "" && (sameSecret(persistenceToken, ledgerToken) || sameSecret(persistenceToken, workloadToken)) {
+		return OpenedRuntimeBindingStage{}, errors.New("runtime binding stage credentials must be pairwise distinct")
 	}
 	decision, _ := bundle.cursor.Decision()
 	binder := &runtimeBindingStageBinder{
@@ -121,8 +161,8 @@ func (bundle VerifiedRuntimeBindingStageBundle) Open(config RuntimeBindingStageR
 			PlanDigest: bundle.plan.PlanDigest, StageID: decision.StageID, StageDigest: decision.StageDigest,
 			Authority: decision.Authority, ContractRevision: bundle.plan.IntentRevision,
 		},
-		bundle: bundle.config, workload: config.Workload, outputPath: config.OutputPath,
-		source: source, clock: config.Clock,
+		bundle: bundle.config, workload: workloadConfig, outputPath: outputPath,
+		source: source, kubernetesStore: kubernetesStore, clock: clock,
 	}
 	return OpenedRuntimeBindingStage{
 		operation: execution.BindingStageOperation{Ledger: store, Binder: binder},
@@ -139,7 +179,7 @@ func (stage OpenedRuntimeBindingStage) Run(ctx context.Context) (execution.Bindi
 
 // EvidenceReceipt exposes only the redaction-safe receipt from a binding call
 // made by this opened stage. Private material and runtime identities remain in
-// the exclusive output file.
+// the selected private persistence implementation.
 func (stage OpenedRuntimeBindingStage) EvidenceReceipt() (RuntimeBindingStageEvidenceReceipt, error) {
 	if !stage.verified || stage.binder == nil {
 		return RuntimeBindingStageEvidenceReceipt{}, errors.New("runtime binding stage is not opened")
@@ -148,15 +188,16 @@ func (stage OpenedRuntimeBindingStage) EvidenceReceipt() (RuntimeBindingStageEvi
 }
 
 type runtimeBindingStageBinder struct {
-	mu          sync.Mutex
-	binding     execution.StageBinderBinding
-	bundle      StageResumeConfig
-	workload    WorkloadAuthorityFileResolverConfig
-	outputPath  string
-	source      *KubernetesRuntimeBindingSource
-	clock       func() time.Time
-	evidence    RuntimeBindingStageEvidenceReceipt
-	hasEvidence bool
+	mu              sync.Mutex
+	binding         execution.StageBinderBinding
+	bundle          StageResumeConfig
+	workload        WorkloadAuthorityFileResolverConfig
+	outputPath      string
+	source          *KubernetesRuntimeBindingSource
+	kubernetesStore *KubernetesRuntimeBindingStore
+	clock           func() time.Time
+	evidence        RuntimeBindingStageEvidenceReceipt
+	hasEvidence     bool
 }
 
 func (binder *runtimeBindingStageBinder) Binding() execution.StageBinderBinding {
@@ -173,7 +214,7 @@ func (binder *runtimeBindingStageBinder) Bind(ctx context.Context) (execution.St
 	}
 	observation, err := binder.source.Observe(ctx)
 	if err != nil {
-		return binder.stop("SOURCE_STOPPED", nil, nil, at)
+		return binder.stop("SOURCE_STOPPED", nil, nil, nil, at)
 	}
 	material, err := BuildRuntimeBindingMaterial(RuntimeBindingMaterialConfig{
 		Bundle: binder.bundle, WorkloadBindingPath: binder.workload.Path,
@@ -181,19 +222,31 @@ func (binder *runtimeBindingStageBinder) Bind(ctx context.Context) (execution.St
 		WorkloadCAFile:                binder.workload.CAFile, Observation: observation,
 	})
 	if err != nil {
-		return binder.stop("MATERIALIZATION_STOPPED", nil, nil, at)
+		return binder.stop("MATERIALIZATION_STOPPED", nil, nil, nil, at)
 	}
 	materialReceipt, err := material.Receipt()
 	if err != nil || materialReceipt.PlanDigest != binder.binding.PlanDigest {
-		return binder.stop("MATERIAL_VERIFICATION_STOPPED", nil, nil, at)
+		return binder.stop("MATERIAL_VERIFICATION_STOPPED", nil, nil, nil, at)
+	}
+	if binder.kubernetesStore != nil {
+		persistence, persistErr := binder.kubernetesStore.Store(ctx, material)
+		if persistErr != nil {
+			return binder.stop("PERSISTENCE_STOPPED", &materialReceipt, nil, &persistence, at)
+		}
+		evidence := RuntimeBindingStageEvidenceReceipt{
+			Format: RuntimeBindingStageKubernetesEvidenceFormat, State: "SUCCEEDED", PlanDigest: binder.binding.PlanDigest,
+			StageID: binder.binding.StageID, Material: &materialReceipt, KubernetesPersistence: &persistence,
+			KubernetesMutationAllowed: true, LifecycleMutationAllowed: runtimeBindingBool(false),
+		}
+		return binder.finish(evidence, "SUCCEEDED", at)
 	}
 	writer, err := OpenRuntimeBindingWriter(material, binder.outputPath)
 	if err != nil {
-		return binder.stop("WRITER_OPEN_STOPPED", &materialReceipt, nil, at)
+		return binder.stop("WRITER_OPEN_STOPPED", &materialReceipt, nil, nil, at)
 	}
 	persistence, writeErr := writer.Write()
 	if writeErr != nil {
-		return binder.stop("PERSISTENCE_STOPPED", &materialReceipt, &persistence, at)
+		return binder.stop("PERSISTENCE_STOPPED", &materialReceipt, &persistence, nil, at)
 	}
 	evidence := RuntimeBindingStageEvidenceReceipt{
 		Format: RuntimeBindingStageEvidenceFormat, State: "SUCCEEDED", PlanDigest: binder.binding.PlanDigest,
@@ -203,11 +256,18 @@ func (binder *runtimeBindingStageBinder) Bind(ctx context.Context) (execution.St
 	return binder.finish(evidence, "SUCCEEDED", at)
 }
 
-func (binder *runtimeBindingStageBinder) stop(category string, material *RuntimeBindingMaterialReceipt, persistence *RuntimeBindingPersistenceReceipt, at time.Time) (execution.StageBindingResult, error) {
+func (binder *runtimeBindingStageBinder) stop(category string, material *RuntimeBindingMaterialReceipt, persistence *RuntimeBindingPersistenceReceipt, kubernetesPersistence *KubernetesRuntimeBindingPersistenceReceipt, at time.Time) (execution.StageBindingResult, error) {
+	format, kubernetesMutationAllowed := RuntimeBindingStageEvidenceFormat, false
+	if binder.kubernetesStore != nil {
+		format, kubernetesMutationAllowed = RuntimeBindingStageKubernetesEvidenceFormat, true
+	}
 	evidence := RuntimeBindingStageEvidenceReceipt{
-		Format: RuntimeBindingStageEvidenceFormat, State: "STOPPED", PlanDigest: binder.binding.PlanDigest,
+		Format: format, State: "STOPPED", PlanDigest: binder.binding.PlanDigest,
 		StageID: binder.binding.StageID, FailureCategory: category, Material: material, Persistence: persistence,
-		KubernetesMutationAllowed: false,
+		KubernetesPersistence: kubernetesPersistence, KubernetesMutationAllowed: kubernetesMutationAllowed,
+	}
+	if binder.kubernetesStore != nil {
+		evidence.LifecycleMutationAllowed = runtimeBindingBool(false)
 	}
 	return binder.finish(evidence, "STOPPED", at)
 }
@@ -260,7 +320,24 @@ func cloneRuntimeBindingStageEvidence(evidence RuntimeBindingStageEvidenceReceip
 		value := *evidence.Persistence
 		clone.Persistence = &value
 	}
+	if evidence.KubernetesPersistence != nil {
+		value := *evidence.KubernetesPersistence
+		clone.KubernetesPersistence = &value
+	}
+	if evidence.LifecycleMutationAllowed != nil {
+		value := *evidence.LifecycleMutationAllowed
+		clone.LifecycleMutationAllowed = &value
+	}
 	return clone
+}
+
+func runtimeBindingBool(value bool) *bool { return &value }
+
+func runtimeBindingSecretName(planDigest string) (string, error) {
+	if !stageReceiptPrefixDigestPattern.MatchString(planDigest) {
+		return "", errors.New("runtime binding plan digest is invalid")
+	}
+	return "ok147-runtime-binding-" + strings.TrimPrefix(planDigest, "sha256:")[:24], nil
 }
 
 func sameRuntimeBindingEndpoint(first, second string) bool {

--- a/internal/runner/runtime_binding_stage_test.go
+++ b/internal/runner/runtime_binding_stage_test.go
@@ -47,7 +47,7 @@ func TestRuntimeBindingStageComposesAndResumesWithoutRebinding(t *testing.T) {
 		t.Fatalf("runtime binding stage did not complete: %#v %v", receipt, err)
 	}
 	evidence, err := opened.EvidenceReceipt()
-	if err != nil || evidence.State != "SUCCEEDED" || evidence.Material == nil || evidence.Persistence == nil || evidence.Persistence.State != "WRITTEN_VERIFIED" || evidence.KubernetesMutationAllowed {
+	if err != nil || evidence.State != "SUCCEEDED" || evidence.Material == nil || evidence.Persistence == nil || evidence.Persistence.State != "WRITTEN_VERIFIED" || evidence.KubernetesPersistence != nil || evidence.KubernetesMutationAllowed || evidence.LifecycleMutationAllowed != nil {
 		t.Fatalf("runtime binding evidence differs: %#v %v", evidence, err)
 	}
 	public, _ := json.Marshal(evidence)
@@ -74,6 +74,51 @@ func TestRuntimeBindingStageComposesAndResumesWithoutRebinding(t *testing.T) {
 	}
 	if !reflect.DeepEqual(workloadAPI.Requests(), wantRequests) {
 		t.Fatal("persisted runtime binding stage rebound the workload")
+	}
+}
+
+func TestRuntimeBindingStageComposesImmutableKubernetesPersistence(t *testing.T) {
+	bundle, err := LoadRuntimeBindingStageBundle(runtimeBindingBundleConfig(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	managementAPI := newRuntimeBindingLedgerAPI(t)
+	defer managementAPI.Close()
+	workloadAPI := newRuntimeBindingWorkloadAPI(t, false)
+	defer workloadAPI.Close()
+	local := runtimeBindingStageRuntime(t, bundle, managementAPI.Server, workloadAPI.Server, "ledger-token", "workload-token")
+	runtime := runtimeBindingStageKubernetesRuntime(t, local, "persistence-token")
+	opened, err := bundle.OpenKubernetes(runtime)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if managementAPI.RequestCount() != 0 || workloadAPI.RequestCount() != 0 {
+		t.Fatal("opening Kubernetes-persisted runtime binding contacted an API")
+	}
+	receipt, err := opened.Run(context.Background())
+	if err != nil || receipt.State != "COMPLETED_SUCCEEDED" {
+		t.Fatalf("Kubernetes-persisted runtime binding did not complete: %#v %v", receipt, err)
+	}
+	evidence, err := opened.EvidenceReceipt()
+	if err != nil || evidence.Format != RuntimeBindingStageKubernetesEvidenceFormat || evidence.State != "SUCCEEDED" || evidence.Material == nil || evidence.Persistence != nil || evidence.KubernetesPersistence == nil || evidence.KubernetesPersistence.State != "CREATED_VERIFIED" || !evidence.KubernetesMutationAllowed || evidence.LifecycleMutationAllowed == nil || *evidence.LifecycleMutationAllowed {
+		t.Fatalf("Kubernetes persistence evidence differs: %#v %v", evidence, err)
+	}
+	secretName, err := runtimeBindingSecretName(evidence.PlanDigest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"POST /api/v1/namespaces/openkubes-execution-system/secrets"}
+	if !reflect.DeepEqual(managementAPI.SecretRequests(), want) {
+		t.Fatalf("runtime binding Secret requests differ: %v", managementAPI.SecretRequests())
+	}
+	if _, err := os.Lstat(local.OutputPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatal("Kubernetes persistence also created the local binding file")
+	}
+	public, _ := json.Marshal(evidence)
+	for _, forbidden := range []string{managementAPI.URL, workloadAPI.URL, "persistence-token", secretName, local.OutputPath} {
+		if strings.Contains(string(public), forbidden) {
+			t.Fatalf("Kubernetes persistence evidence exposed private value %q", forbidden)
+		}
 	}
 }
 
@@ -132,6 +177,30 @@ func TestRuntimeBindingStageOpenFailsClosedWithoutContact(t *testing.T) {
 	}
 	if _, err := (OpenedRuntimeBindingStage{}).Run(context.Background()); err == nil {
 		t.Fatal("unopened runtime binding stage could run")
+	}
+	runtime = runtimeBindingStageRuntime(t, bundle, ledgerAPI.Server, workloadAPI.Server, "ledger-token", "workload-token")
+	kubernetes := runtimeBindingStageKubernetesRuntime(t, runtime, "ledger-token")
+	if _, err := bundle.OpenKubernetes(kubernetes); err == nil {
+		t.Fatal("shared ledger and persistence credential was accepted")
+	}
+	if ledgerAPI.RequestCount() != 0 || workloadAPI.RequestCount() != 0 {
+		t.Fatal("failed Kubernetes persistence open contacted an API")
+	}
+}
+
+func runtimeBindingStageKubernetesRuntime(t *testing.T, local RuntimeBindingStageRuntimeConfig, token string) RuntimeBindingStageKubernetesRuntimeConfig {
+	t.Helper()
+	tokenPath := filepath.Join(filepath.Dir(local.OutputPath), "persistence-token")
+	if err := os.WriteFile(tokenPath, []byte(token), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return RuntimeBindingStageKubernetesRuntimeConfig{
+		Ledger: local.Ledger, Workload: local.Workload,
+		Persistence: KubernetesAuthorityConfig{
+			Endpoint: local.Ledger.Endpoint, AuthorityIdentity: "ok-mgmt",
+			TokenFile: tokenPath, CAFile: local.Ledger.CAFile,
+		},
+		Clock: local.Clock,
 	}
 }
 
@@ -242,9 +311,11 @@ func (api *runtimeBindingWorkloadAPI) RequestCount() int { return len(api.Reques
 
 type runtimeBindingLedgerAPI struct {
 	*httptest.Server
-	mu       sync.Mutex
-	objects  map[string]map[string]any
-	requests int
+	mu             sync.Mutex
+	objects        map[string]map[string]any
+	secret         map[string]any
+	requests       int
+	secretRequests []string
 }
 
 func newRuntimeBindingLedgerAPI(t *testing.T) *runtimeBindingLedgerAPI {
@@ -255,6 +326,23 @@ func newRuntimeBindingLedgerAPI(t *testing.T) *runtimeBindingLedgerAPI {
 		defer api.mu.Unlock()
 		api.requests++
 		response.Header().Set("Content-Type", "application/json")
+		if request.Header.Get("Authorization") == "Bearer persistence-token" {
+			api.secretRequests = append(api.secretRequests, request.Method+" "+request.URL.RequestURI())
+			prefix := "/api/v1/namespaces/openkubes-execution-system/secrets"
+			if request.Method != http.MethodPost || request.URL.Path != prefix || api.secret != nil {
+				response.WriteHeader(http.StatusConflict)
+				return
+			}
+			if err := json.NewDecoder(request.Body).Decode(&api.secret); err != nil {
+				response.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			metadata := api.secret["metadata"].(map[string]any)
+			metadata["uid"], metadata["resourceVersion"] = "runtime-binding-secret-uid", "1"
+			response.WriteHeader(http.StatusCreated)
+			json.NewEncoder(response).Encode(api.secret)
+			return
+		}
 		if request.Header.Get("Authorization") != "Bearer ledger-token" {
 			response.WriteHeader(http.StatusUnauthorized)
 			return
@@ -297,4 +385,10 @@ func (api *runtimeBindingLedgerAPI) RequestCount() int {
 	api.mu.Lock()
 	defer api.mu.Unlock()
 	return api.requests
+}
+
+func (api *runtimeBindingLedgerAPI) SecretRequests() []string {
+	api.mu.Lock()
+	defer api.mu.Unlock()
+	return append([]string(nil), api.secretRequests...)
 }


### PR DESCRIPTION
## Outcome

Composes the immutable runtime-binding Secret store with the crash-safe runtime-binding operation behind a distinct library opener.

## Boundaries

- existing local CLI/file evidence remains v1-compatible
- Secret name is derived from the verified plan digest
- Secret and ledger use the same exact management API
- ledger, persistence, and workload credentials must be pairwise distinct
- v2 evidence permits only persistence mutation and explicitly denies lifecycle mutation
- no CLI or Job activation and no live cluster contact

## Verification

- go test -ldflags=-linkmode=external ./...
- go vet ./...
- go test -race -ldflags=-linkmode=external ./internal/runner/...
- focused post-hardening runner and CLI tests

OK-147