### PR TITLE
OK-147: bind target credential stage

### DIFF
--- a/internal/runner/target_credential_stage_bundle.go
+++ b/internal/runner/target_credential_stage_bundle.go
@@ -1,0 +1,229 @@
+package runner
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/authorization"
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/jsonstrict"
+	"github.com/openkubes/ok-cluster/internal/projection"
+	"github.com/openkubes/ok-cluster/internal/stagecursor"
+	"github.com/openkubes/ok-cluster/internal/stageplan"
+	"github.com/openkubes/ok-cluster/internal/stagereceipt"
+	"github.com/openkubes/ok-cluster/internal/submission"
+)
+
+const (
+	TargetCredentialPolicyFormat             = "ok147-target-credential-policy/v1"
+	TargetCredentialStageBundleReceiptFormat = "ok147-target-credential-stage-bundle/v1"
+	maximumTargetCredentialPolicyBytes       = 64 * 1024
+	targetCredentialLifetimeSeconds          = 3 * 60 * 60
+)
+
+type targetCredentialServiceAccount struct {
+	Namespace string `json:"namespace"`
+	Name      string `json:"name"`
+}
+
+type targetCredentialPolicyDocument struct {
+	Format               string                         `json:"format"`
+	TargetIdentityDigest string                         `json:"targetIdentityDigest"`
+	ServiceAccount       targetCredentialServiceAccount `json:"serviceAccount"`
+	RequestedAudiences   []string                       `json:"requestedAudiences"`
+	ExpirationSeconds    int                            `json:"expirationSeconds"`
+	CredentialUse        string                         `json:"credentialUse"`
+	Retention            string                         `json:"retention"`
+	NativeRotation       bool                           `json:"nativeRotation"`
+	ProductionSuitable   bool                           `json:"productionSuitable"`
+}
+
+// TargetCredentialStageBundleConfig binds the successful seven-stage prefix,
+// the exact target-access artifact, one immutable credential policy and one
+// IssueTargetCredential grant. Loading performs no TokenRequest or API call.
+type TargetCredentialStageBundleConfig struct {
+	PlanPath                    string
+	PlanExpected                stageplan.Expected
+	Receipts                    []StageReceiptSource
+	GrantPath                   string
+	GrantPublicKeyPath          string
+	EvaluationTime              time.Time
+	PolicyPath                  string
+	TargetAccessArtifactPath    string
+	TargetAccessExpectedObjects []projection.ResourceIdentity
+}
+
+type TargetCredentialStageBundleReceipt struct {
+	Format                       string `json:"format"`
+	State                        string `json:"state"`
+	PlanDigest                   string `json:"planDigest"`
+	StageID                      string `json:"stageId"`
+	AuthorizationDigest          string `json:"authorizationDigest"`
+	PolicyDigest                 string `json:"policyDigest"`
+	TargetAccessArtifactDigest   string `json:"targetAccessArtifactDigest"`
+	TargetIdentityDigest         string `json:"targetIdentityDigest"`
+	ServiceAccountIdentityDigest string `json:"serviceAccountIdentityDigest"`
+	AudienceMode                 string `json:"audienceMode"`
+	ExpirationSeconds            int    `json:"expirationSeconds"`
+	CredentialRetention          string `json:"credentialRetention"`
+	NativeRotationClaimed        bool   `json:"nativeRotationClaimed"`
+	ProductionSuitableClaimed    bool   `json:"productionSuitableClaimed"`
+	MutationAllowed              bool   `json:"mutationAllowed"`
+}
+
+type VerifiedTargetCredentialStageBundle struct {
+	plan     stageplan.Binding
+	cursor   stagecursor.Cursor
+	prefix   []stagereceipt.Verified
+	grant    authorization.VerifiedStageGrant
+	policy   targetCredentialPolicyDocument
+	receipt  TargetCredentialStageBundleReceipt
+	verified bool
+}
+
+// LoadTargetCredentialStageBundle proves that the credential request is for
+// the ServiceAccount installed by the successful target-access predecessor.
+// The v1 policy deliberately binds server-default audience selection because
+// OK-141 disproved the earlier guessed custom audience.
+func LoadTargetCredentialStageBundle(config TargetCredentialStageBundleConfig) (VerifiedTargetCredentialStageBundle, error) {
+	if config.Receipts == nil || config.EvaluationTime.IsZero() {
+		return VerifiedTargetCredentialStageBundle{}, errors.New("target-credential receipt prefix and authorization evaluation time are required")
+	}
+	plan, cursor, prefix, err := loadStageResumeWithPrefix(StageResumeConfig{
+		PlanPath: config.PlanPath, PlanExpected: config.PlanExpected, Receipts: config.Receipts,
+	})
+	if err != nil {
+		return VerifiedTargetCredentialStageBundle{}, err
+	}
+	decision, err := cursor.Decision()
+	if err != nil || decision.State != "NEXT" || decision.StageID != "target-credential" || decision.Kind != "Credential" || decision.Authority != "workload" || !decision.RequiresAuthorization || decision.Operation != "IssueTargetCredential" {
+		return VerifiedTargetCredentialStageBundle{}, errors.New("verified prefix does not select target credential issuance")
+	}
+	if len(prefix) != 7 {
+		return VerifiedTargetCredentialStageBundle{}, errors.New("target credential requires the exact seven-receipt prefix")
+	}
+	lifecycle, err := prefix[1].Receipt()
+	if err != nil || lifecycle.StageID != "cluster-lifecycle" || !stageReceiptPrefixDigestPattern.MatchString(lifecycle.TargetClusterUIDDigest) {
+		return VerifiedTargetCredentialStageBundle{}, errors.New("target credential lacks durable workload identity")
+	}
+	targetAccessReceipt, err := prefix[6].Receipt()
+	if err != nil || targetAccessReceipt.StageID != "target-access" || targetAccessReceipt.State != "SUCCEEDED" || targetAccessReceipt.MutationState != "ATTEMPTED" {
+		return VerifiedTargetCredentialStageBundle{}, errors.New("target credential lacks successful target-access installation")
+	}
+	targetAccessStage, _, err := plan.Stage("target-access")
+	if err != nil || len(targetAccessStage.Inputs) != 1 || targetAccessStage.Inputs[0].Name != "stage.target-access" {
+		return VerifiedTargetCredentialStageBundle{}, errors.New("target-access stage must bind exactly one renderer artifact")
+	}
+	access, err := submission.LoadTargetAccess(config.TargetAccessArtifactPath, submission.TargetAccessExpected{
+		ArtifactDigest: targetAccessStage.Inputs[0].Digest, ContractIdentity: plan.ContractIdentity,
+		IntentRevision: plan.IntentRevision, PlatformRevision: plan.PlatformRevision, ExecutionFixture: plan.ExecutionFixture,
+		TargetIdentityDigest: lifecycle.TargetClusterUIDDigest, WorkloadAuthority: lifecycle.TargetClusterUIDDigest,
+		Objects: config.TargetAccessExpectedObjects,
+	})
+	if err != nil {
+		return VerifiedTargetCredentialStageBundle{}, err
+	}
+	if len(access.Workload.Objects) != 8 || access.Workload.Objects[1].Identity.Kind != "ServiceAccount" {
+		return VerifiedTargetCredentialStageBundle{}, errors.New("target-access artifact lacks the credential ServiceAccount")
+	}
+	credentialStage, _, err := plan.Stage("target-credential")
+	if err != nil || len(credentialStage.Inputs) != 1 || credentialStage.Inputs[0].Name != "stage.target-credential" {
+		return VerifiedTargetCredentialStageBundle{}, errors.New("target-credential stage must bind exactly one policy artifact")
+	}
+	policyRaw, err := readBoundedRegular(config.PolicyPath, maximumTargetCredentialPolicyBytes)
+	if err != nil {
+		return VerifiedTargetCredentialStageBundle{}, errors.New("read bounded target-credential policy")
+	}
+	if digest.SHA256(policyRaw) != credentialStage.Inputs[0].Digest {
+		return VerifiedTargetCredentialStageBundle{}, errors.New("target-credential policy digest differs from staged input")
+	}
+	var policy targetCredentialPolicyDocument
+	if err := jsonstrict.Decode(policyRaw, &policy); err != nil {
+		return VerifiedTargetCredentialStageBundle{}, fmt.Errorf("decode target-credential policy: %w", err)
+	}
+	serviceAccount := access.Workload.Objects[1].Identity
+	if err := validateTargetCredentialPolicy(policy, lifecycle.TargetClusterUIDDigest, serviceAccount); err != nil {
+		return VerifiedTargetCredentialStageBundle{}, err
+	}
+	directPredecessors, err := cursor.Predecessors()
+	if err != nil {
+		return VerifiedTargetCredentialStageBundle{}, err
+	}
+	grant, err := authorization.LoadStage(config.GrantPath, config.GrantPublicKeyPath, plan, "target-credential", directPredecessors, config.EvaluationTime)
+	if err != nil {
+		return VerifiedTargetCredentialStageBundle{}, err
+	}
+	if _, err := authorization.BindStageGrant(grant, plan, "target-credential", directPredecessors); err != nil {
+		return VerifiedTargetCredentialStageBundle{}, err
+	}
+	identityRaw, _ := json.Marshal(serviceAccount)
+	receipt := TargetCredentialStageBundleReceipt{
+		Format: TargetCredentialStageBundleReceiptFormat, State: "VERIFIED", PlanDigest: plan.PlanDigest,
+		StageID: "target-credential", AuthorizationDigest: grant.Receipt().AuthorizationDigest,
+		PolicyDigest: credentialStage.Inputs[0].Digest, TargetAccessArtifactDigest: targetAccessStage.Inputs[0].Digest,
+		TargetIdentityDigest: lifecycle.TargetClusterUIDDigest, ServiceAccountIdentityDigest: digest.SHA256(identityRaw),
+		AudienceMode: "server-default", ExpirationSeconds: policy.ExpirationSeconds,
+		CredentialRetention: policy.Retention, NativeRotationClaimed: policy.NativeRotation,
+		ProductionSuitableClaimed: policy.ProductionSuitable, MutationAllowed: false,
+	}
+	return VerifiedTargetCredentialStageBundle{
+		plan: plan, cursor: cursor, prefix: prefix, grant: grant, policy: policy, receipt: receipt, verified: true,
+	}, nil
+}
+
+func validateTargetCredentialPolicy(policy targetCredentialPolicyDocument, targetIdentity string, serviceAccount projection.ResourceIdentity) error {
+	if policy.Format != TargetCredentialPolicyFormat || policy.TargetIdentityDigest != targetIdentity {
+		return errors.New("target-credential policy target identity differs from verified workload")
+	}
+	if policy.ServiceAccount.Namespace != serviceAccount.Namespace || policy.ServiceAccount.Name != serviceAccount.Name || serviceAccount.APIVersion != "v1" || serviceAccount.Kind != "ServiceAccount" {
+		return errors.New("target-credential ServiceAccount differs from target-access artifact")
+	}
+	if len(policy.RequestedAudiences) != 0 {
+		return errors.New("target-credential v1 requires server-default audience selection")
+	}
+	if policy.ExpirationSeconds != targetCredentialLifetimeSeconds || policy.CredentialUse != "argocd-target-registration" || policy.Retention != "memory-only" {
+		return errors.New("target-credential lifetime, use, or retention boundary is invalid")
+	}
+	if policy.NativeRotation || policy.ProductionSuitable {
+		return errors.New("target-credential v1 cannot claim native rotation or production suitability")
+	}
+	if strings.TrimSpace(policy.ServiceAccount.Name) != policy.ServiceAccount.Name || strings.TrimSpace(policy.ServiceAccount.Namespace) != policy.ServiceAccount.Namespace {
+		return errors.New("target-credential ServiceAccount identity is invalid")
+	}
+	return nil
+}
+
+func (bundle VerifiedTargetCredentialStageBundle) Decision() (stagecursor.Decision, error) {
+	if err := verifyTargetCredentialStageBundle(bundle); err != nil {
+		return stagecursor.Decision{}, err
+	}
+	return bundle.cursor.Decision()
+}
+
+func (bundle VerifiedTargetCredentialStageBundle) Receipt() (TargetCredentialStageBundleReceipt, error) {
+	if err := verifyTargetCredentialStageBundle(bundle); err != nil {
+		return TargetCredentialStageBundleReceipt{}, err
+	}
+	return bundle.receipt, nil
+}
+
+func verifyTargetCredentialStageBundle(bundle VerifiedTargetCredentialStageBundle) error {
+	if !bundle.verified || bundle.receipt.Format != TargetCredentialStageBundleReceiptFormat || bundle.receipt.State != "VERIFIED" || bundle.receipt.StageID != "target-credential" || bundle.receipt.MutationAllowed || len(bundle.prefix) != 7 {
+		return errors.New("target-credential stage bundle was not produced by verification")
+	}
+	for _, value := range []string{
+		bundle.receipt.PlanDigest, bundle.receipt.AuthorizationDigest, bundle.receipt.PolicyDigest,
+		bundle.receipt.TargetAccessArtifactDigest, bundle.receipt.TargetIdentityDigest, bundle.receipt.ServiceAccountIdentityDigest,
+	} {
+		if !stageReceiptPrefixDigestPattern.MatchString(value) {
+			return errors.New("target-credential stage bundle digest identity is invalid")
+		}
+	}
+	if bundle.receipt.AudienceMode != "server-default" || bundle.receipt.ExpirationSeconds != targetCredentialLifetimeSeconds || bundle.receipt.CredentialRetention != "memory-only" || bundle.receipt.NativeRotationClaimed || bundle.receipt.ProductionSuitableClaimed {
+		return errors.New("target-credential stage bundle claim boundary changed after verification")
+	}
+	return nil
+}

