### PR TITLE
feat(runner): bind target access stage (OK-147)

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,10 @@ Powered by [Cluster API (CAPI)](https://cluster-api.sigs.k8s.io/), [CAPK (KubeVi
   artifact to `R`, `P`, the execution fixture and immutable target identity,
   fixes object order and REST routes, rejects wildcard/non-resource access,
   foreign subjects and runtime metadata, and returns only a non-authorizing
-  plan. Grant consumption, credentials and target submission remain absent.
+  plan. A runner-owned offline bundle now additionally requires the exact six
+  successful predecessor receipts, durable lifecycle target identity and a
+  signed `CreateTargetAccess` grant before exposing a redacted verified bundle
+  receipt. Credentials, grant consumption and target submission remain absent.
   Stage 4 now has its first distinct path as well:
   `ok cluster stage run enablement --execute` binds the verified three-receipt
   prefix and signed `CreateEnablement` grant to exactly one externally rendered

--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -2447,6 +2447,18 @@ verified output is `ok147-bounded-target-access-plan/v1` with
 This verifier does not render RBAC, consume `CreateTargetAccess` authorization,
 read a credential or contact the workload API. Those remain later boundaries.
 
+The runner now composes this projection into one verified preclaim bundle. It
+requires the complete six-receipt chain through successful runtime binding,
+reuses the raw-UID-free target digest carried by the lifecycle receipt, checks
+that the staged plan binds exactly one `stage.target-access` artifact and
+verifies an Ed25519 `CreateTargetAccess` grant against the runtime-binding
+predecessor. Its redacted `ok147-target-access-stage-bundle/v1` receipt exposes
+only plan, authorization, artifact, target and object digests and remains
+`mutationAllowed: false`.
+
+Bundle loading still does not claim the grant, open the durable ledger, read a
+workload credential or submit any of the eight objects.
+
 ## Bounded convergence observation polling
 
 The aggregate observer can now be wrapped by a bounded polling observer before

--- a/internal/runner/target_access_stage_bundle.go
+++ b/internal/runner/target_access_stage_bundle.go
@@ -1,0 +1,135 @@
+package runner
+
+import (
+	"errors"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/authorization"
+	"github.com/openkubes/ok-cluster/internal/projection"
+	"github.com/openkubes/ok-cluster/internal/stagecursor"
+	"github.com/openkubes/ok-cluster/internal/stageplan"
+	"github.com/openkubes/ok-cluster/internal/stagereceipt"
+	"github.com/openkubes/ok-cluster/internal/submission"
+)
+
+const TargetAccessStageBundleReceiptFormat = "ok147-target-access-stage-bundle/v1"
+
+// TargetAccessStageBundleConfig binds the complete successful prefix, one
+// CreateTargetAccess grant and one externally rendered eight-object artifact.
+// Loading remains entirely offline.
+type TargetAccessStageBundleConfig struct {
+	PlanPath           string
+	PlanExpected       stageplan.Expected
+	Receipts           []StageReceiptSource
+	GrantPath          string
+	GrantPublicKeyPath string
+	EvaluationTime     time.Time
+	ArtifactPath       string
+	ExpectedObjects    []projection.ResourceIdentity
+}
+
+type TargetAccessStageBundleReceipt struct {
+	Format               string   `json:"format"`
+	State                string   `json:"state"`
+	PlanDigest           string   `json:"planDigest"`
+	StageID              string   `json:"stageId"`
+	AuthorizationDigest  string   `json:"authorizationDigest"`
+	ArtifactDigest       string   `json:"artifactDigest"`
+	TargetIdentityDigest string   `json:"targetIdentityDigest"`
+	ObjectDigests        []string `json:"objectDigests"`
+	MutationAllowed      bool     `json:"mutationAllowed"`
+}
+
+type VerifiedTargetAccessStageBundle struct {
+	plan       stageplan.Binding
+	cursor     stagecursor.Cursor
+	prefix     []stagereceipt.Verified
+	grant      authorization.VerifiedStageGrant
+	projection submission.TargetAccessPlan
+	receipt    TargetAccessStageBundleReceipt
+	verified   bool
+}
+
+// LoadTargetAccessStageBundle verifies every immutable input needed before a
+// later claim/open boundary. It reads no credential and contacts no API.
+func LoadTargetAccessStageBundle(config TargetAccessStageBundleConfig) (VerifiedTargetAccessStageBundle, error) {
+	if config.Receipts == nil || config.EvaluationTime.IsZero() {
+		return VerifiedTargetAccessStageBundle{}, errors.New("target-access receipt prefix and authorization evaluation time are required")
+	}
+	plan, cursor, prefix, err := loadStageResumeWithPrefix(StageResumeConfig{
+		PlanPath: config.PlanPath, PlanExpected: config.PlanExpected, Receipts: config.Receipts,
+	})
+	if err != nil {
+		return VerifiedTargetAccessStageBundle{}, err
+	}
+	decision, err := cursor.Decision()
+	if err != nil || decision.State != "NEXT" || decision.StageID != "target-access" || decision.Authority != "workload" || !decision.RequiresAuthorization || decision.Operation != "CreateTargetAccess" {
+		return VerifiedTargetAccessStageBundle{}, errors.New("verified prefix does not select target access")
+	}
+	if len(prefix) != 6 {
+		return VerifiedTargetAccessStageBundle{}, errors.New("target access requires the exact six-receipt prefix")
+	}
+	lifecycle, err := prefix[1].Receipt()
+	if err != nil || lifecycle.StageID != "cluster-lifecycle" || !stageReceiptPrefixDigestPattern.MatchString(lifecycle.TargetClusterUIDDigest) {
+		return VerifiedTargetAccessStageBundle{}, errors.New("target access lacks durable workload identity")
+	}
+	runtimeBinding, err := prefix[5].Receipt()
+	if err != nil || runtimeBinding.StageID != "runtime-binding" || runtimeBinding.State != "SUCCEEDED" {
+		return VerifiedTargetAccessStageBundle{}, errors.New("target access lacks successful runtime binding")
+	}
+	stage, _, err := plan.Stage("target-access")
+	if err != nil {
+		return VerifiedTargetAccessStageBundle{}, err
+	}
+	if len(stage.Inputs) != 1 || stage.Inputs[0].Name != "stage.target-access" {
+		return VerifiedTargetAccessStageBundle{}, errors.New("target-access stage must bind exactly one renderer artifact")
+	}
+	projected, err := submission.LoadTargetAccess(config.ArtifactPath, submission.TargetAccessExpected{
+		ArtifactDigest: stage.Inputs[0].Digest, ContractIdentity: plan.ContractIdentity,
+		IntentRevision: plan.IntentRevision, PlatformRevision: plan.PlatformRevision, ExecutionFixture: plan.ExecutionFixture,
+		TargetIdentityDigest: lifecycle.TargetClusterUIDDigest, WorkloadAuthority: lifecycle.TargetClusterUIDDigest,
+		Objects: config.ExpectedObjects,
+	})
+	if err != nil {
+		return VerifiedTargetAccessStageBundle{}, err
+	}
+	directPredecessors, err := cursor.Predecessors()
+	if err != nil {
+		return VerifiedTargetAccessStageBundle{}, err
+	}
+	grant, err := authorization.LoadStage(config.GrantPath, config.GrantPublicKeyPath, plan, "target-access", directPredecessors, config.EvaluationTime)
+	if err != nil {
+		return VerifiedTargetAccessStageBundle{}, err
+	}
+	if _, err := authorization.BindStageGrant(grant, plan, "target-access", directPredecessors); err != nil {
+		return VerifiedTargetAccessStageBundle{}, err
+	}
+	objectDigests := make([]string, len(projected.Workload.Objects))
+	for index := range projected.Workload.Objects {
+		objectDigests[index] = projected.Workload.Objects[index].Digest
+	}
+	receipt := TargetAccessStageBundleReceipt{
+		Format: TargetAccessStageBundleReceiptFormat, State: "VERIFIED", PlanDigest: plan.PlanDigest, StageID: "target-access",
+		AuthorizationDigest: grant.Receipt().AuthorizationDigest, ArtifactDigest: projected.ArtifactDigest,
+		TargetIdentityDigest: lifecycle.TargetClusterUIDDigest, ObjectDigests: objectDigests, MutationAllowed: false,
+	}
+	return VerifiedTargetAccessStageBundle{
+		plan: plan, cursor: cursor, prefix: prefix, grant: grant, projection: projected, receipt: receipt, verified: true,
+	}, nil
+}
+
+func (bundle VerifiedTargetAccessStageBundle) Decision() (stagecursor.Decision, error) {
+	if !bundle.verified {
+		return stagecursor.Decision{}, errors.New("target-access stage bundle was not produced by verification")
+	}
+	return bundle.cursor.Decision()
+}
+
+func (bundle VerifiedTargetAccessStageBundle) Receipt() (TargetAccessStageBundleReceipt, error) {
+	if !bundle.verified || bundle.receipt.Format != TargetAccessStageBundleReceiptFormat || bundle.receipt.State != "VERIFIED" || bundle.receipt.StageID != "target-access" || bundle.receipt.MutationAllowed || len(bundle.receipt.ObjectDigests) != 8 {
+		return TargetAccessStageBundleReceipt{}, errors.New("target-access stage bundle was not produced by verification")
+	}
+	receipt := bundle.receipt
+	receipt.ObjectDigests = append([]string(nil), bundle.receipt.ObjectDigests...)
+	return receipt, nil
+}

--- a/internal/runner/target_access_stage_bundle_test.go
+++ b/internal/runner/target_access_stage_bundle_test.go
@@ -1,0 +1,198 @@
+package runner
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/projection"
+	"github.com/openkubes/ok-cluster/internal/stageplan"
+	"github.com/openkubes/ok-cluster/internal/stagereceipt"
+)
+
+func TestLoadTargetAccessStageBundleBindsPrefixGrantArtifactAndTarget(t *testing.T) {
+	fixture := targetAccessBundleFixture(t)
+	bundle, err := LoadTargetAccessStageBundle(fixture.config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decision, err := bundle.Decision()
+	if err != nil || decision.StageID != "target-access" || decision.Operation != "CreateTargetAccess" || decision.Authority != "workload" || !decision.RequiresAuthorization {
+		t.Fatalf("unexpected target-access decision: %#v %v", decision, err)
+	}
+	receipt, err := bundle.Receipt()
+	if err != nil || receipt.Format != TargetAccessStageBundleReceiptFormat || receipt.State != "VERIFIED" || receipt.PlanDigest != fixture.plan.PlanDigest || receipt.TargetIdentityDigest != runnerStageSHA("8") || receipt.AuthorizationDigest == "" || len(receipt.ObjectDigests) != 8 || receipt.MutationAllowed {
+		t.Fatalf("unexpected target-access bundle receipt: %#v %v", receipt, err)
+	}
+	if bundle.projection.Workload.Identity != runnerStageSHA("8") || len(bundle.projection.Workload.Objects) != 8 {
+		t.Fatalf("target-access projection differs: %#v", bundle.projection)
+	}
+}
+
+func TestLoadTargetAccessStageBundleFailsClosed(t *testing.T) {
+	fixture := targetAccessBundleFixture(t)
+	fixture.config.Receipts = nil
+	if _, err := LoadTargetAccessStageBundle(fixture.config); err == nil {
+		t.Fatal("implicit target-access receipt prefix was accepted")
+	}
+
+	fixture = targetAccessBundleFixture(t)
+	fixture.config.Receipts = fixture.config.Receipts[:5]
+	if _, err := LoadTargetAccessStageBundle(fixture.config); err == nil {
+		t.Fatal("incomplete target-access receipt prefix was accepted")
+	}
+
+	fixture = targetAccessBundleFixture(t)
+	raw, err := os.ReadFile(fixture.config.ArtifactPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(fixture.config.ArtifactPath, append(raw, '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadTargetAccessStageBundle(fixture.config); err == nil {
+		t.Fatal("changed target-access artifact was accepted")
+	}
+
+	fixture = targetAccessBundleFixture(t)
+	fixture.config.ExpectedObjects[7].Name = "foreign-binding"
+	if _, err := LoadTargetAccessStageBundle(fixture.config); err == nil {
+		t.Fatal("foreign target-access object identity was accepted")
+	}
+
+	if _, err := (VerifiedTargetAccessStageBundle{}).Decision(); err == nil {
+		t.Fatal("unverified target-access bundle exposed a decision")
+	}
+	if _, err := (VerifiedTargetAccessStageBundle{}).Receipt(); err == nil {
+		t.Fatal("unverified target-access bundle exposed a receipt")
+	}
+}
+
+type targetAccessBundleTestFixture struct {
+	config TargetAccessStageBundleConfig
+	plan   stageplan.Binding
+}
+
+func targetAccessBundleFixture(t *testing.T) targetAccessBundleTestFixture {
+	t.Helper()
+	root := t.TempDir()
+	at := time.Date(2026, 8, 17, 14, 0, 0, 0, time.UTC)
+	expected := stageplan.Expected{
+		ContractIdentity: runnerStagedPlan(t).ContractIdentity,
+		IntentRevision:   runnerStageSHA("a"), EnablementRevision: runnerStageSHA("b"), PlatformRevision: runnerStageSHA("c"), ExecutionFixture: runnerStageSHA("d"),
+		InfrastructureAuthority: "ok-infra", ManagementAuthority: "ok-mgmt", GitOpsAuthority: "ok-shared",
+	}
+	artifact := runnerTargetAccessYAML()
+	planRaw := submissionBundlePlan(t, expected, runnerStageSHA("1"), runnerStageSHA("2"))
+	var document map[string]any
+	if err := json.Unmarshal(planRaw, &document); err != nil {
+		t.Fatal(err)
+	}
+	stages := document["stages"].([]any)
+	targetAccess := stages[6].(map[string]any)
+	targetAccess["inputs"] = []any{map[string]any{"name": "stage.target-access", "digest": digest.SHA256(artifact)}}
+	planPath := writeBundleFile(t, root, "staged-plan.json", mustJSON(t, document))
+	plan, err := stageplan.Load(planPath, expected)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	receipts := make([]StageReceiptSource, 0, 6)
+	predecessors := []stagereceipt.Verified{}
+	type stageResult struct{ id, mutation, operation, evidence string }
+	results := []stageResult{
+		{"provider-prerequisites", "ATTEMPTED", runnerStageSHA("1"), runnerStageSHA("2")},
+		{"cluster-lifecycle", "ATTEMPTED", runnerStageSHA("3"), runnerStageSHA("4")},
+		{"lifecycle-observation", "NOT_APPLICABLE", "", runnerStageSHA("5")},
+		{"enablement", "ATTEMPTED", runnerStageSHA("6"), runnerStageSHA("7")},
+		{"network-observation", "NOT_APPLICABLE", "", runnerStageSHA("9")},
+		{"runtime-binding", "NOT_APPLICABLE", "", runnerStageSHA("0")},
+	}
+	for index, result := range results {
+		var receipt stagereceipt.Verified
+		if result.id == "cluster-lifecycle" {
+			receipt, err = stagereceipt.NewWithTargetClusterUIDDigest(plan, result.id, predecessors, "SUCCEEDED", result.mutation, result.operation, result.evidence, runnerStageSHA("8"), at.Add(time.Duration(index-6)*time.Minute))
+		} else {
+			receipt, err = stagereceipt.New(plan, result.id, predecessors, "SUCCEEDED", result.mutation, result.operation, result.evidence, at.Add(time.Duration(index-6)*time.Minute))
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		receipts = appendStageReceipt(t, root, receipts, receipt, result.id+".json")
+		predecessors = []stagereceipt.Verified{receipt}
+	}
+	grantPath, keyPath := writeSubmissionStageGrant(t, root, plan, "target-access", predecessors, at)
+	return targetAccessBundleTestFixture{
+		config: TargetAccessStageBundleConfig{
+			PlanPath: planPath, PlanExpected: expected, Receipts: receipts,
+			GrantPath: grantPath, GrantPublicKeyPath: keyPath, EvaluationTime: at,
+			ArtifactPath: writeBundleFile(t, root, "target-access.yaml", artifact), ExpectedObjects: runnerTargetAccessIdentities(),
+		},
+		plan: plan,
+	}
+}
+
+func runnerTargetAccessIdentities() []projection.ResourceIdentity {
+	return []projection.ResourceIdentity{
+		{APIVersion: "v1", Kind: "Namespace", Name: "ok-observability"},
+		{APIVersion: "v1", Kind: "ServiceAccount", Namespace: "kube-system", Name: "ok147-argocd-manager"},
+		{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "ClusterRole", Name: "ok147-argocd-platform-cluster"},
+		{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "ClusterRoleBinding", Name: "ok147-argocd-platform-cluster"},
+		{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role", Namespace: "ok-observability", Name: "ok147-argocd-platform"},
+		{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "RoleBinding", Namespace: "ok-observability", Name: "ok147-argocd-platform"},
+		{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role", Namespace: "kube-system", Name: "ok147-argocd-kube-system"},
+		{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "RoleBinding", Namespace: "kube-system", Name: "ok147-argocd-kube-system"},
+	}
+}
+
+func runnerTargetAccessYAML() []byte {
+	return []byte(`apiVersion: v1
+kind: Namespace
+metadata:
+  name: ok-observability
+  labels: {pod-security.kubernetes.io/enforce: privileged, pod-security.kubernetes.io/audit: privileged, pod-security.kubernetes.io/warn: privileged}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata: {name: ok147-argocd-manager, namespace: kube-system}
+automountServiceAccountToken: false
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata: {name: ok147-argocd-platform-cluster}
+rules:
+  - {apiGroups: [apiextensions.k8s.io], resources: [customresourcedefinitions], verbs: [get, list, watch]}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata: {name: ok147-argocd-platform-cluster}
+roleRef: {apiGroup: rbac.authorization.k8s.io, kind: ClusterRole, name: ok147-argocd-platform-cluster}
+subjects: [{kind: ServiceAccount, name: ok147-argocd-manager, namespace: kube-system}]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata: {name: ok147-argocd-platform, namespace: ok-observability}
+rules:
+  - {apiGroups: [""], resources: [configmaps, services], verbs: [get, list, watch]}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata: {name: ok147-argocd-platform, namespace: ok-observability}
+roleRef: {apiGroup: rbac.authorization.k8s.io, kind: Role, name: ok147-argocd-platform}
+subjects: [{kind: ServiceAccount, name: ok147-argocd-manager, namespace: kube-system}]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata: {name: ok147-argocd-kube-system, namespace: kube-system}
+rules:
+  - {apiGroups: [""], resources: [services], verbs: [get, list, watch]}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata: {name: ok147-argocd-kube-system, namespace: kube-system}
+roleRef: {apiGroup: rbac.authorization.k8s.io, kind: Role, name: ok147-argocd-kube-system}
+subjects: [{kind: ServiceAccount, name: ok147-argocd-manager, namespace: kube-system}]
+`)
+}


### PR DESCRIPTION
## Summary
- require the exact six-receipt prefix through successful runtime binding
- reuse the durable raw-UID-free lifecycle target identity
- bind one staged target-access artifact and signed CreateTargetAccess grant
- emit only a redacted, non-authorizing bundle receipt

## Verification
- full Go suite: PASS
- go vet ./...: PASS
- race tests for runner and submission: PASS
- git diff --check: PASS

## Boundary
No ledger claim, credential read, API contact or target mutation is introduced.