### PR TITLE
feat(runner): seal target access launch material (OK-147)

### DIFF
--- a/internal/runner/target_access_stage_credentials_test.go
+++ b/internal/runner/target_access_stage_credentials_test.go
@@ -129,6 +129,11 @@ func TestBuildTargetAccessStageCredentialPackageFailsClosed(t *testing.T) {
 }
 
 func targetAccessCredentialConfig(t *testing.T) (TargetAccessStageCredentialPackageConfig, [][]byte) {
+	config, _, tokens := targetAccessCredentialInputs(t)
+	return config, tokens
+}
+
+func targetAccessCredentialInputs(t *testing.T) (TargetAccessStageCredentialPackageConfig, TargetAccessStagePackageConfig, [][]byte) {
 	t.Helper()
 	now := time.Date(2026, 8, 16, 14, 0, 0, 0, time.UTC)
 	issuedAt, expiresAt := now.Add(-time.Minute), now.Add(30*time.Minute)
@@ -187,5 +192,5 @@ func targetAccessCredentialConfig(t *testing.T) (TargetAccessStageCredentialPack
 		Package: packaged, MaterializationTime: now, WorkloadBindingPath: packageConfig.WorkloadBindingPath,
 		LedgerWriter:   source("ok-mgmt", tokenPaths[0], subjects[0], "1", managementCAPath, tokens[0], managementCA),
 		WorkloadWriter: source(digest.SHA256([]byte(binding.TargetClusterUID)), tokenPaths[1], subjects[1], "2", workloadCAPath, tokens[1], workloadCA),
-	}, tokens
+	}, packageConfig, tokens
 }

