### PR TITLE
feat(runner): compose aggregate evidence runtime (OK-147)

### DIFF
--- a/internal/runner/aggregate_evidence_stage_evaluator.go
+++ b/internal/runner/aggregate_evidence_stage_evaluator.go
@@ -1,0 +1,118 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/execution"
+	"github.com/openkubes/ok-cluster/internal/observation"
+	"github.com/openkubes/ok-cluster/internal/stagecursor"
+	"github.com/openkubes/ok-cluster/internal/stageplan"
+	"github.com/openkubes/ok-cluster/internal/stagereceipt"
+)
+
+type AggregateEvidenceStageEvaluatorConfig struct {
+	Plan             stageplan.Binding
+	ReceiptPrefix    []stagereceipt.Verified
+	TargetClusterUID string
+	Profile          AggregateEvidenceProfile
+	Source           ObservationSource
+}
+
+// AggregateEvidenceStageEvaluator adapts the already bounded aggregate
+// observer to the final Evaluation stage. It performs exactly one source pass;
+// prior convergence stages already own polling.
+type AggregateEvidenceStageEvaluator struct {
+	binding execution.StageEvaluationBinding
+	policy  observation.Policy
+	source  ObservationSource
+}
+
+var _ execution.StageEvaluator = (*AggregateEvidenceStageEvaluator)(nil)
+
+func NewAggregateEvidenceStageEvaluator(config AggregateEvidenceStageEvaluatorConfig) (*AggregateEvidenceStageEvaluator, error) {
+	if config.Source == nil {
+		return nil, errors.New("aggregate evidence source is required")
+	}
+	cursor, err := stagecursor.Evaluate(config.Plan, config.ReceiptPrefix)
+	if err != nil {
+		return nil, errors.New("verify aggregate evidence receipt prefix")
+	}
+	decision, err := cursor.Decision()
+	if err != nil || decision.State != "NEXT" || decision.StageID != "aggregate-evidence" || decision.Kind != "Evaluation" || decision.Authority != "runner" || decision.RequiresAuthorization || decision.Operation != "" {
+		return nil, errors.New("stage receipt prefix does not select aggregate evidence evaluation")
+	}
+	if len(config.ReceiptPrefix) != 11 {
+		return nil, errors.New("aggregate evidence receipt prefix is incomplete")
+	}
+	lifecycle, err := config.ReceiptPrefix[1].Receipt()
+	if err != nil || lifecycle.StageID != "cluster-lifecycle" || !platformInputDigestPattern.MatchString(lifecycle.TargetClusterUIDDigest) || digest.SHA256([]byte(config.TargetClusterUID)) != lifecycle.TargetClusterUIDDigest {
+		return nil, errors.New("aggregate evidence target differs from durable lifecycle correlation")
+	}
+	if err := validateAggregateEvidenceProfile(config.Profile); err != nil || config.Profile.IntentRevision != config.Plan.IntentRevision || config.Profile.EnablementRevision != config.Plan.EnablementRevision || config.Profile.PlatformRevision != config.Plan.PlatformRevision || config.Profile.ExecutionFixture != config.Plan.ExecutionFixture {
+		return nil, errors.New("aggregate evidence profile differs from verified execution plan")
+	}
+	stage, stageDigest, err := config.Plan.Stage(decision.StageID)
+	if err != nil || stageDigest != decision.StageDigest {
+		return nil, errors.New("aggregate evidence stage differs from verified plan")
+	}
+	policy := observation.Policy{
+		Format: observation.PolicyFormat, IntentRevision: config.Profile.IntentRevision,
+		EnablementRevision: config.Profile.EnablementRevision, PlatformRevision: config.Profile.PlatformRevision,
+		TargetClusterUID: config.TargetClusterUID, Required: append([]string(nil), config.Profile.Required...),
+	}
+	if _, err := observation.PolicyDigest(policy); err != nil {
+		return nil, errors.New("runtime-bound aggregate evidence policy is invalid")
+	}
+	return &AggregateEvidenceStageEvaluator{
+		binding: execution.StageEvaluationBinding{
+			PlanDigest: config.Plan.PlanDigest, StageID: stage.ID, StageDigest: stageDigest,
+			Authority: stage.Authority, ContractRevision: config.Plan.IntentRevision,
+		},
+		policy: policy, source: config.Source,
+	}, nil
+}
+
+func (evaluator *AggregateEvidenceStageEvaluator) Binding() execution.StageEvaluationBinding {
+	if evaluator == nil {
+		return execution.StageEvaluationBinding{}
+	}
+	return evaluator.binding
+}
+
+func (evaluator *AggregateEvidenceStageEvaluator) Evaluate(ctx context.Context) (execution.StageEvaluationResult, error) {
+	if evaluator == nil || evaluator.source == nil {
+		return execution.StageEvaluationResult{}, errors.New("aggregate evidence evaluator is required")
+	}
+	result, err := evaluator.source.Observe(ctx, evaluator.policy)
+	if err != nil {
+		return execution.StageEvaluationResult{}, errors.New("bounded aggregate evidence collection failed")
+	}
+	receipt, err := result.Receipt()
+	if err != nil {
+		return execution.StageEvaluationResult{}, errors.New("aggregate evidence result is unverified")
+	}
+	policyDigest, err := observation.PolicyDigest(evaluator.policy)
+	if err != nil || receipt.IntentRevision != evaluator.policy.IntentRevision || receipt.PolicyDigest != policyDigest || len(receipt.Conditions) != len(evaluator.policy.Required) {
+		return execution.StageEvaluationResult{}, errors.New("aggregate evidence result differs from runtime policy")
+	}
+	evidenceDigest, err := result.EvidenceDigest()
+	if err != nil {
+		return execution.StageEvaluationResult{}, err
+	}
+	completedAt, err := time.Parse(time.RFC3339Nano, receipt.EvaluatedAt)
+	if err != nil {
+		return execution.StageEvaluationResult{}, errors.New("aggregate evidence completion time is invalid")
+	}
+	outcome := "STOPPED"
+	if receipt.Ready == "True" {
+		outcome = "SUCCEEDED"
+	} else if receipt.Ready == "False" {
+		outcome = "FAILED"
+	} else if receipt.Ready != "Unknown" {
+		return execution.StageEvaluationResult{}, errors.New("aggregate evidence readiness is invalid")
+	}
+	return execution.StageEvaluationResult{Outcome: outcome, EvidenceDigest: evidenceDigest, CompletedAt: completedAt}, nil
+}

