### PR TITLE
OK-147: define aggregate evidence Job envelope

### DIFF
--- a/deploy/contract-executor-aggregate-evidence-job.yaml.tpl
+++ b/deploy/contract-executor-aggregate-evidence-job.yaml.tpl
@@ -1,0 +1,211 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: "${OK147_RUN_ID}"
+  namespace: openkubes-execution-system
+spec:
+  podSelector:
+    matchLabels:
+      openkubes.io/execution-id: "${OK147_RUN_ID}"
+  policyTypes: ["Ingress", "Egress"]
+  ingress: []
+  egress:
+    - to: [{ipBlock: {cidr: "${OK147_LEDGER_API_CIDR}"}}]
+      ports: [{protocol: TCP, port: ${OK147_LEDGER_API_PORT}}]
+    - to: [{ipBlock: {cidr: "${OK147_WORKLOAD_API_CIDR}"}}]
+      ports: [{protocol: TCP, port: ${OK147_WORKLOAD_API_PORT}}]
+    - to: [{ipBlock: {cidr: "${OK147_ARGO_API_CIDR}"}}]
+      ports: [{protocol: TCP, port: ${OK147_ARGO_API_PORT}}]
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "${OK147_RUN_ID}"
+  namespace: openkubes-execution-system
+  labels:
+    app.kubernetes.io/name: ok-cluster-contract-executor
+    openkubes.io/execution-id: "${OK147_RUN_ID}"
+    openkubes.io/stage-id: aggregate-evidence
+spec:
+  backoffLimit: 0
+  completions: 1
+  parallelism: 1
+  activeDeadlineSeconds: 600
+  ttlSecondsAfterFinished: 3600
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ok-cluster-contract-executor
+        openkubes.io/execution-id: "${OK147_RUN_ID}"
+    spec:
+      serviceAccountName: ok147-contract-executor-runtime
+      automountServiceAccountToken: false
+      enableServiceLinks: false
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+        seccompProfile: {type: RuntimeDefault}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - {key: node-role.kubernetes.io/control-plane, operator: DoesNotExist}
+      containers:
+        - name: executor
+          image: "${OK147_IMAGE_DIGEST}"
+          imagePullPolicy: IfNotPresent
+          command: ["/ok"]
+          args:
+            - cluster
+            - stage
+            - evaluate
+            - aggregate
+            - --execute
+            - --plan
+            - /var/run/openkubes/input/staged-plan.json
+            - --contract-namespace
+            - "${OK147_CONTRACT_NAMESPACE}"
+            - --contract-name
+            - "${OK147_CONTRACT_NAME}"
+            - --intent-revision
+            - "${OK147_R}"
+            - --enablement-revision
+            - "${OK147_E}"
+            - --platform-revision
+            - "${OK147_P}"
+            - --execution-fixture
+            - "${OK147_FIXTURE}"
+            - --infrastructure-authority
+            - "${OK147_INFRA_AUTHORITY}"
+            - --management-authority
+            - "${OK147_MGMT_AUTHORITY}"
+            - --gitops-authority
+            - "${OK147_GITOPS_AUTHORITY}"
+            - --receipt-prefix
+            - /var/run/openkubes/input/receipt-prefix.json
+            - --receipt-prefix-digest
+            - "${OK147_RECEIPT_PREFIX_DIGEST}"
+            - --aggregate-profile
+            - /var/run/openkubes/input/aggregate-evidence-profile.json
+            - --aggregate-profile-digest
+            - "${OK147_AGGREGATE_PROFILE_DIGEST}"
+            - --network-profile
+            - /var/run/openkubes/input/network-profile.json
+            - --network-profile-digest
+            - "${OK147_NETWORK_PROFILE_DIGEST}"
+            - --platform-profile
+            - /var/run/openkubes/input/platform-profile.json
+            - --platform-profile-digest
+            - "${OK147_PLATFORM_PROFILE_DIGEST}"
+            - --ledger-api-endpoint
+            - "${OK147_LEDGER_API_URL}"
+            - --ledger-token-file
+            - /var/run/openkubes/ledger/token
+            - --ledger-ca-file
+            - /var/run/openkubes/ledger/ca.crt
+            - --management-api-endpoint
+            - "${OK147_MANAGEMENT_API_URL}"
+            - --management-token-file
+            - /var/run/openkubes/management/token
+            - --management-ca-file
+            - /var/run/openkubes/management/ca.crt
+            - --workload-api-endpoint
+            - "${OK147_WORKLOAD_API_URL}"
+            - --workload-token-file
+            - /var/run/openkubes/workload/token
+            - --workload-ca-file
+            - /var/run/openkubes/workload/ca.crt
+            - --argo-api-endpoint
+            - "${OK147_ARGO_API_URL}"
+            - --argo-token-file
+            - /var/run/openkubes/argo/token
+            - --argo-ca-file
+            - /var/run/openkubes/argo/ca.crt
+            - --runtime-binding
+            - /var/run/openkubes/runtime/runtime-binding.json
+            - --runtime-binding-receipt
+            - /var/run/openkubes/runtime/runtime-binding-receipt.json
+            - --platform-capability
+            - /var/run/openkubes/capability/platform-capability.json
+          resources:
+            requests: {cpu: 50m, memory: 64Mi, ephemeral-storage: 16Mi}
+            limits: {cpu: 250m, memory: 128Mi, ephemeral-storage: 32Mi}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities: {drop: ["ALL"]}
+          volumeMounts:
+            - {name: input, mountPath: /var/run/openkubes/input, readOnly: true}
+            - {name: ledger-credential, mountPath: /var/run/openkubes/ledger, readOnly: true}
+            - {name: management-credential, mountPath: /var/run/openkubes/management, readOnly: true}
+            - {name: workload-credential, mountPath: /var/run/openkubes/workload, readOnly: true}
+            - {name: argo-credential, mountPath: /var/run/openkubes/argo, readOnly: true}
+            - {name: runtime-binding, mountPath: /var/run/openkubes/runtime, readOnly: true}
+            - {name: platform-capability, mountPath: /var/run/openkubes/capability, readOnly: true}
+      volumes:
+        - name: input
+          configMap:
+            name: "${OK147_INPUT_CONFIGMAP}"
+            defaultMode: 0444
+            items:
+              - {key: staged-plan.json, path: staged-plan.json}
+              - {key: receipt-prefix.json, path: receipt-prefix.json}
+              - {key: provider-receipt.json, path: provider-receipt.json}
+              - {key: lifecycle-receipt.json, path: lifecycle-receipt.json}
+              - {key: lifecycle-observation-receipt.json, path: lifecycle-observation-receipt.json}
+              - {key: enablement-receipt.json, path: enablement-receipt.json}
+              - {key: network-observation-receipt.json, path: network-observation-receipt.json}
+              - {key: runtime-binding-receipt.json, path: runtime-binding-receipt.json}
+              - {key: target-access-receipt.json, path: target-access-receipt.json}
+              - {key: target-credential-receipt.json, path: target-credential-receipt.json}
+              - {key: target-registration-receipt.json, path: target-registration-receipt.json}
+              - {key: platform-applications-receipt.json, path: platform-applications-receipt.json}
+              - {key: platform-observation-receipt.json, path: platform-observation-receipt.json}
+              - {key: aggregate-evidence-profile.json, path: aggregate-evidence-profile.json}
+              - {key: network-profile.json, path: network-profile.json}
+              - {key: platform-profile.json, path: platform-profile.json}
+        - name: ledger-credential
+          secret:
+            secretName: "${OK147_LEDGER_CREDENTIAL_SECRET}"
+            defaultMode: 0440
+            items:
+              - {key: token, path: token}
+              - {key: ca.crt, path: ca.crt}
+        - name: management-credential
+          secret:
+            secretName: "${OK147_MANAGEMENT_CREDENTIAL_SECRET}"
+            defaultMode: 0440
+            items:
+              - {key: token, path: token}
+              - {key: ca.crt, path: ca.crt}
+        - name: workload-credential
+          secret:
+            secretName: "${OK147_WORKLOAD_CREDENTIAL_SECRET}"
+            defaultMode: 0440
+            items:
+              - {key: token, path: token}
+              - {key: ca.crt, path: ca.crt}
+        - name: argo-credential
+          secret:
+            secretName: "${OK147_ARGO_CREDENTIAL_SECRET}"
+            defaultMode: 0440
+            items:
+              - {key: token, path: token}
+              - {key: ca.crt, path: ca.crt}
+        - name: runtime-binding
+          secret:
+            secretName: "${OK147_RUNTIME_BINDING_SECRET}"
+            defaultMode: 0440
+            items:
+              - {key: runtime-binding.json, path: runtime-binding.json}
+              - {key: runtime-binding-receipt.json, path: runtime-binding-receipt.json}
+        - name: platform-capability
+          secret:
+            secretName: "${OK147_PLATFORM_CAPABILITY_SECRET}"
+            defaultMode: 0440
+            items:
+              - {key: platform-capability.json, path: platform-capability.json}

