### PR TITLE
feat(runner): bind runtime binding launch plan (OK-147)

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -2354,8 +2354,17 @@ Secret references, then fixes the create order to ConfigMap, NetworkPolicy and
 Job. The plan contains only object identities, paths and digests; it contains
 neither credentials nor object bodies and grants no mutation authority.
 
-Private Secret recovery, the combined seven-object launch plan, bounded
-installation and launch remain separate.
+The complete tokenless prerequisite set is now correlated by
+`ok147-runtime-binding-stage-launch-plan/v1`: shared ServiceAccount, immutable
+input ConfigMap, NetworkPolicy, three immutable credential Secrets and the Job.
+All seven exact GET preflights belong to one global barrier. The shared runtime
+may already exist only when its exact digest matches; every other object must
+be either globally absent or part of a completely exact already-existing set.
+No create can be considered after a mixed or foreign preflight result.
+
+The launch plan contains only paths, identities and digests and remains
+`mutationAllowed: false`. Private Secret recovery, an expiry-bound launch
+candidate, bounded installation and execution remain later checkpoints.
 
 ## Bounded convergence observation polling
 

--- a/internal/runner/runtime_binding_stage_launch_plan.go
+++ b/internal/runner/runtime_binding_stage_launch_plan.go
@@ -1,0 +1,83 @@
+package runner
+
+import "errors"
+
+const RuntimeBindingStageLaunchPlanFormat = "ok147-runtime-binding-stage-launch-plan/v1"
+
+// RuntimeBindingStageLaunchPlan binds all seven exact objects needed for one
+// runtime-binding Job launch. It contains no body or credential and grants no
+// mutation authority.
+type RuntimeBindingStageLaunchPlan struct {
+	Format                  string                           `json:"format"`
+	State                   string                           `json:"state"`
+	StageID                 string                           `json:"stageId"`
+	Authority               string                           `json:"authority"`
+	StagePackageDigest      string                           `json:"stagePackageDigest"`
+	CredentialPackageDigest string                           `json:"credentialPackageDigest"`
+	RuntimeManifestDigest   string                           `json:"runtimeManifestDigest"`
+	PreflightBarrier        string                           `json:"preflightBarrier"`
+	Preflights              []SubmissionStageLaunchPreflight `json:"preflights"`
+	Creates                 []SubmissionStageLaunchCreate    `json:"creates"`
+	MutationAllowed         bool                             `json:"mutationAllowed"`
+}
+
+// PlanRuntimeBindingStageLaunch accepts only one coherent stage package,
+// three-credential package and tokenless runtime prerequisite. Every GET must
+// pass before any create can be considered by a later launcher.
+func PlanRuntimeBindingStageLaunch(packaged VerifiedRuntimeBindingStagePackage, credentials VerifiedRuntimeBindingStageCredentialPackage, runtime VerifiedRuntimeBindingStageRuntimePrerequisite) (RuntimeBindingStageLaunchPlan, error) {
+	stage, err := PlanRuntimeBindingStageInstallation(packaged)
+	if err != nil {
+		return RuntimeBindingStageLaunchPlan{}, err
+	}
+	if err := verifyRuntimeBindingStageCredentialPackage(credentials); err != nil {
+		return RuntimeBindingStageLaunchPlan{}, err
+	}
+	runtimeReceipt, err := runtime.Receipt()
+	if err != nil {
+		return RuntimeBindingStageLaunchPlan{}, err
+	}
+	if stage.StagePackageDigest != credentials.receipt.StagePackageDigest || stage.StagePackageDigest != runtimeReceipt.BindingPackageDigest || stage.StageID != credentials.receipt.StageID || stage.Authority != credentials.installationAuthority || stage.Authority != runtimeReceipt.Authority || credentials.receipt.WorkloadBindingDigest != packaged.receipt.WorkloadBindingDigest {
+		return RuntimeBindingStageLaunchPlan{}, errors.New("runtime binding launch components do not share one verified identity")
+	}
+
+	preflights := make([]SubmissionStageLaunchPreflight, 0, 7)
+	creates := make([]SubmissionStageLaunchCreate, 0, 7)
+	appendObject := func(order int, phase, apiVersion, kind, namespace, name, objectPath, collectionPath, objectDigest, existingPolicy, createPolicy string) {
+		preflights = append(preflights, SubmissionStageLaunchPreflight{
+			Order: order, Phase: phase, APIVersion: apiVersion, Kind: kind, Namespace: namespace, Name: name,
+			Method: "GET", ObjectPath: objectPath, ResponseMode: "FULL_OBJECT", ExistingPolicy: existingPolicy,
+			ObjectDigest: objectDigest,
+		})
+		creates = append(creates, SubmissionStageLaunchCreate{
+			Order: order, Phase: phase, APIVersion: apiVersion, Kind: kind, Namespace: namespace, Name: name,
+			Method: "POST", CollectionPath: collectionPath, CreatePolicy: createPolicy, ObjectDigest: objectDigest,
+		})
+	}
+	runtimeCollection := "/api/v1/namespaces/" + runtimeReceipt.Namespace + "/serviceaccounts"
+	appendObject(1, "runtime", "v1", "ServiceAccount", runtimeReceipt.Namespace, runtimeReceipt.Name,
+		runtimeCollection+"/"+runtimeReceipt.Name, runtimeCollection, runtimeReceipt.ObjectDigest,
+		"VERIFY_EXACT", "CREATE_IF_ABSENT_OR_VERIFY_EXISTING")
+	for index, object := range stage.Creates[:2] {
+		appendObject(index+2, "stage-prerequisites", object.APIVersion, object.Kind, object.Namespace, object.Name,
+			object.ObjectPath, object.CollectionPath, object.ObjectDigest,
+			"VERIFY_EXACT_GLOBAL_STATE", "CREATE_ONLY_AFTER_GLOBAL_ABSENCE")
+	}
+	for index, object := range credentials.objects {
+		collection := "/api/v1/namespaces/" + submissionStageInputNamespace + "/secrets"
+		appendObject(index+4, "credentials", "v1", "Secret", submissionStageInputNamespace, object.name,
+			collection+"/"+object.name, collection, credentials.receipt.Credentials[index].ObjectDigest,
+			"VERIFY_EXACT_GLOBAL_STATE", "CREATE_ONLY_AFTER_GLOBAL_ABSENCE")
+	}
+	job := stage.Creates[2]
+	appendObject(7, "job", job.APIVersion, job.Kind, job.Namespace, job.Name,
+		job.ObjectPath, job.CollectionPath, job.ObjectDigest,
+		"VERIFY_EXACT_GLOBAL_STATE", "CREATE_ONLY_AFTER_GLOBAL_ABSENCE")
+
+	return RuntimeBindingStageLaunchPlan{
+		Format: RuntimeBindingStageLaunchPlanFormat, State: "VERIFIED", StageID: stage.StageID,
+		Authority: stage.Authority, StagePackageDigest: stage.StagePackageDigest,
+		CredentialPackageDigest: credentials.receipt.PackageDigest, RuntimeManifestDigest: runtimeReceipt.ManifestDigest,
+		PreflightBarrier: "ALL_ABSENT_OR_RUNTIME_ONLY_OR_ALL_EXACT", Preflights: preflights, Creates: creates,
+		MutationAllowed: false,
+	}, nil
+}

