### PR TITLE
feat(runner): bind target access credentials (OK-147)

### DIFF
--- a/internal/runner/target_access_stage_credentials.go
+++ b/internal/runner/target_access_stage_credentials.go
@@ -1,0 +1,204 @@
+package runner
+
+import (
+	"crypto/subtle"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/jsonstrict"
+)
+
+const TargetAccessStageCredentialPackageFormat = "ok147-target-access-stage-credential-package/v1"
+
+type TargetAccessStageCredentialPackageConfig struct {
+	Package             VerifiedTargetAccessStagePackage
+	MaterializationTime time.Time
+	WorkloadBindingPath string
+	LedgerWriter        SubmissionStageCredentialSource
+	WorkloadWriter      SubmissionStageCredentialSource
+}
+
+// TargetAccessStageCredentialPackageReceipt binds two private immutable
+// Secrets without exposing token, CA, subject, endpoint, UID or source paths.
+type TargetAccessStageCredentialPackageReceipt struct {
+	Format                    string                                   `json:"format"`
+	State                     string                                   `json:"state"`
+	StageID                   string                                   `json:"stageId"`
+	TargetAccessPackageDigest string                                   `json:"targetAccessPackageDigest"`
+	WorkloadBindingDigest     string                                   `json:"workloadBindingDigest"`
+	InstallationAuthority     string                                   `json:"installationAuthority"`
+	MaterializedAt            string                                   `json:"materializedAt"`
+	PackageDigest             string                                   `json:"packageDigest"`
+	Credentials               []SubmissionStageCredentialObjectReceipt `json:"credentials"`
+	MutationAllowed           bool                                     `json:"mutationAllowed"`
+}
+
+type targetAccessStageCredentialPackageIdentity struct {
+	TargetAccessPackageDigest string                                   `json:"targetAccessPackageDigest"`
+	WorkloadBindingDigest     string                                   `json:"workloadBindingDigest"`
+	InstallationAuthority     string                                   `json:"installationAuthority"`
+	MaterializedAt            string                                   `json:"materializedAt"`
+	Credentials               []SubmissionStageCredentialObjectReceipt `json:"credentials"`
+}
+
+// VerifiedTargetAccessStageCredentialPackage keeps private Secret bytes
+// inaccessible to callers; only the redaction-safe receipt is exposed.
+type VerifiedTargetAccessStageCredentialPackage struct {
+	objects               []submissionStageCredentialObject
+	receipt               TargetAccessStageCredentialPackageReceipt
+	installationAuthority string
+	managementAuthority   string
+	workloadAuthority     string
+	verified              bool
+}
+
+// BuildTargetAccessStageCredentialPackage verifies two independent,
+// short-lived TokenRequest results and the package-bound workload identity.
+// It performs no Kubernetes request.
+func BuildTargetAccessStageCredentialPackage(config TargetAccessStageCredentialPackageConfig) (VerifiedTargetAccessStageCredentialPackage, error) {
+	packageReceipt, err := config.Package.Receipt()
+	if err != nil || packageReceipt.StageID != "target-access" {
+		return VerifiedTargetAccessStageCredentialPackage{}, errors.New("verified target-access package is required")
+	}
+	if config.MaterializationTime.IsZero() || !config.MaterializationTime.Equal(config.MaterializationTime.Truncate(time.Second)) {
+		return VerifiedTargetAccessStageCredentialPackage{}, errors.New("target-access credential materialization time is required")
+	}
+	binding, err := loadWorkloadAuthorityBinding(config.WorkloadBindingPath, packageReceipt.WorkloadBindingDigest)
+	if err != nil {
+		return VerifiedTargetAccessStageCredentialPackage{}, errors.New("verify private target-access workload binding")
+	}
+	if digest.SHA256([]byte(binding.TargetClusterUID)) != config.Package.workloadAuthority || binding.CABundleDigest != config.WorkloadWriter.CABundleDigest {
+		return VerifiedTargetAccessStageCredentialPackage{}, errors.New("target-access workload authority differs from verified package")
+	}
+	bindings := []struct {
+		role      string
+		name      string
+		authority string
+		source    SubmissionStageCredentialSource
+	}{
+		{role: "ledger-writer", name: config.Package.ledgerCredential, authority: config.Package.managementAuthority, source: config.LedgerWriter},
+		{role: "workload-writer", name: config.Package.workloadCredential, authority: config.Package.workloadAuthority, source: config.WorkloadWriter},
+	}
+	objects := make([]submissionStageCredentialObject, 0, len(bindings))
+	receipts := make([]SubmissionStageCredentialObjectReceipt, 0, len(bindings))
+	tokens := make([][]byte, 0, len(bindings))
+	for _, credential := range bindings {
+		object, receipt, token, err := buildSubmissionStageCredentialObject(
+			packageReceipt.StageID, config.MaterializationTime.UTC(), credential.role,
+			credential.name, credential.authority, credential.source,
+		)
+		if err != nil {
+			return VerifiedTargetAccessStageCredentialPackage{}, err
+		}
+		objects = append(objects, object)
+		receipts = append(receipts, receipt)
+		tokens = append(tokens, token)
+	}
+	if len(tokens[0]) == len(tokens[1]) && subtle.ConstantTimeCompare(tokens[0], tokens[1]) == 1 {
+		return VerifiedTargetAccessStageCredentialPackage{}, errors.New("target-access credentials must be distinct")
+	}
+	bindingRaw, err := json.Marshal(binding)
+	if err != nil {
+		return VerifiedTargetAccessStageCredentialPackage{}, errors.New("encode private target-access workload binding")
+	}
+	var workloadSecret map[string]any
+	if err := jsonstrict.Decode(objects[1].raw, &workloadSecret); err != nil {
+		return VerifiedTargetAccessStageCredentialPackage{}, errors.New("decode private target-access workload credential")
+	}
+	data, ok := workloadSecret["data"].(map[string]any)
+	if !ok {
+		return VerifiedTargetAccessStageCredentialPackage{}, errors.New("private target-access workload credential data is missing")
+	}
+	data["binding.json"] = base64.StdEncoding.EncodeToString(bindingRaw)
+	objects[1].raw, err = json.Marshal(workloadSecret)
+	if err != nil || len(objects[1].raw) > maximumStageCredentialObjectBytes {
+		return VerifiedTargetAccessStageCredentialPackage{}, errors.New("target-access workload credential Secret exceeds accepted size")
+	}
+	receipts[1].ObjectDigest = digest.SHA256(objects[1].raw)
+
+	materializedAt := config.MaterializationTime.UTC().Format(time.RFC3339)
+	identity, err := json.Marshal(targetAccessStageCredentialPackageIdentity{
+		TargetAccessPackageDigest: packageReceipt.PackageDigest, WorkloadBindingDigest: packageReceipt.WorkloadBindingDigest,
+		InstallationAuthority: config.Package.installationAuthority, MaterializedAt: materializedAt, Credentials: receipts,
+	})
+	if err != nil {
+		return VerifiedTargetAccessStageCredentialPackage{}, errors.New("encode target-access credential package identity")
+	}
+	receipt := TargetAccessStageCredentialPackageReceipt{
+		Format: TargetAccessStageCredentialPackageFormat, State: "VERIFIED", StageID: packageReceipt.StageID,
+		TargetAccessPackageDigest: packageReceipt.PackageDigest, WorkloadBindingDigest: packageReceipt.WorkloadBindingDigest,
+		InstallationAuthority: config.Package.installationAuthority, MaterializedAt: materializedAt,
+		PackageDigest: digest.SHA256(identity), Credentials: receipts, MutationAllowed: false,
+	}
+	return VerifiedTargetAccessStageCredentialPackage{
+		objects: cloneStageCredentialObjects(objects), receipt: receipt,
+		installationAuthority: config.Package.installationAuthority, managementAuthority: config.Package.managementAuthority,
+		workloadAuthority: config.Package.workloadAuthority, verified: true,
+	}, nil
+}
+
+func (packaged VerifiedTargetAccessStageCredentialPackage) Receipt() (TargetAccessStageCredentialPackageReceipt, error) {
+	if err := verifyTargetAccessStageCredentialPackage(packaged); err != nil {
+		return TargetAccessStageCredentialPackageReceipt{}, errors.New("target-access credential package was not produced by verification")
+	}
+	receipt := packaged.receipt
+	receipt.Credentials = append([]SubmissionStageCredentialObjectReceipt(nil), packaged.receipt.Credentials...)
+	for index := range receipt.Credentials {
+		receipt.Credentials[index].Audiences = append([]string(nil), packaged.receipt.Credentials[index].Audiences...)
+	}
+	return receipt, nil
+}
+
+func verifyTargetAccessStageCredentialPackage(packaged VerifiedTargetAccessStageCredentialPackage) error {
+	if !packaged.verified || packaged.receipt.Format != TargetAccessStageCredentialPackageFormat || packaged.receipt.State != "VERIFIED" || packaged.receipt.StageID != "target-access" || packaged.receipt.MutationAllowed || packaged.installationAuthority == "" || packaged.managementAuthority == "" || packaged.installationAuthority == packaged.managementAuthority || packaged.receipt.InstallationAuthority != packaged.installationAuthority || !stageReceiptPrefixDigestPattern.MatchString(packaged.workloadAuthority) || len(packaged.objects) != 2 || len(packaged.receipt.Credentials) != 2 {
+		return errors.New("target-access credential package identity is incomplete")
+	}
+	identity, err := json.Marshal(targetAccessStageCredentialPackageIdentity{
+		TargetAccessPackageDigest: packaged.receipt.TargetAccessPackageDigest,
+		WorkloadBindingDigest:     packaged.receipt.WorkloadBindingDigest,
+		InstallationAuthority:     packaged.receipt.InstallationAuthority,
+		MaterializedAt:            packaged.receipt.MaterializedAt, Credentials: packaged.receipt.Credentials,
+	})
+	if err != nil || digest.SHA256(identity) != packaged.receipt.PackageDigest {
+		return errors.New("target-access credential package identity changed after verification")
+	}
+	if _, err := time.Parse(time.RFC3339, packaged.receipt.MaterializedAt); err != nil {
+		return errors.New("target-access credential materialization time is invalid")
+	}
+	expectedRoles := []string{"ledger-writer", "workload-writer"}
+	expectedAuthorities := []string{packaged.managementAuthority, packaged.workloadAuthority}
+	for index, object := range packaged.objects {
+		receipt := packaged.receipt.Credentials[index]
+		if object.role != expectedRoles[index] || receipt.Role != expectedRoles[index] || object.authority != expectedAuthorities[index] || receipt.Authority != expectedAuthorities[index] || object.name != receipt.Name || receipt.Namespace != submissionStageInputNamespace || digest.SHA256(object.raw) != receipt.ObjectDigest {
+			return errors.New("target-access credential object identity changed after verification")
+		}
+	}
+	var workloadSecret map[string]any
+	if err := jsonstrict.Decode(packaged.objects[1].raw, &workloadSecret); err != nil {
+		return errors.New("target-access workload credential is invalid")
+	}
+	data, ok := workloadSecret["data"].(map[string]any)
+	if !ok {
+		return errors.New("target-access workload credential data is missing")
+	}
+	bindingEncoded, ok := data["binding.json"].(string)
+	if !ok {
+		return errors.New("target-access workload binding is missing")
+	}
+	bindingRaw, err := base64.StdEncoding.DecodeString(bindingEncoded)
+	if err != nil {
+		return errors.New("target-access workload binding encoding is invalid")
+	}
+	var binding WorkloadAuthorityBinding
+	if err := jsonstrict.Decode(bindingRaw, &binding); err != nil {
+		return errors.New("target-access workload binding is invalid")
+	}
+	bindingDigest, err := WorkloadAuthorityBindingDigest(binding)
+	if err != nil || bindingDigest != packaged.receipt.WorkloadBindingDigest || digest.SHA256([]byte(binding.TargetClusterUID)) != packaged.workloadAuthority {
+		return errors.New("target-access workload authority identity changed after verification")
+	}
+	return nil
+}