--- a/internal/runner/aggregate_evidence_stage_job.go
+++ b/internal/runner/aggregate_evidence_stage_job.go
@@ -1,0 +1,127 @@
+package runner
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/openkubes/ok-cluster/internal/stageplan"
+)
+
+type AggregateEvidenceStageJobValues struct {
+	RunID                      string
+	ImageDigest                string
+	Expected                   stageplan.Expected
+	InputConfigMap             string
+	ReceiptPrefixDigest        string
+	AggregateProfileDigest     string
+	NetworkProfileDigest       string
+	PlatformProfileDigest      string
+	LedgerAPIURL               string
+	LedgerAPICIDR              string
+	LedgerCredentialSecret     string
+	ManagementAPIURL           string
+	ManagementAPICIDR          string
+	ManagementCredentialSecret string
+	WorkloadAPIURL             string
+	WorkloadAPICIDR            string
+	WorkloadCredentialSecret   string
+	ArgoAPIURL                 string
+	ArgoAPICIDR                string
+	ArgoCredentialSecret       string
+	RuntimeBindingSecret       string
+	PlatformCapabilitySecret   string
+}
+
+// RenderAggregateEvidenceStageJobTemplate binds the final one-pass evaluator
+// to exact management, workload and GitOps APIs and seven distinct mounted
+// inputs. It performs literal rendering only and contacts no authority.
+func RenderAggregateEvidenceStageJobTemplate(template []byte, values AggregateEvidenceStageJobValues) ([]byte, error) {
+	if len(template) == 0 || len(template) > 1024*1024 {
+		return nil, errors.New("aggregate evidence Job template size is invalid")
+	}
+	dnsLabel := regexp.MustCompile(`^[a-z0-9](?:[-a-z0-9]*[a-z0-9])?$`)
+	if !dnsLabel.MatchString(values.RunID) || len(values.RunID) > 63 || !strings.HasPrefix(values.RunID, "ok147-") {
+		return nil, errors.New("aggregate evidence Job run ID is invalid")
+	}
+	names := []string{
+		values.InputConfigMap, values.LedgerCredentialSecret, values.ManagementCredentialSecret,
+		values.WorkloadCredentialSecret, values.ArgoCredentialSecret, values.RuntimeBindingSecret,
+		values.PlatformCapabilitySecret,
+	}
+	seen := map[string]struct{}{}
+	for _, value := range names {
+		if !dnsLabel.MatchString(value) || len(value) > 63 {
+			return nil, errors.New("aggregate evidence Job object name is invalid")
+		}
+		if _, duplicate := seen[value]; duplicate {
+			return nil, errors.New("aggregate evidence Job inputs and private objects must be distinct")
+		}
+		seen[value] = struct{}{}
+	}
+	if !regexp.MustCompile(`^[a-z0-9][a-z0-9./:_-]*@sha256:[0-9a-f]{64}$`).MatchString(values.ImageDigest) {
+		return nil, errors.New("aggregate evidence Job image is not digest-bound")
+	}
+	for _, value := range []string{values.ReceiptPrefixDigest, values.AggregateProfileDigest, values.NetworkProfileDigest, values.PlatformProfileDigest} {
+		if !stageReceiptPrefixDigestPattern.MatchString(value) {
+			return nil, errors.New("aggregate evidence Job semantic digest is invalid")
+		}
+	}
+	if err := stageplan.ValidateExpected(values.Expected); err != nil {
+		return nil, fmt.Errorf("aggregate evidence Job expected binding: %w", err)
+	}
+	ledgerPort, ledgerEndpoint, err := exactAPIEndpoint(values.LedgerAPIURL, values.LedgerAPICIDR)
+	if err != nil {
+		return nil, fmt.Errorf("aggregate evidence Job ledger endpoint: %w", err)
+	}
+	managementPort, managementEndpoint, err := exactAPIEndpoint(values.ManagementAPIURL, values.ManagementAPICIDR)
+	if err != nil {
+		return nil, fmt.Errorf("aggregate evidence Job management endpoint: %w", err)
+	}
+	if ledgerEndpoint != managementEndpoint || ledgerPort != managementPort {
+		return nil, errors.New("aggregate evidence ledger and management source must use the same verified API")
+	}
+	workloadPort, workloadEndpoint, err := exactAPIEndpoint(values.WorkloadAPIURL, values.WorkloadAPICIDR)
+	if err != nil {
+		return nil, fmt.Errorf("aggregate evidence Job workload endpoint: %w", err)
+	}
+	argoPort, argoEndpoint, err := exactAPIEndpoint(values.ArgoAPIURL, values.ArgoAPICIDR)
+	if err != nil {
+		return nil, fmt.Errorf("aggregate evidence Job Argo endpoint: %w", err)
+	}
+	if workloadEndpoint == managementEndpoint || argoEndpoint == managementEndpoint || argoEndpoint == workloadEndpoint {
+		return nil, errors.New("aggregate evidence management, workload and Argo endpoints must be distinct")
+	}
+	replacements := map[string]string{
+		"${OK147_RUN_ID}": values.RunID, "${OK147_IMAGE_DIGEST}": values.ImageDigest,
+		"${OK147_CONTRACT_NAMESPACE}": values.Expected.ContractIdentity.Namespace, "${OK147_CONTRACT_NAME}": values.Expected.ContractIdentity.Name,
+		"${OK147_R}": values.Expected.IntentRevision, "${OK147_E}": values.Expected.EnablementRevision,
+		"${OK147_P}": values.Expected.PlatformRevision, "${OK147_FIXTURE}": values.Expected.ExecutionFixture,
+		"${OK147_INFRA_AUTHORITY}": values.Expected.InfrastructureAuthority, "${OK147_MGMT_AUTHORITY}": values.Expected.ManagementAuthority,
+		"${OK147_GITOPS_AUTHORITY}": values.Expected.GitOpsAuthority,
+		"${OK147_INPUT_CONFIGMAP}":  values.InputConfigMap, "${OK147_RECEIPT_PREFIX_DIGEST}": values.ReceiptPrefixDigest,
+		"${OK147_AGGREGATE_PROFILE_DIGEST}": values.AggregateProfileDigest,
+		"${OK147_NETWORK_PROFILE_DIGEST}":   values.NetworkProfileDigest, "${OK147_PLATFORM_PROFILE_DIGEST}": values.PlatformProfileDigest,
+		"${OK147_LEDGER_API_URL}": values.LedgerAPIURL, "${OK147_LEDGER_API_CIDR}": values.LedgerAPICIDR,
+		"${OK147_LEDGER_API_PORT}": ledgerPort, "${OK147_LEDGER_CREDENTIAL_SECRET}": values.LedgerCredentialSecret,
+		"${OK147_MANAGEMENT_API_URL}": values.ManagementAPIURL, "${OK147_MANAGEMENT_CREDENTIAL_SECRET}": values.ManagementCredentialSecret,
+		"${OK147_WORKLOAD_API_URL}": values.WorkloadAPIURL, "${OK147_WORKLOAD_API_CIDR}": values.WorkloadAPICIDR,
+		"${OK147_WORKLOAD_API_PORT}": workloadPort, "${OK147_WORKLOAD_CREDENTIAL_SECRET}": values.WorkloadCredentialSecret,
+		"${OK147_ARGO_API_URL}": values.ArgoAPIURL, "${OK147_ARGO_API_CIDR}": values.ArgoAPICIDR,
+		"${OK147_ARGO_API_PORT}": argoPort, "${OK147_ARGO_CREDENTIAL_SECRET}": values.ArgoCredentialSecret,
+		"${OK147_RUNTIME_BINDING_SECRET}":     values.RuntimeBindingSecret,
+		"${OK147_PLATFORM_CAPABILITY_SECRET}": values.PlatformCapabilitySecret,
+	}
+	result := string(template)
+	for placeholder, value := range replacements {
+		if !strings.Contains(result, placeholder) {
+			return nil, fmt.Errorf("aggregate evidence Job template lacks %s", placeholder)
+		}
+		result = strings.ReplaceAll(result, placeholder, value)
+	}
+	if strings.Contains(result, "${") {
+		return nil, errors.New("aggregate evidence Job template contains an unknown placeholder")
+	}
+	return []byte(result), nil
+}

