### PR TITLE
OK-147: replay persisted runtime binding

### DIFF
--- a/internal/runner/runtime_binding_kubernetes_store.go
+++ b/internal/runner/runtime_binding_kubernetes_store.go
@@ -21,6 +21,7 @@ const (
 	KubernetesRuntimeBindingPersistenceReceiptFormat = "ok147-kubernetes-runtime-binding-persistence-receipt/v1"
 	maximumRuntimeBindingSecretResponse              = 1024 * 1024
 	runtimeBindingSecretDataKey                      = "runtime-binding.json"
+	runtimeBindingReceiptSecretDataKey               = "runtime-binding-receipt.json"
 )
 
 type KubernetesRuntimeBindingPersistenceReceipt struct {
@@ -124,6 +125,10 @@ func (store *KubernetesRuntimeBindingStore) Store(ctx context.Context, material 
 	receipt.PrivateMaterialDigest = digest.SHA256(raw)
 	receipt.ObjectIdentityDigest = digest.SHA256([]byte(store.namespace + "/" + store.name))
 	receipt.AuthorityIdentityDigest = digest.SHA256([]byte(store.authority))
+	materialReceiptRaw, err := json.Marshal(materialReceipt)
+	if err != nil {
+		return receipt, errors.New("encode runtime binding material receipt")
+	}
 	secret := runtimeBindingSecret{
 		APIVersion: "v1", Kind: "Secret",
 		Metadata: runtimeBindingSecretObjectMeta{
@@ -135,7 +140,9 @@ func (store *KubernetesRuntimeBindingStore) Store(ctx context.Context, material 
 				"openkubes.io/content-digest": receipt.PrivateMaterialDigest, "openkubes.io/plan-digest": materialReceipt.PlanDigest,
 			},
 		},
-		Immutable: true, Type: "Opaque", Data: map[string][]byte{runtimeBindingSecretDataKey: raw},
+		Immutable: true, Type: "Opaque", Data: map[string][]byte{
+			runtimeBindingSecretDataKey: raw, runtimeBindingReceiptSecretDataKey: materialReceiptRaw,
+		},
 	}
 	body, err := json.Marshal(secret)
 	if err != nil {
@@ -220,7 +227,7 @@ func verifyRuntimeBindingSecret(raw []byte, expected runtimeBindingSecret, requi
 	if requireServerIdentity && (!runtimeInputUIDPattern.MatchString(observed.Metadata.UID) || !runtimeInputUIDPattern.MatchString(observed.Metadata.ResourceVersion)) {
 		return errors.New("runtime binding Secret lacks server identity")
 	}
-	if len(observed.Data) != 1 || !bytes.Equal(observed.Data[runtimeBindingSecretDataKey], expected.Data[runtimeBindingSecretDataKey]) {
+	if len(observed.Data) != 2 || !bytes.Equal(observed.Data[runtimeBindingSecretDataKey], expected.Data[runtimeBindingSecretDataKey]) || !bytes.Equal(observed.Data[runtimeBindingReceiptSecretDataKey], expected.Data[runtimeBindingReceiptSecretDataKey]) {
 		return errors.New("runtime binding Secret payload differs")
 	}
 	if !equalRuntimeBindingStringMap(observed.Metadata.Labels, expected.Metadata.Labels) || !equalRuntimeBindingStringMap(observed.Metadata.Annotations, expected.Metadata.Annotations) {

--- a/internal/runner/runtime_binding_material_file.go
+++ b/internal/runner/runtime_binding_material_file.go
@@ -1,0 +1,78 @@
+package runner
+
+import (
+	"bytes"
+	"errors"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/jsonstrict"
+)
+
+const maximumRuntimeBindingMaterialFileBytes = 64 * 1024
+
+type RuntimeBindingMaterialFileConfig struct {
+	Bundle       StageResumeConfig
+	MaterialPath string
+	ReceiptPath  string
+}
+
+// LoadRuntimeBindingMaterialFiles reconstructs a verified private runtime
+// binding after executor restart. Both files are mounted from the same
+// immutable management-plane Secret; no API request is performed here.
+func LoadRuntimeBindingMaterialFiles(config RuntimeBindingMaterialFileConfig) (VerifiedRuntimeBindingMaterial, error) {
+	plan, _, prefix, err := loadStageResumeWithPrefix(config.Bundle)
+	if err != nil {
+		return VerifiedRuntimeBindingMaterial{}, err
+	}
+	if len(prefix) < 6 {
+		return VerifiedRuntimeBindingMaterial{}, errors.New("runtime binding replay requires the successful six-stage prefix")
+	}
+	lifecycle, err := prefix[1].Receipt()
+	if err != nil || lifecycle.StageID != "cluster-lifecycle" || lifecycle.State != "SUCCEEDED" || !stageReceiptPrefixDigestPattern.MatchString(lifecycle.TargetClusterUIDDigest) {
+		return VerifiedRuntimeBindingMaterial{}, errors.New("runtime binding replay lacks durable lifecycle identity")
+	}
+	network, err := prefix[4].Receipt()
+	if err != nil || network.StageID != "network-observation" || network.State != "SUCCEEDED" || !stageReceiptPrefixDigestPattern.MatchString(network.EvidenceDigest) {
+		return VerifiedRuntimeBindingMaterial{}, errors.New("runtime binding replay lacks successful network evidence")
+	}
+	runtimeStage, err := prefix[5].Receipt()
+	if err != nil || runtimeStage.StageID != "runtime-binding" || runtimeStage.State != "SUCCEEDED" || !stageReceiptPrefixDigestPattern.MatchString(runtimeStage.EvidenceDigest) {
+		return VerifiedRuntimeBindingMaterial{}, errors.New("runtime binding replay lacks successful persistence evidence")
+	}
+	materialRaw, err := readBoundedRegular(config.MaterialPath, maximumRuntimeBindingMaterialFileBytes)
+	if err != nil {
+		return VerifiedRuntimeBindingMaterial{}, errors.New("read bounded runtime binding material")
+	}
+	receiptRaw, err := readBoundedRegular(config.ReceiptPath, maximumRuntimeBindingMaterialFileBytes)
+	if err != nil {
+		return VerifiedRuntimeBindingMaterial{}, errors.New("read bounded runtime binding material receipt")
+	}
+	var material RuntimeBindingMaterial
+	if err := jsonstrict.Decode(materialRaw, &material); err != nil {
+		return VerifiedRuntimeBindingMaterial{}, errors.New("decode strict runtime binding material")
+	}
+	var receipt RuntimeBindingMaterialReceipt
+	if err := jsonstrict.Decode(receiptRaw, &receipt); err != nil {
+		return VerifiedRuntimeBindingMaterial{}, errors.New("decode strict runtime binding material receipt")
+	}
+	canonical, err := canonicalRuntimeBinding(material)
+	if err != nil || !bytes.Equal(canonical, materialRaw) {
+		return VerifiedRuntimeBindingMaterial{}, errors.New("runtime binding material is not canonical")
+	}
+	if receipt.Format != RuntimeBindingMaterialFormat || receipt.State != "VERIFIED" || receipt.StageID != "runtime-binding" || receipt.PersistentMutationAllowed ||
+		receipt.PlanDigest != plan.PlanDigest || receipt.IntentRevision != plan.IntentRevision || receipt.PrivateMaterialDigest != digest.SHA256(materialRaw) ||
+		receipt.TargetClusterUIDDigest != lifecycle.TargetClusterUIDDigest || receipt.LifecycleEvidenceDigest != lifecycle.EvidenceDigest || receipt.NetworkEvidenceDigest != network.EvidenceDigest {
+		return VerifiedRuntimeBindingMaterial{}, errors.New("runtime binding material receipt differs from durable execution history")
+	}
+	if material.Format != RuntimeBindingMaterialFormat || material.State != "CURRENT_RUNTIME_BOUND" || material.PlanDigest != plan.PlanDigest ||
+		material.IntentRevision != plan.IntentRevision || material.EnablementRevision != plan.EnablementRevision ||
+		material.PlatformRevision != plan.PlatformRevision || material.ExecutionFixture != plan.ExecutionFixture ||
+		material.Target.Name != plan.ContractIdentity.Name {
+		return VerifiedRuntimeBindingMaterial{}, errors.New("runtime binding material differs from verified stage plan")
+	}
+	verified := VerifiedRuntimeBindingMaterial{material: material, raw: append([]byte(nil), materialRaw...), receipt: receipt, verified: true}
+	if err := verifyRuntimeBindingMaterial(verified); err != nil {
+		return VerifiedRuntimeBindingMaterial{}, errors.New("verify replayed runtime binding material")
+	}
+	return verified, nil
+}

--- a/internal/runner/runtime_binding_material_file_test.go
+++ b/internal/runner/runtime_binding_material_file_test.go
@@ -1,0 +1,135 @@
+package runner
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/stageplan"
+	"github.com/openkubes/ok-cluster/internal/stagereceipt"
+)
+
+func TestLoadRuntimeBindingMaterialFilesReplaysPrivateBinding(t *testing.T) {
+	config := runtimeBindingMaterialConfig(t)
+	material, err := BuildRuntimeBindingMaterial(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	materialPath, receiptPath := writeRuntimeBindingReplayFiles(t, material)
+	receipts := appendSuccessfulRuntimeBindingReceipt(t, config.Bundle)
+	loaded, err := LoadRuntimeBindingMaterialFiles(RuntimeBindingMaterialFileConfig{
+		Bundle:       StageResumeConfig{PlanPath: config.Bundle.PlanPath, PlanExpected: config.Bundle.PlanExpected, Receipts: receipts},
+		MaterialPath: materialPath, ReceiptPath: receiptPath,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, _ := material.Receipt()
+	got, err := loaded.Receipt()
+	if err != nil || got != want {
+		t.Fatalf("replayed runtime binding differs: %#v %#v %v", got, want, err)
+	}
+	first, _ := loaded.Bytes()
+	first[0] = 'x'
+	again, _ := loaded.Bytes()
+	if again[0] != '{' {
+		t.Fatal("caller mutated replayed runtime binding")
+	}
+}
+
+func TestLoadRuntimeBindingMaterialFilesFailsClosed(t *testing.T) {
+	base := runtimeBindingMaterialConfig(t)
+	material, err := BuildRuntimeBindingMaterial(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	materialPath, receiptPath := writeRuntimeBindingReplayFiles(t, material)
+	receipts := appendSuccessfulRuntimeBindingReceipt(t, base.Bundle)
+	valid := RuntimeBindingMaterialFileConfig{
+		Bundle:       StageResumeConfig{PlanPath: base.Bundle.PlanPath, PlanExpected: base.Bundle.PlanExpected, Receipts: receipts},
+		MaterialPath: materialPath, ReceiptPath: receiptPath,
+	}
+	for name, mutate := range map[string]func(*RuntimeBindingMaterialFileConfig){
+		"incomplete history": func(config *RuntimeBindingMaterialFileConfig) { config.Bundle.Receipts = config.Bundle.Receipts[:5] },
+		"missing material": func(config *RuntimeBindingMaterialFileConfig) {
+			config.MaterialPath = filepath.Join(t.TempDir(), "missing")
+		},
+		"missing receipt": func(config *RuntimeBindingMaterialFileConfig) {
+			config.ReceiptPath = filepath.Join(t.TempDir(), "missing")
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			config := valid
+			mutate(&config)
+			if _, err := LoadRuntimeBindingMaterialFiles(config); err == nil {
+				t.Fatal("unsafe runtime binding replay was accepted")
+			}
+		})
+	}
+
+	receiptRaw, err := os.ReadFile(receiptPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var receipt RuntimeBindingMaterialReceipt
+	if err := json.Unmarshal(receiptRaw, &receipt); err != nil {
+		t.Fatal(err)
+	}
+	receipt.PrivateMaterialDigest = runnerStageSHA("f")
+	changedReceipt, _ := json.Marshal(receipt)
+	changedReceiptPath := writeBundleFile(t, t.TempDir(), "changed-receipt.json", changedReceipt)
+	valid.ReceiptPath = changedReceiptPath
+	if _, err := LoadRuntimeBindingMaterialFiles(valid); err == nil {
+		t.Fatal("foreign private material digest was accepted")
+	}
+
+	materialRaw, err := os.ReadFile(materialPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pretty := append([]byte("\n"), materialRaw...)
+	valid.ReceiptPath = receiptPath
+	valid.MaterialPath = writeBundleFile(t, t.TempDir(), "noncanonical.json", pretty)
+	if _, err := LoadRuntimeBindingMaterialFiles(valid); err == nil {
+		t.Fatal("non-canonical runtime binding material was accepted")
+	}
+}
+
+func writeRuntimeBindingReplayFiles(t *testing.T, material VerifiedRuntimeBindingMaterial) (string, string) {
+	t.Helper()
+	root := t.TempDir()
+	materialRaw, err := material.Bytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := material.Receipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	receiptRaw, err := json.Marshal(receipt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return writeBundleFile(t, root, "runtime-binding.json", materialRaw), writeBundleFile(t, root, "runtime-binding-receipt.json", receiptRaw)
+}
+
+func appendSuccessfulRuntimeBindingReceipt(t *testing.T, bundle StageResumeConfig) []StageReceiptSource {
+	t.Helper()
+	plan, _, prefix, err := loadStageResumeWithPrefix(bundle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt := successfulRuntimeBindingStageReceipt(t, plan, prefix)
+	return appendStageReceipt(t, t.TempDir(), bundle.Receipts, receipt, "runtime-binding.json")
+}
+
+func successfulRuntimeBindingStageReceipt(t *testing.T, plan stageplan.Binding, prefix []stagereceipt.Verified) stagereceipt.Verified {
+	t.Helper()
+	receipt, err := stagereceipt.New(plan, "runtime-binding", []stagereceipt.Verified{prefix[4]}, "SUCCEEDED", "NOT_APPLICABLE", "", runnerStageSHA("a"), time.Date(2026, 8, 17, 20, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return receipt
+}


### PR DESCRIPTION
## What changed

- persist the redaction-safe runtime-binding material receipt beside the private material in the immutable management-plane Secret
- add a bounded strict loader that reconstructs `VerifiedRuntimeBindingMaterial` after executor restart
- correlate replayed material with the verified plan, successful six-stage history, lifecycle target digest, and NetworkReady evidence
- reject changed receipts, missing files, incomplete history, and non-canonical private material fail closed

## Why

Later stage Jobs must resume from the durable runtime binding rather than relying on Go values retained by the process that originally observed the workload. This checkpoint makes that executor-independent replay path explicit and testable.

Raw runtime UIDs, endpoint and CA material remain confined to the immutable private Secret. They do not enter public receipts or Git.

## Validation

- `go test -ldflags=-linkmode=external ./...`
- `go vet ./...`
- `go test -race -ldflags=-linkmode=external ./internal/runner`

All checks pass. The macOS linker emits the repository's known non-failing platform-load warning.
