### PR TITLE
feat(runner): plan target access install (OK-147)

### DIFF
--- a/internal/runner/target_access_stage_installation_plan.go
+++ b/internal/runner/target_access_stage_installation_plan.go
@@ -1,0 +1,165 @@
+package runner
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"gopkg.in/yaml.v3"
+)
+
+const TargetAccessStageInstallationPlanFormat = "ok147-target-access-stage-installation-plan/v1"
+
+// TargetAccessStageInstallationPlan is a tokenless offline description of
+// the three exact execution-plane objects. It grants no create authority.
+type TargetAccessStageInstallationPlan struct {
+	Format             string                      `json:"format"`
+	State              string                      `json:"state"`
+	StageID            string                      `json:"stageId"`
+	StagePackageDigest string                      `json:"stagePackageDigest"`
+	Authority          string                      `json:"authority"`
+	Creates            []SubmissionStageCreatePlan `json:"creates"`
+	MutationAllowed    bool                        `json:"mutationAllowed"`
+}
+
+// PlanTargetAccessStageInstallation re-verifies the immutable input,
+// NetworkPolicy and Job and derives their exact create order without opening
+// either credential Secret or contacting Kubernetes.
+func PlanTargetAccessStageInstallation(packaged VerifiedTargetAccessStagePackage) (TargetAccessStageInstallationPlan, error) {
+	receipt, err := packaged.Receipt()
+	if err != nil {
+		return TargetAccessStageInstallationPlan{}, err
+	}
+	expectedKinds := []string{"ConfigMap", "NetworkPolicy", "Job"}
+	if !equalStringList(receipt.ObjectKinds, expectedKinds) {
+		return TargetAccessStageInstallationPlan{}, errors.New("target-access package object inventory is invalid")
+	}
+	documents := bytes.Split(packaged.raw, []byte("\n---\n"))
+	if len(documents) != len(expectedKinds) || digest.SHA256(documents[0]) != receipt.InputConfigMapDigest || digest.SHA256(bytes.Join(documents[1:], []byte("\n---\n"))) != receipt.JobEnvelopeDigest {
+		return TargetAccessStageInstallationPlan{}, errors.New("target-access package component identity differs")
+	}
+	decoder := yaml.NewDecoder(bytes.NewReader(packaged.raw))
+	objects := make([]map[string]any, 0, len(expectedKinds))
+	for {
+		var object map[string]any
+		err := decoder.Decode(&object)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil || len(object) == 0 {
+			return TargetAccessStageInstallationPlan{}, errors.New("decode target-access package")
+		}
+		objects = append(objects, object)
+	}
+	if len(objects) != len(expectedKinds) {
+		return TargetAccessStageInstallationPlan{}, errors.New("target-access package object count is invalid")
+	}
+
+	configMapName, runID := "", ""
+	creates := make([]SubmissionStageCreatePlan, 0, len(objects))
+	for index, object := range objects {
+		apiVersion, _ := object["apiVersion"].(string)
+		kind, _ := object["kind"].(string)
+		if kind != expectedKinds[index] {
+			return TargetAccessStageInstallationPlan{}, errors.New("target-access package create order is invalid")
+		}
+		metadata, ok := object["metadata"].(map[string]any)
+		if !ok {
+			return TargetAccessStageInstallationPlan{}, errors.New("target-access package object metadata is invalid")
+		}
+		name, _ := metadata["name"].(string)
+		namespace, _ := metadata["namespace"].(string)
+		if !submissionStageInputNamePattern.MatchString(name) || len(name) > 63 || namespace != submissionStageInputNamespace || metadata["generateName"] != nil {
+			return TargetAccessStageInstallationPlan{}, errors.New("target-access package object identity is invalid")
+		}
+		collectionPath, objectPath, err := submissionStageCreatePaths(apiVersion, kind, namespace, name)
+		if err != nil {
+			return TargetAccessStageInstallationPlan{}, err
+		}
+		canonical, err := json.Marshal(object)
+		if err != nil {
+			return TargetAccessStageInstallationPlan{}, errors.New("encode target-access package object")
+		}
+		creates = append(creates, SubmissionStageCreatePlan{
+			Order: index + 1, APIVersion: apiVersion, Kind: kind, Namespace: namespace, Name: name,
+			PreflightMethod: "GET", ObjectPath: objectPath, CreateMethod: "POST", CollectionPath: collectionPath,
+			ObjectDigest: digest.SHA256(canonical),
+		})
+		switch kind {
+		case "ConfigMap":
+			labels, _ := metadata["labels"].(map[string]any)
+			annotations, _ := metadata["annotations"].(map[string]any)
+			if object["immutable"] != true || labels["openkubes.io/stage-id"] != receipt.StageID || annotations["openkubes.io/target-identity-digest"] != receipt.TargetIdentityDigest {
+				return TargetAccessStageInstallationPlan{}, errors.New("target-access input ConfigMap semantics differ")
+			}
+			configMapName = name
+		case "NetworkPolicy":
+			runID = name
+			spec, _ := object["spec"].(map[string]any)
+			selector, _ := spec["podSelector"].(map[string]any)
+			matchLabels, _ := selector["matchLabels"].(map[string]any)
+			if matchLabels["openkubes.io/execution-id"] != runID || lenArrayValue(spec["ingress"]) != 0 || lenArrayValue(spec["egress"]) != 2 {
+				return TargetAccessStageInstallationPlan{}, errors.New("target-access NetworkPolicy boundary differs")
+			}
+		case "Job":
+			if name != runID {
+				return TargetAccessStageInstallationPlan{}, errors.New("target-access Job and NetworkPolicy identities differ")
+			}
+			spec, _ := object["spec"].(map[string]any)
+			template, _ := spec["template"].(map[string]any)
+			podSpec, _ := template["spec"].(map[string]any)
+			if podSpec["serviceAccountName"] != "ok147-contract-executor-runtime" || podSpec["automountServiceAccountToken"] != false {
+				return TargetAccessStageInstallationPlan{}, errors.New("target-access Job runtime identity is invalid")
+			}
+			if !jobMountsInputConfigMap(podSpec, configMapName) || !jobUsesTargetAccessCredentialSecrets(podSpec, packaged.ledgerCredential, packaged.workloadCredential) {
+				return TargetAccessStageInstallationPlan{}, errors.New("target-access Job binding differs from verified package")
+			}
+		}
+	}
+	return TargetAccessStageInstallationPlan{
+		Format: TargetAccessStageInstallationPlanFormat, State: "VERIFIED", StageID: receipt.StageID,
+		StagePackageDigest: receipt.PackageDigest, Authority: packaged.workloadAuthority,
+		Creates: creates, MutationAllowed: false,
+	}, nil
+}
+
+func jobUsesTargetAccessCredentialSecrets(podSpec map[string]any, ledger, workload string) bool {
+	volumes, ok := podSpec["volumes"].([]any)
+	if !ok {
+		return false
+	}
+	want := map[string]struct {
+		secret string
+		items  map[string]string
+	}{
+		"ledger-credential":   {secret: ledger, items: map[string]string{"token": "token", "ca.crt": "ca.crt"}},
+		"workload-credential": {secret: workload, items: map[string]string{"token": "token", "ca.crt": "ca.crt", "binding.json": "binding.json"}},
+	}
+	found := map[string]bool{}
+	for _, item := range volumes {
+		volume, _ := item.(map[string]any)
+		name, _ := volume["name"].(string)
+		expected, relevant := want[name]
+		if !relevant {
+			continue
+		}
+		secret, _ := volume["secret"].(map[string]any)
+		secretName, _ := secret["secretName"].(string)
+		items, _ := secret["items"].([]any)
+		if secretName != expected.secret || !exactCredentialSecretItems(items, expected.items) {
+			return false
+		}
+		found[name] = true
+	}
+	return len(found) == len(want)
+}
+
+func lenArrayValue(value any) int {
+	items, ok := value.([]any)
+	if !ok {
+		return -1
+	}
+	return len(items)
+}

