### PR TITLE
feat(runner): render target access job (OK-147)

### DIFF
--- a/deploy/contract-executor-target-access-job.yaml.tpl
+++ b/deploy/contract-executor-target-access-job.yaml.tpl
@@ -1,0 +1,193 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: "${OK147_RUN_ID}"
+  namespace: openkubes-execution-system
+spec:
+  podSelector:
+    matchLabels:
+      openkubes.io/execution-id: "${OK147_RUN_ID}"
+  policyTypes: ["Ingress", "Egress"]
+  ingress: []
+  egress:
+    - to: [{ipBlock: {cidr: "${OK147_LEDGER_API_CIDR}"}}]
+      ports: [{protocol: TCP, port: ${OK147_LEDGER_API_PORT}}]
+    - to: [{ipBlock: {cidr: "${OK147_WORKLOAD_API_CIDR}"}}]
+      ports: [{protocol: TCP, port: ${OK147_WORKLOAD_API_PORT}}]
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "${OK147_RUN_ID}"
+  namespace: openkubes-execution-system
+  annotations:
+    openkubes.io/receipt-prefix-digest: "${OK147_RECEIPT_PREFIX_DIGEST}"
+  labels:
+    app.kubernetes.io/name: ok-cluster-contract-executor
+    openkubes.io/execution-id: "${OK147_RUN_ID}"
+    openkubes.io/stage-id: target-access
+spec:
+  backoffLimit: 0
+  completions: 1
+  parallelism: 1
+  activeDeadlineSeconds: 300
+  ttlSecondsAfterFinished: 3600
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ok-cluster-contract-executor
+        openkubes.io/execution-id: "${OK147_RUN_ID}"
+    spec:
+      serviceAccountName: ok147-contract-executor-runtime
+      automountServiceAccountToken: false
+      enableServiceLinks: false
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+        seccompProfile: {type: RuntimeDefault}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - {key: node-role.kubernetes.io/control-plane, operator: DoesNotExist}
+      containers:
+        - name: executor
+          image: "${OK147_IMAGE_DIGEST}"
+          imagePullPolicy: IfNotPresent
+          command: ["/ok"]
+          args:
+            - cluster
+            - stage
+            - run
+            - target-access
+            - --execute
+            - --plan
+            - /var/run/openkubes/input/staged-plan.json
+            - --contract-namespace
+            - "${OK147_CONTRACT_NAMESPACE}"
+            - --contract-name
+            - "${OK147_CONTRACT_NAME}"
+            - --intent-revision
+            - "${OK147_R}"
+            - --enablement-revision
+            - "${OK147_E}"
+            - --platform-revision
+            - "${OK147_P}"
+            - --execution-fixture
+            - "${OK147_FIXTURE}"
+            - --infrastructure-authority
+            - "${OK147_INFRA_AUTHORITY}"
+            - --management-authority
+            - "${OK147_MGMT_AUTHORITY}"
+            - --gitops-authority
+            - "${OK147_GITOPS_AUTHORITY}"
+            - --receipt
+            - /var/run/openkubes/input/provider-receipt.json
+            - --receipt
+            - /var/run/openkubes/input/lifecycle-receipt.json
+            - --receipt
+            - /var/run/openkubes/input/lifecycle-observation-receipt.json
+            - --receipt
+            - /var/run/openkubes/input/enablement-receipt.json
+            - --receipt
+            - /var/run/openkubes/input/network-observation-receipt.json
+            - --receipt
+            - /var/run/openkubes/input/runtime-binding-receipt.json
+            - --grant
+            - /var/run/openkubes/input/stage-grant.json
+            - --grant-key
+            - /var/run/openkubes/input/stage-authority.pub
+            - --evaluation-time
+            - "${OK147_EVALUATION_TIME}"
+            - --target-access-artifact
+            - /var/run/openkubes/input/target-access.yaml
+            - --observability-namespace
+            - "${OK147_OBSERVABILITY_NAMESPACE}"
+            - --manager-serviceaccount
+            - "${OK147_MANAGER_SERVICEACCOUNT}"
+            - --cluster-role
+            - "${OK147_CLUSTER_ROLE}"
+            - --cluster-rolebinding
+            - "${OK147_CLUSTER_ROLEBINDING}"
+            - --platform-role
+            - "${OK147_PLATFORM_ROLE}"
+            - --platform-rolebinding
+            - "${OK147_PLATFORM_ROLEBINDING}"
+            - --kube-system-role
+            - "${OK147_KUBE_SYSTEM_ROLE}"
+            - --kube-system-rolebinding
+            - "${OK147_KUBE_SYSTEM_ROLEBINDING}"
+            - --ledger-api-endpoint
+            - "${OK147_LEDGER_API_URL}"
+            - --ledger-token-file
+            - /var/run/openkubes/ledger/token
+            - --ledger-ca-file
+            - /var/run/openkubes/ledger/ca.crt
+            - --workload-binding
+            - /var/run/openkubes/workload/binding.json
+            - --workload-binding-digest
+            - "${OK147_WORKLOAD_BINDING_DIGEST}"
+            - --workload-token-file
+            - /var/run/openkubes/workload/token
+            - --workload-ca-file
+            - /var/run/openkubes/workload/ca.crt
+          resources:
+            requests: {cpu: 25m, memory: 48Mi, ephemeral-storage: 16Mi}
+            limits: {cpu: 200m, memory: 96Mi, ephemeral-storage: 32Mi}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities: {drop: ["ALL"]}
+          volumeMounts:
+            - {name: input, mountPath: /var/run/openkubes/input/staged-plan.json, subPath: staged-plan.json, readOnly: true}
+            - {name: input, mountPath: /var/run/openkubes/input/receipt-prefix.json, subPath: receipt-prefix.json, readOnly: true}
+            - {name: input, mountPath: /var/run/openkubes/input/provider-receipt.json, subPath: provider-receipt.json, readOnly: true}
+            - {name: input, mountPath: /var/run/openkubes/input/lifecycle-receipt.json, subPath: lifecycle-receipt.json, readOnly: true}
+            - {name: input, mountPath: /var/run/openkubes/input/lifecycle-observation-receipt.json, subPath: lifecycle-observation-receipt.json, readOnly: true}
+            - {name: input, mountPath: /var/run/openkubes/input/enablement-receipt.json, subPath: enablement-receipt.json, readOnly: true}
+            - {name: input, mountPath: /var/run/openkubes/input/network-observation-receipt.json, subPath: network-observation-receipt.json, readOnly: true}
+            - {name: input, mountPath: /var/run/openkubes/input/runtime-binding-receipt.json, subPath: runtime-binding-receipt.json, readOnly: true}
+            - {name: input, mountPath: /var/run/openkubes/input/stage-grant.json, subPath: stage-grant.json, readOnly: true}
+            - {name: input, mountPath: /var/run/openkubes/input/stage-authority.pub, subPath: stage-authority.pub, readOnly: true}
+            - {name: input, mountPath: /var/run/openkubes/input/target-access.yaml, subPath: target-access.yaml, readOnly: true}
+            - {name: ledger-credential, mountPath: /var/run/openkubes/ledger/token, subPath: token, readOnly: true}
+            - {name: ledger-credential, mountPath: /var/run/openkubes/ledger/ca.crt, subPath: ca.crt, readOnly: true}
+            - {name: workload-credential, mountPath: /var/run/openkubes/workload/token, subPath: token, readOnly: true}
+            - {name: workload-credential, mountPath: /var/run/openkubes/workload/ca.crt, subPath: ca.crt, readOnly: true}
+            - {name: workload-credential, mountPath: /var/run/openkubes/workload/binding.json, subPath: binding.json, readOnly: true}
+      volumes:
+        - name: input
+          configMap:
+            name: "${OK147_INPUT_CONFIGMAP}"
+            defaultMode: 0444
+            items:
+              - {key: staged-plan.json, path: staged-plan.json}
+              - {key: receipt-prefix.json, path: receipt-prefix.json}
+              - {key: provider-receipt.json, path: provider-receipt.json}
+              - {key: lifecycle-receipt.json, path: lifecycle-receipt.json}
+              - {key: lifecycle-observation-receipt.json, path: lifecycle-observation-receipt.json}
+              - {key: enablement-receipt.json, path: enablement-receipt.json}
+              - {key: network-observation-receipt.json, path: network-observation-receipt.json}
+              - {key: runtime-binding-receipt.json, path: runtime-binding-receipt.json}
+              - {key: stage-grant.json, path: stage-grant.json}
+              - {key: stage-authority.pub, path: stage-authority.pub}
+              - {key: target-access.yaml, path: target-access.yaml}
+        - name: ledger-credential
+          secret:
+            secretName: "${OK147_LEDGER_CREDENTIAL_SECRET}"
+            defaultMode: 0440
+            items:
+              - {key: token, path: token}
+              - {key: ca.crt, path: ca.crt}
+        - name: workload-credential
+          secret:
+            secretName: "${OK147_WORKLOAD_CREDENTIAL_SECRET}"
+            defaultMode: 0440
+            items:
+              - {key: token, path: token}
+              - {key: ca.crt, path: ca.crt}
+              - {key: binding.json, path: binding.json}

