### PR TITLE
feat(runner): execute runtime binding launch (OK-147)

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -2405,7 +2405,23 @@ behavior on the retained client. Its public
 authority, candidate and validity identities.
 
 Opening performs no HTTP request and still grants no mutation authority. The
-single-use preflight/create execution remains a later checkpoint.
+opened material now exposes only one single-use `Launch` operation. It performs
+all seven exact-name GETs before the first possible POST. A completely exact
+existing set returns `ALREADY_LAUNCHED`; the shared exact runtime alone may
+preexist; every other mixed, foreign or unexpected response stops with zero
+writes.
+
+After a globally absent preflight, the create-only order is ServiceAccount,
+ConfigMap, NetworkPolicy, the three immutable Secrets and finally Job. Every
+response must contain the exact submitted fields and a bounded UID and resource
+version. A failure after the first POST returns
+`STOPPED_PARTIAL_OR_UNKNOWN`, preserves the successful prefix and offers no
+retry, update, patch, delete or cleanup path. Candidate expiry and credential
+remaining lifetime are checked locally before the first API request.
+
+This execution has been tested only against injected local fake Kubernetes
+clients. No DEV cluster was contacted and no public CLI launch command exists
+yet.
 
 ## Bounded convergence observation polling
 

--- a/internal/runner/runtime_binding_stage_launch_open.go
+++ b/internal/runner/runtime_binding_stage_launch_open.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 	"net/url"
+	"sync"
 	"time"
 
 	"github.com/openkubes/ok-cluster/internal/digest"
