### PR TITLE
feat(runner): bind runtime Job inputs (OK-147)

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,9 @@ Powered by [Cluster API (CAPI)](https://cluster-api.sigs.k8s.io/), [CAPK (KubeVi
   `ok-mgmt`; it has no update/delete/retry path. A distinct library opener now
   composes that store with pairwise-separate ledger, persistence and workload
   credentials. The CLI activates it only with explicit `--execute` plus
-  `--persistence-mode immutable-secret`; no Job package activates it yet.
+  `--persistence-mode immutable-secret`; no Job package activates it yet. Its
+  offline immutable input ConfigMap now binds only the public plan and exact
+  five-receipt prefix, excluding all private authority and credential data.
   Stage 4 now has its first distinct path as well:
   `ok cluster stage run enablement --execute` binds the verified three-receipt
   prefix and signed `CreateEnablement` grant to exactly one externally rendered

--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -2277,6 +2277,19 @@ The activation has been tested only through injected local execution paths and
 fake TLS APIs. It has not been invoked against a live Kubernetes API, and no
 Job package selects it yet.
 
+The first offline Job-packaging component now materializes one immutable
+`ok147-runtime-binding-stage-input/v1` ConfigMap. Its data is closed to the
+verified staged plan, an ordered five-receipt prefix manifest and the exact
+provider, lifecycle, lifecycle-observation, enablement and network-observation
+receipts. The ConfigMap is rebuilt against the verified bundle after reading
+all files, so a changed input fails before package output is accepted.
+
+The input deliberately has no slot for the private workload-authority binding,
+endpoint, CA, credential, runtime UID or resulting runtime-binding material.
+Those values must arrive only through separately scoped Secret mounts in the
+future Job envelope. This checkpoint does not yet render that Job or its
+NetworkPolicy and performs no Kubernetes request.
+
 ## Bounded convergence observation polling
 
 The aggregate observer can now be wrapped by a bounded polling observer before

--- a/internal/runner/runtime_binding_stage_input.go
+++ b/internal/runner/runtime_binding_stage_input.go
@@ -1,0 +1,121 @@
+package runner
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"sort"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+const RuntimeBindingStageInputFormat = "ok147-runtime-binding-stage-input/v1"
+
+type RuntimeBindingStageInputReceipt struct {
+	Format              string   `json:"format"`
+	State               string   `json:"state"`
+	StageID             string   `json:"stageId"`
+	ConfigMapName       string   `json:"configMapName"`
+	ConfigMapDigest     string   `json:"configMapDigest"`
+	ReceiptPrefixDigest string   `json:"receiptPrefixDigest"`
+	DataKeys            []string `json:"dataKeys"`
+}
+
+type VerifiedRuntimeBindingStageInput struct {
+	raw      []byte
+	receipt  RuntimeBindingStageInputReceipt
+	verified bool
+}
+
+// BuildRuntimeBindingStageInput packages only the immutable public plan and
+// exact five-receipt prefix. Workload authority, credentials, endpoint, CA and
+// private runtime material remain outside the ConfigMap.
+func BuildRuntimeBindingStageInput(config StageResumeConfig, configMapName string) (VerifiedRuntimeBindingStageInput, error) {
+	if !submissionStageInputNamePattern.MatchString(configMapName) || len(configMapName) > 63 || !strings.HasPrefix(configMapName, "ok147-") {
+		return VerifiedRuntimeBindingStageInput{}, errors.New("runtime binding input ConfigMap name is invalid")
+	}
+	if _, err := LoadRuntimeBindingStageBundle(config); err != nil {
+		return VerifiedRuntimeBindingStageInput{}, err
+	}
+	if len(config.Receipts) != 5 {
+		return VerifiedRuntimeBindingStageInput{}, errors.New("runtime binding input requires the exact five-receipt prefix")
+	}
+	keys := []string{
+		"provider-receipt.json", "lifecycle-receipt.json", "lifecycle-observation-receipt.json",
+		"enablement-receipt.json", "network-observation-receipt.json",
+	}
+	prefix := stageReceiptPrefixDocument{Format: StageReceiptPrefixFormat, Receipts: make([]stageReceiptPrefixEntry, len(keys))}
+	paths := map[string]string{"staged-plan.json": config.PlanPath}
+	for index, key := range keys {
+		paths[key] = config.Receipts[index].Path
+		prefix.Receipts[index] = stageReceiptPrefixEntry{File: key, Digest: config.Receipts[index].Digest}
+	}
+	prefixRaw, err := json.Marshal(prefix)
+	if err != nil {
+		return VerifiedRuntimeBindingStageInput{}, errors.New("encode runtime binding receipt prefix")
+	}
+	data := make(map[string]string, len(paths)+1)
+	data["receipt-prefix.json"] = string(prefixRaw)
+	for key, path := range paths {
+		raw, err := readBoundedRegular(path, maximumSubmissionStageInputBytes)
+		if err != nil {
+			return VerifiedRuntimeBindingStageInput{}, errors.New("read bounded runtime binding input " + key)
+		}
+		if !utf8.Valid(raw) || bytes.IndexByte(raw, 0) >= 0 {
+			return VerifiedRuntimeBindingStageInput{}, errors.New("runtime binding input is not valid ConfigMap text")
+		}
+		data[key] = string(raw)
+	}
+	if _, err := LoadRuntimeBindingStageBundle(config); err != nil {
+		return VerifiedRuntimeBindingStageInput{}, errors.New("runtime binding inputs changed during materialization")
+	}
+	configMap := submissionStageInputConfigMap{
+		APIVersion: "v1", Kind: "ConfigMap",
+		Metadata: submissionStageInputObjectMeta{
+			Name: configMapName, Namespace: submissionStageInputNamespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/name": "ok-cluster-contract-executor", "openkubes.io/stage-id": "runtime-binding",
+			},
+			Annotations: map[string]string{
+				"openkubes.io/input-format": RuntimeBindingStageInputFormat, "openkubes.io/receipt-prefix-digest": digest.SHA256(prefixRaw),
+			},
+		},
+		Immutable: true, Data: data,
+	}
+	raw, err := json.Marshal(configMap)
+	if err != nil {
+		return VerifiedRuntimeBindingStageInput{}, errors.New("encode runtime binding input ConfigMap")
+	}
+	if len(raw) > maximumSubmissionStageInputBytes {
+		return VerifiedRuntimeBindingStageInput{}, errors.New("runtime binding input ConfigMap exceeds size limit")
+	}
+	dataKeys := make([]string, 0, len(data))
+	for key := range data {
+		dataKeys = append(dataKeys, key)
+	}
+	sort.Strings(dataKeys)
+	receipt := RuntimeBindingStageInputReceipt{
+		Format: RuntimeBindingStageInputFormat, State: "VERIFIED", StageID: "runtime-binding",
+		ConfigMapName: configMapName, ConfigMapDigest: digest.SHA256(raw),
+		ReceiptPrefixDigest: digest.SHA256(prefixRaw), DataKeys: dataKeys,
+	}
+	return VerifiedRuntimeBindingStageInput{raw: raw, receipt: receipt, verified: true}, nil
+}
+
+func (input VerifiedRuntimeBindingStageInput) Bytes() ([]byte, error) {
+	if !input.verified || len(input.raw) == 0 {
+		return nil, errors.New("runtime binding input was not produced by verification")
+	}
+	return append([]byte(nil), input.raw...), nil
+}
+
+func (input VerifiedRuntimeBindingStageInput) Receipt() (RuntimeBindingStageInputReceipt, error) {
+	if !input.verified || input.receipt.State != "VERIFIED" || digest.SHA256(input.raw) != input.receipt.ConfigMapDigest {
+		return RuntimeBindingStageInputReceipt{}, errors.New("runtime binding input was not produced by verification")
+	}
+	receipt := input.receipt
+	receipt.DataKeys = append([]string(nil), input.receipt.DataKeys...)
+	return receipt, nil
+}