--- a/internal/runner/target_access_stage_installation_plan_test.go
+++ b/internal/runner/target_access_stage_installation_plan_test.go
@@ -1,0 +1,97 @@
+package runner
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+func TestPlanTargetAccessStageInstallationProducesExactSafeOrder(t *testing.T) {
+	packaged, err := BuildTargetAccessStagePackage(targetAccessStagePackageConfig(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan, err := PlanTargetAccessStageInstallation(packaged)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, _ := packaged.Receipt()
+	if plan.Format != TargetAccessStageInstallationPlanFormat || plan.State != "VERIFIED" || plan.StageID != "target-access" || plan.StagePackageDigest != receipt.PackageDigest || plan.Authority != receipt.TargetIdentityDigest || plan.MutationAllowed {
+		t.Fatalf("unexpected target-access installation plan: %#v", plan)
+	}
+	wantKinds := []string{"ConfigMap", "NetworkPolicy", "Job"}
+	wantCollections := []string{
+		"/api/v1/namespaces/openkubes-execution-system/configmaps",
+		"/apis/networking.k8s.io/v1/namespaces/openkubes-execution-system/networkpolicies",
+		"/apis/batch/v1/namespaces/openkubes-execution-system/jobs",
+	}
+	if len(plan.Creates) != len(wantKinds) {
+		t.Fatalf("creates=%d, want 3", len(plan.Creates))
+	}
+	for index, create := range plan.Creates {
+		if create.Order != index+1 || create.Kind != wantKinds[index] || create.Namespace != submissionStageInputNamespace || create.PreflightMethod != "GET" || create.CreateMethod != "POST" || create.CollectionPath != wantCollections[index] || create.ObjectPath != create.CollectionPath+"/"+create.Name || !stageReceiptPrefixDigestPattern.MatchString(create.ObjectDigest) {
+			t.Fatalf("unexpected target-access create %d: %#v", index, create)
+		}
+		if strings.Contains(strings.ToLower(create.ObjectPath), "secret") {
+			t.Fatalf("installation plan unexpectedly contains credential path: %#v", create)
+		}
+	}
+	if plan.Creates[1].Name != plan.Creates[2].Name {
+		t.Fatal("target-access NetworkPolicy and Job run identities differ")
+	}
+}
+
+func TestPlanTargetAccessStageInstallationFailsClosed(t *testing.T) {
+	valid, err := BuildTargetAccessStagePackage(targetAccessStagePackageConfig(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := PlanTargetAccessStageInstallation(VerifiedTargetAccessStagePackage{}); err == nil {
+		t.Fatal("unverified target-access package was planned")
+	}
+	tests := map[string]func(*VerifiedTargetAccessStagePackage){
+		"wrong inventory": func(packaged *VerifiedTargetAccessStagePackage) {
+			packaged.receipt.ObjectKinds = []string{"ConfigMap", "Job", "NetworkPolicy"}
+		},
+		"foreign authority": func(packaged *VerifiedTargetAccessStagePackage) {
+			packaged.workloadAuthority = bundleSHA("1")
+		},
+		"changed runtime": func(packaged *VerifiedTargetAccessStagePackage) {
+			packaged.raw = bytes.Replace(packaged.raw, []byte("ok147-contract-executor-runtime"), []byte("ok147-foreign-runtime"), 1)
+			updateTargetAccessPackageDigests(packaged)
+		},
+		"changed workload credential": func(packaged *VerifiedTargetAccessStagePackage) {
+			packaged.raw = bytes.Replace(packaged.raw, []byte(packaged.workloadCredential), []byte("ok147-foreign-workload"), 1)
+			updateTargetAccessPackageDigests(packaged)
+		},
+		"broadened egress": func(packaged *VerifiedTargetAccessStagePackage) {
+			packaged.raw = bytes.Replace(packaged.raw, []byte("  egress:\n"), []byte("  egress:\n    - {}\n"), 1)
+			updateTargetAccessPackageDigests(packaged)
+		},
+		"extra object": func(packaged *VerifiedTargetAccessStagePackage) {
+			packaged.raw = append(packaged.raw, []byte("\n---\napiVersion: v1\nkind: Secret\nmetadata: {name: forbidden}\n")...)
+			packaged.receipt.PackageDigest = digest.SHA256(packaged.raw)
+		},
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			packaged := valid
+			packaged.raw = append([]byte(nil), valid.raw...)
+			packaged.receipt.ObjectKinds = append([]string(nil), valid.receipt.ObjectKinds...)
+			mutate(&packaged)
+			if _, err := PlanTargetAccessStageInstallation(packaged); err == nil {
+				t.Fatal("changed target-access package was planned")
+			}
+		})
+	}
+}
+
+func updateTargetAccessPackageDigests(packaged *VerifiedTargetAccessStagePackage) {
+	packaged.receipt.PackageDigest = digest.SHA256(packaged.raw)
+	documents := bytes.SplitN(packaged.raw, []byte("\n---\n"), 2)
+	if len(documents) == 2 {
+		packaged.receipt.JobEnvelopeDigest = digest.SHA256(documents[1])
+	}
+}


### PR DESCRIPTION
## Summary

- derive a tokenless, offline installation plan from the verified target-access package
- enforce the exact ConfigMap -> NetworkPolicy -> Job create order and workload-authority digest
- re-verify immutable input semantics, two-endpoint deny-all egress, runtime identity, and exact credential Secret references
- expose no Secret API path and grant no mutation authority

## Safety boundary

- planning only; no credential read, package installation, Job launch, or Kubernetes API contact
- no retry, update, delete, wildcard, or implicit target identity

## Verification

- `GOCACHE=/private/tmp/ok147-go-build go test -ldflags=-linkmode=external ./...`
- `GOCACHE=/private/tmp/ok147-go-vet go vet ./...`
- `GOCACHE=/private/tmp/ok147-go-race go test -race -ldflags=-linkmode=external ./internal/runner ./cmd/ok`

Jira: OK-147
