### PR TITLE
feat(runner): bind aggregate evidence stage (OK-147)

### DIFF
--- a/internal/execution/staged_evaluation.go
+++ b/internal/execution/staged_evaluation.go
@@ -1,0 +1,121 @@
+package execution
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/ledger"
+	"github.com/openkubes/ok-cluster/internal/stagecursor"
+	"github.com/openkubes/ok-cluster/internal/stageplan"
+	"github.com/openkubes/ok-cluster/internal/stagereceipt"
+)
+
+const EvaluationStageReceiptFormat = "ok147-evaluation-stage-run-receipt/v1"
+
+type StageEvaluationBinding struct {
+	PlanDigest       string
+	StageID          string
+	StageDigest      string
+	Authority        string
+	ContractRevision string
+}
+
+type StageEvaluationResult struct {
+	Outcome        string
+	EvidenceDigest string
+	CompletedAt    time.Time
+}
+
+// StageEvaluator is preconstructed for exactly one bounded, read-only
+// evaluation stage. It has no mutation, authorization, retry or status-write
+// method.
+type StageEvaluator interface {
+	Binding() StageEvaluationBinding
+	Evaluate(context.Context) (StageEvaluationResult, error)
+}
+
+type EvaluationStageOperation struct {
+	Ledger    *ledger.Ledger
+	Evaluator StageEvaluator
+}
+
+type EvaluationStageRunReceipt struct {
+	Format             string `json:"format"`
+	State              string `json:"state"`
+	PlanDigest         string `json:"planDigest,omitempty"`
+	StageID            string `json:"stageId,omitempty"`
+	StageReceiptDigest string `json:"stageReceiptDigest,omitempty"`
+}
+
+type EvaluationStageResultError struct{ State string }
+
+func (err *EvaluationStageResultError) Error() string {
+	return "evaluation stage completed with " + err.State
+}
+
+// Run invokes at most one prebound evaluator. Once its receipt is durable,
+// replay returns that receipt without re-reading any authoritative source.
+func (operation EvaluationStageOperation) Run(ctx context.Context, plan stageplan.Binding, cursor stagecursor.Cursor) (EvaluationStageRunReceipt, error) {
+	receipt := EvaluationStageRunReceipt{Format: EvaluationStageReceiptFormat, State: "PREEVALUATION"}
+	if operation.Ledger == nil || operation.Evaluator == nil {
+		return receipt, errors.New("evaluation stage ledger and evaluator are required")
+	}
+	decision, err := cursor.Decision()
+	if err != nil {
+		return receipt, err
+	}
+	if decision.State != "NEXT" || decision.Kind != "Evaluation" || decision.RequiresAuthorization || decision.Operation != "" {
+		return receipt, errors.New("stage cursor does not select a read-only evaluation stage")
+	}
+	predecessors, err := cursor.Predecessors()
+	if err != nil {
+		return receipt, err
+	}
+	want := StageEvaluationBinding{
+		PlanDigest: plan.PlanDigest, StageID: decision.StageID, StageDigest: decision.StageDigest,
+		Authority: decision.Authority, ContractRevision: plan.IntentRevision,
+	}
+	if operation.Evaluator.Binding() != want {
+		return receipt, errors.New("preconstructed evaluator differs from the selected stage")
+	}
+	receipt.PlanDigest, receipt.StageID = plan.PlanDigest, decision.StageID
+	if existing, found, err := operation.Ledger.InspectStageReceipt(ctx, plan, decision.StageID, predecessors); err != nil {
+		return receipt, err
+	} else if found {
+		return finalizeEvaluationRunReceipt(receipt, existing)
+	}
+
+	result, evaluateErr := operation.Evaluator.Evaluate(ctx)
+	if evaluateErr != nil {
+		return receipt, errors.New("bounded stage evaluation failed")
+	}
+	if !oneOf(result.Outcome, "SUCCEEDED", "FAILED", "STOPPED") || !stagedDigestPattern.MatchString(result.EvidenceDigest) || result.CompletedAt.IsZero() {
+		return receipt, errors.New("stage evaluator returned an invalid redaction-safe result")
+	}
+	verified, err := stagereceipt.New(plan, decision.StageID, predecessors, result.Outcome, "NOT_APPLICABLE", "", result.EvidenceDigest, result.CompletedAt)
+	if err != nil {
+		return receipt, err
+	}
+	if _, err := operation.Ledger.StoreStageReceipt(ctx, plan, verified, predecessors); err != nil {
+		return receipt, err
+	}
+	return finalizeEvaluationRunReceipt(receipt, verified)
+}
+
+func finalizeEvaluationRunReceipt(receipt EvaluationStageRunReceipt, verified stagereceipt.Verified) (EvaluationStageRunReceipt, error) {
+	stageReceipt, err := verified.Receipt()
+	if err != nil {
+		return receipt, err
+	}
+	digest, err := verified.Digest()
+	if err != nil {
+		return receipt, err
+	}
+	receipt.StageReceiptDigest = digest
+	receipt.State = "COMPLETED_" + stageReceipt.State
+	if stageReceipt.State != "SUCCEEDED" {
+		return receipt, &EvaluationStageResultError{State: receipt.State}
+	}
+	return receipt, nil
+}

