### PR TITLE
feat(runner): package runtime binding credentials (OK-147)

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,10 @@ Powered by [Cluster API (CAPI)](https://cluster-api.sigs.k8s.io/), [CAPK (KubeVi
   mounts and only the exact management and workload API egress destinations;
   the ConfigMap and envelope are now correlated under one verified package
   digest. That package is also bound to the shared tokenless runtime
-  ServiceAccount, but remains uninstalled and unlaunched.
+  ServiceAccount. Three independently issued short-lived credentials are now
+  sealed offline into private immutable Secrets for ledger write, binding
+  persistence and workload observation; only the redacted credential receipt
+  is public. The package remains uninstalled and unlaunched.
   Stage 4 now has its first distinct path as well:
   `ok cluster stage run enablement --execute` binds the verified three-receipt
   prefix and signed `CreateEnablement` grant to exactly one externally rendered

--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -2329,8 +2329,23 @@ pull Secrets, owner references or embedded RBAC. The receipt binds both the
 source manifest and normalized object digest to the runtime-binding package.
 
 This prerequisite remains non-mutating. It neither creates the ServiceAccount
-nor issues or mounts a token; credential packaging, installation planning and
-launch remain separate.
+nor issues or mounts a token.
+
+The three private runtime-binding credentials are now composed offline as one
+verified `ok147-runtime-binding-stage-credential-package/v1`. The package
+requires independently issued, short-lived and pairwise-distinct credentials
+for the management-side ledger writer, the management-side immutable Secret
+writer and the workload-side observer. Each token and CA must match its bound
+TokenRequest evidence and authority; the workload CA and raw CAPI Cluster UID
+must additionally match the private workload-authority binding already bound
+by the stage package.
+
+Only the workload observer Secret carries `binding.json`. The public receipt
+contains roles, authority identities, expiry, audiences and digests, but never
+tokens, CA bytes, subjects, API endpoints or source paths. The exact immutable
+Secret bytes remain private for a later installer boundary. Construction is
+still non-mutating: it neither requests a token nor contacts Kubernetes.
+Installation planning, bounded installation and launch remain separate.
 
 ## Bounded convergence observation polling
 

--- a/internal/runner/runtime_binding_stage_credentials.go
+++ b/internal/runner/runtime_binding_stage_credentials.go
@@ -1,0 +1,210 @@
+package runner
+
+import (
+	"crypto/subtle"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/jsonstrict"
+)
+
+const RuntimeBindingStageCredentialPackageFormat = "ok147-runtime-binding-stage-credential-package/v1"
+
+type RuntimeBindingStageCredentialPackageConfig struct {
+	Package             VerifiedRuntimeBindingStagePackage
+	MaterializationTime time.Time
+	WorkloadBindingPath string
+	LedgerWriter        SubmissionStageCredentialSource
+	PersistenceWriter   SubmissionStageCredentialSource
+	WorkloadObserver    SubmissionStageCredentialSource
+}
+
+// RuntimeBindingStageCredentialPackageReceipt is safe to publish. It binds
+// the three private immutable Secrets without exposing token, CA, subject,
+// endpoint or source-path material.
+type RuntimeBindingStageCredentialPackageReceipt struct {
+	Format                string                                   `json:"format"`
+	State                 string                                   `json:"state"`
+	StageID               string                                   `json:"stageId"`
+	StagePackageDigest    string                                   `json:"stagePackageDigest"`
+	WorkloadBindingDigest string                                   `json:"workloadBindingDigest"`
+	InstallationAuthority string                                   `json:"installationAuthority"`
+	MaterializedAt        string                                   `json:"materializedAt"`
+	PackageDigest         string                                   `json:"packageDigest"`
+	Credentials           []SubmissionStageCredentialObjectReceipt `json:"credentials"`
+	MutationAllowed       bool                                     `json:"mutationAllowed"`
+}
+
+type runtimeBindingStageCredentialPackageIdentity struct {
+	StagePackageDigest    string                                   `json:"stagePackageDigest"`
+	WorkloadBindingDigest string                                   `json:"workloadBindingDigest"`
+	InstallationAuthority string                                   `json:"installationAuthority"`
+	MaterializedAt        string                                   `json:"materializedAt"`
+	Credentials           []SubmissionStageCredentialObjectReceipt `json:"credentials"`
+}
+
+// VerifiedRuntimeBindingStageCredentialPackage retains the three exact
+// immutable Secrets privately. Only the workload observer Secret also carries
+// the private workload binding required by the tokenless runtime Job.
+type VerifiedRuntimeBindingStageCredentialPackage struct {
+	objects               []submissionStageCredentialObject
+	receipt               RuntimeBindingStageCredentialPackageReceipt
+	installationAuthority string
+	workloadAuthority     string
+	verified              bool
+}
+
+// BuildRuntimeBindingStageCredentialPackage verifies three independently
+// issued short-lived TokenRequest results and produces private Secret bytes.
+// It is entirely offline and performs no Kubernetes request.
+func BuildRuntimeBindingStageCredentialPackage(config RuntimeBindingStageCredentialPackageConfig) (VerifiedRuntimeBindingStageCredentialPackage, error) {
+	packageReceipt, err := config.Package.Receipt()
+	if err != nil || packageReceipt.StageID != "runtime-binding" {
+		return VerifiedRuntimeBindingStageCredentialPackage{}, errors.New("verified runtime binding package is required")
+	}
+	if config.MaterializationTime.IsZero() || !config.MaterializationTime.Equal(config.MaterializationTime.Truncate(time.Second)) {
+		return VerifiedRuntimeBindingStageCredentialPackage{}, errors.New("runtime binding credential materialization time is required")
+	}
+	binding, err := loadWorkloadAuthorityBinding(config.WorkloadBindingPath, packageReceipt.WorkloadBindingDigest)
+	if err != nil {
+		return VerifiedRuntimeBindingStageCredentialPackage{}, errors.New("verify private runtime binding workload authority")
+	}
+	if digest.SHA256([]byte(binding.TargetClusterUID)) != config.Package.workloadAuthority || binding.CABundleDigest != config.WorkloadObserver.CABundleDigest {
+		return VerifiedRuntimeBindingStageCredentialPackage{}, errors.New("runtime binding workload authority differs from verified package")
+	}
+	bindings := []struct {
+		role      string
+		name      string
+		authority string
+		source    SubmissionStageCredentialSource
+	}{
+		{role: "ledger-writer", name: config.Package.ledgerCredential, authority: config.Package.managementAuthority, source: config.LedgerWriter},
+		{role: "persistence-writer", name: config.Package.persistenceCredential, authority: config.Package.managementAuthority, source: config.PersistenceWriter},
+		{role: "workload-observer", name: config.Package.workloadCredential, authority: config.Package.workloadAuthority, source: config.WorkloadObserver},
+	}
+	objects := make([]submissionStageCredentialObject, 0, len(bindings))
+	receipts := make([]SubmissionStageCredentialObjectReceipt, 0, len(bindings))
+	tokens := make([][]byte, 0, len(bindings))
+	for _, credential := range bindings {
+		object, receipt, token, err := buildSubmissionStageCredentialObject(
+			packageReceipt.StageID, config.MaterializationTime.UTC(), credential.role,
+			credential.name, credential.authority, credential.source,
+		)
+		if err != nil {
+			return VerifiedRuntimeBindingStageCredentialPackage{}, err
+		}
+		objects = append(objects, object)
+		receipts = append(receipts, receipt)
+		tokens = append(tokens, token)
+	}
+	for left := range tokens {
+		for right := left + 1; right < len(tokens); right++ {
+			if len(tokens[left]) == len(tokens[right]) && subtle.ConstantTimeCompare(tokens[left], tokens[right]) == 1 {
+				return VerifiedRuntimeBindingStageCredentialPackage{}, errors.New("runtime binding credentials must be pairwise distinct")
+			}
+		}
+	}
+	bindingRaw, err := json.Marshal(binding)
+	if err != nil {
+		return VerifiedRuntimeBindingStageCredentialPackage{}, errors.New("encode private runtime binding workload authority")
+	}
+	var workloadSecret map[string]any
+	if err := jsonstrict.Decode(objects[2].raw, &workloadSecret); err != nil {
+		return VerifiedRuntimeBindingStageCredentialPackage{}, errors.New("decode private runtime binding workload credential")
+	}
+	data, ok := workloadSecret["data"].(map[string]any)
+	if !ok {
+		return VerifiedRuntimeBindingStageCredentialPackage{}, errors.New("private runtime binding workload credential data is missing")
+	}
+	data["binding.json"] = base64.StdEncoding.EncodeToString(bindingRaw)
+	objects[2].raw, err = json.Marshal(workloadSecret)
+	if err != nil || len(objects[2].raw) > maximumStageCredentialObjectBytes {
+		return VerifiedRuntimeBindingStageCredentialPackage{}, errors.New("runtime binding workload credential Secret exceeds accepted size")
+	}
+	receipts[2].ObjectDigest = digest.SHA256(objects[2].raw)
+
+	materializedAt := config.MaterializationTime.UTC().Format(time.RFC3339)
+	identity, err := json.Marshal(runtimeBindingStageCredentialPackageIdentity{
+		StagePackageDigest: packageReceipt.PackageDigest, WorkloadBindingDigest: packageReceipt.WorkloadBindingDigest,
+		InstallationAuthority: config.Package.managementAuthority, MaterializedAt: materializedAt, Credentials: receipts,
+	})
+	if err != nil {
+		return VerifiedRuntimeBindingStageCredentialPackage{}, errors.New("encode runtime binding credential package identity")
+	}
+	receipt := RuntimeBindingStageCredentialPackageReceipt{
+		Format: RuntimeBindingStageCredentialPackageFormat, State: "VERIFIED", StageID: packageReceipt.StageID,
+		StagePackageDigest: packageReceipt.PackageDigest, WorkloadBindingDigest: packageReceipt.WorkloadBindingDigest,
+		InstallationAuthority: config.Package.managementAuthority, MaterializedAt: materializedAt,
+		PackageDigest: digest.SHA256(identity), Credentials: receipts, MutationAllowed: false,
+	}
+	return VerifiedRuntimeBindingStageCredentialPackage{
+		objects: cloneStageCredentialObjects(objects), receipt: receipt,
+		installationAuthority: config.Package.managementAuthority,
+		workloadAuthority:     config.Package.workloadAuthority, verified: true,
+	}, nil
+}
+
+func (packaged VerifiedRuntimeBindingStageCredentialPackage) Receipt() (RuntimeBindingStageCredentialPackageReceipt, error) {
+	if err := verifyRuntimeBindingStageCredentialPackage(packaged); err != nil {
+		return RuntimeBindingStageCredentialPackageReceipt{}, errors.New("runtime binding credential package was not produced by verification")
+	}
+	receipt := packaged.receipt
+	receipt.Credentials = append([]SubmissionStageCredentialObjectReceipt(nil), packaged.receipt.Credentials...)
+	for index := range receipt.Credentials {
+		receipt.Credentials[index].Audiences = append([]string(nil), packaged.receipt.Credentials[index].Audiences...)
+	}
+	return receipt, nil
+}
+
+func verifyRuntimeBindingStageCredentialPackage(packaged VerifiedRuntimeBindingStageCredentialPackage) error {
+	if !packaged.verified || packaged.receipt.Format != RuntimeBindingStageCredentialPackageFormat || packaged.receipt.State != "VERIFIED" || packaged.receipt.StageID != "runtime-binding" || packaged.installationAuthority == "" || packaged.receipt.InstallationAuthority != packaged.installationAuthority || !stageReceiptPrefixDigestPattern.MatchString(packaged.workloadAuthority) || len(packaged.objects) != 3 || len(packaged.receipt.Credentials) != 3 {
+		return errors.New("runtime binding credential package identity is incomplete")
+	}
+	identity, err := json.Marshal(runtimeBindingStageCredentialPackageIdentity{
+		StagePackageDigest: packaged.receipt.StagePackageDigest, WorkloadBindingDigest: packaged.receipt.WorkloadBindingDigest,
+		InstallationAuthority: packaged.receipt.InstallationAuthority,
+		MaterializedAt:        packaged.receipt.MaterializedAt, Credentials: packaged.receipt.Credentials,
+	})
+	if err != nil || digest.SHA256(identity) != packaged.receipt.PackageDigest {
+		return errors.New("runtime binding credential package identity changed after verification")
+	}
+	if _, err := time.Parse(time.RFC3339, packaged.receipt.MaterializedAt); err != nil {
+		return errors.New("runtime binding credential materialization time is invalid")
+	}
+	expectedRoles := []string{"ledger-writer", "persistence-writer", "workload-observer"}
+	expectedAuthorities := []string{packaged.installationAuthority, packaged.installationAuthority, packaged.workloadAuthority}
+	for index, object := range packaged.objects {
+		receipt := packaged.receipt.Credentials[index]
+		if object.role != expectedRoles[index] || receipt.Role != expectedRoles[index] || object.authority != expectedAuthorities[index] || receipt.Authority != expectedAuthorities[index] || object.name != receipt.Name || receipt.Namespace != submissionStageInputNamespace || digest.SHA256(object.raw) != receipt.ObjectDigest {
+			return errors.New("runtime binding credential object identity changed after verification")
+		}
+	}
+	var workloadSecret map[string]any
+	if err := jsonstrict.Decode(packaged.objects[2].raw, &workloadSecret); err != nil {
+		return errors.New("runtime binding workload credential is invalid")
+	}
+	data, ok := workloadSecret["data"].(map[string]any)
+	if !ok {
+		return errors.New("runtime binding workload credential data is missing")
+	}
+	bindingEncoded, ok := data["binding.json"].(string)
+	if !ok {
+		return errors.New("runtime binding workload authority is missing")
+	}
+	bindingRaw, err := base64.StdEncoding.DecodeString(bindingEncoded)
+	if err != nil {
+		return errors.New("runtime binding workload authority encoding is invalid")
+	}
+	var binding WorkloadAuthorityBinding
+	if err := jsonstrict.Decode(bindingRaw, &binding); err != nil {
+		return errors.New("runtime binding workload authority is invalid")
+	}
+	bindingDigest, err := WorkloadAuthorityBindingDigest(binding)
+	if err != nil || bindingDigest != packaged.receipt.WorkloadBindingDigest || digest.SHA256([]byte(binding.TargetClusterUID)) != packaged.workloadAuthority {
+		return errors.New("runtime binding workload authority identity changed after verification")
+	}
+	return nil
+}

--- a/internal/runner/runtime_binding_stage_credentials_test.go
+++ b/internal/runner/runtime_binding_stage_credentials_test.go
@@ -1,0 +1,198 @@
+package runner
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+func TestBuildRuntimeBindingStageCredentialPackageBindsThreePrivateSecrets(t *testing.T) {
+	config, tokens := runtimeBindingCredentialConfig(t)
+	packaged, err := BuildRuntimeBindingStageCredentialPackage(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := packaged.Receipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	stageReceipt, _ := config.Package.Receipt()
+	if receipt.Format != RuntimeBindingStageCredentialPackageFormat || receipt.State != "VERIFIED" || receipt.StageID != "runtime-binding" || receipt.StagePackageDigest != stageReceipt.PackageDigest || receipt.WorkloadBindingDigest != stageReceipt.WorkloadBindingDigest || receipt.InstallationAuthority != "ok-mgmt" || receipt.MaterializedAt != config.MaterializationTime.Format(time.RFC3339) || !stageReceiptPrefixDigestPattern.MatchString(receipt.PackageDigest) || receipt.MutationAllowed || len(receipt.Credentials) != 3 {
+		t.Fatalf("unexpected runtime binding credential receipt: %#v", receipt)
+	}
+	want := []struct {
+		role      string
+		name      string
+		authority string
+	}{
+		{role: "ledger-writer", name: config.Package.ledgerCredential, authority: "ok-mgmt"},
+		{role: "persistence-writer", name: config.Package.persistenceCredential, authority: "ok-mgmt"},
+		{role: "workload-observer", name: config.Package.workloadCredential, authority: config.Package.workloadAuthority},
+	}
+	for index, expected := range want {
+		object := packaged.objects[index]
+		objectReceipt := receipt.Credentials[index]
+		if object.role != expected.role || object.authority != expected.authority || object.name != expected.name || digest.SHA256(object.raw) != objectReceipt.ObjectDigest {
+			t.Fatalf("private runtime binding credential %d differs: %#v %#v", index, object, objectReceipt)
+		}
+		var secret map[string]any
+		if err := json.Unmarshal(object.raw, &secret); err != nil {
+			t.Fatal(err)
+		}
+		data := secret["data"].(map[string]any)
+		decodedToken, err := base64.StdEncoding.DecodeString(data["token"].(string))
+		if err != nil || !bytes.Equal(decodedToken, tokens[index]) {
+			t.Fatalf("private runtime binding token %d differs", index)
+		}
+		_, hasBinding := data["binding.json"]
+		if hasBinding != (index == 2) {
+			t.Fatalf("credential %d workload-binding presence differs", index)
+		}
+	}
+	public, err := json.Marshal(receipt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range []string{
+		string(tokens[0]), string(tokens[1]), string(tokens[2]), config.WorkloadBindingPath,
+		config.LedgerWriter.TokenFile, config.PersistenceWriter.TokenFile, config.WorkloadObserver.TokenFile,
+		config.LedgerWriter.ExpectedSubject, config.PersistenceWriter.ExpectedSubject, config.WorkloadObserver.ExpectedSubject,
+	} {
+		if bytes.Contains(public, []byte(forbidden)) {
+			t.Fatalf("runtime binding credential receipt exposed private value %q", forbidden)
+		}
+	}
+	receipt.Credentials[0].Audiences[0] = "changed"
+	again, err := packaged.Receipt()
+	if err != nil || again.Credentials[0].Audiences[0] == "changed" {
+		t.Fatal("caller mutated retained runtime binding credential receipt")
+	}
+}
+
+func TestBuildRuntimeBindingStageCredentialPackageFailsClosed(t *testing.T) {
+	for name, mutate := range map[string]func(*RuntimeBindingStageCredentialPackageConfig){
+		"foreign persistence authority": func(config *RuntimeBindingStageCredentialPackageConfig) {
+			config.PersistenceWriter.AuthorityIdentity = "ok-infra"
+		},
+		"foreign workload authority": func(config *RuntimeBindingStageCredentialPackageConfig) {
+			config.WorkloadObserver.AuthorityIdentity = prefixSHA("f")
+		},
+		"workload CA differs from binding": func(config *RuntimeBindingStageCredentialPackageConfig) {
+			config.WorkloadObserver.CABundleDigest = prefixSHA("e")
+		},
+		"shared token": func(config *RuntimeBindingStageCredentialPackageConfig) {
+			config.PersistenceWriter.TokenFile = config.LedgerWriter.TokenFile
+			config.PersistenceWriter.TokenDigest = config.LedgerWriter.TokenDigest
+			config.PersistenceWriter.ExpectedIssuer = config.LedgerWriter.ExpectedIssuer
+			config.PersistenceWriter.ExpectedSubject = config.LedgerWriter.ExpectedSubject
+			config.PersistenceWriter.ExpectedAudiences = append([]string(nil), config.LedgerWriter.ExpectedAudiences...)
+			config.PersistenceWriter.IssuedAt = config.LedgerWriter.IssuedAt
+			config.PersistenceWriter.ExpiresAt = config.LedgerWriter.ExpiresAt
+		},
+		"missing TokenRequest evidence": func(config *RuntimeBindingStageCredentialPackageConfig) {
+			config.LedgerWriter.TokenRequestEvidenceDigest = ""
+		},
+		"unverified package": func(config *RuntimeBindingStageCredentialPackageConfig) {
+			config.Package = VerifiedRuntimeBindingStagePackage{}
+		},
+		"changed package identity": func(config *RuntimeBindingStageCredentialPackageConfig) {
+			config.Package.receipt.PackageDigest = prefixSHA("d")
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			config, _ := runtimeBindingCredentialConfig(t)
+			mutate(&config)
+			_, err := BuildRuntimeBindingStageCredentialPackage(config)
+			if err == nil || strings.Contains(err.Error(), config.WorkloadBindingPath) || strings.Contains(err.Error(), config.WorkloadObserver.TokenFile) {
+				t.Fatalf("unsafe runtime binding credential package accepted: %v", err)
+			}
+		})
+	}
+	if _, err := (VerifiedRuntimeBindingStageCredentialPackage{}).Receipt(); err == nil {
+		t.Fatal("unverified runtime binding credential receipt was exposed")
+	}
+	config, _ := runtimeBindingCredentialConfig(t)
+	packaged, err := BuildRuntimeBindingStageCredentialPackage(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	packaged.objects[2].raw = append(packaged.objects[2].raw, '\n')
+	if _, err := packaged.Receipt(); err == nil {
+		t.Fatal("changed private runtime binding credential was accepted")
+	}
+}
+
+func runtimeBindingCredentialConfig(t *testing.T) (RuntimeBindingStageCredentialPackageConfig, [][]byte) {
+	t.Helper()
+	now := time.Date(2026, 8, 16, 12, 0, 0, 0, time.UTC)
+	issuedAt, expiresAt := now.Add(-time.Minute), now.Add(30*time.Minute)
+	audiences := []string{"https://kubernetes.default.svc"}
+	issuer := "https://kubernetes.default.svc.cluster.local"
+	root := t.TempDir()
+	managementCA, workloadCA := testCA(t), testCA(t)
+	managementCAPath := filepath.Join(root, "management-ca.crt")
+	workloadCAPath := filepath.Join(root, "workload-ca.crt")
+	if err := os.WriteFile(managementCAPath, managementCA, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(workloadCAPath, workloadCA, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	packageConfig := runtimeBindingStagePackageConfig(t)
+	binding, err := loadWorkloadAuthorityBinding(packageConfig.WorkloadBindingPath, packageConfig.ExpectedWorkloadBindingDigest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	binding.CABundleDigest = digest.SHA256(workloadCA)
+	bindingRaw := mustJSON(t, binding)
+	if err := os.WriteFile(packageConfig.WorkloadBindingPath, bindingRaw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	packageConfig.ExpectedWorkloadBindingDigest, err = WorkloadAuthorityBindingDigest(binding)
+	if err != nil {
+		t.Fatal(err)
+	}
+	packaged, err := BuildRuntimeBindingStagePackage(packageConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	subjects := []string{
+		"system:serviceaccount:openkubes-execution-system:ok147-runtime-ledger-writer",
+		"system:serviceaccount:openkubes-execution-system:ok147-runtime-persistence-writer",
+		"system:serviceaccount:openkubes-execution-system:ok147-runtime-workload-observer",
+	}
+	tokens := [][]byte{
+		stageCredentialJWT(t, issuer, subjects[0], audiences, issuedAt, expiresAt, 'b'),
+		stageCredentialJWT(t, issuer, subjects[1], audiences, issuedAt, expiresAt, 'c'),
+		stageCredentialJWT(t, issuer, subjects[2], audiences, issuedAt, expiresAt, 'd'),
+	}
+	tokenPaths := make([]string, len(tokens))
+	for index, token := range tokens {
+		tokenPaths[index] = filepath.Join(root, "token-"+string(rune('0'+index)))
+		if err := os.WriteFile(tokenPaths[index], token, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	source := func(authority, tokenPath, subject, evidence, caPath string, token, ca []byte) SubmissionStageCredentialSource {
+		return SubmissionStageCredentialSource{
+			AuthorityIdentity: authority, TokenFile: tokenPath, TokenDigest: digest.SHA256(token),
+			CAFile: caPath, CABundleDigest: digest.SHA256(ca), TokenRequestEvidenceDigest: prefixSHA(evidence),
+			ExpectedIssuer: issuer, ExpectedSubject: subject, ExpectedAudiences: audiences,
+			IssuedAt: issuedAt, ExpiresAt: expiresAt,
+		}
+	}
+	return RuntimeBindingStageCredentialPackageConfig{
+		Package: packaged, MaterializationTime: now, WorkloadBindingPath: packageConfig.WorkloadBindingPath,
+		LedgerWriter:      source("ok-mgmt", tokenPaths[0], subjects[0], "4", managementCAPath, tokens[0], managementCA),
+		PersistenceWriter: source("ok-mgmt", tokenPaths[1], subjects[1], "5", managementCAPath, tokens[1], managementCA),
+		WorkloadObserver:  source(digest.SHA256([]byte(binding.TargetClusterUID)), tokenPaths[2], subjects[2], "6", workloadCAPath, tokens[2], workloadCA),
+	}, tokens
+}


### PR DESCRIPTION
## Summary
- bind three independently issued short-lived credentials to the verified runtime-binding package
- retain exact immutable Secret bytes privately and add the workload binding only to the workload observer Secret
- expose only a redaction-safe receipt with roles, validity and digests

## Safety
- offline construction only
- no Kubernetes contact or mutation
- fail closed on authority, CA, TokenRequest evidence, shared-token or tamper mismatch

## Verification
- `go test -ldflags=-linkmode=external ./...`
- `go vet ./...`
- `go test -race -ldflags=-linkmode=external ./internal/runner`