### PR TITLE
OK-147: bind target registration stage

### DIFF
--- a/internal/runner/target_registration_stage_bundle.go
+++ b/internal/runner/target_registration_stage_bundle.go
@@ -1,0 +1,145 @@
+package runner
+
+import (
+	"errors"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/authorization"
+	"github.com/openkubes/ok-cluster/internal/stagecursor"
+	"github.com/openkubes/ok-cluster/internal/stageplan"
+	"github.com/openkubes/ok-cluster/internal/stagereceipt"
+	"github.com/openkubes/ok-cluster/internal/submission"
+)
+
+const TargetRegistrationStageBundleReceiptFormat = "ok147-target-registration-stage-bundle/v1"
+
+type TargetRegistrationStageBundleConfig struct {
+	PlanPath           string
+	PlanExpected       stageplan.Expected
+	Receipts           []StageReceiptSource
+	GrantPath          string
+	GrantPublicKeyPath string
+	EvaluationTime     time.Time
+	ArtifactPath       string
+	Expected           submission.TargetRegistrationExpected
+}
+
+type TargetRegistrationStageBundleReceipt struct {
+	Format                     string `json:"format"`
+	State                      string `json:"state"`
+	PlanDigest                 string `json:"planDigest"`
+	StageID                    string `json:"stageId"`
+	AuthorizationDigest        string `json:"authorizationDigest"`
+	ArtifactDigest             string `json:"artifactDigest"`
+	TargetIdentityDigest       string `json:"targetIdentityDigest"`
+	ProjectDigest              string `json:"projectDigest"`
+	RegistrationTemplateDigest string `json:"registrationTemplateDigest"`
+	Authority                  string `json:"authority"`
+	CredentialMaterialPresent  bool   `json:"credentialMaterialPresent"`
+	MutationAllowed            bool   `json:"mutationAllowed"`
+}
+
+type VerifiedTargetRegistrationStageBundle struct {
+	plan       stageplan.Binding
+	cursor     stagecursor.Cursor
+	prefix     []stagereceipt.Verified
+	grant      authorization.VerifiedStageGrant
+	projection submission.TargetRegistrationPlan
+	receipt    TargetRegistrationStageBundleReceipt
+	verified   bool
+}
+
+// LoadTargetRegistrationStageBundle verifies the eight-stage predecessor
+// chain, exact GitOps projection and RegisterTarget grant without opening the
+// in-memory target credential or contacting either Kubernetes API.
+func LoadTargetRegistrationStageBundle(config TargetRegistrationStageBundleConfig) (VerifiedTargetRegistrationStageBundle, error) {
+	if config.Receipts == nil || config.EvaluationTime.IsZero() {
+		return VerifiedTargetRegistrationStageBundle{}, errors.New("target-registration receipt prefix and authorization evaluation time are required")
+	}
+	plan, cursor, prefix, err := loadStageResumeWithPrefix(StageResumeConfig{
+		PlanPath: config.PlanPath, PlanExpected: config.PlanExpected, Receipts: config.Receipts,
+	})
+	if err != nil {
+		return VerifiedTargetRegistrationStageBundle{}, err
+	}
+	decision, err := cursor.Decision()
+	if err != nil || decision.State != "NEXT" || decision.StageID != "target-registration" || decision.Kind != "Submission" || decision.Authority != "gitops" || !decision.RequiresAuthorization || decision.Operation != "RegisterTarget" {
+		return VerifiedTargetRegistrationStageBundle{}, errors.New("verified prefix does not select target registration")
+	}
+	if len(prefix) != 8 {
+		return VerifiedTargetRegistrationStageBundle{}, errors.New("target registration requires the exact eight-receipt prefix")
+	}
+	lifecycle, err := prefix[1].Receipt()
+	if err != nil || lifecycle.StageID != "cluster-lifecycle" || !stageReceiptPrefixDigestPattern.MatchString(lifecycle.TargetClusterUIDDigest) {
+		return VerifiedTargetRegistrationStageBundle{}, errors.New("target registration lacks durable workload identity")
+	}
+	credential, err := prefix[7].Receipt()
+	if err != nil || credential.StageID != "target-credential" || credential.State != "SUCCEEDED" || credential.MutationState != "ATTEMPTED" {
+		return VerifiedTargetRegistrationStageBundle{}, errors.New("target registration lacks successful credential issuance")
+	}
+	stage, _, err := plan.Stage("target-registration")
+	if err != nil || len(stage.Inputs) != 1 || stage.Inputs[0].Name != "stage.target-registration" {
+		return VerifiedTargetRegistrationStageBundle{}, errors.New("target-registration stage must bind exactly one projection artifact")
+	}
+	expected := config.Expected
+	if expected.ArtifactDigest != stage.Inputs[0].Digest || expected.ContractIdentity != plan.ContractIdentity || expected.IntentRevision != plan.IntentRevision || expected.PlatformRevision != plan.PlatformRevision || expected.ExecutionFixture != plan.ExecutionFixture || expected.TargetIdentityDigest != lifecycle.TargetClusterUIDDigest || expected.ArgoAuthority != plan.Authorities.GitOps {
+		return VerifiedTargetRegistrationStageBundle{}, errors.New("target-registration expected identities differ from verified stage plan")
+	}
+	projected, err := submission.LoadTargetRegistration(config.ArtifactPath, expected)
+	if err != nil {
+		return VerifiedTargetRegistrationStageBundle{}, err
+	}
+	directPredecessors, err := cursor.Predecessors()
+	if err != nil {
+		return VerifiedTargetRegistrationStageBundle{}, err
+	}
+	grant, err := authorization.LoadStage(config.GrantPath, config.GrantPublicKeyPath, plan, "target-registration", directPredecessors, config.EvaluationTime)
+	if err != nil {
+		return VerifiedTargetRegistrationStageBundle{}, err
+	}
+	if _, err := authorization.BindStageGrant(grant, plan, "target-registration", directPredecessors); err != nil {
+		return VerifiedTargetRegistrationStageBundle{}, err
+	}
+	receipt := TargetRegistrationStageBundleReceipt{
+		Format: TargetRegistrationStageBundleReceiptFormat, State: "VERIFIED", PlanDigest: plan.PlanDigest,
+		StageID: "target-registration", AuthorizationDigest: grant.Receipt().AuthorizationDigest,
+		ArtifactDigest: projected.ArtifactDigest, TargetIdentityDigest: projected.TargetIdentityDigest,
+		ProjectDigest: projected.Project.Digest, RegistrationTemplateDigest: projected.Registration.Digest,
+		Authority: projected.Authority, CredentialMaterialPresent: false, MutationAllowed: false,
+	}
+	return VerifiedTargetRegistrationStageBundle{
+		plan: plan, cursor: cursor, prefix: prefix, grant: grant, projection: projected, receipt: receipt, verified: true,
+	}, nil
+}
+
+func (bundle VerifiedTargetRegistrationStageBundle) Decision() (stagecursor.Decision, error) {
+	if err := verifyTargetRegistrationStageBundle(bundle); err != nil {
+		return stagecursor.Decision{}, err
+	}
+	return bundle.cursor.Decision()
+}
+
+func (bundle VerifiedTargetRegistrationStageBundle) Receipt() (TargetRegistrationStageBundleReceipt, error) {
+	if err := verifyTargetRegistrationStageBundle(bundle); err != nil {
+		return TargetRegistrationStageBundleReceipt{}, err
+	}
+	return bundle.receipt, nil
+}
+
+func verifyTargetRegistrationStageBundle(bundle VerifiedTargetRegistrationStageBundle) error {
+	if !bundle.verified || bundle.receipt.Format != TargetRegistrationStageBundleReceiptFormat || bundle.receipt.State != "VERIFIED" || bundle.receipt.StageID != "target-registration" || bundle.receipt.CredentialMaterialPresent || bundle.receipt.MutationAllowed || len(bundle.prefix) != 8 {
+		return errors.New("target-registration stage bundle was not produced by verification")
+	}
+	for _, value := range []string{
+		bundle.receipt.PlanDigest, bundle.receipt.AuthorizationDigest, bundle.receipt.ArtifactDigest,
+		bundle.receipt.TargetIdentityDigest, bundle.receipt.ProjectDigest, bundle.receipt.RegistrationTemplateDigest,
+	} {
+		if !stageReceiptPrefixDigestPattern.MatchString(value) {
+			return errors.New("target-registration stage bundle digest identity is invalid")
+		}
+	}
+	if bundle.receipt.Authority == "" || bundle.projection.Authority != bundle.receipt.Authority || bundle.projection.TargetIdentityDigest != bundle.receipt.TargetIdentityDigest {
+		return errors.New("target-registration stage bundle identity changed after verification")
+	}
+	return nil
+}