--- a/internal/runner/target_credential_stage_bundle_test.go
+++ b/internal/runner/target_credential_stage_bundle_test.go
@@ -1,0 +1,171 @@
+package runner
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/projection"
+	"github.com/openkubes/ok-cluster/internal/stageplan"
+	"github.com/openkubes/ok-cluster/internal/stagereceipt"
+)
+
+func TestLoadTargetCredentialStageBundleBindsPrefixPolicyGrantAndAccessIdentity(t *testing.T) {
+	fixture := targetCredentialBundleFixture(t)
+	bundle, err := LoadTargetCredentialStageBundle(fixture.config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decision, err := bundle.Decision()
+	if err != nil || decision.StageID != "target-credential" || decision.Kind != "Credential" || decision.Operation != "IssueTargetCredential" || decision.Authority != "workload" || !decision.RequiresAuthorization {
+		t.Fatalf("unexpected target-credential decision: %#v %v", decision, err)
+	}
+	receipt, err := bundle.Receipt()
+	if err != nil || receipt.Format != TargetCredentialStageBundleReceiptFormat || receipt.State != "VERIFIED" || receipt.PlanDigest != fixture.plan.PlanDigest || receipt.PolicyDigest != fixture.policyDigest || receipt.TargetAccessArtifactDigest != fixture.accessDigest || receipt.TargetIdentityDigest != digest.SHA256([]byte(targetAccessRuntimeUID)) || receipt.AuthorizationDigest == "" || receipt.ServiceAccountIdentityDigest == "" || receipt.AudienceMode != "server-default" || receipt.ExpirationSeconds != 10800 || receipt.CredentialRetention != "memory-only" || receipt.NativeRotationClaimed || receipt.ProductionSuitableClaimed || receipt.MutationAllowed {
+		t.Fatalf("unexpected target-credential receipt: %#v %v", receipt, err)
+	}
+}
+
+func TestLoadTargetCredentialStageBundleFailsClosed(t *testing.T) {
+	tests := map[string]func(*targetCredentialBundleTestFixture){
+		"implicit prefix":   func(f *targetCredentialBundleTestFixture) { f.config.Receipts = nil },
+		"incomplete prefix": func(f *targetCredentialBundleTestFixture) { f.config.Receipts = f.config.Receipts[:6] },
+		"changed policy": func(f *targetCredentialBundleTestFixture) {
+			raw, _ := os.ReadFile(f.config.PolicyPath)
+			_ = os.WriteFile(f.config.PolicyPath, append(raw, '\n'), 0o600)
+		},
+		"changed target access": func(f *targetCredentialBundleTestFixture) {
+			raw, _ := os.ReadFile(f.config.TargetAccessArtifactPath)
+			_ = os.WriteFile(f.config.TargetAccessArtifactPath, append(raw, '\n'), 0o600)
+		},
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			fixture := targetCredentialBundleFixture(t)
+			mutate(&fixture)
+			if _, err := LoadTargetCredentialStageBundle(fixture.config); err == nil {
+				t.Fatal("changed target-credential input was accepted")
+			}
+		})
+	}
+
+	if _, err := (VerifiedTargetCredentialStageBundle{}).Decision(); err == nil {
+		t.Fatal("unverified target-credential bundle exposed a decision")
+	}
+	if _, err := (VerifiedTargetCredentialStageBundle{}).Receipt(); err == nil {
+		t.Fatal("unverified target-credential bundle exposed a receipt")
+	}
+}
+
+func TestValidateTargetCredentialPolicyFailsClosed(t *testing.T) {
+	target := digest.SHA256([]byte(targetAccessRuntimeUID))
+	serviceAccount := projection.ResourceIdentity{APIVersion: "v1", Kind: "ServiceAccount", Namespace: "kube-system", Name: "ok147-argocd-manager"}
+	valid := func() targetCredentialPolicyDocument {
+		return targetCredentialPolicyDocument{
+			Format: TargetCredentialPolicyFormat, TargetIdentityDigest: target,
+			ServiceAccount:     targetCredentialServiceAccount{Namespace: serviceAccount.Namespace, Name: serviceAccount.Name},
+			RequestedAudiences: []string{}, ExpirationSeconds: 10800,
+			CredentialUse: "argocd-target-registration", Retention: "memory-only",
+		}
+	}
+	if err := validateTargetCredentialPolicy(valid(), target, serviceAccount); err != nil {
+		t.Fatal(err)
+	}
+	policyTests := map[string]func(*targetCredentialPolicyDocument){
+		"foreign target":          func(p *targetCredentialPolicyDocument) { p.TargetIdentityDigest = runnerStageSHA("f") },
+		"foreign service account": func(p *targetCredentialPolicyDocument) { p.ServiceAccount.Name = "foreign-manager" },
+		"guessed audience":        func(p *targetCredentialPolicyDocument) { p.RequestedAudiences = []string{"https://guessed.invalid"} },
+		"long lifetime":           func(p *targetCredentialPolicyDocument) { p.ExpirationSeconds++ },
+		"disk retention":          func(p *targetCredentialPolicyDocument) { p.Retention = "file" },
+		"rotation claim":          func(p *targetCredentialPolicyDocument) { p.NativeRotation = true },
+		"production claim":        func(p *targetCredentialPolicyDocument) { p.ProductionSuitable = true },
+	}
+	for name, mutate := range policyTests {
+		t.Run(name, func(t *testing.T) {
+			policy := valid()
+			mutate(&policy)
+			if err := validateTargetCredentialPolicy(policy, target, serviceAccount); err == nil {
+				t.Fatal("invalid target-credential policy was accepted")
+			}
+		})
+	}
+}
+
+type targetCredentialBundleTestFixture struct {
+	config       TargetCredentialStageBundleConfig
+	plan         stageplan.Binding
+	policyDigest string
+	accessDigest string
+}
+
+func targetCredentialBundleFixture(t *testing.T) targetCredentialBundleTestFixture {
+	t.Helper()
+	root := t.TempDir()
+	at := time.Date(2026, 8, 17, 16, 0, 0, 0, time.UTC)
+	expected := stageplan.Expected{
+		ContractIdentity: runnerStagedPlan(t).ContractIdentity,
+		IntentRevision:   runnerStageSHA("a"), EnablementRevision: runnerStageSHA("b"), PlatformRevision: runnerStageSHA("c"), ExecutionFixture: runnerStageSHA("d"),
+		InfrastructureAuthority: "ok-infra", ManagementAuthority: "ok-mgmt", GitOpsAuthority: "ok-shared",
+	}
+	access := runnerTargetAccessYAML()
+	accessDigest := digest.SHA256(access)
+	policy := targetCredentialPolicyDocument{
+		Format: TargetCredentialPolicyFormat, TargetIdentityDigest: digest.SHA256([]byte(targetAccessRuntimeUID)),
+		ServiceAccount:     targetCredentialServiceAccount{Namespace: "kube-system", Name: "ok147-argocd-manager"},
+		RequestedAudiences: []string{}, ExpirationSeconds: 10800, CredentialUse: "argocd-target-registration",
+		Retention: "memory-only", NativeRotation: false, ProductionSuitable: false,
+	}
+	policyRaw, _ := json.Marshal(policy)
+	policyDigest := digest.SHA256(policyRaw)
+	planRaw := submissionBundlePlan(t, expected, runnerStageSHA("1"), runnerStageSHA("2"))
+	var document map[string]any
+	if err := json.Unmarshal(planRaw, &document); err != nil {
+		t.Fatal(err)
+	}
+	stages := document["stages"].([]any)
+	stages[6].(map[string]any)["inputs"] = []any{map[string]any{"name": "stage.target-access", "digest": accessDigest}}
+	stages[7].(map[string]any)["inputs"] = []any{map[string]any{"name": "stage.target-credential", "digest": policyDigest}}
+	planPath := writeBundleFile(t, root, "staged-plan.json", mustJSON(t, document))
+	plan, err := stageplan.Load(planPath, expected)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	receipts := make([]StageReceiptSource, 0, 7)
+	predecessors := []stagereceipt.Verified{}
+	results := []struct{ id, mutation, operation, evidence string }{
+		{"provider-prerequisites", "ATTEMPTED", runnerStageSHA("1"), runnerStageSHA("2")},
+		{"cluster-lifecycle", "ATTEMPTED", runnerStageSHA("3"), runnerStageSHA("4")},
+		{"lifecycle-observation", "NOT_APPLICABLE", "", runnerStageSHA("5")},
+		{"enablement", "ATTEMPTED", runnerStageSHA("6"), runnerStageSHA("7")},
+		{"network-observation", "NOT_APPLICABLE", "", runnerStageSHA("9")},
+		{"runtime-binding", "NOT_APPLICABLE", "", runnerStageSHA("0")},
+		{"target-access", "ATTEMPTED", runnerStageSHA("e"), runnerStageSHA("f")},
+	}
+	for index, result := range results {
+		var receipt stagereceipt.Verified
+		if result.id == "cluster-lifecycle" {
+			receipt, err = stagereceipt.NewWithTargetClusterUIDDigest(plan, result.id, predecessors, "SUCCEEDED", result.mutation, result.operation, result.evidence, digest.SHA256([]byte(targetAccessRuntimeUID)), at.Add(time.Duration(index-7)*time.Minute))
+		} else {
+			receipt, err = stagereceipt.New(plan, result.id, predecessors, "SUCCEEDED", result.mutation, result.operation, result.evidence, at.Add(time.Duration(index-7)*time.Minute))
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		receipts = appendStageReceipt(t, root, receipts, receipt, result.id+".json")
+		predecessors = []stagereceipt.Verified{receipt}
+	}
+	grantPath, keyPath := writeSubmissionStageGrant(t, root, plan, "target-credential", predecessors, at)
+	return targetCredentialBundleTestFixture{
+		config: TargetCredentialStageBundleConfig{
+			PlanPath: planPath, PlanExpected: expected, Receipts: receipts,
+			GrantPath: grantPath, GrantPublicKeyPath: keyPath, EvaluationTime: at,
+			PolicyPath:                  writeBundleFile(t, root, "target-credential.json", policyRaw),
+			TargetAccessArtifactPath:    writeBundleFile(t, root, "target-access.yaml", access),
+			TargetAccessExpectedObjects: runnerTargetAccessIdentities(),
+		},
+		plan: plan, policyDigest: policyDigest, accessDigest: accessDigest,
+	}
+}


### PR DESCRIPTION
## What changed

- add a verified offline bundle for the `target-credential` stage
- bind the exact seven-receipt prefix, `IssueTargetCredential` grant, target-access artifact, workload identity, and credential policy
- require the ServiceAccount installed by the preceding target-access stage
- bind a three-hour, memory-only, server-default-audience DEV credential without claiming native rotation or production suitability

## Why

Stage 8 must not issue an arbitrary token or absorb target registration. This checkpoint establishes the complete fail-closed pre-request boundary while performing no API call and retaining no credential bytes.

## Validation

- `GOCACHE=/private/tmp/ok147-go-build go test -ldflags=-linkmode=external ./...`
- `GOCACHE=/private/tmp/ok147-go-vet go vet ./...`
- `GOCACHE=/private/tmp/ok147-go-race go test -race -ldflags=-linkmode=external ./internal/runner ./cmd/ok`
