### PR TITLE
OK-147: Bind target registration to staged execution

### DIFF
--- a/internal/runner/target_registration_stage_mutator.go
+++ b/internal/runner/target_registration_stage_mutator.go
@@ -1,0 +1,123 @@
+package runner
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+
+	"github.com/openkubes/ok-cluster/internal/contract"
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/execution"
+	"github.com/openkubes/ok-cluster/internal/stageplan"
+)
+
+// TargetRegistrationStageMutator adapts exactly one already prepared
+// create-only launcher to the durable staged-operation protocol. It adds no
+// API route and cannot select another stage or authority at runtime.
+type TargetRegistrationStageMutator struct {
+	binding   execution.StageMutationBinding
+	identity  contract.Identity
+	material  TargetRegistrationMaterialReceipt
+	authority string
+	launcher  *KubernetesTargetRegistrationLauncher
+}
+
+var _ execution.StageMutator = (*TargetRegistrationStageMutator)(nil)
+
+func NewTargetRegistrationStageMutator(plan stageplan.Binding, material VerifiedTargetRegistrationMaterial, launcher *KubernetesTargetRegistrationLauncher) (*TargetRegistrationStageMutator, error) {
+	receipt, err := material.Receipt()
+	if err != nil || launcher == nil || launcher.receipt != receipt || launcher.authority != plan.Authorities.GitOps {
+		return nil, errors.New("target-registration mutator requires exact verified material and launcher")
+	}
+	stage, stageDigest, err := plan.Stage("target-registration")
+	if err != nil {
+		return nil, err
+	}
+	if receipt.PlanDigest != plan.PlanDigest || receipt.TargetIdentityDigest != material.targetIdentityDigest ||
+		stage.Authority != "gitops" || material.authority != plan.Authorities.GitOps || stage.GrantOperation != "RegisterTarget" || len(stage.Inputs) != 1 ||
+		stage.Inputs[0].Name != "stage.target-registration" {
+		return nil, errors.New("target-registration material differs from selected staged plan")
+	}
+	return &TargetRegistrationStageMutator{
+		binding: execution.StageMutationBinding{
+			PlanDigest: plan.PlanDigest, StageID: stage.ID, StageDigest: stageDigest,
+			Operation: stage.GrantOperation, Authority: stage.Authority, ContractRevision: plan.IntentRevision,
+		},
+		identity: plan.ContractIdentity, material: receipt, authority: plan.Authorities.GitOps, launcher: launcher,
+	}, nil
+}
+
+func (mutator *TargetRegistrationStageMutator) Binding() execution.StageMutationBinding {
+	if mutator == nil {
+		return execution.StageMutationBinding{}
+	}
+	return mutator.binding
+}
+
+func (mutator *TargetRegistrationStageMutator) Mutate(ctx context.Context, request execution.StageMutationRequest) (execution.StageMutationResult, error) {
+	if mutator == nil || request.StageMutationBinding != mutator.binding || request.ContractIdentity != mutator.identity ||
+		request.GrantID == "" || !stageReceiptPrefixDigestPattern.MatchString(request.PredecessorDigest) {
+		return execution.StageMutationResult{}, errors.New("target-registration mutation request differs from the preconstructed stage")
+	}
+	receipt, launchErr := mutator.launcher.Install(ctx)
+	mutationState, err := validateTargetRegistrationLaunchOutcome(receipt, mutator.material, mutator.authority, launchErr != nil)
+	if err != nil {
+		return execution.StageMutationResult{}, err
+	}
+	receiptRaw, err := json.Marshal(receipt)
+	if err != nil {
+		return execution.StageMutationResult{}, errors.New("derive bounded target-registration evidence")
+	}
+	result := execution.StageMutationResult{Outcome: "STOPPED", MutationState: mutationState, EvidenceDigest: digest.SHA256(receiptRaw)}
+	if launchErr != nil {
+		return result, errors.New("bounded target-registration launch stopped")
+	}
+	if receipt.State == "INSTALLED" && mutationState == "ATTEMPTED" {
+		result.Outcome = "SUCCEEDED"
+	}
+	return result, nil
+}
+
+func validateTargetRegistrationLaunchOutcome(receipt TargetRegistrationLaunchReceipt, material TargetRegistrationMaterialReceipt, authority string, stopped bool) (string, error) {
+	wantState := "INSTALLED"
+	if stopped {
+		if receipt.State != "STOPPED_ZERO_WRITE" && receipt.State != "STOPPED_PARTIAL_OR_UNKNOWN" {
+			return "", errors.New("target-registration stopped receipt has invalid state")
+		}
+		wantState = receipt.State
+	}
+	if receipt.Format != TargetRegistrationLaunchReceiptFormat || receipt.StageID != "target-registration" ||
+		receipt.PlanDigest != material.PlanDigest || receipt.TargetIdentityDigest != material.TargetIdentityDigest ||
+		receipt.MaterializationBindingDigest != material.MaterializationBindingDigest || receipt.Authority != authority || receipt.State != wantState ||
+		receipt.CredentialBytesInReceipt || len(receipt.Results) > 2 || (!stopped && len(receipt.Results) != 2) {
+		return "", errors.New("target-registration launch receipt differs from verified material")
+	}
+	expectedRoles := []string{"project", "registration"}
+	expectedDigests := []string{material.ProjectDigest, material.RegistrationTemplateDigest}
+	for index, result := range receipt.Results {
+		if result.Order != index+1 || result.Role != expectedRoles[index] || result.BoundDigest != expectedDigests[index] ||
+			result.Namespace == "" || result.Name == "" || result.State != "CREATED" || result.MaterializedObjectDigestRetained ||
+			!stageReceiptPrefixDigestPattern.MatchString(result.UIDDigest) || !stageReceiptPrefixDigestPattern.MatchString(result.ResourceVersionDigest) {
+			return "", errors.New("target-registration launch result differs from exact object order")
+		}
+	}
+	switch receipt.MutationState {
+	case "NOT_ATTEMPTED":
+		if len(receipt.Results) != 0 || !stopped {
+			return "", errors.New("target-registration no-write outcome is inconsistent")
+		}
+		return "NOT_ATTEMPTED", nil
+	case "ATTEMPTED":
+		if len(receipt.Results) == 0 && !stopped {
+			return "", errors.New("target-registration attempted outcome lacks results")
+		}
+		return "ATTEMPTED", nil
+	case "ATTEMPTED_UNKNOWN":
+		if !stopped {
+			return "", errors.New("target-registration unknown outcome is not stopped")
+		}
+		return "UNKNOWN", nil
+	default:
+		return "", errors.New("target-registration mutation state is invalid")
+	}
+}

