### PR TITLE
feat(runner): render runtime binding Job envelope (OK-147)

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,10 @@ Powered by [Cluster API (CAPI)](https://cluster-api.sigs.k8s.io/), [CAPK (KubeVi
   credentials. The CLI activates it only with explicit `--execute` plus
   `--persistence-mode immutable-secret`; no Job package activates it yet. Its
   offline immutable input ConfigMap now binds only the public plan and exact
-  five-receipt prefix, excluding all private authority and credential data.
+  five-receipt prefix, excluding all private authority and credential data. A
+  matching offline Job/NetworkPolicy envelope fixes three distinct credential
+  mounts and only the exact management and workload API egress destinations;
+  it is not yet packaged, installed or launched.
   Stage 4 now has its first distinct path as well:
   `ok cluster stage run enablement --execute` binds the verified three-receipt
   prefix and signed `CreateEnablement` grant to exactly one externally rendered

--- a/deploy/contract-executor-runtime-binding-job.yaml.tpl
+++ b/deploy/contract-executor-runtime-binding-job.yaml.tpl
@@ -1,0 +1,166 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: "${OK147_RUN_ID}"
+  namespace: openkubes-execution-system
+spec:
+  podSelector:
+    matchLabels:
+      openkubes.io/execution-id: "${OK147_RUN_ID}"
+  policyTypes: ["Ingress", "Egress"]
+  ingress: []
+  egress:
+    - to: [{ipBlock: {cidr: "${OK147_LEDGER_API_CIDR}"}}]
+      ports: [{protocol: TCP, port: ${OK147_LEDGER_API_PORT}}]
+    - to: [{ipBlock: {cidr: "${OK147_WORKLOAD_API_CIDR}"}}]
+      ports: [{protocol: TCP, port: ${OK147_WORKLOAD_API_PORT}}]
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "${OK147_RUN_ID}"
+  namespace: openkubes-execution-system
+  labels:
+    app.kubernetes.io/name: ok-cluster-contract-executor
+    openkubes.io/execution-id: "${OK147_RUN_ID}"
+    openkubes.io/stage-id: runtime-binding
+spec:
+  backoffLimit: 0
+  completions: 1
+  parallelism: 1
+  activeDeadlineSeconds: 180
+  ttlSecondsAfterFinished: 3600
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ok-cluster-contract-executor
+        openkubes.io/execution-id: "${OK147_RUN_ID}"
+    spec:
+      serviceAccountName: ok147-contract-executor-runtime
+      automountServiceAccountToken: false
+      enableServiceLinks: false
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+        seccompProfile: {type: RuntimeDefault}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - {key: node-role.kubernetes.io/control-plane, operator: DoesNotExist}
+      containers:
+        - name: executor
+          image: "${OK147_IMAGE_DIGEST}"
+          imagePullPolicy: IfNotPresent
+          command: ["/ok"]
+          args:
+            - cluster
+            - stage
+            - bind
+            - runtime
+            - --execute
+            - --plan
+            - /var/run/openkubes/input/staged-plan.json
+            - --contract-namespace
+            - "${OK147_CONTRACT_NAMESPACE}"
+            - --contract-name
+            - "${OK147_CONTRACT_NAME}"
+            - --intent-revision
+            - "${OK147_R}"
+            - --enablement-revision
+            - "${OK147_E}"
+            - --platform-revision
+            - "${OK147_P}"
+            - --execution-fixture
+            - "${OK147_FIXTURE}"
+            - --infrastructure-authority
+            - "${OK147_INFRA_AUTHORITY}"
+            - --management-authority
+            - "${OK147_MGMT_AUTHORITY}"
+            - --gitops-authority
+            - "${OK147_GITOPS_AUTHORITY}"
+            - --receipt-prefix
+            - /var/run/openkubes/input/receipt-prefix.json
+            - --receipt-prefix-digest
+            - "${OK147_RECEIPT_PREFIX_DIGEST}"
+            - --ledger-api-endpoint
+            - "${OK147_LEDGER_API_URL}"
+            - --ledger-token-file
+            - /var/run/openkubes/ledger/token
+            - --ledger-ca-file
+            - /var/run/openkubes/ledger/ca.crt
+            - --workload-binding
+            - /var/run/openkubes/workload/binding.json
+            - --workload-binding-digest
+            - "${OK147_WORKLOAD_BINDING_DIGEST}"
+            - --workload-token-file
+            - /var/run/openkubes/workload/token
+            - --workload-ca-file
+            - /var/run/openkubes/workload/ca.crt
+            - --persistence-mode
+            - immutable-secret
+            - --persistence-token-file
+            - /var/run/openkubes/persistence/token
+            - --persistence-ca-file
+            - /var/run/openkubes/persistence/ca.crt
+          resources:
+            requests: {cpu: 50m, memory: 64Mi, ephemeral-storage: 16Mi}
+            limits: {cpu: 250m, memory: 128Mi, ephemeral-storage: 32Mi}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities: {drop: ["ALL"]}
+          volumeMounts:
+            - {name: input, mountPath: /var/run/openkubes/input/staged-plan.json, subPath: staged-plan.json, readOnly: true}
+            - {name: input, mountPath: /var/run/openkubes/input/receipt-prefix.json, subPath: receipt-prefix.json, readOnly: true}
+            - {name: input, mountPath: /var/run/openkubes/input/provider-receipt.json, subPath: provider-receipt.json, readOnly: true}
+            - {name: input, mountPath: /var/run/openkubes/input/lifecycle-receipt.json, subPath: lifecycle-receipt.json, readOnly: true}
+            - {name: input, mountPath: /var/run/openkubes/input/lifecycle-observation-receipt.json, subPath: lifecycle-observation-receipt.json, readOnly: true}
+            - {name: input, mountPath: /var/run/openkubes/input/enablement-receipt.json, subPath: enablement-receipt.json, readOnly: true}
+            - {name: input, mountPath: /var/run/openkubes/input/network-observation-receipt.json, subPath: network-observation-receipt.json, readOnly: true}
+            - {name: ledger-credential, mountPath: /var/run/openkubes/ledger/token, subPath: token, readOnly: true}
+            - {name: ledger-credential, mountPath: /var/run/openkubes/ledger/ca.crt, subPath: ca.crt, readOnly: true}
+            - {name: persistence-credential, mountPath: /var/run/openkubes/persistence/token, subPath: token, readOnly: true}
+            - {name: persistence-credential, mountPath: /var/run/openkubes/persistence/ca.crt, subPath: ca.crt, readOnly: true}
+            - {name: workload-credential, mountPath: /var/run/openkubes/workload/token, subPath: token, readOnly: true}
+            - {name: workload-credential, mountPath: /var/run/openkubes/workload/ca.crt, subPath: ca.crt, readOnly: true}
+            - {name: workload-credential, mountPath: /var/run/openkubes/workload/binding.json, subPath: binding.json, readOnly: true}
+      volumes:
+        - name: input
+          configMap:
+            name: "${OK147_INPUT_CONFIGMAP}"
+            defaultMode: 0444
+            items:
+              - {key: staged-plan.json, path: staged-plan.json}
+              - {key: receipt-prefix.json, path: receipt-prefix.json}
+              - {key: provider-receipt.json, path: provider-receipt.json}
+              - {key: lifecycle-receipt.json, path: lifecycle-receipt.json}
+              - {key: lifecycle-observation-receipt.json, path: lifecycle-observation-receipt.json}
+              - {key: enablement-receipt.json, path: enablement-receipt.json}
+              - {key: network-observation-receipt.json, path: network-observation-receipt.json}
+        - name: ledger-credential
+          secret:
+            secretName: "${OK147_LEDGER_CREDENTIAL_SECRET}"
+            defaultMode: 0440
+            items:
+              - {key: token, path: token}
+              - {key: ca.crt, path: ca.crt}
+        - name: persistence-credential
+          secret:
+            secretName: "${OK147_PERSISTENCE_CREDENTIAL_SECRET}"
+            defaultMode: 0440
+            items:
+              - {key: token, path: token}
+              - {key: ca.crt, path: ca.crt}
+        - name: workload-credential
+          secret:
+            secretName: "${OK147_WORKLOAD_CREDENTIAL_SECRET}"
+            defaultMode: 0440
+            items:
+              - {key: token, path: token}
+              - {key: ca.crt, path: ca.crt}
+              - {key: binding.json, path: binding.json}

--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -2290,6 +2290,24 @@ Those values must arrive only through separately scoped Secret mounts in the
 future Job envelope. This checkpoint does not yet render that Job or its
 NetworkPolicy and performs no Kubernetes request.
 
+The matching offline envelope now renders exactly one `NetworkPolicy` and one
+non-retrying `Job`. The tokenless Pod mounts the immutable input ConfigMap plus
+three distinct externally materialized Secrets: ledger writer, runtime-binding
+Secret writer and workload observer. The workload Secret alone also carries
+the previously verified private workload-authority binding. No implicit
+ServiceAccount token is mounted.
+
+The NetworkPolicy permits egress only to the exact management API address used
+by both ledger and persistence, and to the distinct exact workload API
+address. The Job invokes only `bind runtime --execute --persistence-mode
+immutable-secret`, has a three-minute hard deadline, fixed resources, a
+read-only root filesystem and no retry. It accepts neither a local output path
+nor grant, projection, renderer or generic Kubernetes input.
+
+This remains template rendering tested offline. The ConfigMap, NetworkPolicy,
+Job, runtime identity and credential Secrets are not yet assembled as one
+verified package, installed or launched, and no Kubernetes API was contacted.
+
 ## Bounded convergence observation polling
 
 The aggregate observer can now be wrapped by a bounded polling observer before

--- a/internal/runner/runtime_binding_stage_job.go
+++ b/internal/runner/runtime_binding_stage_job.go
@@ -1,0 +1,96 @@
+package runner
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/openkubes/ok-cluster/internal/stageplan"
+)
+
+type RuntimeBindingStageJobValues struct {
+	RunID                       string
+	ImageDigest                 string
+	Expected                    stageplan.Expected
+	InputConfigMap              string
+	ReceiptPrefixDigest         string
+	LedgerAPIURL                string
+	LedgerAPICIDR               string
+	LedgerCredentialSecret      string
+	PersistenceCredentialSecret string
+	WorkloadAPIURL              string
+	WorkloadAPICIDR             string
+	WorkloadCredentialSecret    string
+	WorkloadBindingDigest       string
+}
+
+// RenderRuntimeBindingStageJobTemplate validates and substitutes exactly one
+// two-endpoint NetworkPolicy and one immutable-Secret runtime-binding Job.
+func RenderRuntimeBindingStageJobTemplate(template []byte, values RuntimeBindingStageJobValues) ([]byte, error) {
+	if len(template) == 0 || len(template) > 1024*1024 {
+		return nil, errors.New("runtime binding Job template size is invalid")
+	}
+	dnsLabel := regexp.MustCompile(`^[a-z0-9](?:[-a-z0-9]*[a-z0-9])?$`)
+	if !dnsLabel.MatchString(values.RunID) || len(values.RunID) > 63 || !strings.HasPrefix(values.RunID, "ok147-") {
+		return nil, errors.New("runtime binding Job run ID is invalid")
+	}
+	names := []string{values.InputConfigMap, values.LedgerCredentialSecret, values.PersistenceCredentialSecret, values.WorkloadCredentialSecret}
+	seen := map[string]struct{}{}
+	for _, value := range names {
+		if !dnsLabel.MatchString(value) || len(value) > 63 {
+			return nil, errors.New("runtime binding Job object name is invalid")
+		}
+		if _, duplicate := seen[value]; duplicate {
+			return nil, errors.New("runtime binding Job inputs and credentials must use distinct objects")
+		}
+		seen[value] = struct{}{}
+	}
+	if !regexp.MustCompile(`^[a-z0-9][a-z0-9./:_-]*@sha256:[0-9a-f]{64}$`).MatchString(values.ImageDigest) {
+		return nil, errors.New("runtime binding Job image is not digest-bound")
+	}
+	for _, value := range []string{values.ReceiptPrefixDigest, values.WorkloadBindingDigest} {
+		if !stageReceiptPrefixDigestPattern.MatchString(value) {
+			return nil, errors.New("runtime binding Job semantic digest is invalid")
+		}
+	}
+	if err := stageplan.ValidateExpected(values.Expected); err != nil {
+		return nil, fmt.Errorf("runtime binding Job expected binding: %w", err)
+	}
+	ledgerPort, ledgerEndpoint, err := exactAPIEndpoint(values.LedgerAPIURL, values.LedgerAPICIDR)
+	if err != nil {
+		return nil, fmt.Errorf("runtime binding Job management endpoint: %w", err)
+	}
+	workloadPort, workloadEndpoint, err := exactAPIEndpoint(values.WorkloadAPIURL, values.WorkloadAPICIDR)
+	if err != nil {
+		return nil, fmt.Errorf("runtime binding Job workload endpoint: %w", err)
+	}
+	if workloadEndpoint == ledgerEndpoint {
+		return nil, errors.New("runtime binding management and workload endpoints must differ")
+	}
+	replacements := map[string]string{
+		"${OK147_RUN_ID}": values.RunID, "${OK147_IMAGE_DIGEST}": values.ImageDigest,
+		"${OK147_CONTRACT_NAMESPACE}": values.Expected.ContractIdentity.Namespace, "${OK147_CONTRACT_NAME}": values.Expected.ContractIdentity.Name,
+		"${OK147_R}": values.Expected.IntentRevision, "${OK147_E}": values.Expected.EnablementRevision,
+		"${OK147_P}": values.Expected.PlatformRevision, "${OK147_FIXTURE}": values.Expected.ExecutionFixture,
+		"${OK147_INFRA_AUTHORITY}": values.Expected.InfrastructureAuthority, "${OK147_MGMT_AUTHORITY}": values.Expected.ManagementAuthority,
+		"${OK147_GITOPS_AUTHORITY}": values.Expected.GitOpsAuthority,
+		"${OK147_INPUT_CONFIGMAP}":  values.InputConfigMap, "${OK147_RECEIPT_PREFIX_DIGEST}": values.ReceiptPrefixDigest,
+		"${OK147_LEDGER_API_URL}": values.LedgerAPIURL, "${OK147_LEDGER_API_CIDR}": values.LedgerAPICIDR,
+		"${OK147_LEDGER_API_PORT}": ledgerPort, "${OK147_LEDGER_CREDENTIAL_SECRET}": values.LedgerCredentialSecret,
+		"${OK147_PERSISTENCE_CREDENTIAL_SECRET}": values.PersistenceCredentialSecret,
+		"${OK147_WORKLOAD_API_CIDR}":             values.WorkloadAPICIDR, "${OK147_WORKLOAD_API_PORT}": workloadPort,
+		"${OK147_WORKLOAD_CREDENTIAL_SECRET}": values.WorkloadCredentialSecret, "${OK147_WORKLOAD_BINDING_DIGEST}": values.WorkloadBindingDigest,
+	}
+	result := string(template)
+	for placeholder, value := range replacements {
+		if !strings.Contains(result, placeholder) {
+			return nil, fmt.Errorf("runtime binding Job template lacks %s", placeholder)
+		}
+		result = strings.ReplaceAll(result, placeholder, value)
+	}
+	if strings.Contains(result, "${") {
+		return nil, errors.New("runtime binding Job template contains an unknown placeholder")
+	}
+	return []byte(result), nil
+}

