### PR TITLE
OK-147: plan aggregate evidence stage launch

### DIFF
--- a/internal/runner/aggregate_evidence_stage_launch_plan.go
+++ b/internal/runner/aggregate_evidence_stage_launch_plan.go
@@ -1,0 +1,100 @@
+package runner
+
+import "errors"
+
+const AggregateEvidenceStageLaunchPlanFormat = "ok147-aggregate-evidence-stage-launch-plan/v1"
+
+// AggregateEvidenceStageLaunchPlan binds every exact object needed to start
+// the final evaluator. The durable runtime-binding Secret is preflight-only.
+type AggregateEvidenceStageLaunchPlan struct {
+	Format                    string                           `json:"format"`
+	State                     string                           `json:"state"`
+	StageID                   string                           `json:"stageId"`
+	Authority                 string                           `json:"authority"`
+	EvidencePackageDigest     string                           `json:"evidencePackageDigest"`
+	CredentialPackageDigest   string                           `json:"credentialPackageDigest"`
+	PrivateInputPackageDigest string                           `json:"privateInputPackageDigest"`
+	RuntimeManifestDigest     string                           `json:"runtimeManifestDigest"`
+	PreflightBarrier          string                           `json:"preflightBarrier"`
+	Preflights                []SubmissionStageLaunchPreflight `json:"preflights"`
+	Creates                   []SubmissionStageLaunchCreate    `json:"creates"`
+	MutationAllowed           bool                             `json:"mutationAllowed"`
+}
+
+// PlanAggregateEvidenceStageLaunch accepts only four coherent verified
+// components. All ten GETs must pass before any of the nine create candidates
+// can be considered by a later single-use launcher.
+func PlanAggregateEvidenceStageLaunch(packaged VerifiedAggregateEvidenceStagePackage, credentials VerifiedAggregateEvidenceStageCredentialPackage, privateInputs VerifiedAggregateEvidenceStagePrivateInputPackage, runtime VerifiedAggregateEvidenceStageRuntimePrerequisite) (AggregateEvidenceStageLaunchPlan, error) {
+	stage, err := PlanAggregateEvidenceStageInstallation(packaged)
+	if err != nil {
+		return AggregateEvidenceStageLaunchPlan{}, err
+	}
+	credentialReceipt, credentialObjects, err := prepareAggregateEvidenceStageCredentialInstallation(credentials)
+	if err != nil {
+		return AggregateEvidenceStageLaunchPlan{}, err
+	}
+	privateReceipt, err := privateInputs.Receipt()
+	if err != nil {
+		return AggregateEvidenceStageLaunchPlan{}, err
+	}
+	if err := verifyAggregateEvidenceStageRuntimePrerequisite(runtime); err != nil {
+		return AggregateEvidenceStageLaunchPlan{}, err
+	}
+	if stage.EvidencePackageDigest != credentialReceipt.StagePackageDigest || stage.EvidencePackageDigest != privateReceipt.EvidencePackageDigest || stage.EvidencePackageDigest != runtime.receipt.EvidencePackageDigest || stage.StageID != credentialReceipt.StageID || stage.StageID != privateReceipt.StageID || stage.Authority != credentialReceipt.InstallationAuthority || stage.Authority != privateReceipt.Authority || stage.Authority != runtime.receipt.Authority {
+		return AggregateEvidenceStageLaunchPlan{}, errors.New("aggregate evidence launch components do not share one verified identity")
+	}
+
+	preflights := make([]SubmissionStageLaunchPreflight, 0, 10)
+	creates := make([]SubmissionStageLaunchCreate, 0, 9)
+	appendCreate := func(order int, phase, apiVersion, kind, namespace, name, objectPath, collectionPath, objectDigest, existingPolicy, createPolicy string) {
+		preflights = append(preflights, SubmissionStageLaunchPreflight{
+			Order: order, Phase: phase, APIVersion: apiVersion, Kind: kind, Namespace: namespace, Name: name,
+			Method: "GET", ObjectPath: objectPath, ResponseMode: "FULL_OBJECT", ExistingPolicy: existingPolicy,
+			ObjectDigest: objectDigest,
+		})
+		creates = append(creates, SubmissionStageLaunchCreate{
+			Order: order, Phase: phase, APIVersion: apiVersion, Kind: kind, Namespace: namespace, Name: name,
+			Method: "POST", CollectionPath: collectionPath, CreatePolicy: createPolicy, ObjectDigest: objectDigest,
+		})
+	}
+	runtimeCollection := "/api/v1/namespaces/" + runtime.receipt.Namespace + "/serviceaccounts"
+	appendCreate(1, "runtime", "v1", "ServiceAccount", runtime.receipt.Namespace, runtime.receipt.Name,
+		runtimeCollection+"/"+runtime.receipt.Name, runtimeCollection, runtime.receipt.ObjectDigest,
+		"VERIFY_EXACT", "CREATE_IF_ABSENT_OR_VERIFY_EXISTING")
+
+	secretCollection := "/api/v1/namespaces/" + submissionStageInputNamespace + "/secrets"
+	runtimeInput := privateReceipt.Objects[0]
+	preflights = append(preflights, SubmissionStageLaunchPreflight{
+		Order: 2, Phase: "private-runtime", APIVersion: "v1", Kind: "Secret",
+		Namespace: runtimeInput.Namespace, Name: runtimeInput.Name, Method: "GET",
+		ObjectPath: secretCollection + "/" + runtimeInput.Name, ResponseMode: "FULL_OBJECT",
+		ExistingPolicy: runtimeInput.ExistingPolicy, ObjectDigest: runtimeInput.ObjectDigest,
+	})
+	for index, object := range stage.Creates[:2] {
+		appendCreate(index+3, "stage-prerequisites", object.APIVersion, object.Kind, object.Namespace, object.Name,
+			object.ObjectPath, object.CollectionPath, object.ObjectDigest,
+			"VERIFY_EXACT_GLOBAL_STATE", "CREATE_ONLY_AFTER_GLOBAL_ABSENCE")
+	}
+	for index, object := range credentialObjects {
+		appendCreate(index+5, "credentials", "v1", "Secret", submissionStageInputNamespace, object.name,
+			object.objectPath, object.collectionPath, object.objectDigest,
+			"VERIFY_EXACT_GLOBAL_STATE", "CREATE_ONLY_AFTER_GLOBAL_ABSENCE")
+	}
+	capability := privateReceipt.Objects[1]
+	appendCreate(9, "private-capability", "v1", "Secret", capability.Namespace, capability.Name,
+		secretCollection+"/"+capability.Name, secretCollection, capability.ObjectDigest,
+		capability.ExistingPolicy, capability.CreatePolicy)
+	job := stage.Creates[2]
+	appendCreate(10, "job", job.APIVersion, job.Kind, job.Namespace, job.Name,
+		job.ObjectPath, job.CollectionPath, job.ObjectDigest,
+		"VERIFY_EXACT_GLOBAL_STATE", "CREATE_ONLY_AFTER_GLOBAL_ABSENCE")
+
+	return AggregateEvidenceStageLaunchPlan{
+		Format: AggregateEvidenceStageLaunchPlanFormat, State: "VERIFIED", StageID: stage.StageID,
+		Authority: stage.Authority, EvidencePackageDigest: stage.EvidencePackageDigest,
+		CredentialPackageDigest: credentialReceipt.PackageDigest, PrivateInputPackageDigest: privateReceipt.PackageDigest,
+		RuntimeManifestDigest: runtime.receipt.ManifestDigest,
+		PreflightBarrier:      "RUNTIME_BINDING_REQUIRED_THEN_ALL_ABSENT_OR_RUNTIME_ONLY_OR_ALL_EXACT",
+		Preflights:            preflights, Creates: creates, MutationAllowed: false,
+	}, nil
+}

