### PR TITLE
feat(runner): recover runtime binding install material (OK-147)

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -2363,8 +2363,18 @@ be either globally absent or part of a completely exact already-existing set.
 No create can be considered after a mixed or foreign preflight result.
 
 The launch plan contains only paths, identities and digests and remains
-`mutationAllowed: false`. Private Secret recovery, an expiry-bound launch
-candidate, bounded installation and execution remain later checkpoints.
+`mutationAllowed: false`.
+
+The corresponding private material boundary now reparses the three public
+objects and recovers the three retained immutable Secret bodies. It rechecks
+every planned object digest, Secret label, authority annotation, expiry, CA
+digest and data-key inventory. The two management-side Secrets must not carry
+a workload binding; the workload Secret must carry the exact binding and CA
+already correlated by the stage package. Any changed byte fails closed before
+material can reach an installer.
+
+No public API exposes these recovered bytes. An expiry-bound launch candidate,
+bounded installation and execution remain later checkpoints.
 
 ## Bounded convergence observation polling
 

--- a/internal/runner/runtime_binding_stage_install_material.go
+++ b/internal/runner/runtime_binding_stage_install_material.go
@@ -1,0 +1,111 @@
+package runner
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"io"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/jsonstrict"
+	"gopkg.in/yaml.v3"
+)
+
+// prepareRuntimeBindingStageInstallation recovers the exact three public
+// object bodies retained by a verified package and rechecks every plan digest.
+func prepareRuntimeBindingStageInstallation(packaged VerifiedRuntimeBindingStagePackage) (RuntimeBindingStageInstallationPlan, []submissionStageInstallObject, error) {
+	plan, err := PlanRuntimeBindingStageInstallation(packaged)
+	if err != nil {
+		return RuntimeBindingStageInstallationPlan{}, nil, err
+	}
+	decoder := yaml.NewDecoder(bytes.NewReader(packaged.raw))
+	objects := make([]submissionStageInstallObject, 0, len(plan.Creates))
+	for index := range plan.Creates {
+		var value map[string]any
+		if err := decoder.Decode(&value); err != nil || len(value) == 0 {
+			return RuntimeBindingStageInstallationPlan{}, nil, errors.New("decode runtime binding installation object")
+		}
+		raw, err := json.Marshal(value)
+		if err != nil || digest.SHA256(raw) != plan.Creates[index].ObjectDigest {
+			return RuntimeBindingStageInstallationPlan{}, nil, errors.New("runtime binding installation object differs from plan")
+		}
+		objects = append(objects, submissionStageInstallObject{plan: plan.Creates[index], raw: raw})
+	}
+	var trailing map[string]any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		return RuntimeBindingStageInstallationPlan{}, nil, errors.New("runtime binding installation contains trailing object")
+	}
+	return plan, objects, nil
+}
+
+// prepareRuntimeBindingStageCredentialInstallation recovers the exact private
+// Secret bodies and validates their semantic data once more. Only the workload
+// observer Secret may carry the package-bound private workload binding.
+func prepareRuntimeBindingStageCredentialInstallation(packaged VerifiedRuntimeBindingStageCredentialPackage) (RuntimeBindingStageCredentialPackageReceipt, []submissionStageCredentialInstallObject, error) {
+	if err := verifyRuntimeBindingStageCredentialPackage(packaged); err != nil {
+		return RuntimeBindingStageCredentialPackageReceipt{}, nil, err
+	}
+	objects := make([]submissionStageCredentialInstallObject, 0, 3)
+	for index, private := range packaged.objects {
+		public := packaged.receipt.Credentials[index]
+		var secret map[string]any
+		if err := jsonstrict.Decode(private.raw, &secret); err != nil {
+			return RuntimeBindingStageCredentialPackageReceipt{}, nil, errors.New("runtime binding credential object is invalid JSON")
+		}
+		metadata, _ := secret["metadata"].(map[string]any)
+		labels, _ := metadata["labels"].(map[string]any)
+		annotations, _ := metadata["annotations"].(map[string]any)
+		data, _ := secret["data"].(map[string]any)
+		expectedDataCount := 2
+		if index == 2 {
+			expectedDataCount = 3
+		}
+		if secret["apiVersion"] != "v1" || secret["kind"] != "Secret" || secret["immutable"] != true || secret["type"] != "Opaque" || metadata["name"] != private.name || metadata["namespace"] != submissionStageInputNamespace || labels["openkubes.io/stage-id"] != packaged.receipt.StageID || labels["openkubes.io/credential-role"] != private.role || annotations["openkubes.io/authority-identity"] != private.authority || annotations["openkubes.io/expires-at"] != public.ExpiresAt || len(data) != expectedDataCount {
+			return RuntimeBindingStageCredentialPackageReceipt{}, nil, errors.New("runtime binding credential Secret semantics changed")
+		}
+		tokenEncoded, tokenOK := data["token"].(string)
+		caEncoded, caOK := data["ca.crt"].(string)
+		token, tokenErr := base64.StdEncoding.DecodeString(tokenEncoded)
+		ca, caErr := base64.StdEncoding.DecodeString(caEncoded)
+		expiresAt, timeErr := time.Parse(time.RFC3339, public.ExpiresAt)
+		if !tokenOK || !caOK || tokenErr != nil || caErr != nil || len(token) == 0 || len(ca) == 0 || timeErr != nil || digest.SHA256(ca) != public.CABundleDigest {
+			return RuntimeBindingStageCredentialPackageReceipt{}, nil, errors.New("runtime binding credential Secret data changed")
+		}
+		if index < 2 {
+			if data["binding.json"] != nil {
+				return RuntimeBindingStageCredentialPackageReceipt{}, nil, errors.New("management-side runtime binding credential contains a workload binding")
+			}
+		} else if err := verifyRuntimeBindingCredentialBinding(data, packaged.receipt.WorkloadBindingDigest, packaged.workloadAuthority, public.CABundleDigest); err != nil {
+			return RuntimeBindingStageCredentialPackageReceipt{}, nil, err
+		}
+		collection := "/api/v1/namespaces/" + submissionStageInputNamespace + "/secrets"
+		objects = append(objects, submissionStageCredentialInstallObject{
+			order: index + 4, role: private.role, authority: private.authority, name: private.name,
+			objectPath: collection + "/" + private.name, collectionPath: collection,
+			objectDigest: public.ObjectDigest, expiresAt: expiresAt, raw: append([]byte(nil), private.raw...), token: token,
+		})
+	}
+	return packaged.receipt, objects, nil
+}
+
+func verifyRuntimeBindingCredentialBinding(data map[string]any, expectedDigest, expectedAuthority, expectedCA string) error {
+	bindingEncoded, ok := data["binding.json"].(string)
+	if !ok {
+		return errors.New("runtime binding workload credential binding is missing")
+	}
+	bindingRaw, err := base64.StdEncoding.DecodeString(bindingEncoded)
+	if err != nil {
+		return errors.New("runtime binding workload credential binding encoding is invalid")
+	}
+	var binding WorkloadAuthorityBinding
+	if err := jsonstrict.Decode(bindingRaw, &binding); err != nil {
+		return errors.New("runtime binding workload credential binding is invalid")
+	}
+	bindingDigest, err := WorkloadAuthorityBindingDigest(binding)
+	if err != nil || bindingDigest != expectedDigest || digest.SHA256([]byte(binding.TargetClusterUID)) != expectedAuthority || binding.CABundleDigest != expectedCA {
+		return errors.New("runtime binding workload credential binding identity changed")
+	}
+	return nil
+}

