### PR TITLE
OK-147: bind aggregate source profiles

### DIFF
--- a/internal/runner/aggregate_evidence_stage_input.go
+++ b/internal/runner/aggregate_evidence_stage_input.go
@@ -11,12 +11,16 @@ import (
 	"github.com/openkubes/ok-cluster/internal/digest"
 )
 
-const AggregateEvidenceStageInputFormat = "ok147-aggregate-evidence-stage-input/v1"
+const AggregateEvidenceStageInputFormat = "ok147-aggregate-evidence-stage-input/v2"
 
 type AggregateEvidenceStageInputConfig struct {
 	Bundle                         StageResumeConfig
 	AggregateEvidenceProfilePath   string
 	ExpectedAggregateProfileDigest string
+	NetworkProfilePath             string
+	ExpectedNetworkProfileDigest   string
+	PlatformProfilePath            string
+	ExpectedPlatformProfileDigest  string
 	ConfigMapName                  string
 }
 
@@ -28,6 +32,8 @@ type AggregateEvidenceStageInputReceipt struct {
 	ConfigMapDigest        string   `json:"configMapDigest"`
 	ReceiptPrefixDigest    string   `json:"receiptPrefixDigest"`
 	AggregateProfileDigest string   `json:"aggregateProfileDigest"`
+	NetworkProfileDigest   string   `json:"networkProfileDigest"`
+	PlatformProfileDigest  string   `json:"platformProfileDigest"`
 	DataKeys               []string `json:"dataKeys"`
 }
 
@@ -73,6 +79,26 @@ func BuildAggregateEvidenceStageInput(config AggregateEvidenceStageInputConfig) 
 	if err != nil {
 		return VerifiedAggregateEvidenceStageInput{}, errors.New("load public aggregate evidence profile")
 	}
+	networkProfile, err := LoadNetworkProfileFile(NetworkProfileFileConfig{
+		Path: config.NetworkProfilePath, ExpectedProfileDigest: config.ExpectedNetworkProfileDigest,
+		ExpectedIntentRevision: plan.IntentRevision, ExpectedEnablementRevision: plan.EnablementRevision,
+	})
+	if err != nil {
+		return VerifiedAggregateEvidenceStageInput{}, errors.New("load public aggregate network profile")
+	}
+	platformProfile, err := LoadPlatformProfileFile(PlatformProfileFileConfig{
+		Path: config.PlatformProfilePath, ExpectedProfileDigest: config.ExpectedPlatformProfileDigest,
+		ExpectedIntentRevision: plan.IntentRevision, ExpectedPlatformRevision: plan.PlatformRevision,
+		ExpectedExecutionFixture: plan.ExecutionFixture,
+	})
+	if err != nil {
+		return VerifiedAggregateEvidenceStageInput{}, errors.New("load public aggregate platform profile")
+	}
+	networkStage, _, networkStageErr := plan.Stage("network-observation")
+	platformStage, _, platformStageErr := plan.Stage("platform-observation")
+	if networkStageErr != nil || platformStageErr != nil || len(networkStage.Inputs) != 1 || networkStage.Inputs[0].Digest != networkProfile.Digest || len(platformStage.Inputs) != 1 || platformStage.Inputs[0].Digest != platformProfile.Digest {
+		return VerifiedAggregateEvidenceStageInput{}, errors.New("aggregate source profiles differ from verified stage plan")
+	}
 	if _, err := LoadAggregateEvidenceStageBundle(AggregateEvidenceStageBundleConfig{
 		StageResumeConfig: config.Bundle, Profile: profile.Profile, ExpectedProfileDigest: profile.Digest,
 	}); err != nil {
@@ -83,6 +109,8 @@ func BuildAggregateEvidenceStageInput(config AggregateEvidenceStageInputConfig) 
 	paths := map[string]string{
 		"staged-plan.json":                config.Bundle.PlanPath,
 		"aggregate-evidence-profile.json": config.AggregateEvidenceProfilePath,
+		"network-profile.json":            config.NetworkProfilePath,
+		"platform-profile.json":           config.PlatformProfilePath,
 	}
 	for index, file := range aggregateEvidenceReceiptFiles {
 		prefix.Receipts[index] = stageReceiptPrefixEntry{File: file, Digest: config.Bundle.Receipts[index].Digest}
@@ -116,6 +144,19 @@ func BuildAggregateEvidenceStageInput(config AggregateEvidenceStageInputConfig) 
 	}); err != nil {
 		return VerifiedAggregateEvidenceStageInput{}, errors.New("aggregate evidence profile changed during materialization")
 	}
