### PR TITLE
OK-147: seal aggregate evidence launch material

### DIFF
--- a/internal/runner/aggregate_evidence_stage_credentials_test.go
+++ b/internal/runner/aggregate_evidence_stage_credentials_test.go
@@ -137,6 +137,11 @@ func TestBuildAggregateEvidenceStageCredentialPackageFailsClosed(t *testing.T) {
 
 func aggregateEvidenceCredentialConfig(t *testing.T) (AggregateEvidenceStageCredentialPackageConfig, [][]byte) {
 	t.Helper()
+	return aggregateEvidenceCredentialConfigForPackage(t, aggregateEvidenceStagePackageConfig(t))
+}
+
+func aggregateEvidenceCredentialConfigForPackage(t *testing.T, packageConfig AggregateEvidenceStagePackageConfig) (AggregateEvidenceStageCredentialPackageConfig, [][]byte) {
+	t.Helper()
 	now := time.Date(2026, 8, 16, 12, 0, 0, 0, time.UTC)
 	issuedAt, expiresAt := now.Add(-time.Minute), now.Add(30*time.Minute)
 	audiences := []string{"https://kubernetes.default.svc"}
@@ -146,7 +151,6 @@ func aggregateEvidenceCredentialConfig(t *testing.T) (AggregateEvidenceStageCred
 	managementCAPath := writeBundleFile(t, root, "management-ca.crt", managementCA)
 	argoCAPath := writeBundleFile(t, root, "argo-ca.crt", argoCA)
 
-	packageConfig := aggregateEvidenceStagePackageConfig(t)
 	var runtime RuntimeBindingMaterial
 	runtimeRaw, err := os.ReadFile(packageConfig.RuntimeBindingMaterialPath)
 	if err != nil || jsonstrict.Decode(runtimeRaw, &runtime) != nil {

--- a/internal/runner/aggregate_evidence_stage_launch_material.go
+++ b/internal/runner/aggregate_evidence_stage_launch_material.go
@@ -1,0 +1,136 @@
+package runner
+
+import (
+	"errors"
+	"time"
+)
+
+const AggregateEvidenceStageLaunchMaterialFormat = "ok147-aggregate-evidence-stage-launch-material/v1"
+
+type AggregateEvidenceStageLaunchMaterialConfig struct {
+	Package               AggregateEvidenceStagePackageConfig
+	MaterializationTime   time.Time
+	Ledger                SubmissionStageCredentialSource
+	ManagementObserver    SubmissionStageCredentialSource
+	WorkloadObserver      SubmissionStageCredentialSource
+	ArgoObserver          SubmissionStageCredentialSource
+	RuntimeManifest       []byte
+	RuntimeManifestDigest string
+	Candidate             SubmissionStageLaunchCandidateConfig
+}
+
+type AggregateEvidenceStageLaunchMaterialReceipt struct {
+	Format                    string `json:"format"`
+	State                     string `json:"state"`
+	StageID                   string `json:"stageId"`
+	Authority                 string `json:"authority"`
+	EvidencePackageDigest     string `json:"evidencePackageDigest"`
+	CredentialPackageDigest   string `json:"credentialPackageDigest"`
+	PrivateInputPackageDigest string `json:"privateInputPackageDigest"`
+	RuntimeManifestDigest     string `json:"runtimeManifestDigest"`
+	LaunchPlanDigest          string `json:"launchPlanDigest"`
+	CandidateDigest           string `json:"candidateDigest"`
+	ValidUntil                string `json:"validUntil"`
+	MutationAllowed           bool   `json:"mutationAllowed"`
+}
+
+// VerifiedAggregateEvidenceStageLaunchMaterial retains every exact public
+// object, private object, credential and launch candidate required by a later
+// launcher. Only redaction-safe identities are exposed through its receipt.
+type VerifiedAggregateEvidenceStageLaunchMaterial struct {
+	packaged      VerifiedAggregateEvidenceStagePackage
+	credentials   VerifiedAggregateEvidenceStageCredentialPackage
+	privateInputs VerifiedAggregateEvidenceStagePrivateInputPackage
+	runtime       VerifiedAggregateEvidenceStageRuntimePrerequisite
+	candidate     VerifiedAggregateEvidenceStageLaunchCandidate
+	receipt       AggregateEvidenceStageLaunchMaterialReceipt
+	verified      bool
+}
+
+// BuildAggregateEvidenceStageLaunchMaterial reconstructs and re-verifies the
+// complete private Stage 12 launch input from bounded local sources. It makes
+// no Kubernetes API request and grants no launch authority.
+func BuildAggregateEvidenceStageLaunchMaterial(config AggregateEvidenceStageLaunchMaterialConfig) (VerifiedAggregateEvidenceStageLaunchMaterial, error) {
+	packaged, err := BuildAggregateEvidenceStagePackage(config.Package)
+	if err != nil {
+		return VerifiedAggregateEvidenceStageLaunchMaterial{}, err
+	}
+	credentials, err := BuildAggregateEvidenceStageCredentialPackage(AggregateEvidenceStageCredentialPackageConfig{
+		Package: packaged, MaterializationTime: config.MaterializationTime,
+		Ledger: config.Ledger, ManagementObserver: config.ManagementObserver,
+		WorkloadObserver: config.WorkloadObserver, ArgoObserver: config.ArgoObserver,
+	})
+	if err != nil {
+		return VerifiedAggregateEvidenceStageLaunchMaterial{}, err
+	}
+	privateInputs, err := BuildAggregateEvidenceStagePrivateInputPackage(packaged)
+	if err != nil {
+		return VerifiedAggregateEvidenceStageLaunchMaterial{}, err
+	}
+	runtime, err := BuildAggregateEvidenceStageRuntimePrerequisite(packaged, config.RuntimeManifest, config.RuntimeManifestDigest)
+	if err != nil {
+		return VerifiedAggregateEvidenceStageLaunchMaterial{}, err
+	}
+	candidate, err := PrepareAggregateEvidenceStageLaunchCandidate(config.Candidate, packaged, credentials, privateInputs, runtime)
+	if err != nil {
+		return VerifiedAggregateEvidenceStageLaunchMaterial{}, err
+	}
+	candidateReceipt, err := candidate.Receipt()
+	if err != nil {
+		return VerifiedAggregateEvidenceStageLaunchMaterial{}, err
+	}
+	receipt := AggregateEvidenceStageLaunchMaterialReceipt{
+		Format: AggregateEvidenceStageLaunchMaterialFormat, State: "VERIFIED",
+		StageID: candidateReceipt.StageID, Authority: candidateReceipt.Authority,
+		EvidencePackageDigest:     candidateReceipt.EvidencePackageDigest,
+		CredentialPackageDigest:   candidateReceipt.CredentialPackageDigest,
+		PrivateInputPackageDigest: candidateReceipt.PrivateInputPackageDigest,
+		RuntimeManifestDigest:     candidateReceipt.RuntimeManifestDigest,
+		LaunchPlanDigest:          candidateReceipt.LaunchPlanDigest,
+		CandidateDigest:           candidateReceipt.CandidateDigest,
+		ValidUntil:                candidateReceipt.ValidUntil, MutationAllowed: false,
+	}
+	return VerifiedAggregateEvidenceStageLaunchMaterial{
+		packaged: packaged, credentials: credentials, privateInputs: privateInputs,
+		runtime: runtime, candidate: candidate, receipt: receipt, verified: true,
+	}, nil
+}
+
+func (material VerifiedAggregateEvidenceStageLaunchMaterial) Receipt() (AggregateEvidenceStageLaunchMaterialReceipt, error) {
+	if err := verifyAggregateEvidenceStageLaunchMaterial(material); err != nil {
+		return AggregateEvidenceStageLaunchMaterialReceipt{}, err
+	}
+	return material.receipt, nil
+}
+
+func (material VerifiedAggregateEvidenceStageLaunchMaterial) CandidateReceipt() (AggregateEvidenceStageLaunchCandidateReceipt, error) {
+	if err := verifyAggregateEvidenceStageLaunchMaterial(material); err != nil {
+		return AggregateEvidenceStageLaunchCandidateReceipt{}, err
+	}
+	return material.candidate.Receipt()
+}
+
+func verifyAggregateEvidenceStageLaunchMaterial(material VerifiedAggregateEvidenceStageLaunchMaterial) error {
+	if !material.verified || material.receipt.Format != AggregateEvidenceStageLaunchMaterialFormat || material.receipt.State != "VERIFIED" || material.receipt.MutationAllowed {
+		return errors.New("aggregate evidence launch material was not produced by verification")
+	}
+	plan, err := PlanAggregateEvidenceStageLaunch(material.packaged, material.credentials, material.privateInputs, material.runtime)
+	if err != nil {
+		return err
+	}
+	candidateReceipt, err := material.candidate.Receipt()
+	if err != nil {
+		return err
+	}
+	if material.receipt.StageID != plan.StageID || material.receipt.Authority != plan.Authority ||
+		material.receipt.EvidencePackageDigest != plan.EvidencePackageDigest || material.receipt.CredentialPackageDigest != plan.CredentialPackageDigest ||
+		material.receipt.PrivateInputPackageDigest != plan.PrivateInputPackageDigest || material.receipt.RuntimeManifestDigest != plan.RuntimeManifestDigest ||
+		material.receipt.StageID != candidateReceipt.StageID || material.receipt.Authority != candidateReceipt.Authority ||
+		material.receipt.EvidencePackageDigest != candidateReceipt.EvidencePackageDigest || material.receipt.CredentialPackageDigest != candidateReceipt.CredentialPackageDigest ||
+		material.receipt.PrivateInputPackageDigest != candidateReceipt.PrivateInputPackageDigest || material.receipt.RuntimeManifestDigest != candidateReceipt.RuntimeManifestDigest ||
+		material.receipt.LaunchPlanDigest != candidateReceipt.LaunchPlanDigest || material.receipt.CandidateDigest != candidateReceipt.CandidateDigest ||
+		material.receipt.ValidUntil != candidateReceipt.ValidUntil {
+		return errors.New("aggregate evidence launch material identity changed after verification")
+	}
+	return nil
+}

--- a/internal/runner/aggregate_evidence_stage_launch_material_test.go
+++ b/internal/runner/aggregate_evidence_stage_launch_material_test.go
@@ -1,0 +1,95 @@
+package runner
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+func TestBuildAggregateEvidenceStageLaunchMaterialSealsAllPrivateComponents(t *testing.T) {
+	config, tokens := aggregateEvidenceStageLaunchMaterialConfig(t)
+	material, err := BuildAggregateEvidenceStageLaunchMaterial(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := material.Receipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	candidate, err := material.CandidateReceipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if receipt.Format != AggregateEvidenceStageLaunchMaterialFormat || receipt.State != "VERIFIED" || receipt.StageID != "aggregate-evidence" || receipt.Authority != "ok-mgmt" || receipt.EvidencePackageDigest != candidate.EvidencePackageDigest || receipt.CredentialPackageDigest != candidate.CredentialPackageDigest || receipt.PrivateInputPackageDigest != candidate.PrivateInputPackageDigest || receipt.RuntimeManifestDigest != candidate.RuntimeManifestDigest || receipt.LaunchPlanDigest != candidate.LaunchPlanDigest || receipt.CandidateDigest != candidate.CandidateDigest || receipt.ValidUntil != candidate.ValidUntil || receipt.MutationAllowed {
+		t.Fatalf("unexpected aggregate evidence launch material: %#v", receipt)
+	}
+	public, err := json.Marshal(receipt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range append(tokens,
+		material.packaged.raw,
+		material.credentials.objects[0].raw, material.credentials.objects[1].raw,
+		material.credentials.objects[2].raw, material.credentials.objects[3].raw,
+		material.privateInputs.objects[0].raw, material.privateInputs.objects[1].raw,
+		material.runtime.raw,
+		[]byte(config.Candidate.AuthorityEndpoint), []byte(config.Candidate.InstallerTokenDigest),
+	) {
+		if bytes.Contains(public, forbidden) {
+			t.Fatal("aggregate evidence launch material receipt exposed private source content")
+		}
+	}
+	changed := material
+	changed.receipt.CandidateDigest = digest.SHA256([]byte("foreign"))
+	if _, err := changed.Receipt(); err == nil {
+		t.Fatal("changed aggregate evidence launch material identity accepted")
+	}
+	changed = material
+	changed.privateInputs.objects[1].raw = append(changed.privateInputs.objects[1].raw, '\n')
+	if _, err := changed.Receipt(); err == nil {
+		t.Fatal("changed private capability input accepted")
+	}
+}
+
+func TestBuildAggregateEvidenceStageLaunchMaterialFailsClosed(t *testing.T) {
+	valid, _ := aggregateEvidenceStageLaunchMaterialConfig(t)
+	for name, mutate := range map[string]func(*AggregateEvidenceStageLaunchMaterialConfig){
+		"wrong runtime digest": func(config *AggregateEvidenceStageLaunchMaterialConfig) {
+			config.RuntimeManifestDigest = digest.SHA256([]byte("foreign"))
+		},
+		"foreign Argo observer": func(config *AggregateEvidenceStageLaunchMaterialConfig) {
+			config.ArgoObserver.AuthorityIdentity = "ok-mgmt"
+		},
+		"expired candidate": func(config *AggregateEvidenceStageLaunchMaterialConfig) {
+			config.Candidate.PreparedAt = config.MaterializationTime.Add(16 * time.Minute)
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			config := valid
+			mutate(&config)
+			if _, err := BuildAggregateEvidenceStageLaunchMaterial(config); err == nil {
+				t.Fatal("invalid aggregate evidence launch material accepted")
+			}
+		})
+	}
+	if _, err := (VerifiedAggregateEvidenceStageLaunchMaterial{}).Receipt(); err == nil {
+		t.Fatal("unverified aggregate evidence launch material receipt exposed")
+	}
+}
+
+func aggregateEvidenceStageLaunchMaterialConfig(t *testing.T) (AggregateEvidenceStageLaunchMaterialConfig, [][]byte) {
+	t.Helper()
+	packageConfig := aggregateEvidenceStagePackageConfig(t)
+	credentialConfig, tokens := aggregateEvidenceCredentialConfigForPackage(t, packageConfig)
+	manifest := submissionStageRuntimeManifest(t)
+	return AggregateEvidenceStageLaunchMaterialConfig{
+		Package: packageConfig, MaterializationTime: credentialConfig.MaterializationTime,
+		Ledger: credentialConfig.Ledger, ManagementObserver: credentialConfig.ManagementObserver,
+		WorkloadObserver: credentialConfig.WorkloadObserver, ArgoObserver: credentialConfig.ArgoObserver,
+		RuntimeManifest: manifest, RuntimeManifestDigest: digest.SHA256(manifest),
+		Candidate: submissionStageLaunchCandidateConfig(),
+	}, tokens
+}


### PR DESCRIPTION
## Scope

- reconstruct and verify the complete private Stage 12 launch material from bounded local sources
- seal the public package, four distinct credentials, two private inputs, runtime prerequisite, launch plan, and launch candidate into one coherent identity
- expose only correlated digests and validity in the public receipt
- fail closed when any retained private object, credential, package identity, runtime prerequisite, or candidate changes

## Boundaries

- offline material construction only
- no Kubernetes API contact
- no infrastructure mutation
- no stage launch yet

## Verification

- `go test -ldflags=-linkmode=external ./...`
- `go vet ./...`
- `go test -race -ldflags=-linkmode=external ./internal/runner`

All passed. The macOS external-linker warnings are unchanged and non-fatal.

## OK-147 status

Stage 12 now has complete, redaction-safe launch material. The Kubernetes launcher and CLI wiring remain subsequent checkpoints.
