### PR TITLE
feat(submission): verify target access plan (OK-147)

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,12 @@ Powered by [Cluster API (CAPI)](https://cluster-api.sigs.k8s.io/), [CAPK (KubeVi
   creates the Job last, and has no update, patch, delete, list, watch or retry
   path. The boundary is covered only by local and fake-API tests at this
   checkpoint; no DEV runtime-binding Job has been launched.
+  The next `target-access` stage now starts with a separate offline verifier
+  for one externally rendered eight-object workload RBAC set. It binds the
+  artifact to `R`, `P`, the execution fixture and immutable target identity,
+  fixes object order and REST routes, rejects wildcard/non-resource access,
+  foreign subjects and runtime metadata, and returns only a non-authorizing
+  plan. Grant consumption, credentials and target submission remain absent.
   Stage 4 now has its first distinct path as well:
   `ok cluster stage run enablement --execute` binds the verified three-receipt
   prefix and signed `CreateEnablement` grant to exactly one externally rendered

--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -2420,8 +2420,32 @@ retry, update, patch, delete or cleanup path. Candidate expiry and credential
 remaining lifetime are checked locally before the first API request.
 
 This execution has been tested only against injected local fake Kubernetes
-clients. No DEV cluster was contacted and no public CLI launch command exists
-yet.
+clients. No DEV cluster was contacted. The public CLI preserves the same split
+boundary: `ok cluster stage bind runtime launch prepare` reconstructs the
+material and emits redacted receipts without API contact, while the matching
+`launch execute` command alone can open the installer credential and invoke
+the launcher after receiving the exact candidate digest and explicit
+`--execute`.
+
+## Target-access verified projection
+
+The first `target-access` boundary is again side-effect free. One externally
+rendered artifact is accepted only when its digest and exact eight-object
+identity list are independently supplied by the staged experiment. The plan
+binds `R`, `P`, `FixtureDigest` and the immutable workload target identity to a
+single workload authority plane.
+
+The allowlist fixes this order: Namespace, manager ServiceAccount,
+ClusterRole/ClusterRoleBinding, one namespaced Role/RoleBinding pair for the
+Platform namespace and one Role/RoleBinding pair for `kube-system`. Every
+binding must refer to the exact manager ServiceAccount and corresponding role.
+Wildcard permissions, non-resource URLs, user/group subjects, runtime metadata,
+status, aliases, symlinks, additional or reordered objects fail closed. The
+verified output is `ok147-bounded-target-access-plan/v1` with
+`mutationAllowed: false`.
+
+This verifier does not render RBAC, consume `CreateTargetAccess` authorization,
+read a credential or contact the workload API. Those remain later boundaries.
 
 ## Bounded convergence observation polling
 

--- a/internal/submission/target_access.go
+++ b/internal/submission/target_access.go
@@ -1,0 +1,383 @@
+package submission
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/openkubes/ok-cluster/internal/contract"
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/projection"
+	"gopkg.in/yaml.v3"
+)
+
+const TargetAccessPlanFormat = "ok147-bounded-target-access-plan/v1"
+
+const maximumTargetAccessArtifactBytes = 512 * 1024
+
+// TargetAccessExpected is independently bound by the staged plan, verified
+// runtime binding and authoritative Platform projection. It does not permit a
+// caller to add an object or choose a different workload authority.
+type TargetAccessExpected struct {
+	ArtifactDigest       string
+	ContractIdentity     contract.Identity
+	IntentRevision       string
+	PlatformRevision     string
+	ExecutionFixture     string
+	TargetIdentityDigest string
+	WorkloadAuthority    string
+	Objects              []projection.ResourceIdentity
+}
+
+// TargetAccessPlan contains exactly the externally rendered access objects
+// that prepare one workload cluster for the later target-credential stage. It
+// is verified desired state, not authorization to submit it.
+type TargetAccessPlan struct {
+	Format               string `json:"format"`
+	IntentRevision       string `json:"intentRevision"`
+	PlatformRevision     string `json:"platformRevision"`
+	ExecutionFixture     string `json:"executionFixture"`
+	TargetIdentityDigest string `json:"targetIdentityDigest"`
+	ArtifactDigest       string `json:"artifactDigest"`
+	MutationAllowed      bool   `json:"mutationAllowed"`
+	Workload             Plane  `json:"workload"`
+}
+
+// LoadTargetAccess verifies the complete renderer-owned target-access set
+// offline. It performs no API request and grants no mutation authority.
+func LoadTargetAccess(path string, expected TargetAccessExpected) (TargetAccessPlan, error) {
+	if err := validateTargetAccessExpected(expected); err != nil {
+		return TargetAccessPlan{}, err
+	}
+	raw, err := readBoundedTargetAccessArtifact(path)
+	if err != nil {
+		return TargetAccessPlan{}, err
+	}
+	if digest.SHA256(raw) != expected.ArtifactDigest {
+		return TargetAccessPlan{}, errors.New("target-access artifact digest differs from staged input")
+	}
+	objects, err := decodeTargetAccessObjects(raw, expected)
+	if err != nil {
+		return TargetAccessPlan{}, err
+	}
+	return TargetAccessPlan{
+		Format: TargetAccessPlanFormat, IntentRevision: expected.IntentRevision,
+		PlatformRevision: expected.PlatformRevision, ExecutionFixture: expected.ExecutionFixture,
+		TargetIdentityDigest: expected.TargetIdentityDigest, ArtifactDigest: expected.ArtifactDigest,
+		MutationAllowed: false,
+		Workload:        Plane{Identity: expected.WorkloadAuthority, Role: "target-access-writer", Objects: objects},
+	}, nil
+}
+
+func validateTargetAccessExpected(expected TargetAccessExpected) error {
+	for _, value := range []string{expected.ArtifactDigest, expected.IntentRevision, expected.PlatformRevision, expected.ExecutionFixture, expected.TargetIdentityDigest} {
+		if !immutableDigestPattern.MatchString(value) {
+			return errors.New("target-access expected digest identity is invalid")
+		}
+	}
+	if !validName(expected.ContractIdentity.Namespace, 63) || strings.Contains(expected.ContractIdentity.Namespace, ".") || !validName(expected.ContractIdentity.Name, 253) {
+		return errors.New("target-access Contract identity is invalid")
+	}
+	if expected.WorkloadAuthority != expected.TargetIdentityDigest {
+		return errors.New("target-access workload authority must equal the immutable target identity")
+	}
+	if len(expected.Objects) != 8 {
+		return errors.New("target-access requires exactly eight object identities")
+	}
+	expectedKinds := []string{"Namespace", "ServiceAccount", "ClusterRole", "ClusterRoleBinding", "Role", "RoleBinding", "Role", "RoleBinding"}
+	for index, identity := range expected.Objects {
+		if identity.Kind != expectedKinds[index] || !validName(identity.Name, 253) {
+			return errors.New("target-access expected object order or identity is invalid")
+		}
+		switch identity.Kind {
+		case "Namespace", "ServiceAccount":
+			if identity.APIVersion != "v1" {
+				return errors.New("target-access core object API version is invalid")
+			}
+		case "ClusterRole", "ClusterRoleBinding", "Role", "RoleBinding":
+			if identity.APIVersion != "rbac.authorization.k8s.io/v1" {
+				return errors.New("target-access RBAC API version is invalid")
+			}
+		}
+		if identity.Kind == "Namespace" || identity.Kind == "ClusterRole" || identity.Kind == "ClusterRoleBinding" {
+			if identity.Namespace != "" {
+				return errors.New("target-access cluster-scoped identity contains a namespace")
+			}
+		} else if identity.Namespace == "" || !validName(identity.Namespace, 63) || strings.Contains(identity.Namespace, ".") {
+			return errors.New("target-access namespaced identity is invalid")
+		}
+	}
+	return nil
+}
+
+func readBoundedTargetAccessArtifact(path string) ([]byte, error) {
+	if path == "" {
+		return nil, errors.New("target-access artifact path is required")
+	}
+	info, err := os.Lstat(path)
+	if err != nil {
+		return nil, fmt.Errorf("inspect target-access artifact: %w", err)
+	}
+	if !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 || info.Size() <= 0 || info.Size() > maximumTargetAccessArtifactBytes {
+		return nil, errors.New("target-access artifact metadata is invalid")
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open target-access artifact: %w", err)
+	}
+	defer file.Close()
+	raw, err := io.ReadAll(io.LimitReader(file, maximumTargetAccessArtifactBytes+1))
+	if err != nil || len(raw) > maximumTargetAccessArtifactBytes {
+		return nil, errors.New("read bounded target-access artifact")
+	}
+	return raw, nil
+}
+
+func decodeTargetAccessObjects(raw []byte, expected TargetAccessExpected) ([]Object, error) {
+	decoder := yaml.NewDecoder(bytes.NewReader(raw))
+	objects := make([]Object, 0, len(expected.Objects))
+	values := make([]map[string]any, 0, len(expected.Objects))
+	for {
+		var document yaml.Node
+		if err := decoder.Decode(&document); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return nil, fmt.Errorf("decode target-access YAML: %w", err)
+		}
+		if len(document.Content) == 0 {
+			continue
+		}
+		if err := rejectAliases(document.Content[0]); err != nil {
+			return nil, err
+		}
+		var decoded any
+		if err := document.Content[0].Decode(&decoded); err != nil {
+			return nil, fmt.Errorf("decode target-access object: %w", err)
+		}
+		converted, err := jsonValue(decoded)
+		if err != nil {
+			return nil, err
+		}
+		value, ok := converted.(map[string]any)
+		if !ok {
+			return nil, errors.New("target-access document is not a Kubernetes object")
+		}
+		values = append(values, value)
+	}
+	if len(values) != len(expected.Objects) {
+		return nil, fmt.Errorf("target-access artifact contains %d objects, expected exactly %d", len(values), len(expected.Objects))
+	}
+	for index, value := range values {
+		object, err := validateTargetAccessObject(value, expected.Objects[index])
+		if err != nil {
+			return nil, fmt.Errorf("target-access document %d: %w", index+1, err)
+		}
+		objects = append(objects, object)
+	}
+	if err := validateTargetAccessRelationships(values, expected.Objects); err != nil {
+		return nil, err
+	}
+	return objects, nil
+}
+
+func validateTargetAccessObject(value map[string]any, expected projection.ResourceIdentity) (Object, error) {
+	if _, exists := value["status"]; exists {
+		return Object{}, errors.New("target-access object must not contain status")
+	}
+	metadata, ok := value["metadata"].(map[string]any)
+	if !ok {
+		return Object{}, errors.New("target-access object metadata is missing")
+	}
+	identity := projection.ResourceIdentity{
+		APIVersion: text(value["apiVersion"]), Kind: text(value["kind"]), Name: text(metadata["name"]), Namespace: text(metadata["namespace"]),
+	}
+	if identity != expected {
+		return Object{}, errors.New("target-access object identity differs from the staged input")
+	}
+	for _, forbidden := range []string{"generateName", "uid", "resourceVersion", "generation", "creationTimestamp", "deletionTimestamp", "deletionGracePeriodSeconds", "managedFields", "ownerReferences", "finalizers"} {
+		if _, exists := metadata[forbidden]; exists {
+			return Object{}, fmt.Errorf("target-access metadata.%s is not accepted", forbidden)
+		}
+	}
+	if err := rejectTargetAccessUnknownKeys(metadata, "metadata", "name", "namespace", "labels", "annotations"); err != nil {
+		return Object{}, err
+	}
+	switch identity.Kind {
+	case "Namespace":
+		if err := rejectTargetAccessUnknownKeys(value, "Namespace", "apiVersion", "kind", "metadata"); err != nil {
+			return Object{}, err
+		}
+		if err := validateTargetNamespace(value); err != nil {
+			return Object{}, err
+		}
+	case "ServiceAccount":
+		if err := rejectTargetAccessUnknownKeys(value, "ServiceAccount", "apiVersion", "kind", "metadata", "automountServiceAccountToken"); err != nil {
+			return Object{}, err
+		}
+		if _, exists := value["secrets"]; exists {
+			return Object{}, errors.New("target-access ServiceAccount must not embed Secret references")
+		}
+	case "Role", "ClusterRole":
+		if err := rejectTargetAccessUnknownKeys(value, identity.Kind, "apiVersion", "kind", "metadata", "rules"); err != nil {
+			return Object{}, err
+		}
+		if err := validateTargetAccessRules(value["rules"]); err != nil {
+			return Object{}, err
+		}
+	case "RoleBinding", "ClusterRoleBinding":
+		if err := rejectTargetAccessUnknownKeys(value, identity.Kind, "apiVersion", "kind", "metadata", "roleRef", "subjects"); err != nil {
+			return Object{}, err
+		}
+		if err := validateTargetAccessBindingShape(value); err != nil {
+			return Object{}, err
+		}
+	}
+	collection, err := targetAccessCollectionPath(identity)
+	if err != nil {
+		return Object{}, err
+	}
+	canonical, err := canonicalJSON(value)
+	if err != nil {
+		return Object{}, err
+	}
+	return Object{Identity: identity, Digest: digest.SHA256(canonical), CollectionPath: collection, ObjectPath: collection + "/" + identity.Name, Raw: canonical}, nil
+}
+
+func validateTargetNamespace(value map[string]any) error {
+	metadata, _ := value["metadata"].(map[string]any)
+	labels, _ := metadata["labels"].(map[string]any)
+	for _, key := range []string{"pod-security.kubernetes.io/enforce", "pod-security.kubernetes.io/audit", "pod-security.kubernetes.io/warn"} {
+		level := text(labels[key])
+		if level != "restricted" && level != "baseline" && level != "privileged" {
+			return fmt.Errorf("target-access Namespace lacks an explicit %s level", key)
+		}
+	}
+	return nil
+}
+
+func validateTargetAccessRules(raw any) error {
+	rules, ok := raw.([]any)
+	if !ok || len(rules) == 0 || len(rules) > 32 {
+		return errors.New("target-access RBAC rules are missing or unbounded")
+	}
+	allowedVerbs := map[string]bool{"get": true, "list": true, "watch": true, "create": true, "patch": true, "update": true, "delete": true, "bind": true, "escalate": true}
+	for _, rawRule := range rules {
+		rule, ok := rawRule.(map[string]any)
+		if !ok {
+			return errors.New("target-access RBAC rule is invalid")
+		}
+		if err := rejectTargetAccessUnknownKeys(rule, "RBAC rule", "apiGroups", "resources", "verbs", "resourceNames"); err != nil {
+			return err
+		}
+		for _, key := range []string{"apiGroups", "resources", "verbs"} {
+			values, ok := rule[key].([]any)
+			if !ok || len(values) == 0 || len(values) > 32 {
+				return fmt.Errorf("target-access RBAC %s are missing or unbounded", key)
+			}
+			for _, rawValue := range values {
+				value := text(rawValue)
+				if value == "" && key != "apiGroups" || value == "*" || strings.ContainsAny(value, " \t\r\n") {
+					return fmt.Errorf("target-access RBAC %s contain an unsafe value", key)
+				}
+				if key == "verbs" && !allowedVerbs[value] {
+					return errors.New("target-access RBAC contains an unsupported verb")
+				}
+			}
+		}
+		if names, exists := rule["resourceNames"]; exists {
+			values, ok := names.([]any)
+			if !ok || len(values) == 0 || len(values) > 32 {
+				return errors.New("target-access RBAC resourceNames are invalid")
+			}
+			for _, name := range values {
+				if !validName(text(name), 253) {
+					return errors.New("target-access RBAC resourceName is invalid")
+				}
+			}
+		}
+		for _, forbidden := range []string{"nonResourceURLs"} {
+			if _, exists := rule[forbidden]; exists {
+				return errors.New("target-access RBAC non-resource permissions are forbidden")
+			}
+		}
+	}
+	return nil
+}
+
+func validateTargetAccessBindingShape(value map[string]any) error {
+	roleRef, _ := value["roleRef"].(map[string]any)
+	if err := rejectTargetAccessUnknownKeys(roleRef, "binding roleRef", "apiGroup", "kind", "name"); err != nil {
+		return err
+	}
+	if text(roleRef["apiGroup"]) != "rbac.authorization.k8s.io" || (text(roleRef["kind"]) != "Role" && text(roleRef["kind"]) != "ClusterRole") || !validName(text(roleRef["name"]), 253) {
+		return errors.New("target-access binding roleRef is invalid")
+	}
+	subjects, ok := value["subjects"].([]any)
+	if !ok || len(subjects) != 1 {
+		return errors.New("target-access binding must contain exactly one subject")
+	}
+	subject, _ := subjects[0].(map[string]any)
+	if err := rejectTargetAccessUnknownKeys(subject, "binding subject", "kind", "name", "namespace", "apiGroup"); err != nil {
+		return err
+	}
+	if text(subject["kind"]) != "ServiceAccount" || text(subject["apiGroup"]) != "" || !validName(text(subject["name"]), 253) || !validName(text(subject["namespace"]), 63) {
+		return errors.New("target-access binding subject must be one exact ServiceAccount")
+	}
+	return nil
+}
+
+func rejectTargetAccessUnknownKeys(value map[string]any, description string, allowed ...string) error {
+	accepted := make(map[string]bool, len(allowed))
+	for _, key := range allowed {
+		accepted[key] = true
+	}
+	for key := range value {
+		if !accepted[key] {
+			return fmt.Errorf("target-access %s contains unsupported field %s", description, key)
+		}
+	}
+	return nil
+}
+
+func validateTargetAccessRelationships(values []map[string]any, identities []projection.ResourceIdentity) error {
+	serviceAccount := identities[1]
+	clusterRole := identities[2]
+	for _, index := range []int{3, 5, 7} {
+		roleRef := values[index]["roleRef"].(map[string]any)
+		subject := values[index]["subjects"].([]any)[0].(map[string]any)
+		if text(subject["name"]) != serviceAccount.Name || text(subject["namespace"]) != serviceAccount.Namespace {
+			return errors.New("target-access binding subject differs from the exact manager ServiceAccount")
+		}
+		wantKind, wantName := identities[index-1].Kind, identities[index-1].Name
+		if index == 3 {
+			wantKind, wantName = clusterRole.Kind, clusterRole.Name
+		}
+		if text(roleRef["kind"]) != wantKind || text(roleRef["name"]) != wantName {
+			return errors.New("target-access binding roleRef differs from its exact role")
+		}
+	}
+	return nil
+}
+
+func targetAccessCollectionPath(identity projection.ResourceIdentity) (string, error) {
+	switch identity.Kind {
+	case "Namespace":
+		return "/api/v1/namespaces", nil
+	case "ServiceAccount":
+		return "/api/v1/namespaces/" + identity.Namespace + "/serviceaccounts", nil
+	case "ClusterRole":
+		return "/apis/rbac.authorization.k8s.io/v1/clusterroles", nil
+	case "ClusterRoleBinding":
+		return "/apis/rbac.authorization.k8s.io/v1/clusterrolebindings", nil
+	case "Role":
+		return "/apis/rbac.authorization.k8s.io/v1/namespaces/" + identity.Namespace + "/roles", nil
+	case "RoleBinding":
+		return "/apis/rbac.authorization.k8s.io/v1/namespaces/" + identity.Namespace + "/rolebindings", nil
+	default:
+		return "", errors.New("target-access object kind is outside the fixed allowlist")
+	}
+}

