### PR TITLE
feat(cli): package target access stage (OK-147)

### DIFF
--- a/cmd/ok/main.go
+++ b/cmd/ok/main.go
@@ -93,6 +93,19 @@ var materializeEnablementStagePackage = func(config runner.EnablementStagePackag
 	return raw, receipt, err
 }
 
+var materializeTargetAccessStagePackage = func(config runner.TargetAccessStagePackageConfig) ([]byte, runner.TargetAccessStagePackageReceipt, error) {
+	packaged, err := runner.BuildTargetAccessStagePackage(config)
+	if err != nil {
+		return nil, runner.TargetAccessStagePackageReceipt{}, err
+	}
+	raw, err := packaged.Bytes()
+	if err != nil {
+		return nil, runner.TargetAccessStagePackageReceipt{}, err
+	}
+	receipt, err := packaged.Receipt()
+	return raw, receipt, err
+}
+
 var prepareSubmissionStageLaunch = func(config runner.SubmissionStageLaunchMaterialConfig) (stageLaunchPreparation, error) {
 	material, err := runner.BuildSubmissionStageLaunchMaterial(config)
 	if err != nil {
@@ -646,6 +659,9 @@ func runContext(ctx context.Context, arguments []string, stdout, stderr io.Write
 	}
 	if len(arguments) >= 4 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "run" && arguments[3] == "enablement" {
 		return runClusterStageRunEnablement(ctx, arguments[4:], stdout, stderr)
+	}
+	if len(arguments) >= 5 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "run" && arguments[3] == "target-access" && arguments[4] == "package" {
+		return runClusterStageRunTargetAccessPackage(arguments[5:], stdout, stderr)
 	}
 	if len(arguments) >= 4 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "run" && arguments[3] == "target-access" {
 		return runClusterStageRunTargetAccess(ctx, arguments[4:], stdout, stderr)
@@ -1783,16 +1799,7 @@ func runClusterStageRunTargetAccess(ctx context.Context, arguments []string, std
 	if err != nil {
 		return fmt.Errorf("parse evaluation time: %w", err)
 	}
-	expectedObjects := []projection.ResourceIdentity{
-		{APIVersion: "v1", Kind: "Namespace", Name: *observabilityNamespace},
-		{APIVersion: "v1", Kind: "ServiceAccount", Namespace: "kube-system", Name: *managerServiceAccount},
-		{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "ClusterRole", Name: *clusterRole},
-		{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "ClusterRoleBinding", Name: *clusterRoleBinding},
-		{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role", Namespace: *observabilityNamespace, Name: *platformRole},
-		{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "RoleBinding", Namespace: *observabilityNamespace, Name: *platformRoleBinding},
-		{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role", Namespace: "kube-system", Name: *kubeSystemRole},
-		{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "RoleBinding", Namespace: "kube-system", Name: *kubeSystemRoleBinding},
-	}
+	expectedObjects := targetAccessExpectedObjects(*observabilityNamespace, *managerServiceAccount, *clusterRole, *clusterRoleBinding, *platformRole, *platformRoleBinding, *kubeSystemRole, *kubeSystemRoleBinding)
 	bundleConfig := runner.TargetAccessStageBundleConfig{
 		PlanPath: resume.PlanPath, PlanExpected: resume.PlanExpected, Receipts: resume.Receipts,
 		GrantPath: *grantPath, GrantPublicKeyPath: *grantKeyPath, EvaluationTime: at,

--- a/cmd/ok/target_access_launch.go
+++ b/cmd/ok/target_access_launch.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/projection"
+	"github.com/openkubes/ok-cluster/internal/runner"
+)
+
+func targetAccessExpectedObjects(observabilityNamespace, managerServiceAccount, clusterRole, clusterRoleBinding, platformRole, platformRoleBinding, kubeSystemRole, kubeSystemRoleBinding string) []projection.ResourceIdentity {
+	return []projection.ResourceIdentity{
+		{APIVersion: "v1", Kind: "Namespace", Name: observabilityNamespace},
+		{APIVersion: "v1", Kind: "ServiceAccount", Namespace: "kube-system", Name: managerServiceAccount},
+		{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "ClusterRole", Name: clusterRole},
+		{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "ClusterRoleBinding", Name: clusterRoleBinding},
+		{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role", Namespace: observabilityNamespace, Name: platformRole},
+		{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "RoleBinding", Namespace: observabilityNamespace, Name: platformRoleBinding},
+		{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role", Namespace: "kube-system", Name: kubeSystemRole},
+		{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "RoleBinding", Namespace: "kube-system", Name: kubeSystemRoleBinding},
+	}
+}
+
+func runClusterStageRunTargetAccessPackage(arguments []string, stdout, stderr io.Writer) error {
+	flags := flag.NewFlagSet("ok cluster stage run target-access package", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	resumeFlags := addStageResumeFlags(flags)
+	grantPath := flags.String("grant", "", "path to the signed single-stage grant")
+	grantKeyPath := flags.String("grant-key", "", "path to the trusted stage-authority public key")
+	evaluationTime := flags.String("evaluation-time", "", "explicit RFC3339 grant evaluation time")
+	artifactPath := flags.String("target-access-artifact", "", "path to the exact externally rendered eight-object target-access set")
+	observabilityNamespace := flags.String("observability-namespace", "", "independently expected observability namespace")
+	managerServiceAccount := flags.String("manager-serviceaccount", "", "independently expected kube-system manager ServiceAccount")
+	clusterRole := flags.String("cluster-role", "", "independently expected cluster role")
+	clusterRoleBinding := flags.String("cluster-rolebinding", "", "independently expected cluster role binding")
+	platformRole := flags.String("platform-role", "", "independently expected observability namespace role")
+	platformRoleBinding := flags.String("platform-rolebinding", "", "independently expected observability namespace role binding")
+	kubeSystemRole := flags.String("kube-system-role", "", "independently expected kube-system role")
+	kubeSystemRoleBinding := flags.String("kube-system-rolebinding", "", "independently expected kube-system role binding")
+	jobTemplate := flags.String("job-template", "", "path to the bounded target-access Job template")
+	jobTemplateDigest := flags.String("job-template-digest", "", "expected SHA-256 identity of the Job template")
+	output := flags.String("output", "", "new local file for the verified target-access package")
+	runID := flags.String("run-id", "", "bounded OK-147 target-access Job identity")
+	imageDigest := flags.String("image", "", "digest-pinned ok image")
+	inputConfigMap := flags.String("input-configmap", "", "immutable target-access input ConfigMap name")
+	ledgerAPIURL := flags.String("ledger-api-url", "", "exact management-ledger HTTPS IP endpoint")
+	ledgerAPICIDR := flags.String("ledger-api-cidr", "", "single-address management-ledger CIDR")
+	ledgerCredentialSecret := flags.String("ledger-credential-secret", "", "ledger credential Secret name")
+	workloadAPIURL := flags.String("workload-api-url", "", "exact workload-writer HTTPS IP endpoint")
+	workloadAPICIDR := flags.String("workload-api-cidr", "", "single-address workload-writer CIDR")
+	workloadCredentialSecret := flags.String("workload-credential-secret", "", "workload writer credential Secret name")
+	workloadBinding := flags.String("workload-binding", "", "path to the private runtime-bound workload authority record")
+	workloadBindingDigest := flags.String("workload-binding-digest", "", "expected digest of the private workload authority record")
+	if err := flags.Parse(arguments); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return errors.New("positional arguments are not accepted")
+	}
+	resume, err := resumeFlags.config()
+	if err != nil {
+		return err
+	}
+	for _, input := range []struct{ name, value string }{
+		{"--grant", *grantPath}, {"--grant-key", *grantKeyPath}, {"--evaluation-time", *evaluationTime}, {"--target-access-artifact", *artifactPath},
+		{"--observability-namespace", *observabilityNamespace}, {"--manager-serviceaccount", *managerServiceAccount},
+		{"--cluster-role", *clusterRole}, {"--cluster-rolebinding", *clusterRoleBinding},
+		{"--platform-role", *platformRole}, {"--platform-rolebinding", *platformRoleBinding},
+		{"--kube-system-role", *kubeSystemRole}, {"--kube-system-rolebinding", *kubeSystemRoleBinding},
+		{"--job-template", *jobTemplate}, {"--job-template-digest", *jobTemplateDigest}, {"--output", *output},
+		{"--run-id", *runID}, {"--image", *imageDigest}, {"--input-configmap", *inputConfigMap},
+		{"--ledger-api-url", *ledgerAPIURL}, {"--ledger-api-cidr", *ledgerAPICIDR}, {"--ledger-credential-secret", *ledgerCredentialSecret},
+		{"--workload-api-url", *workloadAPIURL}, {"--workload-api-cidr", *workloadAPICIDR}, {"--workload-credential-secret", *workloadCredentialSecret},
+		{"--workload-binding", *workloadBinding}, {"--workload-binding-digest", *workloadBindingDigest},
+	} {
+		if input.value == "" {
+			return fmt.Errorf("%s is required", input.name)
+		}
+	}
+	evaluatedAt, err := time.Parse(time.RFC3339, *evaluationTime)
+	if err != nil {
+		return fmt.Errorf("parse evaluation time: %w", err)
+	}
+	template, err := readBoundedLocalFile(*jobTemplate, 1024*1024)
+	if err != nil {
+		return fmt.Errorf("read target-access Job template: %w", err)
+	}
+	expectedObjects := targetAccessExpectedObjects(*observabilityNamespace, *managerServiceAccount, *clusterRole, *clusterRoleBinding, *platformRole, *platformRoleBinding, *kubeSystemRole, *kubeSystemRoleBinding)
+	raw, receipt, err := materializeTargetAccessStagePackage(runner.TargetAccessStagePackageConfig{
+		Bundle: runner.TargetAccessStageBundleConfig{
+			PlanPath: resume.PlanPath, PlanExpected: resume.PlanExpected, Receipts: resume.Receipts,
+			GrantPath: *grantPath, GrantPublicKeyPath: *grantKeyPath, EvaluationTime: evaluatedAt,
+			ArtifactPath: *artifactPath, ExpectedObjects: expectedObjects,
+		},
+		JobTemplate: template, JobTemplateDigest: *jobTemplateDigest,
+		RunID: *runID, ImageDigest: *imageDigest, InputConfigMap: *inputConfigMap,
+		ObservabilityNamespace: *observabilityNamespace, ManagerServiceAccount: *managerServiceAccount,
+		ClusterRole: *clusterRole, ClusterRoleBinding: *clusterRoleBinding,
+		PlatformRole: *platformRole, PlatformRoleBinding: *platformRoleBinding,
+		KubeSystemRole: *kubeSystemRole, KubeSystemRoleBinding: *kubeSystemRoleBinding,
+		LedgerAPIURL: *ledgerAPIURL, LedgerAPICIDR: *ledgerAPICIDR, LedgerCredentialSecret: *ledgerCredentialSecret,
+		WorkloadAPIURL: *workloadAPIURL, WorkloadAPICIDR: *workloadAPICIDR, WorkloadCredentialSecret: *workloadCredentialSecret,
+		WorkloadBindingPath: *workloadBinding, ExpectedWorkloadBindingDigest: *workloadBindingDigest,
+	})
+	if err != nil {
+		return err
+	}
+	if err := writeNewLocalFile(*output, raw); err != nil {
+		return fmt.Errorf("write target-access stage package: %w", err)
+	}
+	encoder := json.NewEncoder(stdout)
+	encoder.SetEscapeHTML(false)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(receipt)
+}

--- a/cmd/ok/target_access_launch_test.go
+++ b/cmd/ok/target_access_launch_test.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/runner"
+)
+
+func TestTargetAccessStagePackageWritesVerifiedOfflineArtifact(t *testing.T) {
+	previous := materializeTargetAccessStagePackage
+	defer func() { materializeTargetAccessStagePackage = previous }()
+	var captured runner.TargetAccessStagePackageConfig
+	materializeTargetAccessStagePackage = func(config runner.TargetAccessStagePackageConfig) ([]byte, runner.TargetAccessStagePackageReceipt, error) {
+		captured = config
+		return []byte("verified-target-access-package\n"), runner.TargetAccessStagePackageReceipt{
+			Format: runner.TargetAccessStagePackageFormat, State: "VERIFIED", StageID: "target-access",
+			PackageDigest: testSHA("1"), InputConfigMapDigest: testSHA("2"), ReceiptPrefixDigest: testSHA("3"),
+			TargetAccessDigest: testSHA("4"), TargetIdentityDigest: testSHA("5"), WorkloadBindingDigest: testSHA("6"),
+			InstallationAuthority: "ok-shared", JobTemplateDigest: testSHA("7"), JobEnvelopeDigest: testSHA("8"),
+			ObjectKinds: []string{"ConfigMap", "NetworkPolicy", "Job"}, AuthorizationState: "VERIFIED", MutationAllowed: false,
+		}, nil
+	}
+	root := t.TempDir()
+	template := filepath.Join(root, "target-access-job.yaml.tpl")
+	if err := os.WriteFile(template, []byte("bounded-target-access-template"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	output := filepath.Join(root, "target-access-package.yaml")
+	arguments := targetAccessStagePackageArguments(template, output)
+	var stdout, stderr bytes.Buffer
+	if err := run(arguments, &stdout, &stderr); err != nil {
+		t.Fatalf("run: %v; stderr=%s", err, stderr.String())
+	}
+	if captured.Bundle.PlanPath != "/tmp/plan.json" || len(captured.Bundle.Receipts) != 6 || len(captured.Bundle.ExpectedObjects) != 8 || captured.RunID != "ok147-target-access-20260817-01" {
+		t.Fatalf("unexpected target-access package config: %#v", captured)
+	}
+	if captured.Bundle.ExpectedObjects[0].Name != "ok-observability" || captured.Bundle.ExpectedObjects[7].Namespace != "kube-system" || captured.Bundle.PlanExpected.GitOpsAuthority != "ok-shared" {
+		t.Fatalf("target-access authority or object identities differ: %#v", captured.Bundle)
+	}
+	if string(captured.JobTemplate) != "bounded-target-access-template" || captured.JobTemplateDigest != digest.SHA256([]byte("bounded-target-access-template")) || captured.LedgerCredentialSecret == captured.WorkloadCredentialSecret || captured.WorkloadBindingPath != "/private/tmp/runtime-binding.json" {
+		t.Fatalf("target-access private package inputs differ: %#v", captured)
+	}
+	written, err := os.ReadFile(output)
+	if err != nil || string(written) != "verified-target-access-package\n" {
+		t.Fatalf("unexpected target-access package: %q %v", written, err)
+	}
+	info, err := os.Stat(output)
+	if err != nil || info.Mode().Perm() != 0o600 {
+		t.Fatalf("target-access package mode is not 0600: %v %v", info, err)
+	}
+	var receipt runner.TargetAccessStagePackageReceipt
+	if err := json.Unmarshal(stdout.Bytes(), &receipt); err != nil {
+		t.Fatal(err)
+	}
+	if receipt.AuthorizationState != "VERIFIED" || receipt.MutationAllowed || receipt.InstallationAuthority != "ok-shared" {
+		t.Fatalf("unsafe target-access package receipt: %#v", receipt)
+	}
+	stdout.Reset()
+	if err := run(arguments, &stdout, &stderr); err == nil || stdout.Len() != 0 {
+		t.Fatal("existing target-access package was overwritten")
+	}
+}
+
+func TestTargetAccessStagePackageRejectsIncompleteInputs(t *testing.T) {
+	root := t.TempDir()
+	template := filepath.Join(root, "target-access-job.yaml.tpl")
+	if err := os.WriteFile(template, []byte("bounded-target-access-template"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	valid := targetAccessStagePackageArguments(template, filepath.Join(root, "target-access-package.yaml"))
+	for name, arguments := range map[string][]string{
+		"execute":                    append(append([]string{}, valid...), "--execute"),
+		"missing template digest":    removeArgumentWithValue(valid, "--job-template-digest"),
+		"missing workload secret":    removeArgumentWithValue(valid, "--workload-credential-secret"),
+		"missing workload binding":   removeArgumentWithValue(valid, "--workload-binding"),
+		"missing independent object": removeArgumentWithValue(valid, "--cluster-rolebinding"),
+		"invalid time":               replaceArgument(valid, "--evaluation-time", "not-time"),
+		"positional":                 append(append([]string{}, valid...), "unexpected"),
+	} {
+		t.Run(name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			if err := run(arguments, &stdout, &stderr); err == nil || stdout.Len() != 0 {
+				t.Fatalf("unsafe target-access package input was accepted: %v %s", err, stdout.String())
+			}
+		})
+	}
+}
+
+func targetAccessStagePackageArguments(template, output string) []string {
+	arguments := targetAccessStageRunArguments()
+	arguments = removeArgument(arguments, "--execute")
+	for _, name := range []string{
+		"--ledger-api-endpoint", "--ledger-token-file", "--ledger-ca-file",
+		"--workload-token-file", "--workload-ca-file",
+	} {
+		arguments = removeArgumentWithValue(arguments, name)
+	}
+	arguments = append(arguments[:4], append([]string{"package"}, arguments[4:]...)...)
+	return append(arguments,
+		"--job-template", template, "--job-template-digest", digest.SHA256([]byte("bounded-target-access-template")),
+		"--output", output, "--run-id", "ok147-target-access-20260817-01",
+		"--image", "ghcr.io/openkubes/ok-cluster@"+testSHA("a"), "--input-configmap", "ok147-target-access-input",
+		"--ledger-api-url", "https://192.0.2.12:6443", "--ledger-api-cidr", "192.0.2.12/32", "--ledger-credential-secret", "ok147-ledger-target-access",
+		"--workload-api-url", "https://192.0.2.13:6443", "--workload-api-cidr", "192.0.2.13/32", "--workload-credential-secret", "ok147-workload-target-access",
+	)
+}


### PR DESCRIPTION
## Summary

- add `ok cluster stage run target-access package` as a strictly offline CLI boundary
- bind six predecessor receipts, the signed target-access grant, eight independently named workload objects, and the private runtime binding
- bind exact ledger/workload API endpoints, credential Secret names, immutable input, Job template, and runner image
- write only a new mode-0600 package file and refuse overwrite, execution flags, incomplete inputs, or positional arguments
- reuse one exact expected-object constructor for local execution and Job packaging

## Safety boundary

- no Kubernetes API contact
- no credential read or token issuance
- no object creation and no Job launch
- no output overwrite

## Verification

- `GOCACHE=/private/tmp/ok147-go-build go test -ldflags=-linkmode=external ./...`
- `GOCACHE=/private/tmp/ok147-go-vet go vet ./...`
- `GOCACHE=/private/tmp/ok147-go-race go test -race -ldflags=-linkmode=external ./internal/runner ./cmd/ok`
- `git diff --check`

Jira: OK-147
