### PR TITLE
feat(runner): bind runtime identity to binding package (OK-147)

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,8 @@ Powered by [Cluster API (CAPI)](https://cluster-api.sigs.k8s.io/), [CAPK (KubeVi
   matching offline Job/NetworkPolicy envelope fixes three distinct credential
   mounts and only the exact management and workload API egress destinations;
   the ConfigMap and envelope are now correlated under one verified package
-  digest, but remain uninstalled and unlaunched.
+  digest. That package is also bound to the shared tokenless runtime
+  ServiceAccount, but remains uninstalled and unlaunched.
   Stage 4 now has its first distinct path as well:
   `ok cluster stage run enablement --execute` binds the verified three-receipt
   prefix and signed `CreateEnablement` grant to exactly one externally rendered

--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -2321,6 +2321,17 @@ remains `mutationAllowed: false`: package construction neither creates its
 objects nor authorizes a launcher. Runtime identity, credential packaging,
 installation planning and launch remain later checkpoints.
 
+The shared tokenless runtime ServiceAccount is now bound offline to this exact
+package as `ok147-runtime-binding-stage-runtime-prerequisite/v1`. The verifier
+accepts only the existing `openkubes-execution-system/ok147-contract-executor-runtime`
+ServiceAccount shape: automount disabled, fixed labels, no annotations, image
+pull Secrets, owner references or embedded RBAC. The receipt binds both the
+source manifest and normalized object digest to the runtime-binding package.
+
+This prerequisite remains non-mutating. It neither creates the ServiceAccount
+nor issues or mounts a token; credential packaging, installation planning and
+launch remain separate.
+
 ## Bounded convergence observation polling
 
 The aggregate observer can now be wrapped by a bounded polling observer before

--- a/internal/runner/runtime_binding_stage_runtime.go
+++ b/internal/runner/runtime_binding_stage_runtime.go
@@ -1,0 +1,54 @@
+package runner
+
+import (
+	"errors"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+const RuntimeBindingStageRuntimePrerequisiteFormat = "ok147-runtime-binding-stage-runtime-prerequisite/v1"
+
+type RuntimeBindingStageRuntimePrerequisiteReceipt struct {
+	Format               string `json:"format"`
+	State                string `json:"state"`
+	BindingPackageDigest string `json:"bindingPackageDigest"`
+	ManifestDigest       string `json:"manifestDigest"`
+	ObjectDigest         string `json:"objectDigest"`
+	Authority            string `json:"authority"`
+	Namespace            string `json:"namespace"`
+	Name                 string `json:"name"`
+	MutationAllowed      bool   `json:"mutationAllowed"`
+}
+
+type VerifiedRuntimeBindingStageRuntimePrerequisite struct {
+	raw      []byte
+	receipt  RuntimeBindingStageRuntimePrerequisiteReceipt
+	verified bool
+}
+
+// BuildRuntimeBindingStageRuntimePrerequisite binds the shared tokenless
+// runtime ServiceAccount to one exact runtime-binding package offline.
+func BuildRuntimeBindingStageRuntimePrerequisite(packaged VerifiedRuntimeBindingStagePackage, manifest []byte, expectedDigest string) (VerifiedRuntimeBindingStageRuntimePrerequisite, error) {
+	packageReceipt, err := packaged.Receipt()
+	if err != nil {
+		return VerifiedRuntimeBindingStageRuntimePrerequisite{}, err
+	}
+	raw, objectDigest, err := buildStageRuntimePrerequisiteObject(manifest, expectedDigest)
+	if err != nil {
+		return VerifiedRuntimeBindingStageRuntimePrerequisite{}, err
+	}
+	receipt := RuntimeBindingStageRuntimePrerequisiteReceipt{
+		Format: RuntimeBindingStageRuntimePrerequisiteFormat, State: "VERIFIED",
+		BindingPackageDigest: packageReceipt.PackageDigest, ManifestDigest: expectedDigest,
+		ObjectDigest: objectDigest, Authority: packaged.managementAuthority,
+		Namespace: submissionStageInputNamespace, Name: "ok147-contract-executor-runtime", MutationAllowed: false,
+	}
+	return VerifiedRuntimeBindingStageRuntimePrerequisite{raw: raw, receipt: receipt, verified: true}, nil
+}
+
+func (runtime VerifiedRuntimeBindingStageRuntimePrerequisite) Receipt() (RuntimeBindingStageRuntimePrerequisiteReceipt, error) {
+	if !runtime.verified || runtime.receipt.Format != RuntimeBindingStageRuntimePrerequisiteFormat || runtime.receipt.State != "VERIFIED" || runtime.receipt.Authority == "" || runtime.receipt.Namespace != submissionStageInputNamespace || runtime.receipt.Name != "ok147-contract-executor-runtime" || runtime.receipt.MutationAllowed || !stageReceiptPrefixDigestPattern.MatchString(runtime.receipt.BindingPackageDigest) || !stageReceiptPrefixDigestPattern.MatchString(runtime.receipt.ManifestDigest) || digest.SHA256(runtime.raw) != runtime.receipt.ObjectDigest {
+		return RuntimeBindingStageRuntimePrerequisiteReceipt{}, errors.New("runtime binding runtime prerequisite was not produced by verification")
+	}
+	return runtime.receipt, nil
+}

--- a/internal/runner/runtime_binding_stage_runtime_test.go
+++ b/internal/runner/runtime_binding_stage_runtime_test.go
@@ -1,0 +1,49 @@
+package runner
+
+import (
+	"testing"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+func TestBuildRuntimeBindingStageRuntimePrerequisiteBindsExactPackage(t *testing.T) {
+	packaged, err := BuildRuntimeBindingStagePackage(runtimeBindingStagePackageConfig(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest := submissionStageRuntimeManifest(t)
+	runtime, err := BuildRuntimeBindingStageRuntimePrerequisite(packaged, manifest, digest.SHA256(manifest))
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := runtime.Receipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	packageReceipt, _ := packaged.Receipt()
+	if receipt.Format != RuntimeBindingStageRuntimePrerequisiteFormat || receipt.State != "VERIFIED" || receipt.BindingPackageDigest != packageReceipt.PackageDigest || receipt.Authority != "ok-mgmt" || receipt.Namespace != submissionStageInputNamespace || receipt.Name != "ok147-contract-executor-runtime" || receipt.ManifestDigest != digest.SHA256(manifest) || receipt.ObjectDigest != digest.SHA256(runtime.raw) || receipt.MutationAllowed {
+		t.Fatalf("unexpected runtime binding runtime receipt: %#v", receipt)
+	}
+}
+
+func TestBuildRuntimeBindingStageRuntimePrerequisiteFailsClosed(t *testing.T) {
+	packaged, err := BuildRuntimeBindingStagePackage(runtimeBindingStagePackageConfig(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest := submissionStageRuntimeManifest(t)
+	if _, err := BuildRuntimeBindingStageRuntimePrerequisite(VerifiedRuntimeBindingStagePackage{}, manifest, digest.SHA256(manifest)); err == nil {
+		t.Fatal("unverified runtime binding package accepted")
+	}
+	if _, err := BuildRuntimeBindingStageRuntimePrerequisite(packaged, append(manifest, '\n'), digest.SHA256(manifest)); err == nil {
+		t.Fatal("changed runtime binding runtime manifest accepted")
+	}
+	runtime, err := BuildRuntimeBindingStageRuntimePrerequisite(packaged, manifest, digest.SHA256(manifest))
+	if err != nil {
+		t.Fatal(err)
+	}
+	runtime.raw[0] = 'x'
+	if _, err := runtime.Receipt(); err == nil {
+		t.Fatal("changed runtime binding runtime object accepted")
+	}
+}


### PR DESCRIPTION
## Outcome

Binds the exact verified runtime-binding package to the shared tokenless runtime ServiceAccount prerequisite.

## Boundary

- exact existing runtime ServiceAccount shape only
- automount disabled and no embedded RBAC
- receipt binds source manifest, normalized object, and package digest
- no ServiceAccount creation, TokenRequest, credential material, installation, launch, or cluster contact

## Verification

- go test -ldflags=-linkmode=external ./...
- go vet ./...
- go test -race -ldflags=-linkmode=external ./internal/runner/...

OK-147