--- a/internal/execution/staged_evaluation_test.go
+++ b/internal/execution/staged_evaluation_test.go
@@ -1,0 +1,123 @@
+package execution
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/ledger"
+	"github.com/openkubes/ok-cluster/internal/stagecursor"
+	"github.com/openkubes/ok-cluster/internal/stageplan"
+	"github.com/openkubes/ok-cluster/internal/stagereceipt"
+)
+
+func TestEvaluationStagePersistsAndResumesWithoutReevaluation(t *testing.T) {
+	plan, cursor, at := aggregateEvaluationCursor(t)
+	store, _ := ledger.Open(filepath.Join(t.TempDir(), "ledger"))
+	evaluator := &fakeStageEvaluator{binding: evaluationBinding(t, plan), result: StageEvaluationResult{Outcome: "SUCCEEDED", EvidenceDigest: stagedSHA("e"), CompletedAt: at}}
+	operation := EvaluationStageOperation{Ledger: store, Evaluator: evaluator}
+	first, err := operation.Run(context.Background(), plan, cursor)
+	if err != nil || first.State != "COMPLETED_SUCCEEDED" || first.StageReceiptDigest == "" || evaluator.calls != 1 {
+		t.Fatalf("unexpected evaluation run: %#v calls=%d err=%v", first, evaluator.calls, err)
+	}
+	replayed, err := operation.Run(context.Background(), plan, cursor)
+	if err != nil || replayed != first || evaluator.calls != 1 {
+		t.Fatalf("persisted evaluation was executed again: %#v calls=%d err=%v", replayed, evaluator.calls, err)
+	}
+}
+
+func TestEvaluationStagePersistsTerminalResultWithoutRawError(t *testing.T) {
+	plan, cursor, at := aggregateEvaluationCursor(t)
+	store, _ := ledger.Open(filepath.Join(t.TempDir(), "ledger"))
+	evaluator := &fakeStageEvaluator{binding: evaluationBinding(t, plan), result: StageEvaluationResult{Outcome: "FAILED", EvidenceDigest: stagedSHA("f"), CompletedAt: at}}
+	receipt, err := (EvaluationStageOperation{Ledger: store, Evaluator: evaluator}).Run(context.Background(), plan, cursor)
+	var resultErr *EvaluationStageResultError
+	if !errors.As(err, &resultErr) || receipt.State != "COMPLETED_FAILED" || receipt.StageReceiptDigest == "" {
+		t.Fatalf("terminal evaluation was not retained: %#v %v", receipt, err)
+	}
+}
+
+func TestEvaluationStageFailsClosedBeforePersistence(t *testing.T) {
+	plan, cursor, at := aggregateEvaluationCursor(t)
+	for name, mutate := range map[string]func(*fakeStageEvaluator){
+		"foreign binding": func(evaluator *fakeStageEvaluator) { evaluator.binding.Authority = "gitops" },
+		"raw failure":     func(evaluator *fakeStageEvaluator) { evaluator.err = errors.New("sensitive endpoint detail") },
+		"bad result":      func(evaluator *fakeStageEvaluator) { evaluator.result.EvidenceDigest = "invalid" },
+	} {
+		t.Run(name, func(t *testing.T) {
+			store, _ := ledger.Open(filepath.Join(t.TempDir(), "ledger"))
+			evaluator := &fakeStageEvaluator{binding: evaluationBinding(t, plan), result: StageEvaluationResult{Outcome: "SUCCEEDED", EvidenceDigest: stagedSHA("e"), CompletedAt: at}}
+			mutate(evaluator)
+			receipt, err := (EvaluationStageOperation{Ledger: store, Evaluator: evaluator}).Run(context.Background(), plan, cursor)
+			if err == nil || strings.Contains(err.Error(), "sensitive") || receipt.StageReceiptDigest != "" {
+				t.Fatalf("unsafe evaluation result was accepted: %#v %v", receipt, err)
+			}
+		})
+	}
+}
+
+func TestEvaluationStageRejectsObservationCursor(t *testing.T) {
+	plan, cursor, _ := lifecycleObservationCursor(t)
+	store, _ := ledger.Open(filepath.Join(t.TempDir(), "ledger"))
+	evaluator := &fakeStageEvaluator{}
+	if _, err := (EvaluationStageOperation{Ledger: store, Evaluator: evaluator}).Run(context.Background(), plan, cursor); err == nil || evaluator.calls != 0 {
+		t.Fatalf("observation cursor reached evaluator: calls=%d err=%v", evaluator.calls, err)
+	}
+}
+
+type fakeStageEvaluator struct {
+	binding StageEvaluationBinding
+	result  StageEvaluationResult
+	err     error
+	calls   int
+}
+
+func (evaluator *fakeStageEvaluator) Binding() StageEvaluationBinding { return evaluator.binding }
+func (evaluator *fakeStageEvaluator) Evaluate(context.Context) (StageEvaluationResult, error) {
+	evaluator.calls++
+	return evaluator.result, evaluator.err
+}
+
+func aggregateEvaluationCursor(t *testing.T) (stageplan.Binding, stagecursor.Cursor, time.Time) {
+	t.Helper()
+	plan := stagedPlan(t)
+	at := time.Date(2026, 8, 17, 22, 0, 0, 0, time.UTC)
+	predecessors := []stagereceipt.Verified{}
+	prefix := []stagereceipt.Verified{}
+	for index, stageID := range []string{"provider-prerequisites", "cluster-lifecycle", "lifecycle-observation", "enablement", "network-observation", "runtime-binding", "target-access", "target-credential", "target-registration", "platform-applications", "platform-observation"} {
+		mutation := "ATTEMPTED"
+		operationDigest := stagedSHA(string("123456789ab"[index]))
+		if stageID == "lifecycle-observation" || stageID == "network-observation" || stageID == "runtime-binding" || stageID == "platform-observation" {
+			mutation, operationDigest = "NOT_APPLICABLE", ""
+		}
+		var receipt stagereceipt.Verified
+		var err error
+		if stageID == "cluster-lifecycle" {
+			receipt, err = stagereceipt.NewWithTargetClusterUIDDigest(plan, stageID, predecessors, "SUCCEEDED", mutation, operationDigest, stagedSHA("e"), stagedSHA("7"), at.Add(time.Duration(index-11)*time.Second))
+		} else {
+			receipt, err = stagereceipt.New(plan, stageID, predecessors, "SUCCEEDED", mutation, operationDigest, stagedSHA("e"), at.Add(time.Duration(index-11)*time.Second))
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		prefix = append(prefix, receipt)
+		predecessors = []stagereceipt.Verified{receipt}
+	}
+	cursor, err := stagecursor.Evaluate(plan, prefix)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return plan, cursor, at
+}
+
+func evaluationBinding(t *testing.T, plan stageplan.Binding) StageEvaluationBinding {
+	t.Helper()
+	stage, stageDigest, err := plan.Stage("aggregate-evidence")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return StageEvaluationBinding{PlanDigest: plan.PlanDigest, StageID: stage.ID, StageDigest: stageDigest, Authority: stage.Authority, ContractRevision: plan.IntentRevision}
+}

--- a/internal/runner/aggregate_evidence_profile.go
+++ b/internal/runner/aggregate_evidence_profile.go
@@ -1,0 +1,63 @@
+package runner
+
+import (
+	"encoding/json"
+	"errors"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/stageplan"
+)
+
+const AggregateEvidenceProfileFormat = "ok147-aggregate-evidence-profile/v1"
+
+var aggregateEvidenceRequiredConditions = []string{
+	"InfrastructureReady",
+	"ControlPlaneAvailable",
+	"NetworkReady",
+	"PlatformReady",
+}
+
+// AggregateEvidenceProfile is the immutable, pre-runtime Stage-12 input. It
+// binds the required facts but deliberately excludes the CAPI Cluster UID,
+// which only exists after lifecycle submission and is supplied by the verified
+// private runtime binding.
+type AggregateEvidenceProfile struct {
+	Format             string   `json:"format"`
+	IntentRevision     string   `json:"intentRevision"`
+	EnablementRevision string   `json:"enablementRevision"`
+	PlatformRevision   string   `json:"platformRevision"`
+	ExecutionFixture   string   `json:"executionFixture"`
+	Required           []string `json:"required"`
+}
+
+func AggregateEvidenceProfileForPlan(plan stageplan.Binding) AggregateEvidenceProfile {
+	return AggregateEvidenceProfile{
+		Format: AggregateEvidenceProfileFormat, IntentRevision: plan.IntentRevision,
+		EnablementRevision: plan.EnablementRevision, PlatformRevision: plan.PlatformRevision,
+		ExecutionFixture: plan.ExecutionFixture,
+		Required:         append([]string(nil), aggregateEvidenceRequiredConditions...),
+	}
+}
+
+func AggregateEvidenceProfileDigest(profile AggregateEvidenceProfile) (string, error) {
+	if err := validateAggregateEvidenceProfile(profile); err != nil {
+		return "", err
+	}
+	raw, err := json.Marshal(profile)
+	if err != nil {
+		return "", errors.New("encode aggregate evidence profile")
+	}
+	return digest.SHA256(raw), nil
+}
+
+func validateAggregateEvidenceProfile(profile AggregateEvidenceProfile) error {
+	if profile.Format != AggregateEvidenceProfileFormat || !stageReceiptPrefixDigestPattern.MatchString(profile.IntentRevision) || !stageReceiptPrefixDigestPattern.MatchString(profile.EnablementRevision) || !stageReceiptPrefixDigestPattern.MatchString(profile.PlatformRevision) || !stageReceiptPrefixDigestPattern.MatchString(profile.ExecutionFixture) || len(profile.Required) != len(aggregateEvidenceRequiredConditions) {
+		return errors.New("aggregate evidence profile identity is invalid")
+	}
+	for index, required := range aggregateEvidenceRequiredConditions {
+		if profile.Required[index] != required {
+			return errors.New("aggregate evidence required condition profile is invalid")
+		}
+	}
+	return nil
+}

--- a/internal/runner/aggregate_evidence_stage_bundle.go
+++ b/internal/runner/aggregate_evidence_stage_bundle.go
@@ -1,0 +1,80 @@
+package runner
+
+import (
+	"errors"
+
+	"github.com/openkubes/ok-cluster/internal/stagecursor"
+	"github.com/openkubes/ok-cluster/internal/stageplan"
+	"github.com/openkubes/ok-cluster/internal/stagereceipt"
+)
+
+type AggregateEvidenceStageBundleConfig struct {
+	StageResumeConfig
+	Profile               AggregateEvidenceProfile
+	ExpectedProfileDigest string
+}
+
+type VerifiedAggregateEvidenceStageBundle struct {
+	plan          stageplan.Binding
+	cursor        stagecursor.Cursor
+	prefix        []stagereceipt.Verified
+	profile       AggregateEvidenceProfile
+	profileDigest string
+	verified      bool
+}
+
+// LoadAggregateEvidenceStageBundle closes the offline Stage-12 boundary. It
+// verifies the exact eleven-receipt history and aggregation semantics without
+// opening a credential or contacting any Kubernetes API.
+func LoadAggregateEvidenceStageBundle(config AggregateEvidenceStageBundleConfig) (VerifiedAggregateEvidenceStageBundle, error) {
+	plan, cursor, prefix, err := loadStageResumeWithPrefix(config.StageResumeConfig)
+	if err != nil {
+		return VerifiedAggregateEvidenceStageBundle{}, err
+	}
+	decision, err := cursor.Decision()
+	if err != nil || decision.State != "NEXT" || decision.StageID != "aggregate-evidence" || decision.Kind != "Evaluation" || decision.Authority != "runner" || decision.RequiresAuthorization || decision.Operation != "" {
+		return VerifiedAggregateEvidenceStageBundle{}, errors.New("verified prefix does not select aggregate evidence evaluation")
+	}
+	if len(prefix) != 11 {
+		return VerifiedAggregateEvidenceStageBundle{}, errors.New("aggregate evidence evaluation requires the exact eleven-receipt prefix")
+	}
+	lifecycle, err := prefix[1].Receipt()
+	if err != nil || lifecycle.StageID != "cluster-lifecycle" || lifecycle.State != "SUCCEEDED" || !stageReceiptPrefixDigestPattern.MatchString(lifecycle.TargetClusterUIDDigest) {
+		return VerifiedAggregateEvidenceStageBundle{}, errors.New("aggregate evidence evaluation lacks durable workload identity")
+	}
+	for _, index := range []int{2, 4, 10} {
+		receipt, receiptErr := prefix[index].Receipt()
+		if receiptErr != nil || receipt.State != "SUCCEEDED" || receipt.MutationState != "NOT_APPLICABLE" || !stageReceiptPrefixDigestPattern.MatchString(receipt.EvidenceDigest) {
+			return VerifiedAggregateEvidenceStageBundle{}, errors.New("aggregate evidence evaluation lacks a successful authoritative observation")
+		}
+	}
+	profileDigest, err := AggregateEvidenceProfileDigest(config.Profile)
+	if err != nil || config.ExpectedProfileDigest != profileDigest {
+		return VerifiedAggregateEvidenceStageBundle{}, errors.New("aggregate evidence profile identity is invalid")
+	}
+	stage, _, err := plan.Stage("aggregate-evidence")
+	if err != nil || len(stage.Inputs) != 1 || stage.Inputs[0].Name != "stage.aggregate-evidence" || stage.Inputs[0].Digest != profileDigest || config.Profile.IntentRevision != plan.IntentRevision || config.Profile.EnablementRevision != plan.EnablementRevision || config.Profile.PlatformRevision != plan.PlatformRevision || config.Profile.ExecutionFixture != plan.ExecutionFixture {
+		return VerifiedAggregateEvidenceStageBundle{}, errors.New("aggregate evidence profile differs from verified stage plan")
+	}
+	profile := config.Profile
+	profile.Required = append([]string(nil), config.Profile.Required...)
+	return VerifiedAggregateEvidenceStageBundle{plan: plan, cursor: cursor, prefix: prefix, profile: profile, profileDigest: profileDigest, verified: true}, nil
+}
+
+func (bundle VerifiedAggregateEvidenceStageBundle) Decision() (stagecursor.Decision, error) {
+	if err := verifyAggregateEvidenceStageBundle(bundle); err != nil {
+		return stagecursor.Decision{}, err
+	}
+	return bundle.cursor.Decision()
+}
+
+func verifyAggregateEvidenceStageBundle(bundle VerifiedAggregateEvidenceStageBundle) error {
+	if !bundle.verified || len(bundle.prefix) != 11 || !stageReceiptPrefixDigestPattern.MatchString(bundle.profileDigest) {
+		return errors.New("aggregate evidence stage bundle is not verified")
+	}
+	digest, err := AggregateEvidenceProfileDigest(bundle.profile)
+	if err != nil || digest != bundle.profileDigest || bundle.profile.IntentRevision != bundle.plan.IntentRevision || bundle.profile.EnablementRevision != bundle.plan.EnablementRevision || bundle.profile.PlatformRevision != bundle.plan.PlatformRevision || bundle.profile.ExecutionFixture != bundle.plan.ExecutionFixture {
+		return errors.New("aggregate evidence profile changed after verification")
+	}
+	return nil
+}

--- a/internal/runner/aggregate_evidence_stage_bundle_test.go
+++ b/internal/runner/aggregate_evidence_stage_bundle_test.go
@@ -1,0 +1,68 @@
+package runner
+
+import (
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/stagereceipt"
+)
+
+func TestAggregateEvidenceStageBundleLoadsExactReadOnlyCursor(t *testing.T) {
+	fixture := aggregateEvidenceBundleFixture(t)
+	bundle, err := LoadAggregateEvidenceStageBundle(fixture)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decision, err := bundle.Decision()
+	if err != nil || decision.StageID != "aggregate-evidence" || decision.Kind != "Evaluation" || decision.Authority != "runner" || decision.RequiresAuthorization || decision.Operation != "" {
+		t.Fatalf("unexpected aggregate evidence decision: %#v %v", decision, err)
+	}
+	if _, err := (VerifiedAggregateEvidenceStageBundle{}).Decision(); err == nil {
+		t.Fatal("unverified aggregate evidence bundle exposed decision")
+	}
+}
+
+func TestAggregateEvidenceStageBundleRejectsProfileOrHistoryMismatch(t *testing.T) {
+	for name, mutate := range map[string]func(*AggregateEvidenceStageBundleConfig){
+		"incomplete prefix": func(config *AggregateEvidenceStageBundleConfig) { config.Receipts = config.Receipts[:10] },
+		"foreign digest":    func(config *AggregateEvidenceStageBundleConfig) { config.ExpectedProfileDigest = runnerStageSHA("f") },
+		"foreign revision": func(config *AggregateEvidenceStageBundleConfig) {
+			config.Profile.PlatformRevision = runnerStageSHA("f")
+		},
+		"missing condition": func(config *AggregateEvidenceStageBundleConfig) {
+			config.Profile.Required = config.Profile.Required[:3]
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			fixture := aggregateEvidenceBundleFixture(t)
+			mutate(&fixture)
+			if _, err := LoadAggregateEvidenceStageBundle(fixture); err == nil {
+				t.Fatal("invalid aggregate evidence bundle was accepted")
+			}
+		})
+	}
+}
+
+func aggregateEvidenceBundleFixture(t *testing.T) AggregateEvidenceStageBundleConfig {
+	t.Helper()
+	base := platformObservationBundleFixture(t)
+	plan, _, prefix, err := loadStageResumeWithPrefix(base.config.StageResumeConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	at := time.Date(2026, 8, 17, 22, 0, 0, 0, time.UTC)
+	receipt, err := stagereceipt.New(plan, "platform-observation", []stagereceipt.Verified{prefix[9]}, "SUCCEEDED", "NOT_APPLICABLE", "", runnerStageSHA("e"), at)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipts := appendStageReceipt(t, t.TempDir(), base.config.Receipts, receipt, "platform-observation.json")
+	profile := AggregateEvidenceProfileForPlan(plan)
+	profileDigest, err := AggregateEvidenceProfileDigest(profile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return AggregateEvidenceStageBundleConfig{
+		StageResumeConfig: StageResumeConfig{PlanPath: base.config.PlanPath, PlanExpected: base.config.PlanExpected, Receipts: receipts},
+		Profile:           profile, ExpectedProfileDigest: profileDigest,
+	}
+}

--- a/internal/runner/platform_applications_stage_bundle_test.go
+++ b/internal/runner/platform_applications_stage_bundle_test.go
@@ -125,6 +125,15 @@ func platformApplicationsBundleFixture(t *testing.T) platformApplicationsBundleT
 	if err != nil {
 		t.Fatal(err)
 	}
+	aggregateProfile := AggregateEvidenceProfile{
+		Format: AggregateEvidenceProfileFormat, IntentRevision: expectedPlan.IntentRevision,
+		EnablementRevision: expectedPlan.EnablementRevision, PlatformRevision: expectedPlan.PlatformRevision,
+		ExecutionFixture: expectedPlan.ExecutionFixture, Required: append([]string(nil), aggregateEvidenceRequiredConditions...),
+	}
+	aggregateProfileDigest, err := AggregateEvidenceProfileDigest(aggregateProfile)
+	if err != nil {
+		t.Fatal(err)
+	}
 	planRaw := submissionBundlePlan(t, expectedPlan, runnerStageSHA("1"), runnerStageSHA("2"))
 	var document map[string]any
 	if err := json.Unmarshal(planRaw, &document); err != nil {
@@ -136,6 +145,7 @@ func platformApplicationsBundleFixture(t *testing.T) platformApplicationsBundleT
 	stages[8].(map[string]any)["inputs"] = []any{map[string]any{"name": "stage.target-registration", "digest": runnerStageSHA("5")}}
 	stages[9].(map[string]any)["inputs"] = []any{map[string]any{"name": "stage.platform-applications", "digest": artifactDigest}}
 	stages[10].(map[string]any)["inputs"] = []any{map[string]any{"name": "stage.platform-observation", "digest": profileDigest}}
+	stages[11].(map[string]any)["inputs"] = []any{map[string]any{"name": "stage.aggregate-evidence", "digest": aggregateProfileDigest}}
 	planPath := writeBundleFile(t, root, "staged-plan.json", mustJSON(t, document))
 	plan, err := stageplan.Load(planPath, expectedPlan)
 	if err != nil {


### PR DESCRIPTION
## Summary

- bind Stage 12 `aggregate-evidence` to an immutable four-condition profile and the exact eleven-receipt prefix
- add a fail-closed, read-only evaluation operation with durable single-use/replay semantics
- reject missing authoritative observation receipts, changed profile semantics, foreign stage bindings, and unsafe evaluator output

## Architecture boundary

- no Kubernetes mutation or credential access
- no authorization grant for the evaluation stage
- no persistent status controller or source-resource repair
- runtime Kubernetes aggregate composition remains the next isolated checkpoint

## Verification

- `go test -ldflags=-linkmode=external ./...`
- `go vet ./...`
- `go test -race -ldflags=-linkmode=external ./internal/execution ./internal/runner`

OK-147
