### PR TITLE
feat(runner): bind platform applications stage (OK-147)

### DIFF
--- a/internal/runner/platform_applications_stage_bundle.go
+++ b/internal/runner/platform_applications_stage_bundle.go
@@ -1,0 +1,193 @@
+package runner
+
+import (
+	"errors"
+	"sort"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/authorization"
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/observation"
+	"github.com/openkubes/ok-cluster/internal/stagecursor"
+	"github.com/openkubes/ok-cluster/internal/stageplan"
+	"github.com/openkubes/ok-cluster/internal/stagereceipt"
+	"github.com/openkubes/ok-cluster/internal/submission"
+)
+
+const PlatformApplicationsStageBundleReceiptFormat = "ok147-platform-applications-stage-bundle/v1"
+
+type PlatformApplicationsStageBundleConfig struct {
+	PlanPath           string
+	PlanExpected       stageplan.Expected
+	Receipts           []StageReceiptSource
+	GrantPath          string
+	GrantPublicKeyPath string
+	EvaluationTime     time.Time
+	ArtifactPath       string
+	Expected           submission.PlatformApplicationsExpected
+}
+
+type PlatformApplicationsStageBundleReceipt struct {
+	Format               string   `json:"format"`
+	State                string   `json:"state"`
+	PlanDigest           string   `json:"planDigest"`
+	StageID              string   `json:"stageId"`
+	AuthorizationDigest  string   `json:"authorizationDigest"`
+	ArtifactDigest       string   `json:"artifactDigest"`
+	TargetIdentityDigest string   `json:"targetIdentityDigest"`
+	ProfileDigest        string   `json:"profileDigest"`
+	ApplicationDigests   []string `json:"applicationDigests"`
+	Authority            string   `json:"authority"`
+	MutationAllowed      bool     `json:"mutationAllowed"`
+}
+
+type VerifiedPlatformApplicationsStageBundle struct {
+	plan       stageplan.Binding
+	cursor     stagecursor.Cursor
+	prefix     []stagereceipt.Verified
+	grant      authorization.VerifiedStageGrant
+	projection submission.PlatformApplicationsPlan
+	profile    observation.PlatformProfile
+	receipt    PlatformApplicationsStageBundleReceipt
+	verified   bool
+}
+
+// LoadPlatformApplicationsStageBundle verifies the exact nine-stage
+// predecessor chain, immutable Platform profile, three Application objects and
+// CreatePlatformApplications grant. It performs no credential read, API
+// request, ledger access or mutation.
+func LoadPlatformApplicationsStageBundle(config PlatformApplicationsStageBundleConfig) (VerifiedPlatformApplicationsStageBundle, error) {
+	if config.Receipts == nil || config.EvaluationTime.IsZero() {
+		return VerifiedPlatformApplicationsStageBundle{}, errors.New("platform-applications receipt prefix and authorization evaluation time are required")
+	}
+	plan, cursor, prefix, err := loadStageResumeWithPrefix(StageResumeConfig{
+		PlanPath: config.PlanPath, PlanExpected: config.PlanExpected, Receipts: config.Receipts,
+	})
+	if err != nil {
+		return VerifiedPlatformApplicationsStageBundle{}, err
+	}
+	decision, err := cursor.Decision()
+	if err != nil || decision.State != "NEXT" || decision.StageID != "platform-applications" || decision.Kind != "Submission" || decision.Authority != "gitops" || !decision.RequiresAuthorization || decision.Operation != "CreatePlatformApplications" {
+		return VerifiedPlatformApplicationsStageBundle{}, errors.New("verified prefix does not select platform Applications")
+	}
+	if len(prefix) != 9 {
+		return VerifiedPlatformApplicationsStageBundle{}, errors.New("platform Applications require the exact nine-receipt prefix")
+	}
+	lifecycle, err := prefix[1].Receipt()
+	if err != nil || lifecycle.StageID != "cluster-lifecycle" || !stageReceiptPrefixDigestPattern.MatchString(lifecycle.TargetClusterUIDDigest) {
+		return VerifiedPlatformApplicationsStageBundle{}, errors.New("platform Applications lack durable workload identity")
+	}
+	registration, err := prefix[8].Receipt()
+	if err != nil || registration.StageID != "target-registration" || registration.State != "SUCCEEDED" || registration.MutationState != "ATTEMPTED" {
+		return VerifiedPlatformApplicationsStageBundle{}, errors.New("platform Applications lack successful target registration")
+	}
+	stage, _, err := plan.Stage("platform-applications")
+	if err != nil || len(stage.Inputs) != 1 || stage.Inputs[0].Name != "stage.platform-applications" {
+		return VerifiedPlatformApplicationsStageBundle{}, errors.New("platform-applications stage must bind exactly one projection artifact")
+	}
+	expected := config.Expected
+	if expected.ArtifactDigest != stage.Inputs[0].Digest || expected.ContractIdentity != plan.ContractIdentity || expected.IntentRevision != plan.IntentRevision || expected.PlatformRevision != plan.PlatformRevision || expected.ExecutionFixture != plan.ExecutionFixture || expected.TargetIdentityDigest != lifecycle.TargetClusterUIDDigest || expected.ArgoAuthority != plan.Authorities.GitOps {
+		return VerifiedPlatformApplicationsStageBundle{}, errors.New("platform-applications expected identities differ from verified stage plan")
+	}
+	projected, err := submission.LoadPlatformApplications(config.ArtifactPath, expected)
+	if err != nil {
+		return VerifiedPlatformApplicationsStageBundle{}, err
+	}
+	profile := expected.Profile
+	profile.RequiredApplications = append([]observation.PlatformApplicationExpectation(nil), expected.Profile.RequiredApplications...)
+	profileDigest, err := observation.PlatformProfileDigest(profile)
+	if err != nil {
+		return VerifiedPlatformApplicationsStageBundle{}, errors.New("platform Applications profile is invalid")
+	}
+	directPredecessors, err := cursor.Predecessors()
+	if err != nil {
+		return VerifiedPlatformApplicationsStageBundle{}, err
+	}
+	grant, err := authorization.LoadStage(config.GrantPath, config.GrantPublicKeyPath, plan, "platform-applications", directPredecessors, config.EvaluationTime)
+	if err != nil {
+		return VerifiedPlatformApplicationsStageBundle{}, err
+	}
+	if _, err := authorization.BindStageGrant(grant, plan, "platform-applications", directPredecessors); err != nil {
+		return VerifiedPlatformApplicationsStageBundle{}, err
+	}
+	applicationDigests := make([]string, len(projected.Applications))
+	for index, application := range projected.Applications {
+		applicationDigests[index] = application.Digest
+	}
+	sort.Strings(applicationDigests)
+	receipt := PlatformApplicationsStageBundleReceipt{
+		Format: PlatformApplicationsStageBundleReceiptFormat, State: "VERIFIED", PlanDigest: plan.PlanDigest,
+		StageID: "platform-applications", AuthorizationDigest: grant.Receipt().AuthorizationDigest,
+		ArtifactDigest: projected.ArtifactDigest, TargetIdentityDigest: projected.TargetIdentityDigest,
+		ProfileDigest: profileDigest, ApplicationDigests: applicationDigests,
+		Authority: projected.Authority, MutationAllowed: false,
+	}
+	return VerifiedPlatformApplicationsStageBundle{
+		plan: plan, cursor: cursor, prefix: prefix, grant: grant, projection: projected,
+		profile: profile, receipt: receipt, verified: true,
+	}, nil
+}
+
+func (bundle VerifiedPlatformApplicationsStageBundle) Decision() (stagecursor.Decision, error) {
+	if err := verifyPlatformApplicationsStageBundle(bundle); err != nil {
+		return stagecursor.Decision{}, err
+	}
+	return bundle.cursor.Decision()
+}
+
+func (bundle VerifiedPlatformApplicationsStageBundle) Receipt() (PlatformApplicationsStageBundleReceipt, error) {
+	if err := verifyPlatformApplicationsStageBundle(bundle); err != nil {
+		return PlatformApplicationsStageBundleReceipt{}, err
+	}
+	receipt := bundle.receipt
+	receipt.ApplicationDigests = append([]string(nil), bundle.receipt.ApplicationDigests...)
+	return receipt, nil
+}
+
+func verifyPlatformApplicationsStageBundle(bundle VerifiedPlatformApplicationsStageBundle) error {
+	if !bundle.verified || bundle.receipt.Format != PlatformApplicationsStageBundleReceiptFormat || bundle.receipt.State != "VERIFIED" || bundle.receipt.StageID != "platform-applications" || bundle.receipt.MutationAllowed || len(bundle.prefix) != 9 || len(bundle.receipt.ApplicationDigests) != 3 || len(bundle.projection.Applications) != 3 {
+		return errors.New("platform-applications stage bundle was not produced by verification")
+	}
+	for _, value := range []string{
+		bundle.receipt.PlanDigest, bundle.receipt.AuthorizationDigest, bundle.receipt.ArtifactDigest,
+		bundle.receipt.TargetIdentityDigest, bundle.receipt.ProfileDigest,
+	} {
+		if !stageReceiptPrefixDigestPattern.MatchString(value) {
+			return errors.New("platform-applications stage bundle digest identity is invalid")
+		}
+	}
+	if bundle.receipt.PlanDigest != bundle.plan.PlanDigest ||
+		bundle.receipt.AuthorizationDigest != bundle.grant.Receipt().AuthorizationDigest ||
+		bundle.receipt.ArtifactDigest != bundle.projection.ArtifactDigest ||
+		bundle.receipt.TargetIdentityDigest != bundle.projection.TargetIdentityDigest {
+		return errors.New("platform-applications stage bundle binding changed after verification")
+	}
+	if bundle.receipt.Authority == "" || bundle.receipt.Authority != bundle.plan.Authorities.GitOps || bundle.projection.Authority != bundle.receipt.Authority || bundle.projection.TargetIdentityDigest != bundle.receipt.TargetIdentityDigest {
+		return errors.New("platform-applications stage bundle identity changed after verification")
+	}
+	profileDigest, err := observation.PlatformProfileDigest(bundle.profile)
+	if err != nil || profileDigest != bundle.receipt.ProfileDigest {
+		return errors.New("platform-applications profile changed after verification")
+	}
+	if bundle.projection.Format != submission.PlatformApplicationsPlanFormat || bundle.projection.MutationAllowed ||
+		bundle.projection.ArtifactDigest != bundle.receipt.ArtifactDigest ||
+		bundle.projection.IntentRevision != bundle.plan.IntentRevision ||
+		bundle.projection.PlatformRevision != bundle.plan.PlatformRevision ||
+		bundle.projection.ExecutionFixture != bundle.plan.ExecutionFixture {
+		return errors.New("platform-applications projection changed after verification")
+	}
+	digests := make([]string, len(bundle.projection.Applications))
+	for index, application := range bundle.projection.Applications {
+		if !stageReceiptPrefixDigestPattern.MatchString(application.Digest) || digest.SHA256(application.Raw) != application.Digest {
+			return errors.New("platform Application changed after verification")
+		}
+		digests[index] = application.Digest
+	}
+	sort.Strings(digests)
+	for index := range digests {
+		if digests[index] != bundle.receipt.ApplicationDigests[index] {
+			return errors.New("platform Application set changed after verification")
+		}
+	}
+	return nil
+}