--- a/internal/runner/aggregate_evidence_stage_launch_plan_test.go
+++ b/internal/runner/aggregate_evidence_stage_launch_plan_test.go
@@ -1,0 +1,126 @@
+package runner
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+func TestPlanAggregateEvidenceStageLaunchBindsRequiredRuntimeAndNineCreates(t *testing.T) {
+	stage, credentials, privateInputs, runtime, tokens := aggregateEvidenceStageLaunchFixture(t)
+	plan, err := PlanAggregateEvidenceStageLaunch(stage, credentials, privateInputs, runtime)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stageReceipt, _ := stage.Receipt()
+	credentialReceipt, _ := credentials.Receipt()
+	privateReceipt, _ := privateInputs.Receipt()
+	runtimeReceipt, _ := runtime.Receipt()
+	if plan.Format != AggregateEvidenceStageLaunchPlanFormat || plan.State != "VERIFIED" || plan.StageID != "aggregate-evidence" || plan.Authority != "ok-mgmt" || plan.EvidencePackageDigest != stageReceipt.PackageDigest || plan.CredentialPackageDigest != credentialReceipt.PackageDigest || plan.PrivateInputPackageDigest != privateReceipt.PackageDigest || plan.RuntimeManifestDigest != runtimeReceipt.ManifestDigest || plan.PreflightBarrier != "RUNTIME_BINDING_REQUIRED_THEN_ALL_ABSENT_OR_RUNTIME_ONLY_OR_ALL_EXACT" || plan.MutationAllowed {
+		t.Fatalf("unexpected aggregate evidence launch identity: %#v", plan)
+	}
+	wantKinds := []string{"ServiceAccount", "Secret", "ConfigMap", "NetworkPolicy", "Secret", "Secret", "Secret", "Secret", "Secret", "Job"}
+	wantPhases := []string{"runtime", "private-runtime", "stage-prerequisites", "stage-prerequisites", "credentials", "credentials", "credentials", "credentials", "private-capability", "job"}
+	if len(plan.Preflights) != 10 || len(plan.Creates) != 9 {
+		t.Fatalf("unexpected aggregate launch count: %d %d", len(plan.Preflights), len(plan.Creates))
+	}
+	creates := map[int]SubmissionStageLaunchCreate{}
+	for _, create := range plan.Creates {
+		creates[create.Order] = create
+	}
+	for index, preflight := range plan.Preflights {
+		order := index + 1
+		if preflight.Order != order || preflight.Phase != wantPhases[index] || preflight.Kind != wantKinds[index] || preflight.Method != "GET" || preflight.ResponseMode != "FULL_OBJECT" {
+			t.Fatalf("aggregate preflight %d differs: %#v", order, preflight)
+		}
+		create, exists := creates[order]
+		if order == 2 {
+			if exists || preflight.ExistingPolicy != "REQUIRE_EXACT_EXISTING" {
+				t.Fatalf("runtime binding may not have a create path: %#v %#v", preflight, create)
+			}
+			continue
+		}
+		if !exists || create.Phase != preflight.Phase || create.Kind != preflight.Kind || create.Name != preflight.Name || create.Namespace != preflight.Namespace || create.ObjectDigest != preflight.ObjectDigest || create.Method != "POST" {
+			t.Fatalf("aggregate create %d differs: %#v %#v", order, preflight, create)
+		}
+		if order == 1 {
+			if preflight.ExistingPolicy != "VERIFY_EXACT" || create.CreatePolicy != "CREATE_IF_ABSENT_OR_VERIFY_EXISTING" {
+				t.Fatalf("runtime ServiceAccount policy differs: %#v %#v", preflight, create)
+			}
+		} else if preflight.ExistingPolicy != "VERIFY_EXACT_GLOBAL_STATE" || create.CreatePolicy != "CREATE_ONLY_AFTER_GLOBAL_ABSENCE" {
+			t.Fatalf("global create policy differs at %d: %#v %#v", order, preflight, create)
+		}
+	}
+	public, err := json.Marshal(plan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range append(tokens, credentials.objects[0].raw, credentials.objects[1].raw, credentials.objects[2].raw, credentials.objects[3].raw, privateInputs.objects[0].raw, privateInputs.objects[1].raw, runtime.raw, stage.raw) {
+		if bytes.Contains(public, forbidden) {
+			t.Fatal("aggregate evidence launch plan exposed private object content")
+		}
+	}
+}
+
+func TestPlanAggregateEvidenceStageLaunchRejectsMismatchedComponents(t *testing.T) {
+	stage, credentials, privateInputs, runtime, _ := aggregateEvidenceStageLaunchFixture(t)
+	tests := map[string]func() (VerifiedAggregateEvidenceStagePackage, VerifiedAggregateEvidenceStageCredentialPackage, VerifiedAggregateEvidenceStagePrivateInputPackage, VerifiedAggregateEvidenceStageRuntimePrerequisite){
+		"empty stage": func() (VerifiedAggregateEvidenceStagePackage, VerifiedAggregateEvidenceStageCredentialPackage, VerifiedAggregateEvidenceStagePrivateInputPackage, VerifiedAggregateEvidenceStageRuntimePrerequisite) {
+			return VerifiedAggregateEvidenceStagePackage{}, credentials, privateInputs, runtime
+		},
+		"empty credentials": func() (VerifiedAggregateEvidenceStagePackage, VerifiedAggregateEvidenceStageCredentialPackage, VerifiedAggregateEvidenceStagePrivateInputPackage, VerifiedAggregateEvidenceStageRuntimePrerequisite) {
+			return stage, VerifiedAggregateEvidenceStageCredentialPackage{}, privateInputs, runtime
+		},
+		"empty private inputs": func() (VerifiedAggregateEvidenceStagePackage, VerifiedAggregateEvidenceStageCredentialPackage, VerifiedAggregateEvidenceStagePrivateInputPackage, VerifiedAggregateEvidenceStageRuntimePrerequisite) {
+			return stage, credentials, VerifiedAggregateEvidenceStagePrivateInputPackage{}, runtime
+		},
+		"empty runtime": func() (VerifiedAggregateEvidenceStagePackage, VerifiedAggregateEvidenceStageCredentialPackage, VerifiedAggregateEvidenceStagePrivateInputPackage, VerifiedAggregateEvidenceStageRuntimePrerequisite) {
+			return stage, credentials, privateInputs, VerifiedAggregateEvidenceStageRuntimePrerequisite{}
+		},
+		"foreign credential package": func() (VerifiedAggregateEvidenceStagePackage, VerifiedAggregateEvidenceStageCredentialPackage, VerifiedAggregateEvidenceStagePrivateInputPackage, VerifiedAggregateEvidenceStageRuntimePrerequisite) {
+			changed := credentials
+			changed.receipt.StagePackageDigest = digest.SHA256([]byte("foreign"))
+			return stage, changed, privateInputs, runtime
+		},
+		"foreign private inputs": func() (VerifiedAggregateEvidenceStagePackage, VerifiedAggregateEvidenceStageCredentialPackage, VerifiedAggregateEvidenceStagePrivateInputPackage, VerifiedAggregateEvidenceStageRuntimePrerequisite) {
+			changed := privateInputs
+			changed.receipt.EvidencePackageDigest = digest.SHA256([]byte("foreign"))
+			return stage, credentials, changed, runtime
+		},
+		"foreign runtime": func() (VerifiedAggregateEvidenceStagePackage, VerifiedAggregateEvidenceStageCredentialPackage, VerifiedAggregateEvidenceStagePrivateInputPackage, VerifiedAggregateEvidenceStageRuntimePrerequisite) {
+			changed := runtime
+			changed.receipt.EvidencePackageDigest = digest.SHA256([]byte("foreign"))
+			return stage, credentials, privateInputs, changed
+		},
+	}
+	for name, values := range tests {
+		t.Run(name, func(t *testing.T) {
+			candidateStage, candidateCredentials, candidatePrivate, candidateRuntime := values()
+			if _, err := PlanAggregateEvidenceStageLaunch(candidateStage, candidateCredentials, candidatePrivate, candidateRuntime); err == nil {
+				t.Fatal("mismatched aggregate evidence launch components accepted")
+			}
+		})
+	}
+}
+
+func aggregateEvidenceStageLaunchFixture(t *testing.T) (VerifiedAggregateEvidenceStagePackage, VerifiedAggregateEvidenceStageCredentialPackage, VerifiedAggregateEvidenceStagePrivateInputPackage, VerifiedAggregateEvidenceStageRuntimePrerequisite, [][]byte) {
+	t.Helper()
+	credentialConfig, tokens := aggregateEvidenceCredentialConfig(t)
+	stage := credentialConfig.Package
+	credentials, err := BuildAggregateEvidenceStageCredentialPackage(credentialConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	privateInputs, err := BuildAggregateEvidenceStagePrivateInputPackage(stage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest := submissionStageRuntimeManifest(t)
+	runtime, err := BuildAggregateEvidenceStageRuntimePrerequisite(stage, manifest, digest.SHA256(manifest))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return stage, credentials, privateInputs, runtime, tokens
+}

--- a/internal/runner/aggregate_evidence_stage_runtime_prerequisite.go
+++ b/internal/runner/aggregate_evidence_stage_runtime_prerequisite.go
@@ -1,0 +1,61 @@
+package runner
+
+import (
+	"errors"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+const AggregateEvidenceStageRuntimePrerequisiteFormat = "ok147-aggregate-evidence-stage-runtime-prerequisite/v1"
+
+type AggregateEvidenceStageRuntimePrerequisiteReceipt struct {
+	Format                string `json:"format"`
+	State                 string `json:"state"`
+	EvidencePackageDigest string `json:"evidencePackageDigest"`
+	ManifestDigest        string `json:"manifestDigest"`
+	ObjectDigest          string `json:"objectDigest"`
+	Authority             string `json:"authority"`
+	Namespace             string `json:"namespace"`
+	Name                  string `json:"name"`
+	MutationAllowed       bool   `json:"mutationAllowed"`
+}
+
+type VerifiedAggregateEvidenceStageRuntimePrerequisite struct {
+	raw      []byte
+	receipt  AggregateEvidenceStageRuntimePrerequisiteReceipt
+	verified bool
+}
+
+// BuildAggregateEvidenceStageRuntimePrerequisite binds the shared tokenless
+// runtime ServiceAccount to one exact aggregate-evidence package offline.
+func BuildAggregateEvidenceStageRuntimePrerequisite(packaged VerifiedAggregateEvidenceStagePackage, manifest []byte, expectedDigest string) (VerifiedAggregateEvidenceStageRuntimePrerequisite, error) {
+	plan, err := PlanAggregateEvidenceStageInstallation(packaged)
+	if err != nil {
+		return VerifiedAggregateEvidenceStageRuntimePrerequisite{}, err
+	}
+	raw, objectDigest, err := buildStageRuntimePrerequisiteObject(manifest, expectedDigest)
+	if err != nil {
+		return VerifiedAggregateEvidenceStageRuntimePrerequisite{}, err
+	}
+	receipt := AggregateEvidenceStageRuntimePrerequisiteReceipt{
+		Format: AggregateEvidenceStageRuntimePrerequisiteFormat, State: "VERIFIED",
+		EvidencePackageDigest: plan.EvidencePackageDigest, ManifestDigest: expectedDigest,
+		ObjectDigest: objectDigest, Authority: plan.Authority,
+		Namespace: submissionStageInputNamespace, Name: "ok147-contract-executor-runtime", MutationAllowed: false,
+	}
+	return VerifiedAggregateEvidenceStageRuntimePrerequisite{raw: raw, receipt: receipt, verified: true}, nil
+}
+
+func (runtime VerifiedAggregateEvidenceStageRuntimePrerequisite) Receipt() (AggregateEvidenceStageRuntimePrerequisiteReceipt, error) {
+	if err := verifyAggregateEvidenceStageRuntimePrerequisite(runtime); err != nil {
+		return AggregateEvidenceStageRuntimePrerequisiteReceipt{}, err
+	}
+	return runtime.receipt, nil
+}
+
+func verifyAggregateEvidenceStageRuntimePrerequisite(runtime VerifiedAggregateEvidenceStageRuntimePrerequisite) error {
+	if !runtime.verified || runtime.receipt.Format != AggregateEvidenceStageRuntimePrerequisiteFormat || runtime.receipt.State != "VERIFIED" || runtime.receipt.Authority == "" || runtime.receipt.Namespace != submissionStageInputNamespace || runtime.receipt.Name != "ok147-contract-executor-runtime" || runtime.receipt.MutationAllowed || !stageReceiptPrefixDigestPattern.MatchString(runtime.receipt.EvidencePackageDigest) || !stageReceiptPrefixDigestPattern.MatchString(runtime.receipt.ManifestDigest) || digest.SHA256(runtime.raw) != runtime.receipt.ObjectDigest {
+		return errors.New("aggregate evidence runtime prerequisite was not produced by verification")
+	}
+	return nil
+}


### PR DESCRIPTION
## Scope

- bind one coherent Stage 12 launch plan across public package, credentials, private inputs, and runtime ServiceAccount
- require ten exact GET preflights before any write
- expose nine bounded create candidates in fixed order
- make the durable runtime-binding Secret preflight-only with no create path
- allow only runtime ServiceAccount reuse outside the global all-absent/all-exact barrier
- fail closed on any mismatched package, authority, policy, or runtime identity

## Boundaries

- offline launch planning only
- no Kubernetes API call
- no infrastructure mutation
- no token, Secret body, runtime payload, or public object body in the launch plan

## Verification

- `go test -ldflags=-linkmode=external ./...`
- `go vet ./...`
- `go test -race -ldflags=-linkmode=external ./internal/runner`

All passed. The macOS external-linker warnings are unchanged and non-fatal.
