### PR TITLE
feat(cli): run target access stage (OK-147)

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,11 @@ Powered by [Cluster API (CAPI)](https://cluster-api.sigs.k8s.io/), [CAPK (KubeVi
   that public target digest, requires distinct ledger and short-lived workload
   credentials, and preconstructs exactly one eight-object create-only mutator.
   Opening performs no API request or grant claim; only the returned crash-safe
-  staged operation can claim and submit. No CLI, Job package or DEV activation
+  staged operation can claim and submit. The local
+  `ok cluster stage run target-access --execute` boundary now requires the
+  exact six-receipt prefix, signed grant, eight independently named object
+  identities, private runtime-binding digest and distinct ledger/workload
+  files before it can invoke that operation. No Job package or DEV activation
   exists for target access at this checkpoint. A separated TLS fake-API proof
   now covers the complete claim-to-submit path: exactly eight ordered
   `GET`/conditional-`POST` pairs, durable success replay without another write,

--- a/cmd/ok/main.go
+++ b/cmd/ok/main.go
@@ -492,6 +492,18 @@ var executeEnablementStage = func(ctx context.Context, bundleConfig runner.Enabl
 	return bound.Run(ctx)
 }
 
+var executeTargetAccessStage = func(ctx context.Context, bundleConfig runner.TargetAccessStageBundleConfig, runtimeConfig runner.TargetAccessStageRuntimeConfig) (execution.StagedOperationReceipt, error) {
+	bundle, err := runner.LoadTargetAccessStageBundle(bundleConfig)
+	if err != nil {
+		return execution.StagedOperationReceipt{}, err
+	}
+	bound, err := bundle.Open(runtimeConfig)
+	if err != nil {
+		return execution.StagedOperationReceipt{}, err
+	}
+	return bound.Run(ctx)
+}
+
 var executeLifecycleObservationStage = func(ctx context.Context, bundleConfig runner.StageResumeConfig, runtimeConfig runner.LifecycleObservationStageRuntimeConfig) (execution.ObservationStageRunReceipt, error) {
 	bundle, err := runner.LoadLifecycleObservationStageBundle(bundleConfig)
 	if err != nil {
@@ -635,6 +647,9 @@ func runContext(ctx context.Context, arguments []string, stdout, stderr io.Write
 	if len(arguments) >= 4 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "run" && arguments[3] == "enablement" {
 		return runClusterStageRunEnablement(ctx, arguments[4:], stdout, stderr)
 	}
+	if len(arguments) >= 4 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "run" && arguments[3] == "target-access" {
+		return runClusterStageRunTargetAccess(ctx, arguments[4:], stdout, stderr)
+	}
 	if len(arguments) >= 3 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "run" {
 		return runClusterStageRun(ctx, arguments[3:], stdout, stderr)
 	}
@@ -647,7 +662,7 @@ func runContext(ctx context.Context, arguments []string, stdout, stderr io.Write
 	if len(arguments) >= 4 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "launch" && arguments[3] == "execute" {
 		return runClusterStageLaunchExecute(ctx, arguments[4:], stdout, stderr)
 	}
-	return errors.New("usage: ok cluster create ... | ok cluster stage inspect ... | ok cluster stage resume ... | ok cluster stage observe lifecycle ... | ok cluster stage observe network ... | ok cluster stage bind runtime ... | ok cluster stage bind runtime launch prepare ... | ok cluster stage bind runtime launch execute ... | ok cluster stage observe network package ... | ok cluster stage observe network launch prepare ... | ok cluster stage observe network launch execute ... | ok cluster stage observe lifecycle package ... | ok cluster stage observe lifecycle launch prepare ... | ok cluster stage observe lifecycle launch execute ... | ok cluster stage run ... | ok cluster stage run enablement ... | ok cluster stage run enablement package ... | ok cluster stage run enablement launch prepare ... | ok cluster stage run enablement launch execute ... | ok cluster stage package ... | ok cluster stage launch prepare ... | ok cluster stage launch execute ...")
+	return errors.New("usage: ok cluster create ... | ok cluster stage inspect ... | ok cluster stage resume ... | ok cluster stage observe lifecycle ... | ok cluster stage observe network ... | ok cluster stage bind runtime ... | ok cluster stage bind runtime launch prepare ... | ok cluster stage bind runtime launch execute ... | ok cluster stage observe network package ... | ok cluster stage observe network launch prepare ... | ok cluster stage observe network launch execute ... | ok cluster stage observe lifecycle package ... | ok cluster stage observe lifecycle launch prepare ... | ok cluster stage observe lifecycle launch execute ... | ok cluster stage run ... | ok cluster stage run enablement ... | ok cluster stage run target-access ... | ok cluster stage run enablement package ... | ok cluster stage run enablement launch prepare ... | ok cluster stage run enablement launch execute ... | ok cluster stage package ... | ok cluster stage launch prepare ... | ok cluster stage launch execute ...")
 }
 
 func runClusterCreate(arguments []string, stdout, stderr io.Writer) error {
@@ -1699,6 +1714,99 @@ func runClusterStageRunEnablement(ctx context.Context, arguments []string, stdou
 		Authority: runner.KubernetesAuthorityConfig{
 			Endpoint: *managementAPIEndpoint, AuthorityIdentity: resume.PlanExpected.ManagementAuthority,
 			TokenFile: *managementTokenFile, CAFile: *managementCAFile,
+		},
+		Clock: func() time.Time { return time.Now().UTC() },
+	})
+	if receipt.Format != "" {
+		encoder := json.NewEncoder(stdout)
+		encoder.SetEscapeHTML(false)
+		encoder.SetIndent("", "  ")
+		if err := encoder.Encode(receipt); err != nil {
+			return err
+		}
+	}
+	return runErr
+}
+
+func runClusterStageRunTargetAccess(ctx context.Context, arguments []string, stdout, stderr io.Writer) error {
+	flags := flag.NewFlagSet("ok cluster stage run target-access", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	resumeFlags := addStageResumeFlags(flags)
+	grantPath := flags.String("grant", "", "path to the signed single-stage grant")
+	grantKeyPath := flags.String("grant-key", "", "path to the trusted stage-authority public key")
+	evaluationTime := flags.String("evaluation-time", "", "explicit RFC3339 grant evaluation time")
+	artifactPath := flags.String("target-access-artifact", "", "path to the exact externally rendered eight-object target-access set")
+	observabilityNamespace := flags.String("observability-namespace", "", "independently expected observability namespace")
+	managerServiceAccount := flags.String("manager-serviceaccount", "", "independently expected kube-system manager ServiceAccount")
+	clusterRole := flags.String("cluster-role", "", "independently expected cluster role")
+	clusterRoleBinding := flags.String("cluster-rolebinding", "", "independently expected cluster role binding")
+	platformRole := flags.String("platform-role", "", "independently expected observability namespace role")
+	platformRoleBinding := flags.String("platform-rolebinding", "", "independently expected observability namespace role binding")
+	kubeSystemRole := flags.String("kube-system-role", "", "independently expected kube-system role")
+	kubeSystemRoleBinding := flags.String("kube-system-rolebinding", "", "independently expected kube-system role binding")
+	execute := flags.Bool("execute", false, "claim and execute exactly the selected target-access stage")
+	ledgerAPIEndpoint := flags.String("ledger-api-endpoint", "", "TLS Kubernetes API endpoint for the durable ledger")
+	ledgerTokenFile := flags.String("ledger-token-file", "", "path to the short-lived ledger token")
+	ledgerCAFile := flags.String("ledger-ca-file", "", "path to the ledger Kubernetes API CA bundle")
+	workloadBinding := flags.String("workload-binding", "", "path to the private runtime-bound workload authority record")
+	workloadBindingDigest := flags.String("workload-binding-digest", "", "expected digest of the private workload authority record")
+	workloadTokenFile := flags.String("workload-token-file", "", "path to the short-lived workload writer token")
+	workloadCAFile := flags.String("workload-ca-file", "", "path to the runtime-bound workload Kubernetes API CA bundle")
+	if err := flags.Parse(arguments); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return errors.New("positional arguments are not accepted")
+	}
+	if !*execute {
+		return errors.New("target-access mutation requires explicit --execute")
+	}
+	resume, err := resumeFlags.config()
+	if err != nil {
+		return err
+	}
+	for _, input := range []struct{ name, value string }{
+		{"--grant", *grantPath}, {"--grant-key", *grantKeyPath}, {"--evaluation-time", *evaluationTime}, {"--target-access-artifact", *artifactPath},
+		{"--observability-namespace", *observabilityNamespace}, {"--manager-serviceaccount", *managerServiceAccount},
+		{"--cluster-role", *clusterRole}, {"--cluster-rolebinding", *clusterRoleBinding},
+		{"--platform-role", *platformRole}, {"--platform-rolebinding", *platformRoleBinding},
+		{"--kube-system-role", *kubeSystemRole}, {"--kube-system-rolebinding", *kubeSystemRoleBinding},
+		{"--ledger-api-endpoint", *ledgerAPIEndpoint}, {"--ledger-token-file", *ledgerTokenFile}, {"--ledger-ca-file", *ledgerCAFile},
+		{"--workload-binding", *workloadBinding}, {"--workload-binding-digest", *workloadBindingDigest},
+		{"--workload-token-file", *workloadTokenFile}, {"--workload-ca-file", *workloadCAFile},
+	} {
+		if input.value == "" {
+			return fmt.Errorf("%s is required", input.name)
+		}
+	}
+	at, err := time.Parse(time.RFC3339, *evaluationTime)
+	if err != nil {
+		return fmt.Errorf("parse evaluation time: %w", err)
+	}
+	expectedObjects := []projection.ResourceIdentity{
+		{APIVersion: "v1", Kind: "Namespace", Name: *observabilityNamespace},
+		{APIVersion: "v1", Kind: "ServiceAccount", Namespace: "kube-system", Name: *managerServiceAccount},
+		{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "ClusterRole", Name: *clusterRole},
+		{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "ClusterRoleBinding", Name: *clusterRoleBinding},
+		{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role", Namespace: *observabilityNamespace, Name: *platformRole},
+		{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "RoleBinding", Namespace: *observabilityNamespace, Name: *platformRoleBinding},
+		{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role", Namespace: "kube-system", Name: *kubeSystemRole},
+		{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "RoleBinding", Namespace: "kube-system", Name: *kubeSystemRoleBinding},
+	}
+	bundleConfig := runner.TargetAccessStageBundleConfig{
+		PlanPath: resume.PlanPath, PlanExpected: resume.PlanExpected, Receipts: resume.Receipts,
+		GrantPath: *grantPath, GrantPublicKeyPath: *grantKeyPath, EvaluationTime: at,
+		ArtifactPath: *artifactPath, ExpectedObjects: expectedObjects,
+	}
+	boundedContext, cancel := context.WithTimeout(ctx, stageRunTimeout)
+	defer cancel()
+	receipt, runErr := executeTargetAccessStage(boundedContext, bundleConfig, runner.TargetAccessStageRuntimeConfig{
+		Ledger: runner.KubernetesLedgerConfig{
+			Endpoint: *ledgerAPIEndpoint, Namespace: ledgerNamespace, TokenFile: *ledgerTokenFile, CAFile: *ledgerCAFile,
+		},
+		Workload: runner.WorkloadAuthorityFileResolverConfig{
+			Path: *workloadBinding, ExpectedBindingDigest: *workloadBindingDigest,
+			TokenFile: *workloadTokenFile, CAFile: *workloadCAFile,
 		},
 		Clock: func() time.Time { return time.Now().UTC() },
 	})

--- a/cmd/ok/main_test.go
+++ b/cmd/ok/main_test.go
@@ -884,6 +884,74 @@ func TestEnablementStageRunFailsClosedBeforeExecution(t *testing.T) {
 	}
 }
 
+func TestTargetAccessStageRunBindsExactArtifactAndWorkloadRuntime(t *testing.T) {
+	previous := executeTargetAccessStage
+	defer func() { executeTargetAccessStage = previous }()
+	var calls int
+	executeTargetAccessStage = func(ctx context.Context, bundle runner.TargetAccessStageBundleConfig, runtime runner.TargetAccessStageRuntimeConfig) (execution.StagedOperationReceipt, error) {
+		calls++
+		deadline, bounded := ctx.Deadline()
+		if !bounded || time.Until(deadline) > stageRunTimeout || time.Until(deadline) < stageRunTimeout-time.Minute {
+			t.Fatalf("target-access context is not bounded: %s %t", deadline, bounded)
+		}
+		if bundle.PlanPath != "/tmp/plan.json" || len(bundle.Receipts) != 6 || bundle.ArtifactPath != "/tmp/target-access.yaml" || len(bundle.ExpectedObjects) != 8 {
+			t.Fatalf("target-access bundle differs: %#v", bundle)
+		}
+		wantKinds := []string{"Namespace", "ServiceAccount", "ClusterRole", "ClusterRoleBinding", "Role", "RoleBinding", "Role", "RoleBinding"}
+		for index, object := range bundle.ExpectedObjects {
+			if object.Kind != wantKinds[index] {
+				t.Fatalf("target-access identity %d differs: %#v", index, object)
+			}
+		}
+		if bundle.ExpectedObjects[0].Name != "ok-observability" || bundle.ExpectedObjects[1].Namespace != "kube-system" || bundle.ExpectedObjects[4].Namespace != "ok-observability" || runtime.Ledger.Namespace != ledgerNamespace || runtime.Workload.Path != "/private/tmp/runtime-binding.json" || runtime.Workload.ExpectedBindingDigest != testSHA("5") || runtime.Workload.TokenFile != "/private/tmp/workload-token" || runtime.Clock == nil {
+			t.Fatalf("target-access runtime differs: %#v %#v", bundle.ExpectedObjects, runtime)
+		}
+		return execution.StagedOperationReceipt{Format: execution.StagedReceiptFormat, State: "COMPLETED_SUCCEEDED", StageID: "target-access", StageReceiptDigest: testSHA("8")}, nil
+	}
+	var stdout, stderr bytes.Buffer
+	if err := run(targetAccessStageRunArguments(), &stdout, &stderr); err != nil {
+		t.Fatalf("run: %v; stderr=%s", err, stderr.String())
+	}
+	if calls != 1 {
+		t.Fatalf("target-access runner calls = %d", calls)
+	}
+	var receipt execution.StagedOperationReceipt
+	if err := json.Unmarshal(stdout.Bytes(), &receipt); err != nil || receipt.StageID != "target-access" {
+		t.Fatalf("unexpected target-access receipt: %#v %v", receipt, err)
+	}
+}
+
+func TestTargetAccessStageRunFailsClosedBeforeExecution(t *testing.T) {
+	previous := executeTargetAccessStage
+	defer func() { executeTargetAccessStage = previous }()
+	calls := 0
+	executeTargetAccessStage = func(context.Context, runner.TargetAccessStageBundleConfig, runner.TargetAccessStageRuntimeConfig) (execution.StagedOperationReceipt, error) {
+		calls++
+		return execution.StagedOperationReceipt{}, nil
+	}
+	valid := targetAccessStageRunArguments()
+	for name, arguments := range map[string][]string{
+		"missing execute":         removeArgument(valid, "--execute"),
+		"missing artifact":        removeArgumentWithValue(valid, "--target-access-artifact"),
+		"missing identity":        removeArgumentWithValue(valid, "--cluster-rolebinding"),
+		"missing runtime binding": removeArgumentWithValue(valid, "--workload-binding"),
+		"missing binding digest":  removeArgumentWithValue(valid, "--workload-binding-digest"),
+		"missing credential":      removeArgumentWithValue(valid, "--workload-token-file"),
+		"invalid time":            replaceArgument(valid, "--evaluation-time", "not-time"),
+		"positional":              append(append([]string{}, valid...), "unexpected"),
+	} {
+		t.Run(name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			if err := run(arguments, &stdout, &stderr); err == nil || stdout.Len() != 0 {
+				t.Fatalf("unsafe target-access run was accepted: %v %s", err, stdout.String())
+			}
+		})
+	}
+	if calls != 0 {
+		t.Fatalf("target-access runner reached %d times for invalid input", calls)
+	}
+}
+
 func TestEnablementStagePackageWritesVerifiedOfflineArtifact(t *testing.T) {
 	previous := materializeEnablementStagePackage
 	defer func() { materializeEnablementStagePackage = previous }()
@@ -1495,6 +1563,29 @@ func enablementStageRunArguments() []string {
 		"--execute",
 		"--ledger-api-endpoint", "https://192.0.2.12:6443", "--ledger-token-file", "/tmp/ledger-token", "--ledger-ca-file", "/tmp/ledger-ca",
 		"--management-api-endpoint", "https://192.0.2.12:6443", "--management-token-file", "/tmp/management-token", "--management-ca-file", "/tmp/management-ca",
+	)
+}
+
+func targetAccessStageRunArguments() []string {
+	resume := stageResumeArguments()
+	arguments := append([]string{"cluster", "stage", "run", "target-access"}, resume[3:]...)
+	return append(arguments,
+		"--receipt", "/tmp/provider.json@"+testSHA("1"),
+		"--receipt", "/tmp/lifecycle.json@"+testSHA("2"),
+		"--receipt", "/tmp/lifecycle-observation.json@"+testSHA("3"),
+		"--receipt", "/tmp/enablement.json@"+testSHA("4"),
+		"--receipt", "/tmp/network-observation.json@"+testSHA("5"),
+		"--receipt", "/tmp/runtime-binding.json@"+testSHA("6"),
+		"--grant", "/tmp/target-access-grant.json", "--grant-key", "/tmp/target-access-grant.pub",
+		"--evaluation-time", "2026-08-17T14:00:00Z", "--target-access-artifact", "/tmp/target-access.yaml",
+		"--observability-namespace", "ok-observability", "--manager-serviceaccount", "ok147-argocd-manager",
+		"--cluster-role", "ok147-argocd-platform-cluster", "--cluster-rolebinding", "ok147-argocd-platform-cluster",
+		"--platform-role", "ok147-argocd-platform", "--platform-rolebinding", "ok147-argocd-platform",
+		"--kube-system-role", "ok147-argocd-kube-system", "--kube-system-rolebinding", "ok147-argocd-kube-system",
+		"--execute",
+		"--ledger-api-endpoint", "https://192.0.2.12:6443", "--ledger-token-file", "/private/tmp/ledger-token", "--ledger-ca-file", "/private/tmp/ledger-ca",
+		"--workload-binding", "/private/tmp/runtime-binding.json", "--workload-binding-digest", testSHA("5"),
+		"--workload-token-file", "/private/tmp/workload-token", "--workload-ca-file", "/private/tmp/workload-ca",
 	)
 }
 


### PR DESCRIPTION
## What changed

- add `ok cluster stage run target-access --execute`
- require the exact six-receipt prefix and signed `CreateTargetAccess` grant
- bind the externally rendered artifact to eight independently supplied object identities
- require the private runtime-binding digest plus distinct ledger and short-lived workload files
- emit only the redaction-safe staged-operation receipt

## Why

The verified and fake-API-proven target-access operation now needs one explicit local activation boundary before later immutable Job packaging. The CLI composes existing typed components and does not add a renderer or dynamic dispatcher.

## Boundary

- no Job package or DEV launch
- no target credential issuance or GitOps registration
- no retry, update, patch, delete, list, watch, discovery, or fallback path

## Validation

- `GOCACHE=/private/tmp/ok147-go-build go test -ldflags=-linkmode=external ./...`
- `go vet ./...`
- `GOCACHE=/private/tmp/ok147-go-build go test -race -ldflags=-linkmode=external ./cmd/ok ./internal/runner`