--- a/internal/runner/platform_applications_stage_bundle_test.go
+++ b/internal/runner/platform_applications_stage_bundle_test.go
@@ -1,0 +1,229 @@
+package runner
+
+import (
+	"encoding/json"
+	"os"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/contract"
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/observation"
+	"github.com/openkubes/ok-cluster/internal/stageplan"
+	"github.com/openkubes/ok-cluster/internal/stagereceipt"
+	"github.com/openkubes/ok-cluster/internal/submission"
+)
+
+func TestLoadPlatformApplicationsStageBundleBindsPrefixGrantProfileAndObjects(t *testing.T) {
+	fixture := platformApplicationsBundleFixture(t)
+	bundle, err := LoadPlatformApplicationsStageBundle(fixture.config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decision, err := bundle.Decision()
+	if err != nil || decision.StageID != "platform-applications" || decision.Kind != "Submission" || decision.Operation != "CreatePlatformApplications" || decision.Authority != "gitops" || !decision.RequiresAuthorization {
+		t.Fatalf("unexpected platform-applications decision: %#v %v", decision, err)
+	}
+	receipt, err := bundle.Receipt()
+	if err != nil || receipt.Format != PlatformApplicationsStageBundleReceiptFormat || receipt.State != "VERIFIED" || receipt.PlanDigest != fixture.plan.PlanDigest || receipt.ArtifactDigest != fixture.artifactDigest || receipt.TargetIdentityDigest != digest.SHA256([]byte(targetAccessRuntimeUID)) || receipt.ProfileDigest != fixture.profileDigest || receipt.AuthorizationDigest == "" || receipt.Authority != "ok-shared" || receipt.MutationAllowed || len(receipt.ApplicationDigests) != 3 {
+		t.Fatalf("unexpected platform-applications receipt: %#v %v", receipt, err)
+	}
+	if !sort.StringsAreSorted(receipt.ApplicationDigests) {
+		t.Fatal("Application digests are not canonical")
+	}
+	receipt.ApplicationDigests[0] = runnerStageSHA("f")
+	again, err := bundle.Receipt()
+	if err != nil || again.ApplicationDigests[0] == receipt.ApplicationDigests[0] {
+		t.Fatal("receipt exposed mutable Application digest storage")
+	}
+}
+
+func TestLoadPlatformApplicationsStageBundleFailsClosed(t *testing.T) {
+	tests := map[string]func(*platformApplicationsBundleTestFixture){
+		"implicit prefix":   func(f *platformApplicationsBundleTestFixture) { f.config.Receipts = nil },
+		"incomplete prefix": func(f *platformApplicationsBundleTestFixture) { f.config.Receipts = f.config.Receipts[:8] },
+		"changed artifact": func(f *platformApplicationsBundleTestFixture) {
+			raw, _ := os.ReadFile(f.config.ArtifactPath)
+			_ = os.WriteFile(f.config.ArtifactPath, append(raw, '\n'), 0o600)
+		},
+		"foreign target": func(f *platformApplicationsBundleTestFixture) {
+			f.config.Expected.TargetIdentityDigest = runnerStageSHA("f")
+		},
+		"foreign authority": func(f *platformApplicationsBundleTestFixture) { f.config.Expected.ArgoAuthority = "foreign-gitops" },
+		"foreign platform revision": func(f *platformApplicationsBundleTestFixture) {
+			f.config.Expected.Profile.PlatformRevision = runnerStageSHA("f")
+		},
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			fixture := platformApplicationsBundleFixture(t)
+			mutate(&fixture)
+			if _, err := LoadPlatformApplicationsStageBundle(fixture.config); err == nil {
+				t.Fatal("invalid platform-applications bundle was accepted")
+			}
+		})
+	}
+	if _, err := (VerifiedPlatformApplicationsStageBundle{}).Decision(); err == nil {
+		t.Fatal("unverified platform-applications bundle exposed decision")
+	}
+	if _, err := (VerifiedPlatformApplicationsStageBundle{}).Receipt(); err == nil {
+		t.Fatal("unverified platform-applications bundle exposed receipt")
+	}
+}
+
+func TestPlatformApplicationsStageBundleDetectsPostVerificationMutation(t *testing.T) {
+	fixture := platformApplicationsBundleFixture(t)
+	bundle, err := LoadPlatformApplicationsStageBundle(fixture.config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bundle.projection.Applications[0].Raw[0] ^= 1
+	if _, err := bundle.Receipt(); err == nil {
+		t.Fatal("mutated verified Application was accepted")
+	}
+
+	bundle, err = LoadPlatformApplicationsStageBundle(fixture.config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bundle.profile.RequiredApplications[0].SpecDigest = runnerStageSHA("f")
+	if _, err := bundle.Decision(); err == nil {
+		t.Fatal("mutated verified Platform profile was accepted")
+	}
+
+	bundle, err = LoadPlatformApplicationsStageBundle(fixture.config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bundle.receipt.PlanDigest = runnerStageSHA("f")
+	if _, err := bundle.Receipt(); err == nil {
+		t.Fatal("mutated verified plan binding was accepted")
+	}
+}
+
+type platformApplicationsBundleTestFixture struct {
+	config         PlatformApplicationsStageBundleConfig
+	plan           stageplan.Binding
+	artifactDigest string
+	profileDigest  string
+}
+
+func platformApplicationsBundleFixture(t *testing.T) platformApplicationsBundleTestFixture {
+	t.Helper()
+	root := t.TempDir()
+	at := time.Date(2026, 8, 17, 20, 0, 0, 0, time.UTC)
+	expectedPlan := stageplan.Expected{
+		ContractIdentity: contract.Identity{Namespace: "disposable-ok147", Name: "disposable-ok147"},
+		IntentRevision:   runnerStageSHA("a"), EnablementRevision: runnerStageSHA("b"), PlatformRevision: runnerStageSHA("c"), ExecutionFixture: runnerStageSHA("d"),
+		InfrastructureAuthority: "ok-infra", ManagementAuthority: "ok-mgmt", GitOpsAuthority: "ok-shared",
+	}
+	applications, profile := runnerPlatformApplications(t, expectedPlan)
+	artifactDigest := digest.SHA256(applications)
+	profileDigest, err := observation.PlatformProfileDigest(profile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	planRaw := submissionBundlePlan(t, expectedPlan, runnerStageSHA("1"), runnerStageSHA("2"))
+	var document map[string]any
+	if err := json.Unmarshal(planRaw, &document); err != nil {
+		t.Fatal(err)
+	}
+	stages := document["stages"].([]any)
+	stages[6].(map[string]any)["inputs"] = []any{map[string]any{"name": "stage.target-access", "digest": runnerStageSHA("3")}}
+	stages[7].(map[string]any)["inputs"] = []any{map[string]any{"name": "stage.target-credential", "digest": runnerStageSHA("4")}}
+	stages[8].(map[string]any)["inputs"] = []any{map[string]any{"name": "stage.target-registration", "digest": runnerStageSHA("5")}}
+	stages[9].(map[string]any)["inputs"] = []any{map[string]any{"name": "stage.platform-applications", "digest": artifactDigest}}
+	planPath := writeBundleFile(t, root, "staged-plan.json", mustJSON(t, document))
+	plan, err := stageplan.Load(planPath, expectedPlan)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	receipts := make([]StageReceiptSource, 0, 9)
+	predecessors := []stagereceipt.Verified{}
+	results := []struct{ id, mutation, operation, evidence string }{
+		{"provider-prerequisites", "ATTEMPTED", runnerStageSHA("1"), runnerStageSHA("2")},
+		{"cluster-lifecycle", "ATTEMPTED", runnerStageSHA("3"), runnerStageSHA("4")},
+		{"lifecycle-observation", "NOT_APPLICABLE", "", runnerStageSHA("5")},
+		{"enablement", "ATTEMPTED", runnerStageSHA("6"), runnerStageSHA("7")},
+		{"network-observation", "NOT_APPLICABLE", "", runnerStageSHA("8")},
+		{"runtime-binding", "NOT_APPLICABLE", "", runnerStageSHA("9")},
+		{"target-access", "ATTEMPTED", runnerStageSHA("0"), runnerStageSHA("a")},
+		{"target-credential", "ATTEMPTED", runnerStageSHA("b"), runnerStageSHA("c")},
+		{"target-registration", "ATTEMPTED", runnerStageSHA("d"), runnerStageSHA("e")},
+	}
+	for index, result := range results {
+		var receipt stagereceipt.Verified
+		if result.id == "cluster-lifecycle" {
+			receipt, err = stagereceipt.NewWithTargetClusterUIDDigest(plan, result.id, predecessors, "SUCCEEDED", result.mutation, result.operation, result.evidence, digest.SHA256([]byte(targetAccessRuntimeUID)), at.Add(time.Duration(index-9)*time.Minute))
+		} else {
+			receipt, err = stagereceipt.New(plan, result.id, predecessors, "SUCCEEDED", result.mutation, result.operation, result.evidence, at.Add(time.Duration(index-9)*time.Minute))
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		receipts = appendStageReceipt(t, root, receipts, receipt, result.id+".json")
+		predecessors = []stagereceipt.Verified{receipt}
+	}
+	grantPath, keyPath := writeSubmissionStageGrant(t, root, plan, "platform-applications", predecessors, at)
+	expected := submission.PlatformApplicationsExpected{
+		ArtifactDigest: artifactDigest, ContractIdentity: expectedPlan.ContractIdentity,
+		IntentRevision: expectedPlan.IntentRevision, PlatformRevision: expectedPlan.PlatformRevision, ExecutionFixture: expectedPlan.ExecutionFixture,
+		TargetIdentityDigest: digest.SHA256([]byte(targetAccessRuntimeUID)), ArgoAuthority: "ok-shared", ArgoNamespace: "argocd",
+		ProjectName: "openkubes-disposable", RegistrationName: "disposable-ok147", SourceRepository: "https://github.com/openkubes/ok-observability.git", Profile: profile,
+	}
+	return platformApplicationsBundleTestFixture{
+		config: PlatformApplicationsStageBundleConfig{
+			PlanPath: planPath, PlanExpected: expectedPlan, Receipts: receipts,
+			GrantPath: grantPath, GrantPublicKeyPath: keyPath, EvaluationTime: at,
+			ArtifactPath: writeBundleFile(t, root, "platform-applications.yaml", applications), Expected: expected,
+		},
+		plan: plan, artifactDigest: artifactDigest, profileDigest: profileDigest,
+	}
+}
+
+func runnerPlatformApplications(t *testing.T, expected stageplan.Expected) ([]byte, observation.PlatformProfile) {
+	t.Helper()
+	names := []string{"disposable-ok147-observability-alerting", "disposable-ok147-observability-core", "disposable-ok147-observability-dashboards"}
+	paths := []string{"profiles/minimal-observability/alerting", "profiles/minimal-observability/core", "profiles/minimal-observability/dashboards"}
+	annotations := map[string]any{
+		"openkubes.io/intent-revision": expected.IntentRevision, "openkubes.io/platform-revision": expected.PlatformRevision,
+		"openkubes.io/execution-fixture": expected.ExecutionFixture, "openkubes.io/target-identity-digest": digest.SHA256([]byte(targetAccessRuntimeUID)),
+	}
+	documents := make([][]byte, 0, len(names))
+	expectations := make([]observation.PlatformApplicationExpectation, 0, len(names))
+	for index, name := range names {
+		spec := map[string]any{
+			"project":     "openkubes-disposable",
+			"source":      map[string]any{"repoURL": "https://github.com/openkubes/ok-observability.git", "path": paths[index], "targetRevision": strings.Repeat("6", 40)},
+			"destination": map[string]any{"name": "disposable-ok147", "namespace": "ok-observability"},
+			"syncPolicy":  map[string]any{"automated": map[string]any{"prune": true, "selfHeal": true}, "syncOptions": []any{"CreateNamespace=true"}},
+		}
+		if index == 1 {
+			spec["ignoreDifferences"] = []any{map[string]any{"group": "apps", "kind": "Deployment", "jsonPointers": []any{"/spec/replicas"}}}
+		}
+		specDigest, _, err := observation.PlatformApplicationSpecIdentity(spec)
+		if err != nil {
+			t.Fatal(err)
+		}
+		expectations = append(expectations, observation.PlatformApplicationExpectation{Name: name, SpecDigest: specDigest})
+		document := map[string]any{
+			"apiVersion": "argoproj.io/v1alpha1", "kind": "Application",
+			"metadata": map[string]any{"name": name, "namespace": "argocd", "annotations": annotations}, "spec": spec,
+		}
+		raw, err := json.Marshal(document)
+		if err != nil {
+			t.Fatal(err)
+		}
+		documents = append(documents, raw)
+	}
+	profile := observation.PlatformProfile{
+		Format: observation.PlatformProfileFormat, IntentRevision: expected.IntentRevision, PlatformRevision: expected.PlatformRevision,
+		ExecutionFixture: expected.ExecutionFixture, TargetIdentityScheme: "capi-cluster-uid/v1", ArgoNamespace: "argocd",
+		RegistrationName: "disposable-ok147", RequiredApplications: expectations,
+		CapabilityContractDigest: runnerStageSHA("7"), CapabilityExecutableDigest: runnerStageSHA("8"), MaximumCapabilityAgeSeconds: 900,
+	}
+	return []byte(strings.Join([]string{string(documents[0]), string(documents[1]), string(documents[2])}, "\n---\n")), profile
+}


### PR DESCRIPTION
## Summary

- verify the exact nine-receipt prefix through successful target registration
- bind the signed `CreatePlatformApplications` grant to the immutable Stage-10 projection
- bind `P`, target identity, Platform profile, and exactly three canonical Argo Applications without API access or mutation
- fail closed on altered artifacts, profiles, target/authority identities, grants, plans, or post-verification object changes

## Validation

- `go test ./...`
- `go vet ./...`
- `go test -race ./internal/runner ./internal/submission ./internal/observation ./cmd/ok`

## Scope

Offline bundle verification only. No credentials are opened, no Kubernetes API is contacted, and no mutation is introduced.

Jira: OK-147
