### PR TITLE
feat(runner): open target access stage (OK-147)

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,12 @@ Powered by [Cluster API (CAPI)](https://cluster-api.sigs.k8s.io/), [CAPK (KubeVi
   plan. A runner-owned offline bundle now additionally requires the exact six
   successful predecessor receipts, durable lifecycle target identity and a
   signed `CreateTargetAccess` grant before exposing a redacted verified bundle
-  receipt. Credentials, grant consumption and target submission remain absent.
+  receipt. A typed runtime opener now correlates the private raw CAPI UID with
+  that public target digest, requires distinct ledger and short-lived workload
+  credentials, and preconstructs exactly one eight-object create-only mutator.
+  Opening performs no API request or grant claim; only the returned crash-safe
+  staged operation can claim and submit. No CLI, Job package or DEV activation
+  exists for target access at this checkpoint.
   Stage 4 now has its first distinct path as well:
   `ok cluster stage run enablement --execute` binds the verified three-receipt
   prefix and signed `CreateEnablement` grant to exactly one externally rendered

--- a/internal/execution/target_access_stage.go
+++ b/internal/execution/target_access_stage.go
@@ -1,0 +1,85 @@
+package execution
+
+import (
+	"context"
+	"errors"
+
+	"github.com/openkubes/ok-cluster/internal/contract"
+	"github.com/openkubes/ok-cluster/internal/stageplan"
+	"github.com/openkubes/ok-cluster/internal/submission"
+)
+
+// TargetAccessMutator is bound to the exact eight-object workload access set.
+// It neither issues credentials nor registers the target with GitOps.
+type TargetAccessMutator struct {
+	binding   StageMutationBinding
+	identity  contract.Identity
+	plane     submission.Plane
+	submitter PlaneSubmitter
+}
+
+var _ StageMutator = (*TargetAccessMutator)(nil)
+
+// NewTargetAccessMutator accepts only the verified target-access projection.
+// Authorization and the durable single-use claim remain with StagedOperation.
+func NewTargetAccessMutator(plan stageplan.Binding, projected submission.TargetAccessPlan, submitter PlaneSubmitter) (*TargetAccessMutator, error) {
+	if submitter == nil {
+		return nil, errors.New("target-access stage requires a bounded plane submitter")
+	}
+	stage, stageDigest, err := plan.Stage("target-access")
+	if err != nil {
+		return nil, err
+	}
+	if projected.Format != submission.TargetAccessPlanFormat || projected.MutationAllowed || projected.IntentRevision != plan.IntentRevision || projected.PlatformRevision != plan.PlatformRevision || projected.ExecutionFixture != plan.ExecutionFixture {
+		return nil, errors.New("target-access projection differs from the verified staged plan")
+	}
+	if err := plan.RequireInput(stage.ID, "stage.target-access", projected.ArtifactDigest); err != nil {
+		return nil, err
+	}
+	plane := projected.Workload
+	if !stagedDigestPattern.MatchString(projected.TargetIdentityDigest) || plane.Identity != projected.TargetIdentityDigest || plane.Role != "target-access-writer" || len(plane.Objects) != 8 {
+		return nil, errors.New("target-access projection authority or content differs from the selected stage")
+	}
+	expectedKinds := []string{"Namespace", "ServiceAccount", "ClusterRole", "ClusterRoleBinding", "Role", "RoleBinding", "Role", "RoleBinding"}
+	for index, object := range plane.Objects {
+		if object.Identity.Kind != expectedKinds[index] || !stagedDigestPattern.MatchString(object.Digest) || object.CollectionPath == "" || object.ObjectPath == "" || len(object.Raw) == 0 {
+			return nil, errors.New("target-access projection lacks the exact eight-object set")
+		}
+	}
+	return &TargetAccessMutator{
+		binding: StageMutationBinding{
+			PlanDigest: plan.PlanDigest, StageID: stage.ID, StageDigest: stageDigest,
+			Operation: stage.GrantOperation, Authority: stage.Authority, ContractRevision: plan.IntentRevision,
+		},
+		identity: plan.ContractIdentity, plane: cloneSubmissionPlane(plane), submitter: submitter,
+	}, nil
+}
+
+func (mutator *TargetAccessMutator) Binding() StageMutationBinding {
+	if mutator == nil {
+		return StageMutationBinding{}
+	}
+	return mutator.binding
+}
+
+func (mutator *TargetAccessMutator) Mutate(ctx context.Context, request StageMutationRequest) (StageMutationResult, error) {
+	if mutator == nil || request.StageMutationBinding != mutator.binding || request.ContractIdentity != mutator.identity || request.GrantID == "" || !stagedDigestPattern.MatchString(request.PredecessorDigest) {
+		return StageMutationResult{}, errors.New("target-access mutation request differs from the preconstructed stage")
+	}
+	receipt, submitErr := mutator.submitter.Submit(ctx, cloneSubmissionPlane(mutator.plane))
+	mutationState, err := validateSubmissionPlaneOutcome(receipt, mutator.plane, submitErr != nil)
+	if err != nil {
+		return StageMutationResult{}, err
+	}
+	evidenceDigest, err := canonicalDigest(receipt)
+	if err != nil {
+		return StageMutationResult{}, errors.New("derive bounded target-access evidence")
+	}
+	if submitErr != nil {
+		return StageMutationResult{Outcome: "STOPPED", MutationState: mutationState, EvidenceDigest: evidenceDigest}, errors.New("bounded target-access submission stopped")
+	}
+	if mutationState != "ATTEMPTED" {
+		return StageMutationResult{Outcome: "STOPPED", MutationState: mutationState, EvidenceDigest: evidenceDigest}, nil
+	}
+	return StageMutationResult{Outcome: "SUCCEEDED", MutationState: mutationState, EvidenceDigest: evidenceDigest}, nil
+}

--- a/internal/execution/target_access_stage_test.go
+++ b/internal/execution/target_access_stage_test.go
@@ -1,0 +1,99 @@
+package execution
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/openkubes/ok-cluster/internal/projection"
+	"github.com/openkubes/ok-cluster/internal/submission"
+)
+
+func TestTargetAccessMutatorBindsExactWorkloadAccessSet(t *testing.T) {
+	plan := stagedPlan(t)
+	projected := stagedTargetAccessPlan(plan.IntentRevision, plan.PlatformRevision, plan.ExecutionFixture, stagedSHA("e"))
+	submitter := &fakePlaneSubmitter{receipt: successfulPlaneReceipt(projected.Workload, "CREATED", "ATTEMPTED")}
+	mutator, err := NewTargetAccessMutator(plan, projected, submitter)
+	if err != nil {
+		t.Fatal(err)
+	}
+	projected.Workload.Objects[0].Raw[0] = 'x'
+	result, err := mutator.Mutate(context.Background(), stagedMutationRequest(t, plan, mutator.Binding()))
+	if err != nil || result.Outcome != "SUCCEEDED" || result.MutationState != "ATTEMPTED" || result.EvidenceDigest == "" || submitter.calls != 1 {
+		t.Fatalf("target-access mutation did not complete: %#v calls=%d err=%v", result, submitter.calls, err)
+	}
+	if submitter.plane.Identity != stagedSHA("e") || len(submitter.plane.Objects) != 8 || submitter.plane.Objects[0].Identity.Kind != "Namespace" || string(submitter.plane.Objects[0].Raw) != `{"apiVersion":"v1","kind":"Namespace"}` {
+		t.Fatalf("mutator did not retain the verified workload plane: %#v", submitter.plane)
+	}
+}
+
+func TestTargetAccessMutatorPreservesStoppedEvidence(t *testing.T) {
+	plan := stagedPlan(t)
+	projected := stagedTargetAccessPlan(plan.IntentRevision, plan.PlatformRevision, plan.ExecutionFixture, stagedSHA("e"))
+	receipt := successfulPlaneReceipt(projected.Workload, "CREATED", "ATTEMPTED")
+	receipt.State = "STOPPED_PARTIAL_OR_UNKNOWN"
+	mutator, err := NewTargetAccessMutator(plan, projected, &fakePlaneSubmitter{receipt: receipt, err: errors.New("sensitive API detail")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := mutator.Mutate(context.Background(), stagedMutationRequest(t, plan, mutator.Binding()))
+	if err == nil || err.Error() != "bounded target-access submission stopped" || result.Outcome != "STOPPED" || result.MutationState != "ATTEMPTED" || result.EvidenceDigest == "" {
+		t.Fatalf("target-access stop was not redacted and retained: %#v %v", result, err)
+	}
+}
+
+func TestTargetAccessMutatorRejectsForeignProjectionAndRequest(t *testing.T) {
+	plan := stagedPlan(t)
+	valid := stagedTargetAccessPlan(plan.IntentRevision, plan.PlatformRevision, plan.ExecutionFixture, stagedSHA("e"))
+	tests := map[string]func(*submission.TargetAccessPlan){
+		"authorizing input": func(value *submission.TargetAccessPlan) { value.MutationAllowed = true },
+		"wrong P":           func(value *submission.TargetAccessPlan) { value.PlatformRevision = stagedSHA("1") },
+		"wrong artifact":    func(value *submission.TargetAccessPlan) { value.ArtifactDigest = stagedSHA("1") },
+		"wrong authority":   func(value *submission.TargetAccessPlan) { value.Workload.Identity = stagedSHA("1") },
+		"seventh object":    func(value *submission.TargetAccessPlan) { value.Workload.Objects = value.Workload.Objects[:7] },
+		"wrong kind":        func(value *submission.TargetAccessPlan) { value.Workload.Objects[0].Identity.Kind = "ConfigMap" },
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			candidate := cloneTargetAccessPlan(valid)
+			mutate(&candidate)
+			if _, err := NewTargetAccessMutator(plan, candidate, &fakePlaneSubmitter{}); err == nil {
+				t.Fatal("foreign target-access projection was accepted")
+			}
+		})
+	}
+	mutator, _ := NewTargetAccessMutator(plan, valid, &fakePlaneSubmitter{})
+	request := stagedMutationRequest(t, plan, mutator.Binding())
+	request.ContractIdentity.Name = "other"
+	if _, err := mutator.Mutate(context.Background(), request); err == nil {
+		t.Fatal("foreign target-access request was accepted")
+	}
+}
+
+func stagedTargetAccessPlan(r, p, fixture, targetDigest string) submission.TargetAccessPlan {
+	kinds := []string{"Namespace", "ServiceAccount", "ClusterRole", "ClusterRoleBinding", "Role", "RoleBinding", "Role", "RoleBinding"}
+	objects := make([]submission.Object, len(kinds))
+	for index, kind := range kinds {
+		objects[index] = submission.Object{
+			Identity: projection.ResourceIdentity{APIVersion: "v1", Kind: kind, Name: "object"},
+			Digest:   stagedSHA(string("12345678"[index])), CollectionPath: "/api/v1/resources", ObjectPath: "/api/v1/resources/object",
+			Raw: json.RawMessage(`{"apiVersion":"v1","kind":"` + kind + `"}`),
+		}
+	}
+	return submission.TargetAccessPlan{
+		Format: submission.TargetAccessPlanFormat, IntentRevision: r, PlatformRevision: p, ExecutionFixture: fixture,
+		TargetIdentityDigest: targetDigest, ArtifactDigest: stagedSHA("0"), MutationAllowed: false,
+		Workload: submission.Plane{Identity: targetDigest, Role: "target-access-writer", Objects: objects},
+	}
+}
+
+func cloneTargetAccessPlan(source submission.TargetAccessPlan) submission.TargetAccessPlan {
+	clone := source
+	clone.Workload.Objects = make([]submission.Object, len(source.Workload.Objects))
+	for index, object := range source.Workload.Objects {
+		clone.Workload.Objects[index] = object
+		clone.Workload.Objects[index].Raw = append([]byte(nil), object.Raw...)
+	}
+	return clone
+}

