### PR TITLE
feat(runner): create platform applications exactly once (OK-147)

### DIFF
--- a/internal/runner/platform_applications_launcher.go
+++ b/internal/runner/platform_applications_launcher.go
@@ -1,0 +1,272 @@
+package runner
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+const PlatformApplicationsLaunchReceiptFormat = "ok147-platform-applications-launch-receipt/v1"
+
+type PlatformApplicationsLauncherConfig struct {
+	Authority KubernetesAuthorityConfig
+}
+
+type PlatformApplicationsLaunchReceipt struct {
+	Format               string                        `json:"format"`
+	StageID              string                        `json:"stageId"`
+	PlanDigest           string                        `json:"planDigest"`
+	ArtifactDigest       string                        `json:"artifactDigest"`
+	TargetIdentityDigest string                        `json:"targetIdentityDigest"`
+	ProfileDigest        string                        `json:"profileDigest"`
+	Authority            string                        `json:"authority"`
+	State                string                        `json:"state"`
+	MutationState        string                        `json:"mutationState"`
+	Results              []SubmissionStageLaunchResult `json:"results"`
+}
+
+type platformApplicationLaunchObject struct {
+	order          int
+	apiVersion     string
+	kind           string
+	namespace      string
+	name           string
+	collectionPath string
+	objectPath     string
+	digest         string
+	raw            []byte
+}
+
+// KubernetesPlatformApplicationsLauncher is a single-use, three-Application,
+// create-only writer. All exact absence checks complete before its first POST;
+// a partial or unknown result is preserved and cannot be retried.
+type KubernetesPlatformApplicationsLauncher struct {
+	mu        sync.Mutex
+	used      bool
+	endpoint  *url.URL
+	token     string
+	client    *http.Client
+	authority string
+	receipt   PlatformApplicationsStageBundleReceipt
+	objects   []platformApplicationLaunchObject
+}
+
+type platformApplicationsLauncherClientConfig struct {
+	Endpoint          string
+	BearerToken       string
+	AuthorityIdentity string
+	Client            *http.Client
+}
+
+// OpenKubernetesPlatformApplicationsLauncher opens the bounded GitOps writer
+// credential without contacting an API.
+func OpenKubernetesPlatformApplicationsLauncher(config PlatformApplicationsLauncherConfig, bundle VerifiedPlatformApplicationsStageBundle) (*KubernetesPlatformApplicationsLauncher, error) {
+	if err := verifyPlatformApplicationsStageBundle(bundle); err != nil {
+		return nil, err
+	}
+	if config.Authority.AuthorityIdentity == "" || config.Authority.AuthorityIdentity != bundle.receipt.Authority || !stageReceiptPrefixDigestPattern.MatchString(config.Authority.CABundleDigest) {
+		return nil, errors.New("platform-applications launcher authority differs from verified GitOps authority")
+	}
+	token, ca, client, err := openBoundedKubernetesMaterial(config.Authority.TokenFile, config.Authority.CAFile)
+	if err != nil {
+		return nil, errors.New("open bounded platform-applications launcher credential")
+	}
+	if digest.SHA256(ca) != config.Authority.CABundleDigest {
+		return nil, errors.New("platform-applications launcher CA differs from bound identity")
+	}
+	return newKubernetesPlatformApplicationsLauncher(platformApplicationsLauncherClientConfig{
+		Endpoint: config.Authority.Endpoint, BearerToken: token,
+		AuthorityIdentity: config.Authority.AuthorityIdentity, Client: client,
+	}, bundle)
+}
+
+func newKubernetesPlatformApplicationsLauncher(config platformApplicationsLauncherClientConfig, bundle VerifiedPlatformApplicationsStageBundle) (*KubernetesPlatformApplicationsLauncher, error) {
+	if err := verifyPlatformApplicationsStageBundle(bundle); err != nil {
+		return nil, err
+	}
+	if config.AuthorityIdentity == "" || config.AuthorityIdentity != bundle.receipt.Authority {
+		return nil, errors.New("platform-applications launcher authority differs from verified GitOps authority")
+	}
+	endpoint, err := normalizeSubmissionStageLaunchEndpoint(config.Endpoint)
+	if err != nil {
+		return nil, errors.New("platform-applications launcher endpoint is invalid")
+	}
+	if config.BearerToken == "" || strings.TrimSpace(config.BearerToken) != config.BearerToken || strings.ContainsAny(config.BearerToken, "\r\n") || config.Client == nil {
+		return nil, errors.New("platform-applications launcher credential or client is invalid")
+	}
+	parsedEndpoint, err := url.Parse(endpoint)
+	if err != nil {
+		return nil, errors.New("platform-applications launcher endpoint is invalid")
+	}
+	objects := make([]platformApplicationLaunchObject, len(bundle.projection.Applications))
+	for index, application := range bundle.projection.Applications {
+		objects[index] = platformApplicationLaunchObject{
+			order: index + 1, apiVersion: application.Identity.APIVersion, kind: application.Identity.Kind,
+			namespace: application.Identity.Namespace, name: application.Identity.Name,
+			collectionPath: application.CollectionPath, objectPath: application.ObjectPath,
+			digest: application.Digest, raw: append([]byte(nil), application.Raw...),
+		}
+	}
+	if err := verifyPlatformApplicationLaunchObjects(objects); err != nil {
+		return nil, err
+	}
+	client := *config.Client
+	client.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+	if client.Timeout == 0 {
+		client.Timeout = 15 * time.Second
+	}
+	return &KubernetesPlatformApplicationsLauncher{
+		endpoint: parsedEndpoint, token: config.BearerToken, client: &client,
+		authority: config.AuthorityIdentity, receipt: bundle.receipt, objects: objects,
+	}, nil
+}
+
+func (launcher *KubernetesPlatformApplicationsLauncher) Install(ctx context.Context) (PlatformApplicationsLaunchReceipt, error) {
+	receipt := launcher.newReceipt()
+	if launcher == nil || launcher.client == nil {
+		return receipt, errors.New("platform-applications launcher is required")
+	}
+	launcher.mu.Lock()
+	if launcher.used {
+		launcher.mu.Unlock()
+		return stopPlatformApplicationsLaunch(receipt, "STOPPED_ZERO_WRITE", errors.New("platform-applications launcher is single-use"))
+	}
+	launcher.used = true
+	launcher.mu.Unlock()
+	for _, object := range launcher.objects {
+		_, status, err := launcher.request(ctx, http.MethodGet, object.objectPath, nil)
+		if err != nil {
+			return stopPlatformApplicationsLaunch(receipt, "STOPPED_ZERO_WRITE", err)
+		}
+		switch status {
+		case http.StatusNotFound:
+		case http.StatusOK:
+			return stopPlatformApplicationsLaunch(receipt, "STOPPED_ZERO_WRITE", errors.New("platform Application already exists; zero-write preflight stopped"))
+		default:
+			return stopPlatformApplicationsLaunch(receipt, "STOPPED_ZERO_WRITE", platformApplicationsLaunchStatusError(http.MethodGet, status))
+		}
+	}
+	receipt.State = "CREATING"
+	for _, object := range launcher.objects {
+		receipt.MutationState = "ATTEMPTED_UNKNOWN"
+		raw, status, err := launcher.request(ctx, http.MethodPost, object.collectionPath, object.raw)
+		if err != nil {
+			return stopPlatformApplicationsLaunch(receipt, "STOPPED_PARTIAL_OR_UNKNOWN", err)
+		}
+		if status != http.StatusCreated {
+			receipt.MutationState = "ATTEMPTED"
+			return stopPlatformApplicationsLaunch(receipt, "STOPPED_PARTIAL_OR_UNKNOWN", platformApplicationsLaunchStatusError(http.MethodPost, status))
+		}
+		uid, resourceVersion, err := verifyPlatformApplicationCreatedObject(raw, object)
+		if err != nil {
+			return stopPlatformApplicationsLaunch(receipt, "STOPPED_PARTIAL_OR_UNKNOWN", errors.New("created platform Application differs from verified projection"))
+		}
+		receipt.MutationState = "ATTEMPTED"
+		receipt.Results = append(receipt.Results, SubmissionStageLaunchResult{
+			Order: object.order, Phase: "platform-application", APIVersion: object.apiVersion, Kind: object.kind,
+			Namespace: object.namespace, Name: object.name, ObjectDigest: object.digest, ObjectState: "CREATED",
+			UIDDigest: digest.SHA256([]byte(uid)), ResourceVersionDigest: digest.SHA256([]byte(resourceVersion)),
+		})
+	}
+	receipt.State = "INSTALLED"
+	return receipt, nil
+}
+
+func (launcher *KubernetesPlatformApplicationsLauncher) newReceipt() PlatformApplicationsLaunchReceipt {
+	receipt := PlatformApplicationsLaunchReceipt{
+		Format: PlatformApplicationsLaunchReceiptFormat, StageID: "platform-applications",
+		State: "PREFLIGHT", MutationState: "NOT_ATTEMPTED", Results: []SubmissionStageLaunchResult{},
+	}
+	if launcher != nil {
+		receipt.PlanDigest = launcher.receipt.PlanDigest
+		receipt.ArtifactDigest = launcher.receipt.ArtifactDigest
+		receipt.TargetIdentityDigest = launcher.receipt.TargetIdentityDigest
+		receipt.ProfileDigest = launcher.receipt.ProfileDigest
+		receipt.Authority = launcher.authority
+	}
+	return receipt
+}
+
+func stopPlatformApplicationsLaunch(receipt PlatformApplicationsLaunchReceipt, state string, err error) (PlatformApplicationsLaunchReceipt, error) {
+	receipt.State = state
+	return receipt, err
+}
+
+func verifyPlatformApplicationCreatedObject(raw []byte, expected platformApplicationLaunchObject) (string, string, error) {
+	observed, err := decodeCapabilityJSONObject(raw)
+	if err != nil {
+		return "", "", err
+	}
+	desired, err := decodeCapabilityJSONObject(expected.raw)
+	if err != nil || !capabilitySubset(desired, observed) {
+		return "", "", errors.New("observed platform Application does not contain exact desired fields")
+	}
+	metadata, _ := observed["metadata"].(map[string]any)
+	uid, _ := metadata["uid"].(string)
+	resourceVersion, _ := metadata["resourceVersion"].(string)
+	if metadata["name"] != expected.name || metadata["namespace"] != expected.namespace || !runtimeInputUIDPattern.MatchString(uid) || !runtimeInputUIDPattern.MatchString(resourceVersion) {
+		return "", "", errors.New("observed platform Application server identity is invalid")
+	}
+	return uid, resourceVersion, nil
+}
+
+func (launcher *KubernetesPlatformApplicationsLauncher) request(ctx context.Context, method, path string, body []byte) ([]byte, int, error) {
+	endpoint := *launcher.endpoint
+	endpoint.Path = path
+	request, err := http.NewRequestWithContext(ctx, method, endpoint.String(), bytes.NewReader(body))
+	if err != nil {
+		return nil, 0, errors.New("construct bounded platform-applications request")
+	}
+	request.Header.Set("Accept", "application/json")
+	if method == http.MethodGet {
+		request.Header.Set("Accept", partialObjectMetadataAccept)
+	}
+	request.Header.Set("Authorization", "Bearer "+launcher.token)
+	if body != nil {
+		request.Header.Set("Content-Type", "application/json")
+	}
+	response, err := launcher.client.Do(request)
+	if err != nil {
+		return nil, 0, fmt.Errorf("bounded platform-applications %s request failed", method)
+	}
+	defer response.Body.Close()
+	raw, readErr := io.ReadAll(io.LimitReader(response.Body, maximumStageInstallationResponseBytes+1))
+	if readErr != nil || len(raw) > maximumStageInstallationResponseBytes {
+		return nil, 0, errors.New("bounded platform-applications response exceeds accepted size")
+	}
+	if len(raw) > 0 {
+		mediaType, _, err := mime.ParseMediaType(response.Header.Get("Content-Type"))
+		if err != nil || mediaType != "application/json" {
+			return nil, 0, errors.New("bounded platform-applications response is not JSON")
+		}
+	}
+	return raw, response.StatusCode, nil
+}
+
+func platformApplicationsLaunchStatusError(method string, status int) error {
+	return fmt.Errorf("bounded platform-applications %s returned status %d", method, status)
+}
+
+func verifyPlatformApplicationLaunchObjects(objects []platformApplicationLaunchObject) error {
+	if len(objects) != 3 {
+		return errors.New("platform-applications launcher requires exactly three objects")
+	}
+	for index, object := range objects {
+		var value map[string]any
+		if object.order != index+1 || object.apiVersion != "argoproj.io/v1alpha1" || object.kind != "Application" || object.namespace == "" || object.name == "" || !stageReceiptPrefixDigestPattern.MatchString(object.digest) || digest.SHA256(object.raw) != object.digest || json.Unmarshal(object.raw, &value) != nil {
+			return errors.New("platform-applications launcher object binding is invalid")
+		}
+	}
+	return nil
+}

