### PR TITLE
feat(runner): package target access stage (OK-147)

### DIFF
--- a/internal/runner/target_access_stage_package.go
+++ b/internal/runner/target_access_stage_package.go
@@ -1,0 +1,191 @@
+package runner
+
+import (
+	"errors"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/projection"
+)
+
+const TargetAccessStagePackageFormat = "ok147-target-access-stage-package/v1"
+
+// TargetAccessStagePackageConfig correlates the public input and Job envelope
+// with a private runtime binding without embedding that binding or credentials.
+type TargetAccessStagePackageConfig struct {
+	Bundle                        TargetAccessStageBundleConfig
+	JobTemplate                   []byte
+	JobTemplateDigest             string
+	RunID                         string
+	ImageDigest                   string
+	InputConfigMap                string
+	ObservabilityNamespace        string
+	ManagerServiceAccount         string
+	ClusterRole                   string
+	ClusterRoleBinding            string
+	PlatformRole                  string
+	PlatformRoleBinding           string
+	KubeSystemRole                string
+	KubeSystemRoleBinding         string
+	LedgerAPIURL                  string
+	LedgerAPICIDR                 string
+	LedgerCredentialSecret        string
+	WorkloadAPIURL                string
+	WorkloadAPICIDR               string
+	WorkloadCredentialSecret      string
+	WorkloadBindingPath           string
+	ExpectedWorkloadBindingDigest string
+}
+
+// TargetAccessStagePackageReceipt is a redaction-safe offline composition
+// proof. TargetAccessDigest covers the eight rendered target objects while
+// TargetIdentityDigest correlates the package to the CAPI-created workload.
+type TargetAccessStagePackageReceipt struct {
+	Format                string   `json:"format"`
+	State                 string   `json:"state"`
+	StageID               string   `json:"stageId"`
+	PackageDigest         string   `json:"packageDigest"`
+	InputConfigMapDigest  string   `json:"inputConfigMapDigest"`
+	ReceiptPrefixDigest   string   `json:"receiptPrefixDigest"`
+	TargetAccessDigest    string   `json:"targetAccessDigest"`
+	TargetIdentityDigest  string   `json:"targetIdentityDigest"`
+	WorkloadBindingDigest string   `json:"workloadBindingDigest"`
+	JobTemplateDigest     string   `json:"jobTemplateDigest"`
+	JobEnvelopeDigest     string   `json:"jobEnvelopeDigest"`
+	ObjectKinds           []string `json:"objectKinds"`
+	AuthorizationState    string   `json:"authorizationState"`
+	MutationAllowed       bool     `json:"mutationAllowed"`
+}
+
+type VerifiedTargetAccessStagePackage struct {
+	raw                []byte
+	receipt            TargetAccessStagePackageReceipt
+	ledgerCredential   string
+	workloadCredential string
+	workloadAuthority  string
+	verified           bool
+}
+
+// BuildTargetAccessStagePackage composes one immutable public ConfigMap and
+// one hardened NetworkPolicy/Job envelope. It performs no API request.
+func BuildTargetAccessStagePackage(config TargetAccessStagePackageConfig) (VerifiedTargetAccessStagePackage, error) {
+	if !stageReceiptPrefixDigestPattern.MatchString(config.JobTemplateDigest) || digest.SHA256(config.JobTemplate) != config.JobTemplateDigest {
+		return VerifiedTargetAccessStagePackage{}, errors.New("target-access stage Job template digest differs from expected identity")
+	}
+	jobObjects := []projection.ResourceIdentity{
+		{APIVersion: "v1", Kind: "Namespace", Name: config.ObservabilityNamespace},
+		{APIVersion: "v1", Kind: "ServiceAccount", Namespace: "kube-system", Name: config.ManagerServiceAccount},
+		{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "ClusterRole", Name: config.ClusterRole},
+		{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "ClusterRoleBinding", Name: config.ClusterRoleBinding},
+		{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role", Namespace: config.ObservabilityNamespace, Name: config.PlatformRole},
+		{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "RoleBinding", Namespace: config.ObservabilityNamespace, Name: config.PlatformRoleBinding},
+		{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role", Namespace: "kube-system", Name: config.KubeSystemRole},
+		{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "RoleBinding", Namespace: "kube-system", Name: config.KubeSystemRoleBinding},
+	}
+	if len(config.Bundle.ExpectedObjects) != len(jobObjects) {
+		return VerifiedTargetAccessStagePackage{}, errors.New("target-access Job object identities differ from verified bundle")
+	}
+	for index := range jobObjects {
+		if config.Bundle.ExpectedObjects[index] != jobObjects[index] {
+			return VerifiedTargetAccessStagePackage{}, errors.New("target-access Job object identities differ from verified bundle")
+		}
+	}
+	input, err := BuildTargetAccessStageInput(config.Bundle, config.InputConfigMap)
+	if err != nil {
+		return VerifiedTargetAccessStagePackage{}, err
+	}
+	inputRaw, err := input.Bytes()
+	if err != nil {
+		return VerifiedTargetAccessStagePackage{}, err
+	}
+	inputReceipt, err := input.Receipt()
+	if err != nil {
+		return VerifiedTargetAccessStagePackage{}, err
+	}
+	bundle, err := LoadTargetAccessStageBundle(config.Bundle)
+	if err != nil {
+		return VerifiedTargetAccessStagePackage{}, err
+	}
+	bundleReceipt, err := bundle.Receipt()
+	if err != nil {
+		return VerifiedTargetAccessStagePackage{}, err
+	}
+	binding, err := loadWorkloadAuthorityBinding(config.WorkloadBindingPath, config.ExpectedWorkloadBindingDigest)
+	if err != nil {
+		return VerifiedTargetAccessStagePackage{}, errors.New("verify private target-access runtime binding")
+	}
+	workloadAuthority := digest.SHA256([]byte(binding.TargetClusterUID))
+	if binding.IntentRevision != bundle.plan.IntentRevision || workloadAuthority != bundleReceipt.TargetIdentityDigest || binding.Endpoint != config.WorkloadAPIURL {
+		return VerifiedTargetAccessStagePackage{}, errors.New("private workload binding differs from target-access package target")
+	}
+	jobRaw, err := RenderTargetAccessStageJobTemplate(config.JobTemplate, TargetAccessStageJobValues{
+		RunID: config.RunID, ImageDigest: config.ImageDigest,
+		EvaluationTime: config.Bundle.EvaluationTime.UTC().Format(time.RFC3339), Expected: config.Bundle.PlanExpected,
+		InputConfigMap: config.InputConfigMap, ReceiptPrefixDigest: inputReceipt.ReceiptPrefixDigest,
+		ObservabilityNamespace: config.ObservabilityNamespace, ManagerServiceAccount: config.ManagerServiceAccount,
+		ClusterRole: config.ClusterRole, ClusterRoleBinding: config.ClusterRoleBinding,
+		PlatformRole: config.PlatformRole, PlatformRoleBinding: config.PlatformRoleBinding,
+		KubeSystemRole: config.KubeSystemRole, KubeSystemRoleBinding: config.KubeSystemRoleBinding,
+		LedgerAPIURL: config.LedgerAPIURL, LedgerAPICIDR: config.LedgerAPICIDR, LedgerCredentialSecret: config.LedgerCredentialSecret,
+		WorkloadAPIURL: config.WorkloadAPIURL, WorkloadAPICIDR: config.WorkloadAPICIDR, WorkloadCredentialSecret: config.WorkloadCredentialSecret,
+		WorkloadBindingDigest: config.ExpectedWorkloadBindingDigest,
+	})
+	if err != nil {
+		return VerifiedTargetAccessStagePackage{}, err
+	}
+	packageRaw := make([]byte, 0, len(inputRaw)+len(jobRaw)+6)
+	packageRaw = append(packageRaw, inputRaw...)
+	packageRaw = append(packageRaw, '\n', '-', '-', '-', '\n')
+	packageRaw = append(packageRaw, jobRaw...)
+	receipt := TargetAccessStagePackageReceipt{
+		Format: TargetAccessStagePackageFormat, State: "VERIFIED", StageID: "target-access",
+		PackageDigest: digest.SHA256(packageRaw), InputConfigMapDigest: inputReceipt.ConfigMapDigest,
+		ReceiptPrefixDigest: inputReceipt.ReceiptPrefixDigest, TargetAccessDigest: inputReceipt.TargetAccessDigest,
+		TargetIdentityDigest: inputReceipt.TargetIdentityDigest, WorkloadBindingDigest: config.ExpectedWorkloadBindingDigest,
+		JobTemplateDigest: config.JobTemplateDigest, JobEnvelopeDigest: digest.SHA256(jobRaw),
+		ObjectKinds: []string{"ConfigMap", "NetworkPolicy", "Job"}, AuthorizationState: "VERIFIED", MutationAllowed: false,
+	}
+	return VerifiedTargetAccessStagePackage{
+		raw: packageRaw, receipt: receipt, ledgerCredential: config.LedgerCredentialSecret,
+		workloadCredential: config.WorkloadCredentialSecret, workloadAuthority: workloadAuthority, verified: true,
+	}, nil
+}
+
+func (packaged VerifiedTargetAccessStagePackage) Bytes() ([]byte, error) {
+	if err := verifyTargetAccessStagePackage(packaged); err != nil {
+		return nil, errors.New("target-access stage package was not produced by verification")
+	}
+	return append([]byte(nil), packaged.raw...), nil
+}
+
+func (packaged VerifiedTargetAccessStagePackage) Receipt() (TargetAccessStagePackageReceipt, error) {
+	if err := verifyTargetAccessStagePackage(packaged); err != nil {
+		return TargetAccessStagePackageReceipt{}, errors.New("target-access stage package was not produced by verification")
+	}
+	receipt := packaged.receipt
+	receipt.ObjectKinds = append([]string(nil), packaged.receipt.ObjectKinds...)
+	return receipt, nil
+}
+
+func verifyTargetAccessStagePackage(packaged VerifiedTargetAccessStagePackage) error {
+	if !packaged.verified || packaged.receipt.Format != TargetAccessStagePackageFormat || packaged.receipt.State != "VERIFIED" || packaged.receipt.StageID != "target-access" || packaged.receipt.MutationAllowed || len(packaged.raw) == 0 || packaged.ledgerCredential == "" || packaged.workloadCredential == "" || packaged.ledgerCredential == packaged.workloadCredential || !stageReceiptPrefixDigestPattern.MatchString(packaged.workloadAuthority) {
+		return errors.New("target-access stage package identity is incomplete")
+	}
+	if digest.SHA256(packaged.raw) != packaged.receipt.PackageDigest || packaged.workloadAuthority != packaged.receipt.TargetIdentityDigest {
+		return errors.New("target-access stage package target identity changed after verification")
+	}
+	for _, value := range []string{
+		packaged.receipt.InputConfigMapDigest, packaged.receipt.ReceiptPrefixDigest,
+		packaged.receipt.TargetAccessDigest, packaged.receipt.TargetIdentityDigest,
+		packaged.receipt.WorkloadBindingDigest, packaged.receipt.JobTemplateDigest,
+		packaged.receipt.JobEnvelopeDigest,
+	} {
+		if !stageReceiptPrefixDigestPattern.MatchString(value) {
+			return errors.New("target-access stage package digest identity changed after verification")
+		}
+	}
+	if len(packaged.receipt.ObjectKinds) != 3 || packaged.receipt.ObjectKinds[0] != "ConfigMap" || packaged.receipt.ObjectKinds[1] != "NetworkPolicy" || packaged.receipt.ObjectKinds[2] != "Job" || packaged.receipt.AuthorizationState != "VERIFIED" {
+		return errors.New("target-access stage package object inventory changed after verification")
+	}
+	return nil
+}

--- a/internal/runner/target_access_stage_package_test.go
+++ b/internal/runner/target_access_stage_package_test.go
@@ -1,0 +1,108 @@
+package runner
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+func TestBuildTargetAccessStagePackageCorrelatesPublicAndPrivateInputs(t *testing.T) {
+	config := targetAccessStagePackageConfig(t)
+	packaged, err := BuildTargetAccessStagePackage(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := packaged.Bytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := packaged.Receipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	objects := decodeJobObjects(t, raw)
+	if len(objects) != 3 || objects["ConfigMap"] == nil || objects["NetworkPolicy"] == nil || objects["Job"] == nil {
+		t.Fatalf("unexpected target-access package object set: %#v", objects)
+	}
+	if bytes.Contains(raw, []byte(`"targetClusterUid"`)) || bytes.Contains(raw, []byte(`"caBundleDigest"`)) || bytes.Contains(raw, []byte("target-access-workload-token")) {
+		t.Fatal("private workload authority was copied into target-access package")
+	}
+	if receipt.Format != TargetAccessStagePackageFormat || receipt.State != "VERIFIED" || receipt.StageID != "target-access" || receipt.PackageDigest != digest.SHA256(raw) || receipt.AuthorizationState != "VERIFIED" || receipt.MutationAllowed || receipt.WorkloadBindingDigest != config.ExpectedWorkloadBindingDigest {
+		t.Fatalf("unexpected target-access package receipt: %#v", receipt)
+	}
+	parts := bytes.SplitN(raw, []byte("\n---\n"), 2)
+	if len(parts) != 2 || receipt.InputConfigMapDigest != digest.SHA256(parts[0]) || receipt.JobEnvelopeDigest != digest.SHA256(parts[1]) || !reflect.DeepEqual(receipt.ObjectKinds, []string{"ConfigMap", "NetworkPolicy", "Job"}) {
+		t.Fatal("target-access package component identities differ")
+	}
+	binding, err := loadWorkloadAuthorityBinding(config.WorkloadBindingPath, config.ExpectedWorkloadBindingDigest)
+	if err != nil || receipt.TargetIdentityDigest != digest.SHA256([]byte(binding.TargetClusterUID)) {
+		t.Fatal("target-access package does not correlate the private runtime target")
+	}
+	job := objects["Job"]
+	container := arrayAt(t, objectAt(t, objectAt(t, objectAt(t, job, "spec"), "template"), "spec"), "containers")[0].(map[string]any)
+	args := stringArray(t, container, "args")
+	if argumentValue(args, "--workload-binding-digest") != config.ExpectedWorkloadBindingDigest || argumentValue(args, "--cluster-role") != config.ClusterRole {
+		t.Fatalf("target-access Job and package bindings differ: %v", args)
+	}
+	raw[0] = 'x'
+	again, err := packaged.Bytes()
+	if err != nil || again[0] != '{' {
+		t.Fatal("caller mutated retained target-access package")
+	}
+	receipt.ObjectKinds[0] = "Changed"
+	againReceipt, err := packaged.Receipt()
+	if err != nil || againReceipt.ObjectKinds[0] != "ConfigMap" {
+		t.Fatal("caller mutated retained target-access package receipt")
+	}
+}
+
+func TestBuildTargetAccessStagePackageFailsClosed(t *testing.T) {
+	valid := targetAccessStagePackageConfig(t)
+	for name, mutate := range map[string]func(*TargetAccessStagePackageConfig){
+		"changed template": func(config *TargetAccessStagePackageConfig) { config.JobTemplate = append(config.JobTemplate, '\n') },
+		"shared credentials": func(config *TargetAccessStagePackageConfig) {
+			config.WorkloadCredentialSecret = config.LedgerCredentialSecret
+		},
+		"binding endpoint differs": func(config *TargetAccessStagePackageConfig) {
+			config.WorkloadAPIURL, config.WorkloadAPICIDR = "https://192.0.2.21:6443", "192.0.2.21/32"
+		},
+		"foreign binding digest": func(config *TargetAccessStagePackageConfig) { config.ExpectedWorkloadBindingDigest = bundleSHA("e") },
+		"wrong object identity":  func(config *TargetAccessStagePackageConfig) { config.ClusterRole = "another-role" },
+	} {
+		t.Run(name, func(t *testing.T) {
+			config := valid
+			config.JobTemplate = append([]byte(nil), valid.JobTemplate...)
+			mutate(&config)
+			if _, err := BuildTargetAccessStagePackage(config); err == nil {
+				t.Fatal("unsafe target-access stage package was accepted")
+			}
+		})
+	}
+	if _, err := (VerifiedTargetAccessStagePackage{}).Bytes(); err == nil {
+		t.Fatal("unverified target-access package bytes were exposed")
+	}
+	if _, err := (VerifiedTargetAccessStagePackage{}).Receipt(); err == nil {
+		t.Fatal("unverified target-access package receipt was exposed")
+	}
+}
+
+func targetAccessStagePackageConfig(t *testing.T) TargetAccessStagePackageConfig {
+	t.Helper()
+	fixture := targetAccessBundleFixture(t)
+	runtimeConfig := targetAccessRuntime(t, fixture.plan)
+	values := validTargetAccessStageJobValues()
+	template := targetAccessStageJobTemplate(t)
+	return TargetAccessStagePackageConfig{
+		Bundle: fixture.config, JobTemplate: template, JobTemplateDigest: digest.SHA256(template),
+		RunID: values.RunID, ImageDigest: values.ImageDigest, InputConfigMap: values.InputConfigMap,
+		ObservabilityNamespace: values.ObservabilityNamespace, ManagerServiceAccount: values.ManagerServiceAccount,
+		ClusterRole: values.ClusterRole, ClusterRoleBinding: values.ClusterRoleBinding,
+		PlatformRole: values.PlatformRole, PlatformRoleBinding: values.PlatformRoleBinding,
+		KubeSystemRole: values.KubeSystemRole, KubeSystemRoleBinding: values.KubeSystemRoleBinding,
+		LedgerAPIURL: values.LedgerAPIURL, LedgerAPICIDR: values.LedgerAPICIDR, LedgerCredentialSecret: values.LedgerCredentialSecret,
+		WorkloadAPIURL: "https://192.0.2.147:6443", WorkloadAPICIDR: "192.0.2.147/32", WorkloadCredentialSecret: values.WorkloadCredentialSecret,
+		WorkloadBindingPath: runtimeConfig.Workload.Path, ExpectedWorkloadBindingDigest: runtimeConfig.Workload.ExpectedBindingDigest,
+	}
+}


### PR DESCRIPTION
## Summary

- compose the verified target-access input ConfigMap and hardened Job envelope into one digest-bound offline package
- correlate the private runtime binding to the CAPI target identity without embedding its UID, CA, or credentials
- require the eight independently supplied Job object identities to match the already verified artifact identities exactly
- expose only redaction-safe component and package digests in the package receipt

## Safety boundary

- offline composition and verification only
- no package installation, Job launch, Kubernetes API contact, or target mutation
- ledger and workload credentials remain distinct external Secrets

## Verification

- `GOCACHE=/private/tmp/ok147-go-build go test -ldflags=-linkmode=external ./...`
- `GOCACHE=/private/tmp/ok147-go-vet go vet ./...`
- `GOCACHE=/private/tmp/ok147-go-race go test -race -ldflags=-linkmode=external ./internal/runner ./cmd/ok`

Jira: OK-147