--- a/internal/runner/target_access_stage_bundle.go
+++ b/internal/runner/target_access_stage_bundle.go
@@ -1,10 +1,12 @@
 package runner
 
 import (
+	"context"
 	"errors"
 	"time"
 
 	"github.com/openkubes/ok-cluster/internal/authorization"
+	"github.com/openkubes/ok-cluster/internal/execution"
 	"github.com/openkubes/ok-cluster/internal/projection"
 	"github.com/openkubes/ok-cluster/internal/stagecursor"
 	"github.com/openkubes/ok-cluster/internal/stageplan"
@@ -48,6 +50,22 @@ type VerifiedTargetAccessStageBundle struct {
 	projection submission.TargetAccessPlan
 	receipt    TargetAccessStageBundleReceipt
 	verified   bool
+}
+
+// TargetAccessStageRuntimeConfig keeps the ledger credential separate from
+// the private workload runtime binding and short-lived workload token.
+type TargetAccessStageRuntimeConfig struct {
+	Ledger   KubernetesLedgerConfig
+	Workload WorkloadAuthorityFileResolverConfig
+	Clock    func() time.Time
+}
+
+type BoundTargetAccessStage struct {
+	operation execution.StagedOperation
+	plan      stageplan.Binding
+	cursor    stagecursor.Cursor
+	grant     authorization.VerifiedStageGrant
+	verified  bool
 }
 
 // LoadTargetAccessStageBundle verifies every immutable input needed before a
@@ -132,4 +150,26 @@ func (bundle VerifiedTargetAccessStageBundle) Receipt() (TargetAccessStageBundle
 	receipt := bundle.receipt
 	receipt.ObjectDigests = append([]string(nil), bundle.receipt.ObjectDigests...)
 	return receipt, nil
+}
+
+// Open binds the verified public bundle to private runtime credentials but
+// does not inspect the ledger, claim the grant or contact the workload API.
+func (bundle VerifiedTargetAccessStageBundle) Open(config TargetAccessStageRuntimeConfig) (BoundTargetAccessStage, error) {
+	if !bundle.verified {
+		return BoundTargetAccessStage{}, errors.New("target-access stage bundle was not produced by verification")
+	}
+	operation, err := OpenKubernetesTargetAccessStageOperation(KubernetesTargetAccessStageOperationConfig{
+		Ledger: config.Ledger, Workload: config.Workload, Plan: bundle.plan, Projection: bundle.projection, Clock: config.Clock,
+	})
+	if err != nil {
+		return BoundTargetAccessStage{}, err
+	}
+	return BoundTargetAccessStage{operation: operation, plan: bundle.plan, cursor: bundle.cursor, grant: bundle.grant, verified: true}, nil
+}
+
+func (stage BoundTargetAccessStage) Run(ctx context.Context) (execution.StagedOperationReceipt, error) {
+	if !stage.verified {
+		return execution.StagedOperationReceipt{}, errors.New("target-access stage runtime was not produced by verification")
+	}
+	return stage.operation.Run(ctx, stage.plan, stage.cursor, stage.grant)
 }

--- a/internal/runner/target_access_stage_bundle_test.go
+++ b/internal/runner/target_access_stage_bundle_test.go
@@ -1,6 +1,7 @@
 package runner
 
 import (
+	"context"
 	"encoding/json"
 	"os"
 	"testing"
@@ -23,11 +24,58 @@ func TestLoadTargetAccessStageBundleBindsPrefixGrantArtifactAndTarget(t *testing
 		t.Fatalf("unexpected target-access decision: %#v %v", decision, err)
 	}
 	receipt, err := bundle.Receipt()
-	if err != nil || receipt.Format != TargetAccessStageBundleReceiptFormat || receipt.State != "VERIFIED" || receipt.PlanDigest != fixture.plan.PlanDigest || receipt.TargetIdentityDigest != runnerStageSHA("8") || receipt.AuthorizationDigest == "" || len(receipt.ObjectDigests) != 8 || receipt.MutationAllowed {
+	if err != nil || receipt.Format != TargetAccessStageBundleReceiptFormat || receipt.State != "VERIFIED" || receipt.PlanDigest != fixture.plan.PlanDigest || receipt.TargetIdentityDigest != digest.SHA256([]byte(targetAccessRuntimeUID)) || receipt.AuthorizationDigest == "" || len(receipt.ObjectDigests) != 8 || receipt.MutationAllowed {
 		t.Fatalf("unexpected target-access bundle receipt: %#v %v", receipt, err)
 	}
-	if bundle.projection.Workload.Identity != runnerStageSHA("8") || len(bundle.projection.Workload.Objects) != 8 {
+	if bundle.projection.Workload.Identity != digest.SHA256([]byte(targetAccessRuntimeUID)) || len(bundle.projection.Workload.Objects) != 8 {
 		t.Fatalf("target-access projection differs: %#v", bundle.projection)
+	}
+}
+
+func TestTargetAccessStageBundleOpensRuntimeBoundWorkloadAuthority(t *testing.T) {
+	fixture := targetAccessBundleFixture(t)
+	bundle, err := LoadTargetAccessStageBundle(fixture.config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runtime := targetAccessRuntime(t, fixture.plan)
+	bound, err := bundle.Open(runtime)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bound.verified || bound.operation.Ledger == nil || bound.operation.Mutator == nil || bound.operation.Clock == nil || bound.operation.Mutator.Binding().StageID != "target-access" {
+		t.Fatalf("incomplete target-access stage runtime: %#v", bound)
+	}
+
+	foreign := targetAccessRuntime(t, fixture.plan)
+	binding, err := loadWorkloadAuthorityBinding(foreign.Workload.Path, foreign.Workload.ExpectedBindingDigest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	binding.TargetClusterUID = "foreign-runtime-uid"
+	raw, _ := json.Marshal(binding)
+	if err := os.WriteFile(foreign.Workload.Path, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	foreign.Workload.ExpectedBindingDigest, _ = WorkloadAuthorityBindingDigest(binding)
+	if _, err := bundle.Open(foreign); err == nil {
+		t.Fatal("foreign runtime target was accepted")
+	}
+
+	aliased := targetAccessRuntime(t, fixture.plan)
+	ledgerToken, _ := os.ReadFile(aliased.Ledger.TokenFile)
+	if err := os.WriteFile(aliased.Workload.TokenFile, ledgerToken, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := bundle.Open(aliased); err == nil {
+		t.Fatal("shared ledger and workload credential was accepted")
+	}
+
+	if _, err := (VerifiedTargetAccessStageBundle{}).Open(TargetAccessStageRuntimeConfig{}); err == nil {
+		t.Fatal("unverified target-access bundle opened a runtime")
+	}
+	if _, err := (BoundTargetAccessStage{}).Run(context.Background()); err == nil {
+		t.Fatal("unverified target-access runtime executed")
 	}
 }
 
@@ -75,6 +123,8 @@ type targetAccessBundleTestFixture struct {
 	plan   stageplan.Binding
 }
 
+const targetAccessRuntimeUID = "cluster-runtime-uid-147"
+
 func targetAccessBundleFixture(t *testing.T) targetAccessBundleTestFixture {
 	t.Helper()
 	root := t.TempDir()
@@ -113,7 +163,7 @@ func targetAccessBundleFixture(t *testing.T) targetAccessBundleTestFixture {
 	for index, result := range results {
 		var receipt stagereceipt.Verified
 		if result.id == "cluster-lifecycle" {
-			receipt, err = stagereceipt.NewWithTargetClusterUIDDigest(plan, result.id, predecessors, "SUCCEEDED", result.mutation, result.operation, result.evidence, runnerStageSHA("8"), at.Add(time.Duration(index-6)*time.Minute))
+			receipt, err = stagereceipt.NewWithTargetClusterUIDDigest(plan, result.id, predecessors, "SUCCEEDED", result.mutation, result.operation, result.evidence, digest.SHA256([]byte(targetAccessRuntimeUID)), at.Add(time.Duration(index-6)*time.Minute))
 		} else {
 			receipt, err = stagereceipt.New(plan, result.id, predecessors, "SUCCEEDED", result.mutation, result.operation, result.evidence, at.Add(time.Duration(index-6)*time.Minute))
 		}
@@ -131,6 +181,35 @@ func targetAccessBundleFixture(t *testing.T) targetAccessBundleTestFixture {
 			ArtifactPath: writeBundleFile(t, root, "target-access.yaml", artifact), ExpectedObjects: runnerTargetAccessIdentities(),
 		},
 		plan: plan,
+	}
+}
+
+func targetAccessRuntime(t *testing.T, plan stageplan.Binding) TargetAccessStageRuntimeConfig {
+	t.Helper()
+	root := t.TempDir()
+	ca := testCA(t)
+	caPath := writeBundleFile(t, root, "workload-ca.crt", ca)
+	binding := WorkloadAuthorityBinding{
+		Format: WorkloadAuthorityBindingFormat, IntentRevision: plan.IntentRevision,
+		TargetClusterUID: targetAccessRuntimeUID, TargetIdentityScheme: "capi-cluster-uid/v1",
+		Endpoint: "https://192.0.2.147:6443", CABundleDigest: digest.SHA256(ca),
+	}
+	bindingRaw, _ := json.Marshal(binding)
+	bindingPath := writeBundleFile(t, root, "runtime-binding.json", bindingRaw)
+	bindingDigest, err := WorkloadAuthorityBindingDigest(binding)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return TargetAccessStageRuntimeConfig{
+		Ledger: KubernetesLedgerConfig{
+			Endpoint: "https://192.0.2.12:6443", Namespace: "openkubes-execution-system",
+			TokenFile: writeBundleFile(t, root, "ledger-token", []byte("target-access-ledger-token")), CAFile: caPath,
+		},
+		Workload: WorkloadAuthorityFileResolverConfig{
+			Path: bindingPath, ExpectedBindingDigest: bindingDigest,
+			TokenFile: writeBundleFile(t, root, "workload-token", []byte("target-access-workload-token")), CAFile: caPath,
+		},
+		Clock: func() time.Time { return time.Date(2026, 8, 17, 15, 0, 0, 0, time.UTC) },
 	}
 }
 

--- a/internal/runner/target_access_stage_operation.go
+++ b/internal/runner/target_access_stage_operation.go
@@ -1,0 +1,56 @@
+package runner
+
+import (
+	"crypto/subtle"
+	"errors"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/execution"
+	"github.com/openkubes/ok-cluster/internal/stageplan"
+	"github.com/openkubes/ok-cluster/internal/submission"
+)
+
+// KubernetesTargetAccessStageOperationConfig binds one verified target-access
+// projection to the durable ledger and private runtime-bound workload files.
+type KubernetesTargetAccessStageOperationConfig struct {
+	Ledger     KubernetesLedgerConfig
+	Workload   WorkloadAuthorityFileResolverConfig
+	Plan       stageplan.Binding
+	Projection submission.TargetAccessPlan
+	Clock      func() time.Time
+}
+
+// OpenKubernetesTargetAccessStageOperation verifies the private raw target UID
+// against the public digest and reads bounded credentials without API contact.
+func OpenKubernetesTargetAccessStageOperation(config KubernetesTargetAccessStageOperationConfig) (execution.StagedOperation, error) {
+	if config.Clock == nil {
+		return execution.StagedOperation{}, errors.New("target-access operation clock is required")
+	}
+	binding, authority, err := loadWorkloadAuthorityFiles(config.Workload)
+	if err != nil {
+		return execution.StagedOperation{}, errors.New("open runtime-bound target-access authority")
+	}
+	if binding.IntentRevision != config.Plan.IntentRevision || digest.SHA256([]byte(binding.TargetClusterUID)) != config.Projection.TargetIdentityDigest || config.Projection.Workload.Identity != config.Projection.TargetIdentityDigest {
+		return execution.StagedOperation{}, errors.New("target-access credential differs from the runtime-bound target")
+	}
+	store, ledgerToken, err := openKubernetesLedger(config.Ledger)
+	if err != nil {
+		return execution.StagedOperation{}, errors.New("open target-access stage ledger")
+	}
+	// The API client retains only the public target digest in its receipts. The
+	// raw UID was verified above and remains private runtime material.
+	authority.AuthorityIdentity = config.Projection.TargetIdentityDigest
+	submitter, workloadToken, err := openKubernetesSubmissionClient(authority)
+	if err != nil {
+		return execution.StagedOperation{}, errors.New("open target-access submission authority")
+	}
+	if len(ledgerToken) == len(workloadToken) && subtle.ConstantTimeCompare([]byte(ledgerToken), []byte(workloadToken)) == 1 {
+		return execution.StagedOperation{}, errors.New("ledger and target-access credentials must be distinct")
+	}
+	mutator, err := execution.NewTargetAccessMutator(config.Plan, config.Projection, submitter)
+	if err != nil {
+		return execution.StagedOperation{}, err
+	}
+	return execution.StagedOperation{Ledger: store, Mutator: mutator, Clock: config.Clock}, nil
+}

--- a/internal/submission/kubernetes.go
+++ b/internal/submission/kubernetes.go
@@ -91,7 +91,7 @@ func NewKubernetesClient(config KubernetesClientConfig) (*KubernetesClient, erro
 	if config.BearerToken == "" || strings.TrimSpace(config.BearerToken) != config.BearerToken || strings.ContainsAny(config.BearerToken, "\r\n") {
 		return nil, errors.New("submission Kubernetes bearer token is invalid")
 	}
-	if !validName(config.AuthorityIdentity, 63) || strings.Contains(config.AuthorityIdentity, ".") {
+	if (!validName(config.AuthorityIdentity, 63) || strings.Contains(config.AuthorityIdentity, ".")) && !immutableDigestPattern.MatchString(config.AuthorityIdentity) {
 		return nil, errors.New("submission authority identity is invalid")
 	}
 	if config.Client == nil {

--- a/internal/submission/kubernetes_test.go
+++ b/internal/submission/kubernetes_test.go
@@ -92,6 +92,24 @@ func TestKubernetesSubmitFailsClosedForDriftConflictAndAuthority(t *testing.T) {
 	})
 }
 
+func TestKubernetesClientAcceptsOnlyNamedOrDigestAuthority(t *testing.T) {
+	client := &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return jsonResponse(http.StatusNotFound, nil, nil), nil
+	})}
+	if _, err := NewKubernetesClient(KubernetesClientConfig{
+		Endpoint: "http://127.0.0.1:12345", BearerToken: "short-lived-test-token",
+		AuthorityIdentity: strings.Repeat("a", 64), Client: client,
+	}); err == nil {
+		t.Fatal("untyped long authority identity was accepted")
+	}
+	if _, err := NewKubernetesClient(KubernetesClientConfig{
+		Endpoint: "http://127.0.0.1:12345", BearerToken: "short-lived-test-token",
+		AuthorityIdentity: "sha256:" + strings.Repeat("a", 64), Client: client,
+	}); err != nil {
+		t.Fatalf("redacted digest authority was rejected: %v", err)
+	}
+}
+
 func TestExecutorPreservesAuthorityOrderAndPartialReceipt(t *testing.T) {
 	root, binding := validProjection(t)
 	plan, err := Load(root, binding)


### PR DESCRIPTION
## What changed

- add a typed target-access mutator for the exact eight-object workload RBAC set
- correlate the private raw CAPI Cluster UID with the public target identity digest
- require distinct durable-ledger and short-lived workload credentials
- let the verified target-access bundle open the crash-safe staged operation without API contact or claim
- retain only the redacted target digest in submission receipts

## Why

OK-147 needs a bounded transition from the verified target-access artifacts to an executable operation without introducing a dynamic dispatcher, leaking the raw target UID, or combining ledger and workload authority.

## Boundary

- no CLI or Job package
- no DEV activation
- no credential issuance or Argo registration
- no update, patch, delete, list, watch, discovery, retry, or fallback path

## Validation

- `GOCACHE=/private/tmp/ok147-go-build go test -ldflags=-linkmode=external ./...`
- `go vet ./...`
- `GOCACHE=/private/tmp/ok147-go-build go test -race -ldflags=-linkmode=external ./internal/execution ./internal/submission ./internal/runner`