--- a/internal/runner/target_registration_stage_bundle_test.go
+++ b/internal/runner/target_registration_stage_bundle_test.go
@@ -1,0 +1,177 @@
+package runner
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/contract"
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/stageplan"
+	"github.com/openkubes/ok-cluster/internal/stagereceipt"
+	"github.com/openkubes/ok-cluster/internal/submission"
+)
+
+func TestLoadTargetRegistrationStageBundleBindsPrefixGrantProjectionAndAuthority(t *testing.T) {
+	fixture := targetRegistrationBundleFixture(t)
+	bundle, err := LoadTargetRegistrationStageBundle(fixture.config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decision, err := bundle.Decision()
+	if err != nil || decision.StageID != "target-registration" || decision.Kind != "Submission" || decision.Operation != "RegisterTarget" || decision.Authority != "gitops" || !decision.RequiresAuthorization {
+		t.Fatalf("unexpected target-registration decision: %#v %v", decision, err)
+	}
+	receipt, err := bundle.Receipt()
+	if err != nil || receipt.Format != TargetRegistrationStageBundleReceiptFormat || receipt.State != "VERIFIED" || receipt.PlanDigest != fixture.plan.PlanDigest || receipt.ArtifactDigest != fixture.artifactDigest || receipt.TargetIdentityDigest != digest.SHA256([]byte(targetAccessRuntimeUID)) || receipt.AuthorizationDigest == "" || receipt.ProjectDigest == "" || receipt.RegistrationTemplateDigest == "" || receipt.Authority != "ok-shared" || receipt.CredentialMaterialPresent || receipt.MutationAllowed {
+		t.Fatalf("unexpected target-registration receipt: %#v %v", receipt, err)
+	}
+}
+
+func TestLoadTargetRegistrationStageBundleFailsClosed(t *testing.T) {
+	tests := map[string]func(*targetRegistrationBundleTestFixture){
+		"implicit prefix":   func(f *targetRegistrationBundleTestFixture) { f.config.Receipts = nil },
+		"incomplete prefix": func(f *targetRegistrationBundleTestFixture) { f.config.Receipts = f.config.Receipts[:7] },
+		"changed artifact": func(f *targetRegistrationBundleTestFixture) {
+			raw, _ := os.ReadFile(f.config.ArtifactPath)
+			_ = os.WriteFile(f.config.ArtifactPath, append(raw, '\n'), 0o600)
+		},
+		"foreign target": func(f *targetRegistrationBundleTestFixture) {
+			f.config.Expected.TargetIdentityDigest = runnerStageSHA("f")
+		},
+		"foreign authority": func(f *targetRegistrationBundleTestFixture) { f.config.Expected.ArgoAuthority = "foreign-gitops" },
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			fixture := targetRegistrationBundleFixture(t)
+			mutate(&fixture)
+			if _, err := LoadTargetRegistrationStageBundle(fixture.config); err == nil {
+				t.Fatal("invalid target-registration bundle was accepted")
+			}
+		})
+	}
+	if _, err := (VerifiedTargetRegistrationStageBundle{}).Decision(); err == nil {
+		t.Fatal("unverified target-registration bundle exposed decision")
+	}
+	if _, err := (VerifiedTargetRegistrationStageBundle{}).Receipt(); err == nil {
+		t.Fatal("unverified target-registration bundle exposed receipt")
+	}
+}
+
+type targetRegistrationBundleTestFixture struct {
+	config         TargetRegistrationStageBundleConfig
+	plan           stageplan.Binding
+	artifactDigest string
+}
+
+func targetRegistrationBundleFixture(t *testing.T) targetRegistrationBundleTestFixture {
+	t.Helper()
+	root := t.TempDir()
+	at := time.Date(2026, 8, 17, 18, 0, 0, 0, time.UTC)
+	expectedPlan := stageplan.Expected{
+		ContractIdentity: contract.Identity{Namespace: "disposable-ok147", Name: "disposable-ok147"},
+		IntentRevision:   runnerStageSHA("a"), EnablementRevision: runnerStageSHA("b"), PlatformRevision: runnerStageSHA("c"), ExecutionFixture: runnerStageSHA("d"),
+		InfrastructureAuthority: "ok-infra", ManagementAuthority: "ok-mgmt", GitOpsAuthority: "ok-shared",
+	}
+	access := runnerTargetAccessYAML()
+	policy := targetCredentialPolicyDocument{
+		Format: TargetCredentialPolicyFormat, TargetIdentityDigest: digest.SHA256([]byte(targetAccessRuntimeUID)),
+		ServiceAccount:     targetCredentialServiceAccount{Namespace: "kube-system", Name: "ok147-argocd-manager"},
+		RequestedAudiences: []string{}, ExpirationSeconds: 10800, CredentialUse: "argocd-target-registration", Retention: "memory-only",
+	}
+	policyRaw, _ := json.Marshal(policy)
+	registration := runnerTargetRegistrationYAML(expectedPlan)
+	artifactDigest := digest.SHA256(registration)
+	planRaw := submissionBundlePlan(t, expectedPlan, runnerStageSHA("1"), runnerStageSHA("2"))
+	var document map[string]any
+	if err := json.Unmarshal(planRaw, &document); err != nil {
+		t.Fatal(err)
+	}
+	stages := document["stages"].([]any)
+	stages[6].(map[string]any)["inputs"] = []any{map[string]any{"name": "stage.target-access", "digest": digest.SHA256(access)}}
+	stages[7].(map[string]any)["inputs"] = []any{map[string]any{"name": "stage.target-credential", "digest": digest.SHA256(policyRaw)}}
+	stages[8].(map[string]any)["inputs"] = []any{map[string]any{"name": "stage.target-registration", "digest": artifactDigest}}
+	planPath := writeBundleFile(t, root, "staged-plan.json", mustJSON(t, document))
+	plan, err := stageplan.Load(planPath, expectedPlan)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	receipts := make([]StageReceiptSource, 0, 8)
+	predecessors := []stagereceipt.Verified{}
+	results := []struct{ id, mutation, operation, evidence string }{
+		{"provider-prerequisites", "ATTEMPTED", runnerStageSHA("1"), runnerStageSHA("2")},
+		{"cluster-lifecycle", "ATTEMPTED", runnerStageSHA("3"), runnerStageSHA("4")},
+		{"lifecycle-observation", "NOT_APPLICABLE", "", runnerStageSHA("5")},
+		{"enablement", "ATTEMPTED", runnerStageSHA("6"), runnerStageSHA("7")},
+		{"network-observation", "NOT_APPLICABLE", "", runnerStageSHA("9")},
+		{"runtime-binding", "NOT_APPLICABLE", "", runnerStageSHA("0")},
+		{"target-access", "ATTEMPTED", runnerStageSHA("e"), runnerStageSHA("f")},
+		{"target-credential", "ATTEMPTED", runnerStageSHA("8"), runnerStageSHA("a")},
+	}
+	for index, result := range results {
+		var receipt stagereceipt.Verified
+		if result.id == "cluster-lifecycle" {
+			receipt, err = stagereceipt.NewWithTargetClusterUIDDigest(plan, result.id, predecessors, "SUCCEEDED", result.mutation, result.operation, result.evidence, digest.SHA256([]byte(targetAccessRuntimeUID)), at.Add(time.Duration(index-8)*time.Minute))
+		} else {
+			receipt, err = stagereceipt.New(plan, result.id, predecessors, "SUCCEEDED", result.mutation, result.operation, result.evidence, at.Add(time.Duration(index-8)*time.Minute))
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		receipts = appendStageReceipt(t, root, receipts, receipt, result.id+".json")
+		predecessors = []stagereceipt.Verified{receipt}
+	}
+	grantPath, keyPath := writeSubmissionStageGrant(t, root, plan, "target-registration", predecessors, at)
+	expectedRegistration := submission.TargetRegistrationExpected{
+		ArtifactDigest: artifactDigest, ContractIdentity: expectedPlan.ContractIdentity,
+		IntentRevision: expectedPlan.IntentRevision, PlatformRevision: expectedPlan.PlatformRevision, ExecutionFixture: expectedPlan.ExecutionFixture,
+		TargetIdentityDigest: digest.SHA256([]byte(targetAccessRuntimeUID)), ArgoAuthority: "ok-shared", ArgoNamespace: "argocd",
+		ProjectName: "openkubes-disposable", RegistrationName: "disposable-ok147-cluster", TargetName: "disposable-ok147",
+		SourceRepository: "https://github.com/openkubes/ok-observability.git", TargetNamespaces: []string{"ok-observability", "kube-system"},
+	}
+	return targetRegistrationBundleTestFixture{
+		config: TargetRegistrationStageBundleConfig{
+			PlanPath: planPath, PlanExpected: expectedPlan, Receipts: receipts,
+			GrantPath: grantPath, GrantPublicKeyPath: keyPath, EvaluationTime: at,
+			ArtifactPath: writeBundleFile(t, root, "target-registration.yaml", registration), Expected: expectedRegistration,
+		},
+		plan: plan, artifactDigest: artifactDigest,
+	}
+}
+
+func runnerTargetRegistrationYAML(expected stageplan.Expected) []byte {
+	annotations := map[string]any{
+		"openkubes.io/intent-revision": expected.IntentRevision, "openkubes.io/platform-revision": expected.PlatformRevision,
+		"openkubes.io/execution-fixture": expected.ExecutionFixture, "openkubes.io/target-identity-digest": digest.SHA256([]byte(targetAccessRuntimeUID)),
+	}
+	project := map[string]any{
+		"apiVersion": "argoproj.io/v1alpha1", "kind": "AppProject",
+		"metadata": map[string]any{"name": "openkubes-disposable", "namespace": "argocd", "annotations": annotations},
+		"spec": map[string]any{
+			"description": "bounded OK-147 target", "permitOnlyProjectScopedClusters": true,
+			"sourceRepos": []any{"https://github.com/openkubes/ok-observability.git"}, "sourceNamespaces": []any{"argocd"},
+			"destinations":               []any{map[string]any{"name": "disposable-ok147", "namespace": "ok-observability"}, map[string]any{"name": "disposable-ok147", "namespace": "kube-system"}},
+			"clusterResourceWhitelist":   []any{map[string]any{"group": "apiextensions.k8s.io", "kind": "CustomResourceDefinition"}, map[string]any{"group": "rbac.authorization.k8s.io", "kind": "ClusterRole"}},
+			"namespaceResourceWhitelist": []any{map[string]any{"group": "", "kind": "ConfigMap"}, map[string]any{"group": "apps", "kind": "Deployment"}},
+			"orphanedResources":          map[string]any{"warn": true},
+		},
+	}
+	secretAnnotations := map[string]any{}
+	for key, value := range annotations {
+		secretAnnotations[key] = value
+	}
+	secretAnnotations["openkubes.io/capi-cluster-uid"] = submission.RegistrationCAPIUIDPlaceholder
+	secretAnnotations["openkubes.io/workload-kube-system-uid"] = submission.RegistrationWorkloadUIDPlaceholder
+	secretAnnotations["openkubes.io/workload-api-ca-sha256"] = submission.RegistrationCADigestPlaceholder
+	secretAnnotations["openkubes.io/token-expiration"] = submission.RegistrationExpirationPlaceholder
+	secret := map[string]any{
+		"apiVersion": "v1", "kind": "Secret", "type": "Opaque",
+		"metadata":   map[string]any{"name": "disposable-ok147-cluster", "namespace": "argocd", "labels": map[string]any{"argocd.argoproj.io/secret-type": "cluster"}, "annotations": secretAnnotations},
+		"stringData": map[string]any{"name": "disposable-ok147", "server": submission.RegistrationEndpointPlaceholder, "namespaces": "ok-observability,kube-system", "clusterResources": "true", "project": "openkubes-disposable", "config": submission.RegistrationConfigPlaceholder},
+	}
+	projectRaw, _ := json.Marshal(project)
+	secretRaw, _ := json.Marshal(secret)
+	return append(append(append([]byte{}, projectRaw...), '\n', '-', '-', '-', '\n'), secretRaw...)
+}


### PR DESCRIPTION
## What changed

- add a verified offline bundle for the `target-registration` stage
- bind the exact eight-receipt prefix, durable target identity, registration projection, and signed `RegisterTarget` grant
- require the GitOps authority from the staged plan
- expose a redacted receipt that explicitly contains no credential material and grants no mutation by itself

## Why

Stage 9 must accept only the immediately preceding credential issuance and the exact reviewed Argo projection. This checkpoint closes that pre-materialization boundary without opening the token or contacting Kubernetes.

## Validation

- `GOCACHE=/private/tmp/ok147-go-build go test -ldflags=-linkmode=external ./...`
- `GOCACHE=/private/tmp/ok147-go-vet go vet ./...`
- `GOCACHE=/private/tmp/ok147-go-race go test -race -ldflags=-linkmode=external ./internal/runner ./cmd/ok`
