### PR TITLE
feat(runner): plan target access launch (OK-147)

### DIFF
--- a/internal/runner/target_access_stage_launch_plan.go
+++ b/internal/runner/target_access_stage_launch_plan.go
@@ -1,0 +1,79 @@
+package runner
+
+import "errors"
+
+const TargetAccessStageLaunchPlanFormat = "ok147-target-access-stage-launch-plan/v1"
+
+// TargetAccessStageLaunchPlan binds every exact execution-plane object needed
+// to start the Job. It contains no object or credential bytes.
+type TargetAccessStageLaunchPlan struct {
+	Format                    string                           `json:"format"`
+	State                     string                           `json:"state"`
+	StageID                   string                           `json:"stageId"`
+	Authority                 string                           `json:"authority"`
+	TargetAccessPackageDigest string                           `json:"targetAccessPackageDigest"`
+	CredentialPackageDigest   string                           `json:"credentialPackageDigest"`
+	RuntimeManifestDigest     string                           `json:"runtimeManifestDigest"`
+	PreflightBarrier          string                           `json:"preflightBarrier"`
+	Preflights                []SubmissionStageLaunchPreflight `json:"preflights"`
+	Creates                   []SubmissionStageLaunchCreate    `json:"creates"`
+	MutationAllowed           bool                             `json:"mutationAllowed"`
+}
+
+// PlanTargetAccessStageLaunch requires one coherent stage, credential package
+// and runtime prerequisite. Every GET must complete before the first POST.
+func PlanTargetAccessStageLaunch(packaged VerifiedTargetAccessStagePackage, credentials VerifiedTargetAccessStageCredentialPackage, runtime VerifiedTargetAccessStageRuntimePrerequisite) (TargetAccessStageLaunchPlan, error) {
+	stage, err := PlanTargetAccessStageInstallation(packaged)
+	if err != nil {
+		return TargetAccessStageLaunchPlan{}, err
+	}
+	if err := verifyTargetAccessStageCredentialPackage(credentials); err != nil {
+		return TargetAccessStageLaunchPlan{}, err
+	}
+	if err := verifyTargetAccessStageRuntimePrerequisite(runtime); err != nil {
+		return TargetAccessStageLaunchPlan{}, err
+	}
+	if stage.StagePackageDigest != credentials.receipt.TargetAccessPackageDigest || stage.StagePackageDigest != runtime.receipt.TargetAccessPackageDigest || stage.StageID != credentials.receipt.StageID || stage.Authority != credentials.installationAuthority || stage.Authority != runtime.receipt.Authority {
+		return TargetAccessStageLaunchPlan{}, errors.New("target-access launch components do not share one verified identity")
+	}
+
+	preflights := make([]SubmissionStageLaunchPreflight, 0, 6)
+	creates := make([]SubmissionStageLaunchCreate, 0, 6)
+	appendObject := func(order int, phase, apiVersion, kind, namespace, name, objectPath, collectionPath, objectDigest, existingPolicy, createPolicy string) {
+		preflights = append(preflights, SubmissionStageLaunchPreflight{
+			Order: order, Phase: phase, APIVersion: apiVersion, Kind: kind, Namespace: namespace, Name: name,
+			Method: "GET", ObjectPath: objectPath, ResponseMode: "FULL_OBJECT", ExistingPolicy: existingPolicy, ObjectDigest: objectDigest,
+		})
+		creates = append(creates, SubmissionStageLaunchCreate{
+			Order: order, Phase: phase, APIVersion: apiVersion, Kind: kind, Namespace: namespace, Name: name,
+			Method: "POST", CollectionPath: collectionPath, CreatePolicy: createPolicy, ObjectDigest: objectDigest,
+		})
+	}
+	runtimeCollection := "/api/v1/namespaces/" + runtime.receipt.Namespace + "/serviceaccounts"
+	appendObject(1, "runtime", "v1", "ServiceAccount", runtime.receipt.Namespace, runtime.receipt.Name,
+		runtimeCollection+"/"+runtime.receipt.Name, runtimeCollection, runtime.receipt.ObjectDigest,
+		"VERIFY_EXACT", "CREATE_IF_ABSENT_OR_VERIFY_EXISTING")
+	for index, object := range stage.Creates[:2] {
+		appendObject(index+2, "stage-prerequisites", object.APIVersion, object.Kind, object.Namespace, object.Name,
+			object.ObjectPath, object.CollectionPath, object.ObjectDigest,
+			"VERIFY_EXACT_GLOBAL_STATE", "CREATE_ONLY_AFTER_GLOBAL_ABSENCE")
+	}
+	for index, object := range credentials.objects {
+		collection := "/api/v1/namespaces/" + submissionStageInputNamespace + "/secrets"
+		appendObject(index+4, "credentials", "v1", "Secret", submissionStageInputNamespace, object.name,
+			collection+"/"+object.name, collection, credentials.receipt.Credentials[index].ObjectDigest,
+			"VERIFY_EXACT_GLOBAL_STATE", "CREATE_ONLY_AFTER_GLOBAL_ABSENCE")
+	}
+	job := stage.Creates[2]
+	appendObject(6, "job", job.APIVersion, job.Kind, job.Namespace, job.Name,
+		job.ObjectPath, job.CollectionPath, job.ObjectDigest,
+		"VERIFY_EXACT_GLOBAL_STATE", "CREATE_ONLY_AFTER_GLOBAL_ABSENCE")
+
+	return TargetAccessStageLaunchPlan{
+		Format: TargetAccessStageLaunchPlanFormat, State: "VERIFIED", StageID: stage.StageID,
+		Authority: stage.Authority, TargetAccessPackageDigest: stage.StagePackageDigest,
+		CredentialPackageDigest: credentials.receipt.PackageDigest, RuntimeManifestDigest: runtime.receipt.ManifestDigest,
+		PreflightBarrier: "ALL_ABSENT_OR_RUNTIME_ONLY_OR_ALL_EXACT", Preflights: preflights, Creates: creates,
+		MutationAllowed: false,
+	}, nil
+}