--- a/internal/runner/target_access_stage_launch_material.go
+++ b/internal/runner/target_access_stage_launch_material.go
@@ -1,0 +1,117 @@
+package runner
+
+import (
+	"errors"
+	"time"
+)
+
+const TargetAccessStageLaunchMaterialFormat = "ok147-target-access-stage-launch-material/v1"
+
+type TargetAccessStageLaunchMaterialConfig struct {
+	Package               TargetAccessStagePackageConfig
+	MaterializationTime   time.Time
+	LedgerWriter          SubmissionStageCredentialSource
+	WorkloadWriter        SubmissionStageCredentialSource
+	RuntimeManifest       []byte
+	RuntimeManifestDigest string
+	Candidate             SubmissionStageLaunchCandidateConfig
+}
+
+type TargetAccessStageLaunchMaterialReceipt struct {
+	Format                    string `json:"format"`
+	State                     string `json:"state"`
+	StageID                   string `json:"stageId"`
+	Authority                 string `json:"authority"`
+	TargetAccessPackageDigest string `json:"targetAccessPackageDigest"`
+	CredentialPackageDigest   string `json:"credentialPackageDigest"`
+	RuntimeManifestDigest     string `json:"runtimeManifestDigest"`
+	LaunchPlanDigest          string `json:"launchPlanDigest"`
+	CandidateDigest           string `json:"candidateDigest"`
+	ValidUntil                string `json:"validUntil"`
+	MutationAllowed           bool   `json:"mutationAllowed"`
+}
+
+// VerifiedTargetAccessStageLaunchMaterial retains all exact public and
+// private components needed by a later single-use launcher while exposing
+// only redaction-safe receipts.
+type VerifiedTargetAccessStageLaunchMaterial struct {
+	packaged    VerifiedTargetAccessStagePackage
+	credentials VerifiedTargetAccessStageCredentialPackage
+	runtime     VerifiedTargetAccessStageRuntimePrerequisite
+	candidate   VerifiedTargetAccessStageLaunchCandidate
+	receipt     TargetAccessStageLaunchMaterialReceipt
+	verified    bool
+}
+
+// BuildTargetAccessStageLaunchMaterial reconstructs and re-verifies the
+// complete private launch input from bounded local sources. It performs no API
+// request and grants no launch authority.
+func BuildTargetAccessStageLaunchMaterial(config TargetAccessStageLaunchMaterialConfig) (VerifiedTargetAccessStageLaunchMaterial, error) {
+	packaged, err := BuildTargetAccessStagePackage(config.Package)
+	if err != nil {
+		return VerifiedTargetAccessStageLaunchMaterial{}, err
+	}
+	credentials, err := BuildTargetAccessStageCredentialPackage(TargetAccessStageCredentialPackageConfig{
+		Package: packaged, MaterializationTime: config.MaterializationTime,
+		WorkloadBindingPath: config.Package.WorkloadBindingPath,
+		LedgerWriter:        config.LedgerWriter, WorkloadWriter: config.WorkloadWriter,
+	})
+	if err != nil {
+		return VerifiedTargetAccessStageLaunchMaterial{}, err
+	}
+	runtime, err := BuildTargetAccessStageRuntimePrerequisite(packaged, config.RuntimeManifest, config.RuntimeManifestDigest)
+	if err != nil {
+		return VerifiedTargetAccessStageLaunchMaterial{}, err
+	}
+	candidate, err := PrepareTargetAccessStageLaunchCandidate(config.Candidate, packaged, credentials, runtime)
+	if err != nil {
+		return VerifiedTargetAccessStageLaunchMaterial{}, err
+	}
+	candidateReceipt, err := candidate.Receipt()
+	if err != nil {
+		return VerifiedTargetAccessStageLaunchMaterial{}, err
+	}
+	receipt := TargetAccessStageLaunchMaterialReceipt{
+		Format: TargetAccessStageLaunchMaterialFormat, State: "VERIFIED", StageID: candidateReceipt.StageID,
+		Authority: candidateReceipt.Authority, TargetAccessPackageDigest: candidateReceipt.TargetAccessPackageDigest,
+		CredentialPackageDigest: candidateReceipt.CredentialPackageDigest, RuntimeManifestDigest: candidateReceipt.RuntimeManifestDigest,
+		LaunchPlanDigest: candidateReceipt.LaunchPlanDigest, CandidateDigest: candidateReceipt.CandidateDigest,
+		ValidUntil: candidateReceipt.ValidUntil, MutationAllowed: false,
+	}
+	return VerifiedTargetAccessStageLaunchMaterial{
+		packaged: packaged, credentials: credentials, runtime: runtime, candidate: candidate,
+		receipt: receipt, verified: true,
+	}, nil
+}
+
+func (material VerifiedTargetAccessStageLaunchMaterial) Receipt() (TargetAccessStageLaunchMaterialReceipt, error) {
+	if err := verifyTargetAccessStageLaunchMaterial(material); err != nil {
+		return TargetAccessStageLaunchMaterialReceipt{}, err
+	}
+	return material.receipt, nil
+}
+
+func (material VerifiedTargetAccessStageLaunchMaterial) CandidateReceipt() (TargetAccessStageLaunchCandidateReceipt, error) {
+	if err := verifyTargetAccessStageLaunchMaterial(material); err != nil {
+		return TargetAccessStageLaunchCandidateReceipt{}, err
+	}
+	return material.candidate.Receipt()
+}
+
+func verifyTargetAccessStageLaunchMaterial(material VerifiedTargetAccessStageLaunchMaterial) error {
+	if !material.verified || material.receipt.Format != TargetAccessStageLaunchMaterialFormat || material.receipt.State != "VERIFIED" || material.receipt.MutationAllowed {
+		return errors.New("target-access launch material was not produced by verification")
+	}
+	plan, err := PlanTargetAccessStageLaunch(material.packaged, material.credentials, material.runtime)
+	if err != nil {
+		return err
+	}
+	candidateReceipt, err := material.candidate.Receipt()
+	if err != nil {
+		return err
+	}
+	if material.receipt.StageID != plan.StageID || material.receipt.Authority != plan.Authority || material.receipt.TargetAccessPackageDigest != plan.TargetAccessPackageDigest || material.receipt.CredentialPackageDigest != plan.CredentialPackageDigest || material.receipt.RuntimeManifestDigest != plan.RuntimeManifestDigest || material.receipt.StageID != candidateReceipt.StageID || material.receipt.Authority != candidateReceipt.Authority || material.receipt.TargetAccessPackageDigest != candidateReceipt.TargetAccessPackageDigest || material.receipt.CredentialPackageDigest != candidateReceipt.CredentialPackageDigest || material.receipt.RuntimeManifestDigest != candidateReceipt.RuntimeManifestDigest || material.receipt.LaunchPlanDigest != candidateReceipt.LaunchPlanDigest || material.receipt.CandidateDigest != candidateReceipt.CandidateDigest || material.receipt.ValidUntil != candidateReceipt.ValidUntil {
+		return errors.New("target-access launch material identity changed after verification")
+	}
+	return nil
+}

