### PR TITLE
test(runner): prove target access execution (OK-147)

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,10 @@ Powered by [Cluster API (CAPI)](https://cluster-api.sigs.k8s.io/), [CAPK (KubeVi
   credentials, and preconstructs exactly one eight-object create-only mutator.
   Opening performs no API request or grant claim; only the returned crash-safe
   staged operation can claim and submit. No CLI, Job package or DEV activation
-  exists for target access at this checkpoint.
+  exists for target access at this checkpoint. A separated TLS fake-API proof
+  now covers the complete claim-to-submit path: exactly eight ordered
+  `GET`/conditional-`POST` pairs, durable success replay without another write,
+  and a durably stopped partial prefix without retry.
   Stage 4 now has its first distinct path as well:
   `ok cluster stage run enablement --execute` binds the verified three-receipt
   prefix and signed `CreateEnablement` grant to exactly one externally rendered

--- a/internal/runner/target_access_stage_execution_test.go
+++ b/internal/runner/target_access_stage_execution_test.go
@@ -1,0 +1,190 @@
+package runner
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/execution"
+	"github.com/openkubes/ok-cluster/internal/stageplan"
+	"github.com/openkubes/ok-cluster/internal/submission"
+)
+
+func TestTargetAccessStageRunsExactlyOnceAgainstRuntimeBoundTarget(t *testing.T) {
+	fixture := targetAccessBundleFixture(t)
+	bundle, err := LoadTargetAccessStageBundle(fixture.config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ledgerAPI := newRuntimeBindingLedgerAPI(t)
+	defer ledgerAPI.Close()
+	targetAPI := newTargetAccessAPI(t, 0)
+	defer targetAPI.Close()
+	bound, err := bundle.Open(targetAccessExecutionRuntime(t, fixture.plan, ledgerAPI.Server, targetAPI.Server))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ledgerAPI.RequestCount() != 0 || targetAPI.RequestCount() != 0 {
+		t.Fatal("opening target-access stage contacted Kubernetes")
+	}
+
+	receipt, err := bound.Run(context.Background())
+	if err != nil || receipt.State != "COMPLETED_SUCCEEDED" || receipt.StageID != "target-access" || receipt.StageReceiptDigest == "" {
+		t.Fatalf("target-access stage did not complete: %#v %v", receipt, err)
+	}
+	want := targetAccessRequests(bundle.projection)
+	if !reflect.DeepEqual(targetAPI.Requests(), want) {
+		t.Fatalf("target-access request boundary differs:\n got %v\nwant %v", targetAPI.Requests(), want)
+	}
+	public, _ := json.Marshal(receipt)
+	for _, forbidden := range []string{targetAccessRuntimeUID, "ledger-token", "workload-token", ledgerAPI.URL, targetAPI.URL} {
+		if strings.Contains(string(public), forbidden) {
+			t.Fatalf("target-access receipt exposed private value %q", forbidden)
+		}
+	}
+
+	replayed, err := bound.Run(context.Background())
+	if err != nil || replayed.StageReceiptDigest != receipt.StageReceiptDigest || !reflect.DeepEqual(targetAPI.Requests(), want) {
+		t.Fatalf("durable target-access outcome replayed mutation: %#v %v", replayed, err)
+	}
+}
+
+func TestTargetAccessStagePersistsPartialStopWithoutRetry(t *testing.T) {
+	fixture := targetAccessBundleFixture(t)
+	bundle, err := LoadTargetAccessStageBundle(fixture.config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ledgerAPI := newRuntimeBindingLedgerAPI(t)
+	defer ledgerAPI.Close()
+	targetAPI := newTargetAccessAPI(t, 3)
+	defer targetAPI.Close()
+	bound, err := bundle.Open(targetAccessExecutionRuntime(t, fixture.plan, ledgerAPI.Server, targetAPI.Server))
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, runErr := bound.Run(context.Background())
+	var resultErr *execution.StageResultError
+	if !errors.As(runErr, &resultErr) || receipt.State != "COMPLETED_STOPPED" || receipt.StageReceiptDigest == "" {
+		t.Fatalf("partial target-access state was not durably stopped: %#v %v", receipt, runErr)
+	}
+	requests := targetAPI.Requests()
+	if len(requests) != 6 || requests[5] != "POST "+bundle.projection.Workload.Objects[2].CollectionPath {
+		t.Fatalf("target-access did not stop at the bound failure: %v", requests)
+	}
+	if _, err := bound.Run(context.Background()); !errors.As(err, &resultErr) || !reflect.DeepEqual(targetAPI.Requests(), requests) {
+		t.Fatalf("durable target-access stop was retried: requests=%v err=%v", targetAPI.Requests(), err)
+	}
+}
+
+func targetAccessExecutionRuntime(t *testing.T, plan stageplan.Binding, ledgerServer, targetServer *httptest.Server) TargetAccessStageRuntimeConfig {
+	t.Helper()
+	root := t.TempDir()
+	ledgerCAPath := writeRuntimeBindingServerCA(t, root, "ledger-ca.crt", ledgerServer)
+	targetCAPath := writeRuntimeBindingServerCA(t, root, "target-ca.crt", targetServer)
+	targetCA, err := os.ReadFile(targetCAPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	binding := WorkloadAuthorityBinding{
+		Format: WorkloadAuthorityBindingFormat, IntentRevision: plan.IntentRevision,
+		TargetClusterUID: targetAccessRuntimeUID, TargetIdentityScheme: "capi-cluster-uid/v1",
+		Endpoint: targetServer.URL, CABundleDigest: digest.SHA256(targetCA),
+	}
+	bindingDigest, err := WorkloadAuthorityBindingDigest(binding)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bindingRaw, _ := json.Marshal(binding)
+	return TargetAccessStageRuntimeConfig{
+		Ledger: KubernetesLedgerConfig{
+			Endpoint: ledgerServer.URL, Namespace: "openkubes-execution-system",
+			TokenFile: writeBundleFile(t, root, "ledger-token", []byte("ledger-token")), CAFile: ledgerCAPath,
+		},
+		Workload: WorkloadAuthorityFileResolverConfig{
+			Path: writeBundleFile(t, root, "runtime-binding.json", bindingRaw), ExpectedBindingDigest: bindingDigest,
+			TokenFile: writeBundleFile(t, root, "workload-token", []byte("workload-token")), CAFile: targetCAPath,
+		},
+		Clock: func() time.Time { return time.Date(2026, 8, 17, 14, 1, 0, 0, time.UTC) },
+	}
+}
+
+type targetAccessAPI struct {
+	*httptest.Server
+	mu       sync.Mutex
+	objects  map[string]map[string]any
+	requests []string
+	posts    int
+	failPost int
+}
+
+func newTargetAccessAPI(t *testing.T, failPost int) *targetAccessAPI {
+	t.Helper()
+	api := &targetAccessAPI{objects: map[string]map[string]any{}, failPost: failPost}
+	api.Server = httptest.NewTLSServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		api.mu.Lock()
+		defer api.mu.Unlock()
+		api.requests = append(api.requests, request.Method+" "+request.URL.RequestURI())
+		response.Header().Set("Content-Type", "application/json")
+		if request.Header.Get("Authorization") != "Bearer workload-token" {
+			response.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		switch request.Method {
+		case http.MethodGet:
+			object, exists := api.objects[request.URL.Path]
+			if !exists {
+				response.WriteHeader(http.StatusNotFound)
+				return
+			}
+			json.NewEncoder(response).Encode(object)
+		case http.MethodPost:
+			api.posts++
+			if api.failPost > 0 && api.posts == api.failPost {
+				response.WriteHeader(http.StatusForbidden)
+				return
+			}
+			var object map[string]any
+			if err := json.NewDecoder(request.Body).Decode(&object); err != nil {
+				response.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			metadata, _ := object["metadata"].(map[string]any)
+			metadata["uid"] = "target-object-uid-" + string(rune('0'+api.posts))
+			metadata["resourceVersion"] = "1"
+			name, _ := metadata["name"].(string)
+			objectPath := strings.TrimSuffix(request.URL.Path, "/") + "/" + name
+			api.objects[objectPath] = object
+			response.WriteHeader(http.StatusCreated)
+			json.NewEncoder(response).Encode(object)
+		default:
+			response.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	return api
+}
+
+func (api *targetAccessAPI) Requests() []string {
+	api.mu.Lock()
+	defer api.mu.Unlock()
+	return append([]string(nil), api.requests...)
+}
+
+func (api *targetAccessAPI) RequestCount() int { return len(api.Requests()) }
+
+func targetAccessRequests(plan submission.TargetAccessPlan) []string {
+	requests := make([]string, 0, 2*len(plan.Workload.Objects))
+	for _, object := range plan.Workload.Objects {
+		requests = append(requests, "GET "+object.ObjectPath, "POST "+object.CollectionPath)
+	}
+	return requests
+}


### PR DESCRIPTION
## What changed

- prove the target-access stage end to end against separate TLS fake APIs
- assert that opening performs zero ledger and workload requests
- assert exactly eight ordered exact-name GET / conditional POST pairs
- prove a completed outcome is replayed without another workload write
- prove a partial third-object failure is durably stopped and never retried
- verify public orchestration evidence excludes raw target UID, credentials and endpoints

## Why

The newly opened target-access operation needs executable evidence that its shared ledger and create-only submitter preserve the intended single-use and STOP-PRESERVE-NO-RETRY boundaries before a CLI or Job activation surface is added.

## Boundary

- tests and documentation only
- no CLI or Job package
- no DEV activation or infrastructure mutation

## Validation

- `GOCACHE=/private/tmp/ok147-go-build go test -ldflags=-linkmode=external ./...`
- `go vet ./...`
- `GOCACHE=/private/tmp/ok147-go-build go test -race -ldflags=-linkmode=external ./internal/runner`
