### PR TITLE
feat(runner): prepare runtime binding launch candidate (OK-147)

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -2373,8 +2373,19 @@ a workload binding; the workload Secret must carry the exact binding and CA
 already correlated by the stage package. Any changed byte fails closed before
 material can reach an installer.
 
-No public API exposes these recovered bytes. An expiry-bound launch candidate,
-bounded installation and execution remain later checkpoints.
+No public API exposes these recovered bytes.
+
+The redaction-safe `ok147-runtime-binding-stage-launch-candidate/v1` now binds
+the seven-object launch plan to one normalized management API destination, CA
+identity and independently evidenced installer-token identity. It never reads
+the installer token. Its validity ends fifteen minutes before the first of the
+three Job credentials expires, so a later launcher cannot begin without the
+minimum credential lifetime still available.
+
+The candidate contains endpoint, CA, plan, package, credential and runtime
+digests plus exact preparation and expiry times, but no endpoint, token,
+credential subject or object body. It remains `mutationAllowed: false`.
+Bounded installation and execution remain later checkpoints.
 
 ## Bounded convergence observation polling
 

--- a/internal/runner/runtime_binding_stage_launch_candidate.go
+++ b/internal/runner/runtime_binding_stage_launch_candidate.go
@@ -1,0 +1,171 @@
+package runner
+
+import (
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+const RuntimeBindingStageLaunchCandidateFormat = "ok147-runtime-binding-stage-launch-candidate/v1"
+
+type RuntimeBindingStageLaunchCandidateReceipt struct {
+	Format                            string `json:"format"`
+	State                             string `json:"state"`
+	StageID                           string `json:"stageId"`
+	Authority                         string `json:"authority"`
+	StagePackageDigest                string `json:"stagePackageDigest"`
+	CredentialPackageDigest           string `json:"credentialPackageDigest"`
+	RuntimeManifestDigest             string `json:"runtimeManifestDigest"`
+	LaunchPlanDigest                  string `json:"launchPlanDigest"`
+	AuthorityEndpointDigest           string `json:"authorityEndpointDigest"`
+	CABundleDigest                    string `json:"caBundleDigest"`
+	InstallerCredentialBindingDigest  string `json:"installerCredentialBindingDigest"`
+	InstallerCredentialEvidenceDigest string `json:"installerCredentialEvidenceDigest"`
+	PreparedAt                        string `json:"preparedAt"`
+	ValidUntil                        string `json:"validUntil"`
+	CandidateDigest                   string `json:"candidateDigest"`
+	MutationAllowed                   bool   `json:"mutationAllowed"`
+}
+
+type runtimeBindingStageLaunchCandidateIdentity struct {
+	StageID                           string `json:"stageId"`
+	Authority                         string `json:"authority"`
+	StagePackageDigest                string `json:"stagePackageDigest"`
+	CredentialPackageDigest           string `json:"credentialPackageDigest"`
+	RuntimeManifestDigest             string `json:"runtimeManifestDigest"`
+	LaunchPlanDigest                  string `json:"launchPlanDigest"`
+	AuthorityEndpointDigest           string `json:"authorityEndpointDigest"`
+	CABundleDigest                    string `json:"caBundleDigest"`
+	InstallerCredentialBindingDigest  string `json:"installerCredentialBindingDigest"`
+	InstallerCredentialEvidenceDigest string `json:"installerCredentialEvidenceDigest"`
+	PreparedAt                        string `json:"preparedAt"`
+	ValidUntil                        string `json:"validUntil"`
+}
+
+// VerifiedRuntimeBindingStageLaunchCandidate retains the exact API endpoint
+// and installer token identity outside its redaction-safe receipt.
+type VerifiedRuntimeBindingStageLaunchCandidate struct {
+	receipt              RuntimeBindingStageLaunchCandidateReceipt
+	authorityEndpoint    string
+	installerTokenDigest string
+	verified             bool
+}
+
+// PrepareRuntimeBindingStageLaunchCandidate binds the coherent launch plan to
+// one API, CA and evidenced installer credential without reading a credential
+// or performing an API request.
+func PrepareRuntimeBindingStageLaunchCandidate(config SubmissionStageLaunchCandidateConfig, packaged VerifiedRuntimeBindingStagePackage, credentials VerifiedRuntimeBindingStageCredentialPackage, runtime VerifiedRuntimeBindingStageRuntimePrerequisite) (VerifiedRuntimeBindingStageLaunchCandidate, error) {
+	plan, err := PlanRuntimeBindingStageLaunch(packaged, credentials, runtime)
+	if err != nil {
+		return VerifiedRuntimeBindingStageLaunchCandidate{}, err
+	}
+	if err := verifyRuntimeBindingStageCredentialPackage(credentials); err != nil {
+		return VerifiedRuntimeBindingStageLaunchCandidate{}, err
+	}
+	endpoint, err := normalizeSubmissionStageLaunchEndpoint(config.AuthorityEndpoint)
+	if err != nil {
+		return VerifiedRuntimeBindingStageLaunchCandidate{}, err
+	}
+	if !stageReceiptPrefixDigestPattern.MatchString(config.CABundleDigest) || !stageReceiptPrefixDigestPattern.MatchString(config.InstallerTokenDigest) || !stageReceiptPrefixDigestPattern.MatchString(config.InstallerCredentialEvidenceDigest) {
+		return VerifiedRuntimeBindingStageLaunchCandidate{}, errors.New("runtime binding launch candidate credential identities are invalid")
+	}
+	if config.PreparedAt.IsZero() || !config.PreparedAt.Equal(config.PreparedAt.Truncate(time.Second)) {
+		return VerifiedRuntimeBindingStageLaunchCandidate{}, errors.New("runtime binding launch candidate preparation time is required")
+	}
+	materializedAt, err := time.Parse(time.RFC3339, credentials.receipt.MaterializedAt)
+	if err != nil || config.PreparedAt.Before(materializedAt) {
+		return VerifiedRuntimeBindingStageLaunchCandidate{}, errors.New("runtime binding launch candidate predates credential materialization")
+	}
+	validUntil := time.Time{}
+	for _, credential := range credentials.receipt.Credentials {
+		expiresAt, err := time.Parse(time.RFC3339, credential.ExpiresAt)
+		if err != nil {
+			return VerifiedRuntimeBindingStageLaunchCandidate{}, errors.New("runtime binding credential expiration is invalid")
+		}
+		candidate := expiresAt.Add(-minimumStageCredentialRemaining)
+		if validUntil.IsZero() || candidate.Before(validUntil) {
+			validUntil = candidate
+		}
+	}
+	if validUntil.IsZero() || config.PreparedAt.After(validUntil) {
+		return VerifiedRuntimeBindingStageLaunchCandidate{}, errors.New("runtime binding credentials cannot retain minimum lifetime")
+	}
+	planRaw, err := json.Marshal(plan)
+	if err != nil {
+		return VerifiedRuntimeBindingStageLaunchCandidate{}, errors.New("encode runtime binding launch plan identity")
+	}
+	credentialBindingRaw, err := json.Marshal(submissionStageInstallerCredentialIdentity{TokenDigest: config.InstallerTokenDigest, EvidenceDigest: config.InstallerCredentialEvidenceDigest})
+	if err != nil {
+		return VerifiedRuntimeBindingStageLaunchCandidate{}, errors.New("encode runtime binding installer credential identity")
+	}
+	identity := runtimeBindingStageLaunchCandidateIdentity{
+		StageID: plan.StageID, Authority: plan.Authority, StagePackageDigest: plan.StagePackageDigest,
+		CredentialPackageDigest: plan.CredentialPackageDigest, RuntimeManifestDigest: plan.RuntimeManifestDigest,
+		LaunchPlanDigest: digest.SHA256(planRaw), AuthorityEndpointDigest: digest.SHA256([]byte(endpoint)),
+		CABundleDigest: config.CABundleDigest, InstallerCredentialBindingDigest: digest.SHA256(credentialBindingRaw),
+		InstallerCredentialEvidenceDigest: config.InstallerCredentialEvidenceDigest,
+		PreparedAt:                        config.PreparedAt.UTC().Format(time.RFC3339), ValidUntil: validUntil.UTC().Format(time.RFC3339),
+	}
+	identityRaw, err := json.Marshal(identity)
+	if err != nil {
+		return VerifiedRuntimeBindingStageLaunchCandidate{}, errors.New("encode runtime binding launch candidate identity")
+	}
+	receipt := RuntimeBindingStageLaunchCandidateReceipt{
+		Format: RuntimeBindingStageLaunchCandidateFormat, State: "PREPARED", StageID: identity.StageID, Authority: identity.Authority,
+		StagePackageDigest: identity.StagePackageDigest, CredentialPackageDigest: identity.CredentialPackageDigest,
+		RuntimeManifestDigest: identity.RuntimeManifestDigest, LaunchPlanDigest: identity.LaunchPlanDigest,
+		AuthorityEndpointDigest: identity.AuthorityEndpointDigest, CABundleDigest: identity.CABundleDigest,
+		InstallerCredentialBindingDigest: identity.InstallerCredentialBindingDigest, InstallerCredentialEvidenceDigest: identity.InstallerCredentialEvidenceDigest,
+		PreparedAt: identity.PreparedAt, ValidUntil: identity.ValidUntil, CandidateDigest: digest.SHA256(identityRaw), MutationAllowed: false,
+	}
+	return VerifiedRuntimeBindingStageLaunchCandidate{receipt: receipt, authorityEndpoint: endpoint, installerTokenDigest: config.InstallerTokenDigest, verified: true}, nil
+}
+
+func (candidate VerifiedRuntimeBindingStageLaunchCandidate) Receipt() (RuntimeBindingStageLaunchCandidateReceipt, error) {
+	if err := verifyRuntimeBindingStageLaunchCandidate(candidate); err != nil {
+		return RuntimeBindingStageLaunchCandidateReceipt{}, err
+	}
+	return candidate.receipt, nil
+}
+
+func verifyRuntimeBindingStageLaunchCandidate(candidate VerifiedRuntimeBindingStageLaunchCandidate) error {
+	if !candidate.verified || candidate.receipt.Format != RuntimeBindingStageLaunchCandidateFormat || candidate.receipt.State != "PREPARED" || candidate.receipt.StageID != "runtime-binding" || candidate.receipt.Authority == "" || candidate.receipt.MutationAllowed || candidate.authorityEndpoint == "" || !stageReceiptPrefixDigestPattern.MatchString(candidate.installerTokenDigest) {
+		return errors.New("runtime binding launch candidate was not produced by verification")
+	}
+	for _, value := range []string{
+		candidate.receipt.StagePackageDigest, candidate.receipt.CredentialPackageDigest, candidate.receipt.RuntimeManifestDigest,
+		candidate.receipt.LaunchPlanDigest, candidate.receipt.AuthorityEndpointDigest, candidate.receipt.CABundleDigest,
+		candidate.receipt.InstallerCredentialBindingDigest, candidate.receipt.InstallerCredentialEvidenceDigest, candidate.receipt.CandidateDigest,
+	} {
+		if !stageReceiptPrefixDigestPattern.MatchString(value) {
+			return errors.New("runtime binding launch candidate contains an invalid digest")
+		}
+	}
+	credentialBindingRaw, err := json.Marshal(submissionStageInstallerCredentialIdentity{TokenDigest: candidate.installerTokenDigest, EvidenceDigest: candidate.receipt.InstallerCredentialEvidenceDigest})
+	if err != nil || digest.SHA256(credentialBindingRaw) != candidate.receipt.InstallerCredentialBindingDigest {
+		return errors.New("runtime binding installer credential identity changed after verification")
+	}
+	identity := runtimeBindingStageLaunchCandidateIdentity{
+		StageID: candidate.receipt.StageID, Authority: candidate.receipt.Authority,
+		StagePackageDigest: candidate.receipt.StagePackageDigest, CredentialPackageDigest: candidate.receipt.CredentialPackageDigest,
+		RuntimeManifestDigest: candidate.receipt.RuntimeManifestDigest, LaunchPlanDigest: candidate.receipt.LaunchPlanDigest,
+		AuthorityEndpointDigest: candidate.receipt.AuthorityEndpointDigest, CABundleDigest: candidate.receipt.CABundleDigest,
+		InstallerCredentialBindingDigest: candidate.receipt.InstallerCredentialBindingDigest, InstallerCredentialEvidenceDigest: candidate.receipt.InstallerCredentialEvidenceDigest,
+		PreparedAt: candidate.receipt.PreparedAt, ValidUntil: candidate.receipt.ValidUntil,
+	}
+	raw, err := json.Marshal(identity)
+	if err != nil || digest.SHA256(raw) != candidate.receipt.CandidateDigest || digest.SHA256([]byte(candidate.authorityEndpoint)) != candidate.receipt.AuthorityEndpointDigest {
+		return errors.New("runtime binding launch candidate identity changed after verification")
+	}
+	preparedAt, err := time.Parse(time.RFC3339, candidate.receipt.PreparedAt)
+	if err != nil {
+		return errors.New("runtime binding launch candidate preparation time is invalid")
+	}
+	validUntil, err := time.Parse(time.RFC3339, candidate.receipt.ValidUntil)
+	if err != nil || validUntil.Before(preparedAt) {
+		return errors.New("runtime binding launch candidate validity is invalid")
+	}
+	return nil
+}

--- a/internal/runner/runtime_binding_stage_launch_candidate_test.go
+++ b/internal/runner/runtime_binding_stage_launch_candidate_test.go
@@ -1,0 +1,79 @@
+package runner
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+func TestPrepareRuntimeBindingStageLaunchCandidateBindsDestinationAndCredential(t *testing.T) {
+	stage, credentials, runtime, _ := runtimeBindingStageLaunchFixture(t)
+	config := submissionStageLaunchCandidateConfig()
+	candidate, err := PrepareRuntimeBindingStageLaunchCandidate(config, stage, credentials, runtime)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := candidate.Receipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	again, err := PrepareRuntimeBindingStageLaunchCandidate(config, stage, credentials, runtime)
+	if err != nil {
+		t.Fatal(err)
+	}
+	againReceipt, _ := again.Receipt()
+	if receipt.Format != RuntimeBindingStageLaunchCandidateFormat || receipt.State != "PREPARED" || receipt.StageID != "runtime-binding" || receipt.Authority != "ok-mgmt" || receipt.PreparedAt != "2026-08-16T12:01:00Z" || receipt.ValidUntil != "2026-08-16T12:15:00Z" || receipt.MutationAllowed || receipt.CandidateDigest != againReceipt.CandidateDigest {
+		t.Fatalf("unexpected runtime binding candidate: %#v", receipt)
+	}
+	public, err := json.Marshal(receipt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range []string{config.AuthorityEndpoint, config.InstallerTokenDigest, "installer-token-v1"} {
+		if bytes.Contains(public, []byte(forbidden)) {
+			t.Fatalf("candidate receipt exposed private input %q", forbidden)
+		}
+	}
+	changed := candidate
+	changed.receipt.ValidUntil = "2026-08-16T12:16:00Z"
+	if _, err := changed.Receipt(); err == nil {
+		t.Fatal("changed candidate receipt accepted")
+	}
+	changed = candidate
+	changed.installerTokenDigest = digest.SHA256([]byte("foreign-token"))
+	if _, err := changed.Receipt(); err == nil {
+		t.Fatal("changed private installer binding accepted")
+	}
+}
+
+func TestPrepareRuntimeBindingStageLaunchCandidateFailsClosed(t *testing.T) {
+	stage, credentials, runtime, _ := runtimeBindingStageLaunchFixture(t)
+	valid := submissionStageLaunchCandidateConfig()
+	for name, mutate := range map[string]func(*SubmissionStageLaunchCandidateConfig){
+		"DNS endpoint": func(config *SubmissionStageLaunchCandidateConfig) {
+			config.AuthorityEndpoint = "https://ok-mgmt.example:6443"
+		},
+		"HTTP endpoint": func(config *SubmissionStageLaunchCandidateConfig) {
+			config.AuthorityEndpoint = "http://192.0.2.10:6443"
+		},
+		"missing CA":       func(config *SubmissionStageLaunchCandidateConfig) { config.CABundleDigest = "" },
+		"missing evidence": func(config *SubmissionStageLaunchCandidateConfig) { config.InstallerCredentialEvidenceDigest = "" },
+		"fractional time": func(config *SubmissionStageLaunchCandidateConfig) {
+			config.PreparedAt = config.PreparedAt.Add(time.Nanosecond)
+		},
+		"expired credentials": func(config *SubmissionStageLaunchCandidateConfig) {
+			config.PreparedAt = time.Date(2026, 8, 16, 12, 15, 1, 0, time.UTC)
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			config := valid
+			mutate(&config)
+			if _, err := PrepareRuntimeBindingStageLaunchCandidate(config, stage, credentials, runtime); err == nil {
+				t.Fatal("invalid runtime binding launch candidate accepted")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- bind the seven-object launch plan to one management API, CA and evidenced installer-token identity
- derive candidate expiry from the earliest of the three Job credentials
- expose only redaction-safe digests and validity timestamps

## Safety
- offline candidate preparation only
- no credential read, Kubernetes contact or mutation
- candidate remains mutationAllowed=false

## Verification
- `go test -ldflags=-linkmode=external ./...`
- `go vet ./...`
- `go test -race -ldflags=-linkmode=external ./internal/runner`