--- a/internal/runner/runtime_binding_stage_job_test.go
+++ b/internal/runner/runtime_binding_stage_job_test.go
@@ -1,0 +1,96 @@
+package runner
+
+import (
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestRenderRuntimeBindingStageJobTemplateBindsExactEnvelope(t *testing.T) {
+	values := validRuntimeBindingStageJobValues()
+	raw, err := RenderRuntimeBindingStageJobTemplate(runtimeBindingJobTemplate(t), values)
+	if err != nil {
+		t.Fatal(err)
+	}
+	objects := decodeJobObjects(t, raw)
+	if len(objects) != 2 || objects["NetworkPolicy"] == nil || objects["Job"] == nil {
+		t.Fatalf("unexpected runtime binding object set: %#v", objects)
+	}
+	job := objects["Job"]
+	spec := objectAt(t, job, "spec")
+	if spec["backoffLimit"] != 0 || spec["activeDeadlineSeconds"] != 180 {
+		t.Fatalf("runtime binding retry or deadline differs: %#v", spec)
+	}
+	podSpec := objectAt(t, objectAt(t, spec, "template"), "spec")
+	if podSpec["automountServiceAccountToken"] != false || podSpec["restartPolicy"] != "Never" {
+		t.Fatalf("unsafe runtime binding Pod identity: %#v", podSpec)
+	}
+	container := arrayAt(t, podSpec, "containers")[0].(map[string]any)
+	args := stringArray(t, container, "args")
+	if !reflect.DeepEqual(args[:5], []string{"cluster", "stage", "bind", "runtime", "--execute"}) || argumentValue(args, "--persistence-mode") != "immutable-secret" || argumentValue(args, "--receipt-prefix-digest") != values.ReceiptPrefixDigest || argumentValue(args, "--workload-binding-digest") != values.WorkloadBindingDigest {
+		t.Fatalf("runtime binding command differs: %v", args)
+	}
+	if argumentValue(args, "--ledger-api-endpoint") != values.LedgerAPIURL || argumentValue(args, "--output") != "" {
+		t.Fatalf("runtime binding persistence mode is ambiguous: %v", args)
+	}
+	volumes := arrayAt(t, podSpec, "volumes")
+	if len(volumes) != 4 {
+		t.Fatalf("runtime binding volume boundary differs: %#v", volumes)
+	}
+	egress := arrayAt(t, objectAt(t, objects["NetworkPolicy"], "spec"), "egress")
+	if len(egress) != 2 {
+		t.Fatalf("runtime binding Job has unexpected egress: %#v", egress)
+	}
+	for _, forbidden := range []string{"stage-grant", "projection-manifest", "authority-map", "runtime-binding.json", "--output"} {
+		if strings.Contains(string(raw), forbidden) {
+			t.Fatalf("runtime binding Job contains forbidden input %q", forbidden)
+		}
+	}
+}
+
+func TestRenderRuntimeBindingStageJobTemplateFailsClosed(t *testing.T) {
+	valid := validRuntimeBindingStageJobValues()
+	for name, mutate := range map[string]func(*RuntimeBindingStageJobValues){
+		"mutable image": func(values *RuntimeBindingStageJobValues) { values.ImageDigest = "ghcr.io/openkubes/ok-cluster:latest" },
+		"shared credentials": func(values *RuntimeBindingStageJobValues) {
+			values.PersistenceCredentialSecret = values.LedgerCredentialSecret
+		},
+		"same workload endpoint": func(values *RuntimeBindingStageJobValues) {
+			values.WorkloadAPIURL, values.WorkloadAPICIDR = values.LedgerAPIURL, values.LedgerAPICIDR
+		},
+		"foreign binding digest": func(values *RuntimeBindingStageJobValues) { values.WorkloadBindingDigest = bundleSHA("z") },
+	} {
+		t.Run(name, func(t *testing.T) {
+			candidate := valid
+			mutate(&candidate)
+			if _, err := RenderRuntimeBindingStageJobTemplate(runtimeBindingJobTemplate(t), candidate); err == nil {
+				t.Fatal("unsafe runtime binding Job values were accepted")
+			}
+		})
+	}
+	template := append(runtimeBindingJobTemplate(t), []byte("\n${UNKNOWN}")...)
+	if _, err := RenderRuntimeBindingStageJobTemplate(template, valid); err == nil {
+		t.Fatal("unknown runtime binding Job placeholder was accepted")
+	}
+}
+
+func validRuntimeBindingStageJobValues() RuntimeBindingStageJobValues {
+	return RuntimeBindingStageJobValues{
+		RunID: "ok147-runtime-binding-01", ImageDigest: "ghcr.io/openkubes/ok-cluster@" + bundleSHA("a"),
+		Expected: validSubmissionStageJobValues().Expected, InputConfigMap: "ok147-runtime-binding-input", ReceiptPrefixDigest: bundleSHA("b"),
+		LedgerAPIURL: "https://192.0.2.12:6443", LedgerAPICIDR: "192.0.2.12/32", LedgerCredentialSecret: "ok147-ledger-binding",
+		PersistenceCredentialSecret: "ok147-persistence-binding",
+		WorkloadAPIURL:              "https://192.0.2.20:6443", WorkloadAPICIDR: "192.0.2.20/32", WorkloadCredentialSecret: "ok147-workload-binding",
+		WorkloadBindingDigest: bundleSHA("c"),
+	}
+}
+
+func runtimeBindingJobTemplate(t *testing.T) []byte {
+	t.Helper()
+	raw, err := os.ReadFile("../../deploy/contract-executor-runtime-binding-job.yaml.tpl")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return raw
+}


### PR DESCRIPTION
## Outcome

Adds the hardened offline NetworkPolicy and non-retrying Job envelope for the immutable-secret runtime-binding mode.

## Boundaries

- tokenless runtime ServiceAccount
- three distinct credential Secret mounts
- exact management and workload API egress only
- immutable-secret CLI mode only; no local output path
- fixed resources, read-only root filesystem, three-minute deadline, no retry
- no package installation, launch, or cluster contact

## Verification

- go test -ldflags=-linkmode=external ./...
- go vet ./...
- go test -race -ldflags=-linkmode=external ./internal/runner/...

OK-147