### PR TITLE
feat(runner): launch target access stage (OK-147)

### DIFF
--- a/internal/runner/target_access_stage_install_material.go
+++ b/internal/runner/target_access_stage_install_material.go
@@ -1,0 +1,111 @@
+package runner
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"io"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/jsonstrict"
+	"gopkg.in/yaml.v3"
+)
+
+// prepareTargetAccessStageInstallation recovers the exact three public
+// object bodies retained by a verified package and rechecks every plan digest.
+func prepareTargetAccessStageInstallation(packaged VerifiedTargetAccessStagePackage) (TargetAccessStageInstallationPlan, []submissionStageInstallObject, error) {
+	plan, err := PlanTargetAccessStageInstallation(packaged)
+	if err != nil {
+		return TargetAccessStageInstallationPlan{}, nil, err
+	}
+	decoder := yaml.NewDecoder(bytes.NewReader(packaged.raw))
+	objects := make([]submissionStageInstallObject, 0, len(plan.Creates))
+	for index := range plan.Creates {
+		var value map[string]any
+		if err := decoder.Decode(&value); err != nil || len(value) == 0 {
+			return TargetAccessStageInstallationPlan{}, nil, errors.New("decode target-access installation object")
+		}
+		raw, err := json.Marshal(value)
+		if err != nil || digest.SHA256(raw) != plan.Creates[index].ObjectDigest {
+			return TargetAccessStageInstallationPlan{}, nil, errors.New("target-access installation object differs from plan")
+		}
+		objects = append(objects, submissionStageInstallObject{plan: plan.Creates[index], raw: raw})
+	}
+	var trailing map[string]any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		return TargetAccessStageInstallationPlan{}, nil, errors.New("target-access installation contains trailing object")
+	}
+	return plan, objects, nil
+}
+
+// prepareTargetAccessStageCredentialInstallation recovers both exact private
+// Secret bodies. Only the workload writer Secret may contain the private,
+// package-bound workload authority binding.
+func prepareTargetAccessStageCredentialInstallation(packaged VerifiedTargetAccessStageCredentialPackage) (TargetAccessStageCredentialPackageReceipt, []submissionStageCredentialInstallObject, error) {
+	if err := verifyTargetAccessStageCredentialPackage(packaged); err != nil {
+		return TargetAccessStageCredentialPackageReceipt{}, nil, err
+	}
+	objects := make([]submissionStageCredentialInstallObject, 0, 2)
+	for index, private := range packaged.objects {
+		public := packaged.receipt.Credentials[index]
+		var secret map[string]any
+		if err := jsonstrict.Decode(private.raw, &secret); err != nil {
+			return TargetAccessStageCredentialPackageReceipt{}, nil, errors.New("target-access credential object is invalid JSON")
+		}
+		metadata, _ := secret["metadata"].(map[string]any)
+		labels, _ := metadata["labels"].(map[string]any)
+		annotations, _ := metadata["annotations"].(map[string]any)
+		data, _ := secret["data"].(map[string]any)
+		expectedDataCount := 2
+		if index == 1 {
+			expectedDataCount = 3
+		}
+		if secret["apiVersion"] != "v1" || secret["kind"] != "Secret" || secret["immutable"] != true || secret["type"] != "Opaque" || metadata["name"] != private.name || metadata["namespace"] != submissionStageInputNamespace || labels["openkubes.io/stage-id"] != packaged.receipt.StageID || labels["openkubes.io/credential-role"] != private.role || annotations["openkubes.io/authority-identity"] != private.authority || annotations["openkubes.io/expires-at"] != public.ExpiresAt || len(data) != expectedDataCount {
+			return TargetAccessStageCredentialPackageReceipt{}, nil, errors.New("target-access credential Secret semantics changed")
+		}
+		tokenEncoded, tokenOK := data["token"].(string)
+		caEncoded, caOK := data["ca.crt"].(string)
+		token, tokenErr := base64.StdEncoding.DecodeString(tokenEncoded)
+		ca, caErr := base64.StdEncoding.DecodeString(caEncoded)
+		expiresAt, timeErr := time.Parse(time.RFC3339, public.ExpiresAt)
+		if !tokenOK || !caOK || tokenErr != nil || caErr != nil || len(token) == 0 || len(ca) == 0 || timeErr != nil || digest.SHA256(ca) != public.CABundleDigest {
+			return TargetAccessStageCredentialPackageReceipt{}, nil, errors.New("target-access credential Secret data changed")
+		}
+		if index == 0 {
+			if data["binding.json"] != nil {
+				return TargetAccessStageCredentialPackageReceipt{}, nil, errors.New("ledger target-access credential contains a workload binding")
+			}
+		} else if err := verifyTargetAccessCredentialBinding(data, packaged.receipt.WorkloadBindingDigest, packaged.workloadAuthority, public.CABundleDigest); err != nil {
+			return TargetAccessStageCredentialPackageReceipt{}, nil, err
+		}
+		collection := "/api/v1/namespaces/" + submissionStageInputNamespace + "/secrets"
+		objects = append(objects, submissionStageCredentialInstallObject{
+			order: index + 4, role: private.role, authority: private.authority, name: private.name,
+			objectPath: collection + "/" + private.name, collectionPath: collection,
+			objectDigest: public.ObjectDigest, expiresAt: expiresAt, raw: append([]byte(nil), private.raw...), token: token,
+		})
+	}
+	return packaged.receipt, objects, nil
+}
+
+func verifyTargetAccessCredentialBinding(data map[string]any, expectedDigest, expectedAuthority, expectedCA string) error {
+	bindingEncoded, ok := data["binding.json"].(string)
+	if !ok {
+		return errors.New("target-access workload credential binding is missing")
+	}
+	bindingRaw, err := base64.StdEncoding.DecodeString(bindingEncoded)
+	if err != nil {
+		return errors.New("target-access workload credential binding encoding is invalid")
+	}
+	var binding WorkloadAuthorityBinding
+	if err := jsonstrict.Decode(bindingRaw, &binding); err != nil {
+		return errors.New("target-access workload credential binding is invalid")
+	}
+	bindingDigest, err := WorkloadAuthorityBindingDigest(binding)
+	if err != nil || bindingDigest != expectedDigest || digest.SHA256([]byte(binding.TargetClusterUID)) != expectedAuthority || binding.CABundleDigest != expectedCA {
+		return errors.New("target-access workload credential binding identity changed")
+	}
+	return nil
+}

