### PR TITLE
feat(runner): seal runtime binding launch material (OK-147)

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -2385,7 +2385,17 @@ minimum credential lifetime still available.
 The candidate contains endpoint, CA, plan, package, credential and runtime
 digests plus exact preparation and expiry times, but no endpoint, token,
 credential subject or object body. It remains `mutationAllowed: false`.
-Bounded installation and execution remain later checkpoints.
+
+`ok147-runtime-binding-stage-launch-material/v1` now reconstructs the complete
+private launch input from bounded local sources: stage package, three
+credentials, tokenless runtime and launch candidate. It re-verifies their
+shared identities and retains their private bytes internally while exposing
+only package, plan, candidate and validity digests. Changed private material or
+a mismatched candidate invalidates the whole aggregate.
+
+The material has no method that performs an API request and remains
+`mutationAllowed: false`. Opening an installer credential, bounded installation
+and execution remain later checkpoints.
 
 ## Bounded convergence observation polling
 

--- a/internal/runner/runtime_binding_stage_credentials_test.go
+++ b/internal/runner/runtime_binding_stage_credentials_test.go
@@ -130,6 +130,11 @@ func TestBuildRuntimeBindingStageCredentialPackageFailsClosed(t *testing.T) {
 }
 
 func runtimeBindingCredentialConfig(t *testing.T) (RuntimeBindingStageCredentialPackageConfig, [][]byte) {
+	config, _, tokens := runtimeBindingCredentialInputs(t)
+	return config, tokens
+}
+
+func runtimeBindingCredentialInputs(t *testing.T) (RuntimeBindingStageCredentialPackageConfig, RuntimeBindingStagePackageConfig, [][]byte) {
 	t.Helper()
 	now := time.Date(2026, 8, 16, 12, 0, 0, 0, time.UTC)
 	issuedAt, expiresAt := now.Add(-time.Minute), now.Add(30*time.Minute)
@@ -194,5 +199,5 @@ func runtimeBindingCredentialConfig(t *testing.T) (RuntimeBindingStageCredential
 		LedgerWriter:      source("ok-mgmt", tokenPaths[0], subjects[0], "4", managementCAPath, tokens[0], managementCA),
 		PersistenceWriter: source("ok-mgmt", tokenPaths[1], subjects[1], "5", managementCAPath, tokens[1], managementCA),
 		WorkloadObserver:  source(digest.SHA256([]byte(binding.TargetClusterUID)), tokenPaths[2], subjects[2], "6", workloadCAPath, tokens[2], workloadCA),
-	}, tokens
+	}, packageConfig, tokens
 }

