### PR TITLE
OK-147: Compose target registration with durable ledger

### DIFF
--- a/internal/runner/target_registration_material.go
+++ b/internal/runner/target_registration_material.go
@@ -153,6 +153,10 @@ func BuildTargetRegistrationMaterial(config TargetRegistrationMaterializeConfig)
 	if err != nil {
 		return VerifiedTargetRegistrationMaterial{}, errors.New("canonicalize target-credential receipt")
 	}
+	credentialStageReceipt, err := bundle.prefix[7].Receipt()
+	if err != nil || credentialStageReceipt.StageID != "target-credential" || credentialStageReceipt.EvidenceDigest != digest.SHA256(credentialReceiptRaw) {
+		return VerifiedTargetRegistrationMaterial{}, errors.New("target-credential material differs from durable stage evidence")
+	}
 	binding := targetRegistrationSafeBinding{
 		PlanDigest: bundle.plan.PlanDigest, TargetIdentityDigest: bundle.receipt.TargetIdentityDigest,
 		ProjectDigest: bundle.receipt.ProjectDigest, RegistrationTemplateDigest: bundle.receipt.RegistrationTemplateDigest,

--- a/internal/runner/target_registration_material_test.go
+++ b/internal/runner/target_registration_material_test.go
@@ -90,6 +90,9 @@ func TestBuildTargetRegistrationMaterialFailsClosed(t *testing.T) {
 		"credential target mismatch": func(f *targetRegistrationMaterialTestFixture) {
 			f.config.Credential.targetIdentity = runnerStageSHA("8")
 		},
+		"credential evidence mismatch": func(f *targetRegistrationMaterialTestFixture) {
+			f.config.Credential.receipt.RequestDigest = runnerStageSHA("6")
+		},
 		"credential endpoint mismatch": func(f *targetRegistrationMaterialTestFixture) {
 			f.config.Credential.endpoint = "https://192.0.2.148:6443"
 		},
@@ -156,13 +159,7 @@ func targetRegistrationMaterialFixture(t *testing.T) targetRegistrationMaterialT
 		token: token, caBundle: ca, endpoint: runtime.material.Target.WorkloadAPIEndpoint,
 		targetIdentity: bundle.receipt.TargetIdentityDigest, expiresAt: now.Add(2 * time.Hour), verified: true,
 	}
-	credential.receipt = TargetCredentialIssueReceipt{
-		Format: TargetCredentialIssueReceiptFormat, State: "ISSUED", StageID: "target-credential",
-		PolicyDigest: runnerStageSHA("3"), TargetIdentityDigest: bundle.receipt.TargetIdentityDigest,
-		ServiceAccountIdentityDigest: runnerStageSHA("4"), RequestDigest: runnerStageSHA("5"), AudienceMode: "server-default",
-		IssuedAt: now.Format(time.RFC3339), ExpiresAt: credential.expiresAt.Format(time.RFC3339), LifetimeSeconds: 7200,
-		CredentialBytesInReceipt: false, MutationState: "ATTEMPTED",
-	}
+	credential.receipt = targetRegistrationCredentialReceipt(now.Add(-time.Minute), targetCredentialPolicyDocument{TargetIdentityDigest: bundle.receipt.TargetIdentityDigest})
 	credential.privateDigest, err = targetCredentialPrivateDigest(credential)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/runner/target_registration_stage_bundle.go
+++ b/internal/runner/target_registration_stage_bundle.go
@@ -1,11 +1,14 @@
 package runner
 
 import (
+	"context"
+	"crypto/subtle"
 	"errors"
 	"time"
 
 	"github.com/openkubes/ok-cluster/internal/authorization"
 	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/execution"
 	"github.com/openkubes/ok-cluster/internal/stagecursor"
 	"github.com/openkubes/ok-cluster/internal/stageplan"
 	"github.com/openkubes/ok-cluster/internal/stagereceipt"
@@ -48,6 +51,23 @@ type VerifiedTargetRegistrationStageBundle struct {
 	projection submission.TargetRegistrationPlan
 	receipt    TargetRegistrationStageBundleReceipt
 	verified   bool
+}
+
+type TargetRegistrationStageRuntimeConfig struct {
+	Ledger              KubernetesLedgerConfig
+	GitOps              KubernetesAuthorityConfig
+	Runtime             VerifiedRuntimeBindingMaterial
+	Credential          VerifiedTargetCredentialMaterial
+	MaterializationTime time.Time
+	Clock               func() time.Time
+}
+
+type BoundTargetRegistrationStage struct {
+	operation execution.StagedOperation
+	plan      stageplan.Binding
+	cursor    stagecursor.Cursor
+	grant     authorization.VerifiedStageGrant
+	verified  bool
 }
 
 // LoadTargetRegistrationStageBundle verifies the eight-stage predecessor
@@ -125,6 +145,47 @@ func (bundle VerifiedTargetRegistrationStageBundle) Receipt() (TargetRegistratio
 		return TargetRegistrationStageBundleReceipt{}, err
 	}
 	return bundle.receipt, nil
+}
+
+// Open binds the verified offline bundle to its private runtime, target
+// credential, GitOps writer and durable ledger. It reads bounded credential
+// files but performs no API request and no mutation.
+func (bundle VerifiedTargetRegistrationStageBundle) Open(config TargetRegistrationStageRuntimeConfig) (BoundTargetRegistrationStage, error) {
+	if err := verifyTargetRegistrationStageBundle(bundle); err != nil || config.Clock == nil {
+		return BoundTargetRegistrationStage{}, errors.New("verified target-registration bundle and clock are required")
+	}
+	material, err := BuildTargetRegistrationMaterial(TargetRegistrationMaterializeConfig{
+		Bundle: bundle, Runtime: config.Runtime, Credential: config.Credential, MaterializationTime: config.MaterializationTime,
+	})
+	if err != nil {
+		return BoundTargetRegistrationStage{}, err
+	}
+	launcher, err := OpenKubernetesTargetRegistrationLauncher(TargetRegistrationLauncherConfig{Authority: config.GitOps, Clock: config.Clock}, material)
+	if err != nil {
+		return BoundTargetRegistrationStage{}, err
+	}
+	ledgerStore, ledgerToken, err := openKubernetesLedger(config.Ledger)
+	if err != nil {
+		return BoundTargetRegistrationStage{}, errors.New("open target-registration stage ledger")
+	}
+	if len(ledgerToken) == len(launcher.token) && subtle.ConstantTimeCompare([]byte(ledgerToken), []byte(launcher.token)) == 1 {
+		return BoundTargetRegistrationStage{}, errors.New("ledger and target-registration writer credentials must be distinct")
+	}
+	mutator, err := NewTargetRegistrationStageMutator(bundle.plan, material, launcher)
+	if err != nil {
+		return BoundTargetRegistrationStage{}, err
+	}
+	return BoundTargetRegistrationStage{
+		operation: execution.StagedOperation{Ledger: ledgerStore, Mutator: mutator, Clock: config.Clock},
+		plan:      bundle.plan, cursor: bundle.cursor, grant: bundle.grant, verified: true,
+	}, nil
+}
+
+func (stage BoundTargetRegistrationStage) Run(ctx context.Context) (execution.StagedOperationReceipt, error) {
+	if !stage.verified {
+		return execution.StagedOperationReceipt{}, errors.New("target-registration stage runtime was not produced by verification")
+	}
+	return stage.operation.Run(ctx, stage.plan, stage.cursor, stage.grant)
 }
 
 func verifyTargetRegistrationStageBundle(bundle VerifiedTargetRegistrationStageBundle) error {

--- a/internal/runner/target_registration_stage_bundle_test.go
+++ b/internal/runner/target_registration_stage_bundle_test.go
@@ -81,6 +81,8 @@ func targetRegistrationBundleFixture(t *testing.T) targetRegistrationBundleTestF
 		RequestedAudiences: []string{}, ExpirationSeconds: 10800, CredentialUse: "argocd-target-registration", Retention: "memory-only",
 	}
 	policyRaw, _ := json.Marshal(policy)
+	credentialEvidence := targetRegistrationCredentialReceipt(at, policy)
+	credentialEvidenceRaw, _ := canonicalTargetRegistrationValue(credentialEvidence)
 	registration := runnerTargetRegistrationYAML(expectedPlan)
 	artifactDigest := digest.SHA256(registration)
 	planRaw := submissionBundlePlan(t, expectedPlan, runnerStageSHA("1"), runnerStageSHA("2"))
@@ -108,7 +110,7 @@ func targetRegistrationBundleFixture(t *testing.T) targetRegistrationBundleTestF
 		{"network-observation", "NOT_APPLICABLE", "", runnerStageSHA("9")},
 		{"runtime-binding", "NOT_APPLICABLE", "", runnerStageSHA("0")},
 		{"target-access", "ATTEMPTED", runnerStageSHA("e"), runnerStageSHA("f")},
-		{"target-credential", "ATTEMPTED", runnerStageSHA("8"), runnerStageSHA("a")},
+		{"target-credential", "ATTEMPTED", runnerStageSHA("8"), digest.SHA256(credentialEvidenceRaw)},
 	}
 	for index, result := range results {
 		var receipt stagereceipt.Verified
@@ -138,6 +140,17 @@ func targetRegistrationBundleFixture(t *testing.T) targetRegistrationBundleTestF
 			ArtifactPath: writeBundleFile(t, root, "target-registration.yaml", registration), Expected: expectedRegistration,
 		},
 		plan: plan, artifactDigest: artifactDigest,