--- a/internal/runner/target_access_stage_install_material_test.go
+++ b/internal/runner/target_access_stage_install_material_test.go
@@ -1,0 +1,90 @@
+package runner
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+func TestPrepareTargetAccessStageInstallationRecoversExactObjects(t *testing.T) {
+	stage, _, _, _ := targetAccessStageLaunchFixture(t)
+	plan, objects, err := prepareTargetAccessStageInstallation(stage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(objects) != 3 || len(plan.Creates) != 3 {
+		t.Fatalf("unexpected target-access installation material count: %d %d", len(objects), len(plan.Creates))
+	}
+	for index, object := range objects {
+		if object.plan != plan.Creates[index] || digest.SHA256(object.raw) != plan.Creates[index].ObjectDigest {
+			t.Fatalf("target-access installation object %d differs", index)
+		}
+	}
+	objects[0].raw[0] = 'x'
+	_, again, err := prepareTargetAccessStageInstallation(stage)
+	if err != nil || again[0].raw[0] == 'x' {
+		t.Fatal("caller mutated retained target-access installation material")
+	}
+}
+
+func TestPrepareTargetAccessStageCredentialInstallationRecoversTwoSecrets(t *testing.T) {
+	_, credentials, _, tokens := targetAccessStageLaunchFixture(t)
+	receipt, objects, err := prepareTargetAccessStageCredentialInstallation(credentials)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(objects) != 2 || len(receipt.Credentials) != 2 {
+		t.Fatalf("unexpected target-access credential count: %d %d", len(objects), len(receipt.Credentials))
+	}
+	for index, object := range objects {
+		if object.order != index+4 || object.role != receipt.Credentials[index].Role || object.authority != receipt.Credentials[index].Authority || object.name != receipt.Credentials[index].Name || object.objectDigest != receipt.Credentials[index].ObjectDigest || digest.SHA256(object.raw) != object.objectDigest || string(object.token) != string(tokens[index]) {
+			t.Fatalf("target-access credential installation object %d differs: %#v", index, object)
+		}
+		var secret map[string]any
+		if err := json.Unmarshal(object.raw, &secret); err != nil {
+			t.Fatal(err)
+		}
+		_, hasBinding := secret["data"].(map[string]any)["binding.json"]
+		if hasBinding != (index == 1) {
+			t.Fatalf("target-access credential %d binding presence differs", index)
+		}
+	}
+	objects[1].raw[0] = 'x'
+	_, again, err := prepareTargetAccessStageCredentialInstallation(credentials)
+	if err != nil || again[1].raw[0] == 'x' {
+		t.Fatal("caller mutated retained private target-access credentials")
+	}
+}
+
+func TestPrepareTargetAccessStageCredentialInstallationRejectsChangedBinding(t *testing.T) {
+	_, credentials, _, _ := targetAccessStageLaunchFixture(t)
+	var secret map[string]any
+	if err := json.Unmarshal(credentials.objects[1].raw, &secret); err != nil {
+		t.Fatal(err)
+	}
+	data := secret["data"].(map[string]any)
+	bindingRaw, err := base64.StdEncoding.DecodeString(data["binding.json"].(string))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var binding WorkloadAuthorityBinding
+	if err := json.Unmarshal(bindingRaw, &binding); err != nil {
+		t.Fatal(err)
+	}
+	binding.Endpoint = "https://192.0.2.99:6443"
+	changed, err := json.Marshal(binding)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data["binding.json"] = base64.StdEncoding.EncodeToString(changed)
+	credentials.objects[1].raw, err = json.Marshal(secret)
+	if err != nil {
+		t.Fatal(err)
+	}
+	credentials.receipt.Credentials[1].ObjectDigest = digest.SHA256(credentials.objects[1].raw)
+	if _, _, err := prepareTargetAccessStageCredentialInstallation(credentials); err == nil {
+		t.Fatal("changed private workload binding was accepted")
+	}
+}

--- a/internal/runner/target_access_stage_launch_material.go
+++ b/internal/runner/target_access_stage_launch_material.go
@@ -43,6 +43,12 @@ type VerifiedTargetAccessStageLaunchMaterial struct {
 	verified    bool
 }
 
+type TargetAccessStageLaunchOpenConfig struct {
+	Authority               KubernetesAuthorityConfig
+	Clock                   func() time.Time
+	ExpectedCandidateDigest string
+}
+
 // BuildTargetAccessStageLaunchMaterial reconstructs and re-verifies the
 // complete private launch input from bounded local sources. It performs no API
 // request and grants no launch authority.
@@ -96,6 +102,21 @@ func (material VerifiedTargetAccessStageLaunchMaterial) CandidateReceipt() (Targ
 		return TargetAccessStageLaunchCandidateReceipt{}, err
 	}
 	return material.candidate.Receipt()
+}
+
+// Open requires the exact retained candidate and validates local installer
+// material without contacting Kubernetes.
+func (material VerifiedTargetAccessStageLaunchMaterial) Open(config TargetAccessStageLaunchOpenConfig) (*KubernetesTargetAccessStageLauncher, error) {
+	if err := verifyTargetAccessStageLaunchMaterial(material); err != nil {
+		return nil, err
+	}
+	if config.ExpectedCandidateDigest == "" || config.ExpectedCandidateDigest != material.receipt.CandidateDigest {
+		return nil, errors.New("target-access launch open requires the exact candidate digest")
+	}
+	return OpenKubernetesTargetAccessStageLauncher(TargetAccessStageLauncherConfig{
+		Authority: config.Authority, Clock: config.Clock, Candidate: material.candidate,
+		ExpectedCandidateDigest: config.ExpectedCandidateDigest,
+	}, material.packaged, material.credentials, material.runtime)
 }
 
 func verifyTargetAccessStageLaunchMaterial(material VerifiedTargetAccessStageLaunchMaterial) error {

--- a/internal/runner/target_access_stage_launch_material_test.go
+++ b/internal/runner/target_access_stage_launch_material_test.go
@@ -3,6 +3,8 @@ package runner
 import (
 	"bytes"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -49,6 +51,45 @@ func TestBuildTargetAccessStageLaunchMaterialSealsPrivateComponents(t *testing.T
 	changed.credentials.objects[1].raw = append(changed.credentials.objects[1].raw, '\n')
 	if _, err := changed.Receipt(); err == nil {
 		t.Fatal("changed private workload credential accepted")
+	}
+}
+
+func TestTargetAccessStageLaunchMaterialOpenRetainsExactComponents(t *testing.T) {
+	config, _ := targetAccessStageLaunchMaterialConfig(t)
+	installerToken := []byte("installer-token-v1")
+	ca := testCA(t)
+	config.Candidate.CABundleDigest = digest.SHA256(ca)
+	config.Candidate.InstallerTokenDigest = digest.SHA256(installerToken)
+	material, err := BuildTargetAccessStageLaunchMaterial(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, _ := material.Receipt()
+	root := t.TempDir()
+	tokenPath, caPath := filepath.Join(root, "installer-token"), filepath.Join(root, "ca.crt")
+	if err := os.WriteFile(tokenPath, installerToken, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(caPath, ca, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	open := TargetAccessStageLaunchOpenConfig{
+		Authority: KubernetesAuthorityConfig{
+			Endpoint: config.Candidate.AuthorityEndpoint, AuthorityIdentity: "ok-shared",
+			TokenFile: tokenPath, CAFile: caPath, CABundleDigest: config.Candidate.CABundleDigest,
+		},
+		Clock: func() time.Time { return config.Candidate.PreparedAt }, ExpectedCandidateDigest: receipt.CandidateDigest,
+	}
+	launcher, err := material.Open(open)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if launcher.plan.TargetAccessPackageDigest != receipt.TargetAccessPackageDigest || launcher.plan.CredentialPackageDigest != receipt.CredentialPackageDigest || launcher.plan.RuntimeManifestDigest != receipt.RuntimeManifestDigest {
+		t.Fatal("opened target-access launcher differs from sealed material")
+	}
+	open.ExpectedCandidateDigest = digest.SHA256([]byte("foreign"))
+	if _, err := material.Open(open); err == nil {
+		t.Fatal("foreign candidate digest opened target-access launch material")
 	}
 }
 

--- a/internal/runner/target_access_stage_launcher.go
+++ b/internal/runner/target_access_stage_launcher.go
@@ -1,0 +1,354 @@
+package runner
+
+import (
+	"bytes"
+	"context"
+	"crypto/subtle"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+const TargetAccessStageLaunchReceiptFormat = "ok147-target-access-stage-launch-receipt/v1"
+
+type TargetAccessStageLauncherConfig struct {
+	Authority               KubernetesAuthorityConfig
+	Clock                   func() time.Time
+	Candidate               VerifiedTargetAccessStageLaunchCandidate
+	ExpectedCandidateDigest string
+}
+
+type TargetAccessStageLaunchReceipt struct {
+	Format                    string                        `json:"format"`
+	StageID                   string                        `json:"stageId"`
+	TargetAccessPackageDigest string                        `json:"targetAccessPackageDigest"`
+	CredentialPackageDigest   string                        `json:"credentialPackageDigest"`
+	RuntimeManifestDigest     string                        `json:"runtimeManifestDigest"`
+	Authority                 string                        `json:"authority"`
+	State                     string                        `json:"state"`
+	MutationState             string                        `json:"mutationState"`
+	Results                   []SubmissionStageLaunchResult `json:"results"`
+}
+
+// KubernetesTargetAccessStageLauncher is a single-use six-object create-only
+// operation. It completes all exact GETs before its first POST, creates the
+// Job last and has no retry, update, patch, apply, delete, list or watch path.
+type KubernetesTargetAccessStageLauncher struct {
+	mu          sync.Mutex
+	used        bool
+	endpoint    *url.URL
+	token       string
+	client      *http.Client
+	clock       func() time.Time
+	validUntil  time.Time
+	plan        TargetAccessStageLaunchPlan
+	runtime     VerifiedTargetAccessStageRuntimePrerequisite
+	credentials TargetAccessStageCredentialPackageReceipt
+	secrets     []submissionStageCredentialInstallObject
+	objects     []submissionStageInstallObject
+}
+
+// OpenKubernetesTargetAccessStageLauncher opens the exact prepared API client
+// and bounded installer credential without contacting Kubernetes.
+func OpenKubernetesTargetAccessStageLauncher(config TargetAccessStageLauncherConfig, packaged VerifiedTargetAccessStagePackage, credentials VerifiedTargetAccessStageCredentialPackage, runtime VerifiedTargetAccessStageRuntimePrerequisite) (*KubernetesTargetAccessStageLauncher, error) {
+	plan, err := PlanTargetAccessStageLaunch(packaged, credentials, runtime)
+	if err != nil {
+		return nil, err
+	}
+	if err := verifyTargetAccessStageLaunchCandidate(config.Candidate); err != nil {
+		return nil, err
+	}
+	candidate := config.Candidate.receipt
+	planRaw, err := json.Marshal(plan)
+	if err != nil {
+		return nil, errors.New("encode target-access launcher plan identity")
+	}
+	if config.ExpectedCandidateDigest != candidate.CandidateDigest || digest.SHA256(planRaw) != candidate.LaunchPlanDigest || plan.StageID != candidate.StageID || plan.Authority != candidate.Authority || plan.TargetAccessPackageDigest != candidate.TargetAccessPackageDigest || plan.CredentialPackageDigest != candidate.CredentialPackageDigest || plan.RuntimeManifestDigest != candidate.RuntimeManifestDigest {
+		return nil, errors.New("target-access launcher components differ from exact candidate")
+	}
+	if config.Authority.AuthorityIdentity == "" || config.Authority.AuthorityIdentity != plan.Authority {
+		return nil, errors.New("target-access launcher authority differs from verified execution-plane authority")
+	}
+	endpoint, err := normalizeSubmissionStageLaunchEndpoint(config.Authority.Endpoint)
+	if err != nil || endpoint != config.Candidate.authorityEndpoint || config.Authority.CABundleDigest != candidate.CABundleDigest {
+		return nil, errors.New("target-access launcher destination differs from exact candidate")
+	}
+	token, ca, client, err := openBoundedKubernetesMaterial(config.Authority.TokenFile, config.Authority.CAFile)
+	if err != nil {
+		return nil, errors.New("open bounded target-access launcher credential")
+	}
+	if digest.SHA256(ca) != config.Authority.CABundleDigest || digest.SHA256([]byte(token)) != config.Candidate.installerTokenDigest {
+		return nil, errors.New("target-access launcher credential differs from bound identity")
+	}
+	validUntil, err := time.Parse(time.RFC3339, candidate.ValidUntil)
+	if err != nil {
+		return nil, errors.New("target-access launch candidate validity is invalid")
+	}
+	return newKubernetesTargetAccessStageLauncher(submissionStageLauncherClientConfig{
+		Endpoint: config.Authority.Endpoint, BearerToken: token, AuthorityIdentity: config.Authority.AuthorityIdentity,
+		Client: client, Clock: config.Clock, ValidUntil: validUntil,
+	}, packaged, credentials, runtime)
+}
+
+func newKubernetesTargetAccessStageLauncher(config submissionStageLauncherClientConfig, packaged VerifiedTargetAccessStagePackage, credentials VerifiedTargetAccessStageCredentialPackage, runtime VerifiedTargetAccessStageRuntimePrerequisite) (*KubernetesTargetAccessStageLauncher, error) {
+	plan, err := PlanTargetAccessStageLaunch(packaged, credentials, runtime)
+	if err != nil {
+		return nil, err
+	}
+	credentialReceipt, secrets, err := prepareTargetAccessStageCredentialInstallation(credentials)
+	if err != nil {
+		return nil, err
+	}
+	_, objects, err := prepareTargetAccessStageInstallation(packaged)
+	if err != nil {
+		return nil, err
+	}
+	if config.AuthorityIdentity == "" || config.AuthorityIdentity != plan.Authority {
+		return nil, errors.New("target-access launcher authority differs from verified execution-plane authority")
+	}
+	endpoint, err := url.Parse(config.Endpoint)
+	if err != nil || endpoint.Host == "" || endpoint.User != nil || endpoint.RawQuery != "" || endpoint.Fragment != "" || endpoint.Path != "" && endpoint.Path != "/" || endpoint.Port() == "" || net.ParseIP(endpoint.Hostname()) == nil {
+		return nil, errors.New("target-access launcher Kubernetes endpoint is invalid")
+	}
+	if endpoint.Scheme != "https" && !(endpoint.Scheme == "http" && endpoint.Hostname() == "127.0.0.1") {
+		return nil, errors.New("target-access launcher Kubernetes endpoint must use HTTPS")
+	}
+	if config.BearerToken == "" || strings.TrimSpace(config.BearerToken) != config.BearerToken || strings.ContainsAny(config.BearerToken, "\r\n") || config.Client == nil || config.Clock == nil {
+		return nil, errors.New("target-access launcher credential, client, or clock is invalid")
+	}
+	for _, secret := range secrets {
+		if len(config.BearerToken) == len(secret.token) && subtle.ConstantTimeCompare([]byte(config.BearerToken), secret.token) == 1 {
+			return nil, errors.New("target-access launcher and Job credentials must be distinct")
+		}
+	}
+	client := *config.Client
+	client.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+	if client.Timeout == 0 {
+		client.Timeout = 15 * time.Second
+	}
+	endpoint.Path, endpoint.RawPath = "", ""
+	runtime.raw = append([]byte(nil), runtime.raw...)
+	return &KubernetesTargetAccessStageLauncher{
+		endpoint: endpoint, token: config.BearerToken, client: &client, clock: config.Clock, validUntil: config.ValidUntil,
+		plan: plan, runtime: runtime, credentials: credentialReceipt, secrets: secrets, objects: objects,
+	}, nil
+}
+
+func (launcher *KubernetesTargetAccessStageLauncher) Launch(ctx context.Context) (TargetAccessStageLaunchReceipt, error) {
+	receipt := launcher.newReceipt()
+	if launcher == nil || launcher.client == nil || launcher.clock == nil {
+		return receipt, errors.New("target-access launcher is required")
+	}
+	launcher.mu.Lock()
+	if launcher.used {
+		launcher.mu.Unlock()
+		return stopTargetAccessStageLaunch(receipt, "STOPPED_ZERO_WRITE", errors.New("target-access launcher is single-use"))
+	}
+	launcher.used = true
+	launcher.mu.Unlock()
+
+	now := launcher.clock().UTC()
+	if !launcher.validUntil.IsZero() && now.After(launcher.validUntil) {
+		return stopTargetAccessStageLaunch(receipt, "STOPPED_ZERO_WRITE", errors.New("target-access launch candidate validity has expired"))
+	}
+	materializedAt, err := time.Parse(time.RFC3339, launcher.credentials.MaterializedAt)
+	if err != nil || now.Before(materializedAt) {
+		return stopTargetAccessStageLaunch(receipt, "STOPPED_ZERO_WRITE", errors.New("target-access launch precedes credential materialization"))
+	}
+	for _, secret := range launcher.secrets {
+		if secret.expiresAt.Sub(now) < minimumStageCredentialRemaining {
+			return stopTargetAccessStageLaunch(receipt, "STOPPED_ZERO_WRITE", errors.New("target-access credential has insufficient remaining lifetime"))
+		}
+	}
+
+	existing := make(map[int]SubmissionStageLaunchResult, len(launcher.plan.Preflights))
+	for _, preflight := range launcher.plan.Preflights {
+		raw, status, err := launcher.request(ctx, http.MethodGet, preflight.ObjectPath, nil)
+		if err != nil {
+			return stopTargetAccessStageLaunch(receipt, "STOPPED_ZERO_WRITE", err)
+		}
+		switch status {
+		case http.StatusNotFound:
+		case http.StatusOK:
+			result, err := launcher.verifyExisting(preflight, raw)
+			if err != nil {
+				return stopTargetAccessStageLaunch(receipt, "STOPPED_ZERO_WRITE", err)
+			}
+			existing[preflight.Order] = result
+		default:
+			return stopTargetAccessStageLaunch(receipt, "STOPPED_ZERO_WRITE", submissionStageLaunchStatusError(http.MethodGet, status))
+		}
+	}
+	if len(existing) == len(launcher.plan.Preflights) {
+		receipt.State = "ALREADY_LAUNCHED"
+		for order := 1; order <= len(launcher.plan.Preflights); order++ {
+			receipt.Results = append(receipt.Results, existing[order])
+		}
+		return receipt, nil
+	}
+	runtimeResult, runtimeExists := existing[1]
+	if len(existing) != 0 && !(len(existing) == 1 && runtimeExists) {
+		return stopTargetAccessStageLaunch(receipt, "STOPPED_ZERO_WRITE", errors.New("target-access launch found exact partial state"))
+	}
+
+	receipt.State = "LAUNCHING"
+	if runtimeExists {
+		receipt.Results = append(receipt.Results, runtimeResult)
+	} else {
+		result, err := launcher.createRuntime(ctx)
+		if err != nil {
+			return launcher.stopAfterAttempt(receipt, err)
+		}
+		receipt.MutationState = "ATTEMPTED"
+		receipt.Results = append(receipt.Results, result)
+	}
+	for index := 0; index < 2; index++ {
+		result, err := launcher.createObject(ctx, index+2, "stage-prerequisites", launcher.objects[index])
+		if err != nil {
+			return launcher.stopAfterAttempt(receipt, err)
+		}
+		receipt.MutationState = "ATTEMPTED"
+		receipt.Results = append(receipt.Results, result)
+	}
+	for index, secret := range launcher.secrets {
+		result, err := launcher.createSecret(ctx, index+4, secret)
+		if err != nil {
+			return launcher.stopAfterAttempt(receipt, err)
+		}
+		receipt.MutationState = "ATTEMPTED"
+		receipt.Results = append(receipt.Results, result)
+	}
+	result, err := launcher.createObject(ctx, 6, "job", launcher.objects[2])
+	if err != nil {
+		return launcher.stopAfterAttempt(receipt, err)
+	}
+	receipt.MutationState = "ATTEMPTED"
+	receipt.Results = append(receipt.Results, result)
+	receipt.State = "LAUNCHED"
+	return receipt, nil
+}
+
+func (launcher *KubernetesTargetAccessStageLauncher) verifyExisting(preflight SubmissionStageLaunchPreflight, raw []byte) (SubmissionStageLaunchResult, error) {
+	var uid, resourceVersion string
+	var err error
+	switch preflight.Phase {
+	case "runtime":
+		uid, resourceVersion, err = verifySubmissionStageRuntimeObject(raw, launcher.runtime.raw)
+	case "stage-prerequisites":
+		uid, resourceVersion, err = verifySubmissionStageCreatedObject(raw, launcher.objects[preflight.Order-2])
+	case "credentials":
+		uid, resourceVersion, err = verifySubmissionStageCredentialCreatedObject(raw, launcher.secrets[preflight.Order-4])
+	case "job":
+		uid, resourceVersion, err = verifySubmissionStageCreatedObject(raw, launcher.objects[2])
+	default:
+		return SubmissionStageLaunchResult{}, errors.New("target-access preflight phase is invalid")
+	}
+	if err != nil {
+		return SubmissionStageLaunchResult{}, errors.New("existing target-access object differs from verified plan")
+	}
+	return targetAccessLaunchResult(preflight.Order, preflight.Phase, preflight.APIVersion, preflight.Kind, preflight.Namespace, preflight.Name, preflight.ObjectDigest, "EXISTING_VERIFIED", uid, resourceVersion), nil
+}
+
+func (launcher *KubernetesTargetAccessStageLauncher) createRuntime(ctx context.Context) (SubmissionStageLaunchResult, error) {
+	create := launcher.plan.Creates[0]
+	raw, status, err := launcher.request(ctx, http.MethodPost, create.CollectionPath, launcher.runtime.raw)
+	if err != nil || status != http.StatusCreated {
+		return SubmissionStageLaunchResult{}, submissionStageLaunchCreateError(status, err)
+	}
+	uid, resourceVersion, err := verifySubmissionStageRuntimeObject(raw, launcher.runtime.raw)
+	if err != nil {
+		return SubmissionStageLaunchResult{}, errors.New("created target-access runtime differs")
+	}
+	return targetAccessLaunchResult(1, "runtime", "v1", "ServiceAccount", create.Namespace, create.Name, create.ObjectDigest, "CREATED", uid, resourceVersion), nil
+}
+
+func (launcher *KubernetesTargetAccessStageLauncher) createSecret(ctx context.Context, order int, secret submissionStageCredentialInstallObject) (SubmissionStageLaunchResult, error) {
+	raw, status, err := launcher.request(ctx, http.MethodPost, secret.collectionPath, secret.raw)
+	if err != nil || status != http.StatusCreated {
+		return SubmissionStageLaunchResult{}, submissionStageLaunchCreateError(status, err)
+	}
+	uid, resourceVersion, err := verifySubmissionStageCredentialCreatedObject(raw, secret)
+	if err != nil {
+		return SubmissionStageLaunchResult{}, errors.New("created target-access credential differs")
+	}
+	return targetAccessLaunchResult(order, "credentials", "v1", "Secret", submissionStageInputNamespace, secret.name, secret.objectDigest, "CREATED", uid, resourceVersion), nil
+}
+
+func (launcher *KubernetesTargetAccessStageLauncher) createObject(ctx context.Context, order int, phase string, object submissionStageInstallObject) (SubmissionStageLaunchResult, error) {
+	raw, status, err := launcher.request(ctx, http.MethodPost, object.plan.CollectionPath, object.raw)
+	if err != nil || status != http.StatusCreated {
+		return SubmissionStageLaunchResult{}, submissionStageLaunchCreateError(status, err)
+	}
+	uid, resourceVersion, err := verifySubmissionStageCreatedObject(raw, object)
+	if err != nil {
+		return SubmissionStageLaunchResult{}, errors.New("created target-access object differs")
+	}
+	return targetAccessLaunchResult(order, phase, object.plan.APIVersion, object.plan.Kind, object.plan.Namespace, object.plan.Name, object.plan.ObjectDigest, "CREATED", uid, resourceVersion), nil
+}
+
+func (launcher *KubernetesTargetAccessStageLauncher) stopAfterAttempt(receipt TargetAccessStageLaunchReceipt, err error) (TargetAccessStageLaunchReceipt, error) {
+	receipt.MutationState = "ATTEMPTED_UNKNOWN"
+	return stopTargetAccessStageLaunch(receipt, "STOPPED_PARTIAL_OR_UNKNOWN", err)
+}
+
+func (launcher *KubernetesTargetAccessStageLauncher) request(ctx context.Context, method, path string, body []byte) ([]byte, int, error) {
+	endpoint := *launcher.endpoint
+	endpoint.Path = path
+	request, err := http.NewRequestWithContext(ctx, method, endpoint.String(), bytes.NewReader(body))
+	if err != nil {
+		return nil, 0, errors.New("construct bounded target-access launch request")
+	}
+	request.Header.Set("Accept", "application/json")
+	request.Header.Set("Authorization", "Bearer "+launcher.token)
+	if body != nil {
+		request.Header.Set("Content-Type", "application/json")
+	}
+	response, err := launcher.client.Do(request)
+	if err != nil {
+		return nil, 0, fmt.Errorf("bounded target-access launch %s failed", method)
+	}
+	defer response.Body.Close()
+	raw, readErr := io.ReadAll(io.LimitReader(response.Body, maximumStageInstallationResponseBytes+1))
+	if readErr != nil || len(raw) > maximumStageInstallationResponseBytes {
+		return nil, 0, errors.New("bounded target-access response exceeds accepted size")
+	}
+	if len(raw) > 0 {
+		mediaType, _, err := mime.ParseMediaType(response.Header.Get("Content-Type"))
+		if err != nil || mediaType != "application/json" {
+			return nil, 0, errors.New("bounded target-access response is not JSON")
+		}
+	}
+	return raw, response.StatusCode, nil
+}
+
+func (launcher *KubernetesTargetAccessStageLauncher) newReceipt() TargetAccessStageLaunchReceipt {
+	receipt := TargetAccessStageLaunchReceipt{Format: TargetAccessStageLaunchReceiptFormat, State: "PREFLIGHT", MutationState: "NOT_ATTEMPTED", Results: []SubmissionStageLaunchResult{}}
+	if launcher != nil {
+		receipt.StageID, receipt.Authority = launcher.plan.StageID, launcher.plan.Authority
+		receipt.TargetAccessPackageDigest, receipt.CredentialPackageDigest = launcher.plan.TargetAccessPackageDigest, launcher.plan.CredentialPackageDigest
+		receipt.RuntimeManifestDigest = launcher.plan.RuntimeManifestDigest
+	}
+	return receipt
+}
+
+func stopTargetAccessStageLaunch(receipt TargetAccessStageLaunchReceipt, state string, err error) (TargetAccessStageLaunchReceipt, error) {
+	receipt.State = state
+	return receipt, err
+}
+
+func targetAccessLaunchResult(order int, phase, apiVersion, kind, namespace, name, objectDigest, state, uid, resourceVersion string) SubmissionStageLaunchResult {
+	return SubmissionStageLaunchResult{
+		Order: order, Phase: phase, APIVersion: apiVersion, Kind: kind, Namespace: namespace, Name: name,
+		ObjectDigest: objectDigest, ObjectState: state, UIDDigest: digest.SHA256([]byte(uid)), ResourceVersionDigest: digest.SHA256([]byte(resourceVersion)),
+	}
+}

--- a/internal/runner/target_access_stage_launcher_test.go
+++ b/internal/runner/target_access_stage_launcher_test.go
@@ -1,0 +1,179 @@
+package runner
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+func TestTargetAccessStageLauncherPreflightsThenCreatesJobLast(t *testing.T) {
+	stage, credentials, runtime, tokens := targetAccessStageLaunchFixture(t)
+	api := newSubmissionStageLauncherAPI(t)
+	launcher := newTargetAccessStageLauncher(t, stage, credentials, runtime, api, time.Date(2026, 8, 16, 14, 1, 0, 0, time.UTC))
+	receipt, err := launcher.Launch(context.Background())
+	if err != nil || receipt.State != "LAUNCHED" || receipt.MutationState != "ATTEMPTED" || len(receipt.Results) != 6 {
+		t.Fatalf("target-access launch failed: %#v %v", receipt, err)
+	}
+	if len(api.requests) != 12 || api.posts != 6 {
+		t.Fatalf("requests=%d posts=%d, want six GETs then six POSTs", len(api.requests), api.posts)
+	}
+	for index := 0; index < 6; index++ {
+		preflight, create := api.requests[index], api.requests[index+6]
+		if preflight.method != "GET" || preflight.path != launcher.plan.Preflights[index].ObjectPath || create.method != "POST" || create.path != launcher.plan.Creates[index].CollectionPath || digest.SHA256(create.body) != launcher.plan.Creates[index].ObjectDigest {
+			t.Fatalf("request order %d differs: %#v %#v", index+1, preflight, create)
+		}
+		if receipt.Results[index].Order != index+1 || receipt.Results[index].Kind != launcher.plan.Creates[index].Kind || receipt.Results[index].ObjectState != "CREATED" {
+			t.Fatalf("result %d differs: %#v", index+1, receipt.Results[index])
+		}
+	}
+	if launcher.plan.Creates[5].Kind != "Job" || launcher.plan.Creates[3].Kind != "Secret" || launcher.plan.Creates[4].Kind != "Secret" {
+		t.Fatalf("Job was not held behind both credentials: %#v", launcher.plan.Creates)
+	}
+	public, err := json.Marshal(receipt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range append(tokens, credentials.objects[0].raw, credentials.objects[1].raw, []byte("short-lived-installer-token"), []byte("created-uid")) {
+		if bytes.Contains(public, forbidden) {
+			t.Fatal("target-access receipt exposed private content")
+		}
+	}
+	requests := len(api.requests)
+	retry, retryErr := launcher.Launch(context.Background())
+	if retryErr == nil || retry.State != "STOPPED_ZERO_WRITE" || len(api.requests) != requests {
+		t.Fatalf("single-use launcher retried: %#v %v", retry, retryErr)
+	}
+}
+
+func TestTargetAccessStageLauncherAcceptsOnlyExactCompleteDuplicate(t *testing.T) {
+	stage, credentials, runtime, _ := targetAccessStageLaunchFixture(t)
+	api := newSubmissionStageLauncherAPI(t)
+	now := time.Date(2026, 8, 16, 14, 1, 0, 0, time.UTC)
+	first := newTargetAccessStageLauncher(t, stage, credentials, runtime, api, now)
+	if receipt, err := first.Launch(context.Background()); err != nil || receipt.State != "LAUNCHED" {
+		t.Fatalf("first launch failed: %#v %v", receipt, err)
+	}
+	requests := len(api.requests)
+	duplicate := newTargetAccessStageLauncher(t, stage, credentials, runtime, api, now)
+	receipt, err := duplicate.Launch(context.Background())
+	if err != nil || receipt.State != "ALREADY_LAUNCHED" || receipt.MutationState != "NOT_ATTEMPTED" || len(receipt.Results) != 6 || api.posts != 6 || len(api.requests) != requests+6 {
+		t.Fatalf("exact duplicate was not idempotent: %#v %v", receipt, err)
+	}
+
+	stage, credentials, runtime, _ = targetAccessStageLaunchFixture(t)
+	api = newSubmissionStageLauncherAPI(t)
+	partial := newTargetAccessStageLauncher(t, stage, credentials, runtime, api, now)
+	existing := decodeCapabilityJSONForTest(t, partial.objects[0].raw)
+	metadata := existing["metadata"].(map[string]any)
+	metadata["uid"], metadata["resourceVersion"] = "existing-input-uid", "9"
+	api.objects[partial.plan.Preflights[1].ObjectPath] = existing
+	receipt, err = partial.Launch(context.Background())
+	if err == nil || receipt.State != "STOPPED_ZERO_WRITE" || receipt.MutationState != "NOT_ATTEMPTED" || api.posts != 0 || len(api.requests) != 6 {
+		t.Fatalf("partial target-access state reached mutation: %#v %v", receipt, err)
+	}
+}
+
+func TestTargetAccessStageLauncherReusesOnlyExactSharedRuntime(t *testing.T) {
+	stage, credentials, runtime, _ := targetAccessStageLaunchFixture(t)
+	api := newSubmissionStageLauncherAPI(t)
+	runtimeObject := decodeCapabilityJSONForTest(t, runtime.raw)
+	metadata := runtimeObject["metadata"].(map[string]any)
+	metadata["uid"], metadata["resourceVersion"] = "runtime-existing-uid", "7"
+	api.objects[stageRuntimeObjectPath] = runtimeObject
+	launcher := newTargetAccessStageLauncher(t, stage, credentials, runtime, api, time.Date(2026, 8, 16, 14, 1, 0, 0, time.UTC))
+	receipt, err := launcher.Launch(context.Background())
+	if err != nil || receipt.State != "LAUNCHED" || len(receipt.Results) != 6 || receipt.Results[0].ObjectState != "EXISTING_VERIFIED" || api.posts != 5 || len(api.requests) != 11 {
+		t.Fatalf("existing shared runtime was not reused exactly: %#v requests=%d posts=%d err=%v", receipt, len(api.requests), api.posts, err)
+	}
+
+	stage, credentials, runtime, _ = targetAccessStageLaunchFixture(t)
+	api = newSubmissionStageLauncherAPI(t)
+	runtimeObject = decodeCapabilityJSONForTest(t, runtime.raw)
+	runtimeObject["automountServiceAccountToken"] = true
+	metadata = runtimeObject["metadata"].(map[string]any)
+	metadata["uid"], metadata["resourceVersion"] = "runtime-existing-uid", "7"
+	api.objects[stageRuntimeObjectPath] = runtimeObject
+	launcher = newTargetAccessStageLauncher(t, stage, credentials, runtime, api, time.Date(2026, 8, 16, 14, 1, 0, 0, time.UTC))
+	receipt, err = launcher.Launch(context.Background())
+	if err == nil || receipt.State != "STOPPED_ZERO_WRITE" || api.posts != 0 || len(api.requests) != 1 {
+		t.Fatalf("changed shared runtime reached create phase: %#v requests=%d posts=%d err=%v", receipt, len(api.requests), api.posts, err)
+	}
+}
+
+func TestTargetAccessStageLauncherPreservesPartialPrefixAndStopsStaleLocally(t *testing.T) {
+	stage, credentials, runtime, _ := targetAccessStageLaunchFixture(t)
+	api := newSubmissionStageLauncherAPI(t)
+	api.failPost = 5
+	launcher := newTargetAccessStageLauncher(t, stage, credentials, runtime, api, time.Date(2026, 8, 16, 14, 1, 0, 0, time.UTC))
+	receipt, err := launcher.Launch(context.Background())
+	if err == nil || receipt.State != "STOPPED_PARTIAL_OR_UNKNOWN" || receipt.MutationState != "ATTEMPTED_UNKNOWN" || len(receipt.Results) != 4 || api.posts != 5 {
+		t.Fatalf("partial prefix differs: %#v %v", receipt, err)
+	}
+
+	stage, credentials, runtime, _ = targetAccessStageLaunchFixture(t)
+	api = newSubmissionStageLauncherAPI(t)
+	stale := newTargetAccessStageLauncher(t, stage, credentials, runtime, api, time.Date(2026, 8, 16, 14, 16, 0, 0, time.UTC))
+	receipt, err = stale.Launch(context.Background())
+	if err == nil || receipt.State != "STOPPED_ZERO_WRITE" || receipt.MutationState != "NOT_ATTEMPTED" || len(api.requests) != 0 {
+		t.Fatalf("stale target-access candidate reached API: %#v %v", receipt, err)
+	}
+}
+
+func TestOpenTargetAccessStageLauncherRequiresExactCandidate(t *testing.T) {
+	stage, credentials, runtime, _ := targetAccessStageLaunchFixture(t)
+	installerToken := []byte("installer-token-v1")
+	ca := testCA(t)
+	candidateConfig := targetAccessLaunchCandidateConfig()
+	candidateConfig.CABundleDigest = digest.SHA256(ca)
+	candidateConfig.InstallerTokenDigest = digest.SHA256(installerToken)
+	candidate, err := PrepareTargetAccessStageLaunchCandidate(candidateConfig, stage, credentials, runtime)
+	if err != nil {
+		t.Fatal(err)
+	}
+	candidateReceipt, _ := candidate.Receipt()
+	root := t.TempDir()
+	tokenPath, caPath := filepath.Join(root, "installer-token"), filepath.Join(root, "ca.crt")
+	if err := os.WriteFile(tokenPath, installerToken, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(caPath, ca, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	config := TargetAccessStageLauncherConfig{
+		Authority: KubernetesAuthorityConfig{
+			Endpoint: candidateConfig.AuthorityEndpoint, AuthorityIdentity: "ok-shared", TokenFile: tokenPath, CAFile: caPath, CABundleDigest: candidateConfig.CABundleDigest,
+		},
+		Clock:     func() time.Time { return time.Date(2026, 8, 16, 14, 16, 0, 0, time.UTC) },
+		Candidate: candidate, ExpectedCandidateDigest: candidateReceipt.CandidateDigest,
+	}
+	launcher, err := OpenKubernetesTargetAccessStageLauncher(config, stage, credentials, runtime)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := launcher.Launch(context.Background())
+	if err == nil || receipt.State != "STOPPED_ZERO_WRITE" || receipt.MutationState != "NOT_ATTEMPTED" {
+		t.Fatalf("expired candidate did not stop before API contact: %#v %v", receipt, err)
+	}
+	config.ExpectedCandidateDigest = digest.SHA256([]byte("foreign"))
+	if _, err := OpenKubernetesTargetAccessStageLauncher(config, stage, credentials, runtime); err == nil {
+		t.Fatal("foreign candidate digest accepted")
+	}
+}
+
+func newTargetAccessStageLauncher(t *testing.T, stage VerifiedTargetAccessStagePackage, credentials VerifiedTargetAccessStageCredentialPackage, runtime VerifiedTargetAccessStageRuntimePrerequisite, api *submissionStageLauncherAPI, now time.Time) *KubernetesTargetAccessStageLauncher {
+	t.Helper()
+	launcher, err := newKubernetesTargetAccessStageLauncher(submissionStageLauncherClientConfig{
+		Endpoint: "http://127.0.0.1:12345", BearerToken: "short-lived-installer-token", AuthorityIdentity: "ok-shared",
+		Client: api.client(), Clock: func() time.Time { return now }, ValidUntil: time.Date(2026, 8, 16, 14, 15, 0, 0, time.UTC),
+	}, stage, credentials, runtime)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return launcher
+}


### PR DESCRIPTION
## Summary

- recover and re-verify the exact public and private Target Access installation bodies
- open the sealed launch material only with the exact candidate, destination, CA, and installer credential
- execute one single-use six-object create-only launch with every exact GET before the first POST and the Job last
- accept only a fully exact duplicate or the exact shared runtime; reject changed or partial state with zero writes
- preserve a redaction-safe receipt and stop partial/unknown mutations without retry or cleanup

## Safety boundary

- no update, patch, apply, delete, list, watch, or retry path
- credentials remain private and are never returned in receipts
- shared runtime reuse requires exact semantic equality
- tests use only a local bounded API simulator; no live infrastructure contact

## Verification

- `GOCACHE=/private/tmp/ok147-go-build go test -ldflags=-linkmode=external ./...`
- `GOCACHE=/private/tmp/ok147-go-vet go vet ./...`
- `GOCACHE=/private/tmp/ok147-go-race go test -race -ldflags=-linkmode=external ./internal/runner ./cmd/ok`
- `git diff --check`

Jira: OK-147