--- a/internal/runner/runtime_binding_stage_launch_plan_test.go
+++ b/internal/runner/runtime_binding_stage_launch_plan_test.go
@@ -1,0 +1,99 @@
+package runner
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+func TestPlanRuntimeBindingStageLaunchBindsSevenObjectsBehindOneBarrier(t *testing.T) {
+	stage, credentials, runtime, tokens := runtimeBindingStageLaunchFixture(t)
+	plan, err := PlanRuntimeBindingStageLaunch(stage, credentials, runtime)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stageReceipt, _ := stage.Receipt()
+	credentialReceipt, _ := credentials.Receipt()
+	runtimeReceipt, _ := runtime.Receipt()
+	if plan.Format != RuntimeBindingStageLaunchPlanFormat || plan.State != "VERIFIED" || plan.StageID != "runtime-binding" || plan.Authority != "ok-mgmt" || plan.StagePackageDigest != stageReceipt.PackageDigest || plan.CredentialPackageDigest != credentialReceipt.PackageDigest || plan.RuntimeManifestDigest != runtimeReceipt.ManifestDigest || plan.PreflightBarrier != "ALL_ABSENT_OR_RUNTIME_ONLY_OR_ALL_EXACT" || plan.MutationAllowed {
+		t.Fatalf("unexpected runtime binding launch identity: %#v", plan)
+	}
+	wantKinds := []string{"ServiceAccount", "ConfigMap", "NetworkPolicy", "Secret", "Secret", "Secret", "Job"}
+	wantPhases := []string{"runtime", "stage-prerequisites", "stage-prerequisites", "credentials", "credentials", "credentials", "job"}
+	if len(plan.Preflights) != len(wantKinds) || len(plan.Creates) != len(wantKinds) {
+		t.Fatalf("unexpected launch object count: %d %d", len(plan.Preflights), len(plan.Creates))
+	}
+	for index := range wantKinds {
+		preflight, create := plan.Preflights[index], plan.Creates[index]
+		if preflight.Order != index+1 || create.Order != index+1 || preflight.Phase != wantPhases[index] || create.Phase != wantPhases[index] || preflight.Kind != wantKinds[index] || create.Kind != wantKinds[index] || preflight.Name != create.Name || preflight.Namespace != create.Namespace || preflight.ObjectDigest != create.ObjectDigest || preflight.Method != "GET" || create.Method != "POST" || preflight.ResponseMode != "FULL_OBJECT" {
+			t.Fatalf("runtime binding launch step %d differs: %#v %#v", index+1, preflight, create)
+		}
+		if index == 0 {
+			if preflight.ExistingPolicy != "VERIFY_EXACT" || create.CreatePolicy != "CREATE_IF_ABSENT_OR_VERIFY_EXISTING" {
+				t.Fatalf("runtime policy differs: %#v %#v", preflight, create)
+			}
+		} else if preflight.ExistingPolicy != "VERIFY_EXACT_GLOBAL_STATE" || create.CreatePolicy != "CREATE_ONLY_AFTER_GLOBAL_ABSENCE" {
+			t.Fatalf("global policy differs at %d: %#v %#v", index+1, preflight, create)
+		}
+	}
+	public, err := json.Marshal(plan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range append(tokens, credentials.objects[0].raw, credentials.objects[1].raw, credentials.objects[2].raw, runtime.raw, stage.raw) {
+		if bytes.Contains(public, forbidden) {
+			t.Fatal("runtime binding launch plan exposed private object content")
+		}
+	}
+}
+
+func TestPlanRuntimeBindingStageLaunchRejectsMismatchedComponents(t *testing.T) {
+	stage, credentials, runtime, _ := runtimeBindingStageLaunchFixture(t)
+	tests := map[string]func() (VerifiedRuntimeBindingStagePackage, VerifiedRuntimeBindingStageCredentialPackage, VerifiedRuntimeBindingStageRuntimePrerequisite){
+		"empty stage": func() (VerifiedRuntimeBindingStagePackage, VerifiedRuntimeBindingStageCredentialPackage, VerifiedRuntimeBindingStageRuntimePrerequisite) {
+			return VerifiedRuntimeBindingStagePackage{}, credentials, runtime
+		},
+		"empty credentials": func() (VerifiedRuntimeBindingStagePackage, VerifiedRuntimeBindingStageCredentialPackage, VerifiedRuntimeBindingStageRuntimePrerequisite) {
+			return stage, VerifiedRuntimeBindingStageCredentialPackage{}, runtime
+		},
+		"empty runtime": func() (VerifiedRuntimeBindingStagePackage, VerifiedRuntimeBindingStageCredentialPackage, VerifiedRuntimeBindingStageRuntimePrerequisite) {
+			return stage, credentials, VerifiedRuntimeBindingStageRuntimePrerequisite{}
+		},
+		"foreign credential package": func() (VerifiedRuntimeBindingStagePackage, VerifiedRuntimeBindingStageCredentialPackage, VerifiedRuntimeBindingStageRuntimePrerequisite) {
+			changed := credentials
+			changed.receipt.StagePackageDigest = digest.SHA256([]byte("foreign"))
+			return stage, changed, runtime
+		},
+		"foreign runtime package": func() (VerifiedRuntimeBindingStagePackage, VerifiedRuntimeBindingStageCredentialPackage, VerifiedRuntimeBindingStageRuntimePrerequisite) {
+			changed := runtime
+			changed.receipt.BindingPackageDigest = digest.SHA256([]byte("foreign"))
+			return stage, credentials, changed
+		},
+	}
+	for name, values := range tests {
+		t.Run(name, func(t *testing.T) {
+			candidateStage, candidateCredentials, candidateRuntime := values()
+			if _, err := PlanRuntimeBindingStageLaunch(candidateStage, candidateCredentials, candidateRuntime); err == nil {
+				t.Fatal("mismatched runtime binding launch components accepted")
+			}
+		})
+	}
+}
+
+func runtimeBindingStageLaunchFixture(t *testing.T) (VerifiedRuntimeBindingStagePackage, VerifiedRuntimeBindingStageCredentialPackage, VerifiedRuntimeBindingStageRuntimePrerequisite, [][]byte) {
+	t.Helper()
+	credentialConfig, tokens := runtimeBindingCredentialConfig(t)
+	stage := credentialConfig.Package
+	credentials, err := BuildRuntimeBindingStageCredentialPackage(credentialConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest := submissionStageRuntimeManifest(t)
+	runtime, err := BuildRuntimeBindingStageRuntimePrerequisite(stage, manifest, digest.SHA256(manifest))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return stage, credentials, runtime, tokens
+}


### PR DESCRIPTION
## Summary
- correlate runtime ServiceAccount, stage prerequisites, three private credential identities and Job into one seven-object plan
- require one global preflight barrier before any create
- permit only the exact shared runtime to preexist; reject mixed or foreign state

## Safety
- offline planning only
- no Kubernetes contact or mutation
- no object bodies, tokens, CA data or private binding in the plan

## Verification
- `go test -ldflags=-linkmode=external ./...`
- `go vet ./...`
- `go test -race -ldflags=-linkmode=external ./internal/runner`