### PR TITLE
feat(cli): expose runtime binding launcher (OK-147)

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,15 @@ Powered by [Cluster API (CAPI)](https://cluster-api.sigs.k8s.io/), [CAPK (KubeVi
   ServiceAccount. Three independently issued short-lived credentials are now
   sealed offline into private immutable Secrets for ledger write, binding
   persistence and workload observation; only the redacted credential receipt
-  is public. The package remains uninstalled and unlaunched.
+  is public. `ok cluster stage bind runtime launch prepare` now reconstructs
+  those inputs and emits only the redacted material and candidate receipts
+  without API contact. `ok cluster stage bind runtime launch execute` is the
+  sole CLI path to the single-use, seven-object, create-only launcher; it
+  requires the separately copied candidate digest, bounded installer files and
+  explicit `--execute`. It completes all exact-name GETs before its first POST,
+  creates the Job last, and has no update, patch, delete, list, watch or retry
+  path. The boundary is covered only by local and fake-API tests at this
+  checkpoint; no DEV runtime-binding Job has been launched.
   Stage 4 now has its first distinct path as well:
   `ok cluster stage run enablement --execute` binds the verified three-receipt
   prefix and signed `CreateEnablement` grant to exactly one externally rendered

--- a/cmd/ok/main.go
+++ b/cmd/ok/main.go
@@ -614,6 +614,12 @@ func runContext(ctx context.Context, arguments []string, stdout, stderr io.Write
 	if len(arguments) >= 4 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "observe" && arguments[3] == "network" {
 		return runClusterStageObserveNetwork(ctx, arguments[4:], stdout, stderr)
 	}
+	if len(arguments) >= 6 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "bind" && arguments[3] == "runtime" && arguments[4] == "launch" && arguments[5] == "prepare" {
+		return runClusterStageBindRuntimeLaunchPrepare(arguments[6:], stdout, stderr)
+	}
+	if len(arguments) >= 6 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "bind" && arguments[3] == "runtime" && arguments[4] == "launch" && arguments[5] == "execute" {
+		return runClusterStageBindRuntimeLaunchExecute(ctx, arguments[6:], stdout, stderr)
+	}
 	if len(arguments) >= 4 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "bind" && arguments[3] == "runtime" {
 		return runClusterStageBindRuntime(ctx, arguments[4:], stdout, stderr)
 	}
@@ -641,7 +647,7 @@ func runContext(ctx context.Context, arguments []string, stdout, stderr io.Write
 	if len(arguments) >= 4 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "launch" && arguments[3] == "execute" {
 		return runClusterStageLaunchExecute(ctx, arguments[4:], stdout, stderr)
 	}
-	return errors.New("usage: ok cluster create ... | ok cluster stage inspect ... | ok cluster stage resume ... | ok cluster stage observe lifecycle ... | ok cluster stage observe network ... | ok cluster stage bind runtime ... | ok cluster stage observe network package ... | ok cluster stage observe network launch prepare ... | ok cluster stage observe network launch execute ... | ok cluster stage observe lifecycle package ... | ok cluster stage observe lifecycle launch prepare ... | ok cluster stage observe lifecycle launch execute ... | ok cluster stage run ... | ok cluster stage run enablement ... | ok cluster stage run enablement package ... | ok cluster stage run enablement launch prepare ... | ok cluster stage run enablement launch execute ... | ok cluster stage package ... | ok cluster stage launch prepare ... | ok cluster stage launch execute ...")
+	return errors.New("usage: ok cluster create ... | ok cluster stage inspect ... | ok cluster stage resume ... | ok cluster stage observe lifecycle ... | ok cluster stage observe network ... | ok cluster stage bind runtime ... | ok cluster stage bind runtime launch prepare ... | ok cluster stage bind runtime launch execute ... | ok cluster stage observe network package ... | ok cluster stage observe network launch prepare ... | ok cluster stage observe network launch execute ... | ok cluster stage observe lifecycle package ... | ok cluster stage observe lifecycle launch prepare ... | ok cluster stage observe lifecycle launch execute ... | ok cluster stage run ... | ok cluster stage run enablement ... | ok cluster stage run enablement package ... | ok cluster stage run enablement launch prepare ... | ok cluster stage run enablement launch execute ... | ok cluster stage package ... | ok cluster stage launch prepare ... | ok cluster stage launch execute ...")
 }
 
 func runClusterCreate(arguments []string, stdout, stderr io.Writer) error {

--- a/cmd/ok/runtime_binding_launch.go
+++ b/cmd/ok/runtime_binding_launch.go
@@ -1,0 +1,247 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/runner"
+)
+
+var prepareRuntimeBindingStageLaunch = func(config runner.RuntimeBindingStageLaunchMaterialConfig) (runtimeBindingLaunchPreparation, error) {
+	material, err := runner.BuildRuntimeBindingStageLaunchMaterial(config)
+	if err != nil {
+		return runtimeBindingLaunchPreparation{}, err
+	}
+	materialReceipt, err := material.Receipt()
+	if err != nil {
+		return runtimeBindingLaunchPreparation{}, err
+	}
+	candidateReceipt, err := material.CandidateReceipt()
+	if err != nil {
+		return runtimeBindingLaunchPreparation{}, err
+	}
+	return runtimeBindingLaunchPreparation{
+		Format: "ok147-runtime-binding-stage-launch-preparation/v1", State: "PREPARED",
+		Material: materialReceipt, Candidate: candidateReceipt, MutationAllowed: false,
+	}, nil
+}
+
+var executeRuntimeBindingStageLaunch = func(ctx context.Context, config runner.RuntimeBindingStageLaunchMaterialConfig, authority runner.KubernetesAuthorityConfig, expectedCandidateDigest string) (runner.RuntimeBindingStageLaunchReceipt, error) {
+	material, err := runner.BuildRuntimeBindingStageLaunchMaterial(config)
+	if err != nil {
+		return runner.RuntimeBindingStageLaunchReceipt{}, err
+	}
+	candidate, err := material.CandidateReceipt()
+	if err != nil {
+		return runner.RuntimeBindingStageLaunchReceipt{}, err
+	}
+	authority.AuthorityIdentity = candidate.Authority
+	launcher, err := material.Open(runner.RuntimeBindingStageLaunchOpenConfig{
+		Authority: authority, Clock: func() time.Time { return time.Now().UTC() }, ExpectedCandidateDigest: expectedCandidateDigest,
+	})
+	if err != nil {
+		return runner.RuntimeBindingStageLaunchReceipt{}, err
+	}
+	return launcher.Launch(ctx)
+}
+
+type runtimeBindingLaunchPreparation struct {
+	Format          string                                           `json:"format"`
+	State           string                                           `json:"state"`
+	Material        runner.RuntimeBindingStageLaunchMaterialReceipt  `json:"material"`
+	Candidate       runner.RuntimeBindingStageLaunchCandidateReceipt `json:"candidate"`
+	MutationAllowed bool                                             `json:"mutationAllowed"`
+}
+
+type runtimeBindingLaunchMaterialFlags struct {
+	resume                                                                                       *stageResumeFlags
+	jobTemplate, jobTemplateDigest, runID, imageDigest, inputConfigMap                           *string
+	ledgerAPIURL, ledgerAPICIDR, ledgerCredentialSecret, persistenceCredentialSecret             *string
+	workloadAPIURL, workloadAPICIDR, workloadCredentialSecret, workloadBinding, workloadDigest   *string
+	materializedAt, runtimeManifest, runtimeManifestDigest                                       *string
+	installerAPIEndpoint, installerCADigest, installerTokenDigest, installerEvidence, preparedAt *string
+	ledgerCredential, persistenceCredential, workloadCredential                                  *stageLaunchCredentialFlags
+}
+
+func addRuntimeBindingLaunchMaterialFlags(flags *flag.FlagSet) *runtimeBindingLaunchMaterialFlags {
+	values := &runtimeBindingLaunchMaterialFlags{resume: addStageResumeFlags(flags)}
+	values.jobTemplate = flags.String("job-template", "", "path to the bounded runtime-binding Job template")
+	values.jobTemplateDigest = flags.String("job-template-digest", "", "expected SHA-256 identity of the Job template")
+	values.runID = flags.String("run-id", "", "bounded OK-147 runtime-binding Job identity")
+	values.imageDigest = flags.String("image", "", "digest-pinned ok image")
+	values.inputConfigMap = flags.String("input-configmap", "", "immutable runtime-binding input ConfigMap name")
+	values.ledgerAPIURL = flags.String("ledger-api-url", "", "exact management-ledger HTTPS IP endpoint")
+	values.ledgerAPICIDR = flags.String("ledger-api-cidr", "", "single-address management-ledger CIDR")
+	values.ledgerCredentialSecret = flags.String("ledger-credential-secret", "", "ledger writer credential Secret name")
+	values.persistenceCredentialSecret = flags.String("persistence-credential-secret", "", "runtime-binding persistence writer credential Secret name")
+	values.workloadAPIURL = flags.String("workload-api-url", "", "exact workload-observer HTTPS IP endpoint")
+	values.workloadAPICIDR = flags.String("workload-api-cidr", "", "single-address workload-observer CIDR")
+	values.workloadCredentialSecret = flags.String("workload-credential-secret", "", "workload observer credential Secret name")
+	values.workloadBinding = flags.String("workload-binding", "", "path to the private workload-authority binding")
+	values.workloadDigest = flags.String("workload-binding-digest", "", "expected workload-authority binding digest")
+	values.materializedAt = flags.String("credential-materialized-at", "", "exact credential materialization time")
+	values.ledgerCredential = addStageLaunchCredentialFlags(flags, "ledger-writer-job", "ledger writer Job credential")
+	values.persistenceCredential = addStageLaunchCredentialFlags(flags, "persistence-writer-job", "persistence writer Job credential")
+	values.workloadCredential = addStageLaunchCredentialFlags(flags, "workload-observer-job", "read-only workload observer Job credential")
+	values.runtimeManifest = flags.String("runtime-manifest", "", "path to the tokenless runtime ServiceAccount manifest")
+	values.runtimeManifestDigest = flags.String("runtime-manifest-digest", "", "expected runtime manifest digest")
+	values.installerAPIEndpoint = flags.String("installer-api-endpoint", "", "exact management installer HTTPS IP endpoint")
+	values.installerCADigest = flags.String("installer-ca-digest", "", "expected management installer CA digest")
+	values.installerTokenDigest = flags.String("installer-token-digest", "", "private expected management installer token digest")
+	values.installerEvidence = flags.String("installer-tokenrequest-evidence-digest", "", "management installer TokenRequest evidence digest")
+	values.preparedAt = flags.String("prepared-at", "", "exact launch candidate preparation time")
+	return values
+}
+
+func (values *runtimeBindingLaunchMaterialFlags) config() (runner.RuntimeBindingStageLaunchMaterialConfig, error) {
+	resume, err := values.resume.config()
+	if err != nil {
+		return runner.RuntimeBindingStageLaunchMaterialConfig{}, err
+	}
+	for _, input := range []struct{ name, value string }{
+		{"--job-template", *values.jobTemplate}, {"--job-template-digest", *values.jobTemplateDigest},
+		{"--run-id", *values.runID}, {"--image", *values.imageDigest}, {"--input-configmap", *values.inputConfigMap},
+		{"--ledger-api-url", *values.ledgerAPIURL}, {"--ledger-api-cidr", *values.ledgerAPICIDR}, {"--ledger-credential-secret", *values.ledgerCredentialSecret},
+		{"--persistence-credential-secret", *values.persistenceCredentialSecret},
+		{"--workload-api-url", *values.workloadAPIURL}, {"--workload-api-cidr", *values.workloadAPICIDR}, {"--workload-credential-secret", *values.workloadCredentialSecret},
+		{"--workload-binding", *values.workloadBinding}, {"--workload-binding-digest", *values.workloadDigest},
+		{"--credential-materialized-at", *values.materializedAt}, {"--runtime-manifest", *values.runtimeManifest}, {"--runtime-manifest-digest", *values.runtimeManifestDigest},
+		{"--installer-api-endpoint", *values.installerAPIEndpoint}, {"--installer-ca-digest", *values.installerCADigest},
+		{"--installer-token-digest", *values.installerTokenDigest}, {"--installer-tokenrequest-evidence-digest", *values.installerEvidence}, {"--prepared-at", *values.preparedAt},
+	} {
+		if input.value == "" {
+			return runner.RuntimeBindingStageLaunchMaterialConfig{}, fmt.Errorf("%s is required", input.name)
+		}
+	}
+	for _, value := range []string{*values.jobTemplateDigest, *values.workloadDigest, *values.runtimeManifestDigest, *values.installerCADigest, *values.installerTokenDigest, *values.installerEvidence} {
+		if !sha256DigestPattern.MatchString(value) {
+			return runner.RuntimeBindingStageLaunchMaterialConfig{}, errors.New("runtime binding launch digests must be lowercase SHA-256 identities")
+		}
+	}
+	materializedAt, err := time.Parse(time.RFC3339, *values.materializedAt)
+	if err != nil {
+		return runner.RuntimeBindingStageLaunchMaterialConfig{}, fmt.Errorf("parse credential materialization time: %w", err)
+	}
+	preparedAt, err := time.Parse(time.RFC3339, *values.preparedAt)
+	if err != nil {
+		return runner.RuntimeBindingStageLaunchMaterialConfig{}, fmt.Errorf("parse candidate preparation time: %w", err)
+	}
+	ledger, err := values.ledgerCredential.source("ledger-writer-job")
+	if err != nil {
+		return runner.RuntimeBindingStageLaunchMaterialConfig{}, err
+	}
+	persistence, err := values.persistenceCredential.source("persistence-writer-job")
+	if err != nil {
+		return runner.RuntimeBindingStageLaunchMaterialConfig{}, err
+	}
+	workload, err := values.workloadCredential.source("workload-observer-job")
+	if err != nil {
+		return runner.RuntimeBindingStageLaunchMaterialConfig{}, err
+	}
+	if ledger.TokenFile == persistence.TokenFile || ledger.TokenFile == workload.TokenFile || persistence.TokenFile == workload.TokenFile ||
+		ledger.TokenDigest == persistence.TokenDigest || ledger.TokenDigest == workload.TokenDigest || persistence.TokenDigest == workload.TokenDigest ||
+		*values.ledgerCredentialSecret == *values.persistenceCredentialSecret || *values.ledgerCredentialSecret == *values.workloadCredentialSecret || *values.persistenceCredentialSecret == *values.workloadCredentialSecret {
+		return runner.RuntimeBindingStageLaunchMaterialConfig{}, errors.New("runtime binding launch requires three distinct credential identities")
+	}
+	template, err := readBoundedLocalFile(*values.jobTemplate, 1024*1024)
+	if err != nil {
+		return runner.RuntimeBindingStageLaunchMaterialConfig{}, fmt.Errorf("read runtime binding Job template: %w", err)
+	}
+	runtimeRaw, err := readBoundedLocalFile(*values.runtimeManifest, 128*1024)
+	if err != nil {
+		return runner.RuntimeBindingStageLaunchMaterialConfig{}, fmt.Errorf("read runtime manifest: %w", err)
+	}
+	return runner.RuntimeBindingStageLaunchMaterialConfig{
+		Package: runner.RuntimeBindingStagePackageConfig{
+			Bundle: resume, InputConfigMap: *values.inputConfigMap,
+			JobTemplate: template, JobTemplateDigest: *values.jobTemplateDigest, RunID: *values.runID, ImageDigest: *values.imageDigest,
+			LedgerAPIURL: *values.ledgerAPIURL, LedgerAPICIDR: *values.ledgerAPICIDR, LedgerCredentialSecret: *values.ledgerCredentialSecret,
+			PersistenceCredentialSecret: *values.persistenceCredentialSecret,
+			WorkloadAPIURL:              *values.workloadAPIURL, WorkloadAPICIDR: *values.workloadAPICIDR, WorkloadCredentialSecret: *values.workloadCredentialSecret,
+			WorkloadBindingPath: *values.workloadBinding, ExpectedWorkloadBindingDigest: *values.workloadDigest,
+		},
+		MaterializationTime: materializedAt, LedgerWriter: ledger, PersistenceWriter: persistence, WorkloadObserver: workload,
+		RuntimeManifest: runtimeRaw, RuntimeManifestDigest: *values.runtimeManifestDigest,
+		Candidate: runner.SubmissionStageLaunchCandidateConfig{
+			AuthorityEndpoint: *values.installerAPIEndpoint, CABundleDigest: *values.installerCADigest,
+			InstallerTokenDigest: *values.installerTokenDigest, InstallerCredentialEvidenceDigest: *values.installerEvidence, PreparedAt: preparedAt,
+		},
+	}, nil
+}
+
+func runClusterStageBindRuntimeLaunchPrepare(arguments []string, stdout, stderr io.Writer) error {
+	flags := flag.NewFlagSet("ok cluster stage bind runtime launch prepare", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	materialFlags := addRuntimeBindingLaunchMaterialFlags(flags)
+	if err := flags.Parse(arguments); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return errors.New("positional arguments are not accepted")
+	}
+	config, err := materialFlags.config()
+	if err != nil {
+		return err
+	}
+	preparation, err := prepareRuntimeBindingStageLaunch(config)
+	if err != nil {
+		return err
+	}
+	encoder := json.NewEncoder(stdout)
+	encoder.SetEscapeHTML(false)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(preparation)
+}
+
+func runClusterStageBindRuntimeLaunchExecute(ctx context.Context, arguments []string, stdout, stderr io.Writer) error {
+	flags := flag.NewFlagSet("ok cluster stage bind runtime launch execute", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	materialFlags := addRuntimeBindingLaunchMaterialFlags(flags)
+	execute := flags.Bool("execute", false, "perform the exact single-use seven-object runtime-binding launch")
+	expectedCandidateDigest := flags.String("expected-candidate-digest", "", "exact digest emitted by runtime-binding launch prepare")
+	installerTokenFile := flags.String("installer-token-file", "", "bounded short-lived management installer token file")
+	installerCAFile := flags.String("installer-ca-file", "", "bounded management installer CA file")
+	if err := flags.Parse(arguments); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return errors.New("positional arguments are not accepted")
+	}
+	if !*execute {
+		return errors.New("runtime binding launch mutation requires explicit --execute")
+	}
+	for _, input := range []struct{ name, value string }{
+		{"--expected-candidate-digest", *expectedCandidateDigest}, {"--installer-token-file", *installerTokenFile}, {"--installer-ca-file", *installerCAFile},
+	} {
+		if input.value == "" {
+			return fmt.Errorf("%s is required", input.name)
+		}
+	}
+	if !sha256DigestPattern.MatchString(*expectedCandidateDigest) {
+		return errors.New("--expected-candidate-digest must be sha256:<64 lowercase hex>")
+	}
+	config, err := materialFlags.config()
+	if err != nil {
+		return err
+	}
+	boundedContext, cancel := context.WithTimeout(ctx, stageLaunchTimeout)
+	defer cancel()
+	receipt, launchErr := executeRuntimeBindingStageLaunch(boundedContext, config, runner.KubernetesAuthorityConfig{
+		Endpoint: config.Candidate.AuthorityEndpoint, TokenFile: *installerTokenFile,
+		CAFile: *installerCAFile, CABundleDigest: config.Candidate.CABundleDigest,
+	}, *expectedCandidateDigest)
+	if receipt.Format != "" {
+		encoder := json.NewEncoder(stdout)
+		encoder.SetEscapeHTML(false)
+		encoder.SetIndent("", "  ")
+		if err := encoder.Encode(receipt); err != nil {
+			return err
+		}
+	}
+	return launchErr
+}

--- a/cmd/ok/runtime_binding_launch_test.go
+++ b/cmd/ok/runtime_binding_launch_test.go
@@ -1,0 +1,179 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/runner"
+)
+
+func TestRuntimeBindingLaunchPrepareBuildsOneNonMutatingCandidate(t *testing.T) {
+	previous := prepareRuntimeBindingStageLaunch
+	defer func() { prepareRuntimeBindingStageLaunch = previous }()
+	var captured runner.RuntimeBindingStageLaunchMaterialConfig
+	prepareRuntimeBindingStageLaunch = func(config runner.RuntimeBindingStageLaunchMaterialConfig) (runtimeBindingLaunchPreparation, error) {
+		captured = config
+		return runtimeBindingLaunchPreparation{
+			Format: "ok147-runtime-binding-stage-launch-preparation/v1", State: "PREPARED",
+			Material: runner.RuntimeBindingStageLaunchMaterialReceipt{
+				Format: runner.RuntimeBindingStageLaunchMaterialFormat, State: "VERIFIED", StageID: "runtime-binding",
+				Authority: "ok-mgmt", CandidateDigest: testSHA("1"), MutationAllowed: false,
+			},
+			Candidate: runner.RuntimeBindingStageLaunchCandidateReceipt{
+				Format: runner.RuntimeBindingStageLaunchCandidateFormat, State: "PREPARED", CandidateDigest: testSHA("1"), MutationAllowed: false,
+			},
+			MutationAllowed: false,
+		}, nil
+	}
+	root := t.TempDir()
+	template, runtimeManifest := filepath.Join(root, "runtime-binding.yaml.tpl"), filepath.Join(root, "runtime.yaml")
+	if err := os.WriteFile(template, []byte("bounded-runtime-binding-template"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(runtimeManifest, []byte("bounded-runtime"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	if err := run(runtimeBindingLaunchPrepareArguments(template, runtimeManifest), &stdout, &stderr); err != nil {
+		t.Fatalf("run: %v; stderr=%s", err, stderr.String())
+	}
+	if captured.Package.Bundle.PlanExpected.ManagementAuthority != "ok-mgmt" || captured.Package.RunID != "ok147-runtime-binding-20260817-01" {
+		t.Fatalf("runtime-binding package identity differs: %#v", captured.Package)
+	}
+	if captured.Package.PersistenceCredentialSecret != "ok147-runtime-binding-persistence" || captured.Package.WorkloadBindingPath != "/private/tmp/ok147-workload-binding.json" {
+		t.Fatalf("runtime-binding authority inputs differ: %#v", captured.Package)
+	}
+	if string(captured.Package.JobTemplate) != "bounded-runtime-binding-template" || string(captured.RuntimeManifest) != "bounded-runtime" {
+		t.Fatalf("runtime-binding private templates differ: %q %q", captured.Package.JobTemplate, captured.RuntimeManifest)
+	}
+	if captured.LedgerWriter.TokenFile == captured.PersistenceWriter.TokenFile || captured.LedgerWriter.TokenFile == captured.WorkloadObserver.TokenFile || captured.PersistenceWriter.TokenFile == captured.WorkloadObserver.TokenFile {
+		t.Fatalf("runtime-binding credentials are not distinct: %#v %#v %#v", captured.LedgerWriter, captured.PersistenceWriter, captured.WorkloadObserver)
+	}
+	var preparation runtimeBindingLaunchPreparation
+	if err := json.Unmarshal(stdout.Bytes(), &preparation); err != nil {
+		t.Fatal(err)
+	}
+	if preparation.State != "PREPARED" || preparation.MutationAllowed || preparation.Material.MutationAllowed || preparation.Candidate.MutationAllowed {
+		t.Fatalf("unsafe runtime-binding launch preparation: %#v", preparation)
+	}
+
+	invalid := removeArgumentWithValue(runtimeBindingLaunchPrepareArguments(template, runtimeManifest), "--persistence-writer-job-token-file")
+	stdout.Reset()
+	if err := run(invalid, &stdout, &stderr); err == nil || stdout.Len() != 0 {
+		t.Fatal("incomplete private material reached runtime-binding preparation")
+	}
+}
+
+func TestRuntimeBindingLaunchExecuteUsesExactBoundary(t *testing.T) {
+	previous := executeRuntimeBindingStageLaunch
+	defer func() { executeRuntimeBindingStageLaunch = previous }()
+	var calls int
+	var candidate string
+	executeRuntimeBindingStageLaunch = func(ctx context.Context, config runner.RuntimeBindingStageLaunchMaterialConfig, authority runner.KubernetesAuthorityConfig, expectedCandidateDigest string) (runner.RuntimeBindingStageLaunchReceipt, error) {
+		calls++
+		candidate = expectedCandidateDigest
+		deadline, ok := ctx.Deadline()
+		if !ok || time.Until(deadline) <= 0 || time.Until(deadline) > stageLaunchTimeout {
+			t.Fatal("runtime-binding launch context is not bounded")
+		}
+		if config.Package.RunID != "ok147-runtime-binding-20260817-01" || authority.Endpoint != "https://192.0.2.12:6443" || authority.TokenFile != "/private/tmp/installer-token" {
+			t.Fatalf("execute boundary differs: %#v %#v", config, authority)
+		}
+		return runner.RuntimeBindingStageLaunchReceipt{
+			Format: runner.RuntimeBindingStageLaunchReceiptFormat, StageID: "runtime-binding", Authority: "ok-mgmt",
+			State: "LAUNCHED", MutationState: "ATTEMPTED", Results: []runner.SubmissionStageLaunchResult{},
+		}, nil
+	}
+	root := t.TempDir()
+	template, runtimeManifest := filepath.Join(root, "runtime-binding.yaml.tpl"), filepath.Join(root, "runtime.yaml")
+	if err := os.WriteFile(template, []byte("bounded-runtime-binding-template"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(runtimeManifest, []byte("bounded-runtime"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	if err := run(runtimeBindingLaunchExecuteArguments(template, runtimeManifest), &stdout, &stderr); err != nil {
+		t.Fatalf("run: %v; stderr=%s", err, stderr.String())
+	}
+	if calls != 1 || candidate != testSHA("9") {
+		t.Fatalf("exact runtime-binding candidate not used: calls=%d digest=%q", calls, candidate)
+	}
+	var receipt runner.RuntimeBindingStageLaunchReceipt
+	if err := json.Unmarshal(stdout.Bytes(), &receipt); err != nil || receipt.State != "LAUNCHED" {
+		t.Fatalf("unexpected runtime-binding launch receipt: %#v %v", receipt, err)
+	}
+
+	valid := runtimeBindingLaunchExecuteArguments(template, runtimeManifest)
+	for name, arguments := range map[string][]string{
+		"missing execute":         removeArgument(valid, "--execute"),
+		"missing candidate":       removeArgumentWithValue(valid, "--expected-candidate-digest"),
+		"malformed candidate":     replaceArgument(valid, "--expected-candidate-digest", "sha256:ABC"),
+		"missing installer token": removeArgumentWithValue(valid, "--installer-token-file"),
+		"shared credential":       replaceArgument(valid, "--persistence-writer-job-token-file", "/private/tmp/ledger-runtime-binding-token"),
+	} {
+		t.Run(name, func(t *testing.T) {
+			before := calls
+			stdout.Reset()
+			if err := run(arguments, &stdout, &stderr); err == nil || stdout.Len() != 0 || calls != before {
+				t.Fatal("unsafe runtime-binding launch input reached executor")
+			}
+		})
+	}
+}
+
+func runtimeBindingLaunchPrepareArguments(template, runtimeManifest string) []string {
+	resume := stageResumeArguments()
+	arguments := append([]string{"cluster", "stage", "bind", "runtime", "launch", "prepare"}, resume[3:]...)
+	arguments = append(arguments,
+		"--receipt", "/tmp/provider.json@"+testSHA("1"),
+		"--receipt", "/tmp/lifecycle.json@"+testSHA("2"),
+		"--receipt", "/tmp/lifecycle-observation.json@"+testSHA("3"),
+		"--receipt", "/tmp/enablement.json@"+testSHA("4"),
+		"--receipt", "/tmp/network-observation.json@"+testSHA("5"),
+		"--job-template", template, "--job-template-digest", digest.SHA256([]byte("bounded-runtime-binding-template")),
+		"--run-id", "ok147-runtime-binding-20260817-01", "--image", "ghcr.io/openkubes/ok-cluster@"+testSHA("a"),
+		"--input-configmap", "ok147-runtime-binding-input",
+		"--ledger-api-url", "https://192.0.2.12:6443", "--ledger-api-cidr", "192.0.2.12/32", "--ledger-credential-secret", "ok147-runtime-binding-ledger",
+		"--persistence-credential-secret", "ok147-runtime-binding-persistence",
+		"--workload-api-url", "https://192.0.2.20:6443", "--workload-api-cidr", "192.0.2.20/32", "--workload-credential-secret", "ok147-runtime-binding-workload",
+		"--workload-binding", "/private/tmp/ok147-workload-binding.json", "--workload-binding-digest", testSHA("b"),
+		"--credential-materialized-at", "2026-08-17T08:00:00Z",
+	)
+	for _, credential := range []struct{ prefix, authority, tokenFile, tokenDigest, caFile, caDigest, evidence, subject string }{
+		{"ledger-writer-job", "ok-mgmt", "/private/tmp/ledger-runtime-binding-token", testSHA("1"), "/private/tmp/ledger-runtime-binding-ca", testSHA("2"), testSHA("3"), "system:serviceaccount:openkubes-execution-system:ok147-ledger-writer"},
+		{"persistence-writer-job", "ok-mgmt", "/private/tmp/persistence-runtime-binding-token", testSHA("4"), "/private/tmp/persistence-runtime-binding-ca", testSHA("2"), testSHA("5"), "system:serviceaccount:openkubes-execution-system:ok147-runtime-binding-writer"},
+		{"workload-observer-job", testSHA("b"), "/private/tmp/workload-runtime-binding-token", testSHA("6"), "/private/tmp/workload-runtime-binding-ca", testSHA("7"), testSHA("8"), "system:serviceaccount:openkubes-execution-system:ok147-runtime-binding-observer"},
+	} {
+		arguments = append(arguments,
+			"--"+credential.prefix+"-authority", credential.authority,
+			"--"+credential.prefix+"-token-file", credential.tokenFile, "--"+credential.prefix+"-token-digest", credential.tokenDigest,
+			"--"+credential.prefix+"-ca-file", credential.caFile, "--"+credential.prefix+"-ca-digest", credential.caDigest,
+			"--"+credential.prefix+"-tokenrequest-evidence-digest", credential.evidence,
+			"--"+credential.prefix+"-issuer", "https://kubernetes.default.svc.cluster.local", "--"+credential.prefix+"-subject", credential.subject,
+			"--"+credential.prefix+"-audiences", "https://kubernetes.default.svc",
+			"--"+credential.prefix+"-issued-at", "2026-08-17T07:59:00Z", "--"+credential.prefix+"-expires-at", "2026-08-17T08:30:00Z",
+		)
+	}
+	return append(arguments,
+		"--runtime-manifest", runtimeManifest, "--runtime-manifest-digest", digest.SHA256([]byte("bounded-runtime")),
+		"--installer-api-endpoint", "https://192.0.2.12:6443", "--installer-ca-digest", testSHA("2"),
+		"--installer-token-digest", testSHA("7"), "--installer-tokenrequest-evidence-digest", testSHA("8"),
+		"--prepared-at", "2026-08-17T08:01:00Z",
+	)
+}
+
+func runtimeBindingLaunchExecuteArguments(template, runtimeManifest string) []string {
+	arguments := runtimeBindingLaunchPrepareArguments(template, runtimeManifest)
+	arguments[5] = "execute"
+	return append(arguments,
+		"--execute", "--expected-candidate-digest", testSHA("9"),
+		"--installer-token-file", "/private/tmp/installer-token", "--installer-ca-file", "/private/tmp/installer-ca",
+	)
+}


### PR DESCRIPTION
## Summary
- add offline runtime-binding launch preparation with redacted material and candidate receipts
- add the only CLI execution boundary for the single-use seven-object create-only launcher
- require exact candidate digest, bounded installer material, three distinct Job credentials, and explicit execution
- document that this checkpoint is local/fake-API proven and performs no DEV launch

## Verification
- GOCACHE=/private/tmp/ok147-go-build go test -ldflags=-linkmode=external ./...
- GOCACHE=/private/tmp/ok147-go-build go vet ./...
- GOCACHE=/private/tmp/ok147-go-build go test -race -ldflags=-linkmode=external ./internal/runner

## Boundary
No DEV infrastructure mutation or runtime-binding Job launch is included.