--- a/internal/runner/target_access_stage_job.go
+++ b/internal/runner/target_access_stage_job.go
@@ -1,0 +1,119 @@
+package runner
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/stageplan"
+)
+
+// TargetAccessStageJobValues bind one non-retrying Job to the exact verified
+// target-access input, its independently expected object identities, and the
+// distinct ledger and workload APIs.
+type TargetAccessStageJobValues struct {
+	RunID                    string
+	ImageDigest              string
+	EvaluationTime           string
+	Expected                 stageplan.Expected
+	InputConfigMap           string
+	ReceiptPrefixDigest      string
+	ObservabilityNamespace   string
+	ManagerServiceAccount    string
+	ClusterRole              string
+	ClusterRoleBinding       string
+	PlatformRole             string
+	PlatformRoleBinding      string
+	KubeSystemRole           string
+	KubeSystemRoleBinding    string
+	LedgerAPIURL             string
+	LedgerAPICIDR            string
+	LedgerCredentialSecret   string
+	WorkloadAPIURL           string
+	WorkloadAPICIDR          string
+	WorkloadCredentialSecret string
+	WorkloadBindingDigest    string
+}
+
+// RenderTargetAccessStageJobTemplate performs validated literal substitution
+// for exactly one target-access NetworkPolicy and Job. It does not contact or
+// mutate either Kubernetes API.
+func RenderTargetAccessStageJobTemplate(template []byte, values TargetAccessStageJobValues) ([]byte, error) {
+	if len(template) == 0 || len(template) > 1024*1024 {
+		return nil, errors.New("target-access stage Job template size is invalid")
+	}
+	dnsLabel := regexp.MustCompile(`^[a-z0-9](?:[-a-z0-9]*[a-z0-9])?$`)
+	if !dnsLabel.MatchString(values.RunID) || len(values.RunID) > 63 || !strings.HasPrefix(values.RunID, "ok147-") {
+		return nil, errors.New("target-access stage Job run ID is invalid")
+	}
+	names := []string{
+		values.InputConfigMap, values.ObservabilityNamespace, values.ManagerServiceAccount,
+		values.ClusterRole, values.ClusterRoleBinding, values.PlatformRole,
+		values.PlatformRoleBinding, values.KubeSystemRole, values.KubeSystemRoleBinding,
+		values.LedgerCredentialSecret, values.WorkloadCredentialSecret,
+	}
+	for _, value := range names {
+		if !dnsLabel.MatchString(value) || len(value) > 63 {
+			return nil, errors.New("target-access stage Job object name is invalid")
+		}
+	}
+	if values.InputConfigMap == values.LedgerCredentialSecret || values.InputConfigMap == values.WorkloadCredentialSecret || values.LedgerCredentialSecret == values.WorkloadCredentialSecret {
+		return nil, errors.New("target-access stage Job input and credentials must use distinct objects")
+	}
+	if !regexp.MustCompile(`^[a-z0-9][a-z0-9./:_-]*@sha256:[0-9a-f]{64}$`).MatchString(values.ImageDigest) {
+		return nil, errors.New("target-access stage Job image is not digest-bound")
+	}
+	for _, value := range []string{values.ReceiptPrefixDigest, values.WorkloadBindingDigest} {
+		if !stageReceiptPrefixDigestPattern.MatchString(value) {
+			return nil, errors.New("target-access stage Job semantic digest is invalid")
+		}
+	}
+	if _, err := time.Parse(time.RFC3339, values.EvaluationTime); err != nil {
+		return nil, errors.New("target-access stage Job evaluation time is not RFC3339")
+	}
+	if err := stageplan.ValidateExpected(values.Expected); err != nil {
+		return nil, fmt.Errorf("target-access stage Job expected binding: %w", err)
+	}
+	ledgerPort, ledgerEndpoint, err := exactAPIEndpoint(values.LedgerAPIURL, values.LedgerAPICIDR)
+	if err != nil {
+		return nil, fmt.Errorf("target-access stage Job ledger endpoint: %w", err)
+	}
+	workloadPort, workloadEndpoint, err := exactAPIEndpoint(values.WorkloadAPIURL, values.WorkloadAPICIDR)
+	if err != nil {
+		return nil, fmt.Errorf("target-access stage Job workload endpoint: %w", err)
+	}
+	if workloadEndpoint == ledgerEndpoint {
+		return nil, errors.New("target-access ledger and workload endpoints must differ")
+	}
+	replacements := map[string]string{
+		"${OK147_RUN_ID}": values.RunID, "${OK147_IMAGE_DIGEST}": values.ImageDigest,
+		"${OK147_EVALUATION_TIME}":    values.EvaluationTime,
+		"${OK147_CONTRACT_NAMESPACE}": values.Expected.ContractIdentity.Namespace, "${OK147_CONTRACT_NAME}": values.Expected.ContractIdentity.Name,
+		"${OK147_R}": values.Expected.IntentRevision, "${OK147_E}": values.Expected.EnablementRevision,
+		"${OK147_P}": values.Expected.PlatformRevision, "${OK147_FIXTURE}": values.Expected.ExecutionFixture,
+		"${OK147_INFRA_AUTHORITY}": values.Expected.InfrastructureAuthority, "${OK147_MGMT_AUTHORITY}": values.Expected.ManagementAuthority,
+		"${OK147_GITOPS_AUTHORITY}": values.Expected.GitOpsAuthority,
+		"${OK147_INPUT_CONFIGMAP}":  values.InputConfigMap, "${OK147_RECEIPT_PREFIX_DIGEST}": values.ReceiptPrefixDigest,
+		"${OK147_OBSERVABILITY_NAMESPACE}": values.ObservabilityNamespace, "${OK147_MANAGER_SERVICEACCOUNT}": values.ManagerServiceAccount,
+		"${OK147_CLUSTER_ROLE}": values.ClusterRole, "${OK147_CLUSTER_ROLEBINDING}": values.ClusterRoleBinding,
+		"${OK147_PLATFORM_ROLE}": values.PlatformRole, "${OK147_PLATFORM_ROLEBINDING}": values.PlatformRoleBinding,
+		"${OK147_KUBE_SYSTEM_ROLE}": values.KubeSystemRole, "${OK147_KUBE_SYSTEM_ROLEBINDING}": values.KubeSystemRoleBinding,
+		"${OK147_LEDGER_API_URL}": values.LedgerAPIURL, "${OK147_LEDGER_API_CIDR}": values.LedgerAPICIDR,
+		"${OK147_LEDGER_API_PORT}": ledgerPort, "${OK147_LEDGER_CREDENTIAL_SECRET}": values.LedgerCredentialSecret,
+		"${OK147_WORKLOAD_API_CIDR}": values.WorkloadAPICIDR, "${OK147_WORKLOAD_API_PORT}": workloadPort,
+		"${OK147_WORKLOAD_CREDENTIAL_SECRET}": values.WorkloadCredentialSecret, "${OK147_WORKLOAD_BINDING_DIGEST}": values.WorkloadBindingDigest,
+	}
+	result := string(template)
+	for placeholder, value := range replacements {
+		if !strings.Contains(result, placeholder) {
+			return nil, fmt.Errorf("target-access stage Job template lacks %s", placeholder)
+		}
+		result = strings.ReplaceAll(result, placeholder, value)
+	}
+	if strings.Contains(result, "${") {
+		return nil, errors.New("target-access stage Job template contains an unknown placeholder")
+	}
+	return []byte(result), nil
+}

