### PR TITLE
feat(runner): open runtime binding launch material (OK-147)

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -2394,8 +2394,18 @@ only package, plan, candidate and validity digests. Changed private material or
 a mismatched candidate invalidates the whole aggregate.
 
 The material has no method that performs an API request and remains
-`mutationAllowed: false`. Opening an installer credential, bounded installation
-and execution remain later checkpoints.
+`mutationAllowed: false`.
+
+The first private open boundary now validates one exact candidate digest,
+management authority, normalized API endpoint, CA and installer-token digest.
+It also rejects an installer token reused as any of the three Job credentials,
+rechecks all public and private install material and fixes redirect and timeout
+behavior on the retained client. Its public
+`ok147-runtime-binding-stage-launch-open-receipt/v1` exposes only stage,
+authority, candidate and validity identities.
+
+Opening performs no HTTP request and still grants no mutation authority. The
+single-use preflight/create execution remains a later checkpoint.
 
 ## Bounded convergence observation polling
 

--- a/internal/runner/runtime_binding_stage_launch_open.go
+++ b/internal/runner/runtime_binding_stage_launch_open.go
@@ -1,0 +1,116 @@
+package runner
+
+import (
+	"crypto/subtle"
+	"errors"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+const RuntimeBindingStageLaunchOpenReceiptFormat = "ok147-runtime-binding-stage-launch-open-receipt/v1"
+
+type RuntimeBindingStageLaunchOpenConfig struct {
+	Authority               KubernetesAuthorityConfig
+	Clock                   func() time.Time
+	ExpectedCandidateDigest string
+}
+
+type RuntimeBindingStageLaunchOpenReceipt struct {
+	Format          string `json:"format"`
+	State           string `json:"state"`
+	StageID         string `json:"stageId"`
+	Authority       string `json:"authority"`
+	CandidateDigest string `json:"candidateDigest"`
+	ValidUntil      string `json:"validUntil"`
+	MutationAllowed bool   `json:"mutationAllowed"`
+}
+
+// OpenedRuntimeBindingStageLaunch retains the exact private launch material,
+// bounded installer credential and API client for a later single-use launcher.
+// It exposes only a redaction-safe receipt and performs no API request.
+type OpenedRuntimeBindingStageLaunch struct {
+	material   VerifiedRuntimeBindingStageLaunchMaterial
+	endpoint   *url.URL
+	token      string
+	client     *http.Client
+	clock      func() time.Time
+	validUntil time.Time
+	receipt    RuntimeBindingStageLaunchOpenReceipt
+	verified   bool
+}
+
+// Open validates and consumes local installer material against the exact
+// prepared candidate. It does not contact Kubernetes or authorize mutation.
+func (material VerifiedRuntimeBindingStageLaunchMaterial) Open(config RuntimeBindingStageLaunchOpenConfig) (*OpenedRuntimeBindingStageLaunch, error) {
+	if err := verifyRuntimeBindingStageLaunchMaterial(material); err != nil {
+		return nil, err
+	}
+	candidate, err := material.candidate.Receipt()
+	if err != nil {
+		return nil, err
+	}
+	if config.ExpectedCandidateDigest == "" || config.ExpectedCandidateDigest != candidate.CandidateDigest {
+		return nil, errors.New("runtime binding launch open requires the exact candidate digest")
+	}
+	if config.Authority.AuthorityIdentity == "" || config.Authority.AuthorityIdentity != candidate.Authority || config.Clock == nil {
+		return nil, errors.New("runtime binding launch open authority or clock is invalid")
+	}
+	endpoint, err := normalizeSubmissionStageLaunchEndpoint(config.Authority.Endpoint)
+	if err != nil || endpoint != material.candidate.authorityEndpoint || config.Authority.CABundleDigest != candidate.CABundleDigest {
+		return nil, errors.New("runtime binding launch open destination differs from exact candidate")
+	}
+	token, ca, client, err := openBoundedKubernetesMaterial(config.Authority.TokenFile, config.Authority.CAFile)
+	if err != nil {
+		return nil, errors.New("open bounded runtime binding installer credential")
+	}
+	if digest.SHA256(ca) != config.Authority.CABundleDigest || digest.SHA256([]byte(token)) != material.candidate.installerTokenDigest {
+		return nil, errors.New("runtime binding installer credential differs from bound identity")
+	}
+	_, secrets, err := prepareRuntimeBindingStageCredentialInstallation(material.credentials)
+	if err != nil {
+		return nil, err
+	}
+	for _, secret := range secrets {
+		if len(token) == len(secret.token) && subtle.ConstantTimeCompare([]byte(token), secret.token) == 1 {
+			return nil, errors.New("runtime binding installer and Job credentials must be distinct")
+		}
+	}
+	if _, _, err := prepareRuntimeBindingStageInstallation(material.packaged); err != nil {
+		return nil, err
+	}
+	validUntil, err := time.Parse(time.RFC3339, candidate.ValidUntil)
+	if err != nil {
+		return nil, errors.New("runtime binding launch candidate validity is invalid")
+	}
+	parsed, err := url.Parse(endpoint)
+	if err != nil {
+		return nil, errors.New("runtime binding launch endpoint is invalid")
+	}
+	clientCopy := *client
+	clientCopy.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+	if clientCopy.Timeout == 0 {
+		clientCopy.Timeout = 15 * time.Second
+	}
+	receipt := RuntimeBindingStageLaunchOpenReceipt{
+		Format: RuntimeBindingStageLaunchOpenReceiptFormat, State: "OPENED", StageID: candidate.StageID,
+		Authority: candidate.Authority, CandidateDigest: candidate.CandidateDigest,
+		ValidUntil: candidate.ValidUntil, MutationAllowed: false,
+	}
+	return &OpenedRuntimeBindingStageLaunch{
+		material: material, endpoint: parsed, token: token, client: &clientCopy, clock: config.Clock,
+		validUntil: validUntil, receipt: receipt, verified: true,
+	}, nil
+}
+
+func (opened *OpenedRuntimeBindingStageLaunch) Receipt() (RuntimeBindingStageLaunchOpenReceipt, error) {
+	if opened == nil || !opened.verified || opened.client == nil || opened.clock == nil || opened.endpoint == nil || opened.token == "" || opened.receipt.Format != RuntimeBindingStageLaunchOpenReceiptFormat || opened.receipt.State != "OPENED" || opened.receipt.MutationAllowed || opened.receipt.CandidateDigest != opened.material.receipt.CandidateDigest || opened.receipt.ValidUntil != opened.material.receipt.ValidUntil || opened.validUntil.IsZero() {
+		return RuntimeBindingStageLaunchOpenReceipt{}, errors.New("runtime binding launch was not opened by verification")
+	}
+	if err := verifyRuntimeBindingStageLaunchMaterial(opened.material); err != nil {
+		return RuntimeBindingStageLaunchOpenReceipt{}, err
+	}
+	return opened.receipt, nil
+}

--- a/internal/runner/runtime_binding_stage_launch_open_test.go
+++ b/internal/runner/runtime_binding_stage_launch_open_test.go
@@ -1,0 +1,127 @@
+package runner
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+func TestOpenRuntimeBindingStageLaunchConsumesExactInstallerMaterialOffline(t *testing.T) {
+	material, config, installerToken := runtimeBindingOpenedLaunchFixture(t)
+	opened, err := material.Open(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := opened.Receipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if receipt.Format != RuntimeBindingStageLaunchOpenReceiptFormat || receipt.State != "OPENED" || receipt.StageID != "runtime-binding" || receipt.Authority != "ok-mgmt" || receipt.CandidateDigest != config.ExpectedCandidateDigest || receipt.ValidUntil != material.receipt.ValidUntil || receipt.MutationAllowed {
+		t.Fatalf("unexpected runtime binding open receipt: %#v", receipt)
+	}
+	public, err := json.Marshal(receipt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range [][]byte{installerToken, []byte(config.Authority.Endpoint), material.credentials.objects[0].raw, material.credentials.objects[1].raw, material.credentials.objects[2].raw} {
+		if bytes.Contains(public, forbidden) {
+			t.Fatal("runtime binding open receipt exposed private material")
+		}
+	}
+}
+
+func TestOpenRuntimeBindingStageLaunchFailsClosed(t *testing.T) {
+	material, valid, installerToken := runtimeBindingOpenedLaunchFixture(t)
+	for name, mutate := range map[string]func(*RuntimeBindingStageLaunchOpenConfig){
+		"foreign candidate": func(config *RuntimeBindingStageLaunchOpenConfig) {
+			config.ExpectedCandidateDigest = digest.SHA256([]byte("foreign"))
+		},
+		"foreign authority": func(config *RuntimeBindingStageLaunchOpenConfig) {
+			config.Authority.AuthorityIdentity = "ok-infra"
+		},
+		"foreign endpoint": func(config *RuntimeBindingStageLaunchOpenConfig) {
+			config.Authority.Endpoint = "https://192.0.2.11:6443"
+		},
+		"missing clock": func(config *RuntimeBindingStageLaunchOpenConfig) { config.Clock = nil },
+	} {
+		t.Run(name, func(t *testing.T) {
+			config := valid
+			mutate(&config)
+			if _, err := material.Open(config); err == nil {
+				t.Fatal("unsafe runtime binding launch material opened")
+			}
+		})
+	}
+	shared := valid
+	_, secrets, err := prepareRuntimeBindingStageCredentialInstallation(material.credentials)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(shared.Authority.TokenFile, secrets[0].token, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	sharedMaterial := material
+	sharedMaterial.candidate.installerTokenDigest = digest.SHA256(secrets[0].token)
+	sharedMaterial.candidate.receipt.InstallerCredentialBindingDigest = installerCredentialBindingDigest(t, sharedMaterial.candidate.installerTokenDigest, sharedMaterial.candidate.receipt.InstallerCredentialEvidenceDigest)
+	sharedMaterial.candidate.receipt.CandidateDigest = runtimeBindingCandidateDigest(t, sharedMaterial.candidate.receipt)
+	sharedMaterial.receipt.CandidateDigest = sharedMaterial.candidate.receipt.CandidateDigest
+	shared.ExpectedCandidateDigest = sharedMaterial.receipt.CandidateDigest
+	if _, err := sharedMaterial.Open(shared); err == nil {
+		t.Fatal("shared installer and Job credential accepted")
+	}
+	_ = installerToken
+	if _, err := (*OpenedRuntimeBindingStageLaunch)(nil).Receipt(); err == nil {
+		t.Fatal("nil opened launch exposed a receipt")
+	}
+}
+
+func runtimeBindingOpenedLaunchFixture(t *testing.T) (VerifiedRuntimeBindingStageLaunchMaterial, RuntimeBindingStageLaunchOpenConfig, []byte) {
+	t.Helper()
+	launchConfig, _ := runtimeBindingStageLaunchMaterialConfig(t)
+	installerToken := []byte("runtime-binding-installer-token-v1")
+	ca := testCA(t)
+	launchConfig.Candidate.CABundleDigest = digest.SHA256(ca)
+	launchConfig.Candidate.InstallerTokenDigest = digest.SHA256(installerToken)
+	material, err := BuildRuntimeBindingStageLaunchMaterial(launchConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root := t.TempDir()
+	tokenPath, caPath := filepath.Join(root, "installer-token"), filepath.Join(root, "ca.crt")
+	if err := os.WriteFile(tokenPath, installerToken, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(caPath, ca, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return material, RuntimeBindingStageLaunchOpenConfig{
+		Authority: KubernetesAuthorityConfig{
+			Endpoint: launchConfig.Candidate.AuthorityEndpoint, AuthorityIdentity: "ok-mgmt",
+			TokenFile: tokenPath, CAFile: caPath, CABundleDigest: launchConfig.Candidate.CABundleDigest,
+		},
+		Clock:                   func() time.Time { return time.Date(2026, 8, 16, 12, 2, 0, 0, time.UTC) },
+		ExpectedCandidateDigest: material.receipt.CandidateDigest,
+	}, installerToken
+}
+
+func installerCredentialBindingDigest(t *testing.T, tokenDigest, evidenceDigest string) string {
+	t.Helper()
+	return digest.SHA256(mustJSON(t, submissionStageInstallerCredentialIdentity{TokenDigest: tokenDigest, EvidenceDigest: evidenceDigest}))
+}
+
+func runtimeBindingCandidateDigest(t *testing.T, receipt RuntimeBindingStageLaunchCandidateReceipt) string {
+	t.Helper()
+	return digest.SHA256(mustJSON(t, runtimeBindingStageLaunchCandidateIdentity{
+		StageID: receipt.StageID, Authority: receipt.Authority, StagePackageDigest: receipt.StagePackageDigest,
+		CredentialPackageDigest: receipt.CredentialPackageDigest, RuntimeManifestDigest: receipt.RuntimeManifestDigest,
+		LaunchPlanDigest: receipt.LaunchPlanDigest, AuthorityEndpointDigest: receipt.AuthorityEndpointDigest,
+		CABundleDigest: receipt.CABundleDigest, InstallerCredentialBindingDigest: receipt.InstallerCredentialBindingDigest,
+		InstallerCredentialEvidenceDigest: receipt.InstallerCredentialEvidenceDigest,
+		PreparedAt:                        receipt.PreparedAt, ValidUntil: receipt.ValidUntil,
+	}))
+}


### PR DESCRIPTION
## Summary
- open the exact installer authority only against the prepared candidate
- verify endpoint, CA, installer-token digest and separation from all Job credentials
- retain a bounded client and private material behind a redaction-safe open receipt

## Safety
- no HTTP request or Kubernetes mutation
- exact candidate digest required
- no installer token, endpoint, CA or object bytes in the receipt

## Verification
- `go test -ldflags=-linkmode=external ./...`
- `go vet ./...`
- `go test -race -ldflags=-linkmode=external ./internal/runner`