--- a/internal/runner/target_access_stage_launch_material_test.go
+++ b/internal/runner/target_access_stage_launch_material_test.go
@@ -1,0 +1,91 @@
+package runner
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+func TestBuildTargetAccessStageLaunchMaterialSealsPrivateComponents(t *testing.T) {
+	config, tokens := targetAccessStageLaunchMaterialConfig(t)
+	material, err := BuildTargetAccessStageLaunchMaterial(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := material.Receipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	candidate, err := material.CandidateReceipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	again, err := BuildTargetAccessStageLaunchMaterial(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	againReceipt, _ := again.Receipt()
+	if receipt.Format != TargetAccessStageLaunchMaterialFormat || receipt.State != "VERIFIED" || receipt.StageID != "target-access" || receipt.Authority != "ok-shared" || receipt.TargetAccessPackageDigest != candidate.TargetAccessPackageDigest || receipt.CandidateDigest != candidate.CandidateDigest || receipt.ValidUntil != candidate.ValidUntil || receipt.MutationAllowed || receipt.CandidateDigest != againReceipt.CandidateDigest {
+		t.Fatalf("unexpected target-access launch material: %#v", receipt)
+	}
+	public, err := json.Marshal(receipt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range append(tokens, material.packaged.raw, material.credentials.objects[0].raw, material.credentials.objects[1].raw, material.runtime.raw, []byte(config.Candidate.AuthorityEndpoint), []byte(config.Candidate.InstallerTokenDigest)) {
+		if bytes.Contains(public, forbidden) {
+			t.Fatal("target-access launch material receipt exposed private source content")
+		}
+	}
+	changed := material
+	changed.receipt.CandidateDigest = digest.SHA256([]byte("foreign"))
+	if _, err := changed.Receipt(); err == nil {
+		t.Fatal("changed target-access launch material identity accepted")
+	}
+	changed = material
+	changed.credentials.objects[1].raw = append(changed.credentials.objects[1].raw, '\n')
+	if _, err := changed.Receipt(); err == nil {
+		t.Fatal("changed private workload credential accepted")
+	}
+}
+
+func TestBuildTargetAccessStageLaunchMaterialFailsClosed(t *testing.T) {
+	valid, _ := targetAccessStageLaunchMaterialConfig(t)
+	for name, mutate := range map[string]func(*TargetAccessStageLaunchMaterialConfig){
+		"wrong runtime digest": func(config *TargetAccessStageLaunchMaterialConfig) {
+			config.RuntimeManifestDigest = digest.SHA256([]byte("foreign"))
+		},
+		"foreign workload token": func(config *TargetAccessStageLaunchMaterialConfig) {
+			config.WorkloadWriter.AuthorityIdentity = digest.SHA256([]byte("foreign"))
+		},
+		"expired candidate": func(config *TargetAccessStageLaunchMaterialConfig) {
+			config.Candidate.PreparedAt = config.MaterializationTime.Add(16 * time.Minute)
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			config := valid
+			mutate(&config)
+			if _, err := BuildTargetAccessStageLaunchMaterial(config); err == nil {
+				t.Fatal("invalid target-access launch material accepted")
+			}
+		})
+	}
+	if _, err := (VerifiedTargetAccessStageLaunchMaterial{}).Receipt(); err == nil {
+		t.Fatal("unverified target-access launch material receipt exposed")
+	}
+}
+
+func targetAccessStageLaunchMaterialConfig(t *testing.T) (TargetAccessStageLaunchMaterialConfig, [][]byte) {
+	t.Helper()
+	credentialConfig, packageConfig, tokens := targetAccessCredentialInputs(t)
+	manifest := submissionStageRuntimeManifest(t)
+	return TargetAccessStageLaunchMaterialConfig{
+		Package: packageConfig, MaterializationTime: credentialConfig.MaterializationTime,
+		LedgerWriter: credentialConfig.LedgerWriter, WorkloadWriter: credentialConfig.WorkloadWriter,
+		RuntimeManifest: manifest, RuntimeManifestDigest: digest.SHA256(manifest),
+		Candidate: targetAccessLaunchCandidateConfig(),
+	}, tokens
+}


### PR DESCRIPTION
## Summary

- reconstruct and seal the exact Target Access stage package, private credential package, shared runtime prerequisite, and launch candidate
- bind component digests, authority, validity, and the launch-plan identity in a redaction-safe receipt
- retain private material internally while exposing only verified receipts
- fail closed on runtime, workload-authority, expiry, identity, or private-material changes

## Safety boundary

- offline material construction only
- no credential opening
- no Kubernetes API contact
- no object creation and no Job launch

## Verification

- `GOCACHE=/private/tmp/ok147-go-build go test -ldflags=-linkmode=external ./...`
- `GOCACHE=/private/tmp/ok147-go-vet go vet ./...`
- `GOCACHE=/private/tmp/ok147-go-race go test -race -ldflags=-linkmode=external ./internal/runner ./cmd/ok`
- `git diff --check`

Jira: OK-147
