### PR TITLE
OK-147: Launch target registration create-only

### DIFF
--- a/internal/runner/target_registration_launcher.go
+++ b/internal/runner/target_registration_launcher.go
@@ -1,0 +1,313 @@
+package runner
+
+import (
+	"bytes"
+	"context"
+	"crypto/subtle"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+const TargetRegistrationLaunchReceiptFormat = "ok147-target-registration-launch-receipt/v1"
+
+type TargetRegistrationLauncherConfig struct {
+	Authority KubernetesAuthorityConfig
+	Clock     func() time.Time
+}
+
+type TargetRegistrationLaunchResult struct {
+	Order                            int    `json:"order"`
+	Role                             string `json:"role"`
+	Namespace                        string `json:"namespace"`
+	Name                             string `json:"name"`
+	BoundDigest                      string `json:"boundDigest"`
+	UIDDigest                        string `json:"uidDigest"`
+	ResourceVersionDigest            string `json:"resourceVersionDigest"`
+	State                            string `json:"state"`
+	MaterializedObjectDigestRetained bool   `json:"materializedObjectDigestRetained"`
+}
+
+type TargetRegistrationLaunchReceipt struct {
+	Format                       string                           `json:"format"`
+	StageID                      string                           `json:"stageId"`
+	PlanDigest                   string                           `json:"planDigest"`
+	TargetIdentityDigest         string                           `json:"targetIdentityDigest"`
+	MaterializationBindingDigest string                           `json:"materializationBindingDigest"`
+	Authority                    string                           `json:"authority"`
+	State                        string                           `json:"state"`
+	MutationState                string                           `json:"mutationState"`
+	CredentialBytesInReceipt     bool                             `json:"credentialBytesInReceipt"`
+	Results                      []TargetRegistrationLaunchResult `json:"results"`
+}
+
+type targetRegistrationLaunchObject struct {
+	order           int
+	role            string
+	namespace       string
+	name            string
+	collectionPath  string
+	objectPath      string
+	boundDigest     string
+	privateDigest   string
+	credentialToken []byte
+	raw             []byte
+}
+
+// KubernetesTargetRegistrationLauncher is a single-use, two-object,
+// create-only writer against the verified GitOps authority. Both exact
+// absence checks complete before the AppProject and credential-bearing Secret
+// are submitted. Partial state is preserved and no retry path exists.
+type KubernetesTargetRegistrationLauncher struct {
+	mu             sync.Mutex
+	used           bool
+	endpoint       *url.URL
+	token          string
+	client         *http.Client
+	clock          func() time.Time
+	expiresAt      time.Time
+	materializedAt time.Time
+	authority      string
+	receipt        TargetRegistrationMaterialReceipt
+	objects        []targetRegistrationLaunchObject
+}
+
+type targetRegistrationLauncherClientConfig struct {
+	Endpoint          string
+	BearerToken       string
+	AuthorityIdentity string
+	Client            *http.Client
+	Clock             func() time.Time
+}
+
+// OpenKubernetesTargetRegistrationLauncher opens the bounded ok-shared
+// credential and verifies all private material without contacting an API.
+func OpenKubernetesTargetRegistrationLauncher(config TargetRegistrationLauncherConfig, material VerifiedTargetRegistrationMaterial) (*KubernetesTargetRegistrationLauncher, error) {
+	if err := verifyTargetRegistrationMaterial(material); err != nil {
+		return nil, err
+	}
+	if config.Authority.AuthorityIdentity == "" || config.Authority.AuthorityIdentity != material.authority ||
+		!stageReceiptPrefixDigestPattern.MatchString(config.Authority.CABundleDigest) {
+		return nil, errors.New("target-registration launcher authority differs from verified GitOps authority")
+	}
+	token, ca, client, err := openBoundedKubernetesMaterial(config.Authority.TokenFile, config.Authority.CAFile)
+	if err != nil {
+		return nil, errors.New("open bounded target-registration launcher credential")
+	}
+	if digest.SHA256(ca) != config.Authority.CABundleDigest {
+		return nil, errors.New("target-registration launcher CA differs from bound identity")
+	}
+	return newKubernetesTargetRegistrationLauncher(targetRegistrationLauncherClientConfig{
+		Endpoint: config.Authority.Endpoint, BearerToken: token, AuthorityIdentity: config.Authority.AuthorityIdentity,
+		Client: client, Clock: config.Clock,
+	}, material)
+}
+
+func newKubernetesTargetRegistrationLauncher(config targetRegistrationLauncherClientConfig, material VerifiedTargetRegistrationMaterial) (*KubernetesTargetRegistrationLauncher, error) {
+	receipt, objects, err := prepareTargetRegistrationLaunchMaterial(material)
+	if err != nil {
+		return nil, err
+	}
+	if config.AuthorityIdentity == "" || config.AuthorityIdentity != material.authority {
+		return nil, errors.New("target-registration launcher authority differs from verified GitOps authority")
+	}
+	endpoint, err := normalizeSubmissionStageLaunchEndpoint(config.Endpoint)
+	if err != nil {
+		return nil, errors.New("target-registration launcher endpoint is invalid")
+	}
+	if config.BearerToken == "" || strings.TrimSpace(config.BearerToken) != config.BearerToken || strings.ContainsAny(config.BearerToken, "\r\n") || config.Client == nil || config.Clock == nil {
+		return nil, errors.New("target-registration launcher credential, client, or clock is invalid")
+	}
+	if len(config.BearerToken) == len(objects[1].credentialToken) && subtle.ConstantTimeCompare([]byte(config.BearerToken), objects[1].credentialToken) == 1 {
+		return nil, errors.New("GitOps writer and workload target credentials must be distinct")
+	}
+	expiresAt, err := time.Parse(time.RFC3339, receipt.ExpiresAt)
+	if err != nil {
+		return nil, errors.New("target-registration material expiration is invalid")
+	}
+	parsedEndpoint, err := url.Parse(endpoint)
+	if err != nil {
+		return nil, errors.New("target-registration launcher endpoint is invalid")
+	}
+	client := *config.Client
+	client.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+	if client.Timeout == 0 {
+		client.Timeout = 15 * time.Second
+	}
+	return &KubernetesTargetRegistrationLauncher{
+		endpoint: parsedEndpoint, token: config.BearerToken, client: &client, clock: config.Clock,
+		expiresAt: expiresAt, materializedAt: material.materializedAt,
+		authority: config.AuthorityIdentity, receipt: receipt, objects: objects,
+	}, nil
+}
+
+func (launcher *KubernetesTargetRegistrationLauncher) Install(ctx context.Context) (TargetRegistrationLaunchReceipt, error) {
+	receipt := launcher.newReceipt()
+	if launcher == nil || launcher.client == nil || launcher.clock == nil {
+		return receipt, errors.New("target-registration launcher is required")
+	}
+	launcher.mu.Lock()
+	if launcher.used {
+		launcher.mu.Unlock()
+		return stoppedTargetRegistrationLaunch(receipt, "STOPPED_ZERO_WRITE", errors.New("target-registration launcher is single-use"))
+	}
+	launcher.used = true
+	launcher.mu.Unlock()
+	now := launcher.clock().UTC()
+	if now.Before(launcher.materializedAt) || launcher.expiresAt.Sub(now) < minimumTargetRegistrationCredentialRemaining {
+		return stoppedTargetRegistrationLaunch(receipt, "STOPPED_ZERO_WRITE", errors.New("target-registration credential has insufficient remaining lifetime"))
+	}
+	for _, object := range launcher.objects {
+		_, status, err := launcher.request(ctx, http.MethodGet, object.objectPath, nil)
+		if err != nil {
+			return stoppedTargetRegistrationLaunch(receipt, "STOPPED_ZERO_WRITE", err)
+		}
+		switch status {
+		case http.StatusNotFound:
+		case http.StatusOK:
+			return stoppedTargetRegistrationLaunch(receipt, "STOPPED_ZERO_WRITE", errors.New("target-registration object already exists; zero-write preflight stopped"))
+		default:
+			return stoppedTargetRegistrationLaunch(receipt, "STOPPED_ZERO_WRITE", targetRegistrationLaunchStatusError(http.MethodGet, status))
+		}
+	}
+	receipt.State = "CREATING"
+	for _, object := range launcher.objects {
+		receipt.MutationState = "ATTEMPTED_UNKNOWN"
+		raw, status, err := launcher.request(ctx, http.MethodPost, object.collectionPath, object.raw)
+		if err != nil {
+			return stoppedTargetRegistrationLaunch(receipt, "STOPPED_PARTIAL_OR_UNKNOWN", err)
+		}
+		if status != http.StatusCreated {
+			receipt.MutationState = "ATTEMPTED"
+			return stoppedTargetRegistrationLaunch(receipt, "STOPPED_PARTIAL_OR_UNKNOWN", targetRegistrationLaunchStatusError(http.MethodPost, status))
+		}
+		uid, resourceVersion, err := verifyTargetRegistrationCreatedObject(raw, object)
+		if err != nil {
+			return stoppedTargetRegistrationLaunch(receipt, "STOPPED_PARTIAL_OR_UNKNOWN", errors.New("created target-registration object differs from verified material"))
+		}
+		receipt.MutationState = "ATTEMPTED"
+		receipt.Results = append(receipt.Results, TargetRegistrationLaunchResult{
+			Order: object.order, Role: object.role, Namespace: object.namespace, Name: object.name,
+			BoundDigest: object.boundDigest, UIDDigest: digest.SHA256([]byte(uid)), ResourceVersionDigest: digest.SHA256([]byte(resourceVersion)),
+			State: "CREATED", MaterializedObjectDigestRetained: false,
+		})
+	}
+	receipt.State = "INSTALLED"
+	return receipt, nil
+}
+
+func (launcher *KubernetesTargetRegistrationLauncher) newReceipt() TargetRegistrationLaunchReceipt {
+	receipt := TargetRegistrationLaunchReceipt{
+		Format: TargetRegistrationLaunchReceiptFormat, StageID: "target-registration",
+		State: "PREFLIGHT", MutationState: "NOT_ATTEMPTED", CredentialBytesInReceipt: false,
+		Results: []TargetRegistrationLaunchResult{},
+	}
+	if launcher != nil {
+		receipt.PlanDigest = launcher.receipt.PlanDigest
+		receipt.TargetIdentityDigest = launcher.receipt.TargetIdentityDigest
+		receipt.MaterializationBindingDigest = launcher.receipt.MaterializationBindingDigest
+		receipt.Authority = launcher.authority
+	}
+	return receipt
+}
+
+func stoppedTargetRegistrationLaunch(receipt TargetRegistrationLaunchReceipt, state string, err error) (TargetRegistrationLaunchReceipt, error) {
+	receipt.State = state
+	return receipt, err
+}
+
+func prepareTargetRegistrationLaunchMaterial(material VerifiedTargetRegistrationMaterial) (TargetRegistrationMaterialReceipt, []targetRegistrationLaunchObject, error) {
+	if err := verifyTargetRegistrationMaterial(material); err != nil {
+		return TargetRegistrationMaterialReceipt{}, nil, err
+	}
+	objects := []targetRegistrationLaunchObject{
+		{order: 1, role: "project", collectionPath: material.projectCollection, objectPath: material.projectPath, boundDigest: material.receipt.ProjectDigest, privateDigest: digest.SHA256(material.project), raw: append([]byte(nil), material.project...)},
+		{order: 2, role: "registration", collectionPath: material.registrationCollection, objectPath: material.registrationPath, boundDigest: material.receipt.RegistrationTemplateDigest, privateDigest: material.registrationDigest, raw: append([]byte(nil), material.registration...)},
+	}
+	for index := range objects {
+		var value map[string]any
+		if err := json.Unmarshal(objects[index].raw, &value); err != nil {
+			return TargetRegistrationMaterialReceipt{}, nil, errors.New("target-registration launch object is invalid JSON")
+		}
+		metadata, _ := value["metadata"].(map[string]any)
+		objects[index].namespace, _ = metadata["namespace"].(string)
+		objects[index].name, _ = metadata["name"].(string)
+		if objects[index].namespace == "" || objects[index].name == "" || !stageReceiptPrefixDigestPattern.MatchString(objects[index].privateDigest) {
+			return TargetRegistrationMaterialReceipt{}, nil, errors.New("target-registration launch object identity is invalid")
+		}
+		if objects[index].role == "registration" {
+			stringData, _ := value["stringData"].(map[string]any)
+			configRaw, _ := stringData["config"].(string)
+			var config targetRegistrationSecretConfig
+			if json.Unmarshal([]byte(configRaw), &config) != nil || len(config.BearerToken) < 80 {
+				return TargetRegistrationMaterialReceipt{}, nil, errors.New("target-registration private credential config is invalid")
+			}
+			objects[index].credentialToken = []byte(config.BearerToken)
+		}
+	}
+	return material.receipt, objects, nil
+}
+
+func verifyTargetRegistrationCreatedObject(raw []byte, expected targetRegistrationLaunchObject) (string, string, error) {
+	observed, err := decodeCapabilityJSONObject(raw)
+	if err != nil {
+		return "", "", err
+	}
+	desired, err := decodeCapabilityJSONObject(expected.raw)
+	if err != nil || !capabilitySubset(desired, observed) {
+		return "", "", errors.New("observed target-registration object does not contain exact desired fields")
+	}
+	metadata, _ := observed["metadata"].(map[string]any)
+	uid, _ := metadata["uid"].(string)
+	resourceVersion, _ := metadata["resourceVersion"].(string)
+	if metadata["name"] != expected.name || metadata["namespace"] != expected.namespace || !runtimeInputUIDPattern.MatchString(uid) || !runtimeInputUIDPattern.MatchString(resourceVersion) {
+		return "", "", errors.New("observed target-registration server identity is invalid")
+	}
+	return uid, resourceVersion, nil
+}
+
+func (launcher *KubernetesTargetRegistrationLauncher) request(ctx context.Context, method, path string, body []byte) ([]byte, int, error) {
+	endpoint := *launcher.endpoint
+	endpoint.Path = path
+	request, err := http.NewRequestWithContext(ctx, method, endpoint.String(), bytes.NewReader(body))
+	if err != nil {
+		return nil, 0, errors.New("construct bounded target-registration request")
+	}
+	request.Header.Set("Accept", "application/json")
+	if method == http.MethodGet {
+		request.Header.Set("Accept", partialObjectMetadataAccept)
+	}
+	request.Header.Set("Authorization", "Bearer "+launcher.token)
+	if body != nil {
+		request.Header.Set("Content-Type", "application/json")
+	}
+	response, err := launcher.client.Do(request)
+	if err != nil {
+		return nil, 0, fmt.Errorf("bounded target-registration %s request failed", method)
+	}
+	defer response.Body.Close()
+	raw, readErr := io.ReadAll(io.LimitReader(response.Body, maximumStageInstallationResponseBytes+1))
+	if readErr != nil || len(raw) > maximumStageInstallationResponseBytes {
+		return nil, 0, errors.New("bounded target-registration response exceeds accepted size")
+	}
+	if len(raw) > 0 {
+		mediaType, _, err := mime.ParseMediaType(response.Header.Get("Content-Type"))
+		if err != nil || mediaType != "application/json" {
+			return nil, 0, errors.New("bounded target-registration response is not JSON")
+		}
+	}
+	return raw, response.StatusCode, nil
+}
+
+func targetRegistrationLaunchStatusError(method string, status int) error {
+	return fmt.Errorf("bounded target-registration %s returned status %d", method, status)
+}

--- a/internal/runner/target_registration_launcher_test.go
+++ b/internal/runner/target_registration_launcher_test.go
@@ -1,0 +1,253 @@
+package runner
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+func TestTargetRegistrationLauncherPreflightsThenCreatesExactObjects(t *testing.T) {
+	fixture := targetRegistrationMaterialFixture(t)
+	material, err := BuildTargetRegistrationMaterial(fixture.config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	api := newTargetRegistrationLauncherAPI(t)
+	launcher := newTargetRegistrationLauncher(t, material, api.client(), fixture.config.MaterializationTime.Add(time.Minute))
+	receipt, err := launcher.Install(context.Background())
+	if err != nil || receipt.State != "INSTALLED" || receipt.MutationState != "ATTEMPTED" || len(receipt.Results) != 2 {
+		t.Fatalf("target registration failed: %#v %v", receipt, err)
+	}
+	if receipt.Format != TargetRegistrationLaunchReceiptFormat || receipt.StageID != "target-registration" ||
+		receipt.PlanDigest != material.receipt.PlanDigest || receipt.TargetIdentityDigest != material.receipt.TargetIdentityDigest ||
+		receipt.MaterializationBindingDigest != material.receipt.MaterializationBindingDigest || receipt.Authority != "ok-shared" || receipt.CredentialBytesInReceipt {
+		t.Fatalf("unexpected target-registration receipt: %#v", receipt)
+	}
+	if len(api.requests) != 4 {
+		t.Fatalf("requests=%d, want two GETs then two POSTs", len(api.requests))
+	}
+	for index, object := range launcher.objects {
+		preflight, submission := api.requests[index], api.requests[index+2]
+		if preflight.method != http.MethodGet || preflight.path != object.objectPath || len(preflight.body) != 0 ||
+			submission.method != http.MethodPost || submission.path != object.collectionPath || digest.SHA256(submission.body) != object.privateDigest {
+			t.Fatalf("request %d differs from exact material", index)
+		}
+		result := receipt.Results[index]
+		if result.Order != index+1 || result.Role != object.role || result.Namespace != object.namespace || result.Name != object.name ||
+			result.BoundDigest != object.boundDigest || result.State != "CREATED" || result.MaterializedObjectDigestRetained ||
+			!stageReceiptPrefixDigestPattern.MatchString(result.UIDDigest) || !stageReceiptPrefixDigestPattern.MatchString(result.ResourceVersionDigest) {
+			t.Fatalf("result %d differs: %#v", index, result)
+		}
+	}
+	public, err := json.Marshal(receipt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range []string{
+		string(fixture.credential.token), string(fixture.credential.caBundle), fixture.credential.endpoint,
+		fixture.runtime.material.Target.CAPIClusterUID, fixture.runtime.material.Target.KubeSystemUID,
+		material.registrationDigest, "created-target-registration-uid",
+	} {
+		if bytes.Contains(public, []byte(forbidden)) {
+			t.Fatalf("public launch receipt leaked %q", forbidden)
+		}
+	}
+}
+
+func TestTargetRegistrationLauncherStopsZeroWriteForExistingOrStaleMaterial(t *testing.T) {
+	t.Run("existing registration", func(t *testing.T) {
+		fixture := targetRegistrationMaterialFixture(t)
+		material, _ := BuildTargetRegistrationMaterial(fixture.config)
+		api := newTargetRegistrationLauncherAPI(t)
+		launcher := newTargetRegistrationLauncher(t, material, api.client(), fixture.config.MaterializationTime.Add(time.Minute))
+		api.objects[launcher.objects[1].objectPath] = map[string]any{"kind": "Secret"}
+		receipt, err := launcher.Install(context.Background())
+		if err == nil || receipt.State != "STOPPED_ZERO_WRITE" || receipt.MutationState != "NOT_ATTEMPTED" || api.posts != 0 || len(api.requests) != 2 {
+			t.Fatalf("existing registration did not stop before writes: %#v requests=%d err=%v", receipt, len(api.requests), err)
+		}
+	})
+	t.Run("near expiry", func(t *testing.T) {
+		fixture := targetRegistrationMaterialFixture(t)
+		material, _ := BuildTargetRegistrationMaterial(fixture.config)
+		api := newTargetRegistrationLauncherAPI(t)
+		launcher := newTargetRegistrationLauncher(t, material, api.client(), fixture.credential.expiresAt.Add(-29*time.Minute))
+		receipt, err := launcher.Install(context.Background())
+		if err == nil || receipt.State != "STOPPED_ZERO_WRITE" || receipt.MutationState != "NOT_ATTEMPTED" || len(api.requests) != 0 {
+			t.Fatalf("stale material reached API: %#v requests=%d err=%v", receipt, len(api.requests), err)
+		}
+	})
+	t.Run("before materialization", func(t *testing.T) {
+		fixture := targetRegistrationMaterialFixture(t)
+		material, _ := BuildTargetRegistrationMaterial(fixture.config)
+		api := newTargetRegistrationLauncherAPI(t)
+		launcher := newTargetRegistrationLauncher(t, material, api.client(), fixture.config.MaterializationTime.Add(-time.Second))
+		receipt, err := launcher.Install(context.Background())
+		if err == nil || receipt.State != "STOPPED_ZERO_WRITE" || len(api.requests) != 0 {
+			t.Fatalf("pre-materialization launch reached API: %#v requests=%d err=%v", receipt, len(api.requests), err)
+		}
+	})
+}
+
+func TestTargetRegistrationLauncherPreservesPartialStateAndCannotRetry(t *testing.T) {
+	fixture := targetRegistrationMaterialFixture(t)
+	material, _ := BuildTargetRegistrationMaterial(fixture.config)
+	api := newTargetRegistrationLauncherAPI(t)
+	api.failPost = 2
+	launcher := newTargetRegistrationLauncher(t, material, api.client(), fixture.config.MaterializationTime.Add(time.Minute))
+	receipt, err := launcher.Install(context.Background())
+	if err == nil || receipt.State != "STOPPED_PARTIAL_OR_UNKNOWN" || receipt.MutationState != "ATTEMPTED" || len(receipt.Results) != 1 || receipt.Results[0].Role != "project" {
+		t.Fatalf("partial state differs: %#v %v", receipt, err)
+	}
+	requests := len(api.requests)
+	retry, retryErr := launcher.Install(context.Background())
+	if retryErr == nil || retry.State != "STOPPED_ZERO_WRITE" || len(api.requests) != requests {
+		t.Fatalf("single-use launcher retried: %#v %v", retry, retryErr)
+	}
+}
+
+func TestTargetRegistrationLauncherFailsClosedForTamperingUnknownOutcomeAndRedirect(t *testing.T) {
+	fixture := targetRegistrationMaterialFixture(t)
+	material, _ := BuildTargetRegistrationMaterial(fixture.config)
+	tampered := material
+	tampered.registrationPath = "/api/v1/namespaces/argocd/secrets/foreign"
+	if _, err := newKubernetesTargetRegistrationLauncher(targetRegistrationLauncherClientConfig{
+		Endpoint: "https://127.0.0.1:12345", BearerToken: "short-lived-gitops-token", AuthorityIdentity: "ok-shared",
+		Client: newTargetRegistrationLauncherAPI(t).client(), Clock: time.Now,
+	}, tampered); err == nil {
+		t.Fatal("tampered material opened launcher")
+	}
+	if _, err := newKubernetesTargetRegistrationLauncher(targetRegistrationLauncherClientConfig{
+		Endpoint: "https://127.0.0.1:12345", BearerToken: string(fixture.credential.token), AuthorityIdentity: "ok-shared",
+		Client: newTargetRegistrationLauncherAPI(t).client(), Clock: time.Now,
+	}, material); err == nil {
+		t.Fatal("workload target credential was accepted as GitOps writer credential")
+	}
+
+	api := newTargetRegistrationLauncherAPI(t)
+	api.errorPost = 1
+	launcher := newTargetRegistrationLauncher(t, material, api.client(), fixture.config.MaterializationTime.Add(time.Minute))
+	receipt, err := launcher.Install(context.Background())
+	if err == nil || receipt.State != "STOPPED_PARTIAL_OR_UNKNOWN" || receipt.MutationState != "ATTEMPTED_UNKNOWN" || len(receipt.Results) != 0 || strings.Contains(err.Error(), string(fixture.credential.token)) {
+		t.Fatalf("unknown outcome accepted or leaked: %#v %v", receipt, err)
+	}
+
+	calls := 0
+	redirect := &http.Client{Transport: targetRegistrationRoundTripFunc(func(*http.Request) (*http.Response, error) {
+		calls++
+		return targetRegistrationJSONResponse(http.StatusTemporaryRedirect, nil, map[string]string{"Location": "http://127.0.0.1:12346/foreign"}), nil
+	})}
+	launcher = newTargetRegistrationLauncher(t, material, redirect, fixture.config.MaterializationTime.Add(time.Minute))
+	receipt, err = launcher.Install(context.Background())
+	if err == nil || calls != 1 || receipt.State != "STOPPED_ZERO_WRITE" || receipt.MutationState != "NOT_ATTEMPTED" {
+		t.Fatalf("redirect followed or accepted: calls=%d receipt=%#v err=%v", calls, receipt, err)
+	}
+}
+
+func newTargetRegistrationLauncher(t *testing.T, material VerifiedTargetRegistrationMaterial, client *http.Client, now time.Time) *KubernetesTargetRegistrationLauncher {
+	t.Helper()
+	launcher, err := newKubernetesTargetRegistrationLauncher(targetRegistrationLauncherClientConfig{
+		Endpoint: "https://127.0.0.1:12345", BearerToken: "short-lived-gitops-token", AuthorityIdentity: "ok-shared",
+		Client: client, Clock: func() time.Time { return now },
+	}, material)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return launcher
+}
+
+type targetRegistrationLauncherRequest struct {
+	method string
+	path   string
+	body   []byte
+}
+
+type targetRegistrationLauncherAPI struct {
+	t            *testing.T
+	mu           sync.Mutex
+	objects      map[string]map[string]any
+	requests     []targetRegistrationLauncherRequest
+	posts        int
+	failPost     int
+	errorPost    int
+	mismatchPost int
+}
+
+func newTargetRegistrationLauncherAPI(t *testing.T) *targetRegistrationLauncherAPI {
+	return &targetRegistrationLauncherAPI{t: t, objects: map[string]map[string]any{}}
+}
+
+func (api *targetRegistrationLauncherAPI) client() *http.Client {
+	return &http.Client{Transport: targetRegistrationRoundTripFunc(api.roundTrip)}
+}
+
+func (api *targetRegistrationLauncherAPI) roundTrip(request *http.Request) (*http.Response, error) {
+	api.mu.Lock()
+	defer api.mu.Unlock()
+	body, _ := io.ReadAll(request.Body)
+	api.requests = append(api.requests, targetRegistrationLauncherRequest{method: request.Method, path: request.URL.Path, body: body})
+	if request.Header.Get("Authorization") != "Bearer short-lived-gitops-token" {
+		return targetRegistrationJSONResponse(http.StatusUnauthorized, map[string]any{"reason": "Unauthorized"}, nil), nil
+	}
+	if request.Method == http.MethodGet && request.Header.Get("Accept") != partialObjectMetadataAccept {
+		return targetRegistrationJSONResponse(http.StatusNotAcceptable, map[string]any{"reason": "NotAcceptable"}, nil), nil
+	}
+	switch request.Method {
+	case http.MethodGet:
+		object, exists := api.objects[request.URL.Path]
+		if !exists {
+			return targetRegistrationJSONResponse(http.StatusNotFound, map[string]any{"reason": "NotFound"}, nil), nil
+		}
+		return targetRegistrationJSONResponse(http.StatusOK, object, nil), nil
+	case http.MethodPost:
+		api.posts++
+		if api.errorPost == api.posts {
+			return nil, errors.New("simulated transport error")
+		}
+		if api.failPost == api.posts {
+			return targetRegistrationJSONResponse(http.StatusForbidden, map[string]any{"reason": "Denied"}, nil), nil
+		}
+		var object map[string]any
+		if err := json.Unmarshal(body, &object); err != nil {
+			api.t.Fatal(err)
+		}
+		metadata := object["metadata"].(map[string]any)
+		metadata["uid"] = "created-target-registration-uid-" + string(rune('a'+api.posts-1))
+		metadata["resourceVersion"] = string(rune('1' + api.posts - 1))
+		path := request.URL.Path + "/" + metadata["name"].(string)
+		api.objects[path] = object
+		if api.mismatchPost == api.posts {
+			metadata["name"] = "foreign-object"
+		}
+		return targetRegistrationJSONResponse(http.StatusCreated, object, nil), nil
+	default:
+		return targetRegistrationJSONResponse(http.StatusMethodNotAllowed, map[string]any{"reason": "MethodNotAllowed"}, nil), nil
+	}
+}
+
+type targetRegistrationRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (function targetRegistrationRoundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return function(request)
+}
+
+func targetRegistrationJSONResponse(status int, value any, headers map[string]string) *http.Response {
+	var raw []byte
+	if value != nil {
+		raw, _ = json.Marshal(value)
+	}
+	header := make(http.Header)
+	header.Set("Content-Type", "application/json")
+	for key, value := range headers {
+		header.Set(key, value)
+	}
+	return &http.Response{StatusCode: status, Header: header, Body: io.NopCloser(bytes.NewReader(raw))}
+}

--- a/internal/runner/target_registration_material.go
+++ b/internal/runner/target_registration_material.go
@@ -49,14 +49,19 @@ type TargetRegistrationMaterialReceipt struct {
 // private to the runner package so only the immediately following bounded
 // launcher can consume it. Its Receipt method exposes only redacted bindings.
 type VerifiedTargetRegistrationMaterial struct {
-	project              []byte
-	registration         []byte
-	registrationDigest   string
-	receipt              TargetRegistrationMaterialReceipt
-	targetIdentityDigest string
-	authority            string
-	expiresAt            time.Time
-	verified             bool
+	project                []byte
+	projectCollection      string
+	projectPath            string
+	registration           []byte
+	registrationDigest     string
+	registrationCollection string
+	registrationPath       string
+	receipt                TargetRegistrationMaterialReceipt
+	targetIdentityDigest   string
+	authority              string
+	expiresAt              time.Time
+	materializedAt         time.Time
+	verified               bool
 }
 
 type targetRegistrationTLSConfig struct {
@@ -167,10 +172,14 @@ func BuildTargetRegistrationMaterial(config TargetRegistrationMaterializeConfig)
 		CredentialBytesInReceipt: false, MaterializedSecretDigestRetained: false, MutationAllowed: false,
 	}
 	return VerifiedTargetRegistrationMaterial{
-		project: append([]byte(nil), bundle.projection.Project.Raw...), registration: registrationRaw,
+		project:           append([]byte(nil), bundle.projection.Project.Raw...),
+		projectCollection: bundle.projection.Project.CollectionPath, projectPath: bundle.projection.Project.ObjectPath,
+		registration: registrationRaw, registrationCollection: bundle.projection.Registration.CollectionPath,
+		registrationPath:   bundle.projection.Registration.ObjectPath,
 		registrationDigest: digest.SHA256(registrationRaw), receipt: receipt,
 		targetIdentityDigest: bundle.receipt.TargetIdentityDigest, authority: bundle.receipt.Authority,
 		expiresAt: config.Credential.expiresAt, verified: true,
+		materializedAt: config.MaterializationTime,
 	}, nil
 }
 
@@ -201,8 +210,14 @@ func verifyTargetRegistrationMaterial(material VerifiedTargetRegistrationMateria
 		digest.SHA256(material.registration) != material.registrationDigest || material.registrationDigest == material.receipt.RegistrationTemplateDigest {
 		return errors.New("target-registration material changed after verification")
 	}
+	if err := verifyTargetRegistrationMaterialPath(material.project, "argoproj.io/v1alpha1", "AppProject", material.projectCollection, material.projectPath); err != nil {
+		return err
+	}
+	if err := verifyTargetRegistrationMaterialPath(material.registration, "v1", "Secret", material.registrationCollection, material.registrationPath); err != nil {
+		return err
+	}
 	expiresAt, err := time.Parse(time.RFC3339, material.receipt.ExpiresAt)
-	if err != nil || !expiresAt.Equal(material.expiresAt) {
+	if err != nil || !expiresAt.Equal(material.expiresAt) || material.materializedAt.IsZero() || material.materializedAt.Location() != time.UTC {
 		return errors.New("target-registration material expiration is invalid")
 	}
 	bindingRaw, err := canonicalTargetRegistrationValue(targetRegistrationSafeBinding{
@@ -213,6 +228,27 @@ func verifyTargetRegistrationMaterial(material VerifiedTargetRegistrationMateria
 	})
 	if err != nil || digest.SHA256(bindingRaw) != material.receipt.MaterializationBindingDigest {
 		return errors.New("target-registration material binding changed after verification")
+	}
+	return nil
+}
+
+func verifyTargetRegistrationMaterialPath(raw []byte, apiVersion, kind, collection, objectPath string) error {
+	var value map[string]any
+	if err := json.Unmarshal(raw, &value); err != nil || value["apiVersion"] != apiVersion || value["kind"] != kind {
+		return errors.New("target-registration material object identity is invalid")
+	}
+	metadata, _ := value["metadata"].(map[string]any)
+	namespace, namespaceOK := metadata["namespace"].(string)
+	name, nameOK := metadata["name"].(string)
+	if !namespaceOK || !nameOK || !runtimeInputUIDPattern.MatchString(namespace) || !runtimeInputUIDPattern.MatchString(name) {
+		return errors.New("target-registration material object metadata is invalid")
+	}
+	wantCollection := "/api/v1/namespaces/" + namespace + "/secrets"
+	if kind == "AppProject" {
+		wantCollection = "/apis/argoproj.io/v1alpha1/namespaces/" + namespace + "/appprojects"
+	}
+	if collection != wantCollection || objectPath != wantCollection+"/"+name {
+		return errors.New("target-registration material object path changed after verification")
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary
- add a single-use Stage-9 writer for the verified AppProject and in-memory Argo registration Secret
- complete both exact absence checks before the first write and preserve partial state without retry
- keep target credentials, authority material, raw UIDs and the materialized Secret digest out of public receipts

## Safety boundary
- exactly two create-only writes against the bound GitOps authority
- no update, patch, apply, delete, list, watch or retry path
- GitOps writer and workload target credentials must be distinct

## Verification
- full go test ./...
- go vet ./...
- race tests for internal/runner and cmd/ok