--- a/internal/runner/target_registration_stage_mutator_test.go
+++ b/internal/runner/target_registration_stage_mutator_test.go
@@ -1,0 +1,77 @@
+package runner
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/execution"
+)
+
+func TestTargetRegistrationStageMutatorReturnsBoundedSuccess(t *testing.T) {
+	fixture := targetRegistrationMaterialFixture(t)
+	material, _ := BuildTargetRegistrationMaterial(fixture.config)
+	api := newTargetRegistrationLauncherAPI(t)
+	launcher := newTargetRegistrationLauncher(t, material, api.client(), fixture.config.MaterializationTime.Add(time.Minute))
+	mutator, err := NewTargetRegistrationStageMutator(fixture.bundle.plan, material, launcher)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := targetRegistrationMutationRequest(mutator)
+	result, err := mutator.Mutate(context.Background(), request)
+	if err != nil || result.Outcome != "SUCCEEDED" || result.MutationState != "ATTEMPTED" || !stageReceiptPrefixDigestPattern.MatchString(result.EvidenceDigest) || result.TargetClusterUIDDigest != "" {
+		t.Fatalf("unexpected target-registration mutation result: %#v %v", result, err)
+	}
+}
+
+func TestTargetRegistrationStageMutatorMapsPartialAndUnknownOutcomesToStops(t *testing.T) {
+	for name, test := range map[string]struct {
+		configure    func(*targetRegistrationLauncherAPI)
+		wantMutation string
+	}{
+		"known partial":       {configure: func(api *targetRegistrationLauncherAPI) { api.failPost = 2 }, wantMutation: "ATTEMPTED"},
+		"unknown first write": {configure: func(api *targetRegistrationLauncherAPI) { api.errorPost = 1 }, wantMutation: "UNKNOWN"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			fixture := targetRegistrationMaterialFixture(t)
+			material, _ := BuildTargetRegistrationMaterial(fixture.config)
+			api := newTargetRegistrationLauncherAPI(t)
+			test.configure(api)
+			launcher := newTargetRegistrationLauncher(t, material, api.client(), fixture.config.MaterializationTime.Add(time.Minute))
+			mutator, _ := NewTargetRegistrationStageMutator(fixture.bundle.plan, material, launcher)
+			result, err := mutator.Mutate(context.Background(), targetRegistrationMutationRequest(mutator))
+			if err == nil || result.Outcome != "STOPPED" || result.MutationState != test.wantMutation || !stageReceiptPrefixDigestPattern.MatchString(result.EvidenceDigest) {
+				t.Fatalf("partial outcome was not bounded: %#v %v", result, err)
+			}
+		})
+	}
+}
+
+func TestTargetRegistrationStageMutatorRejectsMismatchedRequestAndMaterial(t *testing.T) {
+	fixture := targetRegistrationMaterialFixture(t)
+	material, _ := BuildTargetRegistrationMaterial(fixture.config)
+	api := newTargetRegistrationLauncherAPI(t)
+	launcher := newTargetRegistrationLauncher(t, material, api.client(), fixture.config.MaterializationTime.Add(time.Minute))
+	mutator, _ := NewTargetRegistrationStageMutator(fixture.bundle.plan, material, launcher)
+	request := targetRegistrationMutationRequest(mutator)
+	request.GrantID = ""
+	if _, err := mutator.Mutate(context.Background(), request); err == nil || len(api.requests) != 0 {
+		t.Fatal("mismatched request reached target-registration API")
+	}
+
+	foreign := material
+	foreign.receipt.PlanDigest = runnerStageSHA("f")
+	if _, err := NewTargetRegistrationStageMutator(fixture.bundle.plan, foreign, launcher); err == nil {
+		t.Fatal("foreign material opened target-registration mutator")
+	}
+	if _, err := NewTargetRegistrationStageMutator(fixture.bundle.plan, material, nil); err == nil {
+		t.Fatal("nil launcher opened target-registration mutator")
+	}
+}
+
+func targetRegistrationMutationRequest(mutator *TargetRegistrationStageMutator) execution.StageMutationRequest {
+	return execution.StageMutationRequest{
+		StageMutationBinding: mutator.Binding(), ContractIdentity: mutator.identity,
+		GrantID: "ok147-target-registration-grant", PredecessorDigest: runnerStageSHA("7"),
+	}
+}


### PR DESCRIPTION
## Summary
- adapt the exact Stage-9 create-only launcher to the durable staged-operation contract
- convert redacted launcher receipts into bounded SUCCEEDED or STOPPED results
- preserve zero-write, known-partial and unknown-write mutation semantics without adding API capability

## Safety boundary
- no new Kubernetes route or credential source
- no dynamic stage or authority selection
- evidence is derived only from the redacted launch receipt

## Verification
- full go test ./...
- go vet ./...
- race tests for internal/runner and cmd/ok