### PR TITLE
docs(runner): close target access launch checkpoint (OK-147)

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,14 +138,25 @@ Powered by [Cluster API (CAPI)](https://cluster-api.sigs.k8s.io/), [CAPK (KubeVi
   `ok cluster stage run target-access --execute` boundary now requires the
   exact six-receipt prefix, signed grant, eight independently named object
   identities, private runtime-binding digest and distinct ledger/workload
-  files before it can invoke that operation. No Job package or DEV activation
-  exists for target access at this checkpoint. A separated TLS fake-API proof
-  now covers the complete claim-to-submit path: exactly eight ordered
+  files before it can invoke that operation. A separated TLS fake-API proof
+  covers the complete claim-to-submit path: exactly eight ordered
   `GET`/conditional-`POST` pairs, durable success replay without another write,
   and a durably stopped partial prefix without retry. Its first Job-package
-  building block is also offline: one immutable ConfigMap binds the plan,
+  boundary is offline: one immutable ConfigMap binds the plan,
   signed grant, exact six-receipt prefix and eight-object artifact while
-  excluding the private runtime binding, CA and both credentials.
+  excluding the private runtime binding, CA and both credentials. A hardened
+  NetworkPolicy and non-retrying Job bind only the exact management-ledger and
+  workload API endpoints. Two distinct short-lived immutable Secrets carry the
+  ledger and workload writer credentials; only the workload Secret carries the
+  runtime-bound target identity. The shared tokenless runtime, three public
+  objects and both private Secrets are sealed behind one six-object global
+  preflight. The Job is created last, a complete exact duplicate is
+  `ALREADY_LAUNCHED`, and every other partial state stops with zero writes.
+  `ok cluster stage run target-access package` emits only a new local `0600`
+  package, `... launch prepare` emits redacted material/candidate receipts, and
+  only `... launch execute --execute` can open the exact expiry-bound installer
+  candidate. These activation paths are covered by local and fake-API tests;
+  no DEV Target Access Job has been launched by the MVP.
   Stage 4 now has its first distinct path as well:
   `ok cluster stage run enablement --execute` binds the verified three-receipt
   prefix and signed `CreateEnablement` grant to exactly one externally rendered

--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -2459,6 +2459,56 @@ only plan, authorization, artifact, target and object digests and remains
 Bundle loading still does not claim the grant, open the durable ledger, read a
 workload credential or submit any of the eight objects.
 
+## Target-access Job launch boundary
+
+The verified Target Access bundle can now be materialized as one immutable
+ConfigMap plus a deny-all NetworkPolicy and non-retrying Job. The package binds
+the exact six-receipt predecessor chain, signed `CreateTargetAccess` grant,
+eight-object workload artifact, private runtime-binding digest, immutable
+target identity, runner image and the distinct ledger/workload API endpoints.
+The private runtime binding, CA bundles and credentials are never embedded in
+the ConfigMap or exposed by its receipt.
+
+Two independently evidenced, short-lived Job credentials are reconstructed as
+immutable Secrets. The management-side ledger writer carries only token and CA
+data. The workload writer additionally carries the exact private workload
+binding, whose target UID digest, endpoint and CA must still match the package.
+The two tokens must be distinct from each other and from the installer token.
+Only redaction-safe object, authority, expiry and package digests are public.
+
+The shared tokenless ServiceAccount, public ConfigMap and NetworkPolicy, both
+private Secrets and final Job form one six-object launch plan. All six exact
+GETs complete before the first POST. The exact shared runtime alone may
+preexist, or the complete exact set may be returned as `ALREADY_LAUNCHED`.
+Every other existing or mixed state stops with zero writes. After global
+absence, the create order is ServiceAccount, ConfigMap, NetworkPolicy, ledger
+Secret, workload Secret and Job. A failed create preserves the resulting
+partial prefix and exposes no retry, update, patch, apply, delete or cleanup
+path.
+
+An expiry-bound candidate binds that plan to one exact `ok-shared` API
+endpoint, CA and independently evidenced installer-token digest. The sealed
+launch material retains all private bytes but exposes only correlated receipts.
+Opening requires the separately copied candidate digest and validates the
+bounded installer files without API contact. The opened launcher is
+single-use.
+
+The CLI preserves all three boundaries:
+
+```text
+ok cluster stage run target-access package
+        -> new local 0600 package only
+
+ok cluster stage run target-access launch prepare
+        -> redacted material and candidate receipts only
+
+ok cluster stage run target-access launch execute --execute
+        -> exact candidate + bounded installer files + single-use launch
+```
+
+The implementation is covered by offline, fake-API and race tests. This
+checkpoint did not contact a DEV cluster or launch a Target Access Job.
+
 ## Bounded convergence observation polling
 
 The aggregate observer can now be wrapped by a bounded polling observer before


### PR DESCRIPTION
## Summary

- replace the obsolete statement that Target Access has no Job package
- document the immutable package, private two-credential boundary, shared runtime, global six-object preflight, and Job-last order
- document exact duplicate/runtime-only behavior and fail-closed partial-state handling
- record the separate package, launch prepare, and launch execute CLI boundaries
- state explicitly that the checkpoint remains local/fake-API proven and has not launched a DEV Target Access Job

## Verification

- `git diff --check`
- checked that the obsolete `No Job package` statement is gone

Jira: OK-147