--- a/internal/runner/target_access_stage_job_test.go
+++ b/internal/runner/target_access_stage_job_test.go
@@ -1,0 +1,147 @@
+package runner
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/openkubes/ok-cluster/internal/contract"
+	"github.com/openkubes/ok-cluster/internal/stageplan"
+)
+
+func TestRenderTargetAccessStageJobBindsExactEnvelope(t *testing.T) {
+	values := validTargetAccessStageJobValues()
+	raw, err := RenderTargetAccessStageJobTemplate(targetAccessStageJobTemplate(t), values)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range [][]byte{[]byte("${"), []byte("system:masters"), []byte("privileged: true"), []byte("kubernetes.default.svc")} {
+		if bytes.Contains(raw, forbidden) {
+			t.Fatalf("materialized target-access Job contains forbidden boundary %q", forbidden)
+		}
+	}
+	objects := decodeJobObjects(t, raw)
+	job, policy := objects["Job"], objects["NetworkPolicy"]
+	if len(objects) != 2 || job == nil || policy == nil {
+		t.Fatalf("unexpected target-access envelope: %#v", objects)
+	}
+	jobSpec := objectAt(t, job, "spec")
+	if jobSpec["backoffLimit"] != 0 || jobSpec["parallelism"] != 1 || jobSpec["completions"] != 1 || jobSpec["activeDeadlineSeconds"] != 300 {
+		t.Fatalf("target-access Job boundary differs: %#v", jobSpec)
+	}
+	podSpec := objectAt(t, objectAt(t, jobSpec, "template"), "spec")
+	if podSpec["serviceAccountName"] != "ok147-contract-executor-runtime" || podSpec["automountServiceAccountToken"] != false || podSpec["restartPolicy"] != "Never" {
+		t.Fatalf("unexpected target-access Pod identity: %#v", podSpec)
+	}
+	container := arrayAt(t, podSpec, "containers")[0].(map[string]any)
+	args := stringArray(t, container, "args")
+	for _, required := range []string{
+		"cluster", "stage", "run", "target-access", "--execute", "--grant",
+		"--target-access-artifact", "--ledger-token-file", "--workload-binding",
+		"--workload-binding-digest", "--workload-token-file",
+	} {
+		if !contains(args, required) {
+			t.Fatalf("target-access Job args do not bind %s: %v", required, args)
+		}
+	}
+	for argument, want := range map[string]string{
+		"--observability-namespace": values.ObservabilityNamespace,
+		"--manager-serviceaccount":  values.ManagerServiceAccount,
+		"--cluster-role":            values.ClusterRole,
+		"--cluster-rolebinding":     values.ClusterRoleBinding,
+		"--platform-role":           values.PlatformRole,
+		"--platform-rolebinding":    values.PlatformRoleBinding,
+		"--kube-system-role":        values.KubeSystemRole,
+		"--kube-system-rolebinding": values.KubeSystemRoleBinding,
+	} {
+		if got := argumentValue(args, argument); got != want {
+			t.Fatalf("target-access Job %s=%q, want %q", argument, got, want)
+		}
+	}
+	receiptCount := 0
+	for _, argument := range args {
+		if argument == "--receipt" {
+			receiptCount++
+		}
+	}
+	if receiptCount != 6 {
+		t.Fatalf("receipt arguments=%d, want 6", receiptCount)
+	}
+	if mounts := arrayAt(t, container, "volumeMounts"); len(mounts) != 16 {
+		t.Fatalf("target-access volumeMounts=%d, want 16", len(mounts))
+	}
+	policySpec := objectAt(t, policy, "spec")
+	if len(arrayAt(t, policySpec, "ingress")) != 0 || len(arrayAt(t, policySpec, "egress")) != 2 {
+		t.Fatalf("target-access NetworkPolicy is not two-endpoint deny-all: %#v", policySpec)
+	}
+}
+
+func TestRenderTargetAccessStageJobFailsClosed(t *testing.T) {
+	template := targetAccessStageJobTemplate(t)
+	for name, mutate := range map[string]func(*TargetAccessStageJobValues){
+		"mutable image": func(values *TargetAccessStageJobValues) { values.ImageDigest = "ghcr.io/openkubes/ok-cluster:latest" },
+		"shared credential": func(values *TargetAccessStageJobValues) {
+			values.WorkloadCredentialSecret = values.LedgerCredentialSecret
+		},
+		"shared endpoint": func(values *TargetAccessStageJobValues) {
+			values.WorkloadAPIURL = values.LedgerAPIURL
+			values.WorkloadAPICIDR = values.LedgerAPICIDR
+		},
+		"broad workload CIDR": func(values *TargetAccessStageJobValues) { values.WorkloadAPICIDR = "192.0.2.0/24" },
+		"DNS endpoint": func(values *TargetAccessStageJobValues) {
+			values.WorkloadAPIURL = "https://kubernetes.default.svc:6443"
+		},
+		"invalid object name":    func(values *TargetAccessStageJobValues) { values.PlatformRole = "Bad_Name" },
+		"foreign binding digest": func(values *TargetAccessStageJobValues) { values.WorkloadBindingDigest = "sha256:short" },
+		"foreign authority": func(values *TargetAccessStageJobValues) {
+			values.Expected.GitOpsAuthority = values.Expected.ManagementAuthority
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			values := validTargetAccessStageJobValues()
+			mutate(&values)
+			if _, err := RenderTargetAccessStageJobTemplate(template, values); err == nil {
+				t.Fatal("unsafe target-access stage Job was accepted")
+			}
+		})
+	}
+	if _, err := RenderTargetAccessStageJobTemplate(append(template, []byte("\n${UNKNOWN}")...), validTargetAccessStageJobValues()); err == nil {
+		t.Fatal("unknown target-access placeholder was accepted")
+	}
+}
+
+func validTargetAccessStageJobValues() TargetAccessStageJobValues {
+	return TargetAccessStageJobValues{
+		RunID: "ok147-target-access-20260817-01", ImageDigest: "ghcr.io/openkubes/ok-cluster@sha256:" + strings.Repeat("a", 64),
+		EvaluationTime: "2026-08-17T14:00:00Z",
+		Expected: stageplan.Expected{
+			ContractIdentity: contract.Identity{Namespace: "disposable-ok147", Name: "disposable-ok147"},
+			IntentRevision:   prefixSHA("a"), EnablementRevision: prefixSHA("b"), PlatformRevision: prefixSHA("c"), ExecutionFixture: prefixSHA("d"),
+			InfrastructureAuthority: "ok-infra", ManagementAuthority: "ok-mgmt", GitOpsAuthority: "ok-shared",
+		},
+		InputConfigMap: "ok147-target-access-input", ReceiptPrefixDigest: prefixSHA("e"),
+		ObservabilityNamespace: "ok-observability", ManagerServiceAccount: "ok147-argocd-manager",
+		ClusterRole: "ok147-argocd-platform-cluster", ClusterRoleBinding: "ok147-argocd-platform-cluster",
+		PlatformRole: "ok147-argocd-platform", PlatformRoleBinding: "ok147-argocd-platform",
+		KubeSystemRole: "ok147-argocd-kube-system", KubeSystemRoleBinding: "ok147-argocd-kube-system",
+		LedgerAPIURL: "https://192.0.2.12:6443", LedgerAPICIDR: "192.0.2.12/32", LedgerCredentialSecret: "ok147-ledger-credential",
+		WorkloadAPIURL: "https://192.0.2.13:6443", WorkloadAPICIDR: "192.0.2.13/32", WorkloadCredentialSecret: "ok147-workload-credential",
+		WorkloadBindingDigest: prefixSHA("f"),
+	}
+}
+
+func targetAccessStageJobTemplate(t *testing.T) []byte {
+	t.Helper()
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("cannot resolve test path")
+	}
+	raw, err := os.ReadFile(filepath.Join(filepath.Dir(filename), "..", "..", "deploy", "contract-executor-target-access-job.yaml.tpl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return raw
+}


### PR DESCRIPTION
## Summary

- add a fail-closed renderer for the target-access Job and NetworkPolicy envelope
- bind all eight expected target object names independently from the rendered artifact
- keep public immutable input, ledger credentials, and workload authority credentials in distinct objects
- permit egress only to the exact ledger and workload Kubernetes API endpoints

## Safety boundary

- offline render and validation only
- no package, launch, installation, or Kubernetes API contact
- no wildcard RBAC, embedded credential, or automatic retry

## Verification

- `GOCACHE=/private/tmp/ok147-go-build go test -ldflags=-linkmode=external ./...`
- `GOCACHE=/private/tmp/ok147-go-vet go vet ./...`
- `GOCACHE=/private/tmp/ok147-go-race go test -race -ldflags=-linkmode=external ./internal/runner ./cmd/ok`

Jira: OK-147
