### PR TITLE
feat(runner): verify runtime binding Job package (OK-147)

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,8 @@ Powered by [Cluster API (CAPI)](https://cluster-api.sigs.k8s.io/), [CAPK (KubeVi
   five-receipt prefix, excluding all private authority and credential data. A
   matching offline Job/NetworkPolicy envelope fixes three distinct credential
   mounts and only the exact management and workload API egress destinations;
-  it is not yet packaged, installed or launched.
+  the ConfigMap and envelope are now correlated under one verified package
+  digest, but remain uninstalled and unlaunched.
   Stage 4 now has its first distinct path as well:
   `ok cluster stage run enablement --execute` binds the verified three-receipt
   prefix and signed `CreateEnablement` grant to exactly one externally rendered

--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -2308,6 +2308,19 @@ This remains template rendering tested offline. The ConfigMap, NetworkPolicy,
 Job, runtime identity and credential Secrets are not yet assembled as one
 verified package, installed or launched, and no Kubernetes API was contacted.
 
+The public input and envelope are now also composed as one verified
+`ok147-runtime-binding-stage-package/v1`. Before emitting bytes, the builder
+reopens the private workload-authority binding and proves that its R, raw CAPI
+Cluster UID digest and API endpoint match the durable lifecycle receipt and
+the Job's exact workload destination. The private binding itself is never
+copied into package output.
+
+The package receipt binds the ConfigMap, receipt prefix, private binding
+identity, template, rendered envelope and final three-object byte stream. It
+remains `mutationAllowed: false`: package construction neither creates its
+objects nor authorizes a launcher. Runtime identity, credential packaging,
+installation planning and launch remain later checkpoints.
+
 ## Bounded convergence observation polling
 
 The aggregate observer can now be wrapped by a bounded polling observer before

--- a/internal/runner/runtime_binding_stage_package.go
+++ b/internal/runner/runtime_binding_stage_package.go
@@ -1,0 +1,131 @@
+package runner
+
+import (
+	"errors"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+const RuntimeBindingStagePackageFormat = "ok147-runtime-binding-stage-package/v1"
+
+type RuntimeBindingStagePackageConfig struct {
+	Bundle                        StageResumeConfig
+	InputConfigMap                string
+	JobTemplate                   []byte
+	JobTemplateDigest             string
+	RunID                         string
+	ImageDigest                   string
+	LedgerAPIURL                  string
+	LedgerAPICIDR                 string
+	LedgerCredentialSecret        string
+	PersistenceCredentialSecret   string
+	WorkloadAPIURL                string
+	WorkloadAPICIDR               string
+	WorkloadCredentialSecret      string
+	WorkloadBindingPath           string
+	ExpectedWorkloadBindingDigest string
+}
+
+type RuntimeBindingStagePackageReceipt struct {
+	Format                string   `json:"format"`
+	State                 string   `json:"state"`
+	StageID               string   `json:"stageId"`
+	PackageDigest         string   `json:"packageDigest"`
+	InputConfigMapDigest  string   `json:"inputConfigMapDigest"`
+	ReceiptPrefixDigest   string   `json:"receiptPrefixDigest"`
+	WorkloadBindingDigest string   `json:"workloadBindingDigest"`
+	JobTemplateDigest     string   `json:"jobTemplateDigest"`
+	JobEnvelopeDigest     string   `json:"jobEnvelopeDigest"`
+	ObjectKinds           []string `json:"objectKinds"`
+	AuthorizationState    string   `json:"authorizationState"`
+	MutationAllowed       bool     `json:"mutationAllowed"`
+}
+
+type VerifiedRuntimeBindingStagePackage struct {
+	raw                   []byte
+	receipt               RuntimeBindingStagePackageReceipt
+	ledgerCredential      string
+	persistenceCredential string
+	workloadCredential    string
+	managementAuthority   string
+	workloadAuthority     string
+	verified              bool
+}
+
+// BuildRuntimeBindingStagePackage correlates the public ConfigMap, private
+// workload binding and hardened Job envelope entirely offline.
+func BuildRuntimeBindingStagePackage(config RuntimeBindingStagePackageConfig) (VerifiedRuntimeBindingStagePackage, error) {
+	if !stageReceiptPrefixDigestPattern.MatchString(config.JobTemplateDigest) || digest.SHA256(config.JobTemplate) != config.JobTemplateDigest {
+		return VerifiedRuntimeBindingStagePackage{}, errors.New("runtime binding Job template digest differs from expected identity")
+	}
+	input, err := BuildRuntimeBindingStageInput(config.Bundle, config.InputConfigMap)
+	if err != nil {
+		return VerifiedRuntimeBindingStagePackage{}, err
+	}
+	inputRaw, err := input.Bytes()
+	if err != nil {
+		return VerifiedRuntimeBindingStagePackage{}, err
+	}
+	inputReceipt, err := input.Receipt()
+	if err != nil {
+		return VerifiedRuntimeBindingStagePackage{}, err
+	}
+	bundle, err := LoadRuntimeBindingStageBundle(config.Bundle)
+	if err != nil {
+		return VerifiedRuntimeBindingStagePackage{}, err
+	}
+	lifecycle, err := bundle.prefix[1].Receipt()
+	if err != nil {
+		return VerifiedRuntimeBindingStagePackage{}, errors.New("read runtime binding package target correlation")
+	}
+	binding, err := loadWorkloadAuthorityBinding(config.WorkloadBindingPath, config.ExpectedWorkloadBindingDigest)
+	if err != nil {
+		return VerifiedRuntimeBindingStagePackage{}, errors.New("verify private runtime binding package authority")
+	}
+	if binding.IntentRevision != bundle.plan.IntentRevision || digest.SHA256([]byte(binding.TargetClusterUID)) != lifecycle.TargetClusterUIDDigest || binding.Endpoint != config.WorkloadAPIURL {
+		return VerifiedRuntimeBindingStagePackage{}, errors.New("private workload binding differs from runtime binding package target")
+	}
+	jobRaw, err := RenderRuntimeBindingStageJobTemplate(config.JobTemplate, RuntimeBindingStageJobValues{
+		RunID: config.RunID, ImageDigest: config.ImageDigest, Expected: config.Bundle.PlanExpected,
+		InputConfigMap: config.InputConfigMap, ReceiptPrefixDigest: inputReceipt.ReceiptPrefixDigest,
+		LedgerAPIURL: config.LedgerAPIURL, LedgerAPICIDR: config.LedgerAPICIDR, LedgerCredentialSecret: config.LedgerCredentialSecret,
+		PersistenceCredentialSecret: config.PersistenceCredentialSecret,
+		WorkloadAPIURL:              config.WorkloadAPIURL, WorkloadAPICIDR: config.WorkloadAPICIDR,
+		WorkloadCredentialSecret: config.WorkloadCredentialSecret, WorkloadBindingDigest: config.ExpectedWorkloadBindingDigest,
+	})
+	if err != nil {
+		return VerifiedRuntimeBindingStagePackage{}, err
+	}
+	packageRaw := make([]byte, 0, len(inputRaw)+len(jobRaw)+6)
+	packageRaw = append(packageRaw, inputRaw...)
+	packageRaw = append(packageRaw, '\n', '-', '-', '-', '\n')
+	packageRaw = append(packageRaw, jobRaw...)
+	receipt := RuntimeBindingStagePackageReceipt{
+		Format: RuntimeBindingStagePackageFormat, State: "VERIFIED", StageID: "runtime-binding",
+		PackageDigest: digest.SHA256(packageRaw), InputConfigMapDigest: inputReceipt.ConfigMapDigest,
+		ReceiptPrefixDigest: inputReceipt.ReceiptPrefixDigest, WorkloadBindingDigest: config.ExpectedWorkloadBindingDigest,
+		JobTemplateDigest: config.JobTemplateDigest, JobEnvelopeDigest: digest.SHA256(jobRaw),
+		ObjectKinds: []string{"ConfigMap", "NetworkPolicy", "Job"}, AuthorizationState: "NOT_REQUIRED", MutationAllowed: false,
+	}
+	return VerifiedRuntimeBindingStagePackage{
+		raw: packageRaw, receipt: receipt, ledgerCredential: config.LedgerCredentialSecret,
+		persistenceCredential: config.PersistenceCredentialSecret, workloadCredential: config.WorkloadCredentialSecret,
+		managementAuthority: bundle.plan.Authorities.Management, workloadAuthority: digest.SHA256([]byte(binding.TargetClusterUID)), verified: true,
+	}, nil
+}
+
+func (packaged VerifiedRuntimeBindingStagePackage) Bytes() ([]byte, error) {
+	if !packaged.verified || len(packaged.raw) == 0 {
+		return nil, errors.New("runtime binding package was not produced by verification")
+	}
+	return append([]byte(nil), packaged.raw...), nil
+}
+
+func (packaged VerifiedRuntimeBindingStagePackage) Receipt() (RuntimeBindingStagePackageReceipt, error) {
+	if !packaged.verified || packaged.receipt.State != "VERIFIED" || digest.SHA256(packaged.raw) != packaged.receipt.PackageDigest || packaged.ledgerCredential == "" || packaged.persistenceCredential == "" || packaged.workloadCredential == "" || packaged.ledgerCredential == packaged.persistenceCredential || packaged.ledgerCredential == packaged.workloadCredential || packaged.persistenceCredential == packaged.workloadCredential || packaged.managementAuthority == "" || !stageReceiptPrefixDigestPattern.MatchString(packaged.workloadAuthority) {
+		return RuntimeBindingStagePackageReceipt{}, errors.New("runtime binding package was not produced by verification")
+	}
+	receipt := packaged.receipt
+	receipt.ObjectKinds = append([]string(nil), packaged.receipt.ObjectKinds...)
+	return receipt, nil
+}

--- a/internal/runner/runtime_binding_stage_package_test.go
+++ b/internal/runner/runtime_binding_stage_package_test.go
@@ -1,0 +1,107 @@
+package runner
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+func TestBuildRuntimeBindingStagePackageCorrelatesPublicAndPrivateInputs(t *testing.T) {
+	config := runtimeBindingStagePackageConfig(t)
+	packaged, err := BuildRuntimeBindingStagePackage(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := packaged.Bytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := packaged.Receipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	objects := decodeJobObjects(t, raw)
+	if len(objects) != 3 || objects["ConfigMap"] == nil || objects["NetworkPolicy"] == nil || objects["Job"] == nil {
+		t.Fatalf("unexpected runtime binding package: %#v", objects)
+	}
+	if bytes.Contains(raw, []byte(`"targetClusterUid"`)) || bytes.Contains(raw, []byte(`"targetIdentityScheme"`)) || bytes.Contains(raw, []byte(`"caBundleDigest"`)) {
+		t.Fatal("private workload binding was copied into runtime binding package")
+	}
+	if receipt.Format != RuntimeBindingStagePackageFormat || receipt.StageID != "runtime-binding" || receipt.PackageDigest != digest.SHA256(raw) || receipt.AuthorizationState != "NOT_REQUIRED" || receipt.MutationAllowed || receipt.WorkloadBindingDigest != config.ExpectedWorkloadBindingDigest {
+		t.Fatalf("unexpected runtime binding package receipt: %#v", receipt)
+	}
+	parts := bytes.SplitN(raw, []byte("\n---\n"), 2)
+	if len(parts) != 2 || receipt.InputConfigMapDigest != digest.SHA256(parts[0]) || receipt.JobEnvelopeDigest != digest.SHA256(parts[1]) || !reflect.DeepEqual(receipt.ObjectKinds, []string{"ConfigMap", "NetworkPolicy", "Job"}) {
+		t.Fatal("runtime binding package component identities differ")
+	}
+	raw[0] = 'x'
+	again, _ := packaged.Bytes()
+	if again[0] != '{' {
+		t.Fatal("caller mutated retained runtime binding package")
+	}
+}
+
+func TestBuildRuntimeBindingStagePackageFailsClosed(t *testing.T) {
+	valid := runtimeBindingStagePackageConfig(t)
+	for name, mutate := range map[string]func(*RuntimeBindingStagePackageConfig){
+		"changed template": func(config *RuntimeBindingStagePackageConfig) { config.JobTemplate = append(config.JobTemplate, '\n') },
+		"shared credentials": func(config *RuntimeBindingStagePackageConfig) {
+			config.PersistenceCredentialSecret = config.LedgerCredentialSecret
+		},
+		"binding endpoint differs": func(config *RuntimeBindingStagePackageConfig) {
+			config.WorkloadAPIURL, config.WorkloadAPICIDR = "https://192.0.2.21:6443", "192.0.2.21/32"
+		},
+		"foreign binding digest": func(config *RuntimeBindingStagePackageConfig) { config.ExpectedWorkloadBindingDigest = bundleSHA("e") },
+	} {
+		t.Run(name, func(t *testing.T) {
+			config := valid
+			config.JobTemplate = append([]byte(nil), valid.JobTemplate...)
+			mutate(&config)
+			if _, err := BuildRuntimeBindingStagePackage(config); err == nil {
+				t.Fatal("unsafe runtime binding package was accepted")
+			}
+		})
+	}
+	if _, err := (VerifiedRuntimeBindingStagePackage{}).Bytes(); err == nil {
+		t.Fatal("unverified runtime binding package bytes were exposed")
+	}
+	if _, err := (VerifiedRuntimeBindingStagePackage{}).Receipt(); err == nil {
+		t.Fatal("unverified runtime binding package receipt was exposed")
+	}
+}
+
+func runtimeBindingStagePackageConfig(t *testing.T) RuntimeBindingStagePackageConfig {
+	t.Helper()
+	bundleConfig := runtimeBindingBundleConfig(t)
+	plan, _, prefix, err := loadStageResumeWithPrefix(bundleConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lifecycle, _ := prefix[1].Receipt()
+	const targetUID = "cluster-runtime-uid-147"
+	if digest.SHA256([]byte(targetUID)) != lifecycle.TargetClusterUIDDigest {
+		t.Fatal("test target differs from lifecycle receipt")
+	}
+	binding := WorkloadAuthorityBinding{
+		Format: WorkloadAuthorityBindingFormat, IntentRevision: plan.IntentRevision,
+		TargetClusterUID: targetUID, TargetIdentityScheme: "capi-cluster-uid/v1",
+		Endpoint: "https://192.0.2.20:6443", CABundleDigest: bundleSHA("9"),
+	}
+	bindingPath := writeBundleFile(t, t.TempDir(), "binding.json", mustJSON(t, binding))
+	bindingDigest, err := WorkloadAuthorityBindingDigest(binding)
+	if err != nil {
+		t.Fatal(err)
+	}
+	template := runtimeBindingJobTemplate(t)
+	return RuntimeBindingStagePackageConfig{
+		Bundle: bundleConfig, InputConfigMap: "ok147-runtime-binding-input",
+		JobTemplate: template, JobTemplateDigest: digest.SHA256(template), RunID: "ok147-runtime-binding-01",
+		ImageDigest:  "ghcr.io/openkubes/ok-cluster@" + bundleSHA("a"),
+		LedgerAPIURL: "https://192.0.2.12:6443", LedgerAPICIDR: "192.0.2.12/32", LedgerCredentialSecret: "ok147-ledger-binding",
+		PersistenceCredentialSecret: "ok147-persistence-binding",
+		WorkloadAPIURL:              binding.Endpoint, WorkloadAPICIDR: "192.0.2.20/32", WorkloadCredentialSecret: "ok147-workload-binding",
+		WorkloadBindingPath: bindingPath, ExpectedWorkloadBindingDigest: bindingDigest,
+	}
+}


### PR DESCRIPTION
## Outcome

Composes the immutable runtime-binding input ConfigMap and hardened Job envelope under one verified package digest.

## Boundary

- correlates R and raw CAPI target UID digest with the private workload binding
- binds the exact workload API destination without copying private binding data into YAML
- receipt covers input, prefix, binding identity, template, envelope, and final bytes
- three-object package remains mutationAllowed false
- no runtime identity, credentials, installation, launch, or cluster contact

## Verification

- go test -ldflags=-linkmode=external ./...
- go vet ./...
- go test -race -ldflags=-linkmode=external ./internal/runner/...

OK-147