--- a/internal/runner/runtime_binding_stage_input_test.go
+++ b/internal/runner/runtime_binding_stage_input_test.go
@@ -1,0 +1,82 @@
+package runner
+
+import (
+	"encoding/json"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+func TestBuildRuntimeBindingStageInputContainsOnlyPublicBoundInputs(t *testing.T) {
+	config := runtimeBindingBundleConfig(t)
+	input, err := BuildRuntimeBindingStageInput(config, "ok147-runtime-binding-input")
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := input.Bytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := input.Receipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var object map[string]any
+	if err := json.Unmarshal(raw, &object); err != nil {
+		t.Fatal(err)
+	}
+	if object["kind"] != "ConfigMap" || object["immutable"] != true || objectAt(t, object, "metadata")["name"] != "ok147-runtime-binding-input" {
+		t.Fatalf("unexpected runtime binding input: %#v", object)
+	}
+	data := objectAt(t, object, "data")
+	wantKeys := []string{
+		"enablement-receipt.json", "lifecycle-observation-receipt.json", "lifecycle-receipt.json",
+		"network-observation-receipt.json", "provider-receipt.json", "receipt-prefix.json", "staged-plan.json",
+	}
+	gotKeys := make([]string, 0, len(data))
+	for key := range data {
+		gotKeys = append(gotKeys, key)
+	}
+	sort.Strings(gotKeys)
+	if !reflect.DeepEqual(gotKeys, wantKeys) || data["workload-binding.json"] != nil || data["token"] != nil || data["ca.crt"] != nil || data["runtime-binding.json"] != nil {
+		t.Fatalf("runtime binding public input boundary differs: %v", gotKeys)
+	}
+	if receipt.Format != RuntimeBindingStageInputFormat || receipt.StageID != "runtime-binding" || receipt.ConfigMapDigest != digest.SHA256(raw) || !stageReceiptPrefixDigestPattern.MatchString(receipt.ReceiptPrefixDigest) || !reflect.DeepEqual(receipt.DataKeys, wantKeys) {
+		t.Fatalf("unexpected runtime binding input receipt: %#v", receipt)
+	}
+	raw[0] = 'x'
+	again, _ := input.Bytes()
+	if again[0] != '{' {
+		t.Fatal("caller mutated retained runtime binding input")
+	}
+	receipt.DataKeys[0] = "changed"
+	againReceipt, _ := input.Receipt()
+	if againReceipt.DataKeys[0] != wantKeys[0] {
+		t.Fatal("caller mutated retained runtime binding input receipt")
+	}
+}
+
+func TestBuildRuntimeBindingStageInputFailsClosed(t *testing.T) {
+	valid := runtimeBindingBundleConfig(t)
+	for name, mutate := range map[string]func(*StageResumeConfig, *string){
+		"missing receipt": func(config *StageResumeConfig, _ *string) { config.Receipts = config.Receipts[:4] },
+		"invalid name":    func(_ *StageResumeConfig, name *string) { *name = "runtime-binding-input" },
+	} {
+		t.Run(name, func(t *testing.T) {
+			config := valid
+			name := "ok147-runtime-binding-input"
+			mutate(&config, &name)
+			if _, err := BuildRuntimeBindingStageInput(config, name); err == nil {
+				t.Fatal("unsafe runtime binding input was accepted")
+			}
+		})
+	}
+	if _, err := (VerifiedRuntimeBindingStageInput{}).Bytes(); err == nil {
+		t.Fatal("unverified runtime binding input bytes were exposed")
+	}
+	if _, err := (VerifiedRuntimeBindingStageInput{}).Receipt(); err == nil {
+		t.Fatal("unverified runtime binding input receipt was exposed")
+	}
+}


### PR DESCRIPTION
## Outcome

Adds the immutable public input ConfigMap contract for a future runtime-binding Job.

## Boundary

- exact verified staged plan plus five-receipt prefix only
- immutable ConfigMap with digest-bound prefix
- re-verification after materialization
- excludes workload binding, endpoint, CA, tokens, runtime UIDs, and private binding material
- no Job rendering, installation, launch, or cluster contact

## Verification

- go test -ldflags=-linkmode=external ./...
- go vet ./...
- go test -race -ldflags=-linkmode=external ./internal/runner/...

OK-147