--- a/internal/runner/target_access_stage_credentials_test.go
+++ b/internal/runner/target_access_stage_credentials_test.go
@@ -1,0 +1,191 @@
+package runner
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+func TestBuildTargetAccessStageCredentialPackageBindsTwoPrivateSecrets(t *testing.T) {
+	config, tokens := targetAccessCredentialConfig(t)
+	packaged, err := BuildTargetAccessStageCredentialPackage(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := packaged.Receipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	stageReceipt, _ := config.Package.Receipt()
+	if receipt.Format != TargetAccessStageCredentialPackageFormat || receipt.State != "VERIFIED" || receipt.StageID != "target-access" || receipt.TargetAccessPackageDigest != stageReceipt.PackageDigest || receipt.WorkloadBindingDigest != stageReceipt.WorkloadBindingDigest || receipt.InstallationAuthority != "ok-shared" || receipt.MaterializedAt != config.MaterializationTime.Format(time.RFC3339) || !stageReceiptPrefixDigestPattern.MatchString(receipt.PackageDigest) || receipt.MutationAllowed || len(receipt.Credentials) != 2 {
+		t.Fatalf("unexpected target-access credential receipt: %#v", receipt)
+	}
+	want := []struct {
+		role      string
+		name      string
+		authority string
+	}{
+		{role: "ledger-writer", name: config.Package.ledgerCredential, authority: "ok-mgmt"},
+		{role: "workload-writer", name: config.Package.workloadCredential, authority: config.Package.workloadAuthority},
+	}
+	for index, expected := range want {
+		object := packaged.objects[index]
+		objectReceipt := receipt.Credentials[index]
+		if object.role != expected.role || object.authority != expected.authority || object.name != expected.name || digest.SHA256(object.raw) != objectReceipt.ObjectDigest {
+			t.Fatalf("private target-access credential %d differs: %#v %#v", index, object, objectReceipt)
+		}
+		var secret map[string]any
+		if err := json.Unmarshal(object.raw, &secret); err != nil {
+			t.Fatal(err)
+		}
+		data := secret["data"].(map[string]any)
+		decodedToken, err := base64.StdEncoding.DecodeString(data["token"].(string))
+		if err != nil || !bytes.Equal(decodedToken, tokens[index]) {
+			t.Fatalf("private target-access token %d differs", index)
+		}
+		_, hasBinding := data["binding.json"]
+		if hasBinding != (index == 1) {
+			t.Fatalf("credential %d workload-binding presence differs", index)
+		}
+	}
+	public, err := json.Marshal(receipt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range []string{
+		string(tokens[0]), string(tokens[1]), config.WorkloadBindingPath,
+		config.LedgerWriter.TokenFile, config.WorkloadWriter.TokenFile,
+		config.LedgerWriter.ExpectedSubject, config.WorkloadWriter.ExpectedSubject,
+	} {
+		if bytes.Contains(public, []byte(forbidden)) {
+			t.Fatalf("target-access credential receipt exposed private value %q", forbidden)
+		}
+	}
+	receipt.Credentials[0].Audiences[0] = "changed"
+	again, err := packaged.Receipt()
+	if err != nil || again.Credentials[0].Audiences[0] == "changed" {
+		t.Fatal("caller mutated retained target-access credential receipt")
+	}
+}
+
+func TestBuildTargetAccessStageCredentialPackageFailsClosed(t *testing.T) {
+	for name, mutate := range map[string]func(*TargetAccessStageCredentialPackageConfig){
+		"foreign ledger authority": func(config *TargetAccessStageCredentialPackageConfig) {
+			config.LedgerWriter.AuthorityIdentity = "ok-infra"
+		},
+		"foreign workload authority": func(config *TargetAccessStageCredentialPackageConfig) {
+			config.WorkloadWriter.AuthorityIdentity = prefixSHA("f")
+		},
+		"workload CA differs from binding": func(config *TargetAccessStageCredentialPackageConfig) {
+			config.WorkloadWriter.CABundleDigest = prefixSHA("e")
+		},
+		"shared token": func(config *TargetAccessStageCredentialPackageConfig) {
+			config.WorkloadWriter.TokenFile = config.LedgerWriter.TokenFile
+			config.WorkloadWriter.TokenDigest = config.LedgerWriter.TokenDigest
+			config.WorkloadWriter.ExpectedIssuer = config.LedgerWriter.ExpectedIssuer
+			config.WorkloadWriter.ExpectedSubject = config.LedgerWriter.ExpectedSubject
+			config.WorkloadWriter.ExpectedAudiences = append([]string(nil), config.LedgerWriter.ExpectedAudiences...)
+			config.WorkloadWriter.IssuedAt = config.LedgerWriter.IssuedAt
+			config.WorkloadWriter.ExpiresAt = config.LedgerWriter.ExpiresAt
+		},
+		"missing TokenRequest evidence": func(config *TargetAccessStageCredentialPackageConfig) {
+			config.LedgerWriter.TokenRequestEvidenceDigest = ""
+		},
+		"unverified package": func(config *TargetAccessStageCredentialPackageConfig) {
+			config.Package = VerifiedTargetAccessStagePackage{}
+		},
+		"changed package identity": func(config *TargetAccessStageCredentialPackageConfig) {
+			config.Package.receipt.PackageDigest = prefixSHA("d")
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			config, _ := targetAccessCredentialConfig(t)
+			mutate(&config)
+			_, err := BuildTargetAccessStageCredentialPackage(config)
+			if err == nil || strings.Contains(err.Error(), config.WorkloadBindingPath) || strings.Contains(err.Error(), config.WorkloadWriter.TokenFile) {
+				t.Fatalf("unsafe target-access credential package accepted: %v", err)
+			}
+		})
+	}
+	if _, err := (VerifiedTargetAccessStageCredentialPackage{}).Receipt(); err == nil {
+		t.Fatal("unverified target-access credential receipt was exposed")
+	}
+	config, _ := targetAccessCredentialConfig(t)
+	packaged, err := BuildTargetAccessStageCredentialPackage(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	packaged.objects[1].raw = append(packaged.objects[1].raw, '\n')
+	if _, err := packaged.Receipt(); err == nil {
+		t.Fatal("changed private target-access credential was accepted")
+	}
+}
+
+func targetAccessCredentialConfig(t *testing.T) (TargetAccessStageCredentialPackageConfig, [][]byte) {
+	t.Helper()
+	now := time.Date(2026, 8, 16, 14, 0, 0, 0, time.UTC)
+	issuedAt, expiresAt := now.Add(-time.Minute), now.Add(30*time.Minute)
+	audiences := []string{"https://kubernetes.default.svc"}
+	issuer := "https://kubernetes.default.svc.cluster.local"
+	root := t.TempDir()
+	managementCA, workloadCA := testCA(t), testCA(t)
+	managementCAPath, workloadCAPath := filepath.Join(root, "management-ca.crt"), filepath.Join(root, "workload-ca.crt")
+	if err := os.WriteFile(managementCAPath, managementCA, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(workloadCAPath, workloadCA, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	packageConfig := targetAccessStagePackageConfig(t)
+	binding, err := loadWorkloadAuthorityBinding(packageConfig.WorkloadBindingPath, packageConfig.ExpectedWorkloadBindingDigest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	binding.CABundleDigest = digest.SHA256(workloadCA)
+	if err := os.WriteFile(packageConfig.WorkloadBindingPath, mustJSON(t, binding), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	packageConfig.ExpectedWorkloadBindingDigest, err = WorkloadAuthorityBindingDigest(binding)
+	if err != nil {
+		t.Fatal(err)
+	}
+	packaged, err := BuildTargetAccessStagePackage(packageConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	subjects := []string{
+		"system:serviceaccount:openkubes-execution-system:ok147-target-ledger-writer",
+		"system:serviceaccount:openkubes-execution-system:ok147-target-workload-writer",
+	}
+	tokens := [][]byte{
+		stageCredentialJWT(t, issuer, subjects[0], audiences, issuedAt, expiresAt, 'e'),
+		stageCredentialJWT(t, issuer, subjects[1], audiences, issuedAt, expiresAt, 'f'),
+	}
+	tokenPaths := make([]string, len(tokens))
+	for index, token := range tokens {
+		tokenPaths[index] = filepath.Join(root, "token-"+string(rune('0'+index)))
+		if err := os.WriteFile(tokenPaths[index], token, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	source := func(authority, tokenPath, subject, evidence, caPath string, token, ca []byte) SubmissionStageCredentialSource {
+		return SubmissionStageCredentialSource{
+			AuthorityIdentity: authority, TokenFile: tokenPath, TokenDigest: digest.SHA256(token),
+			CAFile: caPath, CABundleDigest: digest.SHA256(ca), TokenRequestEvidenceDigest: prefixSHA(evidence),
+			ExpectedIssuer: issuer, ExpectedSubject: subject, ExpectedAudiences: audiences,
+			IssuedAt: issuedAt, ExpiresAt: expiresAt,
+		}
+	}
+	return TargetAccessStageCredentialPackageConfig{
+		Package: packaged, MaterializationTime: now, WorkloadBindingPath: packageConfig.WorkloadBindingPath,
+		LedgerWriter:   source("ok-mgmt", tokenPaths[0], subjects[0], "1", managementCAPath, tokens[0], managementCA),
+		WorkloadWriter: source(digest.SHA256([]byte(binding.TargetClusterUID)), tokenPaths[1], subjects[1], "2", workloadCAPath, tokens[1], workloadCA),
+	}, tokens
+}


### PR DESCRIPTION
## Summary

- materialize two distinct short-lived TokenRequest results into private immutable target-access Secrets
- bind the ledger writer to `ok-mgmt` and the workload writer to the CAPI target UID digest
- embed the digest-verified private runtime binding only in the workload credential Secret
- expose a redaction-safe receipt without tokens, CA payloads, subjects, endpoints, UIDs, or source paths

## Safety boundary

- offline credential verification and Secret-byte construction only
- no Secret exposure API, package installation, Job launch, or Kubernetes API contact
- fail closed on shared tokens, foreign authorities, CA mismatch, missing TokenRequest evidence, or changed private bytes

## Verification

- `GOCACHE=/private/tmp/ok147-go-build go test -ldflags=-linkmode=external ./...`
- `GOCACHE=/private/tmp/ok147-go-vet go vet ./...`
- `GOCACHE=/private/tmp/ok147-go-race go test -race -ldflags=-linkmode=external ./internal/runner ./cmd/ok`

Jira: OK-147