--- a/internal/runner/runtime_binding_stage_launch_material.go
+++ b/internal/runner/runtime_binding_stage_launch_material.go
@@ -1,0 +1,118 @@
+package runner
+
+import (
+	"errors"
+	"time"
+)
+
+const RuntimeBindingStageLaunchMaterialFormat = "ok147-runtime-binding-stage-launch-material/v1"
+
+type RuntimeBindingStageLaunchMaterialConfig struct {
+	Package               RuntimeBindingStagePackageConfig
+	MaterializationTime   time.Time
+	LedgerWriter          SubmissionStageCredentialSource
+	PersistenceWriter     SubmissionStageCredentialSource
+	WorkloadObserver      SubmissionStageCredentialSource
+	RuntimeManifest       []byte
+	RuntimeManifestDigest string
+	Candidate             SubmissionStageLaunchCandidateConfig
+}
+
+type RuntimeBindingStageLaunchMaterialReceipt struct {
+	Format                  string `json:"format"`
+	State                   string `json:"state"`
+	StageID                 string `json:"stageId"`
+	Authority               string `json:"authority"`
+	StagePackageDigest      string `json:"stagePackageDigest"`
+	CredentialPackageDigest string `json:"credentialPackageDigest"`
+	RuntimeManifestDigest   string `json:"runtimeManifestDigest"`
+	LaunchPlanDigest        string `json:"launchPlanDigest"`
+	CandidateDigest         string `json:"candidateDigest"`
+	ValidUntil              string `json:"validUntil"`
+	MutationAllowed         bool   `json:"mutationAllowed"`
+}
+
+// VerifiedRuntimeBindingStageLaunchMaterial retains every exact private
+// object, credential and candidate needed by a later launcher while exposing
+// only redaction-safe receipts.
+type VerifiedRuntimeBindingStageLaunchMaterial struct {
+	packaged    VerifiedRuntimeBindingStagePackage
+	credentials VerifiedRuntimeBindingStageCredentialPackage
+	runtime     VerifiedRuntimeBindingStageRuntimePrerequisite
+	candidate   VerifiedRuntimeBindingStageLaunchCandidate
+	receipt     RuntimeBindingStageLaunchMaterialReceipt
+	verified    bool
+}
+
+// BuildRuntimeBindingStageLaunchMaterial reconstructs and re-verifies the
+// complete private launch input from bounded local sources. It performs no API
+// request and grants no launch authority.
+func BuildRuntimeBindingStageLaunchMaterial(config RuntimeBindingStageLaunchMaterialConfig) (VerifiedRuntimeBindingStageLaunchMaterial, error) {
+	packaged, err := BuildRuntimeBindingStagePackage(config.Package)
+	if err != nil {
+		return VerifiedRuntimeBindingStageLaunchMaterial{}, err
+	}
+	credentials, err := BuildRuntimeBindingStageCredentialPackage(RuntimeBindingStageCredentialPackageConfig{
+		Package: packaged, MaterializationTime: config.MaterializationTime,
+		WorkloadBindingPath: config.Package.WorkloadBindingPath,
+		LedgerWriter:        config.LedgerWriter, PersistenceWriter: config.PersistenceWriter, WorkloadObserver: config.WorkloadObserver,
+	})
+	if err != nil {
+		return VerifiedRuntimeBindingStageLaunchMaterial{}, err
+	}
+	runtime, err := BuildRuntimeBindingStageRuntimePrerequisite(packaged, config.RuntimeManifest, config.RuntimeManifestDigest)
+	if err != nil {
+		return VerifiedRuntimeBindingStageLaunchMaterial{}, err
+	}
+	candidate, err := PrepareRuntimeBindingStageLaunchCandidate(config.Candidate, packaged, credentials, runtime)
+	if err != nil {
+		return VerifiedRuntimeBindingStageLaunchMaterial{}, err
+	}
+	candidateReceipt, err := candidate.Receipt()
+	if err != nil {
+		return VerifiedRuntimeBindingStageLaunchMaterial{}, err
+	}
+	receipt := RuntimeBindingStageLaunchMaterialReceipt{
+		Format: RuntimeBindingStageLaunchMaterialFormat, State: "VERIFIED", StageID: candidateReceipt.StageID,
+		Authority: candidateReceipt.Authority, StagePackageDigest: candidateReceipt.StagePackageDigest,
+		CredentialPackageDigest: candidateReceipt.CredentialPackageDigest, RuntimeManifestDigest: candidateReceipt.RuntimeManifestDigest,
+		LaunchPlanDigest: candidateReceipt.LaunchPlanDigest, CandidateDigest: candidateReceipt.CandidateDigest,
+		ValidUntil: candidateReceipt.ValidUntil, MutationAllowed: false,
+	}
+	return VerifiedRuntimeBindingStageLaunchMaterial{
+		packaged: packaged, credentials: credentials, runtime: runtime, candidate: candidate,
+		receipt: receipt, verified: true,
+	}, nil
+}
+
+func (material VerifiedRuntimeBindingStageLaunchMaterial) Receipt() (RuntimeBindingStageLaunchMaterialReceipt, error) {
+	if err := verifyRuntimeBindingStageLaunchMaterial(material); err != nil {
+		return RuntimeBindingStageLaunchMaterialReceipt{}, err
+	}
+	return material.receipt, nil
+}
+
+func (material VerifiedRuntimeBindingStageLaunchMaterial) CandidateReceipt() (RuntimeBindingStageLaunchCandidateReceipt, error) {
+	if err := verifyRuntimeBindingStageLaunchMaterial(material); err != nil {
+		return RuntimeBindingStageLaunchCandidateReceipt{}, err
+	}
+	return material.candidate.Receipt()
+}
+
+func verifyRuntimeBindingStageLaunchMaterial(material VerifiedRuntimeBindingStageLaunchMaterial) error {
+	if !material.verified || material.receipt.Format != RuntimeBindingStageLaunchMaterialFormat || material.receipt.State != "VERIFIED" || material.receipt.MutationAllowed {
+		return errors.New("runtime binding launch material was not produced by verification")
+	}
+	plan, err := PlanRuntimeBindingStageLaunch(material.packaged, material.credentials, material.runtime)
+	if err != nil {
+		return err
+	}
+	candidateReceipt, err := material.candidate.Receipt()
+	if err != nil {
+		return err
+	}
+	if material.receipt.StageID != plan.StageID || material.receipt.Authority != plan.Authority || material.receipt.StagePackageDigest != plan.StagePackageDigest || material.receipt.CredentialPackageDigest != plan.CredentialPackageDigest || material.receipt.RuntimeManifestDigest != plan.RuntimeManifestDigest || material.receipt.StageID != candidateReceipt.StageID || material.receipt.Authority != candidateReceipt.Authority || material.receipt.StagePackageDigest != candidateReceipt.StagePackageDigest || material.receipt.CredentialPackageDigest != candidateReceipt.CredentialPackageDigest || material.receipt.RuntimeManifestDigest != candidateReceipt.RuntimeManifestDigest || material.receipt.LaunchPlanDigest != candidateReceipt.LaunchPlanDigest || material.receipt.CandidateDigest != candidateReceipt.CandidateDigest || material.receipt.ValidUntil != candidateReceipt.ValidUntil {
+		return errors.New("runtime binding launch material identity changed after verification")
+	}
+	return nil
+}