--- a/internal/runner/runtime_binding_stage_install_material_test.go
+++ b/internal/runner/runtime_binding_stage_install_material_test.go
@@ -1,0 +1,53 @@
+package runner
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+func TestPrepareRuntimeBindingStageInstallationRecoversExactPublicObjects(t *testing.T) {
+	stage, _, _, _ := runtimeBindingStageLaunchFixture(t)
+	plan, objects, err := prepareRuntimeBindingStageInstallation(stage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(objects) != 3 || len(plan.Creates) != 3 {
+		t.Fatalf("unexpected public object count: %d %d", len(objects), len(plan.Creates))
+	}
+	for index, object := range objects {
+		if object.plan != plan.Creates[index] || digest.SHA256(object.raw) != plan.Creates[index].ObjectDigest {
+			t.Fatalf("public install object %d differs", index)
+		}
+	}
+}
+
+func TestPrepareRuntimeBindingStageCredentialInstallationRecoversPrivateSecrets(t *testing.T) {
+	_, credentials, _, tokens := runtimeBindingStageLaunchFixture(t)
+	receipt, objects, err := prepareRuntimeBindingStageCredentialInstallation(credentials)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if receipt.PackageDigest != credentials.receipt.PackageDigest || len(objects) != 3 {
+		t.Fatalf("unexpected private material receipt: %#v objects=%d", receipt, len(objects))
+	}
+	wantRoles := []string{"ledger-writer", "persistence-writer", "workload-observer"}
+	for index, object := range objects {
+		if object.order != index+4 || object.role != wantRoles[index] || object.name != receipt.Credentials[index].Name || object.objectDigest != receipt.Credentials[index].ObjectDigest || digest.SHA256(object.raw) != object.objectDigest || !bytes.Equal(object.token, tokens[index]) {
+			t.Fatalf("private install object %d differs: %#v", index, object)
+		}
+	}
+}
+
+func TestPrepareRuntimeBindingStageInstallMaterialFailsClosedOnTamper(t *testing.T) {
+	stage, credentials, _, _ := runtimeBindingStageLaunchFixture(t)
+	stage.raw = append(stage.raw, '\n')
+	if _, _, err := prepareRuntimeBindingStageInstallation(stage); err == nil {
+		t.Fatal("changed public material was recovered")
+	}
+	credentials.objects[1].raw = append(credentials.objects[1].raw, '\n')
+	if _, _, err := prepareRuntimeBindingStageCredentialInstallation(credentials); err == nil {
+		t.Fatal("changed private material was recovered")
+	}
+}


### PR DESCRIPTION
## Summary
- recover the exact public stage objects from the verified package
- recover the three private immutable credential Secrets without exposing their bytes
- revalidate labels, authority, expiry, CA, data-key inventory and workload binding correlation

## Safety
- offline material recovery only
- no Kubernetes contact or mutation
- fail closed on any byte or semantic mismatch

## Verification
- `go test -ldflags=-linkmode=external ./...`
- `go vet ./...`
- `go test -race -ldflags=-linkmode=external ./internal/runner`