### PR TITLE
OK-147: plan aggregate evidence installation

### DIFF
--- a/internal/runner/aggregate_evidence_stage_install_material.go
+++ b/internal/runner/aggregate_evidence_stage_install_material.go
@@ -1,0 +1,80 @@
+package runner
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"io"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/jsonstrict"
+	"gopkg.in/yaml.v3"
+)
+
+// prepareAggregateEvidenceStageInstallation recovers the exact three public
+// object bodies retained by the verified package.
+func prepareAggregateEvidenceStageInstallation(packaged VerifiedAggregateEvidenceStagePackage) (AggregateEvidenceStageInstallationPlan, []submissionStageInstallObject, error) {
+	plan, err := PlanAggregateEvidenceStageInstallation(packaged)
+	if err != nil {
+		return AggregateEvidenceStageInstallationPlan{}, nil, err
+	}
+	decoder := yaml.NewDecoder(bytes.NewReader(packaged.raw))
+	objects := make([]submissionStageInstallObject, 0, len(plan.Creates))
+	for index := range plan.Creates {
+		var value map[string]any
+		if err := decoder.Decode(&value); err != nil || len(value) == 0 {
+			return AggregateEvidenceStageInstallationPlan{}, nil, errors.New("decode aggregate evidence installation object")
+		}
+		raw, err := json.Marshal(value)
+		if err != nil || digest.SHA256(raw) != plan.Creates[index].ObjectDigest {
+			return AggregateEvidenceStageInstallationPlan{}, nil, errors.New("aggregate evidence installation object differs from plan")
+		}
+		objects = append(objects, submissionStageInstallObject{plan: plan.Creates[index], raw: raw})
+	}
+	var trailing map[string]any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		return AggregateEvidenceStageInstallationPlan{}, nil, errors.New("aggregate evidence installation contains trailing object")
+	}
+	return plan, objects, nil
+}
+
+// prepareAggregateEvidenceStageCredentialInstallation recovers the four
+// private credential Secrets and rechecks their exact semantics.
+func prepareAggregateEvidenceStageCredentialInstallation(packaged VerifiedAggregateEvidenceStageCredentialPackage) (AggregateEvidenceStageCredentialPackageReceipt, []submissionStageCredentialInstallObject, error) {
+	if err := verifyAggregateEvidenceStageCredentialPackage(packaged); err != nil {
+		return AggregateEvidenceStageCredentialPackageReceipt{}, nil, err
+	}
+	objects := make([]submissionStageCredentialInstallObject, 0, 4)
+	for index, private := range packaged.objects {
+		public := packaged.receipt.Credentials[index]
+		var secret map[string]any
+		if err := jsonstrict.Decode(private.raw, &secret); err != nil {
+			return AggregateEvidenceStageCredentialPackageReceipt{}, nil, errors.New("aggregate evidence credential object is invalid JSON")
+		}
+		metadata, _ := secret["metadata"].(map[string]any)
+		labels, _ := metadata["labels"].(map[string]any)
+		annotations, _ := metadata["annotations"].(map[string]any)
+		data, _ := secret["data"].(map[string]any)
+		if secret["apiVersion"] != "v1" || secret["kind"] != "Secret" || secret["immutable"] != true || secret["type"] != "Opaque" || metadata["name"] != private.name || metadata["namespace"] != submissionStageInputNamespace || labels["openkubes.io/stage-id"] != packaged.receipt.StageID || labels["openkubes.io/credential-role"] != private.role || annotations["openkubes.io/authority-identity"] != private.authority || annotations["openkubes.io/expires-at"] != public.ExpiresAt || len(data) != 2 {
+			return AggregateEvidenceStageCredentialPackageReceipt{}, nil, errors.New("aggregate evidence credential Secret semantics changed")
+		}
+		tokenEncoded, tokenOK := data["token"].(string)
+		caEncoded, caOK := data["ca.crt"].(string)
+		token, tokenErr := base64.StdEncoding.DecodeString(tokenEncoded)
+		ca, caErr := base64.StdEncoding.DecodeString(caEncoded)
+		expiresAt, timeErr := time.Parse(time.RFC3339, public.ExpiresAt)
+		if !tokenOK || !caOK || tokenErr != nil || caErr != nil || len(token) == 0 || len(ca) == 0 || timeErr != nil || digest.SHA256(ca) != public.CABundleDigest {
+			return AggregateEvidenceStageCredentialPackageReceipt{}, nil, errors.New("aggregate evidence credential Secret data changed")
+		}
+		collection := "/api/v1/namespaces/" + submissionStageInputNamespace + "/secrets"
+		objects = append(objects, submissionStageCredentialInstallObject{
+			order: index + 4, role: private.role, authority: private.authority, name: private.name,
+			objectPath: collection + "/" + private.name, collectionPath: collection,
+			objectDigest: public.ObjectDigest, expiresAt: expiresAt,
+			raw: append([]byte(nil), private.raw...), token: append([]byte(nil), token...),
+		})
+	}
+	return packaged.receipt, objects, nil
+}