--- a/internal/runner/target_access_stage_launch_plan_test.go
+++ b/internal/runner/target_access_stage_launch_plan_test.go
@@ -1,0 +1,102 @@
+package runner
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+func TestPlanTargetAccessStageLaunchBindsSixObjectsBehindOneBarrier(t *testing.T) {
+	stage, credentials, runtime, tokens := targetAccessStageLaunchFixture(t)
+	plan, err := PlanTargetAccessStageLaunch(stage, credentials, runtime)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stageReceipt, _ := stage.Receipt()
+	credentialReceipt, _ := credentials.Receipt()
+	runtimeReceipt, _ := runtime.Receipt()
+	if plan.Format != TargetAccessStageLaunchPlanFormat || plan.State != "VERIFIED" || plan.StageID != "target-access" || plan.Authority != "ok-shared" || plan.TargetAccessPackageDigest != stageReceipt.PackageDigest || plan.CredentialPackageDigest != credentialReceipt.PackageDigest || plan.RuntimeManifestDigest != runtimeReceipt.ManifestDigest || plan.PreflightBarrier != "ALL_ABSENT_OR_RUNTIME_ONLY_OR_ALL_EXACT" || plan.MutationAllowed {
+		t.Fatalf("unexpected target-access launch identity: %#v", plan)
+	}
+	wantKinds := []string{"ServiceAccount", "ConfigMap", "NetworkPolicy", "Secret", "Secret", "Job"}
+	wantPhases := []string{"runtime", "stage-prerequisites", "stage-prerequisites", "credentials", "credentials", "job"}
+	if len(plan.Preflights) != len(wantKinds) || len(plan.Creates) != len(wantKinds) {
+		t.Fatalf("unexpected target-access launch object count: %d %d", len(plan.Preflights), len(plan.Creates))
+	}
+	for index := range wantKinds {
+		preflight, create := plan.Preflights[index], plan.Creates[index]
+		if preflight.Order != index+1 || create.Order != index+1 || preflight.Phase != wantPhases[index] || create.Phase != wantPhases[index] || preflight.Kind != wantKinds[index] || create.Kind != wantKinds[index] || preflight.Name != create.Name || preflight.Namespace != create.Namespace || preflight.ObjectDigest != create.ObjectDigest || preflight.Method != "GET" || create.Method != "POST" || preflight.ResponseMode != "FULL_OBJECT" {
+			t.Fatalf("target-access launch step %d differs: %#v %#v", index+1, preflight, create)
+		}
+		if index == 0 {
+			if preflight.ExistingPolicy != "VERIFY_EXACT" || create.CreatePolicy != "CREATE_IF_ABSENT_OR_VERIFY_EXISTING" {
+				t.Fatalf("runtime policy differs: %#v %#v", preflight, create)
+			}
+		} else if preflight.ExistingPolicy != "VERIFY_EXACT_GLOBAL_STATE" || create.CreatePolicy != "CREATE_ONLY_AFTER_GLOBAL_ABSENCE" {
+			t.Fatalf("global policy differs at %d: %#v %#v", index+1, preflight, create)
+		}
+	}
+	if plan.Creates[5].Kind != "Job" {
+		t.Fatal("target-access Job was not held behind both credentials")
+	}
+	public, err := json.Marshal(plan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range [][]byte{tokens[0], tokens[1], credentials.objects[0].raw, credentials.objects[1].raw, runtime.raw, stage.raw} {
+		if bytes.Contains(public, forbidden) {
+			t.Fatal("target-access launch plan exposed private object content")
+		}
+	}
+}
+
+func TestPlanTargetAccessStageLaunchRejectsMismatchedComponents(t *testing.T) {
+	stage, credentials, runtime, _ := targetAccessStageLaunchFixture(t)
+	tests := map[string]func() (VerifiedTargetAccessStagePackage, VerifiedTargetAccessStageCredentialPackage, VerifiedTargetAccessStageRuntimePrerequisite){
+		"empty stage": func() (VerifiedTargetAccessStagePackage, VerifiedTargetAccessStageCredentialPackage, VerifiedTargetAccessStageRuntimePrerequisite) {
+			return VerifiedTargetAccessStagePackage{}, credentials, runtime
+		},
+		"empty credentials": func() (VerifiedTargetAccessStagePackage, VerifiedTargetAccessStageCredentialPackage, VerifiedTargetAccessStageRuntimePrerequisite) {
+			return stage, VerifiedTargetAccessStageCredentialPackage{}, runtime
+		},
+		"empty runtime": func() (VerifiedTargetAccessStagePackage, VerifiedTargetAccessStageCredentialPackage, VerifiedTargetAccessStageRuntimePrerequisite) {
+			return stage, credentials, VerifiedTargetAccessStageRuntimePrerequisite{}
+		},
+		"foreign credential package": func() (VerifiedTargetAccessStagePackage, VerifiedTargetAccessStageCredentialPackage, VerifiedTargetAccessStageRuntimePrerequisite) {
+			changed := credentials
+			changed.receipt.TargetAccessPackageDigest = digest.SHA256([]byte("foreign"))
+			return stage, changed, runtime
+		},
+		"foreign runtime package": func() (VerifiedTargetAccessStagePackage, VerifiedTargetAccessStageCredentialPackage, VerifiedTargetAccessStageRuntimePrerequisite) {
+			changed := runtime
+			changed.receipt.TargetAccessPackageDigest = digest.SHA256([]byte("foreign"))
+			return stage, credentials, changed
+		},
+	}
+	for name, values := range tests {
+		t.Run(name, func(t *testing.T) {
+			candidateStage, candidateCredentials, candidateRuntime := values()
+			if _, err := PlanTargetAccessStageLaunch(candidateStage, candidateCredentials, candidateRuntime); err == nil {
+				t.Fatal("mismatched target-access launch components accepted")
+			}
+		})
+	}
+}
+
+func targetAccessStageLaunchFixture(t *testing.T) (VerifiedTargetAccessStagePackage, VerifiedTargetAccessStageCredentialPackage, VerifiedTargetAccessStageRuntimePrerequisite, [][]byte) {
+	t.Helper()
+	credentialConfig, tokens := targetAccessCredentialConfig(t)
+	stage := credentialConfig.Package
+	credentials, err := BuildTargetAccessStageCredentialPackage(credentialConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest := submissionStageRuntimeManifest(t)
+	runtime, err := BuildTargetAccessStageRuntimePrerequisite(stage, manifest, digest.SHA256(manifest))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return stage, credentials, runtime, tokens
+}

--- a/internal/runner/target_access_stage_runtime.go
+++ b/internal/runner/target_access_stage_runtime.go
@@ -1,0 +1,61 @@
+package runner
+
+import (
+	"errors"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+const TargetAccessStageRuntimePrerequisiteFormat = "ok147-target-access-stage-runtime-prerequisite/v1"
+
+type TargetAccessStageRuntimePrerequisiteReceipt struct {
+	Format                    string `json:"format"`
+	State                     string `json:"state"`
+	TargetAccessPackageDigest string `json:"targetAccessPackageDigest"`
+	ManifestDigest            string `json:"manifestDigest"`
+	ObjectDigest              string `json:"objectDigest"`
+	Authority                 string `json:"authority"`
+	Namespace                 string `json:"namespace"`
+	Name                      string `json:"name"`
+	MutationAllowed           bool   `json:"mutationAllowed"`
+}
+
+type VerifiedTargetAccessStageRuntimePrerequisite struct {
+	raw      []byte
+	receipt  TargetAccessStageRuntimePrerequisiteReceipt
+	verified bool
+}
+
+// BuildTargetAccessStageRuntimePrerequisite binds the shared tokenless runner
+// ServiceAccount on the central execution plane entirely offline.
+func BuildTargetAccessStageRuntimePrerequisite(packaged VerifiedTargetAccessStagePackage, manifest []byte, expectedDigest string) (VerifiedTargetAccessStageRuntimePrerequisite, error) {
+	packageReceipt, err := packaged.Receipt()
+	if err != nil || packaged.installationAuthority == "" {
+		return VerifiedTargetAccessStageRuntimePrerequisite{}, errors.New("verified target-access package is required")
+	}
+	raw, objectDigest, err := buildStageRuntimePrerequisiteObject(manifest, expectedDigest)
+	if err != nil {
+		return VerifiedTargetAccessStageRuntimePrerequisite{}, err
+	}
+	receipt := TargetAccessStageRuntimePrerequisiteReceipt{
+		Format: TargetAccessStageRuntimePrerequisiteFormat, State: "VERIFIED",
+		TargetAccessPackageDigest: packageReceipt.PackageDigest, ManifestDigest: expectedDigest,
+		ObjectDigest: objectDigest, Authority: packaged.installationAuthority,
+		Namespace: submissionStageInputNamespace, Name: "ok147-contract-executor-runtime", MutationAllowed: false,
+	}
+	return VerifiedTargetAccessStageRuntimePrerequisite{raw: raw, receipt: receipt, verified: true}, nil
+}
+
+func (runtime VerifiedTargetAccessStageRuntimePrerequisite) Receipt() (TargetAccessStageRuntimePrerequisiteReceipt, error) {
+	if err := verifyTargetAccessStageRuntimePrerequisite(runtime); err != nil {
+		return TargetAccessStageRuntimePrerequisiteReceipt{}, err
+	}
+	return runtime.receipt, nil
+}
+
+func verifyTargetAccessStageRuntimePrerequisite(runtime VerifiedTargetAccessStageRuntimePrerequisite) error {
+	if !runtime.verified || runtime.receipt.Format != TargetAccessStageRuntimePrerequisiteFormat || runtime.receipt.State != "VERIFIED" || runtime.receipt.Authority == "" || runtime.receipt.Namespace != submissionStageInputNamespace || runtime.receipt.Name != "ok147-contract-executor-runtime" || runtime.receipt.MutationAllowed || !stageReceiptPrefixDigestPattern.MatchString(runtime.receipt.TargetAccessPackageDigest) || !stageReceiptPrefixDigestPattern.MatchString(runtime.receipt.ManifestDigest) || digest.SHA256(runtime.raw) != runtime.receipt.ObjectDigest {
+		return errors.New("target-access runtime prerequisite was not produced by verification")
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

- bind the shared tokenless runtime ServiceAccount to the verified target-access package on `ok-shared`
- compose runtime, public prerequisites, two private credentials, and Job into one six-object launch plan
- require a global GET preflight barrier before the first POST
- hold the executable Job last, behind both independently verified credential Secrets

## Safety boundary

- offline runtime verification and launch planning only
- no credential exposure, API contact, object creation, Job launch, retry, update, or delete

## Verification

- `GOCACHE=/private/tmp/ok147-go-build go test -ldflags=-linkmode=external ./...`
- `GOCACHE=/private/tmp/ok147-go-vet go vet ./...`
- `GOCACHE=/private/tmp/ok147-go-race go test -race -ldflags=-linkmode=external ./internal/runner ./cmd/ok`

Jira: OK-147