+	}
+}
+
+func targetRegistrationCredentialReceipt(at time.Time, policy targetCredentialPolicyDocument) TargetCredentialIssueReceipt {
+	issuedAt := at.Add(time.Minute).UTC()
+	return TargetCredentialIssueReceipt{
+		Format: TargetCredentialIssueReceiptFormat, State: "ISSUED", StageID: "target-credential",
+		PolicyDigest: runnerStageSHA("3"), TargetIdentityDigest: policy.TargetIdentityDigest,
+		ServiceAccountIdentityDigest: runnerStageSHA("4"), RequestDigest: runnerStageSHA("5"), AudienceMode: "server-default",
+		IssuedAt: issuedAt.Format(time.RFC3339), ExpiresAt: issuedAt.Add(2 * time.Hour).Format(time.RFC3339), LifetimeSeconds: 7200,
+		CredentialBytesInReceipt: false, MutationState: "ATTEMPTED",
 	}
 }
 

--- a/internal/runner/target_registration_stage_execution_test.go
+++ b/internal/runner/target_registration_stage_execution_test.go
@@ -1,0 +1,182 @@
+package runner
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/execution"
+)
+
+func TestTargetRegistrationStageRunsOnceAndReplaysDurableOutcome(t *testing.T) {
+	fixture := targetRegistrationMaterialFixture(t)
+	ledgerAPI := newRuntimeBindingLedgerAPI(t)
+	defer ledgerAPI.Close()
+	gitopsAPI := newTargetRegistrationExecutionAPI(t, 0)
+	defer gitopsAPI.Close()
+	bound, err := fixture.bundle.Open(targetRegistrationExecutionRuntime(t, fixture, ledgerAPI.Server, gitopsAPI.Server))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ledgerAPI.RequestCount() != 0 || gitopsAPI.RequestCount() != 0 {
+		t.Fatal("opening target-registration stage contacted Kubernetes")
+	}
+	receipt, err := bound.Run(context.Background())
+	if err != nil || receipt.State != "COMPLETED_SUCCEEDED" || receipt.StageID != "target-registration" || receipt.StageReceiptDigest == "" {
+		t.Fatalf("target-registration stage did not complete: %#v %v", receipt, err)
+	}
+	want := []string{
+		"GET " + fixture.bundle.projection.Project.ObjectPath,
+		"GET " + fixture.bundle.projection.Registration.ObjectPath,
+		"POST " + fixture.bundle.projection.Project.CollectionPath,
+		"POST " + fixture.bundle.projection.Registration.CollectionPath,
+	}
+	if !reflect.DeepEqual(gitopsAPI.Requests(), want) {
+		t.Fatalf("target-registration request boundary differs: got %v want %v", gitopsAPI.Requests(), want)
+	}
+	public, _ := json.Marshal(receipt)
+	for _, forbidden := range []string{string(fixture.credential.token), fixture.credential.endpoint, targetAccessRuntimeUID, "ledger-token", "gitops-writer-token", gitopsAPI.URL} {
+		if strings.Contains(string(public), forbidden) {
+			t.Fatalf("stage receipt leaked private value %q", forbidden)
+		}
+	}
+	replayed, err := bound.Run(context.Background())
+	if err != nil || replayed.StageReceiptDigest != receipt.StageReceiptDigest || !reflect.DeepEqual(gitopsAPI.Requests(), want) {
+		t.Fatalf("durable target-registration outcome replayed mutation: %#v %v", replayed, err)
+	}
+}
+
+func TestTargetRegistrationStageDurablyStopsPartialStateWithoutRetry(t *testing.T) {
+	fixture := targetRegistrationMaterialFixture(t)
+	ledgerAPI := newRuntimeBindingLedgerAPI(t)
+	defer ledgerAPI.Close()
+	gitopsAPI := newTargetRegistrationExecutionAPI(t, 2)
+	defer gitopsAPI.Close()
+	bound, err := fixture.bundle.Open(targetRegistrationExecutionRuntime(t, fixture, ledgerAPI.Server, gitopsAPI.Server))
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, runErr := bound.Run(context.Background())
+	var resultErr *execution.StageResultError
+	if !errors.As(runErr, &resultErr) || receipt.State != "COMPLETED_STOPPED" || receipt.StageReceiptDigest == "" {
+		t.Fatalf("partial target-registration state was not durably stopped: %#v %v", receipt, runErr)
+	}
+	requests := gitopsAPI.Requests()
+	if len(requests) != 4 || requests[3] != "POST "+fixture.bundle.projection.Registration.CollectionPath {
+		t.Fatalf("target-registration did not stop at bound failure: %v", requests)
+	}
+	if _, err := bound.Run(context.Background()); !errors.As(err, &resultErr) || !reflect.DeepEqual(gitopsAPI.Requests(), requests) {
+		t.Fatalf("durable target-registration stop was retried: requests=%v err=%v", gitopsAPI.Requests(), err)
+	}
+}
+
+func TestTargetRegistrationStageRejectsSharedLedgerAndWriterCredentialBeforeAPI(t *testing.T) {
+	fixture := targetRegistrationMaterialFixture(t)
+	ledgerAPI := newRuntimeBindingLedgerAPI(t)
+	defer ledgerAPI.Close()
+	gitopsAPI := newTargetRegistrationExecutionAPI(t, 0)
+	defer gitopsAPI.Close()
+	config := targetRegistrationExecutionRuntime(t, fixture, ledgerAPI.Server, gitopsAPI.Server)
+	if err := os.WriteFile(config.GitOps.TokenFile, []byte("ledger-token"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := fixture.bundle.Open(config); err == nil || ledgerAPI.RequestCount() != 0 || gitopsAPI.RequestCount() != 0 {
+		t.Fatal("shared ledger/writer credential opened target-registration runtime")
+	}
+}
+
+func targetRegistrationExecutionRuntime(t *testing.T, fixture targetRegistrationMaterialTestFixture, ledgerServer, gitopsServer *httptest.Server) TargetRegistrationStageRuntimeConfig {
+	t.Helper()
+	root := t.TempDir()
+	ledgerCA := writeRuntimeBindingServerCA(t, root, "ledger-ca.crt", ledgerServer)
+	gitopsCA := writeRuntimeBindingServerCA(t, root, "gitops-ca.crt", gitopsServer)
+	gitopsCABytes, err := os.ReadFile(gitopsCA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return TargetRegistrationStageRuntimeConfig{
+		Ledger: KubernetesLedgerConfig{
+			Endpoint: ledgerServer.URL, Namespace: "openkubes-execution-system",
+			TokenFile: writeBundleFile(t, root, "ledger-token", []byte("ledger-token")), CAFile: ledgerCA,
+		},
+		GitOps: KubernetesAuthorityConfig{
+			Endpoint: gitopsServer.URL, AuthorityIdentity: "ok-shared",
+			TokenFile: writeBundleFile(t, root, "gitops-token", []byte("gitops-writer-token")), CAFile: gitopsCA,
+			CABundleDigest: digest.SHA256(gitopsCABytes),
+		},
+		Runtime: fixture.runtime, Credential: fixture.credential,
+		MaterializationTime: fixture.config.MaterializationTime,
+		Clock:               func() time.Time { return fixture.config.MaterializationTime.Add(time.Minute) },
+	}
+}
+
+type targetRegistrationExecutionAPI struct {
+	*httptest.Server
+	mu       sync.Mutex
+	objects  map[string]map[string]any
+	requests []string
+	posts    int
+	failPost int
+}
+
+func newTargetRegistrationExecutionAPI(t *testing.T, failPost int) *targetRegistrationExecutionAPI {
+	t.Helper()
+	api := &targetRegistrationExecutionAPI{objects: map[string]map[string]any{}, failPost: failPost}
+	api.Server = httptest.NewTLSServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		api.mu.Lock()
+		defer api.mu.Unlock()
+		api.requests = append(api.requests, request.Method+" "+request.URL.RequestURI())
+		response.Header().Set("Content-Type", "application/json")
+		if request.Header.Get("Authorization") != "Bearer gitops-writer-token" {
+			response.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		switch request.Method {
+		case http.MethodGet:
+			object, exists := api.objects[request.URL.Path]
+			if !exists {
+				response.WriteHeader(http.StatusNotFound)
+				return
+			}
+			json.NewEncoder(response).Encode(object)
+		case http.MethodPost:
+			api.posts++
+			if api.failPost > 0 && api.posts == api.failPost {
+				response.WriteHeader(http.StatusForbidden)
+				return
+			}
+			var object map[string]any
+			if json.NewDecoder(request.Body).Decode(&object) != nil {
+				response.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			metadata, _ := object["metadata"].(map[string]any)
+			metadata["uid"] = "target-registration-runtime-uid-" + string(rune('0'+api.posts))
+			metadata["resourceVersion"] = "1"
+			name, _ := metadata["name"].(string)
+			api.objects[strings.TrimSuffix(request.URL.Path, "/")+"/"+name] = object
+			response.WriteHeader(http.StatusCreated)
+			json.NewEncoder(response).Encode(object)
+		default:
+			response.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	return api
+}
+
+func (api *targetRegistrationExecutionAPI) Requests() []string {
+	api.mu.Lock()
+	defer api.mu.Unlock()
+	return append([]string(nil), api.requests...)
+}
+
+func (api *targetRegistrationExecutionAPI) RequestCount() int { return len(api.Requests()) }


### PR DESCRIPTION
## Summary
- bind the verified Stage-9 bundle, runtime identity, in-memory target credential, GitOps writer and durable ledger
- require the exact credential issue receipt to match durable Stage-8 evidence
- prove successful replay is write-free and partial state becomes a durable terminal stop

## Safety boundary
- opening performs no API request
- ledger and GitOps writer credentials must be distinct
- no target credential, endpoint or raw UID enters durable public receipts

## Verification
- full go test ./...
- go vet ./...
- race tests for internal/runner and cmd/ok