### PR TITLE
OK-147: package aggregate evidence stage

### DIFF
--- a/internal/runner/aggregate_evidence_stage_package.go
+++ b/internal/runner/aggregate_evidence_stage_package.go
@@ -1,0 +1,221 @@
+package runner
+
+import (
+	"bytes"
+	"errors"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+const AggregateEvidenceStagePackageFormat = "ok147-aggregate-evidence-stage-package/v1"
+
+type AggregateEvidenceStagePackageConfig struct {
+	Input                            AggregateEvidenceStageInputConfig
+	JobTemplate                      []byte
+	JobTemplateDigest                string
+	RunID                            string
+	ImageDigest                      string
+	LedgerAPIURL                     string
+	LedgerAPICIDR                    string
+	LedgerCredentialSecret           string
+	ManagementAPIURL                 string
+	ManagementAPICIDR                string
+	ManagementCredentialSecret       string
+	WorkloadAPIURL                   string
+	WorkloadAPICIDR                  string
+	WorkloadCredentialSecret         string
+	ArgoAPIURL                       string
+	ArgoAPICIDR                      string
+	ArgoCredentialSecret             string
+	RuntimeBindingSecret             string
+	RuntimeBindingMaterialPath       string
+	RuntimeBindingReceiptPath        string
+	PlatformCapabilitySecret         string
+	PlatformCapabilityPath           string
+	ExpectedPlatformCapabilityDigest string
+}
+
+type AggregateEvidenceStagePackageReceipt struct {
+	Format                   string   `json:"format"`
+	State                    string   `json:"state"`
+	StageID                  string   `json:"stageId"`
+	PackageDigest            string   `json:"packageDigest"`
+	InputConfigMapDigest     string   `json:"inputConfigMapDigest"`
+	ReceiptPrefixDigest      string   `json:"receiptPrefixDigest"`
+	AggregateProfileDigest   string   `json:"aggregateProfileDigest"`
+	NetworkProfileDigest     string   `json:"networkProfileDigest"`
+	PlatformProfileDigest    string   `json:"platformProfileDigest"`
+	RuntimeBindingDigest     string   `json:"runtimeBindingDigest"`
+	PlatformCapabilityDigest string   `json:"platformCapabilityDigest"`
+	JobTemplateDigest        string   `json:"jobTemplateDigest"`
+	JobEnvelopeDigest        string   `json:"jobEnvelopeDigest"`
+	ObjectKinds              []string `json:"objectKinds"`
+	AuthorizationState       string   `json:"authorizationState"`
+	MutationAllowed          bool     `json:"mutationAllowed"`
+}
+
+type VerifiedAggregateEvidenceStagePackage struct {
+	raw                  []byte
+	receipt              AggregateEvidenceStagePackageReceipt
+	ledgerCredential     string
+	managementCredential string
+	workloadCredential   string
+	argoCredential       string
+	runtimeSecret        string
+	capabilitySecret     string
+	managementAuthority  string
+	workloadAuthority    string
+	gitOpsAuthority      string
+	runtimeDigest        string
+	capabilityDigest     string
+	verified             bool
+}
+
+// BuildAggregateEvidenceStagePackage correlates the public input, private
+// runtime replay, private capability assertion and hardened Job envelope
+// entirely offline. Private bytes are never copied into package output.
+func BuildAggregateEvidenceStagePackage(config AggregateEvidenceStagePackageConfig) (VerifiedAggregateEvidenceStagePackage, error) {
+	if !stageReceiptPrefixDigestPattern.MatchString(config.JobTemplateDigest) || digest.SHA256(config.JobTemplate) != config.JobTemplateDigest {
+		return VerifiedAggregateEvidenceStagePackage{}, errors.New("aggregate evidence Job template digest differs from expected identity")
+	}
+	input, err := BuildAggregateEvidenceStageInput(config.Input)
+	if err != nil {
+		return VerifiedAggregateEvidenceStagePackage{}, err
+	}
+	inputRaw, err := input.Bytes()
+	if err != nil {
+		return VerifiedAggregateEvidenceStagePackage{}, err
+	}
+	inputReceipt, err := input.Receipt()
+	if err != nil {
+		return VerifiedAggregateEvidenceStagePackage{}, err
+	}
+	plan, _, _, err := loadStageResumeWithPrefix(config.Input.Bundle)
+	if err != nil {
+		return VerifiedAggregateEvidenceStagePackage{}, err
+	}
+	aggregateProfile, err := LoadAggregateEvidenceProfileFile(AggregateEvidenceProfileFileConfig{
+		Path: config.Input.AggregateEvidenceProfilePath, ExpectedProfileDigest: inputReceipt.AggregateProfileDigest,
+		ExpectedIntentRevision: plan.IntentRevision, ExpectedEnablementRevision: plan.EnablementRevision,
+		ExpectedPlatformRevision: plan.PlatformRevision, ExpectedExecutionFixture: plan.ExecutionFixture,
+	})
+	if err != nil {
+		return VerifiedAggregateEvidenceStagePackage{}, errors.New("verify aggregate evidence package profile")
+	}
+	bundle, err := LoadAggregateEvidenceStageBundle(AggregateEvidenceStageBundleConfig{
+		StageResumeConfig: config.Input.Bundle, Profile: aggregateProfile.Profile, ExpectedProfileDigest: aggregateProfile.Digest,
+	})
+	if err != nil {
+		return VerifiedAggregateEvidenceStagePackage{}, errors.New("verify aggregate evidence package bundle")
+	}
+	runtime, err := LoadRuntimeBindingMaterialFiles(RuntimeBindingMaterialFileConfig{
+		Bundle: config.Input.Bundle, MaterialPath: config.RuntimeBindingMaterialPath, ReceiptPath: config.RuntimeBindingReceiptPath,
+	})
+	if err != nil {
+		return VerifiedAggregateEvidenceStagePackage{}, errors.New("verify private aggregate runtime binding")
+	}
+	lifecycle, err := bundle.prefix[1].Receipt()
+	if err != nil || runtime.material.Target.WorkloadAPIEndpoint != config.WorkloadAPIURL || digest.SHA256([]byte(runtime.material.Target.CAPIClusterUID)) != lifecycle.TargetClusterUIDDigest {
+		return VerifiedAggregateEvidenceStagePackage{}, errors.New("private aggregate runtime differs from package target")
+	}
+	platformProfile, err := LoadPlatformProfileFile(PlatformProfileFileConfig{
+		Path: config.Input.PlatformProfilePath, ExpectedProfileDigest: inputReceipt.PlatformProfileDigest,
+		ExpectedIntentRevision: bundle.plan.IntentRevision, ExpectedPlatformRevision: bundle.plan.PlatformRevision,
+		ExpectedExecutionFixture: bundle.plan.ExecutionFixture,
+	})
+	if err != nil {
+		return VerifiedAggregateEvidenceStagePackage{}, errors.New("verify aggregate platform profile")
+	}
+	capability, err := LoadPlatformCapabilityFile(PlatformCapabilityFileConfig{
+		Path: config.PlatformCapabilityPath, ExpectedEvidenceDigest: config.ExpectedPlatformCapabilityDigest,
+		ExpectedIntentRevision: bundle.plan.IntentRevision, ExpectedPlatformRevision: bundle.plan.PlatformRevision,
+		ExpectedExecutionFixture: bundle.plan.ExecutionFixture, ExpectedTargetClusterUID: runtime.material.Target.CAPIClusterUID,
+		ExpectedContractDigest:   platformProfile.Profile.CapabilityContractDigest,
+		ExpectedExecutableDigest: platformProfile.Profile.CapabilityExecutableDigest,
+	})
+	if err != nil {
+		return VerifiedAggregateEvidenceStagePackage{}, errors.New("verify private aggregate platform capability")
+	}
+	jobRaw, err := RenderAggregateEvidenceStageJobTemplate(config.JobTemplate, AggregateEvidenceStageJobValues{
+		RunID: config.RunID, ImageDigest: config.ImageDigest, Expected: config.Input.Bundle.PlanExpected,
+		InputConfigMap: config.Input.ConfigMapName, ReceiptPrefixDigest: inputReceipt.ReceiptPrefixDigest,
+		AggregateProfileDigest: inputReceipt.AggregateProfileDigest, NetworkProfileDigest: inputReceipt.NetworkProfileDigest,
+		PlatformProfileDigest: inputReceipt.PlatformProfileDigest,
+		LedgerAPIURL:          config.LedgerAPIURL, LedgerAPICIDR: config.LedgerAPICIDR, LedgerCredentialSecret: config.LedgerCredentialSecret,
+		ManagementAPIURL: config.ManagementAPIURL, ManagementAPICIDR: config.ManagementAPICIDR, ManagementCredentialSecret: config.ManagementCredentialSecret,
+		WorkloadAPIURL: config.WorkloadAPIURL, WorkloadAPICIDR: config.WorkloadAPICIDR, WorkloadCredentialSecret: config.WorkloadCredentialSecret,
+		ArgoAPIURL: config.ArgoAPIURL, ArgoAPICIDR: config.ArgoAPICIDR, ArgoCredentialSecret: config.ArgoCredentialSecret,
+		RuntimeBindingSecret: config.RuntimeBindingSecret, PlatformCapabilitySecret: config.PlatformCapabilitySecret,
+	})
+	if err != nil {
+		return VerifiedAggregateEvidenceStagePackage{}, err
+	}
+	packageRaw := make([]byte, 0, len(inputRaw)+len(jobRaw)+6)
+	packageRaw = append(packageRaw, inputRaw...)
+	packageRaw = append(packageRaw, '\n', '-', '-', '-', '\n')
+	packageRaw = append(packageRaw, jobRaw...)
+	receipt := AggregateEvidenceStagePackageReceipt{
+		Format: AggregateEvidenceStagePackageFormat, State: "VERIFIED", StageID: "aggregate-evidence",
+		PackageDigest: digest.SHA256(packageRaw), InputConfigMapDigest: inputReceipt.ConfigMapDigest,
+		ReceiptPrefixDigest: inputReceipt.ReceiptPrefixDigest, AggregateProfileDigest: inputReceipt.AggregateProfileDigest,
+		NetworkProfileDigest: inputReceipt.NetworkProfileDigest, PlatformProfileDigest: inputReceipt.PlatformProfileDigest,
+		RuntimeBindingDigest: runtime.receipt.PrivateMaterialDigest, PlatformCapabilityDigest: capability.EvidenceDigest(),
+		JobTemplateDigest: config.JobTemplateDigest, JobEnvelopeDigest: digest.SHA256(jobRaw),
+		ObjectKinds: []string{"ConfigMap", "NetworkPolicy", "Job"}, AuthorizationState: "NOT_REQUIRED", MutationAllowed: false,
+	}
+	return VerifiedAggregateEvidenceStagePackage{
+		raw: packageRaw, receipt: receipt, ledgerCredential: config.LedgerCredentialSecret,
+		managementCredential: config.ManagementCredentialSecret, workloadCredential: config.WorkloadCredentialSecret,
+		argoCredential: config.ArgoCredentialSecret, runtimeSecret: config.RuntimeBindingSecret,
+		capabilitySecret: config.PlatformCapabilitySecret, managementAuthority: bundle.plan.Authorities.Management,
+		workloadAuthority: digest.SHA256([]byte(runtime.material.Target.CAPIClusterUID)), gitOpsAuthority: bundle.plan.Authorities.GitOps,
+		runtimeDigest: runtime.receipt.PrivateMaterialDigest, capabilityDigest: capability.EvidenceDigest(),
+		verified: true,
+	}, nil
+}
+
+func (packaged VerifiedAggregateEvidenceStagePackage) Bytes() ([]byte, error) {
+	if err := verifyAggregateEvidenceStagePackage(packaged); err != nil {
+		return nil, errors.New("aggregate evidence package was not produced by verification")
+	}
+	return append([]byte(nil), packaged.raw...), nil
+}
+
+func (packaged VerifiedAggregateEvidenceStagePackage) Receipt() (AggregateEvidenceStagePackageReceipt, error) {
+	if err := verifyAggregateEvidenceStagePackage(packaged); err != nil {
+		return AggregateEvidenceStagePackageReceipt{}, errors.New("aggregate evidence package was not produced by verification")
+	}
+	receipt := packaged.receipt
+	receipt.ObjectKinds = append([]string(nil), packaged.receipt.ObjectKinds...)
+	return receipt, nil
+}
+
+func verifyAggregateEvidenceStagePackage(packaged VerifiedAggregateEvidenceStagePackage) error {
+	if !packaged.verified || packaged.receipt.Format != AggregateEvidenceStagePackageFormat || packaged.receipt.State != "VERIFIED" || packaged.receipt.StageID != "aggregate-evidence" || packaged.receipt.MutationAllowed || digest.SHA256(packaged.raw) != packaged.receipt.PackageDigest ||
+		packaged.ledgerCredential == "" || packaged.managementCredential == "" || packaged.workloadCredential == "" || packaged.argoCredential == "" || packaged.runtimeSecret == "" || packaged.capabilitySecret == "" || packaged.managementAuthority == "" || packaged.gitOpsAuthority == "" || !stageReceiptPrefixDigestPattern.MatchString(packaged.workloadAuthority) {
+		return errors.New("aggregate evidence package identity is incomplete")
+	}
+	parts := bytes.SplitN(packaged.raw, []byte("\n---\n"), 2)
+	if len(parts) != 2 || digest.SHA256(parts[0]) != packaged.receipt.InputConfigMapDigest || digest.SHA256(parts[1]) != packaged.receipt.JobEnvelopeDigest ||
+		packaged.runtimeDigest != packaged.receipt.RuntimeBindingDigest || packaged.capabilityDigest != packaged.receipt.PlatformCapabilityDigest {
+		return errors.New("aggregate evidence package component identity changed")
+	}
+	for _, value := range []string{
+		packaged.receipt.ReceiptPrefixDigest, packaged.receipt.AggregateProfileDigest, packaged.receipt.NetworkProfileDigest,
+		packaged.receipt.PlatformProfileDigest, packaged.receipt.RuntimeBindingDigest, packaged.receipt.PlatformCapabilityDigest,
+		packaged.receipt.JobTemplateDigest, packaged.receipt.JobEnvelopeDigest,
+	} {
+		if !stageReceiptPrefixDigestPattern.MatchString(value) {
+			return errors.New("aggregate evidence package digest identity is invalid")
+		}
+	}
+	names := []string{packaged.ledgerCredential, packaged.managementCredential, packaged.workloadCredential, packaged.argoCredential, packaged.runtimeSecret, packaged.capabilitySecret}
+	seen := map[string]struct{}{}
+	for _, name := range names {
+		if _, duplicate := seen[name]; duplicate {
+			return errors.New("aggregate evidence package private objects are not distinct")
+		}
+		seen[name] = struct{}{}
+	}
+	return nil
+}

--- a/internal/runner/aggregate_evidence_stage_package_test.go
+++ b/internal/runner/aggregate_evidence_stage_package_test.go
@@ -1,0 +1,142 @@
+package runner
+
+import (
+	"bytes"
+	"encoding/json"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+func TestBuildAggregateEvidenceStagePackageBindsPublicAndPrivateIdentities(t *testing.T) {
+	config := aggregateEvidenceStagePackageConfig(t)
+	packaged, err := BuildAggregateEvidenceStagePackage(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := packaged.Bytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := packaged.Receipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	objects := decodeJobObjects(t, raw)
+	if len(objects) != 3 || objects["ConfigMap"] == nil || objects["NetworkPolicy"] == nil || objects["Job"] == nil {
+		t.Fatalf("unexpected aggregate evidence package: %#v", objects)
+	}
+	runtimeRaw, _ := readBoundedRegular(config.RuntimeBindingMaterialPath, maximumRuntimeBindingMaterialFileBytes)
+	capabilityRaw, _ := readBoundedRegular(config.PlatformCapabilityPath, maximumPlatformCapabilityBytes)
+	if bytes.Contains(raw, runtimeRaw) || bytes.Contains(raw, capabilityRaw) || bytes.Contains(raw, []byte(targetAccessRuntimeUID)) {
+		t.Fatal("private aggregate runtime or capability was copied into public package output")
+	}
+	if receipt.Format != AggregateEvidenceStagePackageFormat || receipt.StageID != "aggregate-evidence" || receipt.PackageDigest != digest.SHA256(raw) || receipt.AuthorizationState != "NOT_REQUIRED" || receipt.MutationAllowed {
+		t.Fatalf("unexpected aggregate evidence package receipt: %#v", receipt)
+	}
+	parts := bytes.SplitN(raw, []byte("\n---\n"), 2)
+	if len(parts) != 2 || receipt.InputConfigMapDigest != digest.SHA256(parts[0]) || receipt.JobEnvelopeDigest != digest.SHA256(parts[1]) {
+		t.Fatal("aggregate evidence package component digests differ")
+	}
+	if !reflect.DeepEqual(receipt.ObjectKinds, []string{"ConfigMap", "NetworkPolicy", "Job"}) || receipt.PlatformCapabilityDigest != config.ExpectedPlatformCapabilityDigest {
+		t.Fatalf("aggregate evidence package identities differ: %#v", receipt)
+	}
+	raw[0] = 'x'
+	again, _ := packaged.Bytes()
+	if again[0] != '{' {
+		t.Fatal("caller mutated retained aggregate evidence package")
+	}
+}
+
+func TestBuildAggregateEvidenceStagePackageFailsClosed(t *testing.T) {
+	valid := aggregateEvidenceStagePackageConfig(t)
+	for name, mutate := range map[string]func(*AggregateEvidenceStagePackageConfig){
+		"changed template": func(config *AggregateEvidenceStagePackageConfig) {
+			config.JobTemplate = append(config.JobTemplate, '\n')
+		},
+		"wrong template digest": func(config *AggregateEvidenceStagePackageConfig) { config.JobTemplateDigest = bundleSHA("f") },
+		"shared credentials": func(config *AggregateEvidenceStagePackageConfig) {
+			config.ArgoCredentialSecret = config.ManagementCredentialSecret
+		},
+		"runtime endpoint differs": func(config *AggregateEvidenceStagePackageConfig) {
+			config.WorkloadAPIURL, config.WorkloadAPICIDR = "https://192.0.2.21:6443", "192.0.2.21/32"
+		},
+		"foreign capability": func(config *AggregateEvidenceStagePackageConfig) {
+			config.ExpectedPlatformCapabilityDigest = bundleSHA("f")
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			config := valid
+			config.JobTemplate = append([]byte(nil), valid.JobTemplate...)
+			mutate(&config)
+			if _, err := BuildAggregateEvidenceStagePackage(config); err == nil {
+				t.Fatal("unsafe aggregate evidence package was accepted")
+			}
+		})
+	}
+	if _, err := (VerifiedAggregateEvidenceStagePackage{}).Bytes(); err == nil {
+		t.Fatal("unverified aggregate evidence package bytes were exposed")
+	}
+	if _, err := (VerifiedAggregateEvidenceStagePackage{}).Receipt(); err == nil {
+		t.Fatal("unverified aggregate evidence package receipt was exposed")
+	}
+}
+
+func aggregateEvidenceStagePackageConfig(t *testing.T) AggregateEvidenceStagePackageConfig {
+	t.Helper()
+	fixture := aggregateEvidenceBundleFixture(t)
+	bundle, err := LoadAggregateEvidenceStageBundle(fixture)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root := t.TempDir()
+	aggregatePath := writeAggregateEvidenceProfile(t, root, fixture.Profile)
+	networkPath, networkDigest, platformPath, platformDigest := writeAggregateSourceProfiles(t, root, fixture)
+	input := AggregateEvidenceStageInputConfig{
+		Bundle: fixture.StageResumeConfig, AggregateEvidenceProfilePath: aggregatePath,
+		ExpectedAggregateProfileDigest: fixture.ExpectedProfileDigest,
+		NetworkProfilePath:             networkPath, ExpectedNetworkProfileDigest: networkDigest,
+		PlatformProfilePath: platformPath, ExpectedPlatformProfileDigest: platformDigest,
+		ConfigMapName: "ok147-aggregate-evidence-input",
+	}
+	runtime := aggregateRuntimeBindingMaterial(t, bundle)
+	lifecycleReceipt, err := bundle.prefix[1].Receipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	networkReceipt, err := bundle.prefix[4].Receipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	runtime.material.Evidence.LifecycleEvidenceDigest = lifecycleReceipt.EvidenceDigest
+	runtime.material.Evidence.NetworkEvidenceDigest = networkReceipt.EvidenceDigest
+	runtime.receipt.LifecycleEvidenceDigest = lifecycleReceipt.EvidenceDigest
+	runtime.receipt.NetworkEvidenceDigest = networkReceipt.EvidenceDigest
+	runtime.raw, err = canonicalRuntimeBinding(runtime.material)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runtime.receipt.PrivateMaterialDigest = digest.SHA256(runtime.raw)
+	runtimePath, runtimeReceiptPath := writeRuntimeBindingReplayFiles(t, runtime)
+	_, platformProfile := runnerPlatformApplications(t, bundleExpected(bundle))
+	capability := aggregateCapabilityState(t, bundle, platformProfile, time.Date(2026, 8, 17, 23, 0, 0, 0, time.UTC))
+	capabilityRaw, err := json.Marshal(capability)
+	if err != nil {
+		t.Fatal(err)
+	}
+	capabilityPath := writeBundleFile(t, root, "platform-capability.json", capabilityRaw)
+	template := aggregateEvidenceJobTemplate(t)
+	return AggregateEvidenceStagePackageConfig{
+		Input: input, JobTemplate: template, JobTemplateDigest: digest.SHA256(template),
+		RunID: "ok147-aggregate-evidence-01", ImageDigest: "ghcr.io/openkubes/ok-cluster@" + bundleSHA("a"),
+		LedgerAPIURL: "https://192.0.2.12:6443", LedgerAPICIDR: "192.0.2.12/32", LedgerCredentialSecret: "ok147-ledger-aggregate",
+		ManagementAPIURL: "https://192.0.2.12:6443", ManagementAPICIDR: "192.0.2.12/32", ManagementCredentialSecret: "ok147-management-aggregate",
+		WorkloadAPIURL: runtime.material.Target.WorkloadAPIEndpoint, WorkloadAPICIDR: "192.0.2.40/32", WorkloadCredentialSecret: "ok147-workload-aggregate",
+		ArgoAPIURL: "https://192.0.2.30:6443", ArgoAPICIDR: "192.0.2.30/32", ArgoCredentialSecret: "ok147-argo-aggregate",
+		RuntimeBindingSecret: "ok147-runtime-binding-run-01", RuntimeBindingMaterialPath: runtimePath, RuntimeBindingReceiptPath: runtimeReceiptPath,
+		PlatformCapabilitySecret: "ok147-platform-capability-01", PlatformCapabilityPath: capabilityPath,
+		ExpectedPlatformCapabilityDigest: capability.EvidenceDigest,
+	}
+}


### PR DESCRIPTION
## What changed

- compose the verified Stage 12 public input and hardened Job envelope into one immutable package
- replay and verify the private runtime binding against the eleven-receipt execution history
- verify the private Platform capability assertion against the runtime target and bound Platform profile
- retain only redaction-safe digests for private runtime and capability inputs
- detect package, component, receipt, private-object-name, and digest-identity changes fail closed

## Why

Credential materialization and launch must bind to one exact package digest. This checkpoint creates that digest without copying private runtime UIDs, endpoints, CA payloads, or capability content into the public package.

This is offline composition only; no Secret, ConfigMap, NetworkPolicy, or Job is submitted.

## Validation

- `go test -ldflags=-linkmode=external ./...`
- `go vet ./...`
- `go test -race -ldflags=-linkmode=external ./internal/runner`

All checks pass. The macOS linker emits the repository's known non-failing platform-load warning.