--- a/internal/submission/target_access_test.go
+++ b/internal/submission/target_access_test.go
@@ -1,0 +1,208 @@
+package submission
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/openkubes/ok-cluster/internal/contract"
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/projection"
+)
+
+func TestLoadTargetAccessBindsExactEightObjectSet(t *testing.T) {
+	raw := targetAccessYAML()
+	path := writeTargetAccessArtifact(t, raw)
+	expected := targetAccessExpected(raw)
+	plan, err := LoadTargetAccess(path, expected)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plan.Format != TargetAccessPlanFormat || plan.IntentRevision != expected.IntentRevision || plan.PlatformRevision != expected.PlatformRevision || plan.TargetIdentityDigest != expected.TargetIdentityDigest || plan.MutationAllowed {
+		t.Fatalf("unexpected target-access plan: %#v", plan)
+	}
+	if plan.Workload.Identity != expected.TargetIdentityDigest || plan.Workload.Role != "target-access-writer" || len(plan.Workload.Objects) != 8 {
+		t.Fatalf("unexpected target-access authority plane: %#v", plan.Workload)
+	}
+	for index, object := range plan.Workload.Objects {
+		if object.Identity != expected.Objects[index] || !immutableDigestPattern.MatchString(object.Digest) || object.CollectionPath == "" || object.ObjectPath != object.CollectionPath+"/"+object.Identity.Name || len(object.Raw) == 0 {
+			t.Fatalf("invalid target-access object %d: %#v", index+1, object)
+		}
+	}
+
+	again, err := LoadTargetAccess(path, expected)
+	if err != nil || again.ArtifactDigest != plan.ArtifactDigest || again.Workload.Objects[7].Digest != plan.Workload.Objects[7].Digest {
+		t.Fatalf("target-access plan is not reproducible: %#v %v", again, err)
+	}
+}
+
+func TestLoadTargetAccessFailsClosed(t *testing.T) {
+	valid := targetAccessYAML()
+	for name, mutate := range map[string]func([]byte) []byte{
+		"missing object": func(raw []byte) []byte {
+			marker := []byte("---\napiVersion: rbac.authorization.k8s.io/v1\nkind: RoleBinding\nmetadata:\n  name: ok147-argocd-kube-system")
+			return raw[:strings.Index(string(raw), string(marker))]
+		},
+		"wrong order": func(raw []byte) []byte {
+			return []byte(strings.Replace(string(raw), "kind: ServiceAccount", "kind: Role", 1))
+		},
+		"wildcard permission": func(raw []byte) []byte {
+			return []byte(strings.Replace(string(raw), "verbs: [get, list, watch]", "verbs: ['*']", 1))
+		},
+		"user subject": func(raw []byte) []byte {
+			return []byte(strings.Replace(string(raw), "kind: ServiceAccount, name: ok147-argocd-manager", "kind: User, name: cluster-admin", 1))
+		},
+		"foreign role reference": func(raw []byte) []byte {
+			return []byte(strings.Replace(string(raw), "name: ok147-argocd-platform-cluster\nsubjects:", "name: cluster-admin\nsubjects:", 1))
+		},
+		"runtime metadata": func(raw []byte) []byte {
+			return []byte(strings.Replace(string(raw), "name: ok-observability\n  labels:", "name: ok-observability\n  uid: foreign\n  labels:", 1))
+		},
+		"unknown rule field": func(raw []byte) []byte {
+			return []byte(strings.Replace(string(raw), "resources: [customresourcedefinitions]\n    verbs:", "resources: [customresourcedefinitions]\n    arbitrary: true\n    verbs:", 1))
+		},
+		"status": func(raw []byte) []byte { return append(raw, []byte("status: {}\n")...) },
+	} {
+		t.Run(name, func(t *testing.T) {
+			raw := mutate(append([]byte(nil), valid...))
+			expected := targetAccessExpected(raw)
+			if _, err := LoadTargetAccess(writeTargetAccessArtifact(t, raw), expected); err == nil {
+				t.Fatal("unsafe target-access artifact was accepted")
+			}
+		})
+	}
+
+	expected := targetAccessExpected(valid)
+	path := writeTargetAccessArtifact(t, valid)
+	expected.ArtifactDigest = targetAccessSHA("0")
+	if _, err := LoadTargetAccess(path, expected); err == nil {
+		t.Fatal("changed target-access artifact digest was accepted")
+	}
+
+	expected = targetAccessExpected(valid)
+	expected.WorkloadAuthority = targetAccessSHA("f")
+	if _, err := LoadTargetAccess(path, expected); err == nil {
+		t.Fatal("foreign target-access workload authority was accepted")
+	}
+
+	symlink := filepath.Join(t.TempDir(), "target-access.yaml")
+	if err := os.Symlink(path, symlink); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadTargetAccess(symlink, targetAccessExpected(valid)); err == nil {
+		t.Fatal("symlink target-access artifact was accepted")
+	}
+}
+
+func targetAccessExpected(raw []byte) TargetAccessExpected {
+	return TargetAccessExpected{
+		ArtifactDigest: digest.SHA256(raw), ContractIdentity: contract.Identity{Namespace: "disposable-ok147", Name: "disposable-ok147"},
+		IntentRevision: targetAccessSHA("a"), PlatformRevision: targetAccessSHA("b"), ExecutionFixture: targetAccessSHA("c"),
+		TargetIdentityDigest: targetAccessSHA("d"), WorkloadAuthority: targetAccessSHA("d"),
+		Objects: []projection.ResourceIdentity{
+			{APIVersion: "v1", Kind: "Namespace", Name: "ok-observability"},
+			{APIVersion: "v1", Kind: "ServiceAccount", Namespace: "kube-system", Name: "ok147-argocd-manager"},
+			{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "ClusterRole", Name: "ok147-argocd-platform-cluster"},
+			{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "ClusterRoleBinding", Name: "ok147-argocd-platform-cluster"},
+			{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role", Namespace: "ok-observability", Name: "ok147-argocd-platform"},
+			{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "RoleBinding", Namespace: "ok-observability", Name: "ok147-argocd-platform"},
+			{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role", Namespace: "kube-system", Name: "ok147-argocd-kube-system"},
+			{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "RoleBinding", Namespace: "kube-system", Name: "ok147-argocd-kube-system"},
+		},
+	}
+}
+
+func writeTargetAccessArtifact(t *testing.T, raw []byte) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "target-access.yaml")
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func targetAccessYAML() []byte {
+	return []byte(`apiVersion: v1
+kind: Namespace
+metadata:
+  name: ok-observability
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ok147-argocd-manager
+  namespace: kube-system
+automountServiceAccountToken: false
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ok147-argocd-platform-cluster
+rules:
+  - apiGroups: [apiextensions.k8s.io]
+    resources: [customresourcedefinitions]
+    verbs: [get, list, watch]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ok147-argocd-platform-cluster
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ok147-argocd-platform-cluster
+subjects:
+  - {kind: ServiceAccount, name: ok147-argocd-manager, namespace: kube-system}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ok147-argocd-platform
+  namespace: ok-observability
+rules:
+  - apiGroups: [""]
+    resources: [configmaps, services]
+    verbs: [get, list, watch, create, patch, update, delete]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ok147-argocd-platform
+  namespace: ok-observability
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ok147-argocd-platform
+subjects:
+  - {kind: ServiceAccount, name: ok147-argocd-manager, namespace: kube-system}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ok147-argocd-kube-system
+  namespace: kube-system
+rules:
+  - apiGroups: [""]
+    resources: [services]
+    verbs: [get, list, watch]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ok147-argocd-kube-system
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ok147-argocd-kube-system
+subjects:
+  - {kind: ServiceAccount, name: ok147-argocd-manager, namespace: kube-system}
+`)
+}
+
+func targetAccessSHA(value string) string { return "sha256:" + strings.Repeat(value, 64) }


### PR DESCRIPTION
## Summary
- add an offline verifier for the exact externally rendered eight-object target-access set
- bind R, P, FixtureDigest and immutable workload target identity to one workload authority plane
- fix object order and REST routes and validate RoleBinding/ServiceAccount relationships
- reject wildcards, non-resource access, unknown fields, foreign subjects, runtime metadata, symlinks and changed artifacts

## Verification
- full Go suite: PASS
- go vet ./...: PASS
- race test for internal/submission: PASS
- git diff --check: PASS

## Boundary
The result remains mutationAllowed=false. No grant is consumed, no credential is read, and no cluster is contacted.