--- a/internal/runner/aggregate_evidence_stage_evaluator_test.go
+++ b/internal/runner/aggregate_evidence_stage_evaluator_test.go
@@ -1,0 +1,191 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/execution"
+	"github.com/openkubes/ok-cluster/internal/observation"
+	"github.com/openkubes/ok-cluster/internal/stageplan"
+)
+
+func TestAggregateEvidenceStageEvaluatorMapsDeterministicReadiness(t *testing.T) {
+	for readiness, outcome := range map[string]string{"True": "SUCCEEDED", "False": "FAILED", "Unknown": "STOPPED"} {
+		t.Run(readiness, func(t *testing.T) {
+			config := aggregateEvidenceBundleFixture(t)
+			bundle, err := LoadAggregateEvidenceStageBundle(config)
+			if err != nil {
+				t.Fatal(err)
+			}
+			source := &aggregateEvaluationSource{at: time.Date(2026, 8, 17, 22, 30, 0, 0, time.UTC), readiness: readiness}
+			evaluator, err := NewAggregateEvidenceStageEvaluator(AggregateEvidenceStageEvaluatorConfig{
+				Plan: bundle.plan, ReceiptPrefix: bundle.prefix, TargetClusterUID: targetAccessRuntimeUID,
+				Profile: bundle.profile, Source: source,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			result, err := evaluator.Evaluate(context.Background())
+			if err != nil || result.Outcome != outcome || result.EvidenceDigest == "" || result.CompletedAt != source.at || source.calls != 1 {
+				t.Fatalf("unexpected aggregate result: %#v calls=%d err=%v", result, source.calls, err)
+			}
+			stage, stageDigest, _ := bundle.plan.Stage("aggregate-evidence")
+			if evaluator.Binding() != (execution.StageEvaluationBinding{PlanDigest: bundle.plan.PlanDigest, StageID: stage.ID, StageDigest: stageDigest, Authority: "runner", ContractRevision: bundle.plan.IntentRevision}) {
+				t.Fatal("aggregate evaluator binding differs from verified stage")
+			}
+		})
+	}
+}
+
+func TestAggregateEvidenceStageEvaluatorFailsClosed(t *testing.T) {
+	config := aggregateEvidenceBundleFixture(t)
+	bundle, err := LoadAggregateEvidenceStageBundle(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := NewAggregateEvidenceStageEvaluator(AggregateEvidenceStageEvaluatorConfig{Plan: bundle.plan, ReceiptPrefix: bundle.prefix, TargetClusterUID: "replacement-runtime-uid", Profile: bundle.profile, Source: &aggregateEvaluationSource{}}); err == nil {
+		t.Fatal("replacement target opened aggregate evaluator")
+	}
+	evaluator, err := NewAggregateEvidenceStageEvaluator(AggregateEvidenceStageEvaluatorConfig{Plan: bundle.plan, ReceiptPrefix: bundle.prefix, TargetClusterUID: targetAccessRuntimeUID, Profile: bundle.profile, Source: &aggregateEvaluationSource{err: errors.New("sensitive endpoint detail")}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := evaluator.Evaluate(context.Background()); err == nil || err.Error() != "bounded aggregate evidence collection failed" {
+		t.Fatalf("raw source failure escaped aggregate evaluator: %v", err)
+	}
+}
+
+func TestAggregateEvidenceStageBundleOpensWithoutClusterContact(t *testing.T) {
+	config := aggregateEvidenceBundleFixture(t)
+	bundle, err := LoadAggregateEvidenceStageBundle(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runtime := aggregateEvidenceRuntime(t, bundle, "ledger-token", "management-token", "argo-token")
+	opened, err := bundle.Open(runtime)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !opened.verified {
+		t.Fatal("opened aggregate evidence stage is not verified")
+	}
+	if _, err := (OpenedAggregateEvidenceStage{}).Run(context.Background()); err == nil {
+		t.Fatal("unopened aggregate evidence stage could run")
+	}
+
+	runtime = aggregateEvidenceRuntime(t, bundle, "shared-token", "shared-token", "argo-token")
+	if _, err := bundle.Open(runtime); err == nil {
+		t.Fatal("shared ledger/management credential opened aggregate evidence")
+	}
+	runtime = aggregateEvidenceRuntime(t, bundle, "shared-token", "management-token", "shared-token")
+	if _, err := bundle.Open(runtime); err == nil {
+		t.Fatal("shared ledger/Argo credential opened aggregate evidence")
+	}
+	runtime = aggregateEvidenceRuntime(t, bundle, "ledger-token", "shared-token", "shared-token")
+	if _, err := bundle.Open(runtime); err == nil {
+		t.Fatal("shared management/Argo credential opened aggregate evidence")
+	}
+	runtime = aggregateEvidenceRuntime(t, bundle, "ledger-token", "management-token", "argo-token")
+	runtime.Observer.NetworkProfile.ExpectedNodeCount++
+	if _, err := bundle.Open(runtime); err == nil {
+		t.Fatal("changed Network profile opened aggregate evidence")
+	}
+}
+
+type aggregateEvaluationSource struct {
+	at        time.Time
+	readiness string
+	err       error
+	calls     int
+}
+
+func (source *aggregateEvaluationSource) Observe(_ context.Context, policy observation.Policy) (observation.VerifiedResult, error) {
+	source.calls++
+	if source.err != nil {
+		return observation.VerifiedResult{}, source.err
+	}
+	evidence := []observation.Evidence{
+		aggregateRunnerEvidence(policy, "InfrastructureReady"),
+		aggregateRunnerEvidence(policy, "ControlPlaneAvailable"),
+		aggregateRunnerEvidence(policy, "NetworkReady"),
+		aggregateRunnerEvidence(policy, "PlatformReady"),
+	}
+	if source.readiness == "False" {
+		evidence[2].Status, evidence[2].Reason = "False", "NetworkUnavailable"
+	} else if source.readiness == "Unknown" {
+		evidence = evidence[:3]
+	}
+	return observation.Evaluate(policy, observation.Bundle{
+		Format: observation.BundleFormat, IntentRevision: policy.IntentRevision,
+		EvaluatedAt: source.at.UTC().Format(time.RFC3339Nano), Evidence: evidence,
+	})
+}
+
+func aggregateEvidenceRuntime(t *testing.T, bundle VerifiedAggregateEvidenceStageBundle, ledgerToken, managementToken, argoToken string) AggregateEvidenceStageRuntimeConfig {
+	t.Helper()
+	root := t.TempDir()
+	ca := testCA(t)
+	caPath := writeBundleFile(t, root, "ca.crt", ca)
+	ledgerTokenPath := writeBundleFile(t, root, "ledger-token", []byte(ledgerToken))
+	managementTokenPath := writeBundleFile(t, root, "management-token", []byte(managementToken))
+	argoTokenPath := writeBundleFile(t, root, "argo-token", []byte(argoToken))
+	planExpected := bundleExpected(bundle)
+	_, platformProfile := runnerPlatformApplications(t, planExpected)
+	networkProfile := runnerAggregateNetworkProfile(planExpected)
+	runtime := aggregateRuntimeBindingMaterial(t, bundle)
+	return AggregateEvidenceStageRuntimeConfig{
+		Ledger: KubernetesLedgerConfig{Endpoint: "https://192.0.2.10:6443", Namespace: "openkubes-execution-system", TokenFile: ledgerTokenPath, CAFile: caPath},
+		Observer: KubernetesAggregateObserverConfig{
+			Management:                  KubernetesAuthorityConfig{Endpoint: "https://192.0.2.20:6443", AuthorityIdentity: bundle.plan.Authorities.Management, TokenFile: managementTokenPath, CAFile: caPath, CABundleDigest: digest.SHA256(ca)},
+			ExpectedManagementAuthority: bundle.plan.Authorities.Management,
+			Argo:                        KubernetesAuthorityConfig{Endpoint: "https://192.0.2.30:6443", AuthorityIdentity: bundle.plan.Authorities.GitOps, TokenFile: argoTokenPath, CAFile: caPath, CABundleDigest: digest.SHA256(ca)},
+			ExpectedArgoAuthority:       bundle.plan.Authorities.GitOps,
+			Namespace:                   bundle.plan.ContractIdentity.Namespace, Name: bundle.plan.ContractIdentity.Name, HCPName: bundle.plan.ContractIdentity.Name + "-cilium",
+			NetworkProfile: networkProfile, PlatformProfile: platformProfile,
+			WorkloadAuthority: WorkloadAuthorityResolverFunc(func(_ context.Context, policy observation.Policy) (KubernetesAuthorityConfig, error) {
+				return KubernetesAuthorityConfig{AuthorityIdentity: policy.TargetClusterUID}, nil
+			}),
+			PlatformCapability: PlatformCapabilityResolverFunc(func(context.Context, observation.Policy, observation.PlatformProfile) (observation.PlatformCapabilitySource, error) {
+				return inertPlatformCapabilitySource{}, nil
+			}),
+			Clock: time.Now,
+		},
+		Runtime: runtime,
+	}
+}
+
+func bundleExpected(bundle VerifiedAggregateEvidenceStageBundle) stageplan.Expected {
+	return stageplan.Expected{
+		ContractIdentity: bundle.plan.ContractIdentity, IntentRevision: bundle.plan.IntentRevision,
+		EnablementRevision: bundle.plan.EnablementRevision, PlatformRevision: bundle.plan.PlatformRevision,
+		ExecutionFixture: bundle.plan.ExecutionFixture, InfrastructureAuthority: bundle.plan.Authorities.Infrastructure,
+		ManagementAuthority: bundle.plan.Authorities.Management, GitOpsAuthority: bundle.plan.Authorities.GitOps,
+	}
+}
+
+func aggregateRuntimeBindingMaterial(t *testing.T, bundle VerifiedAggregateEvidenceStageBundle) VerifiedRuntimeBindingMaterial {
+	t.Helper()
+	material := RuntimeBindingMaterial{
+		Format: RuntimeBindingMaterialFormat, State: "CURRENT_RUNTIME_BOUND", PlanDigest: bundle.plan.PlanDigest,
+		IntentRevision: bundle.plan.IntentRevision, EnablementRevision: bundle.plan.EnablementRevision,
+		PlatformRevision: bundle.plan.PlatformRevision, ExecutionFixture: bundle.plan.ExecutionFixture,
+		Target:   RuntimeBindingTarget{Name: bundle.plan.ContractIdentity.Name, CAPIClusterUID: targetAccessRuntimeUID, TargetIdentityScheme: "capi-cluster-uid/v1", WorkloadAPIEndpoint: "https://192.0.2.40:6443", WorkloadAPICAData: "Y2E=", WorkloadAPICADigest: runnerStageSHA("1"), KubeSystemUID: "kube-system-runtime-uid"},
+		Storage:  RuntimeBindingStorage{Name: "local-path", UID: "local-path-runtime-uid", Provisioner: "rancher.io/local-path"},
+		Evidence: RuntimeBindingEvidence{LifecycleEvidenceDigest: runnerStageSHA("2"), NetworkEvidenceDigest: runnerStageSHA("3")},
+	}
+	raw, err := canonicalRuntimeBinding(material)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt := RuntimeBindingMaterialReceipt{
+		Format: RuntimeBindingMaterialFormat, State: "VERIFIED", StageID: "runtime-binding", PlanDigest: bundle.plan.PlanDigest,
+		IntentRevision: bundle.plan.IntentRevision, TargetClusterUIDDigest: digest.SHA256([]byte(material.Target.CAPIClusterUID)), WorkloadAPICADigest: runnerStageSHA("1"),
+		KubeSystemUIDDigest: digest.SHA256([]byte(material.Target.KubeSystemUID)), LocalPathStorageUIDDigest: digest.SHA256([]byte(material.Storage.UID)),
+		LifecycleEvidenceDigest: runnerStageSHA("2"), NetworkEvidenceDigest: runnerStageSHA("3"),
+		PrivateMaterialDigest: digest.SHA256(raw), PersistentMutationAllowed: false,
+	}
+	return VerifiedRuntimeBindingMaterial{material: material, raw: raw, receipt: receipt, verified: true}
+}

--- a/internal/runner/aggregate_evidence_stage_runtime.go
+++ b/internal/runner/aggregate_evidence_stage_runtime.go
@@ -1,0 +1,96 @@
+package runner
+
+import (
+	"context"
+	"errors"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/execution"
+	"github.com/openkubes/ok-cluster/internal/observation"
+	"github.com/openkubes/ok-cluster/internal/stagecursor"
+	"github.com/openkubes/ok-cluster/internal/stageplan"
+)
+
+type AggregateEvidenceStageRuntimeConfig struct {
+	Ledger   KubernetesLedgerConfig
+	Observer KubernetesAggregateObserverConfig
+	Runtime  VerifiedRuntimeBindingMaterial
+}
+
+type OpenedAggregateEvidenceStage struct {
+	operation execution.EvaluationStageOperation
+	plan      stageplan.Binding
+	cursor    stagecursor.Cursor
+	verified  bool
+}
+
+// Open validates credentials and composes the final bounded source pass, but
+// performs no Kubernetes request.
+func (bundle VerifiedAggregateEvidenceStageBundle) Open(config AggregateEvidenceStageRuntimeConfig) (OpenedAggregateEvidenceStage, error) {
+	if err := verifyAggregateEvidenceStageBundle(bundle); err != nil {
+		return OpenedAggregateEvidenceStage{}, err
+	}
+	if err := verifyRuntimeBindingMaterial(config.Runtime); err != nil ||
+		config.Runtime.receipt.PlanDigest != bundle.plan.PlanDigest || config.Runtime.material.PlanDigest != bundle.plan.PlanDigest ||
+		config.Runtime.material.IntentRevision != bundle.plan.IntentRevision || config.Runtime.material.EnablementRevision != bundle.plan.EnablementRevision ||
+		config.Runtime.material.PlatformRevision != bundle.plan.PlatformRevision || config.Runtime.material.ExecutionFixture != bundle.plan.ExecutionFixture ||
+		config.Runtime.receipt.TargetClusterUIDDigest != digest.SHA256([]byte(config.Runtime.material.Target.CAPIClusterUID)) {
+		return OpenedAggregateEvidenceStage{}, errors.New("aggregate evidence runtime differs from verified execution target")
+	}
+	lifecycle, err := bundle.prefix[1].Receipt()
+	if err != nil || lifecycle.TargetClusterUIDDigest != config.Runtime.receipt.TargetClusterUIDDigest {
+		return OpenedAggregateEvidenceStage{}, errors.New("aggregate evidence runtime differs from durable lifecycle target")
+	}
+	if config.Observer.ExpectedManagementAuthority != bundle.plan.Authorities.Management || config.Observer.Management.AuthorityIdentity != bundle.plan.Authorities.Management ||
+		config.Observer.ExpectedArgoAuthority != bundle.plan.Authorities.GitOps || config.Observer.Argo.AuthorityIdentity != bundle.plan.Authorities.GitOps ||
+		config.Observer.Namespace != bundle.plan.ContractIdentity.Namespace || config.Observer.Name != bundle.plan.ContractIdentity.Name || config.Observer.HCPName != bundle.plan.ContractIdentity.Name+"-cilium" {
+		return OpenedAggregateEvidenceStage{}, errors.New("aggregate evidence source authorities differ from verified plan")
+	}
+	networkDigest, networkErr := observation.NetworkProfileDigest(config.Observer.NetworkProfile)
+	platformDigest, platformErr := observation.PlatformProfileDigest(config.Observer.PlatformProfile)
+	if networkErr != nil || platformErr != nil || config.Observer.NetworkProfile.IntentRevision != bundle.plan.IntentRevision || config.Observer.NetworkProfile.EnablementRevision != bundle.plan.EnablementRevision || config.Observer.PlatformProfile.IntentRevision != bundle.plan.IntentRevision || config.Observer.PlatformProfile.PlatformRevision != bundle.plan.PlatformRevision || config.Observer.PlatformProfile.ExecutionFixture != bundle.plan.ExecutionFixture || networkDigest == "" || platformDigest == "" {
+		return OpenedAggregateEvidenceStage{}, errors.New("aggregate evidence source profiles differ from verified plan")
+	}
+	networkStage, _, networkStageErr := bundle.plan.Stage("network-observation")
+	platformStage, _, platformStageErr := bundle.plan.Stage("platform-observation")
+	if networkStageErr != nil || platformStageErr != nil || len(networkStage.Inputs) != 1 || networkStage.Inputs[0].Digest != networkDigest || len(platformStage.Inputs) != 1 || platformStage.Inputs[0].Digest != platformDigest {
+		return OpenedAggregateEvidenceStage{}, errors.New("aggregate evidence source profiles differ from bound observation stages")
+	}
+	store, ledgerToken, err := openKubernetesLedger(config.Ledger)
+	if err != nil {
+		return OpenedAggregateEvidenceStage{}, errors.New("open aggregate evidence ledger")
+	}
+	managementToken, _, err := openBoundedKubernetesHTTP(config.Observer.Management.TokenFile, config.Observer.Management.CAFile)
+	if err != nil {
+		return OpenedAggregateEvidenceStage{}, errors.New("open aggregate management observation credential")
+	}
+	argoToken, _, err := openBoundedKubernetesHTTP(config.Observer.Argo.TokenFile, config.Observer.Argo.CAFile)
+	if err != nil {
+		return OpenedAggregateEvidenceStage{}, errors.New("open aggregate platform observation credential")
+	}
+	if sameSecret(ledgerToken, managementToken) || sameSecret(ledgerToken, argoToken) || sameSecret(managementToken, argoToken) {
+		return OpenedAggregateEvidenceStage{}, errors.New("aggregate evidence credentials must be pairwise distinct")
+	}
+	aggregate, err := OpenKubernetesAggregateObserver(config.Observer)
+	if err != nil {
+		return OpenedAggregateEvidenceStage{}, errors.New("open bounded Kubernetes aggregate observer")
+	}
+	evaluator, err := NewAggregateEvidenceStageEvaluator(AggregateEvidenceStageEvaluatorConfig{
+		Plan: bundle.plan, ReceiptPrefix: bundle.prefix, TargetClusterUID: config.Runtime.material.Target.CAPIClusterUID,
+		Profile: bundle.profile, Source: aggregate,
+	})
+	if err != nil {
+		return OpenedAggregateEvidenceStage{}, err
+	}
+	return OpenedAggregateEvidenceStage{
+		operation: execution.EvaluationStageOperation{Ledger: store, Evaluator: evaluator},
+		plan:      bundle.plan, cursor: bundle.cursor, verified: true,
+	}, nil
+}
+
+func (stage OpenedAggregateEvidenceStage) Run(ctx context.Context) (execution.EvaluationStageRunReceipt, error) {
+	if !stage.verified {
+		return execution.EvaluationStageRunReceipt{}, errors.New("aggregate evidence stage is not opened")
+	}
+	return stage.operation.Run(ctx, stage.plan, stage.cursor)
+}

--- a/internal/runner/platform_applications_stage_bundle_test.go
+++ b/internal/runner/platform_applications_stage_bundle_test.go
@@ -125,6 +125,11 @@ func platformApplicationsBundleFixture(t *testing.T) platformApplicationsBundleT
 	if err != nil {
 		t.Fatal(err)
 	}
+	networkProfile := runnerAggregateNetworkProfile(expectedPlan)
+	networkProfileDigest, err := observation.NetworkProfileDigest(networkProfile)
+	if err != nil {
+		t.Fatal(err)
+	}
 	aggregateProfile := AggregateEvidenceProfile{
 		Format: AggregateEvidenceProfileFormat, IntentRevision: expectedPlan.IntentRevision,
 		EnablementRevision: expectedPlan.EnablementRevision, PlatformRevision: expectedPlan.PlatformRevision,
@@ -144,6 +149,7 @@ func platformApplicationsBundleFixture(t *testing.T) platformApplicationsBundleT
 	stages[7].(map[string]any)["inputs"] = []any{map[string]any{"name": "stage.target-credential", "digest": runnerStageSHA("4")}}
 	stages[8].(map[string]any)["inputs"] = []any{map[string]any{"name": "stage.target-registration", "digest": runnerStageSHA("5")}}
 	stages[9].(map[string]any)["inputs"] = []any{map[string]any{"name": "stage.platform-applications", "digest": artifactDigest}}
+	stages[4].(map[string]any)["inputs"] = []any{map[string]any{"name": "stage.network-observation", "digest": networkProfileDigest}}
 	stages[10].(map[string]any)["inputs"] = []any{map[string]any{"name": "stage.platform-observation", "digest": profileDigest}}
 	stages[11].(map[string]any)["inputs"] = []any{map[string]any{"name": "stage.aggregate-evidence", "digest": aggregateProfileDigest}}
 	planPath := writeBundleFile(t, root, "staged-plan.json", mustJSON(t, document))
@@ -237,4 +243,17 @@ func runnerPlatformApplications(t *testing.T, expected stageplan.Expected) ([]by
 		CapabilityContractDigest: runnerStageSHA("7"), CapabilityExecutableDigest: runnerStageSHA("8"), MaximumCapabilityAgeSeconds: 900,
 	}
 	return []byte(strings.Join([]string{string(documents[0]), string(documents[1]), string(documents[2])}, "\n---\n")), profile
+}
+
+func runnerAggregateNetworkProfile(expected stageplan.Expected) observation.NetworkProfile {
+	return observation.NetworkProfile{
+		Format: observation.NetworkProfileFormat, IntentRevision: expected.IntentRevision, EnablementRevision: expected.EnablementRevision,
+		ExpectedNodeCount: 2, ExpectedHCPSpecDigest: runnerStageSHA("4"), ExpectedHRPSpecDigest: runnerStageSHA("5"),
+		ExpectedImages: observation.NetworkImages{
+			CiliumAgent:    "example.invalid/cilium@sha256:" + strings.Repeat("1", 64),
+			CiliumEnvoy:    "example.invalid/envoy@sha256:" + strings.Repeat("2", 64),
+			CiliumOperator: "example.invalid/operator@sha256:" + strings.Repeat("3", 64),
+		},
+		MinimumProbeFreshnessSeconds: 60, MaximumProbeIntervalSeconds: 60, CacheExposureSeconds: 30,
+	}
 }


### PR DESCRIPTION
## Summary

- compose Stage 12 with the existing bounded CAPI, NetworkReady, and PlatformReady sources
- bind the final runtime policy to the private CAPI Cluster UID and the exact prior Network/Platform profile identities
- map deterministic aggregate `True`, `False`, and `Unknown` to durable `SUCCEEDED`, `FAILED`, and `STOPPED` outcomes
- require pairwise-distinct ledger, management-observer, and Argo-observer credentials

## Architecture boundary

- exactly one read-only source pass; convergence polling remains owned by the earlier observation stages
- no authorization grant, Kubernetes mutation, retry, status publication, or source-resource repair
- credentials and private runtime identity are never retained in public receipts

## Verification

- `go test -ldflags=-linkmode=external ./...`
- `go vet ./...`
- `go test -race -ldflags=-linkmode=external ./internal/execution ./internal/runner`

OK-147