--- a/internal/runner/runtime_binding_stage_launch_material_test.go
+++ b/internal/runner/runtime_binding_stage_launch_material_test.go
@@ -1,0 +1,87 @@
+package runner
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+func TestBuildRuntimeBindingStageLaunchMaterialSealsPrivateComponents(t *testing.T) {
+	config, tokens := runtimeBindingStageLaunchMaterialConfig(t)
+	material, err := BuildRuntimeBindingStageLaunchMaterial(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := material.Receipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	candidate, err := material.CandidateReceipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if receipt.Format != RuntimeBindingStageLaunchMaterialFormat || receipt.State != "VERIFIED" || receipt.StageID != "runtime-binding" || receipt.Authority != "ok-mgmt" || receipt.StagePackageDigest != candidate.StagePackageDigest || receipt.CandidateDigest != candidate.CandidateDigest || receipt.ValidUntil != candidate.ValidUntil || receipt.MutationAllowed {
+		t.Fatalf("unexpected runtime binding launch material: %#v", receipt)
+	}
+	public, err := json.Marshal(receipt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range append(tokens, material.packaged.raw, material.credentials.objects[0].raw, material.credentials.objects[1].raw, material.credentials.objects[2].raw, material.runtime.raw, []byte(config.Candidate.AuthorityEndpoint), []byte(config.Candidate.InstallerTokenDigest)) {
+		if bytes.Contains(public, forbidden) {
+			t.Fatal("runtime binding launch material receipt exposed private source content")
+		}
+	}
+	changed := material
+	changed.receipt.CandidateDigest = digest.SHA256([]byte("foreign"))
+	if _, err := changed.Receipt(); err == nil {
+		t.Fatal("changed runtime binding launch material identity accepted")
+	}
+	changed = material
+	changed.credentials.objects[2].raw = append(changed.credentials.objects[2].raw, '\n')
+	if _, err := changed.Receipt(); err == nil {
+		t.Fatal("changed private workload credential accepted")
+	}
+}
+
+func TestBuildRuntimeBindingStageLaunchMaterialFailsClosed(t *testing.T) {
+	valid, _ := runtimeBindingStageLaunchMaterialConfig(t)
+	for name, mutate := range map[string]func(*RuntimeBindingStageLaunchMaterialConfig){
+		"wrong runtime digest": func(config *RuntimeBindingStageLaunchMaterialConfig) {
+			config.RuntimeManifestDigest = digest.SHA256([]byte("foreign"))
+		},
+		"foreign workload token": func(config *RuntimeBindingStageLaunchMaterialConfig) {
+			config.WorkloadObserver.AuthorityIdentity = digest.SHA256([]byte("foreign"))
+		},
+		"expired candidate": func(config *RuntimeBindingStageLaunchMaterialConfig) {
+			config.Candidate.PreparedAt = config.MaterializationTime.Add(16 * time.Minute)
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			config := valid
+			mutate(&config)
+			if _, err := BuildRuntimeBindingStageLaunchMaterial(config); err == nil {
+				t.Fatal("invalid runtime binding launch material accepted")
+			}
+		})
+	}
+	if _, err := (VerifiedRuntimeBindingStageLaunchMaterial{}).Receipt(); err == nil {
+		t.Fatal("unverified runtime binding launch material receipt exposed")
+	}
+}
+
+func runtimeBindingStageLaunchMaterialConfig(t *testing.T) (RuntimeBindingStageLaunchMaterialConfig, [][]byte) {
+	t.Helper()
+	credentialConfig, packageConfig, tokens := runtimeBindingCredentialInputs(t)
+	manifest := submissionStageRuntimeManifest(t)
+	return RuntimeBindingStageLaunchMaterialConfig{
+		Package: packageConfig, MaterializationTime: credentialConfig.MaterializationTime,
+		LedgerWriter: credentialConfig.LedgerWriter, PersistenceWriter: credentialConfig.PersistenceWriter,
+		WorkloadObserver: credentialConfig.WorkloadObserver,
+		RuntimeManifest:  manifest, RuntimeManifestDigest: digest.SHA256(manifest),
+		Candidate: submissionStageLaunchCandidateConfig(),
+	}, tokens
+}


### PR DESCRIPTION
## Summary
- rebuild and reverify package, credentials, tokenless runtime and candidate from bounded local sources
- retain all exact private bytes internally under one coherent identity
- expose only redaction-safe package, plan, candidate and validity digests

## Safety
- offline aggregation only
- no API client, credential opening, Kubernetes contact or mutation
- fail closed on any changed private component

## Verification
- `go test -ldflags=-linkmode=external ./...`
- `go vet ./...`
- `go test -race -ldflags=-linkmode=external ./internal/runner`