+	if _, err := LoadNetworkProfileFile(NetworkProfileFileConfig{
+		Path: config.NetworkProfilePath, ExpectedProfileDigest: networkProfile.Digest,
+		ExpectedIntentRevision: plan.IntentRevision, ExpectedEnablementRevision: plan.EnablementRevision,
+	}); err != nil {
+		return VerifiedAggregateEvidenceStageInput{}, errors.New("aggregate network profile changed during materialization")
+	}
+	if _, err := LoadPlatformProfileFile(PlatformProfileFileConfig{
+		Path: config.PlatformProfilePath, ExpectedProfileDigest: platformProfile.Digest,
+		ExpectedIntentRevision: plan.IntentRevision, ExpectedPlatformRevision: plan.PlatformRevision,
+		ExpectedExecutionFixture: plan.ExecutionFixture,
+	}); err != nil {
+		return VerifiedAggregateEvidenceStageInput{}, errors.New("aggregate platform profile changed during materialization")
+	}
 
 	configMap := submissionStageInputConfigMap{
 		APIVersion: "v1", Kind: "ConfigMap",
@@ -128,6 +169,8 @@ func BuildAggregateEvidenceStageInput(config AggregateEvidenceStageInputConfig) 
 				"openkubes.io/input-format":             AggregateEvidenceStageInputFormat,
 				"openkubes.io/receipt-prefix-digest":    digest.SHA256(prefixRaw),
 				"openkubes.io/aggregate-profile-digest": profile.Digest,
+				"openkubes.io/network-profile-digest":   networkProfile.Digest,
+				"openkubes.io/platform-profile-digest":  platformProfile.Digest,
 			},
 		},
 		Immutable: true, Data: data,
@@ -149,7 +192,8 @@ func BuildAggregateEvidenceStageInput(config AggregateEvidenceStageInputConfig) 
 		receipt: AggregateEvidenceStageInputReceipt{
 			Format: AggregateEvidenceStageInputFormat, State: "VERIFIED", StageID: "aggregate-evidence",
 			ConfigMapName: config.ConfigMapName, ConfigMapDigest: digest.SHA256(raw),
-			ReceiptPrefixDigest: digest.SHA256(prefixRaw), AggregateProfileDigest: profile.Digest, DataKeys: dataKeys,
+			ReceiptPrefixDigest: digest.SHA256(prefixRaw), AggregateProfileDigest: profile.Digest,
+			NetworkProfileDigest: networkProfile.Digest, PlatformProfileDigest: platformProfile.Digest, DataKeys: dataKeys,
 		},
 		verified: true,
 	}, nil

