### PR TITLE
fix(runner): separate target install authority (OK-147)

### DIFF
--- a/internal/runner/target_access_stage_installation_plan.go
+++ b/internal/runner/target_access_stage_installation_plan.go
@@ -120,7 +120,7 @@ func PlanTargetAccessStageInstallation(packaged VerifiedTargetAccessStagePackage
 	}
 	return TargetAccessStageInstallationPlan{
 		Format: TargetAccessStageInstallationPlanFormat, State: "VERIFIED", StageID: receipt.StageID,
-		StagePackageDigest: receipt.PackageDigest, Authority: packaged.workloadAuthority,
+		StagePackageDigest: receipt.PackageDigest, Authority: packaged.installationAuthority,
 		Creates: creates, MutationAllowed: false,
 	}, nil
 }

--- a/internal/runner/target_access_stage_installation_plan_test.go
+++ b/internal/runner/target_access_stage_installation_plan_test.go
@@ -18,7 +18,7 @@ func TestPlanTargetAccessStageInstallationProducesExactSafeOrder(t *testing.T) {
 		t.Fatal(err)
 	}
 	receipt, _ := packaged.Receipt()
-	if plan.Format != TargetAccessStageInstallationPlanFormat || plan.State != "VERIFIED" || plan.StageID != "target-access" || plan.StagePackageDigest != receipt.PackageDigest || plan.Authority != receipt.TargetIdentityDigest || plan.MutationAllowed {
+	if plan.Format != TargetAccessStageInstallationPlanFormat || plan.State != "VERIFIED" || plan.StageID != "target-access" || plan.StagePackageDigest != receipt.PackageDigest || plan.Authority != "ok-shared" || plan.MutationAllowed {
 		t.Fatalf("unexpected target-access installation plan: %#v", plan)
 	}
 	wantKinds := []string{"ConfigMap", "NetworkPolicy", "Job"}
@@ -56,7 +56,7 @@ func TestPlanTargetAccessStageInstallationFailsClosed(t *testing.T) {
 			packaged.receipt.ObjectKinds = []string{"ConfigMap", "Job", "NetworkPolicy"}
 		},
 		"foreign authority": func(packaged *VerifiedTargetAccessStagePackage) {
-			packaged.workloadAuthority = bundleSHA("1")
+			packaged.installationAuthority = "ok-mgmt"
 		},
 		"changed runtime": func(packaged *VerifiedTargetAccessStagePackage) {
 			packaged.raw = bytes.Replace(packaged.raw, []byte("ok147-contract-executor-runtime"), []byte("ok147-foreign-runtime"), 1)

--- a/internal/runner/target_access_stage_package.go
+++ b/internal/runner/target_access_stage_package.go
@@ -50,6 +50,7 @@ type TargetAccessStagePackageReceipt struct {
 	TargetAccessDigest    string   `json:"targetAccessDigest"`
 	TargetIdentityDigest  string   `json:"targetIdentityDigest"`
 	WorkloadBindingDigest string   `json:"workloadBindingDigest"`
+	InstallationAuthority string   `json:"installationAuthority"`
 	JobTemplateDigest     string   `json:"jobTemplateDigest"`
 	JobEnvelopeDigest     string   `json:"jobEnvelopeDigest"`
 	ObjectKinds           []string `json:"objectKinds"`
@@ -58,12 +59,14 @@ type TargetAccessStagePackageReceipt struct {
 }
 
 type VerifiedTargetAccessStagePackage struct {
-	raw                []byte
-	receipt            TargetAccessStagePackageReceipt
-	ledgerCredential   string
-	workloadCredential string
-	workloadAuthority  string
-	verified           bool
+	raw                   []byte
+	receipt               TargetAccessStagePackageReceipt
+	ledgerCredential      string
+	workloadCredential    string
+	installationAuthority string
+	managementAuthority   string
+	workloadAuthority     string
+	verified              bool
 }
 
 // BuildTargetAccessStagePackage composes one immutable public ConfigMap and
@@ -142,12 +145,15 @@ func BuildTargetAccessStagePackage(config TargetAccessStagePackageConfig) (Verif
 		PackageDigest: digest.SHA256(packageRaw), InputConfigMapDigest: inputReceipt.ConfigMapDigest,
 		ReceiptPrefixDigest: inputReceipt.ReceiptPrefixDigest, TargetAccessDigest: inputReceipt.TargetAccessDigest,
 		TargetIdentityDigest: inputReceipt.TargetIdentityDigest, WorkloadBindingDigest: config.ExpectedWorkloadBindingDigest,
-		JobTemplateDigest: config.JobTemplateDigest, JobEnvelopeDigest: digest.SHA256(jobRaw),
+		InstallationAuthority: bundle.plan.Authorities.GitOps,
+		JobTemplateDigest:     config.JobTemplateDigest, JobEnvelopeDigest: digest.SHA256(jobRaw),
 		ObjectKinds: []string{"ConfigMap", "NetworkPolicy", "Job"}, AuthorizationState: "VERIFIED", MutationAllowed: false,
 	}
 	return VerifiedTargetAccessStagePackage{
 		raw: packageRaw, receipt: receipt, ledgerCredential: config.LedgerCredentialSecret,
-		workloadCredential: config.WorkloadCredentialSecret, workloadAuthority: workloadAuthority, verified: true,
+		workloadCredential:    config.WorkloadCredentialSecret,
+		installationAuthority: bundle.plan.Authorities.GitOps, managementAuthority: bundle.plan.Authorities.Management,
+		workloadAuthority: workloadAuthority, verified: true,
 	}, nil
 }
 
@@ -168,7 +174,7 @@ func (packaged VerifiedTargetAccessStagePackage) Receipt() (TargetAccessStagePac
 }
 
 func verifyTargetAccessStagePackage(packaged VerifiedTargetAccessStagePackage) error {
-	if !packaged.verified || packaged.receipt.Format != TargetAccessStagePackageFormat || packaged.receipt.State != "VERIFIED" || packaged.receipt.StageID != "target-access" || packaged.receipt.MutationAllowed || len(packaged.raw) == 0 || packaged.ledgerCredential == "" || packaged.workloadCredential == "" || packaged.ledgerCredential == packaged.workloadCredential || !stageReceiptPrefixDigestPattern.MatchString(packaged.workloadAuthority) {
+	if !packaged.verified || packaged.receipt.Format != TargetAccessStagePackageFormat || packaged.receipt.State != "VERIFIED" || packaged.receipt.StageID != "target-access" || packaged.receipt.MutationAllowed || len(packaged.raw) == 0 || packaged.ledgerCredential == "" || packaged.workloadCredential == "" || packaged.ledgerCredential == packaged.workloadCredential || packaged.installationAuthority == "" || packaged.managementAuthority == "" || packaged.installationAuthority == packaged.managementAuthority || packaged.receipt.InstallationAuthority != packaged.installationAuthority || !stageReceiptPrefixDigestPattern.MatchString(packaged.workloadAuthority) {
 		return errors.New("target-access stage package identity is incomplete")
 	}
 	if digest.SHA256(packaged.raw) != packaged.receipt.PackageDigest || packaged.workloadAuthority != packaged.receipt.TargetIdentityDigest {

--- a/internal/runner/target_access_stage_package_test.go
+++ b/internal/runner/target_access_stage_package_test.go
@@ -29,7 +29,7 @@ func TestBuildTargetAccessStagePackageCorrelatesPublicAndPrivateInputs(t *testin
 	if bytes.Contains(raw, []byte(`"targetClusterUid"`)) || bytes.Contains(raw, []byte(`"caBundleDigest"`)) || bytes.Contains(raw, []byte("target-access-workload-token")) {
 		t.Fatal("private workload authority was copied into target-access package")
 	}
-	if receipt.Format != TargetAccessStagePackageFormat || receipt.State != "VERIFIED" || receipt.StageID != "target-access" || receipt.PackageDigest != digest.SHA256(raw) || receipt.AuthorizationState != "VERIFIED" || receipt.MutationAllowed || receipt.WorkloadBindingDigest != config.ExpectedWorkloadBindingDigest {
+	if receipt.Format != TargetAccessStagePackageFormat || receipt.State != "VERIFIED" || receipt.StageID != "target-access" || receipt.PackageDigest != digest.SHA256(raw) || receipt.AuthorizationState != "VERIFIED" || receipt.MutationAllowed || receipt.WorkloadBindingDigest != config.ExpectedWorkloadBindingDigest || receipt.InstallationAuthority != "ok-shared" {
 		t.Fatalf("unexpected target-access package receipt: %#v", receipt)
 	}
 	parts := bytes.SplitN(raw, []byte("\n---\n"), 2)


### PR DESCRIPTION
## Summary

- distinguish target-access installation authority from ledger and workload mutation authorities
- bind the package and installation plan to `ok-shared` as the central execution plane
- retain `ok-mgmt` as ledger authority and the CAPI target UID digest as workload authority
- fail closed if installation and management authority collapse to the same identity

## Safety boundary

- metadata and offline planning correction only
- no credential read, package installation, Job launch, or Kubernetes API contact

## Verification

- `GOCACHE=/private/tmp/ok147-go-build go test -ldflags=-linkmode=external ./...`
- `GOCACHE=/private/tmp/ok147-go-vet go vet ./...`
- `GOCACHE=/private/tmp/ok147-go-race go test -race -ldflags=-linkmode=external ./internal/runner ./cmd/ok`

Jira: OK-147
