### PR TITLE
feat(cli): launch target access stage (OK-147)

### DIFF
--- a/cmd/ok/main.go
+++ b/cmd/ok/main.go
@@ -660,6 +660,12 @@ func runContext(ctx context.Context, arguments []string, stdout, stderr io.Write
 	if len(arguments) >= 4 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "run" && arguments[3] == "enablement" {
 		return runClusterStageRunEnablement(ctx, arguments[4:], stdout, stderr)
 	}
+	if len(arguments) >= 6 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "run" && arguments[3] == "target-access" && arguments[4] == "launch" && arguments[5] == "prepare" {
+		return runClusterStageRunTargetAccessLaunchPrepare(arguments[6:], stdout, stderr)
+	}
+	if len(arguments) >= 6 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "run" && arguments[3] == "target-access" && arguments[4] == "launch" && arguments[5] == "execute" {
+		return runClusterStageRunTargetAccessLaunchExecute(ctx, arguments[6:], stdout, stderr)
+	}
 	if len(arguments) >= 5 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "run" && arguments[3] == "target-access" && arguments[4] == "package" {
 		return runClusterStageRunTargetAccessPackage(arguments[5:], stdout, stderr)
 	}

--- a/cmd/ok/target_access_launch.go
+++ b/cmd/ok/target_access_launch.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -11,6 +12,52 @@ import (
 	"github.com/openkubes/ok-cluster/internal/projection"
 	"github.com/openkubes/ok-cluster/internal/runner"
 )
+
+var prepareTargetAccessStageLaunch = func(config runner.TargetAccessStageLaunchMaterialConfig) (targetAccessLaunchPreparation, error) {
+	material, err := runner.BuildTargetAccessStageLaunchMaterial(config)
+	if err != nil {
+		return targetAccessLaunchPreparation{}, err
+	}
+	materialReceipt, err := material.Receipt()
+	if err != nil {
+		return targetAccessLaunchPreparation{}, err
+	}
+	candidateReceipt, err := material.CandidateReceipt()
+	if err != nil {
+		return targetAccessLaunchPreparation{}, err
+	}
+	return targetAccessLaunchPreparation{
+		Format: "ok147-target-access-stage-launch-preparation/v1", State: "PREPARED",
+		Material: materialReceipt, Candidate: candidateReceipt, MutationAllowed: false,
+	}, nil
+}
+
+var executeTargetAccessStageLaunch = func(ctx context.Context, config runner.TargetAccessStageLaunchMaterialConfig, authority runner.KubernetesAuthorityConfig, expectedCandidateDigest string) (runner.TargetAccessStageLaunchReceipt, error) {
+	material, err := runner.BuildTargetAccessStageLaunchMaterial(config)
+	if err != nil {
+		return runner.TargetAccessStageLaunchReceipt{}, err
+	}
+	candidate, err := material.CandidateReceipt()
+	if err != nil {
+		return runner.TargetAccessStageLaunchReceipt{}, err
+	}
+	authority.AuthorityIdentity = candidate.Authority
+	launcher, err := material.Open(runner.TargetAccessStageLaunchOpenConfig{
+		Authority: authority, Clock: func() time.Time { return time.Now().UTC() }, ExpectedCandidateDigest: expectedCandidateDigest,
+	})
+	if err != nil {
+		return runner.TargetAccessStageLaunchReceipt{}, err
+	}
+	return launcher.Launch(ctx)
+}
+
+type targetAccessLaunchPreparation struct {
+	Format          string                                         `json:"format"`
+	State           string                                         `json:"state"`
+	Material        runner.TargetAccessStageLaunchMaterialReceipt  `json:"material"`
+	Candidate       runner.TargetAccessStageLaunchCandidateReceipt `json:"candidate"`
+	MutationAllowed bool                                           `json:"mutationAllowed"`
+}
 
 func targetAccessExpectedObjects(observabilityNamespace, managerServiceAccount, clusterRole, clusterRoleBinding, platformRole, platformRoleBinding, kubeSystemRole, kubeSystemRoleBinding string) []projection.ResourceIdentity {
 	return []projection.ResourceIdentity{
@@ -116,4 +163,211 @@ func runClusterStageRunTargetAccessPackage(arguments []string, stdout, stderr io
 	encoder.SetEscapeHTML(false)
 	encoder.SetIndent("", "  ")
 	return encoder.Encode(receipt)
+}
+
+type targetAccessLaunchMaterialFlags struct {
+	resume                                                                                            *stageResumeFlags
+	grantPath, grantKeyPath, evaluationTime, artifactPath                                             *string
+	observabilityNamespace, managerServiceAccount                                                     *string
+	clusterRole, clusterRoleBinding, platformRole, platformRoleBinding                                *string
+	kubeSystemRole, kubeSystemRoleBinding                                                             *string
+	jobTemplate, jobTemplateDigest, runID, imageDigest, inputConfigMap                                *string
+	ledgerAPIURL, ledgerAPICIDR, ledgerCredentialSecret                                               *string
+	workloadAPIURL, workloadAPICIDR, workloadCredentialSecret, workloadBinding, workloadBindingDigest *string
+	materializedAt, runtimeManifest, runtimeManifestDigest                                            *string
+	installerAPIEndpoint, installerCADigest, installerTokenDigest, installerEvidence, preparedAt      *string
+	ledgerCredential, workloadCredential                                                              *stageLaunchCredentialFlags
+}
+
+func addTargetAccessLaunchMaterialFlags(flags *flag.FlagSet) *targetAccessLaunchMaterialFlags {
+	values := &targetAccessLaunchMaterialFlags{resume: addStageResumeFlags(flags)}
+	values.grantPath = flags.String("grant", "", "path to the signed single-stage grant")
+	values.grantKeyPath = flags.String("grant-key", "", "path to the trusted stage-authority public key")
+	values.evaluationTime = flags.String("evaluation-time", "", "explicit RFC3339 grant evaluation time")
+	values.artifactPath = flags.String("target-access-artifact", "", "path to the exact externally rendered eight-object target-access set")
+	values.observabilityNamespace = flags.String("observability-namespace", "", "independently expected observability namespace")
+	values.managerServiceAccount = flags.String("manager-serviceaccount", "", "independently expected kube-system manager ServiceAccount")
+	values.clusterRole = flags.String("cluster-role", "", "independently expected cluster role")
+	values.clusterRoleBinding = flags.String("cluster-rolebinding", "", "independently expected cluster role binding")
+	values.platformRole = flags.String("platform-role", "", "independently expected observability namespace role")
+	values.platformRoleBinding = flags.String("platform-rolebinding", "", "independently expected observability namespace role binding")
+	values.kubeSystemRole = flags.String("kube-system-role", "", "independently expected kube-system role")
+	values.kubeSystemRoleBinding = flags.String("kube-system-rolebinding", "", "independently expected kube-system role binding")
+	values.jobTemplate = flags.String("job-template", "", "path to the bounded target-access Job template")
+	values.jobTemplateDigest = flags.String("job-template-digest", "", "expected SHA-256 identity of the Job template")
+	values.runID = flags.String("run-id", "", "bounded OK-147 target-access Job identity")
+	values.imageDigest = flags.String("image", "", "digest-pinned ok image")
+	values.inputConfigMap = flags.String("input-configmap", "", "immutable target-access input ConfigMap name")
+	values.ledgerAPIURL = flags.String("ledger-api-url", "", "exact management-ledger HTTPS IP endpoint")
+	values.ledgerAPICIDR = flags.String("ledger-api-cidr", "", "single-address management-ledger CIDR")
+	values.ledgerCredentialSecret = flags.String("ledger-credential-secret", "", "ledger credential Secret name")
+	values.workloadAPIURL = flags.String("workload-api-url", "", "exact workload-writer HTTPS IP endpoint")
+	values.workloadAPICIDR = flags.String("workload-api-cidr", "", "single-address workload-writer CIDR")
+	values.workloadCredentialSecret = flags.String("workload-credential-secret", "", "workload writer credential Secret name")
+	values.workloadBinding = flags.String("workload-binding", "", "path to the private runtime-bound workload authority record")
+	values.workloadBindingDigest = flags.String("workload-binding-digest", "", "expected digest of the private workload authority record")
+	values.materializedAt = flags.String("credential-materialized-at", "", "exact credential materialization time")
+	values.ledgerCredential = addStageLaunchCredentialFlags(flags, "ledger-job", "ledger Job credential")
+	values.workloadCredential = addStageLaunchCredentialFlags(flags, "workload-writer-job", "workload writer Job credential")
+	values.runtimeManifest = flags.String("runtime-manifest", "", "path to the tokenless runtime ServiceAccount manifest")
+	values.runtimeManifestDigest = flags.String("runtime-manifest-digest", "", "expected runtime manifest digest")
+	values.installerAPIEndpoint = flags.String("installer-api-endpoint", "", "exact execution-plane installer HTTPS IP endpoint")
+	values.installerCADigest = flags.String("installer-ca-digest", "", "expected execution-plane installer CA digest")
+	values.installerTokenDigest = flags.String("installer-token-digest", "", "private expected execution-plane installer token digest")
+	values.installerEvidence = flags.String("installer-tokenrequest-evidence-digest", "", "execution-plane installer TokenRequest evidence digest")
+	values.preparedAt = flags.String("prepared-at", "", "exact launch candidate preparation time")
+	return values
+}
+
+func (values *targetAccessLaunchMaterialFlags) config() (runner.TargetAccessStageLaunchMaterialConfig, error) {
+	resume, err := values.resume.config()
+	if err != nil {
+		return runner.TargetAccessStageLaunchMaterialConfig{}, err
+	}
+	for _, input := range []struct{ name, value string }{
+		{"--grant", *values.grantPath}, {"--grant-key", *values.grantKeyPath}, {"--evaluation-time", *values.evaluationTime}, {"--target-access-artifact", *values.artifactPath},
+		{"--observability-namespace", *values.observabilityNamespace}, {"--manager-serviceaccount", *values.managerServiceAccount},
+		{"--cluster-role", *values.clusterRole}, {"--cluster-rolebinding", *values.clusterRoleBinding},
+		{"--platform-role", *values.platformRole}, {"--platform-rolebinding", *values.platformRoleBinding},
+		{"--kube-system-role", *values.kubeSystemRole}, {"--kube-system-rolebinding", *values.kubeSystemRoleBinding},
+		{"--job-template", *values.jobTemplate}, {"--job-template-digest", *values.jobTemplateDigest}, {"--run-id", *values.runID}, {"--image", *values.imageDigest},
+		{"--input-configmap", *values.inputConfigMap}, {"--ledger-api-url", *values.ledgerAPIURL}, {"--ledger-api-cidr", *values.ledgerAPICIDR},
+		{"--ledger-credential-secret", *values.ledgerCredentialSecret}, {"--workload-api-url", *values.workloadAPIURL},
+		{"--workload-api-cidr", *values.workloadAPICIDR}, {"--workload-credential-secret", *values.workloadCredentialSecret},
+		{"--workload-binding", *values.workloadBinding}, {"--workload-binding-digest", *values.workloadBindingDigest},
+		{"--credential-materialized-at", *values.materializedAt}, {"--runtime-manifest", *values.runtimeManifest},
+		{"--runtime-manifest-digest", *values.runtimeManifestDigest}, {"--installer-api-endpoint", *values.installerAPIEndpoint},
+		{"--installer-ca-digest", *values.installerCADigest}, {"--installer-token-digest", *values.installerTokenDigest},
+		{"--installer-tokenrequest-evidence-digest", *values.installerEvidence}, {"--prepared-at", *values.preparedAt},
+	} {
+		if input.value == "" {
+			return runner.TargetAccessStageLaunchMaterialConfig{}, fmt.Errorf("%s is required", input.name)
+		}
+	}
+	evaluatedAt, err := time.Parse(time.RFC3339, *values.evaluationTime)
+	if err != nil {
+		return runner.TargetAccessStageLaunchMaterialConfig{}, fmt.Errorf("parse evaluation time: %w", err)
+	}
+	materializedAt, err := time.Parse(time.RFC3339, *values.materializedAt)
+	if err != nil {
+		return runner.TargetAccessStageLaunchMaterialConfig{}, fmt.Errorf("parse credential materialization time: %w", err)
+	}
+	preparedAt, err := time.Parse(time.RFC3339, *values.preparedAt)
+	if err != nil {
+		return runner.TargetAccessStageLaunchMaterialConfig{}, fmt.Errorf("parse candidate preparation time: %w", err)
+	}
+	ledgerSource, err := values.ledgerCredential.source("ledger-job")
+	if err != nil {
+		return runner.TargetAccessStageLaunchMaterialConfig{}, err
+	}
+	workloadSource, err := values.workloadCredential.source("workload-writer-job")
+	if err != nil {
+		return runner.TargetAccessStageLaunchMaterialConfig{}, err
+	}
+	template, err := readBoundedLocalFile(*values.jobTemplate, 1024*1024)
+	if err != nil {
+		return runner.TargetAccessStageLaunchMaterialConfig{}, fmt.Errorf("read target-access Job template: %w", err)
+	}
+	runtimeRaw, err := readBoundedLocalFile(*values.runtimeManifest, 128*1024)
+	if err != nil {
+		return runner.TargetAccessStageLaunchMaterialConfig{}, fmt.Errorf("read runtime manifest: %w", err)
+	}
+	expectedObjects := targetAccessExpectedObjects(*values.observabilityNamespace, *values.managerServiceAccount, *values.clusterRole, *values.clusterRoleBinding, *values.platformRole, *values.platformRoleBinding, *values.kubeSystemRole, *values.kubeSystemRoleBinding)
+	return runner.TargetAccessStageLaunchMaterialConfig{
+		Package: runner.TargetAccessStagePackageConfig{
+			Bundle: runner.TargetAccessStageBundleConfig{
+				PlanPath: resume.PlanPath, PlanExpected: resume.PlanExpected, Receipts: resume.Receipts,
+				GrantPath: *values.grantPath, GrantPublicKeyPath: *values.grantKeyPath, EvaluationTime: evaluatedAt,
+				ArtifactPath: *values.artifactPath, ExpectedObjects: expectedObjects,
+			},
+			JobTemplate: template, JobTemplateDigest: *values.jobTemplateDigest,
+			RunID: *values.runID, ImageDigest: *values.imageDigest, InputConfigMap: *values.inputConfigMap,
+			ObservabilityNamespace: *values.observabilityNamespace, ManagerServiceAccount: *values.managerServiceAccount,
+			ClusterRole: *values.clusterRole, ClusterRoleBinding: *values.clusterRoleBinding,
+			PlatformRole: *values.platformRole, PlatformRoleBinding: *values.platformRoleBinding,
+			KubeSystemRole: *values.kubeSystemRole, KubeSystemRoleBinding: *values.kubeSystemRoleBinding,
+			LedgerAPIURL: *values.ledgerAPIURL, LedgerAPICIDR: *values.ledgerAPICIDR, LedgerCredentialSecret: *values.ledgerCredentialSecret,
+			WorkloadAPIURL: *values.workloadAPIURL, WorkloadAPICIDR: *values.workloadAPICIDR, WorkloadCredentialSecret: *values.workloadCredentialSecret,
+			WorkloadBindingPath: *values.workloadBinding, ExpectedWorkloadBindingDigest: *values.workloadBindingDigest,
+		},
+		MaterializationTime: materializedAt, LedgerWriter: ledgerSource, WorkloadWriter: workloadSource,
+		RuntimeManifest: runtimeRaw, RuntimeManifestDigest: *values.runtimeManifestDigest,
+		Candidate: runner.SubmissionStageLaunchCandidateConfig{
+			AuthorityEndpoint: *values.installerAPIEndpoint, CABundleDigest: *values.installerCADigest,
+			InstallerTokenDigest: *values.installerTokenDigest, InstallerCredentialEvidenceDigest: *values.installerEvidence,
+			PreparedAt: preparedAt,
+		},
+	}, nil
+}
+
+func runClusterStageRunTargetAccessLaunchPrepare(arguments []string, stdout, stderr io.Writer) error {
+	flags := flag.NewFlagSet("ok cluster stage run target-access launch prepare", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	materialFlags := addTargetAccessLaunchMaterialFlags(flags)
+	if err := flags.Parse(arguments); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return errors.New("positional arguments are not accepted")
+	}
+	config, err := materialFlags.config()
+	if err != nil {
+		return err
+	}
+	preparation, err := prepareTargetAccessStageLaunch(config)
+	if err != nil {
+		return err
+	}
+	encoder := json.NewEncoder(stdout)
+	encoder.SetEscapeHTML(false)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(preparation)
+}
+
+func runClusterStageRunTargetAccessLaunchExecute(ctx context.Context, arguments []string, stdout, stderr io.Writer) error {
+	flags := flag.NewFlagSet("ok cluster stage run target-access launch execute", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	materialFlags := addTargetAccessLaunchMaterialFlags(flags)
+	execute := flags.Bool("execute", false, "perform the exact single-use six-object Target Access launch")
+	expectedCandidateDigest := flags.String("expected-candidate-digest", "", "exact digest emitted by Target Access launch prepare")
+	installerTokenFile := flags.String("installer-token-file", "", "bounded short-lived execution-plane installer token file")
+	installerCAFile := flags.String("installer-ca-file", "", "bounded execution-plane installer CA file")
+	if err := flags.Parse(arguments); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return errors.New("positional arguments are not accepted")
+	}
+	if !*execute {
+		return errors.New("target-access launch mutation requires explicit --execute")
+	}
+	for _, input := range []struct{ name, value string }{
+		{"--expected-candidate-digest", *expectedCandidateDigest}, {"--installer-token-file", *installerTokenFile}, {"--installer-ca-file", *installerCAFile},
+	} {
+		if input.value == "" {
+			return fmt.Errorf("%s is required", input.name)
+		}
+	}
+	if !sha256DigestPattern.MatchString(*expectedCandidateDigest) {
+		return errors.New("--expected-candidate-digest must be sha256:<64 lowercase hex>")
+	}
+	config, err := materialFlags.config()
+	if err != nil {
+		return err
+	}
+	boundedContext, cancel := context.WithTimeout(ctx, stageLaunchTimeout)
+	defer cancel()
+	receipt, launchErr := executeTargetAccessStageLaunch(boundedContext, config, runner.KubernetesAuthorityConfig{
+		Endpoint: config.Candidate.AuthorityEndpoint, TokenFile: *installerTokenFile,
+		CAFile: *installerCAFile, CABundleDigest: config.Candidate.CABundleDigest,
+	}, *expectedCandidateDigest)
+	if receipt.Format != "" {
+		encoder := json.NewEncoder(stdout)
+		encoder.SetEscapeHTML(false)
+		encoder.SetIndent("", "  ")
+		if err := encoder.Encode(receipt); err != nil {
+			return err
+		}
+	}
+	return launchErr
 }

--- a/cmd/ok/target_access_launch_test.go
+++ b/cmd/ok/target_access_launch_test.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/openkubes/ok-cluster/internal/digest"
 	"github.com/openkubes/ok-cluster/internal/runner"
@@ -66,6 +68,118 @@ func TestTargetAccessStagePackageWritesVerifiedOfflineArtifact(t *testing.T) {
 	}
 }
 
+func TestTargetAccessLaunchPrepareBuildsOneNonMutatingCandidate(t *testing.T) {
+	previous := prepareTargetAccessStageLaunch
+	defer func() { prepareTargetAccessStageLaunch = previous }()
+	var captured runner.TargetAccessStageLaunchMaterialConfig
+	prepareTargetAccessStageLaunch = func(config runner.TargetAccessStageLaunchMaterialConfig) (targetAccessLaunchPreparation, error) {
+		captured = config
+		return targetAccessLaunchPreparation{
+			Format: "ok147-target-access-stage-launch-preparation/v1", State: "PREPARED",
+			Material: runner.TargetAccessStageLaunchMaterialReceipt{
+				Format: runner.TargetAccessStageLaunchMaterialFormat, State: "VERIFIED", StageID: "target-access",
+				Authority: "ok-shared", CandidateDigest: testSHA("1"), MutationAllowed: false,
+			},
+			Candidate: runner.TargetAccessStageLaunchCandidateReceipt{
+				Format: runner.TargetAccessStageLaunchCandidateFormat, State: "PREPARED", CandidateDigest: testSHA("1"), MutationAllowed: false,
+			},
+			MutationAllowed: false,
+		}, nil
+	}
+	root := t.TempDir()
+	template, runtimeManifest := filepath.Join(root, "target-access.yaml.tpl"), filepath.Join(root, "runtime.yaml")
+	if err := os.WriteFile(template, []byte("bounded-target-access-template"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(runtimeManifest, []byte("bounded-runtime"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	if err := run(targetAccessLaunchPrepareArguments(template, runtimeManifest), &stdout, &stderr); err != nil {
+		t.Fatalf("run: %v; stderr=%s", err, stderr.String())
+	}
+	if captured.Package.Bundle.PlanExpected.GitOpsAuthority != "ok-shared" || len(captured.Package.Bundle.ExpectedObjects) != 8 || captured.Package.RunID != "ok147-target-access-20260817-01" {
+		t.Fatalf("target-access package identity differs: %#v", captured.Package)
+	}
+	if string(captured.Package.JobTemplate) != "bounded-target-access-template" || string(captured.RuntimeManifest) != "bounded-runtime" {
+		t.Fatalf("target-access private templates differ: %q %q", captured.Package.JobTemplate, captured.RuntimeManifest)
+	}
+	if captured.LedgerWriter.AuthorityIdentity != "ok-mgmt" || captured.WorkloadWriter.AuthorityIdentity != testSHA("f") || captured.LedgerWriter.TokenFile == captured.WorkloadWriter.TokenFile || captured.Candidate.AuthorityEndpoint != "https://192.0.2.14:6443" {
+		t.Fatalf("target-access credential boundary differs: %#v %#v %#v", captured.LedgerWriter, captured.WorkloadWriter, captured.Candidate)
+	}
+	var preparation targetAccessLaunchPreparation
+	if err := json.Unmarshal(stdout.Bytes(), &preparation); err != nil {
+		t.Fatal(err)
+	}
+	if preparation.State != "PREPARED" || preparation.MutationAllowed || preparation.Material.MutationAllowed || preparation.Candidate.MutationAllowed {
+		t.Fatalf("unsafe target-access launch preparation: %#v", preparation)
+	}
+
+	invalid := removeArgumentWithValue(targetAccessLaunchPrepareArguments(template, runtimeManifest), "--workload-writer-job-token-file")
+	stdout.Reset()
+	if err := run(invalid, &stdout, &stderr); err == nil || stdout.Len() != 0 {
+		t.Fatal("incomplete private target-access material reached preparation")
+	}
+}
+
+func TestTargetAccessLaunchExecuteUsesExactBoundary(t *testing.T) {
+	previous := executeTargetAccessStageLaunch
+	defer func() { executeTargetAccessStageLaunch = previous }()
+	var calls int
+	var candidate string
+	executeTargetAccessStageLaunch = func(ctx context.Context, config runner.TargetAccessStageLaunchMaterialConfig, authority runner.KubernetesAuthorityConfig, expectedCandidateDigest string) (runner.TargetAccessStageLaunchReceipt, error) {
+		calls++
+		candidate = expectedCandidateDigest
+		deadline, ok := ctx.Deadline()
+		if !ok || time.Until(deadline) <= 0 || time.Until(deadline) > stageLaunchTimeout {
+			t.Fatal("target-access launch context is not bounded")
+		}
+		if config.Package.RunID != "ok147-target-access-20260817-01" || authority.Endpoint != "https://192.0.2.14:6443" || authority.TokenFile != "/private/tmp/installer-token" {
+			t.Fatalf("execute boundary differs: %#v %#v", config, authority)
+		}
+		return runner.TargetAccessStageLaunchReceipt{
+			Format: runner.TargetAccessStageLaunchReceiptFormat, StageID: "target-access", Authority: "ok-shared",
+			State: "LAUNCHED", MutationState: "ATTEMPTED", Results: []runner.SubmissionStageLaunchResult{},
+		}, nil
+	}
+	root := t.TempDir()
+	template, runtimeManifest := filepath.Join(root, "target-access.yaml.tpl"), filepath.Join(root, "runtime.yaml")
+	if err := os.WriteFile(template, []byte("bounded-target-access-template"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(runtimeManifest, []byte("bounded-runtime"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var stdout, stderr bytes.Buffer
+	if err := run(targetAccessLaunchExecuteArguments(template, runtimeManifest), &stdout, &stderr); err != nil {
+		t.Fatalf("run: %v; stderr=%s", err, stderr.String())
+	}
+	if calls != 1 || candidate != testSHA("9") {
+		t.Fatalf("exact target-access candidate not used: calls=%d digest=%q", calls, candidate)
+	}
+	var receipt runner.TargetAccessStageLaunchReceipt
+	if err := json.Unmarshal(stdout.Bytes(), &receipt); err != nil || receipt.State != "LAUNCHED" {
+		t.Fatalf("unexpected target-access launch receipt: %#v %v", receipt, err)
+	}
+
+	valid := targetAccessLaunchExecuteArguments(template, runtimeManifest)
+	for name, arguments := range map[string][]string{
+		"missing execute":         removeArgument(valid, "--execute"),
+		"missing candidate":       removeArgumentWithValue(valid, "--expected-candidate-digest"),
+		"malformed candidate":     replaceArgument(valid, "--expected-candidate-digest", "sha256:ABC"),
+		"missing installer token": removeArgumentWithValue(valid, "--installer-token-file"),
+		"missing workload source": removeArgumentWithValue(valid, "--workload-writer-job-authority"),
+	} {
+		t.Run(name, func(t *testing.T) {
+			before := calls
+			stdout.Reset()
+			if err := run(arguments, &stdout, &stderr); err == nil || stdout.Len() != 0 || calls != before {
+				t.Fatal("unsafe target-access launch input reached executor")
+			}
+		})
+	}
+}
+
 func TestTargetAccessStagePackageRejectsIncompleteInputs(t *testing.T) {
 	root := t.TempDir()
 	template := filepath.Join(root, "target-access-job.yaml.tpl")
@@ -107,5 +221,41 @@ func targetAccessStagePackageArguments(template, output string) []string {
 		"--image", "ghcr.io/openkubes/ok-cluster@"+testSHA("a"), "--input-configmap", "ok147-target-access-input",
 		"--ledger-api-url", "https://192.0.2.12:6443", "--ledger-api-cidr", "192.0.2.12/32", "--ledger-credential-secret", "ok147-ledger-target-access",
 		"--workload-api-url", "https://192.0.2.13:6443", "--workload-api-cidr", "192.0.2.13/32", "--workload-credential-secret", "ok147-workload-target-access",
+	)
+}
+
+func targetAccessLaunchPrepareArguments(template, runtimeManifest string) []string {
+	packaged := targetAccessStagePackageArguments(template, "/private/tmp/not-used-package")
+	packaged = removeArgumentWithValue(packaged, "--output")
+	arguments := append([]string{"cluster", "stage", "run", "target-access", "launch", "prepare"}, packaged[5:]...)
+	arguments = append(arguments, "--credential-materialized-at", "2026-08-17T14:00:00Z")
+	for _, credential := range []struct{ prefix, authority, tokenFile, tokenDigest, caFile, caDigest, evidence, subject string }{
+		{"ledger-job", "ok-mgmt", "/private/tmp/ledger-target-token", testSHA("1"), "/private/tmp/ledger-target-ca", testSHA("2"), testSHA("3"), "system:serviceaccount:openkubes-execution-system:ok147-ledger-writer"},
+		{"workload-writer-job", testSHA("f"), "/private/tmp/workload-writer-token", testSHA("4"), "/private/tmp/workload-writer-ca", testSHA("5"), testSHA("6"), "system:serviceaccount:kube-system:ok147-argocd-manager"},
+	} {
+		arguments = append(arguments,
+			"--"+credential.prefix+"-authority", credential.authority,
+			"--"+credential.prefix+"-token-file", credential.tokenFile, "--"+credential.prefix+"-token-digest", credential.tokenDigest,
+			"--"+credential.prefix+"-ca-file", credential.caFile, "--"+credential.prefix+"-ca-digest", credential.caDigest,
+			"--"+credential.prefix+"-tokenrequest-evidence-digest", credential.evidence,
+			"--"+credential.prefix+"-issuer", "https://kubernetes.default.svc.cluster.local", "--"+credential.prefix+"-subject", credential.subject,
+			"--"+credential.prefix+"-audiences", "https://kubernetes.default.svc",
+			"--"+credential.prefix+"-issued-at", "2026-08-17T13:59:00Z", "--"+credential.prefix+"-expires-at", "2026-08-17T14:30:00Z",
+		)
+	}
+	return append(arguments,
+		"--runtime-manifest", runtimeManifest, "--runtime-manifest-digest", digest.SHA256([]byte("bounded-runtime")),
+		"--installer-api-endpoint", "https://192.0.2.14:6443", "--installer-ca-digest", testSHA("7"),
+		"--installer-token-digest", testSHA("8"), "--installer-tokenrequest-evidence-digest", testSHA("a"),
+		"--prepared-at", "2026-08-17T14:01:00Z",
+	)
+}
+
+func targetAccessLaunchExecuteArguments(template, runtimeManifest string) []string {
+	arguments := targetAccessLaunchPrepareArguments(template, runtimeManifest)
+	arguments[5] = "execute"
+	return append(arguments,
+		"--execute", "--expected-candidate-digest", testSHA("9"),
+		"--installer-token-file", "/private/tmp/installer-token", "--installer-ca-file", "/private/tmp/installer-ca",
 	)
 }


### PR DESCRIPTION
## Summary

- add separate `target-access launch prepare` and `target-access launch execute` CLI boundaries
- reconstruct the complete package, two private Job credentials, shared runtime, and expiry-bound installer candidate from exact inputs
- keep prepare fully offline and expose only redaction-safe material and candidate receipts
- require explicit `--execute`, the separately copied candidate digest, and bounded installer token/CA files before launch
- preserve the Target Access installation authority on `ok-shared` while keeping ledger and workload writer authorities distinct

## Safety boundary

- prepare performs no API contact and cannot mutate
- execute opens only the exact verified candidate and single-use launcher
- malformed or incomplete inputs stop before executor invocation
- no update, delete, list, watch, retry, rollback, or cleanup path is added
- tests use only local fixtures and the bounded fake API

## Verification

- `GOCACHE=/private/tmp/ok147-go-build go test -ldflags=-linkmode=external ./...`
- `GOCACHE=/private/tmp/ok147-go-vet go vet ./...`
- `GOCACHE=/private/tmp/ok147-go-race go test -race -ldflags=-linkmode=external ./internal/runner ./cmd/ok`
- `git diff --check`

Jira: OK-147