--- a/internal/runner/aggregate_evidence_stage_input_test.go
+++ b/internal/runner/aggregate_evidence_stage_input_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/observation"
 )
 
 func TestAggregateEvidenceProfileFileBindsCanonicalIdentity(t *testing.T) {
@@ -69,9 +70,13 @@ func TestBuildAggregateEvidenceStageInputContainsOnlyPublicBoundInputs(t *testin
 	fixture := aggregateEvidenceBundleFixture(t)
 	root := t.TempDir()
 	profilePath := writeAggregateEvidenceProfile(t, root, fixture.Profile)
+	networkPath, networkDigest, platformPath, platformDigest := writeAggregateSourceProfiles(t, root, fixture)
 	input, err := BuildAggregateEvidenceStageInput(AggregateEvidenceStageInputConfig{
 		Bundle: fixture.StageResumeConfig, AggregateEvidenceProfilePath: profilePath,
-		ExpectedAggregateProfileDigest: fixture.ExpectedProfileDigest, ConfigMapName: "ok147-aggregate-evidence-input",
+		ExpectedAggregateProfileDigest: fixture.ExpectedProfileDigest,
+		NetworkProfilePath:             networkPath, ExpectedNetworkProfileDigest: networkDigest,
+		PlatformProfilePath: platformPath, ExpectedPlatformProfileDigest: platformDigest,
+		ConfigMapName: "ok147-aggregate-evidence-input",
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -92,7 +97,7 @@ func TestBuildAggregateEvidenceStageInputContainsOnlyPublicBoundInputs(t *testin
 		t.Fatalf("unexpected aggregate evidence input: %#v", object)
 	}
 	data := objectAt(t, object, "data")
-	wantKeys := append([]string{"aggregate-evidence-profile.json", "receipt-prefix.json", "staged-plan.json"}, aggregateEvidenceReceiptFiles...)
+	wantKeys := append([]string{"aggregate-evidence-profile.json", "network-profile.json", "platform-profile.json", "receipt-prefix.json", "staged-plan.json"}, aggregateEvidenceReceiptFiles...)
 	sort.Strings(wantKeys)
 	gotKeys := make([]string, 0, len(data))
 	for key := range data {
@@ -102,7 +107,7 @@ func TestBuildAggregateEvidenceStageInputContainsOnlyPublicBoundInputs(t *testin
 	if !reflect.DeepEqual(gotKeys, wantKeys) || data["token"] != nil || data["ca.crt"] != nil || data["runtime-binding.json"] != nil || data["capability-evidence.json"] != nil {
 		t.Fatalf("aggregate evidence public input boundary differs: %v", gotKeys)
 	}
-	if receipt.Format != AggregateEvidenceStageInputFormat || receipt.StageID != "aggregate-evidence" || receipt.ConfigMapDigest != digest.SHA256(raw) || receipt.AggregateProfileDigest != fixture.ExpectedProfileDigest || !reflect.DeepEqual(receipt.DataKeys, wantKeys) {
+	if receipt.Format != AggregateEvidenceStageInputFormat || receipt.StageID != "aggregate-evidence" || receipt.ConfigMapDigest != digest.SHA256(raw) || receipt.AggregateProfileDigest != fixture.ExpectedProfileDigest || receipt.NetworkProfileDigest != networkDigest || receipt.PlatformProfileDigest != platformDigest || !reflect.DeepEqual(receipt.DataKeys, wantKeys) {
 		t.Fatalf("unexpected aggregate evidence input receipt: %#v", receipt)
 	}
 	raw[0] = 'x'
@@ -116,15 +121,25 @@ func TestBuildAggregateEvidenceStageInputFailsClosed(t *testing.T) {
 	fixture := aggregateEvidenceBundleFixture(t)
 	root := t.TempDir()
 	profilePath := writeAggregateEvidenceProfile(t, root, fixture.Profile)
+	networkPath, networkDigest, platformPath, platformDigest := writeAggregateSourceProfiles(t, root, fixture)
 	valid := AggregateEvidenceStageInputConfig{
 		Bundle: fixture.StageResumeConfig, AggregateEvidenceProfilePath: profilePath,
-		ExpectedAggregateProfileDigest: fixture.ExpectedProfileDigest, ConfigMapName: "ok147-aggregate-evidence-input",
+		ExpectedAggregateProfileDigest: fixture.ExpectedProfileDigest,
+		NetworkProfilePath:             networkPath, ExpectedNetworkProfileDigest: networkDigest,
+		PlatformProfilePath: platformPath, ExpectedPlatformProfileDigest: platformDigest,
+		ConfigMapName: "ok147-aggregate-evidence-input",
 	}
 	for name, mutate := range map[string]func(*AggregateEvidenceStageInputConfig){
 		"missing receipt": func(config *AggregateEvidenceStageInputConfig) { config.Bundle.Receipts = config.Bundle.Receipts[:10] },
 		"invalid name":    func(config *AggregateEvidenceStageInputConfig) { config.ConfigMapName = "aggregate-evidence-input" },
 		"foreign digest": func(config *AggregateEvidenceStageInputConfig) {
 			config.ExpectedAggregateProfileDigest = runnerStageSHA("f")
+		},
+		"foreign network profile": func(config *AggregateEvidenceStageInputConfig) {
+			config.ExpectedNetworkProfileDigest = runnerStageSHA("f")
+		},
+		"foreign platform profile": func(config *AggregateEvidenceStageInputConfig) {
+			config.ExpectedPlatformProfileDigest = runnerStageSHA("f")
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -153,4 +168,32 @@ func writeAggregateEvidenceProfile(t *testing.T, root string, profile AggregateE
 		t.Fatal(err)
 	}
 	return writeBundleFile(t, root, "aggregate-evidence-profile.json", raw)
+}
+
+func writeAggregateSourceProfiles(t *testing.T, root string, fixture AggregateEvidenceStageBundleConfig) (string, string, string, string) {
+	t.Helper()
+	bundle, err := LoadAggregateEvidenceStageBundle(fixture)
+	if err != nil {
+		t.Fatal(err)
+	}
+	networkProfile := runnerAggregateNetworkProfile(bundleExpected(bundle))
+	networkDigest, err := observation.NetworkProfileDigest(networkProfile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, platformProfile := runnerPlatformApplications(t, bundleExpected(bundle))
+	platformDigest, err := observation.PlatformProfileDigest(platformProfile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	networkRaw, err := json.Marshal(networkProfile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	platformRaw, err := json.Marshal(platformProfile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return writeBundleFile(t, root, "network-profile.json", networkRaw), networkDigest,
+		writeBundleFile(t, root, "platform-profile.json", platformRaw), platformDigest
 }


### PR DESCRIPTION
## What changed

- advance the Stage 12 public input envelope to `ok147-aggregate-evidence-stage-input/v2`
- bind the exact NetworkReady and PlatformReady source profiles required for fresh final evaluation
- verify both profile digests against their existing staged-plan inputs before and after materialization
- expose the two additional public profile identities in the redaction-safe input receipt

## Why

Job preparation exposed that the v1 envelope carried the aggregate policy but not the source semantics needed to evaluate NetworkReady and PlatformReady again. The v2 envelope closes that gap without introducing orchestration or infrastructure mutation.

Private runtime identity, credentials, endpoints, CA material, capability evidence, and tokens remain explicitly excluded.

## Validation

- `go test -ldflags=-linkmode=external ./...`
- `go vet ./...`
- `go test -race -ldflags=-linkmode=external ./internal/runner`

All checks pass. The macOS linker emits the repository's known non-failing platform-load warning.
