### PR TITLE
feat(runner): plan runtime binding installation (OK-147)

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -2345,7 +2345,17 @@ contains roles, authority identities, expiry, audiences and digests, but never
 tokens, CA bytes, subjects, API endpoints or source paths. The exact immutable
 Secret bytes remain private for a later installer boundary. Construction is
 still non-mutating: it neither requests a token nor contacts Kubernetes.
-Installation planning, bounded installation and launch remain separate.
+
+The public side of that boundary now also has a verified
+`ok147-runtime-binding-stage-installation-plan/v1`. It reparses the package,
+rechecks the ConfigMap and Job-envelope digests, verifies the tokenless runtime
+identity, exact input mount, management authority and all three credential
+Secret references, then fixes the create order to ConfigMap, NetworkPolicy and
+Job. The plan contains only object identities, paths and digests; it contains
+neither credentials nor object bodies and grants no mutation authority.
+
+Private Secret recovery, the combined seven-object launch plan, bounded
+installation and launch remain separate.
 
 ## Bounded convergence observation polling
 

--- a/internal/runner/runtime_binding_stage_installation_plan.go
+++ b/internal/runner/runtime_binding_stage_installation_plan.go
@@ -1,0 +1,157 @@
+package runner
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"gopkg.in/yaml.v3"
+)
+
+const RuntimeBindingStageInstallationPlanFormat = "ok147-runtime-binding-stage-installation-plan/v1"
+
+// RuntimeBindingStageInstallationPlan is a tokenless offline description of
+// the three exact public stage objects. It grants no create authority.
+type RuntimeBindingStageInstallationPlan struct {
+	Format             string                      `json:"format"`
+	State              string                      `json:"state"`
+	StageID            string                      `json:"stageId"`
+	StagePackageDigest string                      `json:"stagePackageDigest"`
+	Authority          string                      `json:"authority"`
+	Creates            []SubmissionStageCreatePlan `json:"creates"`
+	MutationAllowed    bool                        `json:"mutationAllowed"`
+}
+
+// PlanRuntimeBindingStageInstallation verifies the immutable input,
+// NetworkPolicy and Job and derives their exact create order without opening
+// credentials or contacting Kubernetes.
+func PlanRuntimeBindingStageInstallation(packaged VerifiedRuntimeBindingStagePackage) (RuntimeBindingStageInstallationPlan, error) {
+	receipt, err := packaged.Receipt()
+	if err != nil {
+		return RuntimeBindingStageInstallationPlan{}, err
+	}
+	expectedKinds := []string{"ConfigMap", "NetworkPolicy", "Job"}
+	if !equalStringList(receipt.ObjectKinds, expectedKinds) {
+		return RuntimeBindingStageInstallationPlan{}, errors.New("runtime binding package object inventory is invalid")
+	}
+	documents := bytes.Split(packaged.raw, []byte("\n---\n"))
+	if len(documents) != len(expectedKinds) || digest.SHA256(documents[0]) != receipt.InputConfigMapDigest || digest.SHA256(bytes.Join(documents[1:], []byte("\n---\n"))) != receipt.JobEnvelopeDigest {
+		return RuntimeBindingStageInstallationPlan{}, errors.New("runtime binding package component identity differs")
+	}
+	decoder := yaml.NewDecoder(bytes.NewReader(packaged.raw))
+	objects := make([]map[string]any, 0, len(expectedKinds))
+	for {
+		var object map[string]any
+		err := decoder.Decode(&object)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil || len(object) == 0 {
+			return RuntimeBindingStageInstallationPlan{}, errors.New("decode runtime binding package")
+		}
+		objects = append(objects, object)
+	}
+	if len(objects) != len(expectedKinds) {
+		return RuntimeBindingStageInstallationPlan{}, errors.New("runtime binding package object count is invalid")
+	}
+
+	configMapName, runID := "", ""
+	creates := make([]SubmissionStageCreatePlan, 0, len(objects))
+	for index, object := range objects {
+		apiVersion, _ := object["apiVersion"].(string)
+		kind, _ := object["kind"].(string)
+		if kind != expectedKinds[index] {
+			return RuntimeBindingStageInstallationPlan{}, errors.New("runtime binding package create order is invalid")
+		}
+		metadata, ok := object["metadata"].(map[string]any)
+		if !ok {
+			return RuntimeBindingStageInstallationPlan{}, errors.New("runtime binding package object metadata is invalid")
+		}
+		name, _ := metadata["name"].(string)
+		namespace, _ := metadata["namespace"].(string)
+		if !submissionStageInputNamePattern.MatchString(name) || len(name) > 63 || namespace != submissionStageInputNamespace || metadata["generateName"] != nil {
+			return RuntimeBindingStageInstallationPlan{}, errors.New("runtime binding package object identity is invalid")
+		}
+		collectionPath, objectPath, err := submissionStageCreatePaths(apiVersion, kind, namespace, name)
+		if err != nil {
+			return RuntimeBindingStageInstallationPlan{}, err
+		}
+		canonical, err := json.Marshal(object)
+		if err != nil {
+			return RuntimeBindingStageInstallationPlan{}, errors.New("encode runtime binding package object")
+		}
+		creates = append(creates, SubmissionStageCreatePlan{
+			Order: index + 1, APIVersion: apiVersion, Kind: kind, Namespace: namespace, Name: name,
+			PreflightMethod: "GET", ObjectPath: objectPath, CreateMethod: "POST", CollectionPath: collectionPath,
+			ObjectDigest: digest.SHA256(canonical),
+		})
+		switch kind {
+		case "ConfigMap":
+			labels, _ := metadata["labels"].(map[string]any)
+			if object["immutable"] != true || labels["openkubes.io/stage-id"] != receipt.StageID {
+				return RuntimeBindingStageInstallationPlan{}, errors.New("runtime binding input ConfigMap semantics differ")
+			}
+			configMapName = name
+		case "NetworkPolicy":
+			runID = name
+			spec, _ := object["spec"].(map[string]any)
+			selector, _ := spec["podSelector"].(map[string]any)
+			matchLabels, _ := selector["matchLabels"].(map[string]any)
+			if matchLabels["openkubes.io/execution-id"] != runID {
+				return RuntimeBindingStageInstallationPlan{}, errors.New("runtime binding NetworkPolicy selector differs from run identity")
+			}
+		case "Job":
+			if name != runID {
+				return RuntimeBindingStageInstallationPlan{}, errors.New("runtime binding Job and NetworkPolicy identities differ")
+			}
+			spec, _ := object["spec"].(map[string]any)
+			template, _ := spec["template"].(map[string]any)
+			podSpec, _ := template["spec"].(map[string]any)
+			if podSpec["serviceAccountName"] != "ok147-contract-executor-runtime" || podSpec["automountServiceAccountToken"] != false {
+				return RuntimeBindingStageInstallationPlan{}, errors.New("runtime binding Job runtime identity is invalid")
+			}
+			if !jobMountsInputConfigMap(podSpec, configMapName) || !jobUsesManagementAuthority(podSpec, packaged.managementAuthority) || !jobUsesRuntimeBindingCredentialSecrets(podSpec, packaged.ledgerCredential, packaged.persistenceCredential, packaged.workloadCredential) {
+				return RuntimeBindingStageInstallationPlan{}, errors.New("runtime binding Job binding differs from verified package")
+			}
+		}
+	}
+	return RuntimeBindingStageInstallationPlan{
+		Format: RuntimeBindingStageInstallationPlanFormat, State: "VERIFIED", StageID: receipt.StageID,
+		StagePackageDigest: receipt.PackageDigest, Authority: packaged.managementAuthority,
+		Creates: creates, MutationAllowed: false,
+	}, nil
+}
+
+func jobUsesRuntimeBindingCredentialSecrets(podSpec map[string]any, ledger, persistence, workload string) bool {
+	volumes, ok := podSpec["volumes"].([]any)
+	if !ok {
+		return false
+	}
+	want := map[string]struct {
+		secret string
+		items  map[string]string
+	}{
+		"ledger-credential":      {secret: ledger, items: map[string]string{"token": "token", "ca.crt": "ca.crt"}},
+		"persistence-credential": {secret: persistence, items: map[string]string{"token": "token", "ca.crt": "ca.crt"}},
+		"workload-credential":    {secret: workload, items: map[string]string{"token": "token", "ca.crt": "ca.crt", "binding.json": "binding.json"}},
+	}
+	found := map[string]bool{}
+	for _, item := range volumes {
+		volume, _ := item.(map[string]any)
+		name, _ := volume["name"].(string)
+		expected, relevant := want[name]
+		if !relevant {
+			continue
+		}
+		secret, _ := volume["secret"].(map[string]any)
+		secretName, _ := secret["secretName"].(string)
+		items, _ := secret["items"].([]any)
+		if secretName != expected.secret || !exactCredentialSecretItems(items, expected.items) {
+			return false
+		}
+		found[name] = true
+	}
+	return len(found) == len(want)
+}

