### PR TITLE
feat(runner): execute platform applications stage durably (OK-147)

### DIFF
--- a/internal/runner/platform_applications_stage_bundle.go
+++ b/internal/runner/platform_applications_stage_bundle.go
@@ -1,12 +1,15 @@
 package runner
 
 import (
+	"context"
+	"crypto/subtle"
 	"errors"
 	"sort"
 	"time"
 
 	"github.com/openkubes/ok-cluster/internal/authorization"
 	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/execution"
 	"github.com/openkubes/ok-cluster/internal/observation"
 	"github.com/openkubes/ok-cluster/internal/stagecursor"
 	"github.com/openkubes/ok-cluster/internal/stageplan"
@@ -50,6 +53,20 @@ type VerifiedPlatformApplicationsStageBundle struct {
 	profile    observation.PlatformProfile
 	receipt    PlatformApplicationsStageBundleReceipt
 	verified   bool
+}
+
+type PlatformApplicationsStageRuntimeConfig struct {
+	Ledger KubernetesLedgerConfig
+	GitOps KubernetesAuthorityConfig
+	Clock  func() time.Time
+}
+
+type BoundPlatformApplicationsStage struct {
+	operation execution.StagedOperation
+	plan      stageplan.Binding
+	cursor    stagecursor.Cursor
+	grant     authorization.VerifiedStageGrant
+	verified  bool
 }
 
 // LoadPlatformApplicationsStageBundle verifies the exact nine-stage
@@ -142,6 +159,41 @@ func (bundle VerifiedPlatformApplicationsStageBundle) Receipt() (PlatformApplica
 	receipt := bundle.receipt
 	receipt.ApplicationDigests = append([]string(nil), bundle.receipt.ApplicationDigests...)
 	return receipt, nil
+}
+
+// Open binds the verified offline bundle to its GitOps writer and durable
+// ledger. It opens bounded credential files but performs no API request and no
+// mutation.
+func (bundle VerifiedPlatformApplicationsStageBundle) Open(config PlatformApplicationsStageRuntimeConfig) (BoundPlatformApplicationsStage, error) {
+	if err := verifyPlatformApplicationsStageBundle(bundle); err != nil || config.Clock == nil {
+		return BoundPlatformApplicationsStage{}, errors.New("verified platform-applications bundle and clock are required")
+	}
+	launcher, err := OpenKubernetesPlatformApplicationsLauncher(PlatformApplicationsLauncherConfig{Authority: config.GitOps}, bundle)
+	if err != nil {
+		return BoundPlatformApplicationsStage{}, err
+	}
+	ledgerStore, ledgerToken, err := openKubernetesLedger(config.Ledger)
+	if err != nil {
+		return BoundPlatformApplicationsStage{}, errors.New("open platform-applications stage ledger")
+	}
+	if len(ledgerToken) == len(launcher.token) && subtle.ConstantTimeCompare([]byte(ledgerToken), []byte(launcher.token)) == 1 {
+		return BoundPlatformApplicationsStage{}, errors.New("ledger and platform-applications writer credentials must be distinct")
+	}
+	mutator, err := NewPlatformApplicationsStageMutator(bundle.plan, bundle, launcher)
+	if err != nil {
+		return BoundPlatformApplicationsStage{}, err
+	}
+	return BoundPlatformApplicationsStage{
+		operation: execution.StagedOperation{Ledger: ledgerStore, Mutator: mutator, Clock: config.Clock},
+		plan:      bundle.plan, cursor: bundle.cursor, grant: bundle.grant, verified: true,
+	}, nil
+}
+
+func (stage BoundPlatformApplicationsStage) Run(ctx context.Context) (execution.StagedOperationReceipt, error) {
+	if !stage.verified {
+		return execution.StagedOperationReceipt{}, errors.New("platform-applications stage runtime was not produced by verification")
+	}
+	return stage.operation.Run(ctx, stage.plan, stage.cursor, stage.grant)
 }
 
 func verifyPlatformApplicationsStageBundle(bundle VerifiedPlatformApplicationsStageBundle) error {

--- a/internal/runner/platform_applications_stage_execution_test.go
+++ b/internal/runner/platform_applications_stage_execution_test.go
@@ -1,0 +1,120 @@
+package runner
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http/httptest"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/execution"
+)
+
+func TestPlatformApplicationsStageRunsOnceAndReplaysDurableOutcome(t *testing.T) {
+	fixture := platformApplicationsBundleFixture(t)
+	bundle, _ := LoadPlatformApplicationsStageBundle(fixture.config)
+	ledgerAPI := newRuntimeBindingLedgerAPI(t)
+	defer ledgerAPI.Close()
+	gitopsAPI := newTargetRegistrationExecutionAPI(t, 0)
+	defer gitopsAPI.Close()
+	bound, err := bundle.Open(platformApplicationsExecutionRuntime(t, ledgerAPI.Server, gitopsAPI.Server))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ledgerAPI.RequestCount() != 0 || gitopsAPI.RequestCount() != 0 {
+		t.Fatal("opening platform-applications stage contacted Kubernetes")
+	}
+	receipt, err := bound.Run(context.Background())
+	if err != nil || receipt.State != "COMPLETED_SUCCEEDED" || receipt.StageID != "platform-applications" || receipt.StageReceiptDigest == "" {
+		t.Fatalf("platform-applications stage did not complete: %#v %v", receipt, err)
+	}
+	want := []string{}
+	for _, application := range bundle.projection.Applications {
+		want = append(want, "GET "+application.ObjectPath)
+	}
+	for _, application := range bundle.projection.Applications {
+		want = append(want, "POST "+application.CollectionPath)
+	}
+	if !reflect.DeepEqual(gitopsAPI.Requests(), want) {
+		t.Fatalf("platform-applications request boundary differs: got %v want %v", gitopsAPI.Requests(), want)
+	}
+	public, _ := json.Marshal(receipt)
+	for _, forbidden := range []string{"ledger-token", "gitops-writer-token", gitopsAPI.URL} {
+		if strings.Contains(string(public), forbidden) {
+			t.Fatalf("stage receipt leaked private value %q", forbidden)
+		}
+	}
+	replayed, err := bound.Run(context.Background())
+	if err != nil || replayed.StageReceiptDigest != receipt.StageReceiptDigest || !reflect.DeepEqual(gitopsAPI.Requests(), want) {
+		t.Fatalf("durable platform-applications outcome replayed mutation: %#v %v", replayed, err)
+	}
+}
+
+func TestPlatformApplicationsStageDurablyStopsPartialStateWithoutRetry(t *testing.T) {
+	fixture := platformApplicationsBundleFixture(t)
+	bundle, _ := LoadPlatformApplicationsStageBundle(fixture.config)
+	ledgerAPI := newRuntimeBindingLedgerAPI(t)
+	defer ledgerAPI.Close()
+	gitopsAPI := newTargetRegistrationExecutionAPI(t, 2)
+	defer gitopsAPI.Close()
+	bound, err := bundle.Open(platformApplicationsExecutionRuntime(t, ledgerAPI.Server, gitopsAPI.Server))
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, runErr := bound.Run(context.Background())
+	var resultErr *execution.StageResultError
+	if !errors.As(runErr, &resultErr) || receipt.State != "COMPLETED_STOPPED" || receipt.StageReceiptDigest == "" {
+		t.Fatalf("partial platform-applications state was not durably stopped: %#v %v", receipt, runErr)
+	}
+	requests := gitopsAPI.Requests()
+	if len(requests) != 5 || !strings.HasPrefix(requests[4], "POST ") {
+		t.Fatalf("platform-applications did not stop at bound failure: %v", requests)
+	}
+	if _, err := bound.Run(context.Background()); !errors.As(err, &resultErr) || !reflect.DeepEqual(gitopsAPI.Requests(), requests) {
+		t.Fatalf("durable platform-applications stop was retried: requests=%v err=%v", gitopsAPI.Requests(), err)
+	}
+}
+
+func TestPlatformApplicationsStageRejectsSharedLedgerAndWriterCredentialBeforeAPI(t *testing.T) {
+	fixture := platformApplicationsBundleFixture(t)
+	bundle, _ := LoadPlatformApplicationsStageBundle(fixture.config)
+	ledgerAPI := newRuntimeBindingLedgerAPI(t)
+	defer ledgerAPI.Close()
+	gitopsAPI := newTargetRegistrationExecutionAPI(t, 0)
+	defer gitopsAPI.Close()
+	config := platformApplicationsExecutionRuntime(t, ledgerAPI.Server, gitopsAPI.Server)
+	if err := os.WriteFile(config.GitOps.TokenFile, []byte("ledger-token"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := bundle.Open(config); err == nil || ledgerAPI.RequestCount() != 0 || gitopsAPI.RequestCount() != 0 {
+		t.Fatal("shared ledger/writer credential opened platform-applications runtime")
+	}
+}
+
+func platformApplicationsExecutionRuntime(t *testing.T, ledgerServer, gitopsServer *httptest.Server) PlatformApplicationsStageRuntimeConfig {
+	t.Helper()
+	root := t.TempDir()
+	ledgerCA := writeRuntimeBindingServerCA(t, root, "ledger-ca.crt", ledgerServer)
+	gitopsCA := writeRuntimeBindingServerCA(t, root, "gitops-ca.crt", gitopsServer)
+	gitopsCABytes, err := os.ReadFile(gitopsCA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return PlatformApplicationsStageRuntimeConfig{
+		Ledger: KubernetesLedgerConfig{
+			Endpoint: ledgerServer.URL, Namespace: "openkubes-execution-system",
+			TokenFile: writeBundleFile(t, root, "ledger-token", []byte("ledger-token")), CAFile: ledgerCA,
+		},
+		GitOps: KubernetesAuthorityConfig{
+			Endpoint: gitopsServer.URL, AuthorityIdentity: "ok-shared",
+			TokenFile: writeBundleFile(t, root, "gitops-token", []byte("gitops-writer-token")), CAFile: gitopsCA,
+			CABundleDigest: digest.SHA256(gitopsCABytes),
+		},
+		Clock: func() time.Time { return time.Date(2026, 8, 17, 20, 1, 0, 0, time.UTC) },
+	}
+}

--- a/internal/runner/platform_applications_stage_mutator.go
+++ b/internal/runner/platform_applications_stage_mutator.go
@@ -1,0 +1,135 @@
+package runner
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+
+	"github.com/openkubes/ok-cluster/internal/contract"
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/execution"
+	"github.com/openkubes/ok-cluster/internal/stageplan"
+)
+
+// PlatformApplicationsStageMutator adapts one already verified create-only
+// launcher to the durable staged-operation protocol. It cannot select another
+// stage, authority, Application set or operation at runtime.
+type PlatformApplicationsStageMutator struct {
+	binding   execution.StageMutationBinding
+	identity  contract.Identity
+	bundle    PlatformApplicationsStageBundleReceipt
+	authority string
+	objects   []platformApplicationLaunchObject
+	launcher  *KubernetesPlatformApplicationsLauncher
+}
+
+var _ execution.StageMutator = (*PlatformApplicationsStageMutator)(nil)
+
+func NewPlatformApplicationsStageMutator(plan stageplan.Binding, bundle VerifiedPlatformApplicationsStageBundle, launcher *KubernetesPlatformApplicationsLauncher) (*PlatformApplicationsStageMutator, error) {
+	if err := verifyPlatformApplicationsStageBundle(bundle); err != nil || launcher == nil || !samePlatformApplicationsBundleReceipt(launcher.receipt, bundle.receipt) || launcher.authority != plan.Authorities.GitOps || verifyPlatformApplicationLaunchObjects(launcher.objects) != nil {
+		return nil, errors.New("platform-applications mutator requires exact verified bundle and launcher")
+	}
+	stage, stageDigest, err := plan.Stage("platform-applications")
+	if err != nil {
+		return nil, err
+	}
+	if bundle.receipt.PlanDigest != plan.PlanDigest || stage.Authority != "gitops" || bundle.receipt.Authority != plan.Authorities.GitOps || stage.GrantOperation != "CreatePlatformApplications" || len(stage.Inputs) != 1 || stage.Inputs[0].Name != "stage.platform-applications" || stage.Inputs[0].Digest != bundle.receipt.ArtifactDigest {
+		return nil, errors.New("platform-applications bundle differs from selected staged plan")
+	}
+	objects := make([]platformApplicationLaunchObject, len(launcher.objects))
+	for index, object := range launcher.objects {
+		objects[index] = object
+		objects[index].raw = append([]byte(nil), object.raw...)
+	}
+	return &PlatformApplicationsStageMutator{
+		binding: execution.StageMutationBinding{
+			PlanDigest: plan.PlanDigest, StageID: stage.ID, StageDigest: stageDigest,
+			Operation: stage.GrantOperation, Authority: stage.Authority, ContractRevision: plan.IntentRevision,
+		},
+		identity: plan.ContractIdentity, bundle: bundle.receipt, authority: plan.Authorities.GitOps,
+		objects: objects, launcher: launcher,
+	}, nil
+}
+
+func samePlatformApplicationsBundleReceipt(left, right PlatformApplicationsStageBundleReceipt) bool {
+	if left.Format != right.Format || left.State != right.State || left.PlanDigest != right.PlanDigest || left.StageID != right.StageID || left.AuthorizationDigest != right.AuthorizationDigest || left.ArtifactDigest != right.ArtifactDigest || left.TargetIdentityDigest != right.TargetIdentityDigest || left.ProfileDigest != right.ProfileDigest || left.Authority != right.Authority || left.MutationAllowed != right.MutationAllowed || len(left.ApplicationDigests) != len(right.ApplicationDigests) {
+		return false
+	}
+	for index := range left.ApplicationDigests {
+		if left.ApplicationDigests[index] != right.ApplicationDigests[index] {
+			return false
+		}
+	}
+	return true
+}
+
+func (mutator *PlatformApplicationsStageMutator) Binding() execution.StageMutationBinding {
+	if mutator == nil {
+		return execution.StageMutationBinding{}
+	}
+	return mutator.binding
+}
+
+func (mutator *PlatformApplicationsStageMutator) Mutate(ctx context.Context, request execution.StageMutationRequest) (execution.StageMutationResult, error) {
+	if mutator == nil || request.StageMutationBinding != mutator.binding || request.ContractIdentity != mutator.identity || request.GrantID == "" || !stageReceiptPrefixDigestPattern.MatchString(request.PredecessorDigest) {
+		return execution.StageMutationResult{}, errors.New("platform-applications mutation request differs from the preconstructed stage")
+	}
+	receipt, launchErr := mutator.launcher.Install(ctx)
+	mutationState, err := validatePlatformApplicationsLaunchOutcome(receipt, mutator.bundle, mutator.objects, mutator.authority, launchErr != nil)
+	if err != nil {
+		return execution.StageMutationResult{}, err
+	}
+	receiptRaw, err := json.Marshal(receipt)
+	if err != nil {
+		return execution.StageMutationResult{}, errors.New("derive bounded platform-applications evidence")
+	}
+	result := execution.StageMutationResult{Outcome: "STOPPED", MutationState: mutationState, EvidenceDigest: digest.SHA256(receiptRaw)}
+	if launchErr != nil {
+		return result, errors.New("bounded platform-applications launch stopped")
+	}
+	if receipt.State == "INSTALLED" && mutationState == "ATTEMPTED" {
+		result.Outcome = "SUCCEEDED"
+	}
+	return result, nil
+}
+
+func validatePlatformApplicationsLaunchOutcome(receipt PlatformApplicationsLaunchReceipt, bundle PlatformApplicationsStageBundleReceipt, objects []platformApplicationLaunchObject, authority string, stopped bool) (string, error) {
+	wantState := "INSTALLED"
+	if stopped {
+		if receipt.State != "STOPPED_ZERO_WRITE" && receipt.State != "STOPPED_PARTIAL_OR_UNKNOWN" {
+			return "", errors.New("platform-applications stopped receipt has invalid state")
+		}
+		wantState = receipt.State
+	}
+	if receipt.Format != PlatformApplicationsLaunchReceiptFormat || receipt.StageID != "platform-applications" ||
+		receipt.PlanDigest != bundle.PlanDigest || receipt.ArtifactDigest != bundle.ArtifactDigest ||
+		receipt.TargetIdentityDigest != bundle.TargetIdentityDigest || receipt.ProfileDigest != bundle.ProfileDigest ||
+		receipt.Authority != authority || receipt.State != wantState || len(receipt.Results) > len(objects) || (!stopped && len(receipt.Results) != len(objects)) {
+		return "", errors.New("platform-applications launch receipt differs from verified bundle")
+	}
+	for index, result := range receipt.Results {
+		object := objects[index]
+		if result.Order != index+1 || result.Phase != "platform-application" || result.APIVersion != object.apiVersion || result.Kind != object.kind || result.Namespace != object.namespace || result.Name != object.name || result.ObjectDigest != object.digest || result.ObjectState != "CREATED" || !stageReceiptPrefixDigestPattern.MatchString(result.UIDDigest) || !stageReceiptPrefixDigestPattern.MatchString(result.ResourceVersionDigest) {
+			return "", errors.New("platform-applications launch result differs from exact object order")
+		}
+	}
+	switch receipt.MutationState {
+	case "NOT_ATTEMPTED":
+		if len(receipt.Results) != 0 || !stopped {
+			return "", errors.New("platform-applications no-write outcome is inconsistent")
+		}
+		return "NOT_ATTEMPTED", nil
+	case "ATTEMPTED":
+		if len(receipt.Results) == 0 && !stopped {
+			return "", errors.New("platform-applications attempted outcome lacks results")
+		}
+		return "ATTEMPTED", nil
+	case "ATTEMPTED_UNKNOWN":
+		if !stopped {
+			return "", errors.New("platform-applications unknown outcome is not stopped")
+		}
+		return "UNKNOWN", nil
+	default:
+		return "", errors.New("platform-applications mutation state is invalid")
+	}
+}

--- a/internal/runner/platform_applications_stage_mutator_test.go
+++ b/internal/runner/platform_applications_stage_mutator_test.go
@@ -1,0 +1,75 @@
+package runner
+
+import (
+	"context"
+	"testing"
+
+	"github.com/openkubes/ok-cluster/internal/execution"
+)
+
+func TestPlatformApplicationsStageMutatorReturnsBoundedSuccess(t *testing.T) {
+	fixture := platformApplicationsBundleFixture(t)
+	bundle, _ := LoadPlatformApplicationsStageBundle(fixture.config)
+	api := newPlatformApplicationsLauncherAPI(t)
+	launcher := newPlatformApplicationsLauncher(t, bundle, api.client())
+	mutator, err := NewPlatformApplicationsStageMutator(bundle.plan, bundle, launcher)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := mutator.Mutate(context.Background(), platformApplicationsMutationRequest(mutator))
+	if err != nil || result.Outcome != "SUCCEEDED" || result.MutationState != "ATTEMPTED" || !stageReceiptPrefixDigestPattern.MatchString(result.EvidenceDigest) || result.TargetClusterUIDDigest != "" {
+		t.Fatalf("unexpected platform-applications mutation result: %#v %v", result, err)
+	}
+}
+
+func TestPlatformApplicationsStageMutatorMapsPartialAndUnknownOutcomesToStops(t *testing.T) {
+	for name, test := range map[string]struct {
+		configure    func(*platformApplicationsLauncherAPI)
+		wantMutation string
+	}{
+		"known partial":       {configure: func(api *platformApplicationsLauncherAPI) { api.failPost = 2 }, wantMutation: "ATTEMPTED"},
+		"unknown first write": {configure: func(api *platformApplicationsLauncherAPI) { api.errorPost = 1 }, wantMutation: "UNKNOWN"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			fixture := platformApplicationsBundleFixture(t)
+			bundle, _ := LoadPlatformApplicationsStageBundle(fixture.config)
+			api := newPlatformApplicationsLauncherAPI(t)
+			test.configure(api)
+			launcher := newPlatformApplicationsLauncher(t, bundle, api.client())
+			mutator, _ := NewPlatformApplicationsStageMutator(bundle.plan, bundle, launcher)
+			result, err := mutator.Mutate(context.Background(), platformApplicationsMutationRequest(mutator))
+			if err == nil || result.Outcome != "STOPPED" || result.MutationState != test.wantMutation || !stageReceiptPrefixDigestPattern.MatchString(result.EvidenceDigest) {
+				t.Fatalf("partial outcome was not bounded: %#v %v", result, err)
+			}
+		})
+	}
+}
+
+func TestPlatformApplicationsStageMutatorRejectsMismatchedRequestAndBundle(t *testing.T) {
+	fixture := platformApplicationsBundleFixture(t)
+	bundle, _ := LoadPlatformApplicationsStageBundle(fixture.config)
+	api := newPlatformApplicationsLauncherAPI(t)
+	launcher := newPlatformApplicationsLauncher(t, bundle, api.client())
+	mutator, _ := NewPlatformApplicationsStageMutator(bundle.plan, bundle, launcher)
+	request := platformApplicationsMutationRequest(mutator)
+	request.GrantID = ""
+	if _, err := mutator.Mutate(context.Background(), request); err == nil || len(api.requests) != 0 {
+		t.Fatal("mismatched request reached platform-applications API")
+	}
+
+	foreign := bundle
+	foreign.receipt.PlanDigest = runnerStageSHA("f")
+	if _, err := NewPlatformApplicationsStageMutator(bundle.plan, foreign, launcher); err == nil {
+		t.Fatal("foreign bundle opened platform-applications mutator")
+	}
+	if _, err := NewPlatformApplicationsStageMutator(bundle.plan, bundle, nil); err == nil {
+		t.Fatal("nil launcher opened platform-applications mutator")
+	}
+}
+
+func platformApplicationsMutationRequest(mutator *PlatformApplicationsStageMutator) execution.StageMutationRequest {
+	return execution.StageMutationRequest{
+		StageMutationBinding: mutator.Binding(), ContractIdentity: mutator.identity,
+		GrantID: "ok147-platform-applications-grant", PredecessorDigest: runnerStageSHA("7"),
+	}
+}


### PR DESCRIPTION
## Summary

- adapt the verified Stage-10 launcher to the durable staged-operation protocol
- compose the signed grant, exact receipt prefix, GitOps writer and independent ledger in `Open` without API contact
- persist successful, partial and unknown outcomes as redaction-safe evidence
- replay durable outcomes without another Application GET or POST
- reject shared ledger and GitOps writer credentials before API contact

## Validation

- `go test ./...`
- `go vet ./...`
- `go test -race ./internal/runner ./internal/submission ./internal/observation ./cmd/ok`

## Scope

Runner runtime composition and tests only. No live infrastructure action is performed by this PR.

Jira: OK-147
