### PR TITLE
feat(runner): bind target access input (OK-147)

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,10 @@ Powered by [Cluster API (CAPI)](https://cluster-api.sigs.k8s.io/), [CAPK (KubeVi
   exists for target access at this checkpoint. A separated TLS fake-API proof
   now covers the complete claim-to-submit path: exactly eight ordered
   `GET`/conditional-`POST` pairs, durable success replay without another write,
-  and a durably stopped partial prefix without retry.
+  and a durably stopped partial prefix without retry. Its first Job-package
+  building block is also offline: one immutable ConfigMap binds the plan,
+  signed grant, exact six-receipt prefix and eight-object artifact while
+  excluding the private runtime binding, CA and both credentials.
   Stage 4 now has its first distinct path as well:
   `ok cluster stage run enablement --execute` binds the verified three-receipt
   prefix and signed `CreateEnablement` grant to exactly one externally rendered

--- a/internal/runner/target_access_stage_input.go
+++ b/internal/runner/target_access_stage_input.go
@@ -1,0 +1,136 @@
+package runner
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"sort"
+	"unicode/utf8"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+const TargetAccessStageInputFormat = "ok147-target-access-stage-input/v1"
+
+// TargetAccessStageInputReceipt exposes only immutable public artifact and
+// target-digest identities. The ConfigMap contains no runtime binding or token.
+type TargetAccessStageInputReceipt struct {
+	Format               string   `json:"format"`
+	State                string   `json:"state"`
+	StageID              string   `json:"stageId"`
+	ConfigMapName        string   `json:"configMapName"`
+	ConfigMapDigest      string   `json:"configMapDigest"`
+	ReceiptPrefixDigest  string   `json:"receiptPrefixDigest"`
+	TargetAccessDigest   string   `json:"targetAccessDigest"`
+	TargetIdentityDigest string   `json:"targetIdentityDigest"`
+	DataKeys             []string `json:"dataKeys"`
+}
+
+type VerifiedTargetAccessStageInput struct {
+	raw      []byte
+	receipt  TargetAccessStageInputReceipt
+	verified bool
+}
+
+// BuildTargetAccessStageInput snapshots the verified seventh-stage public
+// chain into one immutable ConfigMap without reading credentials or runtime
+// binding material and without contacting an API.
+func BuildTargetAccessStageInput(config TargetAccessStageBundleConfig, configMapName string) (VerifiedTargetAccessStageInput, error) {
+	if !submissionStageInputNamePattern.MatchString(configMapName) || len(configMapName) > 63 || len(configMapName) < len("ok147-") || configMapName[:len("ok147-")] != "ok147-" {
+		return VerifiedTargetAccessStageInput{}, errors.New("target-access stage input ConfigMap name is invalid")
+	}
+	if len(config.Receipts) != 6 {
+		return VerifiedTargetAccessStageInput{}, errors.New("target-access stage input requires exactly six predecessor receipts")
+	}
+	bundle, err := LoadTargetAccessStageBundle(config)
+	if err != nil {
+		return VerifiedTargetAccessStageInput{}, err
+	}
+	bundleReceipt, err := bundle.Receipt()
+	if err != nil {
+		return VerifiedTargetAccessStageInput{}, err
+	}
+
+	receiptFiles := []string{
+		"provider-receipt.json", "lifecycle-receipt.json", "lifecycle-observation-receipt.json",
+		"enablement-receipt.json", "network-observation-receipt.json", "runtime-binding-receipt.json",
+	}
+	prefix := stageReceiptPrefixDocument{Format: StageReceiptPrefixFormat, Receipts: make([]stageReceiptPrefixEntry, len(receiptFiles))}
+	paths := map[string]string{
+		"staged-plan.json": config.PlanPath, "stage-grant.json": config.GrantPath,
+		"stage-authority.pub": config.GrantPublicKeyPath, "target-access.yaml": config.ArtifactPath,
+	}
+	for index, file := range receiptFiles {
+		prefix.Receipts[index] = stageReceiptPrefixEntry{File: file, Digest: config.Receipts[index].Digest}
+		paths[file] = config.Receipts[index].Path
+	}
+	prefixRaw, err := json.Marshal(prefix)
+	if err != nil {
+		return VerifiedTargetAccessStageInput{}, errors.New("encode target-access receipt prefix")
+	}
+	data := make(map[string]string, len(paths)+1)
+	data["receipt-prefix.json"] = string(prefixRaw)
+	for key, path := range paths {
+		raw, err := readBoundedRegular(path, maximumSubmissionStageInputBytes)
+		if err != nil {
+			return VerifiedTargetAccessStageInput{}, errors.New("read bounded target-access stage input " + key)
+		}
+		if !utf8.Valid(raw) || bytes.IndexByte(raw, 0) >= 0 {
+			return VerifiedTargetAccessStageInput{}, errors.New("target-access stage input is not valid ConfigMap text")
+		}
+		data[key] = string(raw)
+	}
+	if _, err := LoadTargetAccessStageBundle(config); err != nil {
+		return VerifiedTargetAccessStageInput{}, errors.New("target-access stage inputs changed during materialization")
+	}
+
+	configMap := submissionStageInputConfigMap{
+		APIVersion: "v1", Kind: "ConfigMap",
+		Metadata: submissionStageInputObjectMeta{
+			Name: configMapName, Namespace: submissionStageInputNamespace,
+			Labels: map[string]string{"app.kubernetes.io/name": "ok-cluster-contract-executor", "openkubes.io/stage-id": "target-access"},
+			Annotations: map[string]string{
+				"openkubes.io/input-format": TargetAccessStageInputFormat, "openkubes.io/receipt-prefix-digest": digest.SHA256(prefixRaw),
+				"openkubes.io/target-identity-digest": bundleReceipt.TargetIdentityDigest,
+			},
+		},
+		Immutable: true, Data: data,
+	}
+	raw, err := json.Marshal(configMap)
+	if err != nil {
+		return VerifiedTargetAccessStageInput{}, errors.New("encode target-access stage input ConfigMap")
+	}
+	if len(raw) > maximumSubmissionStageInputBytes {
+		return VerifiedTargetAccessStageInput{}, errors.New("target-access stage input ConfigMap exceeds size limit")
+	}
+	keys := make([]string, 0, len(data))
+	for key := range data {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return VerifiedTargetAccessStageInput{
+		raw: raw,
+		receipt: TargetAccessStageInputReceipt{
+			Format: TargetAccessStageInputFormat, State: "VERIFIED", StageID: "target-access", ConfigMapName: configMapName,
+			ConfigMapDigest: digest.SHA256(raw), ReceiptPrefixDigest: digest.SHA256(prefixRaw),
+			TargetAccessDigest: digest.SHA256([]byte(data["target-access.yaml"])), TargetIdentityDigest: bundleReceipt.TargetIdentityDigest, DataKeys: keys,
+		},
+		verified: true,
+	}, nil
+}
+
+func (input VerifiedTargetAccessStageInput) Bytes() ([]byte, error) {
+	if !input.verified || len(input.raw) == 0 {
+		return nil, errors.New("target-access stage input was not produced by verification")
+	}
+	return append([]byte(nil), input.raw...), nil
+}
+
+func (input VerifiedTargetAccessStageInput) Receipt() (TargetAccessStageInputReceipt, error) {
+	if !input.verified || input.receipt.State != "VERIFIED" || !stageReceiptPrefixDigestPattern.MatchString(input.receipt.TargetIdentityDigest) {
+		return TargetAccessStageInputReceipt{}, errors.New("target-access stage input was not produced by verification")
+	}
+	receipt := input.receipt
+	receipt.DataKeys = append([]string(nil), input.receipt.DataKeys...)
+	return receipt, nil
+}

--- a/internal/runner/target_access_stage_input_test.go
+++ b/internal/runner/target_access_stage_input_test.go
@@ -1,0 +1,79 @@
+package runner
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+func TestBuildTargetAccessStageInputCapturesOnlyPublicBoundArtifacts(t *testing.T) {
+	fixture := targetAccessBundleFixture(t)
+	input, err := BuildTargetAccessStageInput(fixture.config, "ok147-target-access-input")
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := input.Bytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := input.Receipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if receipt.Format != TargetAccessStageInputFormat || receipt.State != "VERIFIED" || receipt.StageID != "target-access" || receipt.ConfigMapDigest != digest.SHA256(raw) || receipt.TargetAccessDigest != digest.SHA256(runnerTargetAccessYAML()) || receipt.TargetIdentityDigest != digest.SHA256([]byte(targetAccessRuntimeUID)) || len(receipt.DataKeys) != 11 {
+		t.Fatalf("unexpected target-access input receipt: %#v", receipt)
+	}
+	var object submissionStageInputConfigMap
+	if err := json.Unmarshal(raw, &object); err != nil {
+		t.Fatal(err)
+	}
+	if !object.Immutable || object.Metadata.Namespace != submissionStageInputNamespace || object.Metadata.Labels["openkubes.io/stage-id"] != "target-access" || object.Metadata.Annotations["openkubes.io/target-identity-digest"] != receipt.TargetIdentityDigest || len(object.Data) != 11 {
+		t.Fatalf("unexpected target-access ConfigMap: %#v", object)
+	}
+	for _, forbidden := range []string{"token", "ca.crt", "kubeconfig", "workload-binding.json", "runtime-binding-private.json"} {
+		if _, exists := object.Data[forbidden]; exists {
+			t.Fatalf("private target-access input %q was packaged", forbidden)
+		}
+	}
+	if _, exists := object.Data["runtime-binding-receipt.json"]; !exists {
+		t.Fatal("public runtime-binding receipt is absent")
+	}
+
+	raw[0] = 'x'
+	again, err := input.Bytes()
+	if err != nil || again[0] != '{' {
+		t.Fatal("caller mutated retained target-access input")
+	}
+	receipt.DataKeys[0] = "changed"
+	againReceipt, err := input.Receipt()
+	if err != nil || againReceipt.DataKeys[0] == "changed" {
+		t.Fatal("caller mutated retained target-access receipt")
+	}
+}
+
+func TestBuildTargetAccessStageInputFailsClosed(t *testing.T) {
+	fixture := targetAccessBundleFixture(t)
+	if _, err := BuildTargetAccessStageInput(fixture.config, "not-ok147"); err == nil {
+		t.Fatal("foreign ConfigMap name was accepted")
+	}
+	fixture = targetAccessBundleFixture(t)
+	fixture.config.Receipts = fixture.config.Receipts[:5]
+	if _, err := BuildTargetAccessStageInput(fixture.config, "ok147-target-access-input"); err == nil {
+		t.Fatal("incomplete receipt prefix was accepted")
+	}
+	fixture = targetAccessBundleFixture(t)
+	if err := os.WriteFile(fixture.config.ArtifactPath, []byte("changed"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := BuildTargetAccessStageInput(fixture.config, "ok147-target-access-input"); err == nil {
+		t.Fatal("changed target-access artifact was accepted")
+	}
+	if _, err := (VerifiedTargetAccessStageInput{}).Bytes(); err == nil {
+		t.Fatal("unverified target-access input exposed bytes")
+	}
+	if _, err := (VerifiedTargetAccessStageInput{}).Receipt(); err == nil {
+		t.Fatal("unverified target-access input exposed receipt")
+	}
+}


### PR DESCRIPTION
## What changed

- add an immutable ConfigMap materializer for the target-access stage
- bind the staged plan, signed grant, authority key, exact six-receipt prefix and eight-object artifact
- retain the public target identity digest in the receipt and ConfigMap metadata
- reverify all inputs after reading them to close materialization-time changes
- exclude private runtime binding, raw UID, CA and credentials

## Why

The local target-access command is proven, but a future bounded Job needs an immutable public input object that can be installed separately from all private runtime and credential material.

## Boundary

- offline materialization only
- no Job or NetworkPolicy yet
- no credential packaging, installation, launch, or DEV mutation

## Validation

- `GOCACHE=/private/tmp/ok147-go-build go test -ldflags=-linkmode=external ./...`
- `go vet ./...`
- `GOCACHE=/private/tmp/ok147-go-build go test -race -ldflags=-linkmode=external ./internal/runner`
