### PR TITLE
OK-147: bind aggregate evidence stage credentials

### DIFF
--- a/internal/runner/aggregate_evidence_stage_credentials.go
+++ b/internal/runner/aggregate_evidence_stage_credentials.go
@@ -1,0 +1,167 @@
+package runner
+
+import (
+	"crypto/subtle"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+const AggregateEvidenceStageCredentialPackageFormat = "ok147-aggregate-evidence-stage-credential-package/v1"
+
+type AggregateEvidenceStageCredentialPackageConfig struct {
+	Package             VerifiedAggregateEvidenceStagePackage
+	MaterializationTime time.Time
+	Ledger              SubmissionStageCredentialSource
+	ManagementObserver  SubmissionStageCredentialSource
+	WorkloadObserver    SubmissionStageCredentialSource
+	ArgoObserver        SubmissionStageCredentialSource
+}
+
+type AggregateEvidenceStageCredentialPackageReceipt struct {
+	Format                string                                   `json:"format"`
+	State                 string                                   `json:"state"`
+	StageID               string                                   `json:"stageId"`
+	StagePackageDigest    string                                   `json:"stagePackageDigest"`
+	InstallationAuthority string                                   `json:"installationAuthority"`
+	MaterializedAt        string                                   `json:"materializedAt"`
+	PackageDigest         string                                   `json:"packageDigest"`
+	Credentials           []SubmissionStageCredentialObjectReceipt `json:"credentials"`
+	MutationAllowed       bool                                     `json:"mutationAllowed"`
+}
+
+type aggregateEvidenceStageCredentialPackageIdentity struct {
+	StagePackageDigest    string                                   `json:"stagePackageDigest"`
+	InstallationAuthority string                                   `json:"installationAuthority"`
+	MaterializedAt        string                                   `json:"materializedAt"`
+	Credentials           []SubmissionStageCredentialObjectReceipt `json:"credentials"`
+}
+
+// VerifiedAggregateEvidenceStageCredentialPackage retains four exact Secret
+// objects privately. The receipt exposes only their identities and expiry.
+type VerifiedAggregateEvidenceStageCredentialPackage struct {
+	objects               []submissionStageCredentialObject
+	receipt               AggregateEvidenceStageCredentialPackageReceipt
+	installationAuthority string
+	workloadAuthority     string
+	workloadCABundle      string
+	gitOpsAuthority       string
+	verified              bool
+}
+
+// BuildAggregateEvidenceStageCredentialPackage verifies four independent,
+// short-lived credentials entirely offline. It performs no TokenRequest and no
+// Kubernetes API request.
+func BuildAggregateEvidenceStageCredentialPackage(config AggregateEvidenceStageCredentialPackageConfig) (VerifiedAggregateEvidenceStageCredentialPackage, error) {
+	packageReceipt, err := config.Package.Receipt()
+	if err != nil || packageReceipt.StageID != "aggregate-evidence" {
+		return VerifiedAggregateEvidenceStageCredentialPackage{}, errors.New("verified aggregate evidence package is required")
+	}
+	if config.MaterializationTime.IsZero() || !config.MaterializationTime.Equal(config.MaterializationTime.Truncate(time.Second)) {
+		return VerifiedAggregateEvidenceStageCredentialPackage{}, errors.New("aggregate evidence credential materialization time is required")
+	}
+	if config.Ledger.CABundleDigest != config.ManagementObserver.CABundleDigest {
+		return VerifiedAggregateEvidenceStageCredentialPackage{}, errors.New("aggregate evidence management credentials use different CA identities")
+	}
+	if config.WorkloadObserver.CABundleDigest != config.Package.workloadCABundle {
+		return VerifiedAggregateEvidenceStageCredentialPackage{}, errors.New("aggregate evidence workload credential differs from runtime CA identity")
+	}
+
+	bindings := []struct {
+		role      string
+		name      string
+		authority string
+		source    SubmissionStageCredentialSource
+	}{
+		{role: "ledger", name: config.Package.ledgerCredential, authority: config.Package.managementAuthority, source: config.Ledger},
+		{role: "management-observer", name: config.Package.managementCredential, authority: config.Package.managementAuthority, source: config.ManagementObserver},
+		{role: "workload-observer", name: config.Package.workloadCredential, authority: config.Package.workloadAuthority, source: config.WorkloadObserver},
+		{role: "argo-observer", name: config.Package.argoCredential, authority: config.Package.gitOpsAuthority, source: config.ArgoObserver},
+	}
+	objects := make([]submissionStageCredentialObject, 0, len(bindings))
+	receipts := make([]SubmissionStageCredentialObjectReceipt, 0, len(bindings))
+	tokens := make([][]byte, 0, len(bindings))
+	for _, credential := range bindings {
+		object, receipt, token, err := buildSubmissionStageCredentialObject(
+			packageReceipt.StageID, config.MaterializationTime.UTC(), credential.role,
+			credential.name, credential.authority, credential.source,
+		)
+		if err != nil {
+			return VerifiedAggregateEvidenceStageCredentialPackage{}, err
+		}
+		objects = append(objects, object)
+		receipts = append(receipts, receipt)
+		tokens = append(tokens, token)
+	}
+	for left := range tokens {
+		for right := left + 1; right < len(tokens); right++ {
+			if len(tokens[left]) == len(tokens[right]) && subtle.ConstantTimeCompare(tokens[left], tokens[right]) == 1 {
+				return VerifiedAggregateEvidenceStageCredentialPackage{}, errors.New("aggregate evidence credentials must be pairwise distinct")
+			}
+		}
+	}
+
+	materializedAt := config.MaterializationTime.UTC().Format(time.RFC3339)
+	identity, err := json.Marshal(aggregateEvidenceStageCredentialPackageIdentity{
+		StagePackageDigest: packageReceipt.PackageDigest, InstallationAuthority: config.Package.managementAuthority,
+		MaterializedAt: materializedAt, Credentials: receipts,
+	})
+	if err != nil {
+		return VerifiedAggregateEvidenceStageCredentialPackage{}, errors.New("encode aggregate evidence credential package identity")
+	}
+	receipt := AggregateEvidenceStageCredentialPackageReceipt{
+		Format: AggregateEvidenceStageCredentialPackageFormat, State: "VERIFIED", StageID: packageReceipt.StageID,
+		StagePackageDigest: packageReceipt.PackageDigest, InstallationAuthority: config.Package.managementAuthority,
+		MaterializedAt: materializedAt, PackageDigest: digest.SHA256(identity), Credentials: receipts,
+		MutationAllowed: false,
+	}
+	return VerifiedAggregateEvidenceStageCredentialPackage{
+		objects: cloneStageCredentialObjects(objects), receipt: receipt,
+		installationAuthority: config.Package.managementAuthority,
+		workloadAuthority:     config.Package.workloadAuthority, workloadCABundle: config.Package.workloadCABundle,
+		gitOpsAuthority: config.Package.gitOpsAuthority, verified: true,
+	}, nil
+}
+
+func (packaged VerifiedAggregateEvidenceStageCredentialPackage) Receipt() (AggregateEvidenceStageCredentialPackageReceipt, error) {
+	if err := verifyAggregateEvidenceStageCredentialPackage(packaged); err != nil {
+		return AggregateEvidenceStageCredentialPackageReceipt{}, errors.New("aggregate evidence credential package was not produced by verification")
+	}
+	receipt := packaged.receipt
+	receipt.Credentials = append([]SubmissionStageCredentialObjectReceipt(nil), packaged.receipt.Credentials...)
+	for index := range receipt.Credentials {
+		receipt.Credentials[index].Audiences = append([]string(nil), packaged.receipt.Credentials[index].Audiences...)
+	}
+	return receipt, nil
+}
+
+func verifyAggregateEvidenceStageCredentialPackage(packaged VerifiedAggregateEvidenceStageCredentialPackage) error {
+	if !packaged.verified || packaged.receipt.Format != AggregateEvidenceStageCredentialPackageFormat || packaged.receipt.State != "VERIFIED" || packaged.receipt.StageID != "aggregate-evidence" || packaged.receipt.MutationAllowed || !stageReceiptPrefixDigestPattern.MatchString(packaged.receipt.StagePackageDigest) || !stageReceiptPrefixDigestPattern.MatchString(packaged.receipt.PackageDigest) || packaged.installationAuthority == "" || packaged.receipt.InstallationAuthority != packaged.installationAuthority || !stageReceiptPrefixDigestPattern.MatchString(packaged.workloadAuthority) || !stageReceiptPrefixDigestPattern.MatchString(packaged.workloadCABundle) || packaged.gitOpsAuthority == "" || len(packaged.objects) != 4 || len(packaged.receipt.Credentials) != 4 {
+		return errors.New("aggregate evidence credential package identity is incomplete")
+	}
+	identity, err := json.Marshal(aggregateEvidenceStageCredentialPackageIdentity{
+		StagePackageDigest:    packaged.receipt.StagePackageDigest,
+		InstallationAuthority: packaged.receipt.InstallationAuthority,
+		MaterializedAt:        packaged.receipt.MaterializedAt, Credentials: packaged.receipt.Credentials,
+	})
+	if err != nil || digest.SHA256(identity) != packaged.receipt.PackageDigest {
+		return errors.New("aggregate evidence credential package identity changed after verification")
+	}
+	if _, err := time.Parse(time.RFC3339, packaged.receipt.MaterializedAt); err != nil {
+		return errors.New("aggregate evidence credential materialization time is invalid")
+	}
+	expectedRoles := []string{"ledger", "management-observer", "workload-observer", "argo-observer"}
+	expectedAuthorities := []string{packaged.installationAuthority, packaged.installationAuthority, packaged.workloadAuthority, packaged.gitOpsAuthority}
+	for index, object := range packaged.objects {
+		receipt := packaged.receipt.Credentials[index]
+		if object.role != expectedRoles[index] || receipt.Role != expectedRoles[index] || object.authority != expectedAuthorities[index] || receipt.Authority != expectedAuthorities[index] || object.name != receipt.Name || receipt.Namespace != submissionStageInputNamespace || digest.SHA256(object.raw) != receipt.ObjectDigest {
+			return errors.New("aggregate evidence credential object identity changed after verification")
+		}
+	}
+	if packaged.receipt.Credentials[0].CABundleDigest != packaged.receipt.Credentials[1].CABundleDigest || packaged.receipt.Credentials[2].CABundleDigest != packaged.workloadCABundle {
+		return errors.New("aggregate evidence credential CA identity changed after verification")
+	}
+	return nil
+}

--- a/internal/runner/aggregate_evidence_stage_credentials_test.go
+++ b/internal/runner/aggregate_evidence_stage_credentials_test.go
@@ -1,0 +1,199 @@
+package runner
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/jsonstrict"
+)
+
+func TestBuildAggregateEvidenceStageCredentialPackageBindsFourPrivateSecrets(t *testing.T) {
+	config, tokens := aggregateEvidenceCredentialConfig(t)
+	packaged, err := BuildAggregateEvidenceStageCredentialPackage(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := packaged.Receipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	stageReceipt, _ := config.Package.Receipt()
+	if receipt.Format != AggregateEvidenceStageCredentialPackageFormat || receipt.State != "VERIFIED" || receipt.StageID != "aggregate-evidence" || receipt.StagePackageDigest != stageReceipt.PackageDigest || receipt.InstallationAuthority != "ok-mgmt" || receipt.MaterializedAt != config.MaterializationTime.Format(time.RFC3339) || !stageReceiptPrefixDigestPattern.MatchString(receipt.PackageDigest) || receipt.MutationAllowed || len(receipt.Credentials) != 4 {
+		t.Fatalf("unexpected aggregate evidence credential receipt: %#v", receipt)
+	}
+	want := []struct {
+		role      string
+		name      string
+		authority string
+	}{
+		{role: "ledger", name: config.Package.ledgerCredential, authority: "ok-mgmt"},
+		{role: "management-observer", name: config.Package.managementCredential, authority: "ok-mgmt"},
+		{role: "workload-observer", name: config.Package.workloadCredential, authority: config.Package.workloadAuthority},
+		{role: "argo-observer", name: config.Package.argoCredential, authority: "ok-shared"},
+	}
+	for index, expected := range want {
+		object := packaged.objects[index]
+		objectReceipt := receipt.Credentials[index]
+		if object.role != expected.role || object.authority != expected.authority || object.name != expected.name || digest.SHA256(object.raw) != objectReceipt.ObjectDigest {
+			t.Fatalf("private aggregate credential %d differs: %#v %#v", index, object, objectReceipt)
+		}
+		var secret map[string]any
+		if err := json.Unmarshal(object.raw, &secret); err != nil {
+			t.Fatal(err)
+		}
+		data := secret["data"].(map[string]any)
+		decodedToken, err := base64.StdEncoding.DecodeString(data["token"].(string))
+		if err != nil || !bytes.Equal(decodedToken, tokens[index]) || len(data) != 2 {
+			t.Fatalf("private aggregate token %d differs", index)
+		}
+	}
+	public, err := json.Marshal(receipt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range []string{
+		string(tokens[0]), string(tokens[1]), string(tokens[2]), string(tokens[3]),
+		config.Ledger.TokenFile, config.ManagementObserver.TokenFile,
+		config.WorkloadObserver.TokenFile, config.ArgoObserver.TokenFile,
+		config.Ledger.ExpectedSubject, config.ManagementObserver.ExpectedSubject,
+		config.WorkloadObserver.ExpectedSubject, config.ArgoObserver.ExpectedSubject,
+	} {
+		if bytes.Contains(public, []byte(forbidden)) {
+			t.Fatalf("aggregate evidence credential receipt exposed private value %q", forbidden)
+		}
+	}
+	receipt.Credentials[0].Audiences[0] = "changed"
+	again, err := packaged.Receipt()
+	if err != nil || again.Credentials[0].Audiences[0] == "changed" {
+		t.Fatal("caller mutated retained aggregate evidence credential receipt")
+	}
+}
+
+func TestBuildAggregateEvidenceStageCredentialPackageFailsClosed(t *testing.T) {
+	for name, mutate := range map[string]func(*AggregateEvidenceStageCredentialPackageConfig){
+		"foreign management authority": func(config *AggregateEvidenceStageCredentialPackageConfig) {
+			config.ManagementObserver.AuthorityIdentity = "ok-infra"
+		},
+		"management CA differs": func(config *AggregateEvidenceStageCredentialPackageConfig) {
+			config.ManagementObserver.CABundleDigest = prefixSHA("d")
+		},
+		"foreign workload authority": func(config *AggregateEvidenceStageCredentialPackageConfig) {
+			config.WorkloadObserver.AuthorityIdentity = prefixSHA("f")
+		},
+		"workload CA differs from runtime": func(config *AggregateEvidenceStageCredentialPackageConfig) {
+			config.WorkloadObserver.CABundleDigest = prefixSHA("e")
+		},
+		"foreign Argo authority": func(config *AggregateEvidenceStageCredentialPackageConfig) {
+			config.ArgoObserver.AuthorityIdentity = "ok-mgmt"
+		},
+		"shared token": func(config *AggregateEvidenceStageCredentialPackageConfig) {
+			config.ArgoObserver.TokenFile = config.WorkloadObserver.TokenFile
+			config.ArgoObserver.TokenDigest = config.WorkloadObserver.TokenDigest
+			config.ArgoObserver.ExpectedIssuer = config.WorkloadObserver.ExpectedIssuer
+			config.ArgoObserver.ExpectedSubject = config.WorkloadObserver.ExpectedSubject
+			config.ArgoObserver.ExpectedAudiences = append([]string(nil), config.WorkloadObserver.ExpectedAudiences...)
+			config.ArgoObserver.IssuedAt = config.WorkloadObserver.IssuedAt
+			config.ArgoObserver.ExpiresAt = config.WorkloadObserver.ExpiresAt
+		},
+		"missing TokenRequest evidence": func(config *AggregateEvidenceStageCredentialPackageConfig) {
+			config.Ledger.TokenRequestEvidenceDigest = ""
+		},
+		"unverified package": func(config *AggregateEvidenceStageCredentialPackageConfig) {
+			config.Package = VerifiedAggregateEvidenceStagePackage{}
+		},
+		"changed package identity": func(config *AggregateEvidenceStageCredentialPackageConfig) {
+			config.Package.receipt.PackageDigest = prefixSHA("c")
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			config, _ := aggregateEvidenceCredentialConfig(t)
+			mutate(&config)
+			_, err := BuildAggregateEvidenceStageCredentialPackage(config)
+			if err == nil || strings.Contains(err.Error(), config.WorkloadObserver.TokenFile) {
+				t.Fatalf("unsafe aggregate evidence credential package accepted: %v", err)
+			}
+		})
+	}
+	if _, err := (VerifiedAggregateEvidenceStageCredentialPackage{}).Receipt(); err == nil {
+		t.Fatal("unverified aggregate evidence credential receipt was exposed")
+	}
+	config, _ := aggregateEvidenceCredentialConfig(t)
+	packaged, err := BuildAggregateEvidenceStageCredentialPackage(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	packaged.objects[3].raw = append(packaged.objects[3].raw, '\n')
+	if _, err := packaged.Receipt(); err == nil {
+		t.Fatal("changed private aggregate evidence credential was accepted")
+	}
+}
+
+func aggregateEvidenceCredentialConfig(t *testing.T) (AggregateEvidenceStageCredentialPackageConfig, [][]byte) {
+	t.Helper()
+	now := time.Date(2026, 8, 16, 12, 0, 0, 0, time.UTC)
+	issuedAt, expiresAt := now.Add(-time.Minute), now.Add(30*time.Minute)
+	audiences := []string{"https://kubernetes.default.svc"}
+	issuer := "https://kubernetes.default.svc.cluster.local"
+	root := t.TempDir()
+	managementCA, argoCA := testCA(t), testCA(t)
+	managementCAPath := writeBundleFile(t, root, "management-ca.crt", managementCA)
+	argoCAPath := writeBundleFile(t, root, "argo-ca.crt", argoCA)
+
+	packageConfig := aggregateEvidenceStagePackageConfig(t)
+	var runtime RuntimeBindingMaterial
+	runtimeRaw, err := os.ReadFile(packageConfig.RuntimeBindingMaterialPath)
+	if err != nil || jsonstrict.Decode(runtimeRaw, &runtime) != nil {
+		t.Fatal("read aggregate runtime fixture")
+	}
+	workloadCA, err := base64.StdEncoding.DecodeString(runtime.Target.WorkloadAPICAData)
+	if err != nil {
+		t.Fatal(err)
+	}
+	workloadCAPath := writeBundleFile(t, root, "workload-ca.crt", workloadCA)
+	packaged, err := BuildAggregateEvidenceStagePackage(packageConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	subjects := []string{
+		"system:serviceaccount:openkubes-execution-system:ok147-ledger-writer",
+		"system:serviceaccount:openkubes-execution-system:ok147-aggregate-management-observer",
+		"system:serviceaccount:openkubes-execution-system:ok147-aggregate-workload-observer",
+		"system:serviceaccount:openkubes-execution-system:ok147-aggregate-argo-observer",
+	}
+	tokens := [][]byte{
+		stageCredentialJWT(t, issuer, subjects[0], audiences, issuedAt, expiresAt, 'b'),
+		stageCredentialJWT(t, issuer, subjects[1], audiences, issuedAt, expiresAt, 'c'),
+		stageCredentialJWT(t, issuer, subjects[2], audiences, issuedAt, expiresAt, 'd'),
+		stageCredentialJWT(t, issuer, subjects[3], audiences, issuedAt, expiresAt, 'e'),
+	}
+	tokenPaths := make([]string, len(tokens))
+	for index, token := range tokens {
+		tokenPaths[index] = filepath.Join(root, "token-"+string(rune('0'+index)))
+		if err := os.WriteFile(tokenPaths[index], token, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	source := func(authority, tokenPath, subject, evidence, caPath string, token, ca []byte) SubmissionStageCredentialSource {
+		return SubmissionStageCredentialSource{
+			AuthorityIdentity: authority, TokenFile: tokenPath, TokenDigest: digest.SHA256(token),
+			CAFile: caPath, CABundleDigest: digest.SHA256(ca), TokenRequestEvidenceDigest: prefixSHA(evidence),
+			ExpectedIssuer: issuer, ExpectedSubject: subject, ExpectedAudiences: audiences,
+			IssuedAt: issuedAt, ExpiresAt: expiresAt,
+		}
+	}
+	return AggregateEvidenceStageCredentialPackageConfig{
+		Package: packaged, MaterializationTime: now,
+		Ledger:             source("ok-mgmt", tokenPaths[0], subjects[0], "1", managementCAPath, tokens[0], managementCA),
+		ManagementObserver: source("ok-mgmt", tokenPaths[1], subjects[1], "2", managementCAPath, tokens[1], managementCA),
+		WorkloadObserver:   source(packaged.workloadAuthority, tokenPaths[2], subjects[2], "3", workloadCAPath, tokens[2], workloadCA),
+		ArgoObserver:       source("ok-shared", tokenPaths[3], subjects[3], "4", argoCAPath, tokens[3], argoCA),
+	}, tokens
+}

--- a/internal/runner/aggregate_evidence_stage_package.go
+++ b/internal/runner/aggregate_evidence_stage_package.go
@@ -65,6 +65,7 @@ type VerifiedAggregateEvidenceStagePackage struct {
 	capabilitySecret     string
 	managementAuthority  string
 	workloadAuthority    string
+	workloadCABundle     string
 	gitOpsAuthority      string
 	runtimeDigest        string
 	capabilityDigest     string
@@ -168,8 +169,9 @@ func BuildAggregateEvidenceStagePackage(config AggregateEvidenceStagePackageConf
 		managementCredential: config.ManagementCredentialSecret, workloadCredential: config.WorkloadCredentialSecret,
 		argoCredential: config.ArgoCredentialSecret, runtimeSecret: config.RuntimeBindingSecret,
 		capabilitySecret: config.PlatformCapabilitySecret, managementAuthority: bundle.plan.Authorities.Management,
-		workloadAuthority: digest.SHA256([]byte(runtime.material.Target.CAPIClusterUID)), gitOpsAuthority: bundle.plan.Authorities.GitOps,
-		runtimeDigest: runtime.receipt.PrivateMaterialDigest, capabilityDigest: capability.EvidenceDigest(),
+		workloadAuthority: digest.SHA256([]byte(runtime.material.Target.CAPIClusterUID)), workloadCABundle: runtime.material.Target.WorkloadAPICADigest,
+		gitOpsAuthority: bundle.plan.Authorities.GitOps,
+		runtimeDigest:   runtime.receipt.PrivateMaterialDigest, capabilityDigest: capability.EvidenceDigest(),
 		verified: true,
 	}, nil
 }
@@ -192,7 +194,7 @@ func (packaged VerifiedAggregateEvidenceStagePackage) Receipt() (AggregateEviden
 
 func verifyAggregateEvidenceStagePackage(packaged VerifiedAggregateEvidenceStagePackage) error {
 	if !packaged.verified || packaged.receipt.Format != AggregateEvidenceStagePackageFormat || packaged.receipt.State != "VERIFIED" || packaged.receipt.StageID != "aggregate-evidence" || packaged.receipt.MutationAllowed || digest.SHA256(packaged.raw) != packaged.receipt.PackageDigest ||
-		packaged.ledgerCredential == "" || packaged.managementCredential == "" || packaged.workloadCredential == "" || packaged.argoCredential == "" || packaged.runtimeSecret == "" || packaged.capabilitySecret == "" || packaged.managementAuthority == "" || packaged.gitOpsAuthority == "" || !stageReceiptPrefixDigestPattern.MatchString(packaged.workloadAuthority) {
+		packaged.ledgerCredential == "" || packaged.managementCredential == "" || packaged.workloadCredential == "" || packaged.argoCredential == "" || packaged.runtimeSecret == "" || packaged.capabilitySecret == "" || packaged.managementAuthority == "" || packaged.gitOpsAuthority == "" || !stageReceiptPrefixDigestPattern.MatchString(packaged.workloadAuthority) || !stageReceiptPrefixDigestPattern.MatchString(packaged.workloadCABundle) {
 		return errors.New("aggregate evidence package identity is incomplete")
 	}
 	parts := bytes.SplitN(packaged.raw, []byte("\n---\n"), 2)

--- a/internal/runner/aggregate_evidence_stage_package_test.go
+++ b/internal/runner/aggregate_evidence_stage_package_test.go
@@ -2,6 +2,7 @@ package runner
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"reflect"
 	"testing"
@@ -112,8 +113,12 @@ func aggregateEvidenceStagePackageConfig(t *testing.T) AggregateEvidenceStagePac
 	}
 	runtime.material.Evidence.LifecycleEvidenceDigest = lifecycleReceipt.EvidenceDigest
 	runtime.material.Evidence.NetworkEvidenceDigest = networkReceipt.EvidenceDigest
+	workloadCA := testCA(t)
+	runtime.material.Target.WorkloadAPICAData = base64.StdEncoding.EncodeToString(workloadCA)
+	runtime.material.Target.WorkloadAPICADigest = digest.SHA256(workloadCA)
 	runtime.receipt.LifecycleEvidenceDigest = lifecycleReceipt.EvidenceDigest
 	runtime.receipt.NetworkEvidenceDigest = networkReceipt.EvidenceDigest
+	runtime.receipt.WorkloadAPICADigest = digest.SHA256(workloadCA)
 	runtime.raw, err = canonicalRuntimeBinding(runtime.material)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## Scope

- bind four pairwise-distinct, short-lived aggregate-evidence credentials
- separate ledger, management observer, workload observer, and Argo observer authorities
- bind the workload credential CA to the verified private runtime binding
- retain all Secret bytes privately and expose only redaction-safe receipts
- fail closed on authority, CA, token, TokenRequest-evidence, package, and Secret tampering

## Boundaries

- offline materialization only
- no TokenRequest
- no Kubernetes API call
- no infrastructure mutation
- no credential, CA payload, subject, or source path in public receipts

## Verification

- `go test -ldflags=-linkmode=external ./...`
- `go vet ./...`
- `go test -race -ldflags=-linkmode=external ./internal/runner`

All passed. The macOS external-linker warnings are unchanged and non-fatal.