--- a/internal/runner/aggregate_evidence_stage_install_material_test.go
+++ b/internal/runner/aggregate_evidence_stage_install_material_test.go
@@ -1,0 +1,79 @@
+package runner
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+func TestPrepareAggregateEvidenceStageInstallationRecoversExactObjects(t *testing.T) {
+	stage, err := BuildAggregateEvidenceStagePackage(aggregateEvidenceStagePackageConfig(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan, objects, err := prepareAggregateEvidenceStageInstallation(stage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(objects) != 3 || len(plan.Creates) != 3 {
+		t.Fatalf("unexpected aggregate installation material count: %d %d", len(objects), len(plan.Creates))
+	}
+	for index, object := range objects {
+		if object.plan != plan.Creates[index] || digest.SHA256(object.raw) != plan.Creates[index].ObjectDigest {
+			t.Fatalf("aggregate installation object %d differs", index)
+		}
+	}
+	objects[0].raw[0] = 'x'
+	_, again, err := prepareAggregateEvidenceStageInstallation(stage)
+	if err != nil || again[0].raw[0] == 'x' {
+		t.Fatal("caller mutated retained aggregate installation material")
+	}
+}
+
+func TestPrepareAggregateEvidenceStageCredentialInstallationRecoversFourSecrets(t *testing.T) {
+	config, tokens := aggregateEvidenceCredentialConfig(t)
+	credentials, err := BuildAggregateEvidenceStageCredentialPackage(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, objects, err := prepareAggregateEvidenceStageCredentialInstallation(credentials)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(objects) != 4 || len(receipt.Credentials) != 4 {
+		t.Fatalf("unexpected aggregate credential material count: %d %d", len(objects), len(receipt.Credentials))
+	}
+	for index, object := range objects {
+		if object.order != index+4 || object.role != receipt.Credentials[index].Role || object.authority != receipt.Credentials[index].Authority || object.name != receipt.Credentials[index].Name || object.objectDigest != receipt.Credentials[index].ObjectDigest || digest.SHA256(object.raw) != object.objectDigest || string(object.token) != string(tokens[index]) {
+			t.Fatalf("aggregate credential installation object %d differs: %#v", index, object)
+		}
+		var secret map[string]any
+		if err := json.Unmarshal(object.raw, &secret); err != nil {
+			t.Fatal(err)
+		}
+		if len(secret["data"].(map[string]any)) != 2 {
+			t.Fatalf("aggregate credential %d contains unexpected private data", index)
+		}
+	}
+	objects[3].raw[0] = 'x'
+	_, again, err := prepareAggregateEvidenceStageCredentialInstallation(credentials)
+	if err != nil || again[3].raw[0] == 'x' {
+		t.Fatal("caller mutated retained private aggregate credentials")
+	}
+}
+
+func TestPrepareAggregateEvidenceStageCredentialInstallationRejectsTampering(t *testing.T) {
+	config, _ := aggregateEvidenceCredentialConfig(t)
+	credentials, err := BuildAggregateEvidenceStageCredentialPackage(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	credentials.objects[2].raw = append(credentials.objects[2].raw, '\n')
+	if _, _, err := prepareAggregateEvidenceStageCredentialInstallation(credentials); err == nil {
+		t.Fatal("changed aggregate evidence credential was accepted")
+	}
+	if _, _, err := prepareAggregateEvidenceStageCredentialInstallation(VerifiedAggregateEvidenceStageCredentialPackage{}); err == nil {
+		t.Fatal("unverified aggregate evidence credentials were accepted")
+	}
+}

--- a/internal/runner/aggregate_evidence_stage_installation_plan.go
+++ b/internal/runner/aggregate_evidence_stage_installation_plan.go
@@ -1,0 +1,178 @@
+package runner
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"gopkg.in/yaml.v3"
+)
+
+const AggregateEvidenceStageInstallationPlanFormat = "ok147-aggregate-evidence-stage-installation-plan/v1"
+
+// AggregateEvidenceStageInstallationPlan is a tokenless offline description
+// of the three exact public objects. It grants no create authority.
+type AggregateEvidenceStageInstallationPlan struct {
+	Format                string                      `json:"format"`
+	State                 string                      `json:"state"`
+	StageID               string                      `json:"stageId"`
+	EvidencePackageDigest string                      `json:"evidencePackageDigest"`
+	Authority             string                      `json:"authority"`
+	Creates               []SubmissionStageCreatePlan `json:"creates"`
+	MutationAllowed       bool                        `json:"mutationAllowed"`
+}
+
+// PlanAggregateEvidenceStageInstallation verifies the immutable input,
+// NetworkPolicy and Job and derives their exact create order without opening
+// credentials or contacting Kubernetes.
+func PlanAggregateEvidenceStageInstallation(packaged VerifiedAggregateEvidenceStagePackage) (AggregateEvidenceStageInstallationPlan, error) {
+	receipt, err := packaged.Receipt()
+	if err != nil {
+		return AggregateEvidenceStageInstallationPlan{}, err
+	}
+	expectedKinds := []string{"ConfigMap", "NetworkPolicy", "Job"}
+	if !equalStringList(receipt.ObjectKinds, expectedKinds) {
+		return AggregateEvidenceStageInstallationPlan{}, errors.New("aggregate evidence package object inventory is invalid")
+	}
+	documents := bytes.Split(packaged.raw, []byte("\n---\n"))
+	if len(documents) != len(expectedKinds) || digest.SHA256(documents[0]) != receipt.InputConfigMapDigest || digest.SHA256(bytes.Join(documents[1:], []byte("\n---\n"))) != receipt.JobEnvelopeDigest {
+		return AggregateEvidenceStageInstallationPlan{}, errors.New("aggregate evidence package component identity differs")
+	}
+	decoder := yaml.NewDecoder(bytes.NewReader(packaged.raw))
+	objects := make([]map[string]any, 0, len(expectedKinds))
+	for {
+		var object map[string]any
+		err := decoder.Decode(&object)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil || len(object) == 0 {
+			return AggregateEvidenceStageInstallationPlan{}, errors.New("decode aggregate evidence package")
+		}
+		objects = append(objects, object)
+	}
+	if len(objects) != len(expectedKinds) {
+		return AggregateEvidenceStageInstallationPlan{}, errors.New("aggregate evidence package object count is invalid")
+	}
+
+	configMapName, runID := "", ""
+	creates := make([]SubmissionStageCreatePlan, 0, len(objects))
+	for index, object := range objects {
+		apiVersion, _ := object["apiVersion"].(string)
+		kind, _ := object["kind"].(string)
+		if kind != expectedKinds[index] {
+			return AggregateEvidenceStageInstallationPlan{}, errors.New("aggregate evidence package create order is invalid")
+		}
+		metadata, ok := object["metadata"].(map[string]any)
+		if !ok {
+			return AggregateEvidenceStageInstallationPlan{}, errors.New("aggregate evidence package object metadata is invalid")
+		}
+		name, _ := metadata["name"].(string)
+		namespace, _ := metadata["namespace"].(string)
+		if !submissionStageInputNamePattern.MatchString(name) || len(name) > 63 || namespace != submissionStageInputNamespace || metadata["generateName"] != nil {
+			return AggregateEvidenceStageInstallationPlan{}, errors.New("aggregate evidence package object identity is invalid")
+		}
+		collectionPath, objectPath, err := submissionStageCreatePaths(apiVersion, kind, namespace, name)
+		if err != nil {
+			return AggregateEvidenceStageInstallationPlan{}, err
+		}
+		canonical, err := json.Marshal(object)
+		if err != nil {
+			return AggregateEvidenceStageInstallationPlan{}, errors.New("encode aggregate evidence package object")
+		}
+		creates = append(creates, SubmissionStageCreatePlan{
+			Order: index + 1, APIVersion: apiVersion, Kind: kind, Namespace: namespace, Name: name,
+			PreflightMethod: "GET", ObjectPath: objectPath, CreateMethod: "POST", CollectionPath: collectionPath,
+			ObjectDigest: digest.SHA256(canonical),
+		})
+		switch kind {
+		case "ConfigMap":
+			labels, _ := metadata["labels"].(map[string]any)
+			if object["immutable"] != true || labels["openkubes.io/stage-id"] != receipt.StageID {
+				return AggregateEvidenceStageInstallationPlan{}, errors.New("aggregate evidence input ConfigMap semantics differ")
+			}
+			configMapName = name
+		case "NetworkPolicy":
+			runID = name
+			spec, _ := object["spec"].(map[string]any)
+			selector, _ := spec["podSelector"].(map[string]any)
+			matchLabels, _ := selector["matchLabels"].(map[string]any)
+			if matchLabels["openkubes.io/execution-id"] != runID {
+				return AggregateEvidenceStageInstallationPlan{}, errors.New("aggregate evidence NetworkPolicy selector differs from run identity")
+			}
+		case "Job":
+			if name != runID {
+				return AggregateEvidenceStageInstallationPlan{}, errors.New("aggregate evidence Job and NetworkPolicy identities differ")
+			}
+			spec, _ := object["spec"].(map[string]any)
+			template, _ := spec["template"].(map[string]any)
+			podSpec, _ := template["spec"].(map[string]any)
+			if podSpec["serviceAccountName"] != "ok147-contract-executor-runtime" || podSpec["automountServiceAccountToken"] != false {
+				return AggregateEvidenceStageInstallationPlan{}, errors.New("aggregate evidence Job runtime identity is invalid")
+			}
+			if !jobMountsInputConfigMap(podSpec, configMapName) || !jobUsesManagementAuthority(podSpec, packaged.managementAuthority) || !aggregateEvidenceJobUsesAuthority(podSpec, "--gitops-authority", packaged.gitOpsAuthority) || !jobUsesAggregateEvidencePrivateObjects(podSpec, packaged) {
+				return AggregateEvidenceStageInstallationPlan{}, errors.New("aggregate evidence Job binding differs from verified package")
+			}
+		}
+	}
+	return AggregateEvidenceStageInstallationPlan{
+		Format: AggregateEvidenceStageInstallationPlanFormat, State: "VERIFIED", StageID: receipt.StageID,
+		EvidencePackageDigest: receipt.PackageDigest, Authority: packaged.managementAuthority,
+		Creates: creates, MutationAllowed: false,
+	}, nil
+}
+
+func aggregateEvidenceJobUsesAuthority(podSpec map[string]any, flag, authority string) bool {
+	containers, ok := podSpec["containers"].([]any)
+	if !ok || len(containers) != 1 {
+		return false
+	}
+	container, _ := containers[0].(map[string]any)
+	arguments, ok := container["args"].([]any)
+	if !ok {
+		return false
+	}
+	for index := 0; index+1 < len(arguments); index++ {
+		if arguments[index] == flag && arguments[index+1] == authority {
+			return true
+		}
+	}
+	return false
+}
+
+func jobUsesAggregateEvidencePrivateObjects(podSpec map[string]any, packaged VerifiedAggregateEvidenceStagePackage) bool {
+	volumes, ok := podSpec["volumes"].([]any)
+	if !ok {
+		return false
+	}
+	want := map[string]struct {
+		secret string
+		items  map[string]string
+	}{
+		"ledger-credential":     {secret: packaged.ledgerCredential, items: map[string]string{"token": "token", "ca.crt": "ca.crt"}},
+		"management-credential": {secret: packaged.managementCredential, items: map[string]string{"token": "token", "ca.crt": "ca.crt"}},
+		"workload-credential":   {secret: packaged.workloadCredential, items: map[string]string{"token": "token", "ca.crt": "ca.crt"}},
+		"argo-credential":       {secret: packaged.argoCredential, items: map[string]string{"token": "token", "ca.crt": "ca.crt"}},
+		"runtime-binding":       {secret: packaged.runtimeSecret, items: map[string]string{"runtime-binding.json": "runtime-binding.json", "runtime-binding-receipt.json": "runtime-binding-receipt.json"}},
+		"platform-capability":   {secret: packaged.capabilitySecret, items: map[string]string{"platform-capability.json": "platform-capability.json"}},
+	}
+	found := map[string]bool{}
+	for _, item := range volumes {
+		volume, _ := item.(map[string]any)
+		name, _ := volume["name"].(string)
+		expected, relevant := want[name]
+		if !relevant {
+			continue
+		}
+		secret, _ := volume["secret"].(map[string]any)
+		secretName, _ := secret["secretName"].(string)
+		items, _ := secret["items"].([]any)
+		if secretName != expected.secret || !exactCredentialSecretItems(items, expected.items) {
+			return false
+		}
+		found[name] = true
+	}
+	return len(found) == len(want)
+}

--- a/internal/runner/aggregate_evidence_stage_installation_plan_test.go
+++ b/internal/runner/aggregate_evidence_stage_installation_plan_test.go
@@ -1,0 +1,65 @@
+package runner
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+func TestPlanAggregateEvidenceStageInstallationBindsThreePublicObjects(t *testing.T) {
+	packaged, err := BuildAggregateEvidenceStagePackage(aggregateEvidenceStagePackageConfig(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan, err := PlanAggregateEvidenceStageInstallation(packaged)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, _ := packaged.Receipt()
+	if plan.Format != AggregateEvidenceStageInstallationPlanFormat || plan.State != "VERIFIED" || plan.StageID != "aggregate-evidence" || plan.EvidencePackageDigest != receipt.PackageDigest || plan.Authority != "ok-mgmt" || plan.MutationAllowed || len(plan.Creates) != 3 {
+		t.Fatalf("unexpected aggregate evidence installation plan: %#v", plan)
+	}
+	wantKinds := []string{"ConfigMap", "NetworkPolicy", "Job"}
+	for index, create := range plan.Creates {
+		if create.Order != index+1 || create.Kind != wantKinds[index] || create.Namespace != submissionStageInputNamespace || create.PreflightMethod != "GET" || create.CreateMethod != "POST" || !stageReceiptPrefixDigestPattern.MatchString(create.ObjectDigest) {
+			t.Fatalf("unexpected aggregate evidence create %d: %#v", index, create)
+		}
+	}
+	plan.Creates[0].Name = "changed"
+	again, err := PlanAggregateEvidenceStageInstallation(packaged)
+	if err != nil || again.Creates[0].Name == "changed" {
+		t.Fatal("caller mutated retained aggregate evidence installation plan")
+	}
+}
+
+func TestPlanAggregateEvidenceStageInstallationFailsClosed(t *testing.T) {
+	packaged, err := BuildAggregateEvidenceStagePackage(aggregateEvidenceStagePackageConfig(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldName := []byte(packaged.runtimeSecret)
+	newName := []byte("ok147-runtime-binding-run-02")
+	if len(oldName) != len(newName) || !bytes.Contains(packaged.raw, oldName) {
+		t.Fatal("aggregate runtime Secret fixture is unavailable")
+	}
+	packaged.raw = bytes.Replace(packaged.raw, oldName, newName, 1)
+	parts := bytes.SplitN(packaged.raw, []byte("\n---\n"), 2)
+	packaged.receipt.PackageDigest = digest.SHA256(packaged.raw)
+	packaged.receipt.JobEnvelopeDigest = digest.SHA256(parts[1])
+	if _, err := PlanAggregateEvidenceStageInstallation(packaged); err == nil {
+		t.Fatal("aggregate evidence Job with foreign private input was accepted")
+	}
+
+	packaged, err = BuildAggregateEvidenceStagePackage(aggregateEvidenceStagePackageConfig(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	packaged.receipt.ObjectKinds = []string{"ConfigMap", "Job", "NetworkPolicy"}
+	if _, err := PlanAggregateEvidenceStageInstallation(packaged); err == nil {
+		t.Fatal("aggregate evidence object reordering was accepted")
+	}
+	if _, err := PlanAggregateEvidenceStageInstallation(VerifiedAggregateEvidenceStagePackage{}); err == nil {
+		t.Fatal("unverified aggregate evidence package was accepted")
+	}
+}


### PR DESCRIPTION
## Scope

- derive a tokenless installation plan for the exact aggregate ConfigMap, NetworkPolicy, and Job
- re-verify create order, immutable input, run identity, runtime ServiceAccount, authorities, and all six private volume bindings
- recover exact canonical public object bodies without exposing credentials
- recover and semantically re-verify the four private credential Secrets
- fail closed on object reordering, foreign private inputs, changed Secret semantics, and private-byte tampering

## Boundaries

- offline planning and material recovery only
- no Kubernetes API call
- no infrastructure mutation
- no credential or private payload in public plans

## Verification

- `go test -ldflags=-linkmode=external ./...`
- `go vet ./...`
- `go test -race -ldflags=-linkmode=external ./internal/runner`

All passed. The macOS external-linker warnings are unchanged and non-fatal.
