### PR TITLE
OK-147: Materialize target registration in memory

### DIFF
--- a/internal/runner/target_credential_issuer.go
+++ b/internal/runner/target_credential_issuer.go
@@ -65,8 +65,17 @@ type VerifiedTargetCredentialMaterial struct {
 	endpoint       string
 	targetIdentity string
 	expiresAt      time.Time
+	privateDigest  string
 	receipt        TargetCredentialIssueReceipt
 	verified       bool
+}
+
+type targetCredentialPrivateBinding struct {
+	Token          []byte `json:"token"`
+	CABundle       []byte `json:"caBundle"`
+	Endpoint       string `json:"endpoint"`
+	TargetIdentity string `json:"targetIdentity"`
+	ExpiresAt      string `json:"expiresAt"`
 }
 
 type KubernetesTargetCredentialIssuer struct {
@@ -265,10 +274,15 @@ func (issuer *KubernetesTargetCredentialIssuer) verifyResponse(value targetCrede
 		IssuedAt: now.Format(time.RFC3339), ExpiresAt: expiresAt.UTC().Format(time.RFC3339),
 		LifetimeSeconds: int64(lifetime / time.Second), CredentialBytesInReceipt: false, MutationState: "ATTEMPTED",
 	}
-	return VerifiedTargetCredentialMaterial{
+	material := VerifiedTargetCredentialMaterial{
 		token: []byte(value.Status.Token), caBundle: append([]byte(nil), issuer.caBundle...), endpoint: issuer.endpoint.String(),
 		targetIdentity: issuer.targetIdentity, expiresAt: expiresAt.UTC(), receipt: receipt, verified: true,
-	}, nil
+	}
+	material.privateDigest, err = targetCredentialPrivateDigest(material)
+	if err != nil {
+		return VerifiedTargetCredentialMaterial{}, errors.New("bind private target-credential material")
+	}
+	return material, nil
 }
 
 func decodeTargetCredentialClaims(token string) (targetCredentialJWTClaims, error) {
@@ -290,8 +304,32 @@ func decodeTargetCredentialClaims(token string) (targetCredentialJWTClaims, erro
 }
 
 func (material VerifiedTargetCredentialMaterial) Receipt() (TargetCredentialIssueReceipt, error) {
-	if !material.verified || len(material.token) < 80 || len(material.caBundle) == 0 || material.endpoint == "" || !stageReceiptPrefixDigestPattern.MatchString(material.targetIdentity) || material.expiresAt.IsZero() || material.receipt.Format != TargetCredentialIssueReceiptFormat || material.receipt.State != "ISSUED" || material.receipt.CredentialBytesInReceipt {
+	privateDigest, err := targetCredentialPrivateDigest(material)
+	if err != nil || privateDigest != material.privateDigest || !stageReceiptPrefixDigestPattern.MatchString(material.privateDigest) ||
+		!material.verified || len(material.token) < 80 || len(material.caBundle) == 0 || material.endpoint == "" ||
+		!stageReceiptPrefixDigestPattern.MatchString(material.targetIdentity) || material.expiresAt.IsZero() ||
+		material.receipt.Format != TargetCredentialIssueReceiptFormat || material.receipt.State != "ISSUED" ||
+		material.receipt.StageID != "target-credential" || material.receipt.MutationState != "ATTEMPTED" ||
+		material.receipt.AudienceMode != "server-default" || material.receipt.CredentialBytesInReceipt ||
+		material.receipt.TargetIdentityDigest != material.targetIdentity || material.receipt.ExpiresAt != material.expiresAt.UTC().Format(time.RFC3339) {
 		return TargetCredentialIssueReceipt{}, errors.New("target-credential material was not produced by verification")
 	}
+	for _, value := range []string{material.receipt.PolicyDigest, material.receipt.TargetIdentityDigest, material.receipt.ServiceAccountIdentityDigest, material.receipt.RequestDigest} {
+		if !stageReceiptPrefixDigestPattern.MatchString(value) {
+			return TargetCredentialIssueReceipt{}, errors.New("target-credential receipt digest identity is invalid")
+		}
+	}
 	return material.receipt, nil
+}
+
+func targetCredentialPrivateDigest(material VerifiedTargetCredentialMaterial) (string, error) {
+	raw, err := json.Marshal(targetCredentialPrivateBinding{
+		Token: append([]byte(nil), material.token...), CABundle: append([]byte(nil), material.caBundle...),
+		Endpoint: material.endpoint, TargetIdentity: material.targetIdentity,
+		ExpiresAt: material.expiresAt.UTC().Format(time.RFC3339),
+	})
+	if err != nil {
+		return "", err
+	}
+	return digest.SHA256(raw), nil
 }

--- a/internal/runner/target_registration_material.go
+++ b/internal/runner/target_registration_material.go
@@ -1,0 +1,259 @@
+package runner
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"io"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/contract"
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/submission"
+)
+
+const (
+	TargetRegistrationMaterialReceiptFormat      = "ok147-target-registration-material/v1"
+	minimumTargetRegistrationCredentialRemaining = 30 * time.Minute
+)
+
+type TargetRegistrationMaterializeConfig struct {
+	Bundle              VerifiedTargetRegistrationStageBundle
+	Runtime             VerifiedRuntimeBindingMaterial
+	Credential          VerifiedTargetCredentialMaterial
+	MaterializationTime time.Time
+}
+
+// TargetRegistrationMaterialReceipt is deliberately safe for durable public
+// evidence. It binds the inputs used for materialization, but never the
+// endpoint, CA, token, raw runtime UIDs or digest of the resulting Secret.
+type TargetRegistrationMaterialReceipt struct {
+	Format                           string `json:"format"`
+	State                            string `json:"state"`
+	StageID                          string `json:"stageId"`
+	PlanDigest                       string `json:"planDigest"`
+	TargetIdentityDigest             string `json:"targetIdentityDigest"`
+	ProjectDigest                    string `json:"projectDigest"`
+	RegistrationTemplateDigest       string `json:"registrationTemplateDigest"`
+	RuntimeBindingDigest             string `json:"runtimeBindingDigest"`
+	CredentialIssueReceiptDigest     string `json:"credentialIssueReceiptDigest"`
+	MaterializationBindingDigest     string `json:"materializationBindingDigest"`
+	ExpiresAt                        string `json:"expiresAt"`
+	CredentialBytesInReceipt         bool   `json:"credentialBytesInReceipt"`
+	MaterializedSecretDigestRetained bool   `json:"materializedSecretDigestRetained"`
+	MutationAllowed                  bool   `json:"mutationAllowed"`
+}
+
+// VerifiedTargetRegistrationMaterial keeps the credential-bearing Secret
+// private to the runner package so only the immediately following bounded
+// launcher can consume it. Its Receipt method exposes only redacted bindings.
+type VerifiedTargetRegistrationMaterial struct {
+	project              []byte
+	registration         []byte
+	registrationDigest   string
+	receipt              TargetRegistrationMaterialReceipt
+	targetIdentityDigest string
+	authority            string
+	expiresAt            time.Time
+	verified             bool
+}
+
+type targetRegistrationTLSConfig struct {
+	CAData   string `json:"caData"`
+	Insecure bool   `json:"insecure"`
+}
+
+type targetRegistrationSecretConfig struct {
+	BearerToken     string                      `json:"bearerToken"`
+	TLSClientConfig targetRegistrationTLSConfig `json:"tlsClientConfig"`
+}
+
+type targetRegistrationSafeBinding struct {
+	PlanDigest                   string `json:"planDigest"`
+	TargetIdentityDigest         string `json:"targetIdentityDigest"`
+	ProjectDigest                string `json:"projectDigest"`
+	RegistrationTemplateDigest   string `json:"registrationTemplateDigest"`
+	RuntimeBindingDigest         string `json:"runtimeBindingDigest"`
+	CredentialIssueReceiptDigest string `json:"credentialIssueReceiptDigest"`
+}
+
+// BuildTargetRegistrationMaterial replaces the six explicitly bound runtime
+// placeholders in memory. It performs no API request and writes no file.
+func BuildTargetRegistrationMaterial(config TargetRegistrationMaterializeConfig) (VerifiedTargetRegistrationMaterial, error) {
+	if config.MaterializationTime.IsZero() || config.MaterializationTime.Location() != time.UTC {
+		return VerifiedTargetRegistrationMaterial{}, errors.New("target-registration materialization time must be UTC")
+	}
+	if err := verifyTargetRegistrationStageBundle(config.Bundle); err != nil {
+		return VerifiedTargetRegistrationMaterial{}, err
+	}
+	if err := verifyRuntimeBindingMaterial(config.Runtime); err != nil {
+		return VerifiedTargetRegistrationMaterial{}, err
+	}
+	credentialReceipt, err := config.Credential.Receipt()
+	if err != nil {
+		return VerifiedTargetRegistrationMaterial{}, err
+	}
+	bundle, runtime := config.Bundle, config.Runtime
+	if runtime.material.PlanDigest != bundle.plan.PlanDigest ||
+		runtime.material.IntentRevision != bundle.plan.IntentRevision ||
+		runtime.material.EnablementRevision != bundle.plan.EnablementRevision ||
+		runtime.material.PlatformRevision != bundle.plan.PlatformRevision ||
+		runtime.material.ExecutionFixture != bundle.plan.ExecutionFixture ||
+		runtime.material.Target.Name != bundle.plan.ContractIdentity.Name ||
+		runtime.material.Target.TargetIdentityScheme != "capi-cluster-uid/v1" {
+		return VerifiedTargetRegistrationMaterial{}, errors.New("runtime binding differs from target-registration plan")
+	}
+	if digest.SHA256([]byte(runtime.material.Target.CAPIClusterUID)) != bundle.receipt.TargetIdentityDigest ||
+		credentialReceipt.TargetIdentityDigest != bundle.receipt.TargetIdentityDigest ||
+		config.Credential.targetIdentity != bundle.receipt.TargetIdentityDigest {
+		return VerifiedTargetRegistrationMaterial{}, errors.New("target-registration target identity differs")
+	}
+	if config.Credential.endpoint != runtime.material.Target.WorkloadAPIEndpoint ||
+		digest.SHA256(config.Credential.caBundle) != runtime.material.Target.WorkloadAPICADigest ||
+		base64.StdEncoding.EncodeToString(config.Credential.caBundle) != runtime.material.Target.WorkloadAPICAData {
+		return VerifiedTargetRegistrationMaterial{}, errors.New("target-registration credential authority differs from runtime binding")
+	}
+	issuedAt, err := time.Parse(time.RFC3339, credentialReceipt.IssuedAt)
+	if err != nil || !config.Credential.expiresAt.Equal(mustParseTargetRegistrationTime(credentialReceipt.ExpiresAt)) ||
+		config.MaterializationTime.Before(issuedAt) || config.Credential.expiresAt.Sub(config.MaterializationTime) < minimumTargetRegistrationCredentialRemaining {
+		return VerifiedTargetRegistrationMaterial{}, errors.New("target-registration credential validity window is insufficient")
+	}
+
+	registration, err := decodeTargetRegistrationTemplate(bundle.projection.Registration.Raw)
+	if err != nil {
+		return VerifiedTargetRegistrationMaterial{}, err
+	}
+	metadata := registration["metadata"].(map[string]any)
+	annotations := metadata["annotations"].(map[string]any)
+	stringData := registration["stringData"].(map[string]any)
+	annotations["openkubes.io/capi-cluster-uid"] = runtime.material.Target.CAPIClusterUID
+	annotations["openkubes.io/workload-kube-system-uid"] = runtime.material.Target.KubeSystemUID
+	annotations["openkubes.io/workload-api-ca-sha256"] = runtime.material.Target.WorkloadAPICADigest
+	annotations["openkubes.io/token-expiration"] = credentialReceipt.ExpiresAt
+	stringData["server"] = runtime.material.Target.WorkloadAPIEndpoint
+	secretConfig, err := json.Marshal(targetRegistrationSecretConfig{
+		BearerToken:     string(config.Credential.token),
+		TLSClientConfig: targetRegistrationTLSConfig{CAData: runtime.material.Target.WorkloadAPICAData, Insecure: false},
+	})
+	if err != nil {
+		return VerifiedTargetRegistrationMaterial{}, errors.New("encode target-registration credential config")
+	}
+	stringData["config"] = string(secretConfig)
+	registrationRaw, err := canonicalTargetRegistrationValue(registration)
+	if err != nil {
+		return VerifiedTargetRegistrationMaterial{}, errors.New("canonicalize target-registration Secret")
+	}
+	credentialReceiptRaw, err := canonicalTargetRegistrationValue(credentialReceipt)
+	if err != nil {
+		return VerifiedTargetRegistrationMaterial{}, errors.New("canonicalize target-credential receipt")
+	}
+	binding := targetRegistrationSafeBinding{
+		PlanDigest: bundle.plan.PlanDigest, TargetIdentityDigest: bundle.receipt.TargetIdentityDigest,
+		ProjectDigest: bundle.receipt.ProjectDigest, RegistrationTemplateDigest: bundle.receipt.RegistrationTemplateDigest,
+		RuntimeBindingDigest:         runtime.receipt.PrivateMaterialDigest,
+		CredentialIssueReceiptDigest: digest.SHA256(credentialReceiptRaw),
+	}
+	bindingRaw, err := canonicalTargetRegistrationValue(binding)
+	if err != nil {
+		return VerifiedTargetRegistrationMaterial{}, errors.New("canonicalize target-registration binding")
+	}
+	receipt := TargetRegistrationMaterialReceipt{
+		Format: TargetRegistrationMaterialReceiptFormat, State: "VERIFIED", StageID: "target-registration",
+		PlanDigest: binding.PlanDigest, TargetIdentityDigest: binding.TargetIdentityDigest,
+		ProjectDigest: binding.ProjectDigest, RegistrationTemplateDigest: binding.RegistrationTemplateDigest,
+		RuntimeBindingDigest: binding.RuntimeBindingDigest, CredentialIssueReceiptDigest: binding.CredentialIssueReceiptDigest,
+		MaterializationBindingDigest: digest.SHA256(bindingRaw), ExpiresAt: credentialReceipt.ExpiresAt,
+		CredentialBytesInReceipt: false, MaterializedSecretDigestRetained: false, MutationAllowed: false,
+	}
+	return VerifiedTargetRegistrationMaterial{
+		project: append([]byte(nil), bundle.projection.Project.Raw...), registration: registrationRaw,
+		registrationDigest: digest.SHA256(registrationRaw), receipt: receipt,
+		targetIdentityDigest: bundle.receipt.TargetIdentityDigest, authority: bundle.receipt.Authority,
+		expiresAt: config.Credential.expiresAt, verified: true,
+	}, nil
+}
+
+func (material VerifiedTargetRegistrationMaterial) Receipt() (TargetRegistrationMaterialReceipt, error) {
+	if err := verifyTargetRegistrationMaterial(material); err != nil {
+		return TargetRegistrationMaterialReceipt{}, err
+	}
+	return material.receipt, nil
+}
+
+func verifyTargetRegistrationMaterial(material VerifiedTargetRegistrationMaterial) error {
+	if !material.verified || material.receipt.Format != TargetRegistrationMaterialReceiptFormat ||
+		material.receipt.State != "VERIFIED" || material.receipt.StageID != "target-registration" ||
+		material.receipt.CredentialBytesInReceipt || material.receipt.MaterializedSecretDigestRetained || material.receipt.MutationAllowed ||
+		material.authority == "" || material.targetIdentityDigest != material.receipt.TargetIdentityDigest {
+		return errors.New("target-registration material was not produced by verification")
+	}
+	for _, value := range []string{
+		material.receipt.PlanDigest, material.receipt.TargetIdentityDigest, material.receipt.ProjectDigest,
+		material.receipt.RegistrationTemplateDigest, material.receipt.RuntimeBindingDigest,
+		material.receipt.CredentialIssueReceiptDigest, material.receipt.MaterializationBindingDigest,
+	} {
+		if !stageReceiptPrefixDigestPattern.MatchString(value) {
+			return errors.New("target-registration material digest identity is invalid")
+		}
+	}
+	if digest.SHA256(material.project) != material.receipt.ProjectDigest ||
+		digest.SHA256(material.registration) != material.registrationDigest || material.registrationDigest == material.receipt.RegistrationTemplateDigest {
+		return errors.New("target-registration material changed after verification")
+	}
+	expiresAt, err := time.Parse(time.RFC3339, material.receipt.ExpiresAt)
+	if err != nil || !expiresAt.Equal(material.expiresAt) {
+		return errors.New("target-registration material expiration is invalid")
+	}
+	bindingRaw, err := canonicalTargetRegistrationValue(targetRegistrationSafeBinding{
+		PlanDigest: material.receipt.PlanDigest, TargetIdentityDigest: material.receipt.TargetIdentityDigest,
+		ProjectDigest: material.receipt.ProjectDigest, RegistrationTemplateDigest: material.receipt.RegistrationTemplateDigest,
+		RuntimeBindingDigest:         material.receipt.RuntimeBindingDigest,
+		CredentialIssueReceiptDigest: material.receipt.CredentialIssueReceiptDigest,
+	})
+	if err != nil || digest.SHA256(bindingRaw) != material.receipt.MaterializationBindingDigest {
+		return errors.New("target-registration material binding changed after verification")
+	}
+	return nil
+}
+
+func decodeTargetRegistrationTemplate(raw []byte) (map[string]any, error) {
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	var value map[string]any
+	if err := decoder.Decode(&value); err != nil || decoder.Decode(&struct{}{}) != io.EOF {
+		return nil, errors.New("decode target-registration Secret template")
+	}
+	metadata, metadataOK := value["metadata"].(map[string]any)
+	annotations, annotationsOK := metadata["annotations"].(map[string]any)
+	stringData, stringDataOK := value["stringData"].(map[string]any)
+	if !metadataOK || !annotationsOK || !stringDataOK ||
+		annotations["openkubes.io/capi-cluster-uid"] != submission.RegistrationCAPIUIDPlaceholder ||
+		annotations["openkubes.io/workload-kube-system-uid"] != submission.RegistrationWorkloadUIDPlaceholder ||
+		annotations["openkubes.io/workload-api-ca-sha256"] != submission.RegistrationCADigestPlaceholder ||
+		annotations["openkubes.io/token-expiration"] != submission.RegistrationExpirationPlaceholder ||
+		stringData["server"] != submission.RegistrationEndpointPlaceholder ||
+		stringData["config"] != submission.RegistrationConfigPlaceholder {
+		return nil, errors.New("target-registration runtime placeholders differ")
+	}
+	return value, nil
+}
+
+func canonicalTargetRegistrationValue(value any) ([]byte, error) {
+	raw, err := json.Marshal(value)
+	if err != nil {
+		return nil, err
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	var decoded any
+	if err := decoder.Decode(&decoded); err != nil {
+		return nil, err
+	}
+	return contract.JCS(decoded)
+}
+
+func mustParseTargetRegistrationTime(value string) time.Time {
+	parsed, _ := time.Parse(time.RFC3339, value)
+	return parsed
+}

--- a/internal/runner/target_registration_material_test.go
+++ b/internal/runner/target_registration_material_test.go
@@ -1,0 +1,192 @@
+package runner
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+func TestBuildTargetRegistrationMaterialReplacesOnlyBoundPlaceholdersInMemory(t *testing.T) {
+	fixture := targetRegistrationMaterialFixture(t)
+	material, err := BuildTargetRegistrationMaterial(fixture.config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := material.Receipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if receipt.Format != TargetRegistrationMaterialReceiptFormat || receipt.State != "VERIFIED" || receipt.StageID != "target-registration" ||
+		receipt.PlanDigest != fixture.bundle.plan.PlanDigest || receipt.TargetIdentityDigest != fixture.bundle.receipt.TargetIdentityDigest ||
+		receipt.ProjectDigest != fixture.bundle.receipt.ProjectDigest || receipt.RegistrationTemplateDigest != fixture.bundle.receipt.RegistrationTemplateDigest ||
+		receipt.RuntimeBindingDigest != fixture.runtime.receipt.PrivateMaterialDigest || receipt.CredentialIssueReceiptDigest == "" ||
+		receipt.MaterializationBindingDigest == "" || receipt.CredentialBytesInReceipt || receipt.MaterializedSecretDigestRetained || receipt.MutationAllowed {
+		t.Fatalf("unexpected material receipt: %#v", receipt)
+	}
+	if !bytes.Equal(material.project, fixture.bundle.projection.Project.Raw) {
+		t.Fatal("AppProject changed during materialization")
+	}
+	var secret map[string]any
+	if err := json.Unmarshal(material.registration, &secret); err != nil {
+		t.Fatal(err)
+	}
+	metadata := secret["metadata"].(map[string]any)
+	annotations := metadata["annotations"].(map[string]any)
+	data := secret["stringData"].(map[string]any)
+	if annotations["openkubes.io/capi-cluster-uid"] != fixture.runtime.material.Target.CAPIClusterUID ||
+		annotations["openkubes.io/workload-kube-system-uid"] != fixture.runtime.material.Target.KubeSystemUID ||
+		annotations["openkubes.io/workload-api-ca-sha256"] != fixture.runtime.material.Target.WorkloadAPICADigest ||
+		annotations["openkubes.io/token-expiration"] != fixture.credential.receipt.ExpiresAt ||
+		data["server"] != fixture.runtime.material.Target.WorkloadAPIEndpoint {
+		t.Fatal("runtime placeholders were not replaced exactly")
+	}
+	var secretConfig targetRegistrationSecretConfig
+	if err := json.Unmarshal([]byte(data["config"].(string)), &secretConfig); err != nil {
+		t.Fatal(err)
+	}
+	if secretConfig.BearerToken != string(fixture.credential.token) || secretConfig.TLSClientConfig.CAData != fixture.runtime.material.Target.WorkloadAPICAData || secretConfig.TLSClientConfig.Insecure {
+		t.Fatal("Argo credential config differs from verified in-memory authority")
+	}
+
+	publicRaw, err := json.Marshal(receipt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, private := range []string{
+		string(fixture.credential.token), string(fixture.credential.caBundle), fixture.credential.endpoint,
+		fixture.runtime.material.Target.CAPIClusterUID, fixture.runtime.material.Target.KubeSystemUID,
+		fixture.runtime.material.Target.WorkloadAPICAData, material.registrationDigest,
+	} {
+		if bytes.Contains(publicRaw, []byte(private)) {
+			t.Fatalf("public receipt leaked private material %q", private)
+		}
+	}
+	if _, err := (VerifiedTargetRegistrationMaterial{}).Receipt(); err == nil {
+		t.Fatal("unverified material exposed a receipt")
+	}
+}
+
+func TestBuildTargetRegistrationMaterialFailsClosed(t *testing.T) {
+	tests := map[string]func(*targetRegistrationMaterialTestFixture){
+		"unverified bundle": func(f *targetRegistrationMaterialTestFixture) { f.config.Bundle.verified = false },
+		"mutated projection": func(f *targetRegistrationMaterialTestFixture) {
+			f.config.Bundle.projection.Registration.Raw[0] ^= 1
+		},
+		"unverified runtime": func(f *targetRegistrationMaterialTestFixture) { f.config.Runtime.verified = false },
+		"foreign plan": func(f *targetRegistrationMaterialTestFixture) {
+			f.config.Runtime.material.PlanDigest = runnerStageSHA("9")
+			refreshTargetRegistrationRuntime(t, &f.config.Runtime)
+		},
+		"foreign target": func(f *targetRegistrationMaterialTestFixture) {
+			f.config.Runtime.material.Target.CAPIClusterUID = "foreign-runtime-uid"
+			refreshTargetRegistrationRuntime(t, &f.config.Runtime)
+		},
+		"unverified credential": func(f *targetRegistrationMaterialTestFixture) { f.config.Credential.verified = false },
+		"credential target mismatch": func(f *targetRegistrationMaterialTestFixture) {
+			f.config.Credential.targetIdentity = runnerStageSHA("8")
+		},
+		"credential endpoint mismatch": func(f *targetRegistrationMaterialTestFixture) {
+			f.config.Credential.endpoint = "https://192.0.2.148:6443"
+		},
+		"credential CA mismatch": func(f *targetRegistrationMaterialTestFixture) {
+			f.config.Credential.caBundle = []byte("foreign-ca")
+		},
+		"credential token tamper": func(f *targetRegistrationMaterialTestFixture) {
+			f.config.Credential.token[0] ^= 1
+		},
+		"credential near expiry": func(f *targetRegistrationMaterialTestFixture) {
+			f.config.Credential.expiresAt = f.config.MaterializationTime.Add(29 * time.Minute)
+			f.config.Credential.receipt.ExpiresAt = f.config.Credential.expiresAt.Format(time.RFC3339)
+			f.config.Credential.privateDigest, _ = targetCredentialPrivateDigest(f.config.Credential)
+		},
+		"materialization before issue": func(f *targetRegistrationMaterialTestFixture) {
+			f.config.MaterializationTime = f.config.MaterializationTime.Add(-time.Minute)
+		},
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			fixture := targetRegistrationMaterialFixture(t)
+			mutate(&fixture)
+			if _, err := BuildTargetRegistrationMaterial(fixture.config); err == nil {
+				t.Fatal("invalid target-registration materialization was accepted")
+			}
+		})
+	}
+}
+
+type targetRegistrationMaterialTestFixture struct {
+	bundle     VerifiedTargetRegistrationStageBundle
+	runtime    VerifiedRuntimeBindingMaterial
+	credential VerifiedTargetCredentialMaterial
+	config     TargetRegistrationMaterializeConfig
+}
+
+func targetRegistrationMaterialFixture(t *testing.T) targetRegistrationMaterialTestFixture {
+	t.Helper()
+	bundleFixture := targetRegistrationBundleFixture(t)
+	bundle, err := LoadTargetRegistrationStageBundle(bundleFixture.config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ca := []byte("-----BEGIN CERTIFICATE-----\nok147-test-ca\n-----END CERTIFICATE-----\n")
+	runtime := VerifiedRuntimeBindingMaterial{verified: true}
+	runtime.material = RuntimeBindingMaterial{
+		Format: RuntimeBindingMaterialFormat, State: "CURRENT_RUNTIME_BOUND",
+		PlanDigest: bundle.plan.PlanDigest, IntentRevision: bundle.plan.IntentRevision,
+		EnablementRevision: bundle.plan.EnablementRevision, PlatformRevision: bundle.plan.PlatformRevision,
+		ExecutionFixture: bundle.plan.ExecutionFixture,
+		Target: RuntimeBindingTarget{
+			Name: bundle.plan.ContractIdentity.Name, CAPIClusterUID: targetAccessRuntimeUID,
+			TargetIdentityScheme: "capi-cluster-uid/v1", WorkloadAPIEndpoint: "https://192.0.2.147:6443",
+			WorkloadAPICAData: base64.StdEncoding.EncodeToString(ca), WorkloadAPICADigest: digest.SHA256(ca),
+			KubeSystemUID: "kube-system-runtime-uid-147",
+		},
+		Storage:  RuntimeBindingStorage{Name: "local-path", UID: "local-path-runtime-uid-147", Provisioner: "rancher.io/local-path"},
+		Evidence: RuntimeBindingEvidence{LifecycleEvidenceDigest: runnerStageSHA("1"), NetworkEvidenceDigest: runnerStageSHA("2")},
+	}
+	refreshTargetRegistrationRuntime(t, &runtime)
+	now := time.Date(2026, 8, 17, 18, 1, 0, 0, time.UTC)
+	token := []byte("header.payload.signature-" + strings.Repeat("x", 96))
+	credential := VerifiedTargetCredentialMaterial{
+		token: token, caBundle: ca, endpoint: runtime.material.Target.WorkloadAPIEndpoint,
+		targetIdentity: bundle.receipt.TargetIdentityDigest, expiresAt: now.Add(2 * time.Hour), verified: true,
+	}
+	credential.receipt = TargetCredentialIssueReceipt{
+		Format: TargetCredentialIssueReceiptFormat, State: "ISSUED", StageID: "target-credential",
+		PolicyDigest: runnerStageSHA("3"), TargetIdentityDigest: bundle.receipt.TargetIdentityDigest,
+		ServiceAccountIdentityDigest: runnerStageSHA("4"), RequestDigest: runnerStageSHA("5"), AudienceMode: "server-default",
+		IssuedAt: now.Format(time.RFC3339), ExpiresAt: credential.expiresAt.Format(time.RFC3339), LifetimeSeconds: 7200,
+		CredentialBytesInReceipt: false, MutationState: "ATTEMPTED",
+	}
+	credential.privateDigest, err = targetCredentialPrivateDigest(credential)
+	if err != nil {
+		t.Fatal(err)
+	}
+	config := TargetRegistrationMaterializeConfig{Bundle: bundle, Runtime: runtime, Credential: credential, MaterializationTime: now}
+	return targetRegistrationMaterialTestFixture{bundle: bundle, runtime: runtime, credential: credential, config: config}
+}
+
+func refreshTargetRegistrationRuntime(t *testing.T, runtime *VerifiedRuntimeBindingMaterial) {
+	t.Helper()
+	raw, err := canonicalRuntimeBinding(runtime.material)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runtime.raw = raw
+	runtime.receipt = RuntimeBindingMaterialReceipt{
+		Format: RuntimeBindingMaterialFormat, State: "VERIFIED", StageID: "runtime-binding",
+		PlanDigest: runtime.material.PlanDigest, IntentRevision: runtime.material.IntentRevision,
+		TargetClusterUIDDigest:    digest.SHA256([]byte(runtime.material.Target.CAPIClusterUID)),
+		WorkloadAPICADigest:       runtime.material.Target.WorkloadAPICADigest,
+		KubeSystemUIDDigest:       digest.SHA256([]byte(runtime.material.Target.KubeSystemUID)),
+		LocalPathStorageUIDDigest: digest.SHA256([]byte(runtime.material.Storage.UID)),
+		LifecycleEvidenceDigest:   runtime.material.Evidence.LifecycleEvidenceDigest,
+		NetworkEvidenceDigest:     runtime.material.Evidence.NetworkEvidenceDigest,
+		PrivateMaterialDigest:     digest.SHA256(raw), PersistentMutationAllowed: false,
+	}
+}

--- a/internal/runner/target_registration_stage_bundle.go
+++ b/internal/runner/target_registration_stage_bundle.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/openkubes/ok-cluster/internal/authorization"
+	"github.com/openkubes/ok-cluster/internal/digest"
 	"github.com/openkubes/ok-cluster/internal/stagecursor"
 	"github.com/openkubes/ok-cluster/internal/stageplan"
 	"github.com/openkubes/ok-cluster/internal/stagereceipt"
@@ -140,6 +141,17 @@ func verifyTargetRegistrationStageBundle(bundle VerifiedTargetRegistrationStageB
 	}
 	if bundle.receipt.Authority == "" || bundle.projection.Authority != bundle.receipt.Authority || bundle.projection.TargetIdentityDigest != bundle.receipt.TargetIdentityDigest {
 		return errors.New("target-registration stage bundle identity changed after verification")
+	}
+	if bundle.projection.Format != submission.TargetRegistrationPlanFormat || bundle.projection.MutationAllowed ||
+		bundle.projection.ArtifactDigest != bundle.receipt.ArtifactDigest ||
+		bundle.projection.IntentRevision != bundle.plan.IntentRevision ||
+		bundle.projection.PlatformRevision != bundle.plan.PlatformRevision ||
+		bundle.projection.ExecutionFixture != bundle.plan.ExecutionFixture ||
+		bundle.projection.Project.Digest != bundle.receipt.ProjectDigest ||
+		bundle.projection.Registration.Digest != bundle.receipt.RegistrationTemplateDigest ||
+		digest.SHA256(bundle.projection.Project.Raw) != bundle.receipt.ProjectDigest ||
+		digest.SHA256(bundle.projection.Registration.Raw) != bundle.receipt.RegistrationTemplateDigest {
+		return errors.New("target-registration projection changed after verification")
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary
- materialize the exact AppProject and Argo cluster Secret template from verified Stage-9 inputs
- bind runtime target identity, API authority and short-lived credential without exposing secret bytes or the materialized Secret digest in public receipts
- harden credential and projection objects against post-verification tampering

## Safety boundary
- no Kubernetes API request
- no file write
- no mutation authority
- credential, CA, endpoint and raw runtime UIDs remain process-private

## Verification
- full go test ./...
- go vet ./...
- race tests for internal/runner and cmd/ok