@@ -32,6 +33,8 @@ type RuntimeBindingStageLaunchOpenReceipt struct {
 // bounded installer credential and API client for a later single-use launcher.
 // It exposes only a redaction-safe receipt and performs no API request.
 type OpenedRuntimeBindingStageLaunch struct {
+	mu         sync.Mutex
+	used       bool
 	material   VerifiedRuntimeBindingStageLaunchMaterial
 	endpoint   *url.URL
 	token      string
@@ -111,6 +114,9 @@ func (opened *OpenedRuntimeBindingStageLaunch) Receipt() (RuntimeBindingStageLau
 	}
 	if err := verifyRuntimeBindingStageLaunchMaterial(opened.material); err != nil {
 		return RuntimeBindingStageLaunchOpenReceipt{}, err
+	}
+	if digest.SHA256([]byte(opened.endpoint.String())) != opened.material.candidate.receipt.AuthorityEndpointDigest || digest.SHA256([]byte(opened.token)) != opened.material.candidate.installerTokenDigest {
+		return RuntimeBindingStageLaunchOpenReceipt{}, errors.New("runtime binding opened destination or credential changed")
 	}
 	return opened.receipt, nil
 }

--- a/internal/runner/runtime_binding_stage_launcher.go
+++ b/internal/runner/runtime_binding_stage_launcher.go
@@ -1,0 +1,242 @@
+package runner
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+const RuntimeBindingStageLaunchReceiptFormat = "ok147-runtime-binding-stage-launch-receipt/v1"
+
+type RuntimeBindingStageLaunchReceipt struct {
+	Format                  string                        `json:"format"`
+	StageID                 string                        `json:"stageId"`
+	StagePackageDigest      string                        `json:"stagePackageDigest"`
+	CredentialPackageDigest string                        `json:"credentialPackageDigest"`
+	RuntimeManifestDigest   string                        `json:"runtimeManifestDigest"`
+	Authority               string                        `json:"authority"`
+	State                   string                        `json:"state"`
+	MutationState           string                        `json:"mutationState"`
+	Results                 []SubmissionStageLaunchResult `json:"results"`
+}
+
+// Launch is a single-use, seven-object create-only operation. It completes all
+// exact GETs before its first POST and has no retry, update, patch, apply,
+// delete, list or watch path.
+func (opened *OpenedRuntimeBindingStageLaunch) Launch(ctx context.Context) (RuntimeBindingStageLaunchReceipt, error) {
+	receipt := opened.newLaunchReceipt()
+	if opened == nil || opened.client == nil || opened.clock == nil || opened.endpoint == nil {
+		return receipt, errors.New("opened runtime binding launch is required")
+	}
+	opened.mu.Lock()
+	if opened.used {
+		opened.mu.Unlock()
+		return stopRuntimeBindingStageLaunch(receipt, "STOPPED_ZERO_WRITE", errors.New("runtime binding launcher is single-use"))
+	}
+	opened.used = true
+	opened.mu.Unlock()
+	if _, err := opened.Receipt(); err != nil {
+		return stopRuntimeBindingStageLaunch(receipt, "STOPPED_ZERO_WRITE", err)
+	}
+
+	plan, err := PlanRuntimeBindingStageLaunch(opened.material.packaged, opened.material.credentials, opened.material.runtime)
+	if err != nil {
+		return stopRuntimeBindingStageLaunch(receipt, "STOPPED_ZERO_WRITE", err)
+	}
+	_, objects, err := prepareRuntimeBindingStageInstallation(opened.material.packaged)
+	if err != nil {
+		return stopRuntimeBindingStageLaunch(receipt, "STOPPED_ZERO_WRITE", err)
+	}
+	credentials, secrets, err := prepareRuntimeBindingStageCredentialInstallation(opened.material.credentials)
+	if err != nil {
+		return stopRuntimeBindingStageLaunch(receipt, "STOPPED_ZERO_WRITE", err)
+	}
+	now := opened.clock().UTC()
+	if now.After(opened.validUntil) {
+		return stopRuntimeBindingStageLaunch(receipt, "STOPPED_ZERO_WRITE", errors.New("runtime binding launch candidate validity has expired"))
+	}
+	for _, secret := range secrets {
+		if secret.expiresAt.Sub(now) < minimumStageCredentialRemaining {
+			return stopRuntimeBindingStageLaunch(receipt, "STOPPED_ZERO_WRITE", errors.New("runtime binding credential has insufficient remaining lifetime"))
+		}
+	}
+	if credentials.PackageDigest != opened.material.receipt.CredentialPackageDigest {
+		return stopRuntimeBindingStageLaunch(receipt, "STOPPED_ZERO_WRITE", errors.New("runtime binding credential package changed before launch"))
+	}
+
+	existing := make(map[int]SubmissionStageLaunchResult, len(plan.Preflights))
+	for _, preflight := range plan.Preflights {
+		raw, status, err := opened.launchRequest(ctx, http.MethodGet, preflight.ObjectPath, nil)
+		if err != nil {
+			return stopRuntimeBindingStageLaunch(receipt, "STOPPED_ZERO_WRITE", err)
+		}
+		switch status {
+		case http.StatusNotFound:
+		case http.StatusOK:
+			result, err := verifyExistingRuntimeBindingLaunchObject(preflight, raw, opened.material.runtime, objects, secrets)
+			if err != nil {
+				return stopRuntimeBindingStageLaunch(receipt, "STOPPED_ZERO_WRITE", err)
+			}
+			existing[preflight.Order] = result
+		default:
+			return stopRuntimeBindingStageLaunch(receipt, "STOPPED_ZERO_WRITE", submissionStageLaunchStatusError(http.MethodGet, status))
+		}
+	}
+	if len(existing) == len(plan.Preflights) {
+		receipt.State = "ALREADY_LAUNCHED"
+		for order := 1; order <= len(plan.Preflights); order++ {
+			receipt.Results = append(receipt.Results, existing[order])
+		}
+		return receipt, nil
+	}
+	runtimeResult, runtimeExists := existing[1]
+	if len(existing) != 0 && !(len(existing) == 1 && runtimeExists) {
+		return stopRuntimeBindingStageLaunch(receipt, "STOPPED_ZERO_WRITE", errors.New("runtime binding launch found exact partial state"))
+	}
+
+	receipt.State = "LAUNCHING"
+	if runtimeExists {
+		receipt.Results = append(receipt.Results, runtimeResult)
+	} else {
+		result, err := opened.createRuntimeBindingLaunchObject(ctx, plan.Creates[0], opened.material.runtime.raw, "runtime")
+		if err != nil {
+			return stopRuntimeBindingAfterAttempt(receipt, err)
+		}
+		receipt.MutationState = "ATTEMPTED"
+		receipt.Results = append(receipt.Results, result)
+	}
+	for index := 0; index < 2; index++ {
+		result, err := opened.createRuntimeBindingLaunchObject(ctx, plan.Creates[index+1], objects[index].raw, "stage-prerequisites")
+		if err != nil {
+			return stopRuntimeBindingAfterAttempt(receipt, err)
+		}
+		receipt.MutationState = "ATTEMPTED"
+		receipt.Results = append(receipt.Results, result)
+	}
+	for index, secret := range secrets {
+		result, err := opened.createRuntimeBindingLaunchObject(ctx, plan.Creates[index+3], secret.raw, "credentials")
+		if err != nil {
+			return stopRuntimeBindingAfterAttempt(receipt, err)
+		}
+		receipt.MutationState = "ATTEMPTED"
+		receipt.Results = append(receipt.Results, result)
+	}
+	result, err := opened.createRuntimeBindingLaunchObject(ctx, plan.Creates[6], objects[2].raw, "job")
+	if err != nil {
+		return stopRuntimeBindingAfterAttempt(receipt, err)
+	}
+	receipt.MutationState = "ATTEMPTED"
+	receipt.Results = append(receipt.Results, result)
+	receipt.State = "LAUNCHED"
+	return receipt, nil
+}
+
+func verifyExistingRuntimeBindingLaunchObject(preflight SubmissionStageLaunchPreflight, raw []byte, runtime VerifiedRuntimeBindingStageRuntimePrerequisite, objects []submissionStageInstallObject, secrets []submissionStageCredentialInstallObject) (SubmissionStageLaunchResult, error) {
+	var uid, resourceVersion string
+	var err error
+	switch preflight.Phase {
+	case "runtime":
+		uid, resourceVersion, err = verifySubmissionStageRuntimeObject(raw, runtime.raw)
+	case "stage-prerequisites":
+		uid, resourceVersion, err = verifySubmissionStageCreatedObject(raw, objects[preflight.Order-2])
+	case "credentials":
+		uid, resourceVersion, err = verifySubmissionStageCredentialCreatedObject(raw, secrets[preflight.Order-4])
+	case "job":
+		uid, resourceVersion, err = verifySubmissionStageCreatedObject(raw, objects[2])
+	default:
+		return SubmissionStageLaunchResult{}, errors.New("runtime binding preflight phase is invalid")
+	}
+	if err != nil {
+		return SubmissionStageLaunchResult{}, errors.New("existing runtime binding object differs from verified plan")
+	}
+	return runtimeBindingLaunchResult(preflight, "EXISTING_VERIFIED", uid, resourceVersion), nil
+}
+
+func (opened *OpenedRuntimeBindingStageLaunch) createRuntimeBindingLaunchObject(ctx context.Context, create SubmissionStageLaunchCreate, body []byte, phase string) (SubmissionStageLaunchResult, error) {
+	raw, status, err := opened.launchRequest(ctx, http.MethodPost, create.CollectionPath, body)
+	if err != nil || status != http.StatusCreated {
+		return SubmissionStageLaunchResult{}, submissionStageLaunchCreateError(status, err)
+	}
+	var uid, resourceVersion string
+	if phase == "runtime" {
+		uid, resourceVersion, err = verifySubmissionStageRuntimeObject(raw, body)
+	} else {
+		uid, resourceVersion, err = verifyCreatedRuntimeBindingBody(raw, body)
+	}
+	if err != nil {
+		return SubmissionStageLaunchResult{}, errors.New("created runtime binding object differs")
+	}
+	preflight := SubmissionStageLaunchPreflight{Order: create.Order, Phase: phase, APIVersion: create.APIVersion, Kind: create.Kind, Namespace: create.Namespace, Name: create.Name, ObjectDigest: create.ObjectDigest}
+	return runtimeBindingLaunchResult(preflight, "CREATED", uid, resourceVersion), nil
+}
+
+func verifyCreatedRuntimeBindingBody(response, expected []byte) (string, string, error) {
+	object := submissionStageInstallObject{raw: expected}
+	return verifySubmissionStageCreatedObject(response, object)
+}
+
+func (opened *OpenedRuntimeBindingStageLaunch) launchRequest(ctx context.Context, method, path string, body []byte) ([]byte, int, error) {
+	endpoint := *opened.endpoint
+	endpoint.Path = path
+	request, err := http.NewRequestWithContext(ctx, method, endpoint.String(), bytes.NewReader(body))
+	if err != nil {
+		return nil, 0, errors.New("construct bounded runtime binding launch request")
+	}
+	request.Header.Set("Accept", "application/json")
+	request.Header.Set("Authorization", "Bearer "+opened.token)
+	if body != nil {
+		request.Header.Set("Content-Type", "application/json")
+	}
+	response, err := opened.client.Do(request)
+	if err != nil {
+		return nil, 0, fmt.Errorf("bounded runtime binding launch %s failed", method)
+	}
+	defer response.Body.Close()
+	raw, readErr := io.ReadAll(io.LimitReader(response.Body, maximumStageInstallationResponseBytes+1))
+	if readErr != nil || len(raw) > maximumStageInstallationResponseBytes {
+		return nil, 0, errors.New("bounded runtime binding response exceeds accepted size")
+	}
+	if len(raw) > 0 {
+		mediaType, _, err := mime.ParseMediaType(response.Header.Get("Content-Type"))
+		if err != nil || mediaType != "application/json" {
+			return nil, 0, errors.New("bounded runtime binding response is not JSON")
+		}
+	}
+	return raw, response.StatusCode, nil
+}
+
+func (opened *OpenedRuntimeBindingStageLaunch) newLaunchReceipt() RuntimeBindingStageLaunchReceipt {
+	receipt := RuntimeBindingStageLaunchReceipt{Format: RuntimeBindingStageLaunchReceiptFormat, State: "PREFLIGHT", MutationState: "NOT_ATTEMPTED", Results: []SubmissionStageLaunchResult{}}
+	if opened != nil {
+		receipt.StageID = opened.material.receipt.StageID
+		receipt.Authority = opened.material.receipt.Authority
+		receipt.StagePackageDigest = opened.material.receipt.StagePackageDigest
+		receipt.CredentialPackageDigest = opened.material.receipt.CredentialPackageDigest
+		receipt.RuntimeManifestDigest = opened.material.receipt.RuntimeManifestDigest
+	}
+	return receipt
+}
+
+func runtimeBindingLaunchResult(preflight SubmissionStageLaunchPreflight, state, uid, resourceVersion string) SubmissionStageLaunchResult {
+	return SubmissionStageLaunchResult{
+		Order: preflight.Order, Phase: preflight.Phase, APIVersion: preflight.APIVersion, Kind: preflight.Kind,
+		Namespace: preflight.Namespace, Name: preflight.Name, ObjectDigest: preflight.ObjectDigest, ObjectState: state,
+		UIDDigest: digest.SHA256([]byte(uid)), ResourceVersionDigest: digest.SHA256([]byte(resourceVersion)),
+	}
+}
+
+func stopRuntimeBindingAfterAttempt(receipt RuntimeBindingStageLaunchReceipt, err error) (RuntimeBindingStageLaunchReceipt, error) {
+	receipt.MutationState = "ATTEMPTED_UNKNOWN"
+	return stopRuntimeBindingStageLaunch(receipt, "STOPPED_PARTIAL_OR_UNKNOWN", err)
+}
+
+func stopRuntimeBindingStageLaunch(receipt RuntimeBindingStageLaunchReceipt, state string, err error) (RuntimeBindingStageLaunchReceipt, error) {
+	receipt.State = state
+	return receipt, err
+}

--- a/internal/runner/runtime_binding_stage_launcher_test.go
+++ b/internal/runner/runtime_binding_stage_launcher_test.go
@@ -1,0 +1,131 @@
+package runner
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/url"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+func TestRuntimeBindingStageLauncherPreflightsThenCreatesJobLast(t *testing.T) {
+	api := newSubmissionStageLauncherAPI(t)
+	opened := newRuntimeBindingStageLauncher(t, api, time.Date(2026, 8, 16, 12, 2, 0, 0, time.UTC))
+	receipt, err := opened.Launch(context.Background())
+	if err != nil || receipt.State != "LAUNCHED" || receipt.MutationState != "ATTEMPTED" || len(receipt.Results) != 7 {
+		t.Fatalf("runtime binding launch failed: %#v %v", receipt, err)
+	}
+	plan, _ := PlanRuntimeBindingStageLaunch(opened.material.packaged, opened.material.credentials, opened.material.runtime)
+	if len(api.requests) != 14 || api.posts != 7 {
+		t.Fatalf("requests=%d posts=%d, want seven GETs then seven POSTs", len(api.requests), api.posts)
+	}
+	for index := 0; index < 7; index++ {
+		preflight, create := api.requests[index], api.requests[index+7]
+		if preflight.method != "GET" || preflight.path != plan.Preflights[index].ObjectPath || create.method != "POST" || create.path != plan.Creates[index].CollectionPath || digest.SHA256(create.body) != plan.Creates[index].ObjectDigest {
+			t.Fatalf("request order %d differs: %#v %#v", index+1, preflight, create)
+		}
+		if receipt.Results[index].Order != index+1 || receipt.Results[index].Kind != plan.Creates[index].Kind || receipt.Results[index].ObjectState != "CREATED" {
+			t.Fatalf("result %d differs: %#v", index+1, receipt.Results[index])
+		}
+	}
+	if plan.Creates[6].Kind != "Job" {
+		t.Fatal("runtime binding Job was not created last")
+	}
+	public, err := json.Marshal(receipt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range [][]byte{[]byte(opened.token), opened.material.credentials.objects[0].raw, opened.material.credentials.objects[1].raw, opened.material.credentials.objects[2].raw, []byte("created-uid")} {
+		if bytes.Contains(public, forbidden) {
+			t.Fatal("runtime binding launch receipt exposed private content")
+		}
+	}
+	requests := len(api.requests)
+	retry, retryErr := opened.Launch(context.Background())
+	if retryErr == nil || retry.State != "STOPPED_ZERO_WRITE" || len(api.requests) != requests {
+		t.Fatalf("single-use runtime binding launcher retried: %#v %v", retry, retryErr)
+	}
+}
+
+func TestRuntimeBindingStageLauncherAcceptsOnlyExactCompleteDuplicate(t *testing.T) {
+	api := newSubmissionStageLauncherAPI(t)
+	now := time.Date(2026, 8, 16, 12, 2, 0, 0, time.UTC)
+	first := newRuntimeBindingStageLauncher(t, api, now)
+	if receipt, err := first.Launch(context.Background()); err != nil || receipt.State != "LAUNCHED" {
+		t.Fatalf("first runtime binding launch failed: %#v %v", receipt, err)
+	}
+	requests := len(api.requests)
+	duplicate := &OpenedRuntimeBindingStageLaunch{
+		mu: sync.Mutex{}, material: first.material, endpoint: first.endpoint, token: first.token,
+		client: first.client, clock: first.clock, validUntil: first.validUntil,
+		receipt: first.receipt, verified: true,
+	}
+	receipt, err := duplicate.Launch(context.Background())
+	if err != nil || receipt.State != "ALREADY_LAUNCHED" || receipt.MutationState != "NOT_ATTEMPTED" || len(receipt.Results) != 7 || api.posts != 7 || len(api.requests) != requests+7 {
+		t.Fatalf("exact runtime binding duplicate was not idempotent: %#v %v", receipt, err)
+	}
+
+	api = newSubmissionStageLauncherAPI(t)
+	partial := newRuntimeBindingStageLauncher(t, api, now)
+	_, objects, _ := prepareRuntimeBindingStageInstallation(partial.material.packaged)
+	existing := decodeCapabilityJSONForTest(t, objects[0].raw)
+	metadata := existing["metadata"].(map[string]any)
+	metadata["uid"], metadata["resourceVersion"] = "existing-input-uid", "9"
+	plan, _ := PlanRuntimeBindingStageLaunch(partial.material.packaged, partial.material.credentials, partial.material.runtime)
+	api.objects[plan.Preflights[1].ObjectPath] = existing
+	receipt, err = partial.Launch(context.Background())
+	if err == nil || receipt.State != "STOPPED_ZERO_WRITE" || receipt.MutationState != "NOT_ATTEMPTED" || api.posts != 0 || len(api.requests) != 7 {
+		t.Fatalf("partial runtime binding state reached mutation: %#v %v", receipt, err)
+	}
+}
+
+func TestRuntimeBindingStageLauncherPreservesPartialPrefixAndStopsStaleLocally(t *testing.T) {
+	api := newSubmissionStageLauncherAPI(t)
+	api.failPost = 6
+	opened := newRuntimeBindingStageLauncher(t, api, time.Date(2026, 8, 16, 12, 2, 0, 0, time.UTC))
+	receipt, err := opened.Launch(context.Background())
+	if err == nil || receipt.State != "STOPPED_PARTIAL_OR_UNKNOWN" || receipt.MutationState != "ATTEMPTED_UNKNOWN" || len(receipt.Results) != 5 || api.posts != 6 {
+		t.Fatalf("partial runtime binding prefix differs: %#v %v", receipt, err)
+	}
+
+	api = newSubmissionStageLauncherAPI(t)
+	stale := newRuntimeBindingStageLauncher(t, api, time.Date(2026, 8, 16, 12, 16, 0, 0, time.UTC))
+	receipt, err = stale.Launch(context.Background())
+	if err == nil || receipt.State != "STOPPED_ZERO_WRITE" || receipt.MutationState != "NOT_ATTEMPTED" || len(api.requests) != 0 {
+		t.Fatalf("stale runtime binding candidate reached API: %#v %v", receipt, err)
+	}
+}
+
+func newRuntimeBindingStageLauncher(t *testing.T, api *submissionStageLauncherAPI, now time.Time) *OpenedRuntimeBindingStageLaunch {
+	t.Helper()
+	config, _ := runtimeBindingStageLaunchMaterialConfig(t)
+	config.Candidate.AuthorityEndpoint = "https://192.0.2.10:6443"
+	config.Candidate.CABundleDigest = prefixSHA("7")
+	config.Candidate.InstallerTokenDigest = digest.SHA256([]byte("short-lived-installer-token"))
+	material, err := BuildRuntimeBindingStageLaunchMaterial(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	endpoint, err := url.Parse(config.Candidate.AuthorityEndpoint)
+	if err != nil {
+		t.Fatal(err)
+	}
+	validUntil, err := time.Parse(time.RFC3339, material.receipt.ValidUntil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &OpenedRuntimeBindingStageLaunch{
+		material: material, endpoint: endpoint, token: "short-lived-installer-token", client: api.client(),
+		clock: func() time.Time { return now }, validUntil: validUntil,
+		receipt: RuntimeBindingStageLaunchOpenReceipt{
+			Format: RuntimeBindingStageLaunchOpenReceiptFormat, State: "OPENED", StageID: "runtime-binding",
+			Authority: "ok-mgmt", CandidateDigest: material.receipt.CandidateDigest,
+			ValidUntil: material.receipt.ValidUntil, MutationAllowed: false,
+		},
+		verified: true,
+	}
+}


### PR DESCRIPTION
## Summary
- add the single-use seven-object runtime-binding launcher
- complete all exact GET preflights before any create and hold the Job until last
- accept only exact complete duplicates or the exact shared runtime alone
- preserve partial state and stop without retry or cleanup after an attempted write

## Safety
- exercised only with injected local fake Kubernetes clients
- no DEV cluster contact or mutation
- no update, patch, apply, delete, list, watch or retry path

## Verification
- `go test -ldflags=-linkmode=external ./...`
- `go vet ./...`
- `go test -race -ldflags=-linkmode=external ./internal/runner`