--- a/internal/runner/platform_applications_launcher_test.go
+++ b/internal/runner/platform_applications_launcher_test.go
@@ -1,0 +1,181 @@
+package runner
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+func TestPlatformApplicationsLauncherPreflightsThenCreatesExactApplications(t *testing.T) {
+	fixture := platformApplicationsBundleFixture(t)
+	bundle, err := LoadPlatformApplicationsStageBundle(fixture.config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	api := newPlatformApplicationsLauncherAPI(t)
+	launcher := newPlatformApplicationsLauncher(t, bundle, api.client())
+	receipt, err := launcher.Install(context.Background())
+	if err != nil || receipt.State != "INSTALLED" || receipt.MutationState != "ATTEMPTED" || len(receipt.Results) != 3 {
+		t.Fatalf("platform Applications launch failed: %#v %v", receipt, err)
+	}
+	if receipt.Format != PlatformApplicationsLaunchReceiptFormat || receipt.StageID != "platform-applications" || receipt.PlanDigest != bundle.receipt.PlanDigest || receipt.ArtifactDigest != bundle.receipt.ArtifactDigest || receipt.TargetIdentityDigest != bundle.receipt.TargetIdentityDigest || receipt.ProfileDigest != bundle.receipt.ProfileDigest || receipt.Authority != "ok-shared" {
+		t.Fatalf("unexpected platform Applications receipt: %#v", receipt)
+	}
+	if len(api.requests) != 6 {
+		t.Fatalf("requests=%d, want three GETs then three POSTs", len(api.requests))
+	}
+	for index, object := range launcher.objects {
+		preflight, submission := api.requests[index], api.requests[index+3]
+		if preflight.method != http.MethodGet || preflight.path != object.objectPath || len(preflight.body) != 0 || submission.method != http.MethodPost || submission.path != object.collectionPath || digest.SHA256(submission.body) != object.digest {
+			t.Fatalf("request %d differs from exact Application", index)
+		}
+		result := receipt.Results[index]
+		if result.Order != index+1 || result.Phase != "platform-application" || result.APIVersion != object.apiVersion || result.Kind != object.kind || result.Namespace != object.namespace || result.Name != object.name || result.ObjectDigest != object.digest || result.ObjectState != "CREATED" || !stageReceiptPrefixDigestPattern.MatchString(result.UIDDigest) || !stageReceiptPrefixDigestPattern.MatchString(result.ResourceVersionDigest) {
+			t.Fatalf("result %d differs: %#v", index, result)
+		}
+	}
+}
+
+func TestPlatformApplicationsLauncherStopsZeroWriteForExistingApplication(t *testing.T) {
+	fixture := platformApplicationsBundleFixture(t)
+	bundle, _ := LoadPlatformApplicationsStageBundle(fixture.config)
+	api := newPlatformApplicationsLauncherAPI(t)
+	launcher := newPlatformApplicationsLauncher(t, bundle, api.client())
+	api.objects[launcher.objects[1].objectPath] = map[string]any{"kind": "Application"}
+	receipt, err := launcher.Install(context.Background())
+	if err == nil || receipt.State != "STOPPED_ZERO_WRITE" || receipt.MutationState != "NOT_ATTEMPTED" || api.posts != 0 || len(api.requests) != 2 {
+		t.Fatalf("existing Application did not stop before writes: %#v requests=%d err=%v", receipt, len(api.requests), err)
+	}
+}
+
+func TestPlatformApplicationsLauncherPreservesPartialStateAndCannotRetry(t *testing.T) {
+	fixture := platformApplicationsBundleFixture(t)
+	bundle, _ := LoadPlatformApplicationsStageBundle(fixture.config)
+	api := newPlatformApplicationsLauncherAPI(t)
+	api.failPost = 2
+	launcher := newPlatformApplicationsLauncher(t, bundle, api.client())
+	receipt, err := launcher.Install(context.Background())
+	if err == nil || receipt.State != "STOPPED_PARTIAL_OR_UNKNOWN" || receipt.MutationState != "ATTEMPTED" || len(receipt.Results) != 1 {
+		t.Fatalf("partial state differs: %#v %v", receipt, err)
+	}
+	requests := len(api.requests)
+	retry, retryErr := launcher.Install(context.Background())
+	if retryErr == nil || retry.State != "STOPPED_ZERO_WRITE" || len(api.requests) != requests {
+		t.Fatalf("single-use launcher retried: %#v %v", retry, retryErr)
+	}
+}
+
+func TestPlatformApplicationsLauncherFailsClosedForTamperingUnknownOutcomeAndRedirect(t *testing.T) {
+	fixture := platformApplicationsBundleFixture(t)
+	bundle, _ := LoadPlatformApplicationsStageBundle(fixture.config)
+	tampered := bundle
+	tampered.projection.Applications[0].Raw[0] ^= 1
+	if _, err := newKubernetesPlatformApplicationsLauncher(platformApplicationsLauncherClientConfig{
+		Endpoint: "https://127.0.0.1:12345", BearerToken: "short-lived-gitops-token", AuthorityIdentity: "ok-shared", Client: newPlatformApplicationsLauncherAPI(t).client(),
+	}, tampered); err == nil {
+		t.Fatal("tampered platform Applications bundle opened launcher")
+	}
+	bundle, _ = LoadPlatformApplicationsStageBundle(fixture.config)
+
+	api := newPlatformApplicationsLauncherAPI(t)
+	api.errorPost = 1
+	launcher := newPlatformApplicationsLauncher(t, bundle, api.client())
+	receipt, err := launcher.Install(context.Background())
+	if err == nil || receipt.State != "STOPPED_PARTIAL_OR_UNKNOWN" || receipt.MutationState != "ATTEMPTED_UNKNOWN" || len(receipt.Results) != 0 || strings.Contains(err.Error(), "short-lived-gitops-token") {
+		t.Fatalf("unknown outcome accepted or leaked: %#v %v", receipt, err)
+	}
+
+	calls := 0
+	redirect := &http.Client{Transport: targetRegistrationRoundTripFunc(func(*http.Request) (*http.Response, error) {
+		calls++
+		return targetRegistrationJSONResponse(http.StatusTemporaryRedirect, nil, map[string]string{"Location": "http://127.0.0.1:12346/foreign"}), nil
+	})}
+	launcher = newPlatformApplicationsLauncher(t, bundle, redirect)
+	receipt, err = launcher.Install(context.Background())
+	if err == nil || calls != 1 || receipt.State != "STOPPED_ZERO_WRITE" || receipt.MutationState != "NOT_ATTEMPTED" {
+		t.Fatalf("redirect followed or accepted: calls=%d receipt=%#v err=%v", calls, receipt, err)
+	}
+}
+
+func newPlatformApplicationsLauncher(t *testing.T, bundle VerifiedPlatformApplicationsStageBundle, client *http.Client) *KubernetesPlatformApplicationsLauncher {
+	t.Helper()
+	launcher, err := newKubernetesPlatformApplicationsLauncher(platformApplicationsLauncherClientConfig{
+		Endpoint: "https://127.0.0.1:12345", BearerToken: "short-lived-gitops-token", AuthorityIdentity: "ok-shared", Client: client,
+	}, bundle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return launcher
+}
+
+type platformApplicationsLauncherRequest struct {
+	method string
+	path   string
+	body   []byte
+}
+
+type platformApplicationsLauncherAPI struct {
+	t         *testing.T
+	mu        sync.Mutex
+	objects   map[string]map[string]any
+	requests  []platformApplicationsLauncherRequest
+	posts     int
+	failPost  int
+	errorPost int
+}
+
+func newPlatformApplicationsLauncherAPI(t *testing.T) *platformApplicationsLauncherAPI {
+	return &platformApplicationsLauncherAPI{t: t, objects: map[string]map[string]any{}}
+}
+
+func (api *platformApplicationsLauncherAPI) client() *http.Client {
+	return &http.Client{Transport: targetRegistrationRoundTripFunc(api.roundTrip)}
+}
+
+func (api *platformApplicationsLauncherAPI) roundTrip(request *http.Request) (*http.Response, error) {
+	api.mu.Lock()
+	defer api.mu.Unlock()
+	body, _ := io.ReadAll(request.Body)
+	api.requests = append(api.requests, platformApplicationsLauncherRequest{method: request.Method, path: request.URL.Path, body: body})
+	if request.Header.Get("Authorization") != "Bearer short-lived-gitops-token" {
+		return targetRegistrationJSONResponse(http.StatusUnauthorized, map[string]any{"reason": "Unauthorized"}, nil), nil
+	}
+	if request.Method == http.MethodGet && request.Header.Get("Accept") != partialObjectMetadataAccept {
+		return targetRegistrationJSONResponse(http.StatusNotAcceptable, map[string]any{"reason": "NotAcceptable"}, nil), nil
+	}
+	switch request.Method {
+	case http.MethodGet:
+		object, exists := api.objects[request.URL.Path]
+		if !exists {
+			return targetRegistrationJSONResponse(http.StatusNotFound, map[string]any{"reason": "NotFound"}, nil), nil
+		}
+		return targetRegistrationJSONResponse(http.StatusOK, object, nil), nil
+	case http.MethodPost:
+		api.posts++
+		if api.errorPost == api.posts {
+			return nil, errors.New("simulated transport error")
+		}
+		if api.failPost == api.posts {
+			return targetRegistrationJSONResponse(http.StatusForbidden, map[string]any{"reason": "Denied"}, nil), nil
+		}
+		var object map[string]any
+		if err := json.Unmarshal(body, &object); err != nil {
+			api.t.Fatal(err)
+		}
+		metadata := object["metadata"].(map[string]any)
+		metadata["uid"] = "created-platform-application-uid-" + string(rune('a'+api.posts-1))
+		metadata["resourceVersion"] = string(rune('1' + api.posts - 1))
+		path := request.URL.Path + "/" + metadata["name"].(string)
+		api.objects[path] = object
+		return targetRegistrationJSONResponse(http.StatusCreated, object, nil), nil
+	default:
+		return targetRegistrationJSONResponse(http.StatusMethodNotAllowed, map[string]any{"reason": "MethodNotAllowed"}, nil), nil
+	}
+}


### PR DESCRIPTION
## Summary

- add a single-use create-only Stage-10 launcher for the three verified Argo Applications
- complete all three exact-name absence checks before the first POST
- preserve partial or unknown state without retry when any create outcome is not fully verified
- retain only redaction-safe object and runtime identity digests in the public receipt

## Validation

- `go test ./...`
- `go vet ./...`
- `go test -race ./internal/runner ./internal/submission ./internal/observation ./cmd/ok`

## Scope

Bounded launcher implementation and tests only. No live infrastructure action is performed by this PR.

Jira: OK-147