--- a/internal/runner/runtime_binding_stage_installation_plan_test.go
+++ b/internal/runner/runtime_binding_stage_installation_plan_test.go
@@ -1,0 +1,89 @@
+package runner
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+func TestPlanRuntimeBindingStageInstallationProducesExactSafeOrder(t *testing.T) {
+	packaged, err := BuildRuntimeBindingStagePackage(runtimeBindingStagePackageConfig(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan, err := PlanRuntimeBindingStageInstallation(packaged)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, _ := packaged.Receipt()
+	if plan.Format != RuntimeBindingStageInstallationPlanFormat || plan.State != "VERIFIED" || plan.StageID != "runtime-binding" || plan.StagePackageDigest != receipt.PackageDigest || plan.Authority != "ok-mgmt" || plan.MutationAllowed {
+		t.Fatalf("unexpected runtime binding installation plan: %#v", plan)
+	}
+	wantKinds := []string{"ConfigMap", "NetworkPolicy", "Job"}
+	wantCollections := []string{
+		"/api/v1/namespaces/openkubes-execution-system/configmaps",
+		"/apis/networking.k8s.io/v1/namespaces/openkubes-execution-system/networkpolicies",
+		"/apis/batch/v1/namespaces/openkubes-execution-system/jobs",
+	}
+	if len(plan.Creates) != len(wantKinds) {
+		t.Fatalf("creates=%d, want 3", len(plan.Creates))
+	}
+	for index, create := range plan.Creates {
+		if create.Order != index+1 || create.Kind != wantKinds[index] || create.Namespace != submissionStageInputNamespace || create.PreflightMethod != "GET" || create.CreateMethod != "POST" || create.CollectionPath != wantCollections[index] || create.ObjectPath != create.CollectionPath+"/"+create.Name || !stageReceiptPrefixDigestPattern.MatchString(create.ObjectDigest) {
+			t.Fatalf("unexpected runtime binding create %d: %#v", index, create)
+		}
+		if strings.Contains(strings.ToLower(create.ObjectPath), "secret") {
+			t.Fatalf("installation plan unexpectedly contains credential path: %#v", create)
+		}
+	}
+	if plan.Creates[1].Name != plan.Creates[2].Name {
+		t.Fatal("NetworkPolicy and Job run identities differ")
+	}
+}
+
+func TestPlanRuntimeBindingStageInstallationFailsClosed(t *testing.T) {
+	valid, err := BuildRuntimeBindingStagePackage(runtimeBindingStagePackageConfig(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := PlanRuntimeBindingStageInstallation(VerifiedRuntimeBindingStagePackage{}); err == nil {
+		t.Fatal("unverified runtime binding package was planned")
+	}
+	tests := map[string]func(*VerifiedRuntimeBindingStagePackage){
+		"wrong inventory": func(packaged *VerifiedRuntimeBindingStagePackage) {
+			packaged.receipt.ObjectKinds = []string{"ConfigMap", "Job", "NetworkPolicy"}
+		},
+		"foreign authority": func(packaged *VerifiedRuntimeBindingStagePackage) {
+			packaged.managementAuthority = "ok-infra"
+		},
+		"changed runtime": func(packaged *VerifiedRuntimeBindingStagePackage) {
+			packaged.raw = bytes.Replace(packaged.raw, []byte("ok147-contract-executor-runtime"), []byte("ok147-foreign-runtime"), 1)
+			packaged.receipt.PackageDigest = digest.SHA256(packaged.raw)
+		},
+		"changed persistence credential": func(packaged *VerifiedRuntimeBindingStagePackage) {
+			packaged.raw = bytes.Replace(packaged.raw, []byte(packaged.persistenceCredential), []byte("ok147-foreign-persistence"), 1)
+			packaged.receipt.PackageDigest = digest.SHA256(packaged.raw)
+		},
+		"changed workload credential": func(packaged *VerifiedRuntimeBindingStagePackage) {
+			packaged.raw = bytes.Replace(packaged.raw, []byte(packaged.workloadCredential), []byte("ok147-foreign-workload"), 1)
+			packaged.receipt.PackageDigest = digest.SHA256(packaged.raw)
+		},
+		"extra object": func(packaged *VerifiedRuntimeBindingStagePackage) {
+			packaged.raw = append(packaged.raw, []byte("\n---\napiVersion: v1\nkind: Secret\nmetadata: {name: forbidden}\n")...)
+			packaged.receipt.PackageDigest = digest.SHA256(packaged.raw)
+		},
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			packaged := valid
+			packaged.raw = append([]byte(nil), valid.raw...)
+			packaged.receipt.ObjectKinds = append([]string(nil), valid.receipt.ObjectKinds...)
+			mutate(&packaged)
+			if _, err := PlanRuntimeBindingStageInstallation(packaged); err == nil {
+				t.Fatal("changed runtime binding package was planned")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- reparse and verify the exact runtime-binding ConfigMap, NetworkPolicy and Job package
- bind the tokenless ServiceAccount, management authority, input ConfigMap and three credential Secret references
- emit a redaction-safe exact GET/POST create plan without object bodies or credentials

## Safety
- offline planning only
- no Kubernetes contact or mutation
- no credentials or private workload binding in the plan

## Verification
- `go test -ldflags=-linkmode=external ./...`
- `go vet ./...`
- `go test -race -ldflags=-linkmode=external ./internal/runner`