### PR TITLE
OK-147: package immutable aggregate evidence stage input

### DIFF
--- a/internal/runner/aggregate_evidence_profile.go
+++ b/internal/runner/aggregate_evidence_profile.go
@@ -5,10 +5,13 @@ import (
 	"errors"
 
 	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/jsonstrict"
 	"github.com/openkubes/ok-cluster/internal/stageplan"
 )
 
 const AggregateEvidenceProfileFormat = "ok147-aggregate-evidence-profile/v1"
+
+const maximumAggregateEvidenceProfileBytes = 64 * 1024
 
 var aggregateEvidenceRequiredConditions = []string{
 	"InfrastructureReady",
@@ -30,6 +33,20 @@ type AggregateEvidenceProfile struct {
 	Required           []string `json:"required"`
 }
 
+type AggregateEvidenceProfileFileConfig struct {
+	Path                       string
+	ExpectedProfileDigest      string
+	ExpectedIntentRevision     string
+	ExpectedEnablementRevision string
+	ExpectedPlatformRevision   string
+	ExpectedExecutionFixture   string
+}
+
+type LoadedAggregateEvidenceProfile struct {
+	Profile AggregateEvidenceProfile
+	Digest  string
+}
+
 func AggregateEvidenceProfileForPlan(plan stageplan.Binding) AggregateEvidenceProfile {
 	return AggregateEvidenceProfile{
 		Format: AggregateEvidenceProfileFormat, IntentRevision: plan.IntentRevision,
@@ -48,6 +65,39 @@ func AggregateEvidenceProfileDigest(profile AggregateEvidenceProfile) (string, e
 		return "", errors.New("encode aggregate evidence profile")
 	}
 	return digest.SHA256(raw), nil
+}
+
+// LoadAggregateEvidenceProfileFile reads one bounded regular strict-JSON
+// document and binds it to identities obtained from the verified staged plan.
+func LoadAggregateEvidenceProfileFile(config AggregateEvidenceProfileFileConfig) (LoadedAggregateEvidenceProfile, error) {
+	if config.Path == "" || !stageReceiptPrefixDigestPattern.MatchString(config.ExpectedProfileDigest) ||
+		!stageReceiptPrefixDigestPattern.MatchString(config.ExpectedIntentRevision) ||
+		!stageReceiptPrefixDigestPattern.MatchString(config.ExpectedEnablementRevision) ||
+		!stageReceiptPrefixDigestPattern.MatchString(config.ExpectedPlatformRevision) ||
+		!stageReceiptPrefixDigestPattern.MatchString(config.ExpectedExecutionFixture) {
+		return LoadedAggregateEvidenceProfile{}, errors.New("aggregate evidence profile file binding is invalid")
+	}
+	raw, err := readBoundedRegular(config.Path, maximumAggregateEvidenceProfileBytes)
+	if err != nil {
+		return LoadedAggregateEvidenceProfile{}, errors.New("read bounded aggregate evidence profile")
+	}
+	var profile AggregateEvidenceProfile
+	if err := jsonstrict.Decode(raw, &profile); err != nil {
+		return LoadedAggregateEvidenceProfile{}, errors.New("decode strict aggregate evidence profile")
+	}
+	if profile.IntentRevision != config.ExpectedIntentRevision || profile.EnablementRevision != config.ExpectedEnablementRevision ||
+		profile.PlatformRevision != config.ExpectedPlatformRevision || profile.ExecutionFixture != config.ExpectedExecutionFixture {
+		return LoadedAggregateEvidenceProfile{}, errors.New("aggregate evidence profile identity differs from verified execution input")
+	}
+	profileDigest, err := AggregateEvidenceProfileDigest(profile)
+	if err != nil {
+		return LoadedAggregateEvidenceProfile{}, errors.New("validate semantic aggregate evidence profile")
+	}
+	if profileDigest != config.ExpectedProfileDigest {
+		return LoadedAggregateEvidenceProfile{}, errors.New("aggregate evidence profile digest differs from verified execution input")
+	}
+	profile.Required = append([]string(nil), profile.Required...)
+	return LoadedAggregateEvidenceProfile{Profile: profile, Digest: profileDigest}, nil
 }
 
 func validateAggregateEvidenceProfile(profile AggregateEvidenceProfile) error {

--- a/internal/runner/aggregate_evidence_stage_input.go
+++ b/internal/runner/aggregate_evidence_stage_input.go
@@ -1,0 +1,172 @@
+package runner
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"sort"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+const AggregateEvidenceStageInputFormat = "ok147-aggregate-evidence-stage-input/v1"
+
+type AggregateEvidenceStageInputConfig struct {
+	Bundle                         StageResumeConfig
+	AggregateEvidenceProfilePath   string
+	ExpectedAggregateProfileDigest string
+	ConfigMapName                  string
+}
+
+type AggregateEvidenceStageInputReceipt struct {
+	Format                 string   `json:"format"`
+	State                  string   `json:"state"`
+	StageID                string   `json:"stageId"`
+	ConfigMapName          string   `json:"configMapName"`
+	ConfigMapDigest        string   `json:"configMapDigest"`
+	ReceiptPrefixDigest    string   `json:"receiptPrefixDigest"`
+	AggregateProfileDigest string   `json:"aggregateProfileDigest"`
+	DataKeys               []string `json:"dataKeys"`
+}
+
+type VerifiedAggregateEvidenceStageInput struct {
+	raw      []byte
+	receipt  AggregateEvidenceStageInputReceipt
+	verified bool
+}
+
+var aggregateEvidenceReceiptFiles = []string{
+	"provider-receipt.json",
+	"lifecycle-receipt.json",
+	"lifecycle-observation-receipt.json",
+	"enablement-receipt.json",
+	"network-observation-receipt.json",
+	"runtime-binding-receipt.json",
+	"target-access-receipt.json",
+	"target-credential-receipt.json",
+	"target-registration-receipt.json",
+	"platform-applications-receipt.json",
+	"platform-observation-receipt.json",
+}
+
+// BuildAggregateEvidenceStageInput snapshots the exact public Stage-12 input.
+// Private runtime identity, credentials, endpoints, CA material and capability
+// evidence remain outside this immutable ConfigMap.
+func BuildAggregateEvidenceStageInput(config AggregateEvidenceStageInputConfig) (VerifiedAggregateEvidenceStageInput, error) {
+	if !submissionStageInputNamePattern.MatchString(config.ConfigMapName) || len(config.ConfigMapName) > 63 || !strings.HasPrefix(config.ConfigMapName, "ok147-") {
+		return VerifiedAggregateEvidenceStageInput{}, errors.New("aggregate evidence input ConfigMap name is invalid")
+	}
+	if len(config.Bundle.Receipts) != len(aggregateEvidenceReceiptFiles) {
+		return VerifiedAggregateEvidenceStageInput{}, errors.New("aggregate evidence input requires the exact eleven-receipt prefix")
+	}
+	plan, _, _, err := loadStageResumeWithPrefix(config.Bundle)
+	if err != nil {
+		return VerifiedAggregateEvidenceStageInput{}, err
+	}
+	profile, err := LoadAggregateEvidenceProfileFile(AggregateEvidenceProfileFileConfig{
+		Path: config.AggregateEvidenceProfilePath, ExpectedProfileDigest: config.ExpectedAggregateProfileDigest,
+		ExpectedIntentRevision: plan.IntentRevision, ExpectedEnablementRevision: plan.EnablementRevision,
+		ExpectedPlatformRevision: plan.PlatformRevision, ExpectedExecutionFixture: plan.ExecutionFixture,
+	})
+	if err != nil {
+		return VerifiedAggregateEvidenceStageInput{}, errors.New("load public aggregate evidence profile")
+	}
+	if _, err := LoadAggregateEvidenceStageBundle(AggregateEvidenceStageBundleConfig{
+		StageResumeConfig: config.Bundle, Profile: profile.Profile, ExpectedProfileDigest: profile.Digest,
+	}); err != nil {
+		return VerifiedAggregateEvidenceStageInput{}, err
+	}
+
+	prefix := stageReceiptPrefixDocument{Format: StageReceiptPrefixFormat, Receipts: make([]stageReceiptPrefixEntry, len(aggregateEvidenceReceiptFiles))}
+	paths := map[string]string{
+		"staged-plan.json":                config.Bundle.PlanPath,
+		"aggregate-evidence-profile.json": config.AggregateEvidenceProfilePath,
+	}
+	for index, file := range aggregateEvidenceReceiptFiles {
+		prefix.Receipts[index] = stageReceiptPrefixEntry{File: file, Digest: config.Bundle.Receipts[index].Digest}
+		paths[file] = config.Bundle.Receipts[index].Path
+	}
+	prefixRaw, err := json.Marshal(prefix)
+	if err != nil {
+		return VerifiedAggregateEvidenceStageInput{}, errors.New("encode aggregate evidence receipt prefix")
+	}
+	data := make(map[string]string, len(paths)+1)
+	data["receipt-prefix.json"] = string(prefixRaw)
+	for key, path := range paths {
+		raw, err := readBoundedRegular(path, maximumSubmissionStageInputBytes)
+		if err != nil {
+			return VerifiedAggregateEvidenceStageInput{}, errors.New("read bounded aggregate evidence input " + key)
+		}
+		if !utf8.Valid(raw) || bytes.IndexByte(raw, 0) >= 0 {
+			return VerifiedAggregateEvidenceStageInput{}, errors.New("aggregate evidence input is not valid ConfigMap text")
+		}
+		data[key] = string(raw)
+	}
+	if _, err := LoadAggregateEvidenceStageBundle(AggregateEvidenceStageBundleConfig{
+		StageResumeConfig: config.Bundle, Profile: profile.Profile, ExpectedProfileDigest: profile.Digest,
+	}); err != nil {
+		return VerifiedAggregateEvidenceStageInput{}, errors.New("aggregate evidence receipts changed during materialization")
+	}
+	if _, err := LoadAggregateEvidenceProfileFile(AggregateEvidenceProfileFileConfig{
+		Path: config.AggregateEvidenceProfilePath, ExpectedProfileDigest: profile.Digest,
+		ExpectedIntentRevision: plan.IntentRevision, ExpectedEnablementRevision: plan.EnablementRevision,
+		ExpectedPlatformRevision: plan.PlatformRevision, ExpectedExecutionFixture: plan.ExecutionFixture,
+	}); err != nil {
+		return VerifiedAggregateEvidenceStageInput{}, errors.New("aggregate evidence profile changed during materialization")
+	}
+
+	configMap := submissionStageInputConfigMap{
+		APIVersion: "v1", Kind: "ConfigMap",
+		Metadata: submissionStageInputObjectMeta{
+			Name: config.ConfigMapName, Namespace: submissionStageInputNamespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/name": "ok-cluster-contract-executor", "openkubes.io/stage-id": "aggregate-evidence",
+			},
+			Annotations: map[string]string{
+				"openkubes.io/input-format":             AggregateEvidenceStageInputFormat,
+				"openkubes.io/receipt-prefix-digest":    digest.SHA256(prefixRaw),
+				"openkubes.io/aggregate-profile-digest": profile.Digest,
+			},
+		},
+		Immutable: true, Data: data,
+	}
+	raw, err := json.Marshal(configMap)
+	if err != nil {
+		return VerifiedAggregateEvidenceStageInput{}, errors.New("encode aggregate evidence input ConfigMap")
+	}
+	if len(raw) > maximumSubmissionStageInputBytes {
+		return VerifiedAggregateEvidenceStageInput{}, errors.New("aggregate evidence input ConfigMap exceeds size limit")
+	}
+	dataKeys := make([]string, 0, len(data))
+	for key := range data {
+		dataKeys = append(dataKeys, key)
+	}
+	sort.Strings(dataKeys)
+	return VerifiedAggregateEvidenceStageInput{
+		raw: raw,
+		receipt: AggregateEvidenceStageInputReceipt{
+			Format: AggregateEvidenceStageInputFormat, State: "VERIFIED", StageID: "aggregate-evidence",
+			ConfigMapName: config.ConfigMapName, ConfigMapDigest: digest.SHA256(raw),
+			ReceiptPrefixDigest: digest.SHA256(prefixRaw), AggregateProfileDigest: profile.Digest, DataKeys: dataKeys,
+		},
+		verified: true,
+	}, nil
+}
+
+func (input VerifiedAggregateEvidenceStageInput) Bytes() ([]byte, error) {
+	if !input.verified || len(input.raw) == 0 {
+		return nil, errors.New("aggregate evidence input was not produced by verification")
+	}
+	return append([]byte(nil), input.raw...), nil
+}
+
+func (input VerifiedAggregateEvidenceStageInput) Receipt() (AggregateEvidenceStageInputReceipt, error) {
+	if !input.verified || input.receipt.State != "VERIFIED" || digest.SHA256(input.raw) != input.receipt.ConfigMapDigest {
+		return AggregateEvidenceStageInputReceipt{}, errors.New("aggregate evidence input was not produced by verification")
+	}
+	receipt := input.receipt
+	receipt.DataKeys = append([]string(nil), input.receipt.DataKeys...)
+	return receipt, nil
+}

--- a/internal/runner/aggregate_evidence_stage_input_test.go
+++ b/internal/runner/aggregate_evidence_stage_input_test.go
@@ -1,0 +1,156 @@
+package runner
+
+import (
+	"encoding/json"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+func TestAggregateEvidenceProfileFileBindsCanonicalIdentity(t *testing.T) {
+	fixture := aggregateEvidenceBundleFixture(t)
+	root := t.TempDir()
+	profilePath := writeAggregateEvidenceProfile(t, root, fixture.Profile)
+	loaded, err := LoadAggregateEvidenceProfileFile(AggregateEvidenceProfileFileConfig{
+		Path: profilePath, ExpectedProfileDigest: fixture.ExpectedProfileDigest,
+		ExpectedIntentRevision: fixture.Profile.IntentRevision, ExpectedEnablementRevision: fixture.Profile.EnablementRevision,
+		ExpectedPlatformRevision: fixture.Profile.PlatformRevision, ExpectedExecutionFixture: fixture.Profile.ExecutionFixture,
+	})
+	if err != nil || loaded.Digest != fixture.ExpectedProfileDigest || !reflect.DeepEqual(loaded.Profile, fixture.Profile) {
+		t.Fatalf("aggregate evidence profile did not load: %#v %v", loaded, err)
+	}
+	loaded.Profile.Required[0] = "changed"
+	again, err := LoadAggregateEvidenceProfileFile(AggregateEvidenceProfileFileConfig{
+		Path: profilePath, ExpectedProfileDigest: fixture.ExpectedProfileDigest,
+		ExpectedIntentRevision: fixture.Profile.IntentRevision, ExpectedEnablementRevision: fixture.Profile.EnablementRevision,
+		ExpectedPlatformRevision: fixture.Profile.PlatformRevision, ExpectedExecutionFixture: fixture.Profile.ExecutionFixture,
+	})
+	if err != nil || again.Profile.Required[0] != aggregateEvidenceRequiredConditions[0] {
+		t.Fatal("caller mutated subsequently loaded aggregate evidence profile")
+	}
+}
+
+func TestAggregateEvidenceProfileFileRejectsMalformedOrForeignInput(t *testing.T) {
+	fixture := aggregateEvidenceBundleFixture(t)
+	root := t.TempDir()
+	profilePath := writeAggregateEvidenceProfile(t, root, fixture.Profile)
+	base := AggregateEvidenceProfileFileConfig{
+		Path: profilePath, ExpectedProfileDigest: fixture.ExpectedProfileDigest,
+		ExpectedIntentRevision: fixture.Profile.IntentRevision, ExpectedEnablementRevision: fixture.Profile.EnablementRevision,
+		ExpectedPlatformRevision: fixture.Profile.PlatformRevision, ExpectedExecutionFixture: fixture.Profile.ExecutionFixture,
+	}
+	for name, mutate := range map[string]func(*AggregateEvidenceProfileFileConfig){
+		"foreign digest": func(config *AggregateEvidenceProfileFileConfig) { config.ExpectedProfileDigest = runnerStageSHA("f") },
+		"foreign intent": func(config *AggregateEvidenceProfileFileConfig) { config.ExpectedIntentRevision = runnerStageSHA("f") },
+		"missing path":   func(config *AggregateEvidenceProfileFileConfig) { config.Path = "" },
+		"foreign platform": func(config *AggregateEvidenceProfileFileConfig) {
+			config.ExpectedPlatformRevision = runnerStageSHA("f")
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			config := base
+			mutate(&config)
+			if _, err := LoadAggregateEvidenceProfileFile(config); err == nil {
+				t.Fatal("unsafe aggregate evidence profile was accepted")
+			}
+		})
+	}
+	malformed := writeBundleFile(t, root, "aggregate-malformed.json", []byte(`{"format":"ok147-aggregate-evidence-profile/v1","unknown":true}`))
+	base.Path = malformed
+	if _, err := LoadAggregateEvidenceProfileFile(base); err == nil {
+		t.Fatal("unknown aggregate evidence profile field was accepted")
+	}
+}
+
+func TestBuildAggregateEvidenceStageInputContainsOnlyPublicBoundInputs(t *testing.T) {
+	fixture := aggregateEvidenceBundleFixture(t)
+	root := t.TempDir()
+	profilePath := writeAggregateEvidenceProfile(t, root, fixture.Profile)
+	input, err := BuildAggregateEvidenceStageInput(AggregateEvidenceStageInputConfig{
+		Bundle: fixture.StageResumeConfig, AggregateEvidenceProfilePath: profilePath,
+		ExpectedAggregateProfileDigest: fixture.ExpectedProfileDigest, ConfigMapName: "ok147-aggregate-evidence-input",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := input.Bytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := input.Receipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var object map[string]any
+	if err := json.Unmarshal(raw, &object); err != nil {
+		t.Fatal(err)
+	}
+	if object["kind"] != "ConfigMap" || object["immutable"] != true || objectAt(t, object, "metadata")["name"] != "ok147-aggregate-evidence-input" {
+		t.Fatalf("unexpected aggregate evidence input: %#v", object)
+	}
+	data := objectAt(t, object, "data")
+	wantKeys := append([]string{"aggregate-evidence-profile.json", "receipt-prefix.json", "staged-plan.json"}, aggregateEvidenceReceiptFiles...)
+	sort.Strings(wantKeys)
+	gotKeys := make([]string, 0, len(data))
+	for key := range data {
+		gotKeys = append(gotKeys, key)
+	}
+	sort.Strings(gotKeys)
+	if !reflect.DeepEqual(gotKeys, wantKeys) || data["token"] != nil || data["ca.crt"] != nil || data["runtime-binding.json"] != nil || data["capability-evidence.json"] != nil {
+		t.Fatalf("aggregate evidence public input boundary differs: %v", gotKeys)
+	}
+	if receipt.Format != AggregateEvidenceStageInputFormat || receipt.StageID != "aggregate-evidence" || receipt.ConfigMapDigest != digest.SHA256(raw) || receipt.AggregateProfileDigest != fixture.ExpectedProfileDigest || !reflect.DeepEqual(receipt.DataKeys, wantKeys) {
+		t.Fatalf("unexpected aggregate evidence input receipt: %#v", receipt)
+	}
+	raw[0] = 'x'
+	again, _ := input.Bytes()
+	if again[0] != '{' {
+		t.Fatal("caller mutated retained aggregate evidence input")
+	}
+}
+
+func TestBuildAggregateEvidenceStageInputFailsClosed(t *testing.T) {
+	fixture := aggregateEvidenceBundleFixture(t)
+	root := t.TempDir()
+	profilePath := writeAggregateEvidenceProfile(t, root, fixture.Profile)
+	valid := AggregateEvidenceStageInputConfig{
+		Bundle: fixture.StageResumeConfig, AggregateEvidenceProfilePath: profilePath,
+		ExpectedAggregateProfileDigest: fixture.ExpectedProfileDigest, ConfigMapName: "ok147-aggregate-evidence-input",
+	}
+	for name, mutate := range map[string]func(*AggregateEvidenceStageInputConfig){
+		"missing receipt": func(config *AggregateEvidenceStageInputConfig) { config.Bundle.Receipts = config.Bundle.Receipts[:10] },
+		"invalid name":    func(config *AggregateEvidenceStageInputConfig) { config.ConfigMapName = "aggregate-evidence-input" },
+		"foreign digest": func(config *AggregateEvidenceStageInputConfig) {
+			config.ExpectedAggregateProfileDigest = runnerStageSHA("f")
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			config := valid
+			mutate(&config)
+			if _, err := BuildAggregateEvidenceStageInput(config); err == nil {
+				t.Fatal("unsafe aggregate evidence stage input was accepted")
+			}
+		})
+	}
+	if _, err := (VerifiedAggregateEvidenceStageInput{}).Bytes(); err == nil {
+		t.Fatal("unverified aggregate evidence input bytes were exposed")
+	}
+	if _, err := (VerifiedAggregateEvidenceStageInput{}).Receipt(); err == nil {
+		t.Fatal("unverified aggregate evidence input receipt was exposed")
+	}
+	if !strings.HasPrefix(valid.ConfigMapName, "ok147-") {
+		t.Fatal("test fixture no longer exercises OK-147 name boundary")
+	}
+}
+
+func writeAggregateEvidenceProfile(t *testing.T, root string, profile AggregateEvidenceProfile) string {
+	t.Helper()
+	raw, err := json.Marshal(profile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return writeBundleFile(t, root, "aggregate-evidence-profile.json", raw)
+}


### PR DESCRIPTION
## What changed

- add a bounded strict-JSON loader for the Stage 12 aggregate-evidence profile
- package the exact staged plan, eleven-receipt prefix, and public aggregate profile into one immutable ConfigMap
- expose a redaction-safe verification receipt with ConfigMap, prefix, and profile digests
- reject malformed, foreign, incomplete, oversized, or mutable input fail closed

## Why

The 12-stage runtime chain is complete, but the final stage still lacked a Kubernetes-safe public input envelope shared by a future local CLI and bounded Job. This checkpoint adds that envelope without introducing orchestration or infrastructure mutation.

Private runtime identity, credentials, endpoints, CA material, capability evidence, and tokens are explicitly excluded.

## Validation

- `go test -ldflags=-linkmode=external ./...`
- `go vet ./...`
- `go test -race -ldflags=-linkmode=external ./internal/runner`

All checks pass. The macOS linker emits the repository's known non-failing platform-load warning.
