### PR TITLE
OK-147: Verify platform Applications projection

### DIFF
--- a/internal/observation/platform_collector.go
+++ b/internal/observation/platform_collector.go
@@ -162,7 +162,7 @@ func normalizePlatformApplication(object map[string]any, profile PlatformProfile
 	if err != nil {
 		return PlatformApplicationState{}, errors.New("Argo Application spec is missing")
 	}
-	normalizedSpec, desiredRevision, err := normalizedPlatformApplicationSpec(spec)
+	normalizedSpec, _, err := normalizedPlatformApplicationSpec(spec)
 	if err != nil {
 		return PlatformApplicationState{}, err
 	}
@@ -170,9 +170,9 @@ func normalizePlatformApplication(object map[string]any, profile PlatformProfile
 	if text(destination["name"]) != profile.RegistrationName {
 		return PlatformApplicationState{}, errors.New("Argo Application destination differs from the bound registration")
 	}
-	specDigest, err := canonicalDigest(normalizedSpec)
+	specDigest, desiredRevision, err := PlatformApplicationSpecIdentity(spec)
 	if err != nil {
-		return PlatformApplicationState{}, errors.New("digest normalized Argo Application spec")
+		return PlatformApplicationState{}, err
 	}
 	status, _ := objectMap(object, "status")
 	sync, _ := objectMap(status, "sync")
@@ -210,7 +210,25 @@ func normalizedPlatformApplicationSpec(spec map[string]any) (map[string]any, str
 	if syncPolicy, exists := spec["syncPolicy"]; exists {
 		normalized["syncPolicy"] = syncPolicy
 	}
+	if ignoreDifferences, exists := spec["ignoreDifferences"]; exists {
+		normalized["ignoreDifferences"] = ignoreDifferences
+	}
 	return normalized, revision, nil
+}
+
+// PlatformApplicationSpecIdentity is the shared semantic identity used by
+// both the externally rendered Application verifier and the later read-only
+// Argo observer. It prevents a second, drifting definition of applied P.
+func PlatformApplicationSpecIdentity(spec map[string]any) (string, string, error) {
+	normalized, revision, err := normalizedPlatformApplicationSpec(spec)
+	if err != nil {
+		return "", "", err
+	}
+	specDigest, err := canonicalDigest(normalized)
+	if err != nil {
+		return "", "", errors.New("digest normalized Argo Application spec")
+	}
+	return specDigest, revision, nil
 }
 
 func validGitCommit(value string) bool {

--- a/internal/submission/platform_applications.go
+++ b/internal/submission/platform_applications.go
@@ -1,0 +1,227 @@
+package submission
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"sort"
+
+	"github.com/openkubes/ok-cluster/internal/contract"
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/observation"
+	"github.com/openkubes/ok-cluster/internal/projection"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	PlatformApplicationsPlanFormat   = "ok147-bounded-platform-applications-plan/v1"
+	maximumPlatformApplicationsBytes = 2 * 1024 * 1024
+)
+
+type PlatformApplicationsExpected struct {
+	ArtifactDigest       string
+	ContractIdentity     contract.Identity
+	IntentRevision       string
+	PlatformRevision     string
+	ExecutionFixture     string
+	TargetIdentityDigest string
+	ArgoAuthority        string
+	ArgoNamespace        string
+	ProjectName          string
+	RegistrationName     string
+	SourceRepository     string
+	Profile              observation.PlatformProfile
+}
+
+type PlatformApplicationsPlan struct {
+	Format               string   `json:"format"`
+	IntentRevision       string   `json:"intentRevision"`
+	PlatformRevision     string   `json:"platformRevision"`
+	ExecutionFixture     string   `json:"executionFixture"`
+	TargetIdentityDigest string   `json:"targetIdentityDigest"`
+	ArtifactDigest       string   `json:"artifactDigest"`
+	Authority            string   `json:"authority"`
+	Applications         []Object `json:"applications"`
+	MutationAllowed      bool     `json:"mutationAllowed"`
+}
+
+// LoadPlatformApplications verifies the complete exact Application set for P.
+// It performs no API request and grants no mutation authority.
+func LoadPlatformApplications(path string, expected PlatformApplicationsExpected) (PlatformApplicationsPlan, error) {
+	if err := validatePlatformApplicationsExpected(expected); err != nil {
+		return PlatformApplicationsPlan{}, err
+	}
+	raw, err := readPlatformApplicationsArtifact(path)
+	if err != nil {
+		return PlatformApplicationsPlan{}, err
+	}
+	if digest.SHA256(raw) != expected.ArtifactDigest {
+		return PlatformApplicationsPlan{}, errors.New("platform Applications artifact digest differs from staged input")
+	}
+	documents, err := decodePlatformApplicationDocuments(raw)
+	if err != nil {
+		return PlatformApplicationsPlan{}, err
+	}
+	if len(documents) != len(expected.Profile.RequiredApplications) {
+		return PlatformApplicationsPlan{}, errors.New("platform Applications artifact membership differs from profile")
+	}
+	wanted := make(map[string]string, len(expected.Profile.RequiredApplications))
+	for _, application := range expected.Profile.RequiredApplications {
+		wanted[application.Name] = application.SpecDigest
+	}
+	objects := make([]Object, 0, len(documents))
+	seen := map[string]struct{}{}
+	for _, document := range documents {
+		object, specDigest, err := validatePlatformApplication(document, expected)
+		if err != nil {
+			return PlatformApplicationsPlan{}, err
+		}
+		wantDigest, exists := wanted[object.Identity.Name]
+		if !exists || wantDigest != specDigest {
+			return PlatformApplicationsPlan{}, errors.New("platform Application spec differs from immutable profile")
+		}
+		if _, duplicate := seen[object.Identity.Name]; duplicate {
+			return PlatformApplicationsPlan{}, errors.New("platform Applications artifact contains duplicate identity")
+		}
+		seen[object.Identity.Name] = struct{}{}
+		objects = append(objects, object)
+	}
+	sort.Slice(objects, func(i, j int) bool { return objects[i].Identity.Name < objects[j].Identity.Name })
+	return PlatformApplicationsPlan{
+		Format: PlatformApplicationsPlanFormat, IntentRevision: expected.IntentRevision,
+		PlatformRevision: expected.PlatformRevision, ExecutionFixture: expected.ExecutionFixture,
+		TargetIdentityDigest: expected.TargetIdentityDigest, ArtifactDigest: expected.ArtifactDigest,
+		Authority: expected.ArgoAuthority, Applications: objects, MutationAllowed: false,
+	}, nil
+}
+
+func validatePlatformApplicationsExpected(expected PlatformApplicationsExpected) error {
+	for _, value := range []string{expected.ArtifactDigest, expected.IntentRevision, expected.PlatformRevision, expected.ExecutionFixture, expected.TargetIdentityDigest} {
+		if !immutableDigestPattern.MatchString(value) {
+			return errors.New("platform Applications expected digest identity is invalid")
+		}
+	}
+	if !validName(expected.ContractIdentity.Namespace, 63) || !validName(expected.ContractIdentity.Name, 253) ||
+		!validName(expected.ArgoAuthority, 63) || !validName(expected.ArgoNamespace, 63) ||
+		!validName(expected.ProjectName, 253) || !validName(expected.RegistrationName, 253) {
+		return errors.New("platform Applications expected object identity is invalid")
+	}
+	if err := observation.ValidatePlatformProfile(expected.Profile); err != nil ||
+		expected.Profile.IntentRevision != expected.IntentRevision || expected.Profile.PlatformRevision != expected.PlatformRevision ||
+		expected.Profile.ExecutionFixture != expected.ExecutionFixture || expected.Profile.ArgoNamespace != expected.ArgoNamespace ||
+		expected.Profile.RegistrationName != expected.RegistrationName || len(expected.Profile.RequiredApplications) != 3 {
+		return errors.New("platform Applications profile differs from expected P")
+	}
+	repository, err := url.Parse(expected.SourceRepository)
+	if err != nil || repository.Scheme != "https" || repository.Host == "" || repository.User != nil || repository.RawQuery != "" || repository.Fragment != "" {
+		return errors.New("platform Applications source repository is invalid")
+	}
+	return nil
+}
+
+func readPlatformApplicationsArtifact(path string) ([]byte, error) {
+	if path == "" {
+		return nil, errors.New("platform Applications artifact path is required")
+	}
+	info, err := os.Lstat(path)
+	if err != nil || !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 || info.Size() <= 0 || info.Size() > maximumPlatformApplicationsBytes {
+		return nil, errors.New("platform Applications artifact metadata is invalid")
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, errors.New("open platform Applications artifact")
+	}
+	defer file.Close()
+	raw, err := io.ReadAll(io.LimitReader(file, maximumPlatformApplicationsBytes+1))
+	if err != nil || len(raw) > maximumPlatformApplicationsBytes {
+		return nil, errors.New("read bounded platform Applications artifact")
+	}
+	return raw, nil
+}
+
+func decodePlatformApplicationDocuments(raw []byte) ([]map[string]any, error) {
+	decoder := yaml.NewDecoder(bytes.NewReader(raw))
+	values := []map[string]any{}
+	for {
+		var document yaml.Node
+		if err := decoder.Decode(&document); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return nil, errors.New("decode platform Applications YAML")
+		}
+		if len(document.Content) == 0 {
+			continue
+		}
+		if err := rejectAliases(document.Content[0]); err != nil {
+			return nil, err
+		}
+		var decoded any
+		if err := document.Content[0].Decode(&decoded); err != nil {
+			return nil, errors.New("decode platform Application object")
+		}
+		converted, err := jsonValue(decoded)
+		if err != nil {
+			return nil, err
+		}
+		value, ok := converted.(map[string]any)
+		if !ok {
+			return nil, errors.New("platform Application document is not an object")
+		}
+		values = append(values, value)
+	}
+	return values, nil
+}
+
+func validatePlatformApplication(value map[string]any, expected PlatformApplicationsExpected) (Object, string, error) {
+	if err := rejectTargetAccessUnknownKeys(value, "Application", "apiVersion", "kind", "metadata", "spec"); err != nil {
+		return Object{}, "", err
+	}
+	metadata, ok := value["metadata"].(map[string]any)
+	if !ok {
+		return Object{}, "", errors.New("platform Application metadata is missing")
+	}
+	if err := rejectTargetAccessUnknownKeys(metadata, "Application metadata", "name", "namespace", "annotations"); err != nil {
+		return Object{}, "", err
+	}
+	name, namespace := text(metadata["name"]), text(metadata["namespace"])
+	if text(value["apiVersion"]) != "argoproj.io/v1alpha1" || text(value["kind"]) != "Application" || namespace != expected.ArgoNamespace || !validName(name, 253) {
+		return Object{}, "", errors.New("platform Application identity is invalid")
+	}
+	annotations, ok := metadata["annotations"].(map[string]any)
+	wantAnnotations := map[string]string{
+		"openkubes.io/intent-revision": expected.IntentRevision, "openkubes.io/platform-revision": expected.PlatformRevision,
+		"openkubes.io/execution-fixture": expected.ExecutionFixture, "openkubes.io/target-identity-digest": expected.TargetIdentityDigest,
+	}
+	if !ok || len(annotations) != len(wantAnnotations) {
+		return Object{}, "", errors.New("platform Application annotations differ from exact revision carriers")
+	}
+	for key, want := range wantAnnotations {
+		if text(annotations[key]) != want {
+			return Object{}, "", errors.New("platform Application revision carrier differs")
+		}
+	}
+	spec, ok := value["spec"].(map[string]any)
+	if !ok || text(spec["project"]) != expected.ProjectName {
+		return Object{}, "", errors.New("platform Application project differs")
+	}
+	source, _ := spec["source"].(map[string]any)
+	destination, _ := spec["destination"].(map[string]any)
+	if text(source["repoURL"]) != expected.SourceRepository || text(destination["name"]) != expected.RegistrationName || text(destination["namespace"]) != "ok-observability" {
+		return Object{}, "", errors.New("platform Application source or destination differs")
+	}
+	specDigest, _, err := observation.PlatformApplicationSpecIdentity(spec)
+	if err != nil {
+		return Object{}, "", fmt.Errorf("platform Application semantic identity: %w", err)
+	}
+	identity := projection.ResourceIdentity{APIVersion: "argoproj.io/v1alpha1", Kind: "Application", Namespace: namespace, Name: name}
+	raw, err := canonicalJSON(value)
+	if err != nil {
+		return Object{}, "", errors.New("canonicalize platform Application")
+	}
+	collection := "/apis/argoproj.io/v1alpha1/namespaces/" + namespace + "/applications"
+	return Object{Identity: identity, Digest: digest.SHA256(raw), CollectionPath: collection, ObjectPath: collection + "/" + name, Raw: raw}, specDigest, nil
+}

--- a/internal/submission/platform_applications_test.go
+++ b/internal/submission/platform_applications_test.go
@@ -1,0 +1,163 @@
+package submission
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/openkubes/ok-cluster/internal/contract"
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/observation"
+)
+
+func TestLoadPlatformApplicationsBindsExactProfileSet(t *testing.T) {
+	fixture := platformApplicationsFixture(t)
+	plan, err := LoadPlatformApplications(fixture.path, fixture.expected)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plan.Format != PlatformApplicationsPlanFormat || plan.IntentRevision != fixture.expected.IntentRevision ||
+		plan.PlatformRevision != fixture.expected.PlatformRevision || plan.ExecutionFixture != fixture.expected.ExecutionFixture ||
+		plan.TargetIdentityDigest != fixture.expected.TargetIdentityDigest || plan.ArtifactDigest != fixture.expected.ArtifactDigest ||
+		plan.Authority != "ok-shared" || plan.MutationAllowed || len(plan.Applications) != 3 {
+		t.Fatalf("unexpected platform Applications plan: %#v", plan)
+	}
+	wantNames := []string{"disposable-ok147-observability-alerting", "disposable-ok147-observability-core", "disposable-ok147-observability-dashboards"}
+	for index, object := range plan.Applications {
+		if object.Identity.Name != wantNames[index] || object.Identity.Namespace != "argocd" || object.Identity.Kind != "Application" ||
+			object.CollectionPath != "/apis/argoproj.io/v1alpha1/namespaces/argocd/applications" ||
+			object.ObjectPath != object.CollectionPath+"/"+object.Identity.Name || digest.SHA256(object.Raw) != object.Digest {
+			t.Fatalf("unexpected platform Application %d: %#v", index, object)
+		}
+	}
+}
+
+func TestPlatformApplicationSpecIdentityIncludesIgnoreDifferences(t *testing.T) {
+	fixture := platformApplicationsFixture(t)
+	spec := fixture.documents[0]["spec"].(map[string]any)
+	first, revision, err := observation.PlatformApplicationSpecIdentity(spec)
+	if err != nil || revision != strings.Repeat("6", 40) {
+		t.Fatalf("unexpected spec identity: %s %s %v", first, revision, err)
+	}
+	spec["ignoreDifferences"] = []any{map[string]any{"group": "apps", "kind": "StatefulSet", "jsonPointers": []any{"/spec/template"}}}
+	second, _, err := observation.PlatformApplicationSpecIdentity(spec)
+	if err != nil || first == second {
+		t.Fatal("ignoreDifferences change did not change semantic spec identity")
+	}
+}
+
+func TestLoadPlatformApplicationsFailsClosed(t *testing.T) {
+	tests := map[string]func(*platformApplicationsTestFixture){
+		"missing Application": func(f *platformApplicationsTestFixture) { f.documents = f.documents[:2] },
+		"duplicate Application": func(f *platformApplicationsTestFixture) {
+			f.documents[2]["metadata"].(map[string]any)["name"] = f.documents[1]["metadata"].(map[string]any)["name"]
+		},
+		"mutable source revision": func(f *platformApplicationsTestFixture) {
+			f.documents[0]["spec"].(map[string]any)["source"].(map[string]any)["targetRevision"] = "main"
+		},
+		"foreign target": func(f *platformApplicationsTestFixture) {
+			f.documents[0]["spec"].(map[string]any)["destination"].(map[string]any)["name"] = "foreign-target"
+		},
+		"wrong revision carrier": func(f *platformApplicationsTestFixture) {
+			f.documents[0]["metadata"].(map[string]any)["annotations"].(map[string]any)["openkubes.io/platform-revision"] = platformApplicationsSHA("f")
+		},
+		"unprofiled semantic change": func(f *platformApplicationsTestFixture) {
+			f.documents[0]["spec"].(map[string]any)["syncPolicy"] = map[string]any{"automated": map[string]any{"enabled": true, "prune": false, "selfHeal": true, "allowEmpty": false}}
+		},
+		"unknown metadata": func(f *platformApplicationsTestFixture) {
+			f.documents[0]["metadata"].(map[string]any)["labels"] = map[string]any{"unexpected": "value"}
+		},
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			fixture := platformApplicationsFixture(t)
+			mutate(&fixture)
+			fixture.write(t)
+			if _, err := LoadPlatformApplications(fixture.path, fixture.expected); err == nil {
+				t.Fatal("invalid platform Applications artifact was accepted")
+			}
+		})
+	}
+}
+
+type platformApplicationsTestFixture struct {
+	path      string
+	documents []map[string]any
+	expected  PlatformApplicationsExpected
+}
+
+func platformApplicationsFixture(t *testing.T) platformApplicationsTestFixture {
+	t.Helper()
+	intent, platform, execution, target := platformApplicationsSHA("a"), platformApplicationsSHA("b"), platformApplicationsSHA("c"), platformApplicationsSHA("d")
+	commit := strings.Repeat("6", 40)
+	names := []string{"disposable-ok147-observability-core", "disposable-ok147-observability-alerting", "disposable-ok147-observability-dashboards"}
+	paths := []string{"profiles/ok-observability-standard", "alerting", "dashboards"}
+	documents := make([]map[string]any, 0, 3)
+	profileApplications := make([]observation.PlatformApplicationExpectation, 0, 3)
+	for index, name := range names {
+		spec := map[string]any{
+			"project":     "openkubes-disposable",
+			"source":      map[string]any{"repoURL": "https://github.com/openkubes/ok-observability.git", "path": paths[index], "targetRevision": commit},
+			"destination": map[string]any{"name": "disposable-ok147", "namespace": "ok-observability"},
+			"syncPolicy":  map[string]any{"automated": map[string]any{"enabled": true, "prune": true, "selfHeal": true, "allowEmpty": false}},
+		}
+		if index == 0 {
+			spec["ignoreDifferences"] = []any{map[string]any{"group": "apps", "kind": "StatefulSet", "jsonPointers": []any{"/spec/revisionHistoryLimit"}}}
+		}
+		specDigest, _, err := observation.PlatformApplicationSpecIdentity(spec)
+		if err != nil {
+			t.Fatal(err)
+		}
+		profileApplications = append(profileApplications, observation.PlatformApplicationExpectation{Name: name, SpecDigest: specDigest})
+		documents = append(documents, map[string]any{
+			"apiVersion": "argoproj.io/v1alpha1", "kind": "Application",
+			"metadata": map[string]any{
+				"name": name, "namespace": "argocd",
+				"annotations": map[string]any{
+					"openkubes.io/intent-revision": intent, "openkubes.io/platform-revision": platform,
+					"openkubes.io/execution-fixture": execution, "openkubes.io/target-identity-digest": target,
+				},
+			},
+			"spec": spec,
+		})
+	}
+	profile := observation.PlatformProfile{
+		Format: observation.PlatformProfileFormat, IntentRevision: intent, PlatformRevision: platform,
+		ExecutionFixture: execution, TargetIdentityScheme: "capi-cluster-uid/v1", ArgoNamespace: "argocd",
+		RegistrationName: "disposable-ok147", RequiredApplications: profileApplications,
+		CapabilityContractDigest: platformApplicationsSHA("e"), CapabilityExecutableDigest: platformApplicationsSHA("f"), MaximumCapabilityAgeSeconds: 3600,
+	}
+	fixture := platformApplicationsTestFixture{
+		path: t.TempDir() + "/platform-applications.yaml", documents: documents,
+		expected: PlatformApplicationsExpected{
+			ContractIdentity: contract.Identity{Namespace: "disposable-ok147", Name: "disposable-ok147"},
+			IntentRevision:   intent, PlatformRevision: platform, ExecutionFixture: execution, TargetIdentityDigest: target,
+			ArgoAuthority: "ok-shared", ArgoNamespace: "argocd", ProjectName: "openkubes-disposable",
+			RegistrationName: "disposable-ok147", SourceRepository: "https://github.com/openkubes/ok-observability.git", Profile: profile,
+		},
+	}
+	fixture.write(t)
+	return fixture
+}
+
+func platformApplicationsSHA(value string) string { return "sha256:" + strings.Repeat(value, 64) }
+
+func (fixture *platformApplicationsTestFixture) write(t *testing.T) {
+	t.Helper()
+	raw := []byte{}
+	for index, document := range fixture.documents {
+		if index > 0 {
+			raw = append(raw, []byte("\n---\n")...)
+		}
+		encoded, err := json.Marshal(document)
+		if err != nil {
+			t.Fatal(err)
+		}
+		raw = append(raw, encoded...)
+	}
+	if err := os.WriteFile(fixture.path, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	fixture.expected.ArtifactDigest = digest.SHA256(raw)
+}


### PR DESCRIPTION
## Summary
- verify exactly three immutable Argo Applications against the bound Platform profile
- share one normalized Application-spec identity between submission verification and later PlatformReady observation
- include sync policy and ignoreDifferences in the semantic digest of P

## Safety boundary
- parser only; no API request and no mutation authority
- immutable Git commit, exact target registration and R/P/fixture/target carriers required
- missing, duplicate, mutable or unprofiled Applications fail closed

## Verification
- full go test ./...
- go vet ./...
- race tests for runner, submission, observation and cmd/ok