### PR TITLE
feat(runner): bind platform observation stage (OK-147)

### DIFF
--- a/internal/runner/kubernetes.go
+++ b/internal/runner/kubernetes.go
@@ -246,22 +246,37 @@ func openKubernetesNetworkSourceCollector(config KubernetesNetworkObserverConfig
 // to exact Argo Application GETs on the configured GitOps control plane. It
 // performs no API request itself and exposes no sync or mutation operation.
 func OpenKubernetesPlatformSourceCollector(config KubernetesPlatformObserverConfig) (*observation.PlatformSourceCollector, error) {
+	collector, _, err := openKubernetesPlatformSourceCollector(config)
+	return collector, err
+}
+
+func openKubernetesPlatformSourceCollector(config KubernetesPlatformObserverConfig) (*observation.PlatformSourceCollector, string, error) {
 	if config.ExpectedArgoAuthority == "" || config.Argo.AuthorityIdentity != config.ExpectedArgoAuthority {
-		return nil, errors.New("platform observer authority differs from the verified GitOps control plane")
+		return nil, "", errors.New("platform observer authority differs from the verified GitOps control plane")
 	}
-	token, client, err := openBoundedKubernetesHTTP(config.Argo.TokenFile, config.Argo.CAFile)
+	if !platformInputDigestPattern.MatchString(config.Argo.CABundleDigest) {
+		return nil, "", errors.New("platform observer CA identity is required")
+	}
+	token, ca, client, err := openBoundedKubernetesMaterial(config.Argo.TokenFile, config.Argo.CAFile)
 	if err != nil {
-		return nil, errors.New("open bounded GitOps observation credential")
+		return nil, "", errors.New("open bounded GitOps observation credential")
+	}
+	if digest.SHA256(ca) != config.Argo.CABundleDigest {
+		return nil, "", errors.New("platform observer CA differs from bound identity")
 	}
 	reader, err := observation.NewKubernetesPlatformReader(observation.KubernetesPlatformReaderConfig{
 		Endpoint: config.Argo.Endpoint, BearerToken: token, Client: client,
 	}, config.Profile)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
-	return observation.NewPlatformSourceCollector(reader, config.Capability, observation.PlatformCollectorConfig{
+	collector, err := observation.NewPlatformSourceCollector(reader, config.Capability, observation.PlatformCollectorConfig{
 		Profile: config.Profile, TargetClusterUID: config.TargetClusterUID, Clock: config.Clock,
 	})
+	if err != nil {
+		return nil, "", err
+	}
+	return collector, token, nil
 }
 
 // OpenKubernetesObservabilityTransport binds the fixed capability lifecycle to

--- a/internal/runner/kubernetes_test.go
+++ b/internal/runner/kubernetes_test.go
@@ -193,19 +193,20 @@ func TestOpenKubernetesPlatformSourceCollectorBindsGitOpsAuthority(t *testing.T)
 	if err := os.WriteFile(tokenPath, []byte("short-lived-platform-token"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(caPath, testCA(t), 0o600); err != nil {
+	ca := testCA(t)
+	if err := os.WriteFile(caPath, ca, 0o600); err != nil {
 		t.Fatal(err)
 	}
-	digest := func(character string) string { return "sha256:" + strings.Repeat(character, 64) }
+	digestOf := func(character string) string { return "sha256:" + strings.Repeat(character, 64) }
 	profile := observation.PlatformProfile{
-		Format: observation.PlatformProfileFormat, IntentRevision: digest("a"), PlatformRevision: digest("b"), ExecutionFixture: digest("c"),
+		Format: observation.PlatformProfileFormat, IntentRevision: digestOf("a"), PlatformRevision: digestOf("b"), ExecutionFixture: digestOf("c"),
 		TargetIdentityScheme: "capi-cluster-uid/v1", ArgoNamespace: "argocd", RegistrationName: "disposable-ok141",
-		RequiredApplications:     []observation.PlatformApplicationExpectation{{Name: "disposable-ok141-observability-core", SpecDigest: digest("d")}},
-		CapabilityContractDigest: digest("e"), CapabilityExecutableDigest: digest("f"), MaximumCapabilityAgeSeconds: 3600,
+		RequiredApplications:     []observation.PlatformApplicationExpectation{{Name: "disposable-ok141-observability-core", SpecDigest: digestOf("d")}},
+		CapabilityContractDigest: digestOf("e"), CapabilityExecutableDigest: digestOf("f"), MaximumCapabilityAgeSeconds: 3600,
 	}
 	config := KubernetesPlatformObserverConfig{
 		Argo: KubernetesAuthorityConfig{
-			Endpoint: "https://10.43.0.1:443", AuthorityIdentity: "ok-shared", TokenFile: tokenPath, CAFile: caPath,
+			Endpoint: "https://10.43.0.1:443", AuthorityIdentity: "ok-shared", TokenFile: tokenPath, CAFile: caPath, CABundleDigest: digest.SHA256(ca),
 		},
 		ExpectedArgoAuthority: "ok-shared", Profile: profile, Capability: inertPlatformCapabilitySource{}, TargetClusterUID: "cluster-uid-disposable-ok141", Clock: time.Now,
 	}

--- a/internal/runner/platform_applications_stage_bundle_test.go
+++ b/internal/runner/platform_applications_stage_bundle_test.go
@@ -135,6 +135,7 @@ func platformApplicationsBundleFixture(t *testing.T) platformApplicationsBundleT
 	stages[7].(map[string]any)["inputs"] = []any{map[string]any{"name": "stage.target-credential", "digest": runnerStageSHA("4")}}
 	stages[8].(map[string]any)["inputs"] = []any{map[string]any{"name": "stage.target-registration", "digest": runnerStageSHA("5")}}
 	stages[9].(map[string]any)["inputs"] = []any{map[string]any{"name": "stage.platform-applications", "digest": artifactDigest}}
+	stages[10].(map[string]any)["inputs"] = []any{map[string]any{"name": "stage.platform-observation", "digest": profileDigest}}
 	planPath := writeBundleFile(t, root, "staged-plan.json", mustJSON(t, document))
 	plan, err := stageplan.Load(planPath, expectedPlan)
 	if err != nil {

--- a/internal/runner/platform_observation_bundle.go
+++ b/internal/runner/platform_observation_bundle.go
@@ -1,0 +1,151 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/execution"
+	"github.com/openkubes/ok-cluster/internal/observation"
+	"github.com/openkubes/ok-cluster/internal/stagecursor"
+	"github.com/openkubes/ok-cluster/internal/stageplan"
+	"github.com/openkubes/ok-cluster/internal/stagereceipt"
+)
+
+type PlatformObservationStageBundleConfig struct {
+	StageResumeConfig
+	Profile               observation.PlatformProfile
+	ExpectedProfileDigest string
+}
+
+type VerifiedPlatformObservationStageBundle struct {
+	plan          stageplan.Binding
+	cursor        stagecursor.Cursor
+	prefix        []stagereceipt.Verified
+	profile       observation.PlatformProfile
+	profileDigest string
+	verified      bool
+}
+
+type PlatformObservationStageRuntimeConfig struct {
+	Ledger       KubernetesLedgerConfig
+	Argo         KubernetesAuthorityConfig
+	Runtime      VerifiedRuntimeBindingMaterial
+	Capability   observation.PlatformCapabilitySource
+	PollInterval time.Duration
+	PollTimeout  time.Duration
+	Clock        func() time.Time
+	Wait         ObservationWaiter
+}
+
+type OpenedPlatformObservationStage struct {
+	operation execution.ObservationStageOperation
+	plan      stageplan.Binding
+	cursor    stagecursor.Cursor
+	verified  bool
+}
+
+func LoadPlatformObservationStageBundle(config PlatformObservationStageBundleConfig) (VerifiedPlatformObservationStageBundle, error) {
+	plan, cursor, prefix, err := loadStageResumeWithPrefix(config.StageResumeConfig)
+	if err != nil {
+		return VerifiedPlatformObservationStageBundle{}, err
+	}
+	decision, err := cursor.Decision()
+	if err != nil || decision.State != "NEXT" || decision.StageID != "platform-observation" || decision.Kind != "Observation" || decision.Authority != "gitops" || decision.RequiresAuthorization || decision.Operation != "" {
+		return VerifiedPlatformObservationStageBundle{}, errors.New("verified prefix does not select platform observation")
+	}
+	if len(prefix) != 10 {
+		return VerifiedPlatformObservationStageBundle{}, errors.New("platform observation requires the exact ten-receipt prefix")
+	}
+	lifecycle, err := prefix[1].Receipt()
+	if err != nil || lifecycle.StageID != "cluster-lifecycle" || !stageReceiptPrefixDigestPattern.MatchString(lifecycle.TargetClusterUIDDigest) {
+		return VerifiedPlatformObservationStageBundle{}, errors.New("platform observation lacks durable workload identity")
+	}
+	platformApplications, err := prefix[9].Receipt()
+	if err != nil || platformApplications.StageID != "platform-applications" || platformApplications.State != "SUCCEEDED" || platformApplications.MutationState != "ATTEMPTED" {
+		return VerifiedPlatformObservationStageBundle{}, errors.New("platform observation lacks successful Application submission")
+	}
+	profileDigest, err := observation.PlatformProfileDigest(config.Profile)
+	if err != nil || config.ExpectedProfileDigest != profileDigest {
+		return VerifiedPlatformObservationStageBundle{}, errors.New("platform observation profile identity is invalid")
+	}
+	stage, _, err := plan.Stage("platform-observation")
+	if err != nil || len(stage.Inputs) != 1 || stage.Inputs[0].Name != "stage.platform-observation" || stage.Inputs[0].Digest != profileDigest || config.Profile.IntentRevision != plan.IntentRevision || config.Profile.PlatformRevision != plan.PlatformRevision || config.Profile.ExecutionFixture != plan.ExecutionFixture {
+		return VerifiedPlatformObservationStageBundle{}, errors.New("platform observation profile differs from verified stage plan")
+	}
+	profile := config.Profile
+	profile.RequiredApplications = append([]observation.PlatformApplicationExpectation(nil), config.Profile.RequiredApplications...)
+	return VerifiedPlatformObservationStageBundle{plan: plan, cursor: cursor, prefix: prefix, profile: profile, profileDigest: profileDigest, verified: true}, nil
+}
+
+func (bundle VerifiedPlatformObservationStageBundle) Decision() (stagecursor.Decision, error) {
+	if err := verifyPlatformObservationStageBundle(bundle); err != nil {
+		return stagecursor.Decision{}, err
+	}
+	return bundle.cursor.Decision()
+}
+
+// Open reads bounded credentials and private runtime identity but performs no
+// Kubernetes request and no capability action.
+func (bundle VerifiedPlatformObservationStageBundle) Open(config PlatformObservationStageRuntimeConfig) (OpenedPlatformObservationStage, error) {
+	if err := verifyPlatformObservationStageBundle(bundle); err != nil || config.Capability == nil || config.Clock == nil || config.Wait == nil {
+		return OpenedPlatformObservationStage{}, errors.New("verified platform observation bundle, capability, clock, and waiter are required")
+	}
+	if err := verifyRuntimeBindingMaterial(config.Runtime); err != nil ||
+		config.Runtime.receipt.PlanDigest != bundle.plan.PlanDigest || config.Runtime.material.PlanDigest != bundle.plan.PlanDigest ||
+		config.Runtime.material.IntentRevision != bundle.plan.IntentRevision || config.Runtime.material.EnablementRevision != bundle.plan.EnablementRevision ||
+		config.Runtime.material.PlatformRevision != bundle.plan.PlatformRevision || config.Runtime.material.ExecutionFixture != bundle.plan.ExecutionFixture ||
+		config.Runtime.receipt.TargetClusterUIDDigest != digest.SHA256([]byte(config.Runtime.material.Target.CAPIClusterUID)) {
+		return OpenedPlatformObservationStage{}, errors.New("platform observation runtime differs from verified execution target")
+	}
+	lifecycle, err := bundle.prefix[1].Receipt()
+	if err != nil || lifecycle.TargetClusterUIDDigest != config.Runtime.receipt.TargetClusterUIDDigest {
+		return OpenedPlatformObservationStage{}, errors.New("platform observation runtime differs from durable lifecycle target")
+	}
+	store, ledgerToken, err := openKubernetesLedger(config.Ledger)
+	if err != nil {
+		return OpenedPlatformObservationStage{}, errors.New("open platform observation ledger")
+	}
+	source, argoToken, err := openKubernetesPlatformSourceCollector(KubernetesPlatformObserverConfig{
+		Argo: config.Argo, ExpectedArgoAuthority: bundle.plan.Authorities.GitOps,
+		Profile: bundle.profile, Capability: config.Capability,
+		TargetClusterUID: config.Runtime.material.Target.CAPIClusterUID, Clock: config.Clock,
+	})
+	if err != nil {
+		return OpenedPlatformObservationStage{}, errors.New("open bounded platform observation source")
+	}
+	if sameSecret(ledgerToken, argoToken) {
+		return OpenedPlatformObservationStage{}, errors.New("ledger and platform observation credentials must be distinct")
+	}
+	observer, err := NewPlatformStageObserver(PlatformStageObserverConfig{
+		Plan: bundle.plan, ReceiptPrefix: bundle.prefix, TargetClusterUID: config.Runtime.material.Target.CAPIClusterUID,
+		Source: source, Profile: bundle.profile, PollInterval: config.PollInterval, PollTimeout: config.PollTimeout,
+		Clock: config.Clock, Wait: config.Wait,
+	})
+	if err != nil {
+		return OpenedPlatformObservationStage{}, err
+	}
+	return OpenedPlatformObservationStage{
+		operation: execution.ObservationStageOperation{Ledger: store, Observer: observer},
+		plan:      bundle.plan, cursor: bundle.cursor, verified: true,
+	}, nil
+}
+
+func (stage OpenedPlatformObservationStage) Run(ctx context.Context) (execution.ObservationStageRunReceipt, error) {
+	if !stage.verified {
+		return execution.ObservationStageRunReceipt{}, errors.New("platform observation stage is not opened")
+	}
+	return stage.operation.Run(ctx, stage.plan, stage.cursor)
+}
+
+func verifyPlatformObservationStageBundle(bundle VerifiedPlatformObservationStageBundle) error {
+	if !bundle.verified || len(bundle.prefix) != 10 || !stageReceiptPrefixDigestPattern.MatchString(bundle.profileDigest) {
+		return errors.New("platform observation stage bundle is not verified")
+	}
+	digest, err := observation.PlatformProfileDigest(bundle.profile)
+	if err != nil || digest != bundle.profileDigest || bundle.profile.IntentRevision != bundle.plan.IntentRevision || bundle.profile.PlatformRevision != bundle.plan.PlatformRevision || bundle.profile.ExecutionFixture != bundle.plan.ExecutionFixture {
+		return errors.New("platform observation profile changed after verification")
+	}
+	return nil
+}

--- a/internal/runner/platform_observation_bundle_test.go
+++ b/internal/runner/platform_observation_bundle_test.go
@@ -1,0 +1,148 @@
+package runner
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/observation"
+	"github.com/openkubes/ok-cluster/internal/stagereceipt"
+)
+
+func TestPlatformObservationStageBundleLoadsExactReadOnlyCursor(t *testing.T) {
+	fixture := platformObservationBundleFixture(t)
+	bundle, err := LoadPlatformObservationStageBundle(fixture.config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decision, err := bundle.Decision()
+	if err != nil || decision.StageID != "platform-observation" || decision.Authority != "gitops" || decision.RequiresAuthorization || decision.Operation != "" {
+		t.Fatalf("unexpected platform observation decision: %#v %v", decision, err)
+	}
+	if _, err := (VerifiedPlatformObservationStageBundle{}).Decision(); err == nil {
+		t.Fatal("unverified platform observation bundle exposed decision")
+	}
+}
+
+func TestPlatformObservationStageBundleRejectsProfileOrHistoryMismatch(t *testing.T) {
+	for name, mutate := range map[string]func(*platformObservationBundleTestFixture){
+		"incomplete prefix": func(f *platformObservationBundleTestFixture) { f.config.Receipts = f.config.Receipts[:9] },
+		"foreign digest":    func(f *platformObservationBundleTestFixture) { f.config.ExpectedProfileDigest = runnerStageSHA("f") },
+		"foreign profile": func(f *platformObservationBundleTestFixture) {
+			f.config.Profile.PlatformRevision = runnerStageSHA("f")
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			fixture := platformObservationBundleFixture(t)
+			mutate(&fixture)
+			if _, err := LoadPlatformObservationStageBundle(fixture.config); err == nil {
+				t.Fatal("invalid platform observation bundle was accepted")
+			}
+		})
+	}
+}
+
+func TestPlatformObservationStageBundleOpensWithoutClusterContact(t *testing.T) {
+	fixture := platformObservationBundleFixture(t)
+	bundle, err := LoadPlatformObservationStageBundle(fixture.config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runtime := platformObservationRuntime(t, bundle, "ledger-token", "argo-reader-token")
+	opened, err := bundle.Open(runtime)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !opened.verified {
+		t.Fatal("opened platform observation stage is not verified")
+	}
+	if _, err := (OpenedPlatformObservationStage{}).Run(context.Background()); err == nil {
+		t.Fatal("unopened platform observation stage could run")
+	}
+
+	runtime = platformObservationRuntime(t, bundle, "shared-token", "shared-token")
+	if _, err := bundle.Open(runtime); err == nil {
+		t.Fatal("shared ledger/Argo credential opened platform observation")
+	}
+	runtime = platformObservationRuntime(t, bundle, "ledger-token", "argo-reader-token")
+	runtime.Runtime.material.Target.CAPIClusterUID = "replacement-runtime-uid"
+	if _, err := bundle.Open(runtime); err == nil {
+		t.Fatal("replacement runtime target opened platform observation")
+	}
+}
+
+type platformObservationBundleTestFixture struct {
+	config PlatformObservationStageBundleConfig
+}
+
+func platformObservationBundleFixture(t *testing.T) platformObservationBundleTestFixture {
+	t.Helper()
+	base := platformApplicationsBundleFixture(t)
+	_, _, prefix, err := loadStageResumeWithPrefix(StageResumeConfig{PlanPath: base.config.PlanPath, PlanExpected: base.config.PlanExpected, Receipts: base.config.Receipts})
+	if err != nil {
+		t.Fatal(err)
+	}
+	at := time.Date(2026, 8, 17, 20, 1, 0, 0, time.UTC)
+	receipt, err := stagereceipt.New(base.plan, "platform-applications", []stagereceipt.Verified{prefix[8]}, "SUCCEEDED", "ATTEMPTED", runnerStageSHA("1"), runnerStageSHA("2"), at)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipts := appendStageReceipt(t, t.TempDir(), base.config.Receipts, receipt, "platform-applications.json")
+	return platformObservationBundleTestFixture{config: PlatformObservationStageBundleConfig{
+		StageResumeConfig: StageResumeConfig{PlanPath: base.config.PlanPath, PlanExpected: base.config.PlanExpected, Receipts: receipts},
+		Profile:           base.config.Expected.Profile, ExpectedProfileDigest: base.profileDigest,
+	}}
+}
+
+func platformObservationRuntime(t *testing.T, bundle VerifiedPlatformObservationStageBundle, ledgerToken, argoToken string) PlatformObservationStageRuntimeConfig {
+	t.Helper()
+	root := t.TempDir()
+	ca := testCA(t)
+	ledgerTokenPath := writeBundleFile(t, root, "ledger-token", []byte(ledgerToken))
+	argoTokenPath := writeBundleFile(t, root, "argo-token", []byte(argoToken))
+	caPath := writeBundleFile(t, root, "ca.crt", ca)
+	runtime := platformObservationRuntimeMaterial(t, bundle)
+	return PlatformObservationStageRuntimeConfig{
+		Ledger: KubernetesLedgerConfig{Endpoint: "https://192.0.2.10:6443", Namespace: "openkubes-execution-system", TokenFile: ledgerTokenPath, CAFile: caPath},
+		Argo: KubernetesAuthorityConfig{
+			Endpoint: "https://192.0.2.30:6443", AuthorityIdentity: bundle.plan.Authorities.GitOps,
+			TokenFile: argoTokenPath, CAFile: caPath, CABundleDigest: digest.SHA256(ca),
+		},
+		Runtime: runtime, Capability: inertPlatformCapabilitySource{}, PollInterval: time.Second, PollTimeout: time.Minute,
+		Clock: time.Now, Wait: func(context.Context, time.Duration) error { return nil },
+	}
+}
+
+func platformObservationRuntimeMaterial(t *testing.T, bundle VerifiedPlatformObservationStageBundle) VerifiedRuntimeBindingMaterial {
+	t.Helper()
+	material := RuntimeBindingMaterial{
+		Format: RuntimeBindingMaterialFormat, State: "CURRENT_RUNTIME_BOUND", PlanDigest: bundle.plan.PlanDigest,
+		IntentRevision: bundle.plan.IntentRevision, EnablementRevision: bundle.plan.EnablementRevision,
+		PlatformRevision: bundle.plan.PlatformRevision, ExecutionFixture: bundle.plan.ExecutionFixture,
+		Target:   RuntimeBindingTarget{Name: bundle.plan.ContractIdentity.Name, CAPIClusterUID: targetAccessRuntimeUID, TargetIdentityScheme: "capi-cluster-uid/v1", WorkloadAPIEndpoint: "https://192.0.2.20:6443", WorkloadAPICAData: "Y2E=", WorkloadAPICADigest: runnerStageSHA("1"), KubeSystemUID: "kube-system-runtime-uid"},
+		Storage:  RuntimeBindingStorage{Name: "local-path", UID: "local-path-runtime-uid", Provisioner: "rancher.io/local-path"},
+		Evidence: RuntimeBindingEvidence{LifecycleEvidenceDigest: runnerStageSHA("2"), NetworkEvidenceDigest: runnerStageSHA("3")},
+	}
+	raw, err := canonicalRuntimeBinding(material)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt := RuntimeBindingMaterialReceipt{
+		Format: RuntimeBindingMaterialFormat, State: "VERIFIED", StageID: "runtime-binding", PlanDigest: bundle.plan.PlanDigest,
+		IntentRevision: bundle.plan.IntentRevision, TargetClusterUIDDigest: runnerStageSHA("0"), WorkloadAPICADigest: runnerStageSHA("1"),
+		KubeSystemUIDDigest: runnerStageSHA("4"), LocalPathStorageUIDDigest: runnerStageSHA("5"),
+		LifecycleEvidenceDigest: runnerStageSHA("2"), NetworkEvidenceDigest: runnerStageSHA("3"),
+		PrivateMaterialDigest: runnerStageSHA("6"), PersistentMutationAllowed: false,
+	}
+	receipt.TargetClusterUIDDigest = digestForTest(material.Target.CAPIClusterUID)
+	receipt.KubeSystemUIDDigest = digestForTest(material.Target.KubeSystemUID)
+	receipt.LocalPathStorageUIDDigest = digestForTest(material.Storage.UID)
+	receipt.PrivateMaterialDigest = digestForBytes(raw)
+	return VerifiedRuntimeBindingMaterial{material: material, raw: raw, receipt: receipt, verified: true}
+}
+
+func digestForTest(value string) string  { return digest.SHA256([]byte(value)) }
+func digestForBytes(value []byte) string { return digest.SHA256(value) }
+
+var _ observation.PlatformCapabilitySource = inertPlatformCapabilitySource{}

--- a/internal/runner/platform_stage_observer.go
+++ b/internal/runner/platform_stage_observer.go
@@ -1,0 +1,148 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/execution"
+	"github.com/openkubes/ok-cluster/internal/observation"
+	"github.com/openkubes/ok-cluster/internal/stagecursor"
+	"github.com/openkubes/ok-cluster/internal/stageplan"
+	"github.com/openkubes/ok-cluster/internal/stagereceipt"
+)
+
+type PlatformStageObserverConfig struct {
+	Plan             stageplan.Binding
+	ReceiptPrefix    []stagereceipt.Verified
+	TargetClusterUID string
+	Source           observation.PlatformEvidenceSource
+	Profile          observation.PlatformProfile
+	PollInterval     time.Duration
+	PollTimeout      time.Duration
+	Clock            func() time.Time
+	Wait             ObservationWaiter
+}
+
+// PlatformStageObserver is a read-only adapter around exact Argo Application
+// GETs, an independently bounded capability assertion and deterministic
+// PlatformReady evaluation. It has no sync, repair or status-write path.
+type PlatformStageObserver struct {
+	binding      execution.StageObservationBinding
+	source       observation.PlatformEvidenceSource
+	profile      observation.PlatformProfile
+	policy       observation.Policy
+	pollInterval time.Duration
+	pollLimit    time.Duration
+	clock        func() time.Time
+	wait         ObservationWaiter
+}
+
+var _ execution.StageObserver = (*PlatformStageObserver)(nil)
+
+func NewPlatformStageObserver(config PlatformStageObserverConfig) (*PlatformStageObserver, error) {
+	if config.Source == nil || config.Clock == nil || config.Wait == nil {
+		return nil, errors.New("platform stage observer source, clock, and waiter are required")
+	}
+	cursor, err := stagecursor.Evaluate(config.Plan, config.ReceiptPrefix)
+	if err != nil {
+		return nil, errors.New("verify platform observation receipt prefix")
+	}
+	decision, err := cursor.Decision()
+	if err != nil || decision.State != "NEXT" || decision.StageID != "platform-observation" || decision.Kind != "Observation" || decision.Authority != "gitops" || decision.RequiresAuthorization || decision.Operation != "" {
+		return nil, errors.New("stage receipt prefix does not select platform observation")
+	}
+	if len(config.ReceiptPrefix) != 10 {
+		return nil, errors.New("platform observation receipt prefix is incomplete")
+	}
+	lifecycle, err := config.ReceiptPrefix[1].Receipt()
+	if err != nil || lifecycle.StageID != "cluster-lifecycle" || !platformInputDigestPattern.MatchString(lifecycle.TargetClusterUIDDigest) || digest.SHA256([]byte(config.TargetClusterUID)) != lifecycle.TargetClusterUIDDigest {
+		return nil, errors.New("platform observation target differs from durable lifecycle correlation")
+	}
+	platformApplications, err := config.ReceiptPrefix[9].Receipt()
+	if err != nil || platformApplications.StageID != "platform-applications" || platformApplications.State != "SUCCEEDED" || platformApplications.MutationState != "ATTEMPTED" {
+		return nil, errors.New("platform observation lacks successful Application submission")
+	}
+	if err := observation.ValidatePlatformProfile(config.Profile); err != nil || config.Profile.IntentRevision != config.Plan.IntentRevision || config.Profile.PlatformRevision != config.Plan.PlatformRevision || config.Profile.ExecutionFixture != config.Plan.ExecutionFixture {
+		return nil, errors.New("platform profile differs from the verified execution plan")
+	}
+	stage, stageDigest, err := config.Plan.Stage(decision.StageID)
+	if err != nil || stageDigest != decision.StageDigest {
+		return nil, errors.New("platform observation stage differs from verified plan")
+	}
+	profile := config.Profile
+	profile.RequiredApplications = append([]observation.PlatformApplicationExpectation(nil), config.Profile.RequiredApplications...)
+	return &PlatformStageObserver{
+		binding: execution.StageObservationBinding{
+			PlanDigest: config.Plan.PlanDigest, StageID: stage.ID, StageDigest: stageDigest,
+			Authority: stage.Authority, ContractRevision: config.Plan.IntentRevision,
+		},
+		source: config.Source, profile: profile,
+		policy: observation.Policy{
+			Format: observation.PolicyFormat, IntentRevision: config.Plan.IntentRevision,
+			EnablementRevision: config.Plan.EnablementRevision, PlatformRevision: config.Plan.PlatformRevision,
+			TargetClusterUID: config.TargetClusterUID, Required: []string{"PlatformReady"},
+		},
+		pollInterval: config.PollInterval, pollLimit: config.PollTimeout, clock: config.Clock, wait: config.Wait,
+	}, nil
+}
+
+func (observer *PlatformStageObserver) Binding() execution.StageObservationBinding {
+	if observer == nil {
+		return execution.StageObservationBinding{}
+	}
+	return observer.binding
+}
+
+func (observer *PlatformStageObserver) Observe(ctx context.Context) (execution.StageObservationResult, error) {
+	if observer == nil {
+		return execution.StageObservationResult{}, errors.New("platform stage observer is required")
+	}
+	polling, err := NewBoundedPollingObserver(BoundedPollingObserverConfig{
+		Source:   &platformPollingSource{source: observer.source, clock: observer.clock},
+		Interval: observer.pollInterval, Timeout: observer.pollLimit, Clock: observer.clock, Wait: observer.wait,
+	})
+	if err != nil {
+		return execution.StageObservationResult{}, err
+	}
+	result, err := polling.Observe(ctx, observer.policy)
+	if err != nil {
+		return execution.StageObservationResult{}, errors.New("bounded platform convergence observation failed")
+	}
+	receipt, err := result.Receipt()
+	if err != nil {
+		return execution.StageObservationResult{}, err
+	}
+	evidenceDigest, err := result.EvidenceDigest()
+	if err != nil {
+		return execution.StageObservationResult{}, err
+	}
+	completedAt, err := time.Parse(time.RFC3339Nano, receipt.EvaluatedAt)
+	if err != nil {
+		return execution.StageObservationResult{}, errors.New("platform observation completion time is invalid")
+	}
+	outcome := "STOPPED"
+	if receipt.Ready == "True" {
+		outcome = "SUCCEEDED"
+	} else if receipt.Ready == "False" {
+		outcome = "FAILED"
+	}
+	return execution.StageObservationResult{Outcome: outcome, EvidenceDigest: evidenceDigest, CompletedAt: completedAt}, nil
+}
+
+type platformPollingSource struct {
+	source observation.PlatformEvidenceSource
+	clock  func() time.Time
+}
+
+func (source *platformPollingSource) Observe(ctx context.Context, policy observation.Policy) (observation.VerifiedResult, error) {
+	evidence, err := source.source.Observe(ctx, policy)
+	if err != nil {
+		return observation.VerifiedResult{}, err
+	}
+	return observation.Evaluate(policy, observation.Bundle{
+		Format: observation.BundleFormat, IntentRevision: policy.IntentRevision,
+		EvaluatedAt: source.clock().UTC().Format(time.RFC3339Nano), Evidence: []observation.Evidence{evidence},
+	})
+}

--- a/internal/runner/platform_stage_observer_test.go
+++ b/internal/runner/platform_stage_observer_test.go
@@ -1,0 +1,144 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/observation"
+)
+
+func TestPlatformStageObserverBindsHistoricalTargetAndConverges(t *testing.T) {
+	fixture := platformObservationBundleFixture(t)
+	bundle, err := LoadPlatformObservationStageBundle(fixture.config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	current := time.Date(2026, 8, 17, 21, 0, 0, 0, time.UTC)
+	source := &fakePlatformStageSource{statuses: []string{"Unknown", "True"}}
+	observer, err := NewPlatformStageObserver(PlatformStageObserverConfig{
+		Plan: bundle.plan, ReceiptPrefix: bundle.prefix, TargetClusterUID: targetAccessRuntimeUID,
+		Source: source, Profile: bundle.profile, PollInterval: time.Second, PollTimeout: time.Minute,
+		Clock: func() time.Time { return current },
+		Wait:  func(_ context.Context, wait time.Duration) error { current = current.Add(wait); return nil },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := observer.Observe(context.Background())
+	if err != nil || result.Outcome != "SUCCEEDED" || !stageReceiptPrefixDigestPattern.MatchString(result.EvidenceDigest) || source.calls != 2 {
+		t.Fatalf("unexpected platform observation: %#v calls=%d err=%v", result, source.calls, err)
+	}
+	if binding := observer.Binding(); binding.StageID != "platform-observation" || binding.Authority != "gitops" || binding.PlanDigest != bundle.plan.PlanDigest {
+		t.Fatalf("unexpected platform stage binding: %#v", binding)
+	}
+	if source.policy.TargetClusterUID != targetAccessRuntimeUID || source.policy.PlatformRevision != bundle.plan.PlatformRevision || len(source.policy.Required) != 1 || source.policy.Required[0] != "PlatformReady" {
+		t.Fatalf("platform source received an unbound policy: %#v", source.policy)
+	}
+}
+
+func TestPlatformStageObserverReturnsTerminalFalseAndBoundedUnknown(t *testing.T) {
+	for name, testCase := range map[string]struct {
+		statuses []string
+		want     string
+		calls    int
+	}{
+		"terminal false":  {statuses: []string{"False"}, want: "FAILED", calls: 1},
+		"bounded unknown": {statuses: []string{"Unknown"}, want: "STOPPED", calls: 3},
+	} {
+		t.Run(name, func(t *testing.T) {
+			fixture := platformObservationBundleFixture(t)
+			bundle, _ := LoadPlatformObservationStageBundle(fixture.config)
+			current := time.Date(2026, 8, 17, 21, 0, 0, 0, time.UTC)
+			source := &fakePlatformStageSource{statuses: testCase.statuses}
+			observer, err := NewPlatformStageObserver(PlatformStageObserverConfig{
+				Plan: bundle.plan, ReceiptPrefix: bundle.prefix, TargetClusterUID: targetAccessRuntimeUID,
+				Source: source, Profile: bundle.profile, PollInterval: time.Second, PollTimeout: 2 * time.Second,
+				Clock: func() time.Time { return current },
+				Wait:  func(_ context.Context, wait time.Duration) error { current = current.Add(wait); return nil },
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			result, err := observer.Observe(context.Background())
+			if err != nil || result.Outcome != testCase.want || source.calls != testCase.calls {
+				t.Fatalf("unexpected terminal platform result: %#v calls=%d err=%v", result, source.calls, err)
+			}
+		})
+	}
+}
+
+func TestPlatformStageObserverRejectsForeignTargetProfileAndIncompleteHistory(t *testing.T) {
+	fixture := platformObservationBundleFixture(t)
+	bundle, _ := LoadPlatformObservationStageBundle(fixture.config)
+	base := PlatformStageObserverConfig{
+		Plan: bundle.plan, ReceiptPrefix: bundle.prefix, TargetClusterUID: targetAccessRuntimeUID,
+		Source: &fakePlatformStageSource{statuses: []string{"True"}}, Profile: bundle.profile,
+		PollInterval: time.Second, PollTimeout: time.Minute, Clock: time.Now,
+		Wait: func(context.Context, time.Duration) error { return nil },
+	}
+	for name, mutate := range map[string]func(*PlatformStageObserverConfig){
+		"same-name replacement": func(config *PlatformStageObserverConfig) { config.TargetClusterUID = "replacement-runtime-uid" },
+		"incomplete prefix":     func(config *PlatformStageObserverConfig) { config.ReceiptPrefix = config.ReceiptPrefix[:9] },
+		"foreign profile":       func(config *PlatformStageObserverConfig) { config.Profile.PlatformRevision = runnerStageSHA("f") },
+	} {
+		t.Run(name, func(t *testing.T) {
+			config := base
+			mutate(&config)
+			if _, err := NewPlatformStageObserver(config); err == nil {
+				t.Fatal("unsafe platform stage boundary was accepted")
+			}
+		})
+	}
+}
+
+func TestPlatformStageObserverRedactsSourceFailure(t *testing.T) {
+	fixture := platformObservationBundleFixture(t)
+	bundle, _ := LoadPlatformObservationStageBundle(fixture.config)
+	observer, err := NewPlatformStageObserver(PlatformStageObserverConfig{
+		Plan: bundle.plan, ReceiptPrefix: bundle.prefix, TargetClusterUID: targetAccessRuntimeUID,
+		Source: &fakePlatformStageSource{err: errors.New("sensitive Argo endpoint")}, Profile: bundle.profile,
+		PollInterval: time.Second, PollTimeout: time.Minute, Clock: time.Now,
+		Wait: func(context.Context, time.Duration) error { return nil },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = observer.Observe(context.Background())
+	if err == nil || strings.Contains(err.Error(), "sensitive") || strings.Contains(err.Error(), "endpoint") {
+		t.Fatalf("platform source failure leaked detail or was accepted: %v", err)
+	}
+}
+
+type fakePlatformStageSource struct {
+	statuses []string
+	err      error
+	calls    int
+	policy   observation.Policy
+}
+
+func (source *fakePlatformStageSource) Observe(_ context.Context, policy observation.Policy) (observation.Evidence, error) {
+	source.calls++
+	source.policy = policy
+	if source.err != nil {
+		return observation.Evidence{}, source.err
+	}
+	status := source.statuses[len(source.statuses)-1]
+	if source.calls <= len(source.statuses) {
+		status = source.statuses[source.calls-1]
+	}
+	reason := "PlatformConverged"
+	if status == "False" {
+		reason = "PlatformInvariantFailed"
+	} else if status == "Unknown" {
+		reason = "PlatformEvidencePending"
+	}
+	return observation.Evidence{
+		Type: "PlatformReady", Source: "BoundedPlatformEvaluator", SourceUID: "platform-evidence-ok147",
+		TargetClusterUID: policy.TargetClusterUID, Status: status, Reason: reason,
+		DesiredRevision: policy.PlatformRevision, ObservedRevision: policy.PlatformRevision,
+		EvidenceDigest: runnerStageSHA("7"),
+	}, nil
+}


### PR DESCRIPTION
## Summary

- bind Stage 11 to the exact ten-receipt prefix and successful Stage-10 Application submission
- correlate the immutable Platform profile and private runtime target to the durable lifecycle UID digest
- poll only read-only `PlatformReady` evidence with bounded True/False/Unknown outcomes
- open the ledger and exact Argo reader with distinct credentials and no API contact
- verify the configured Argo API CA digest before constructing the source collector

## Validation

- `go test ./...`
- `go vet ./...`
- `go test -race ./internal/runner ./internal/submission ./internal/observation ./cmd/ok`

## Scope

Read-only observation composition and tests only. No live infrastructure action is performed by this PR.

Jira: OK-147