--- a/internal/runner/aggregate_evidence_stage_job_test.go
+++ b/internal/runner/aggregate_evidence_stage_job_test.go
@@ -1,0 +1,120 @@
+package runner
+
+import (
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestRenderAggregateEvidenceStageJobTemplateBindsExactEnvelope(t *testing.T) {
+	values := validAggregateEvidenceStageJobValues()
+	raw, err := RenderAggregateEvidenceStageJobTemplate(aggregateEvidenceJobTemplate(t), values)
+	if err != nil {
+		t.Fatal(err)
+	}
+	objects := decodeJobObjects(t, raw)
+	if len(objects) != 2 || objects["NetworkPolicy"] == nil || objects["Job"] == nil {
+		t.Fatalf("unexpected aggregate evidence object set: %#v", objects)
+	}
+	job := objects["Job"]
+	spec := objectAt(t, job, "spec")
+	if spec["backoffLimit"] != 0 || spec["activeDeadlineSeconds"] != 600 {
+		t.Fatalf("aggregate evidence Job retry or deadline differs: %#v", spec)
+	}
+	podSpec := objectAt(t, objectAt(t, spec, "template"), "spec")
+	if podSpec["automountServiceAccountToken"] != false || podSpec["restartPolicy"] != "Never" || podSpec["serviceAccountName"] != "ok147-contract-executor-runtime" {
+		t.Fatalf("unsafe aggregate evidence Pod identity or restart policy: %#v", podSpec)
+	}
+	container := arrayAt(t, podSpec, "containers")[0].(map[string]any)
+	args := stringArray(t, container, "args")
+	if !reflect.DeepEqual(args[:5], []string{"cluster", "stage", "evaluate", "aggregate", "--execute"}) {
+		t.Fatalf("unexpected aggregate evidence command: %v", args)
+	}
+	for flag, want := range map[string]string{
+		"--receipt-prefix-digest":    values.ReceiptPrefixDigest,
+		"--aggregate-profile-digest": values.AggregateProfileDigest,
+		"--network-profile-digest":   values.NetworkProfileDigest,
+		"--platform-profile-digest":  values.PlatformProfileDigest,
+		"--runtime-binding":          "/var/run/openkubes/runtime/runtime-binding.json",
+		"--runtime-binding-receipt":  "/var/run/openkubes/runtime/runtime-binding-receipt.json",
+		"--platform-capability":      "/var/run/openkubes/capability/platform-capability.json",
+	} {
+		if got := argumentValue(args, flag); got != want {
+			t.Fatalf("%s=%q, want %q", flag, got, want)
+		}
+	}
+	volumes := arrayAt(t, podSpec, "volumes")
+	if len(volumes) != 7 {
+		t.Fatalf("aggregate evidence Job volume count differs: %#v", volumes)
+	}
+	inputItems := arrayAt(t, objectAt(t, volumes[0].(map[string]any), "configMap"), "items")
+	if len(inputItems) != 16 {
+		t.Fatalf("aggregate evidence public input key set differs: %#v", inputItems)
+	}
+	egress := arrayAt(t, objectAt(t, objects["NetworkPolicy"], "spec"), "egress")
+	if len(egress) != 3 {
+		t.Fatalf("aggregate evidence Job must have exact management, workload and Argo egress: %#v", egress)
+	}
+	text := string(raw)
+	for _, forbidden := range []string{"stage-grant", "authority-map", "system:masters", "privileged: true", "serviceAccountToken: true"} {
+		if strings.Contains(text, forbidden) {
+			t.Fatalf("aggregate evidence Job contains forbidden input %q", forbidden)
+		}
+	}
+}
+
+func TestRenderAggregateEvidenceStageJobTemplateFailsClosed(t *testing.T) {
+	valid := validAggregateEvidenceStageJobValues()
+	for name, mutate := range map[string]func(*AggregateEvidenceStageJobValues){
+		"mutable image": func(values *AggregateEvidenceStageJobValues) {
+			values.ImageDigest = "ghcr.io/openkubes/ok-cluster:latest"
+		},
+		"shared credential": func(values *AggregateEvidenceStageJobValues) {
+			values.ArgoCredentialSecret = values.ManagementCredentialSecret
+		},
+		"foreign management endpoint": func(values *AggregateEvidenceStageJobValues) {
+			values.ManagementAPIURL, values.ManagementAPICIDR = "https://192.0.2.13:6443", "192.0.2.13/32"
+		},
+		"shared API endpoint": func(values *AggregateEvidenceStageJobValues) {
+			values.ArgoAPIURL, values.ArgoAPICIDR = values.ManagementAPIURL, values.ManagementAPICIDR
+		},
+		"broad workload CIDR": func(values *AggregateEvidenceStageJobValues) { values.WorkloadAPICIDR = "192.0.2.0/24" },
+		"bad profile digest":  func(values *AggregateEvidenceStageJobValues) { values.PlatformProfileDigest = "sha256:bad" },
+	} {
+		t.Run(name, func(t *testing.T) {
+			candidate := valid
+			mutate(&candidate)
+			if _, err := RenderAggregateEvidenceStageJobTemplate(aggregateEvidenceJobTemplate(t), candidate); err == nil {
+				t.Fatal("unsafe aggregate evidence Job values were accepted")
+			}
+		})
+	}
+	template := append(aggregateEvidenceJobTemplate(t), []byte("\n${UNKNOWN}")...)
+	if _, err := RenderAggregateEvidenceStageJobTemplate(template, valid); err == nil {
+		t.Fatal("unknown aggregate evidence placeholder was accepted")
+	}
+}
+
+func validAggregateEvidenceStageJobValues() AggregateEvidenceStageJobValues {
+	return AggregateEvidenceStageJobValues{
+		RunID: "ok147-aggregate-evidence-01", ImageDigest: "ghcr.io/openkubes/ok-cluster@" + bundleSHA("a"),
+		Expected: validSubmissionStageJobValues().Expected, InputConfigMap: "ok147-aggregate-evidence-input",
+		ReceiptPrefixDigest: bundleSHA("b"), AggregateProfileDigest: bundleSHA("c"),
+		NetworkProfileDigest: bundleSHA("d"), PlatformProfileDigest: bundleSHA("e"),
+		LedgerAPIURL: "https://192.0.2.12:6443", LedgerAPICIDR: "192.0.2.12/32", LedgerCredentialSecret: "ok147-ledger-aggregate",
+		ManagementAPIURL: "https://192.0.2.12:6443", ManagementAPICIDR: "192.0.2.12/32", ManagementCredentialSecret: "ok147-management-aggregate",
+		WorkloadAPIURL: "https://192.0.2.20:6443", WorkloadAPICIDR: "192.0.2.20/32", WorkloadCredentialSecret: "ok147-workload-aggregate",
+		ArgoAPIURL: "https://192.0.2.30:6443", ArgoAPICIDR: "192.0.2.30/32", ArgoCredentialSecret: "ok147-argo-aggregate",
+		RuntimeBindingSecret: "ok147-runtime-binding-run-01", PlatformCapabilitySecret: "ok147-platform-capability-01",
+	}
+}
+
+func aggregateEvidenceJobTemplate(t *testing.T) []byte {
+	t.Helper()
+	raw, err := os.ReadFile("../../deploy/contract-executor-aggregate-evidence-job.yaml.tpl")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return raw
+}


### PR DESCRIPTION
## What changed

- add the digest-pinned Stage 12 `aggregate-evidence` Job template
- bind exact management, workload, and Argo API endpoints to a three-destination NetworkPolicy
- mount an explicit 16-key public input set plus six distinct private Secret sources
- enforce no retry, no service-account autotoken, non-root execution, read-only filesystem, dropped capabilities, bounded resources, and a ten-minute deadline
- validate all identities, endpoint CIDRs, object-name separation, and placeholders before rendering

## Why

The final evaluator now has a Kubernetes Job envelope that can consume the shared Stage 12 library without broad network access or ambient credentials. This is rendering and validation only; no Job is submitted.

The command route referenced by the template is the next orchestration checkpoint and is not claimed as implemented here.

## Validation

- `go test -ldflags=-linkmode=external ./...`
- `go vet ./...`
- `go test -race -ldflags=-linkmode=external ./internal/runner`

All checks pass. The macOS linker emits the repository's known non-failing platform-load warning.
