### PR TITLE
feat(cli): activate Kubernetes runtime binding persistence (OK-147)

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,8 @@ Powered by [Cluster API (CAPI)](https://cluster-api.sigs.k8s.io/), [CAPK (KubeVi
   candidate can create or verify one exact immutable runtime-binding Secret on
   `ok-mgmt`; it has no update/delete/retry path. A distinct library opener now
   composes that store with pairwise-separate ledger, persistence and workload
-  credentials, but neither the CLI nor a Job package activates it yet.
+  credentials. The CLI activates it only with explicit `--execute` plus
+  `--persistence-mode immutable-secret`; no Job package activates it yet.
   Stage 4 now has its first distinct path as well:
   `ok cluster stage run enablement --execute` binds the verified three-receipt
   prefix and signed `CreateEnablement` grant to exactly one externally rendered

--- a/cmd/ok/main.go
+++ b/cmd/ok/main.go
@@ -535,6 +535,23 @@ var executeRuntimeBindingStage = func(ctx context.Context, bundleConfig runner.S
 	return receipt, nil, runErr
 }
 
+var executeKubernetesRuntimeBindingStage = func(ctx context.Context, bundleConfig runner.StageResumeConfig, runtimeConfig runner.RuntimeBindingStageKubernetesRuntimeConfig) (execution.BindingStageRunReceipt, *runner.RuntimeBindingStageEvidenceReceipt, error) {
+	bundle, err := runner.LoadRuntimeBindingStageBundle(bundleConfig)
+	if err != nil {
+		return execution.BindingStageRunReceipt{}, nil, err
+	}
+	opened, err := bundle.OpenKubernetes(runtimeConfig)
+	if err != nil {
+		return execution.BindingStageRunReceipt{}, nil, err
+	}
+	receipt, runErr := opened.Run(ctx)
+	evidence, evidenceErr := opened.EvidenceReceipt()
+	if evidenceErr == nil {
+		return receipt, &evidence, runErr
+	}
+	return receipt, nil, runErr
+}
+
 func submissionStageAuthority(decision stagecursor.Decision, expected stageplan.Expected) (string, error) {
 	switch decision.Authority {
 	case "infrastructure":
@@ -955,6 +972,9 @@ func runClusterStageBindRuntime(ctx context.Context, arguments []string, stdout,
 	workloadBindingDigest := flags.String("workload-binding-digest", "", "expected workload-authority binding digest")
 	workloadTokenFile := flags.String("workload-token-file", "", "path to the short-lived read-only workload token")
 	workloadCAFile := flags.String("workload-ca-file", "", "path to the workload Kubernetes API CA bundle")
+	persistenceMode := flags.String("persistence-mode", "local-file", "exact persistence mode: local-file or immutable-secret")
+	persistenceTokenFile := flags.String("persistence-token-file", "", "path to the distinct short-lived runtime-binding Secret writer token")
+	persistenceCAFile := flags.String("persistence-ca-file", "", "path to the runtime-binding Secret writer Kubernetes API CA bundle")
 	output := flags.String("output", "", "absent absolute path in a private directory for the runtime binding")
 	if err := flags.Parse(arguments); err != nil {
 		return err
@@ -972,7 +992,7 @@ func runClusterStageBindRuntime(ctx context.Context, arguments []string, stdout,
 	for _, input := range []struct{ name, value string }{
 		{"--ledger-api-endpoint", *ledgerAPIEndpoint}, {"--ledger-token-file", *ledgerTokenFile}, {"--ledger-ca-file", *ledgerCAFile},
 		{"--workload-binding", *workloadBinding}, {"--workload-binding-digest", *workloadBindingDigest},
-		{"--workload-token-file", *workloadTokenFile}, {"--workload-ca-file", *workloadCAFile}, {"--output", *output},
+		{"--workload-token-file", *workloadTokenFile}, {"--workload-ca-file", *workloadCAFile},
 	} {
 		if input.value == "" {
 			return fmt.Errorf("%s is required", input.name)
@@ -981,26 +1001,56 @@ func runClusterStageBindRuntime(ctx context.Context, arguments []string, stdout,
 	if !sha256DigestPattern.MatchString(*workloadBindingDigest) {
 		return errors.New("workload binding digest must be a lowercase SHA-256 identity")
 	}
-	if !filepath.IsAbs(*output) || filepath.Clean(*output) != *output {
-		return errors.New("--output must be a clean absolute path")
+	switch *persistenceMode {
+	case "local-file":
+		if *persistenceTokenFile != "" || *persistenceCAFile != "" {
+			return errors.New("local-file persistence cannot accept Kubernetes persistence credentials")
+		}
+		if *output == "" || !filepath.IsAbs(*output) || filepath.Clean(*output) != *output {
+			return errors.New("--output must be a clean absolute path for local-file persistence")
+		}
+	case "immutable-secret":
+		if *output != "" {
+			return errors.New("immutable-secret persistence cannot accept --output")
+		}
+		if *persistenceTokenFile == "" || *persistenceCAFile == "" {
+			return errors.New("immutable-secret persistence requires token and CA files")
+		}
+	default:
+		return errors.New("unsupported runtime binding persistence mode")
 	}
 	boundedContext, cancel := context.WithTimeout(ctx, runtimeBindingRunTimeout)
 	defer cancel()
-	receipt, evidence, runErr := executeRuntimeBindingStage(boundedContext, bundleConfig, runner.RuntimeBindingStageRuntimeConfig{
-		Ledger: runner.KubernetesLedgerConfig{
-			Endpoint: *ledgerAPIEndpoint, Namespace: ledgerNamespace, TokenFile: *ledgerTokenFile, CAFile: *ledgerCAFile,
-		},
-		Workload: runner.WorkloadAuthorityFileResolverConfig{
-			Path: *workloadBinding, ExpectedBindingDigest: *workloadBindingDigest,
-			TokenFile: *workloadTokenFile, CAFile: *workloadCAFile,
-		},
-		OutputPath: *output, Clock: func() time.Time { return time.Now().UTC() },
-	})
+	ledgerConfig := runner.KubernetesLedgerConfig{Endpoint: *ledgerAPIEndpoint, Namespace: ledgerNamespace, TokenFile: *ledgerTokenFile, CAFile: *ledgerCAFile}
+	workloadConfig := runner.WorkloadAuthorityFileResolverConfig{
+		Path: *workloadBinding, ExpectedBindingDigest: *workloadBindingDigest,
+		TokenFile: *workloadTokenFile, CAFile: *workloadCAFile,
+	}
+	var receipt execution.BindingStageRunReceipt
+	var evidence *runner.RuntimeBindingStageEvidenceReceipt
+	var runErr error
+	outputFormat := "ok147-runtime-binding-execution/v1"
+	if *persistenceMode == "immutable-secret" {
+		outputFormat = "ok147-runtime-binding-execution/v2"
+		receipt, evidence, runErr = executeKubernetesRuntimeBindingStage(boundedContext, bundleConfig, runner.RuntimeBindingStageKubernetesRuntimeConfig{
+			Ledger: ledgerConfig, Workload: workloadConfig,
+			Persistence: runner.KubernetesAuthorityConfig{
+				Endpoint: *ledgerAPIEndpoint, AuthorityIdentity: bundleConfig.PlanExpected.ManagementAuthority,
+				TokenFile: *persistenceTokenFile, CAFile: *persistenceCAFile,
+			},
+			Clock: func() time.Time { return time.Now().UTC() },
+		})
+	} else {
+		receipt, evidence, runErr = executeRuntimeBindingStage(boundedContext, bundleConfig, runner.RuntimeBindingStageRuntimeConfig{
+			Ledger: ledgerConfig, Workload: workloadConfig, OutputPath: *output,
+			Clock: func() time.Time { return time.Now().UTC() },
+		})
+	}
 	if receipt.Format != "" {
 		encoder := json.NewEncoder(stdout)
 		encoder.SetEscapeHTML(false)
 		encoder.SetIndent("", "  ")
-		if err := encoder.Encode(runtimeBindingExecution{Format: "ok147-runtime-binding-execution/v1", Receipt: receipt, Evidence: evidence}); err != nil {
+		if err := encoder.Encode(runtimeBindingExecution{Format: outputFormat, Receipt: receipt, Evidence: evidence}); err != nil {
 			return err
 		}
 	}

--- a/cmd/ok/main_test.go
+++ b/cmd/ok/main_test.go
@@ -484,6 +484,47 @@ func TestStageBindRuntimeRequiresExplicitExecutionAndBindsRuntime(t *testing.T) 
 	}
 }
 
+func TestStageBindRuntimeSelectsImmutableSecretPersistence(t *testing.T) {
+	previousLocal := executeRuntimeBindingStage
+	previousKubernetes := executeKubernetesRuntimeBindingStage
+	defer func() {
+		executeRuntimeBindingStage = previousLocal
+		executeKubernetesRuntimeBindingStage = previousKubernetes
+	}()
+	localCalls := 0
+	executeRuntimeBindingStage = func(context.Context, runner.StageResumeConfig, runner.RuntimeBindingStageRuntimeConfig) (execution.BindingStageRunReceipt, *runner.RuntimeBindingStageEvidenceReceipt, error) {
+		localCalls++
+		return execution.BindingStageRunReceipt{}, nil, nil
+	}
+	var captured runner.RuntimeBindingStageKubernetesRuntimeConfig
+	executeKubernetesRuntimeBindingStage = func(_ context.Context, _ runner.StageResumeConfig, runtime runner.RuntimeBindingStageKubernetesRuntimeConfig) (execution.BindingStageRunReceipt, *runner.RuntimeBindingStageEvidenceReceipt, error) {
+		captured = runtime
+		denied := false
+		evidence := &runner.RuntimeBindingStageEvidenceReceipt{
+			Format: runner.RuntimeBindingStageKubernetesEvidenceFormat, State: "SUCCEEDED", PlanDigest: testSHA("9"), StageID: "runtime-binding",
+			KubernetesMutationAllowed: true, LifecycleMutationAllowed: &denied,
+		}
+		return execution.BindingStageRunReceipt{
+			Format: execution.BindingStageReceiptFormat, State: "COMPLETED_SUCCEEDED",
+			PlanDigest: testSHA("9"), StageID: "runtime-binding", StageReceiptDigest: testSHA("8"),
+		}, evidence, nil
+	}
+	var stdout, stderr bytes.Buffer
+	if err := run(stageBindRuntimeKubernetesArguments(), &stdout, &stderr); err != nil {
+		t.Fatalf("run: %v; stderr=%s", err, stderr.String())
+	}
+	if localCalls != 0 || captured.Persistence.AuthorityIdentity != "ok-mgmt" || captured.Persistence.Endpoint != captured.Ledger.Endpoint || captured.Persistence.TokenFile != "/tmp/persistence-token" || captured.Persistence.CAFile != "/tmp/persistence-ca" || captured.Clock == nil {
+		t.Fatalf("immutable Secret persistence config differs: local=%d config=%#v", localCalls, captured)
+	}
+	var result runtimeBindingExecution
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatal(err)
+	}
+	if result.Format != "ok147-runtime-binding-execution/v2" || result.Evidence == nil || result.Evidence.Format != runner.RuntimeBindingStageKubernetesEvidenceFormat || !result.Evidence.KubernetesMutationAllowed || result.Evidence.LifecycleMutationAllowed == nil || *result.Evidence.LifecycleMutationAllowed {
+		t.Fatalf("immutable Secret execution output differs: %#v", result)
+	}
+}
+
 func TestStageBindRuntimeFailsClosedBeforeExecution(t *testing.T) {
 	previous := executeRuntimeBindingStage
 	defer func() { executeRuntimeBindingStage = previous }()
@@ -512,6 +553,33 @@ func TestStageBindRuntimeFailsClosedBeforeExecution(t *testing.T) {
 	}
 	if calls != 0 {
 		t.Fatalf("runtime binding execution was reached %d times for invalid input", calls)
+	}
+}
+
+func TestStageBindRuntimeImmutableSecretFailsClosedBeforeExecution(t *testing.T) {
+	previous := executeKubernetesRuntimeBindingStage
+	defer func() { executeKubernetesRuntimeBindingStage = previous }()
+	calls := 0
+	executeKubernetesRuntimeBindingStage = func(context.Context, runner.StageResumeConfig, runner.RuntimeBindingStageKubernetesRuntimeConfig) (execution.BindingStageRunReceipt, *runner.RuntimeBindingStageEvidenceReceipt, error) {
+		calls++
+		return execution.BindingStageRunReceipt{}, nil, nil
+	}
+	valid := stageBindRuntimeKubernetesArguments()
+	for name, arguments := range map[string][]string{
+		"missing persistence token": removeArgumentWithValue(valid, "--persistence-token-file"),
+		"missing persistence CA":    removeArgumentWithValue(valid, "--persistence-ca-file"),
+		"ambiguous output":          append(append([]string{}, valid...), "--output", "/private/tmp/runtime-binding.json"),
+		"unknown mode":              replaceArgument(valid, "--persistence-mode", "other"),
+	} {
+		t.Run(name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			if err := run(arguments, &stdout, &stderr); err == nil || stdout.Len() != 0 {
+				t.Fatalf("unsafe immutable Secret input was accepted: err=%v stdout=%s", err, stdout.String())
+			}
+		})
+	}
+	if calls != 0 {
+		t.Fatalf("Kubernetes runtime binding execution was reached %d times for invalid input", calls)
 	}
 }
 
@@ -1491,6 +1559,15 @@ func stageBindRuntimeArguments() []string {
 		"--workload-binding", "/tmp/workload-binding.json", "--workload-binding-digest", testSHA("5"),
 		"--workload-token-file", "/tmp/workload-observer-token", "--workload-ca-file", "/tmp/workload-ca",
 		"--output", "/private/tmp/ok147-runtime-binding.json",
+	)
+}
+
+func stageBindRuntimeKubernetesArguments() []string {
+	arguments := removeArgumentWithValue(stageBindRuntimeArguments(), "--output")
+	return append(arguments,
+		"--persistence-mode", "immutable-secret",
+		"--persistence-token-file", "/tmp/persistence-token",
+		"--persistence-ca-file", "/tmp/persistence-ca",
 	)
 }
 

--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -2253,9 +2253,29 @@ operation stores the immutable ledger receipt. A later process can therefore
 verify an equivalent pre-existing Secret if it stopped between those two
 writes, without gaining an update or generic retry path.
 
-This remains library-only composition tested against local fake TLS APIs. The
-CLI still selects the exclusive local file, no Job package selects
-`OpenKubernetes`, and no live Kubernetes API was contacted.
+The CLI now exposes the composition through an explicit, mutually exclusive
+mode:
+
+```text
+ok cluster stage bind runtime --execute
+  --persistence-mode local-file
+  --output /private/absolute/path
+
+ok cluster stage bind runtime --execute
+  --persistence-mode immutable-secret
+  --persistence-token-file /bounded/persistence/token
+  --persistence-ca-file /bounded/persistence/ca.crt
+```
+
+`local-file` remains the compatibility default and rejects Kubernetes
+persistence credentials. `immutable-secret` rejects `--output`, reuses the
+exact ledger API destination, derives the management authority from the
+verified plan and emits outer execution format v2. Both modes retain the fixed
+two-minute context and explicit `--execute` requirement.
+
+The activation has been tested only through injected local execution paths and
+fake TLS APIs. It has not been invoked against a live Kubernetes API, and no
+Job package selects it yet.
 
 ## Bounded convergence observation polling
 


### PR DESCRIPTION
## Outcome

Adds the explicit immutable-secret persistence mode to the bounded runtime-binding CLI so a future Job package can target the already verified Kubernetes store.

## Boundaries

- local-file remains the compatibility default
- immutable-secret requires explicit mode, execute intent, a distinct token, and CA
- immutable-secret rejects local output paths
- management authority comes only from the verified plan
- fixed two-minute deadline and redaction-safe v2 output
- tested with injected local execution only; no live cluster invocation

## Verification

- go test -ldflags=-linkmode=external ./...
- go vet ./...
- go test -race -ldflags=-linkmode=external ./cmd/ok ./internal/runner/...

OK-147