### PR TITLE
feat(runner): prepare target access launch (OK-147)

### DIFF
--- a/internal/runner/target_access_stage_launch_candidate.go
+++ b/internal/runner/target_access_stage_launch_candidate.go
@@ -1,0 +1,171 @@
+package runner
+
+import (
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+const TargetAccessStageLaunchCandidateFormat = "ok147-target-access-stage-launch-candidate/v1"
+
+type TargetAccessStageLaunchCandidateReceipt struct {
+	Format                            string `json:"format"`
+	State                             string `json:"state"`
+	StageID                           string `json:"stageId"`
+	Authority                         string `json:"authority"`
+	TargetAccessPackageDigest         string `json:"targetAccessPackageDigest"`
+	CredentialPackageDigest           string `json:"credentialPackageDigest"`
+	RuntimeManifestDigest             string `json:"runtimeManifestDigest"`
+	LaunchPlanDigest                  string `json:"launchPlanDigest"`
+	AuthorityEndpointDigest           string `json:"authorityEndpointDigest"`
+	CABundleDigest                    string `json:"caBundleDigest"`
+	InstallerCredentialBindingDigest  string `json:"installerCredentialBindingDigest"`
+	InstallerCredentialEvidenceDigest string `json:"installerCredentialEvidenceDigest"`
+	PreparedAt                        string `json:"preparedAt"`
+	ValidUntil                        string `json:"validUntil"`
+	CandidateDigest                   string `json:"candidateDigest"`
+	MutationAllowed                   bool   `json:"mutationAllowed"`
+}
+
+type targetAccessStageLaunchCandidateIdentity struct {
+	StageID                           string `json:"stageId"`
+	Authority                         string `json:"authority"`
+	TargetAccessPackageDigest         string `json:"targetAccessPackageDigest"`
+	CredentialPackageDigest           string `json:"credentialPackageDigest"`
+	RuntimeManifestDigest             string `json:"runtimeManifestDigest"`
+	LaunchPlanDigest                  string `json:"launchPlanDigest"`
+	AuthorityEndpointDigest           string `json:"authorityEndpointDigest"`
+	CABundleDigest                    string `json:"caBundleDigest"`
+	InstallerCredentialBindingDigest  string `json:"installerCredentialBindingDigest"`
+	InstallerCredentialEvidenceDigest string `json:"installerCredentialEvidenceDigest"`
+	PreparedAt                        string `json:"preparedAt"`
+	ValidUntil                        string `json:"validUntil"`
+}
+
+// VerifiedTargetAccessStageLaunchCandidate retains the exact ok-shared API
+// endpoint and installer-token identity outside its redaction-safe receipt.
+type VerifiedTargetAccessStageLaunchCandidate struct {
+	receipt              TargetAccessStageLaunchCandidateReceipt
+	authorityEndpoint    string
+	installerTokenDigest string
+	verified             bool
+}
+
+// PrepareTargetAccessStageLaunchCandidate binds the coherent launch plan to
+// one API, CA and evidenced installer credential without opening a credential
+// or performing an API request.
+func PrepareTargetAccessStageLaunchCandidate(config SubmissionStageLaunchCandidateConfig, packaged VerifiedTargetAccessStagePackage, credentials VerifiedTargetAccessStageCredentialPackage, runtime VerifiedTargetAccessStageRuntimePrerequisite) (VerifiedTargetAccessStageLaunchCandidate, error) {
+	plan, err := PlanTargetAccessStageLaunch(packaged, credentials, runtime)
+	if err != nil {
+		return VerifiedTargetAccessStageLaunchCandidate{}, err
+	}
+	if err := verifyTargetAccessStageCredentialPackage(credentials); err != nil {
+		return VerifiedTargetAccessStageLaunchCandidate{}, err
+	}
+	endpoint, err := normalizeSubmissionStageLaunchEndpoint(config.AuthorityEndpoint)
+	if err != nil {
+		return VerifiedTargetAccessStageLaunchCandidate{}, err
+	}
+	if !stageReceiptPrefixDigestPattern.MatchString(config.CABundleDigest) || !stageReceiptPrefixDigestPattern.MatchString(config.InstallerTokenDigest) || !stageReceiptPrefixDigestPattern.MatchString(config.InstallerCredentialEvidenceDigest) {
+		return VerifiedTargetAccessStageLaunchCandidate{}, errors.New("target-access launch candidate credential identities are invalid")
+	}
+	if config.PreparedAt.IsZero() || !config.PreparedAt.Equal(config.PreparedAt.Truncate(time.Second)) {
+		return VerifiedTargetAccessStageLaunchCandidate{}, errors.New("target-access launch candidate preparation time is required")
+	}
+	materializedAt, err := time.Parse(time.RFC3339, credentials.receipt.MaterializedAt)
+	if err != nil || config.PreparedAt.Before(materializedAt) {
+		return VerifiedTargetAccessStageLaunchCandidate{}, errors.New("target-access launch candidate predates credential materialization")
+	}
+	validUntil := time.Time{}
+	for _, credential := range credentials.receipt.Credentials {
+		expiresAt, err := time.Parse(time.RFC3339, credential.ExpiresAt)
+		if err != nil {
+			return VerifiedTargetAccessStageLaunchCandidate{}, errors.New("target-access credential expiration is invalid")
+		}
+		candidate := expiresAt.Add(-minimumStageCredentialRemaining)
+		if validUntil.IsZero() || candidate.Before(validUntil) {
+			validUntil = candidate
+		}
+	}
+	if validUntil.IsZero() || config.PreparedAt.After(validUntil) {
+		return VerifiedTargetAccessStageLaunchCandidate{}, errors.New("target-access credentials cannot retain minimum lifetime")
+	}
+	planRaw, err := json.Marshal(plan)
+	if err != nil {
+		return VerifiedTargetAccessStageLaunchCandidate{}, errors.New("encode target-access launch plan identity")
+	}
+	credentialBindingRaw, err := json.Marshal(submissionStageInstallerCredentialIdentity{TokenDigest: config.InstallerTokenDigest, EvidenceDigest: config.InstallerCredentialEvidenceDigest})
+	if err != nil {
+		return VerifiedTargetAccessStageLaunchCandidate{}, errors.New("encode target-access installer credential identity")
+	}
+	identity := targetAccessStageLaunchCandidateIdentity{
+		StageID: plan.StageID, Authority: plan.Authority, TargetAccessPackageDigest: plan.TargetAccessPackageDigest,
+		CredentialPackageDigest: plan.CredentialPackageDigest, RuntimeManifestDigest: plan.RuntimeManifestDigest,
+		LaunchPlanDigest: digest.SHA256(planRaw), AuthorityEndpointDigest: digest.SHA256([]byte(endpoint)),
+		CABundleDigest: config.CABundleDigest, InstallerCredentialBindingDigest: digest.SHA256(credentialBindingRaw),
+		InstallerCredentialEvidenceDigest: config.InstallerCredentialEvidenceDigest,
+		PreparedAt:                        config.PreparedAt.UTC().Format(time.RFC3339), ValidUntil: validUntil.UTC().Format(time.RFC3339),
+	}
+	identityRaw, err := json.Marshal(identity)
+	if err != nil {
+		return VerifiedTargetAccessStageLaunchCandidate{}, errors.New("encode target-access launch candidate identity")
+	}
+	receipt := TargetAccessStageLaunchCandidateReceipt{
+		Format: TargetAccessStageLaunchCandidateFormat, State: "PREPARED", StageID: identity.StageID, Authority: identity.Authority,
+		TargetAccessPackageDigest: identity.TargetAccessPackageDigest, CredentialPackageDigest: identity.CredentialPackageDigest,
+		RuntimeManifestDigest: identity.RuntimeManifestDigest, LaunchPlanDigest: identity.LaunchPlanDigest,
+		AuthorityEndpointDigest: identity.AuthorityEndpointDigest, CABundleDigest: identity.CABundleDigest,
+		InstallerCredentialBindingDigest: identity.InstallerCredentialBindingDigest, InstallerCredentialEvidenceDigest: identity.InstallerCredentialEvidenceDigest,
+		PreparedAt: identity.PreparedAt, ValidUntil: identity.ValidUntil, CandidateDigest: digest.SHA256(identityRaw), MutationAllowed: false,
+	}
+	return VerifiedTargetAccessStageLaunchCandidate{receipt: receipt, authorityEndpoint: endpoint, installerTokenDigest: config.InstallerTokenDigest, verified: true}, nil
+}
+
+func (candidate VerifiedTargetAccessStageLaunchCandidate) Receipt() (TargetAccessStageLaunchCandidateReceipt, error) {
+	if err := verifyTargetAccessStageLaunchCandidate(candidate); err != nil {
+		return TargetAccessStageLaunchCandidateReceipt{}, err
+	}
+	return candidate.receipt, nil
+}
+
+func verifyTargetAccessStageLaunchCandidate(candidate VerifiedTargetAccessStageLaunchCandidate) error {
+	if !candidate.verified || candidate.receipt.Format != TargetAccessStageLaunchCandidateFormat || candidate.receipt.State != "PREPARED" || candidate.receipt.StageID != "target-access" || candidate.receipt.Authority == "" || candidate.receipt.MutationAllowed || candidate.authorityEndpoint == "" || !stageReceiptPrefixDigestPattern.MatchString(candidate.installerTokenDigest) {
+		return errors.New("target-access launch candidate was not produced by verification")
+	}
+	for _, value := range []string{
+		candidate.receipt.TargetAccessPackageDigest, candidate.receipt.CredentialPackageDigest, candidate.receipt.RuntimeManifestDigest,
+		candidate.receipt.LaunchPlanDigest, candidate.receipt.AuthorityEndpointDigest, candidate.receipt.CABundleDigest,
+		candidate.receipt.InstallerCredentialBindingDigest, candidate.receipt.InstallerCredentialEvidenceDigest, candidate.receipt.CandidateDigest,
+	} {
+		if !stageReceiptPrefixDigestPattern.MatchString(value) {
+			return errors.New("target-access launch candidate contains an invalid digest")
+		}
+	}
+	credentialBindingRaw, err := json.Marshal(submissionStageInstallerCredentialIdentity{TokenDigest: candidate.installerTokenDigest, EvidenceDigest: candidate.receipt.InstallerCredentialEvidenceDigest})
+	if err != nil || digest.SHA256(credentialBindingRaw) != candidate.receipt.InstallerCredentialBindingDigest {
+		return errors.New("target-access installer credential identity changed after verification")
+	}
+	identity := targetAccessStageLaunchCandidateIdentity{
+		StageID: candidate.receipt.StageID, Authority: candidate.receipt.Authority,
+		TargetAccessPackageDigest: candidate.receipt.TargetAccessPackageDigest, CredentialPackageDigest: candidate.receipt.CredentialPackageDigest,
+		RuntimeManifestDigest: candidate.receipt.RuntimeManifestDigest, LaunchPlanDigest: candidate.receipt.LaunchPlanDigest,
+		AuthorityEndpointDigest: candidate.receipt.AuthorityEndpointDigest, CABundleDigest: candidate.receipt.CABundleDigest,
+		InstallerCredentialBindingDigest: candidate.receipt.InstallerCredentialBindingDigest, InstallerCredentialEvidenceDigest: candidate.receipt.InstallerCredentialEvidenceDigest,
+		PreparedAt: candidate.receipt.PreparedAt, ValidUntil: candidate.receipt.ValidUntil,
+	}
+	raw, err := json.Marshal(identity)
+	if err != nil || digest.SHA256(raw) != candidate.receipt.CandidateDigest || digest.SHA256([]byte(candidate.authorityEndpoint)) != candidate.receipt.AuthorityEndpointDigest {
+		return errors.New("target-access launch candidate identity changed after verification")
+	}
+	preparedAt, err := time.Parse(time.RFC3339, candidate.receipt.PreparedAt)
+	if err != nil {
+		return errors.New("target-access launch candidate preparation time is invalid")
+	}
+	validUntil, err := time.Parse(time.RFC3339, candidate.receipt.ValidUntil)
+	if err != nil || validUntil.Before(preparedAt) {
+		return errors.New("target-access launch candidate validity is invalid")
+	}
+	return nil
+}

--- a/internal/runner/target_access_stage_launch_candidate_test.go
+++ b/internal/runner/target_access_stage_launch_candidate_test.go
@@ -1,0 +1,85 @@
+package runner
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+func TestPrepareTargetAccessStageLaunchCandidateBindsDestinationAndCredential(t *testing.T) {
+	stage, credentials, runtime, _ := targetAccessStageLaunchFixture(t)
+	config := targetAccessLaunchCandidateConfig()
+	candidate, err := PrepareTargetAccessStageLaunchCandidate(config, stage, credentials, runtime)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := candidate.Receipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	again, err := PrepareTargetAccessStageLaunchCandidate(config, stage, credentials, runtime)
+	if err != nil {
+		t.Fatal(err)
+	}
+	againReceipt, _ := again.Receipt()
+	if receipt.Format != TargetAccessStageLaunchCandidateFormat || receipt.State != "PREPARED" || receipt.StageID != "target-access" || receipt.Authority != "ok-shared" || receipt.PreparedAt != "2026-08-16T14:01:00Z" || receipt.ValidUntil != "2026-08-16T14:15:00Z" || receipt.MutationAllowed || receipt.CandidateDigest != againReceipt.CandidateDigest {
+		t.Fatalf("unexpected target-access candidate: %#v", receipt)
+	}
+	public, err := json.Marshal(receipt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range []string{config.AuthorityEndpoint, config.InstallerTokenDigest, "installer-token-v1"} {
+		if bytes.Contains(public, []byte(forbidden)) {
+			t.Fatalf("target-access candidate receipt exposed private input %q", forbidden)
+		}
+	}
+	changed := candidate
+	changed.receipt.ValidUntil = "2026-08-16T14:16:00Z"
+	if _, err := changed.Receipt(); err == nil {
+		t.Fatal("changed target-access candidate receipt accepted")
+	}
+	changed = candidate
+	changed.installerTokenDigest = digest.SHA256([]byte("foreign-token"))
+	if _, err := changed.Receipt(); err == nil {
+		t.Fatal("changed private target-access installer binding accepted")
+	}
+}
+
+func TestPrepareTargetAccessStageLaunchCandidateFailsClosed(t *testing.T) {
+	stage, credentials, runtime, _ := targetAccessStageLaunchFixture(t)
+	valid := targetAccessLaunchCandidateConfig()
+	for name, mutate := range map[string]func(*SubmissionStageLaunchCandidateConfig){
+		"DNS endpoint": func(config *SubmissionStageLaunchCandidateConfig) {
+			config.AuthorityEndpoint = "https://ok-shared.example:6443"
+		},
+		"HTTP endpoint": func(config *SubmissionStageLaunchCandidateConfig) {
+			config.AuthorityEndpoint = "http://192.0.2.10:6443"
+		},
+		"missing CA":       func(config *SubmissionStageLaunchCandidateConfig) { config.CABundleDigest = "" },
+		"missing evidence": func(config *SubmissionStageLaunchCandidateConfig) { config.InstallerCredentialEvidenceDigest = "" },
+		"fractional time": func(config *SubmissionStageLaunchCandidateConfig) {
+			config.PreparedAt = config.PreparedAt.Add(time.Nanosecond)
+		},
+		"expired credentials": func(config *SubmissionStageLaunchCandidateConfig) {
+			config.PreparedAt = time.Date(2026, 8, 16, 14, 15, 1, 0, time.UTC)
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			config := valid
+			mutate(&config)
+			if _, err := PrepareTargetAccessStageLaunchCandidate(config, stage, credentials, runtime); err == nil {
+				t.Fatal("invalid target-access launch candidate accepted")
+			}
+		})
+	}
+}
+
+func targetAccessLaunchCandidateConfig() SubmissionStageLaunchCandidateConfig {
+	config := submissionStageLaunchCandidateConfig()
+	config.PreparedAt = time.Date(2026, 8, 16, 14, 1, 0, 0, time.UTC)
+	return config
+}


### PR DESCRIPTION
## Summary

- bind the coherent target-access launch plan to one exact `ok-shared` API destination
- bind the installer CA, token identity, and independent credential evidence without exposing endpoint or token digest
- derive a deterministic candidate digest and validity deadline from the earliest stage credential expiration
- reject stale, fractional-time, mutable-endpoint, or incoherent candidates offline

## Safety boundary

- candidate preparation only; no credential read and no Kubernetes API contact
- no object creation, Job launch, retry, update, or delete

## Verification

- `GOCACHE=/private/tmp/ok147-go-build go test -ldflags=-linkmode=external ./...`
- `GOCACHE=/private/tmp/ok147-go-vet go vet ./...`
- `GOCACHE=/private/tmp/ok147-go-race go test -race -ldflags=-linkmode=external ./internal/runner ./cmd/ok`

Jira: OK-147
