### PR TITLE
OK-147: expose aggregate evidence launch

### DIFF
--- a/cmd/ok/aggregate_evidence_launch.go
+++ b/cmd/ok/aggregate_evidence_launch.go
@@ -1,0 +1,294 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/runner"
+)
+
+var prepareAggregateEvidenceStageLaunch = func(config runner.AggregateEvidenceStageLaunchMaterialConfig) (aggregateEvidenceLaunchPreparation, error) {
+	material, err := runner.BuildAggregateEvidenceStageLaunchMaterial(config)
+	if err != nil {
+		return aggregateEvidenceLaunchPreparation{}, err
+	}
+	materialReceipt, err := material.Receipt()
+	if err != nil {
+		return aggregateEvidenceLaunchPreparation{}, err
+	}
+	candidateReceipt, err := material.CandidateReceipt()
+	if err != nil {
+		return aggregateEvidenceLaunchPreparation{}, err
+	}
+	return aggregateEvidenceLaunchPreparation{
+		Format: "ok147-aggregate-evidence-stage-launch-preparation/v1", State: "PREPARED",
+		Material: materialReceipt, Candidate: candidateReceipt, MutationAllowed: false,
+	}, nil
+}
+
+var executeAggregateEvidenceStageLaunch = func(ctx context.Context, config runner.AggregateEvidenceStageLaunchMaterialConfig, authority runner.KubernetesAuthorityConfig, expectedCandidateDigest string) (runner.AggregateEvidenceStageLaunchReceipt, error) {
+	material, err := runner.BuildAggregateEvidenceStageLaunchMaterial(config)
+	if err != nil {
+		return runner.AggregateEvidenceStageLaunchReceipt{}, err
+	}
+	candidate, err := material.CandidateReceipt()
+	if err != nil {
+		return runner.AggregateEvidenceStageLaunchReceipt{}, err
+	}
+	authority.AuthorityIdentity = candidate.Authority
+	launcher, err := material.Open(runner.AggregateEvidenceStageLaunchOpenConfig{
+		Authority: authority, Clock: func() time.Time { return time.Now().UTC() }, ExpectedCandidateDigest: expectedCandidateDigest,
+	})
+	if err != nil {
+		return runner.AggregateEvidenceStageLaunchReceipt{}, err
+	}
+	return launcher.Launch(ctx)
+}
+
+type aggregateEvidenceLaunchPreparation struct {
+	Format          string                                              `json:"format"`
+	State           string                                              `json:"state"`
+	Material        runner.AggregateEvidenceStageLaunchMaterialReceipt  `json:"material"`
+	Candidate       runner.AggregateEvidenceStageLaunchCandidateReceipt `json:"candidate"`
+	MutationAllowed bool                                                `json:"mutationAllowed"`
+}
+
+type aggregateEvidenceLaunchMaterialFlags struct {
+	resume *stageResumeFlags
+
+	aggregateProfile, aggregateProfileDigest *string
+	networkProfile, networkProfileDigest     *string
+	platformProfile, platformProfileDigest   *string
+	inputConfigMap                           *string
+
+	jobTemplate, jobTemplateDigest, runID, imageDigest    *string
+	ledgerAPIURL, ledgerAPICIDR, ledgerSecret             *string
+	managementAPIURL, managementAPICIDR, managementSecret *string
+	workloadAPIURL, workloadAPICIDR, workloadSecret       *string
+	argoAPIURL, argoAPICIDR, argoSecret                   *string
+
+	runtimeBindingSecret, runtimeBindingMaterial, runtimeBindingReceipt *string
+	capabilitySecret, capabilityPath, capabilityDigest                  *string
+
+	materializedAt, runtimeManifest, runtimeManifestDigest                                       *string
+	installerAPIEndpoint, installerCADigest, installerTokenDigest, installerEvidence, preparedAt *string
+	ledgerCredential, managementCredential, workloadCredential, argoCredential                   *stageLaunchCredentialFlags
+}
+
+func addAggregateEvidenceLaunchMaterialFlags(flags *flag.FlagSet) *aggregateEvidenceLaunchMaterialFlags {
+	values := &aggregateEvidenceLaunchMaterialFlags{resume: addStageResumeFlags(flags)}
+	values.aggregateProfile = flags.String("aggregate-profile", "", "path to the aggregate evidence profile")
+	values.aggregateProfileDigest = flags.String("aggregate-profile-digest", "", "expected aggregate evidence profile digest")
+	values.networkProfile = flags.String("network-profile", "", "path to the NetworkReady profile")
+	values.networkProfileDigest = flags.String("network-profile-digest", "", "expected NetworkReady profile digest")
+	values.platformProfile = flags.String("platform-profile", "", "path to the PlatformReady profile")
+	values.platformProfileDigest = flags.String("platform-profile-digest", "", "expected PlatformReady profile digest")
+	values.inputConfigMap = flags.String("input-configmap", "", "immutable aggregate evidence input ConfigMap name")
+	values.jobTemplate = flags.String("job-template", "", "path to the bounded aggregate-evidence Job template")
+	values.jobTemplateDigest = flags.String("job-template-digest", "", "expected aggregate-evidence Job template digest")
+	values.runID = flags.String("run-id", "", "bounded OK-147 aggregate-evidence Job identity")
+	values.imageDigest = flags.String("image", "", "digest-pinned ok image")
+	values.ledgerAPIURL = flags.String("ledger-api-url", "", "exact management-ledger HTTPS IP endpoint")
+	values.ledgerAPICIDR = flags.String("ledger-api-cidr", "", "single-address management-ledger CIDR")
+	values.ledgerSecret = flags.String("ledger-credential-secret", "", "ledger credential Secret name")
+	values.managementAPIURL = flags.String("management-api-url", "", "exact management observer HTTPS IP endpoint")
+	values.managementAPICIDR = flags.String("management-api-cidr", "", "single-address management observer CIDR")
+	values.managementSecret = flags.String("management-credential-secret", "", "management observer credential Secret name")
+	values.workloadAPIURL = flags.String("workload-api-url", "", "exact workload observer HTTPS IP endpoint")
+	values.workloadAPICIDR = flags.String("workload-api-cidr", "", "single-address workload observer CIDR")
+	values.workloadSecret = flags.String("workload-credential-secret", "", "workload observer credential Secret name")
+	values.argoAPIURL = flags.String("argo-api-url", "", "exact Argo control-plane HTTPS IP endpoint")
+	values.argoAPICIDR = flags.String("argo-api-cidr", "", "single-address Argo control-plane CIDR")
+	values.argoSecret = flags.String("argo-credential-secret", "", "Argo observer credential Secret name")
+	values.runtimeBindingSecret = flags.String("runtime-binding-secret", "", "pre-existing private runtime-binding Secret name")
+	values.runtimeBindingMaterial = flags.String("runtime-binding-material", "", "path to private runtime-binding material")
+	values.runtimeBindingReceipt = flags.String("runtime-binding-receipt", "", "path to private runtime-binding receipt")
+	values.capabilitySecret = flags.String("platform-capability-secret", "", "private platform capability Secret name")
+	values.capabilityPath = flags.String("platform-capability", "", "path to private platform capability evidence")
+	values.capabilityDigest = flags.String("platform-capability-digest", "", "expected private platform capability evidence digest")
+	values.materializedAt = flags.String("credential-materialized-at", "", "exact credential materialization time")
+	values.ledgerCredential = addStageLaunchCredentialFlags(flags, "ledger-job", "ledger Job credential")
+	values.managementCredential = addStageLaunchCredentialFlags(flags, "management-observer-job", "management observer Job credential")
+	values.workloadCredential = addStageLaunchCredentialFlags(flags, "workload-observer-job", "workload observer Job credential")
+	values.argoCredential = addStageLaunchCredentialFlags(flags, "argo-observer-job", "Argo observer Job credential")
+	values.runtimeManifest = flags.String("runtime-manifest", "", "path to the tokenless runtime ServiceAccount manifest")
+	values.runtimeManifestDigest = flags.String("runtime-manifest-digest", "", "expected runtime manifest digest")
+	values.installerAPIEndpoint = flags.String("installer-api-endpoint", "", "exact management installer HTTPS IP endpoint")
+	values.installerCADigest = flags.String("installer-ca-digest", "", "expected management installer CA digest")
+	values.installerTokenDigest = flags.String("installer-token-digest", "", "private expected management installer token digest")
+	values.installerEvidence = flags.String("installer-tokenrequest-evidence-digest", "", "management installer TokenRequest evidence digest")
+	values.preparedAt = flags.String("prepared-at", "", "exact launch candidate preparation time")
+	return values
+}
+
+func (values *aggregateEvidenceLaunchMaterialFlags) config() (runner.AggregateEvidenceStageLaunchMaterialConfig, error) {
+	resume, err := values.resume.config()
+	if err != nil {
+		return runner.AggregateEvidenceStageLaunchMaterialConfig{}, err
+	}
+	for _, input := range []struct{ name, value string }{
+		{"--aggregate-profile", *values.aggregateProfile}, {"--aggregate-profile-digest", *values.aggregateProfileDigest},
+		{"--network-profile", *values.networkProfile}, {"--network-profile-digest", *values.networkProfileDigest},
+		{"--platform-profile", *values.platformProfile}, {"--platform-profile-digest", *values.platformProfileDigest},
+		{"--input-configmap", *values.inputConfigMap}, {"--job-template", *values.jobTemplate}, {"--job-template-digest", *values.jobTemplateDigest},
+		{"--run-id", *values.runID}, {"--image", *values.imageDigest},
+		{"--ledger-api-url", *values.ledgerAPIURL}, {"--ledger-api-cidr", *values.ledgerAPICIDR}, {"--ledger-credential-secret", *values.ledgerSecret},
+		{"--management-api-url", *values.managementAPIURL}, {"--management-api-cidr", *values.managementAPICIDR}, {"--management-credential-secret", *values.managementSecret},
+		{"--workload-api-url", *values.workloadAPIURL}, {"--workload-api-cidr", *values.workloadAPICIDR}, {"--workload-credential-secret", *values.workloadSecret},
+		{"--argo-api-url", *values.argoAPIURL}, {"--argo-api-cidr", *values.argoAPICIDR}, {"--argo-credential-secret", *values.argoSecret},
+		{"--runtime-binding-secret", *values.runtimeBindingSecret}, {"--runtime-binding-material", *values.runtimeBindingMaterial}, {"--runtime-binding-receipt", *values.runtimeBindingReceipt},
+		{"--platform-capability-secret", *values.capabilitySecret}, {"--platform-capability", *values.capabilityPath}, {"--platform-capability-digest", *values.capabilityDigest},
+		{"--credential-materialized-at", *values.materializedAt}, {"--runtime-manifest", *values.runtimeManifest}, {"--runtime-manifest-digest", *values.runtimeManifestDigest},
+		{"--installer-api-endpoint", *values.installerAPIEndpoint}, {"--installer-ca-digest", *values.installerCADigest}, {"--installer-token-digest", *values.installerTokenDigest},
+		{"--installer-tokenrequest-evidence-digest", *values.installerEvidence}, {"--prepared-at", *values.preparedAt},
+	} {
+		if input.value == "" {
+			return runner.AggregateEvidenceStageLaunchMaterialConfig{}, fmt.Errorf("%s is required", input.name)
+		}
+	}
+	for _, value := range []string{
+		*values.aggregateProfileDigest, *values.networkProfileDigest, *values.platformProfileDigest,
+		*values.jobTemplateDigest, *values.capabilityDigest, *values.runtimeManifestDigest,
+		*values.installerCADigest, *values.installerTokenDigest, *values.installerEvidence,
+	} {
+		if !sha256DigestPattern.MatchString(value) {
+			return runner.AggregateEvidenceStageLaunchMaterialConfig{}, errors.New("aggregate evidence launch digests must be lowercase SHA-256 identities")
+		}
+	}
+	materializedAt, err := time.Parse(time.RFC3339, *values.materializedAt)
+	if err != nil {
+		return runner.AggregateEvidenceStageLaunchMaterialConfig{}, fmt.Errorf("parse credential materialization time: %w", err)
+	}
+	preparedAt, err := time.Parse(time.RFC3339, *values.preparedAt)
+	if err != nil {
+		return runner.AggregateEvidenceStageLaunchMaterialConfig{}, fmt.Errorf("parse candidate preparation time: %w", err)
+	}
+	ledger, err := values.ledgerCredential.source("ledger-job")
+	if err != nil {
+		return runner.AggregateEvidenceStageLaunchMaterialConfig{}, err
+	}
+	management, err := values.managementCredential.source("management-observer-job")
+	if err != nil {
+		return runner.AggregateEvidenceStageLaunchMaterialConfig{}, err
+	}
+	workload, err := values.workloadCredential.source("workload-observer-job")
+	if err != nil {
+		return runner.AggregateEvidenceStageLaunchMaterialConfig{}, err
+	}
+	argo, err := values.argoCredential.source("argo-observer-job")
+	if err != nil {
+		return runner.AggregateEvidenceStageLaunchMaterialConfig{}, err
+	}
+	template, err := readBoundedLocalFile(*values.jobTemplate, 1024*1024)
+	if err != nil {
+		return runner.AggregateEvidenceStageLaunchMaterialConfig{}, fmt.Errorf("read aggregate evidence Job template: %w", err)
+	}
+	runtimeRaw, err := readBoundedLocalFile(*values.runtimeManifest, 128*1024)
+	if err != nil {
+		return runner.AggregateEvidenceStageLaunchMaterialConfig{}, fmt.Errorf("read runtime manifest: %w", err)
+	}
+	return runner.AggregateEvidenceStageLaunchMaterialConfig{
+		Package: runner.AggregateEvidenceStagePackageConfig{
+			Input: runner.AggregateEvidenceStageInputConfig{
+				Bundle: resume, AggregateEvidenceProfilePath: *values.aggregateProfile,
+				ExpectedAggregateProfileDigest: *values.aggregateProfileDigest,
+				NetworkProfilePath:             *values.networkProfile, ExpectedNetworkProfileDigest: *values.networkProfileDigest,
+				PlatformProfilePath: *values.platformProfile, ExpectedPlatformProfileDigest: *values.platformProfileDigest,
+				ConfigMapName: *values.inputConfigMap,
+			},
+			JobTemplate: template, JobTemplateDigest: *values.jobTemplateDigest, RunID: *values.runID, ImageDigest: *values.imageDigest,
+			LedgerAPIURL: *values.ledgerAPIURL, LedgerAPICIDR: *values.ledgerAPICIDR, LedgerCredentialSecret: *values.ledgerSecret,
+			ManagementAPIURL: *values.managementAPIURL, ManagementAPICIDR: *values.managementAPICIDR, ManagementCredentialSecret: *values.managementSecret,
+			WorkloadAPIURL: *values.workloadAPIURL, WorkloadAPICIDR: *values.workloadAPICIDR, WorkloadCredentialSecret: *values.workloadSecret,
+			ArgoAPIURL: *values.argoAPIURL, ArgoAPICIDR: *values.argoAPICIDR, ArgoCredentialSecret: *values.argoSecret,
+			RuntimeBindingSecret: *values.runtimeBindingSecret, RuntimeBindingMaterialPath: *values.runtimeBindingMaterial,
+			RuntimeBindingReceiptPath: *values.runtimeBindingReceipt, PlatformCapabilitySecret: *values.capabilitySecret,
+			PlatformCapabilityPath: *values.capabilityPath, ExpectedPlatformCapabilityDigest: *values.capabilityDigest,
+		},
+		MaterializationTime: materializedAt, Ledger: ledger, ManagementObserver: management,
+		WorkloadObserver: workload, ArgoObserver: argo,
+		RuntimeManifest: runtimeRaw, RuntimeManifestDigest: *values.runtimeManifestDigest,
+		Candidate: runner.SubmissionStageLaunchCandidateConfig{
+			AuthorityEndpoint: *values.installerAPIEndpoint, CABundleDigest: *values.installerCADigest,
+			InstallerTokenDigest: *values.installerTokenDigest, InstallerCredentialEvidenceDigest: *values.installerEvidence,
+			PreparedAt: preparedAt,
+		},
+	}, nil
+}
+
+func runClusterStageRunAggregateEvidenceLaunchPrepare(arguments []string, stdout, stderr io.Writer) error {
+	flags := flag.NewFlagSet("ok cluster stage run aggregate-evidence launch prepare", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	materialFlags := addAggregateEvidenceLaunchMaterialFlags(flags)
+	if err := flags.Parse(arguments); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return errors.New("positional arguments are not accepted")
+	}
+	config, err := materialFlags.config()
+	if err != nil {
+		return err
+	}
+	preparation, err := prepareAggregateEvidenceStageLaunch(config)
+	if err != nil {
+		return err
+	}
+	encoder := json.NewEncoder(stdout)
+	encoder.SetEscapeHTML(false)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(preparation)
+}
+
+func runClusterStageRunAggregateEvidenceLaunchExecute(ctx context.Context, arguments []string, stdout, stderr io.Writer) error {
+	flags := flag.NewFlagSet("ok cluster stage run aggregate-evidence launch execute", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	materialFlags := addAggregateEvidenceLaunchMaterialFlags(flags)
+	execute := flags.Bool("execute", false, "perform the exact single-use nine-create aggregate evidence launch")
+	expectedCandidateDigest := flags.String("expected-candidate-digest", "", "exact digest emitted by aggregate evidence launch prepare")
+	installerTokenFile := flags.String("installer-token-file", "", "bounded short-lived management installer token file")
+	installerCAFile := flags.String("installer-ca-file", "", "bounded management installer CA file")
+	if err := flags.Parse(arguments); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return errors.New("positional arguments are not accepted")
+	}
+	if !*execute {
+		return errors.New("aggregate evidence launch mutation requires explicit --execute")
+	}
+	for _, input := range []struct{ name, value string }{
+		{"--expected-candidate-digest", *expectedCandidateDigest}, {"--installer-token-file", *installerTokenFile}, {"--installer-ca-file", *installerCAFile},
+	} {
+		if input.value == "" {
+			return fmt.Errorf("%s is required", input.name)
+		}
+	}
+	if !sha256DigestPattern.MatchString(*expectedCandidateDigest) {
+		return errors.New("--expected-candidate-digest must be sha256:<64 lowercase hex>")
+	}
+	config, err := materialFlags.config()
+	if err != nil {
+		return err
+	}
+	boundedContext, cancel := context.WithTimeout(ctx, stageLaunchTimeout)
+	defer cancel()
+	receipt, launchErr := executeAggregateEvidenceStageLaunch(boundedContext, config, runner.KubernetesAuthorityConfig{
+		Endpoint: config.Candidate.AuthorityEndpoint, TokenFile: *installerTokenFile,
+		CAFile: *installerCAFile, CABundleDigest: config.Candidate.CABundleDigest,
+	}, *expectedCandidateDigest)
+	if receipt.Format != "" {
+		encoder := json.NewEncoder(stdout)
+		encoder.SetEscapeHTML(false)
+		encoder.SetIndent("", "  ")
+		if err := encoder.Encode(receipt); err != nil {
+			return err
+		}
+	}
+	return launchErr
+}

--- a/cmd/ok/aggregate_evidence_launch_test.go
+++ b/cmd/ok/aggregate_evidence_launch_test.go
@@ -1,0 +1,197 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/runner"
+)
+
+func TestAggregateEvidenceLaunchPrepareBuildsOneNonMutatingCandidate(t *testing.T) {
+	previous := prepareAggregateEvidenceStageLaunch
+	defer func() { prepareAggregateEvidenceStageLaunch = previous }()
+	var captured runner.AggregateEvidenceStageLaunchMaterialConfig
+	prepareAggregateEvidenceStageLaunch = func(config runner.AggregateEvidenceStageLaunchMaterialConfig) (aggregateEvidenceLaunchPreparation, error) {
+		captured = config
+		return aggregateEvidenceLaunchPreparation{
+			Format: "ok147-aggregate-evidence-stage-launch-preparation/v1", State: "PREPARED",
+			Material: runner.AggregateEvidenceStageLaunchMaterialReceipt{
+				Format: runner.AggregateEvidenceStageLaunchMaterialFormat, State: "VERIFIED", StageID: "aggregate-evidence",
+				Authority: "ok-mgmt", CandidateDigest: testSHA("1"), MutationAllowed: false,
+			},
+			Candidate: runner.AggregateEvidenceStageLaunchCandidateReceipt{
+				Format: runner.AggregateEvidenceStageLaunchCandidateFormat, State: "PREPARED",
+				CandidateDigest: testSHA("1"), MutationAllowed: false,
+			},
+			MutationAllowed: false,
+		}, nil
+	}
+	paths := aggregateEvidenceLaunchTestFiles(t)
+	var stdout, stderr bytes.Buffer
+	if err := run(aggregateEvidenceLaunchPrepareArguments(paths), &stdout, &stderr); err != nil {
+		t.Fatalf("run: %v; stderr=%s", err, stderr.String())
+	}
+	if captured.Package.Input.Bundle.PlanExpected.ManagementAuthority != "ok-mgmt" || len(captured.Package.Input.Bundle.Receipts) != 11 || captured.Package.RunID != "ok147-aggregate-evidence-20260817-01" {
+		t.Fatalf("aggregate evidence package identity differs: %#v", captured.Package)
+	}
+	if captured.Package.RuntimeBindingMaterialPath != paths.runtimeBinding || captured.Package.PlatformCapabilityPath != paths.capability || string(captured.Package.JobTemplate) != "bounded-aggregate-template" || string(captured.RuntimeManifest) != "bounded-runtime" {
+		t.Fatalf("aggregate evidence private inputs differ: %#v", captured.Package)
+	}
+	credentials := []runner.SubmissionStageCredentialSource{captured.Ledger, captured.ManagementObserver, captured.WorkloadObserver, captured.ArgoObserver}
+	seen := map[string]bool{}
+	for _, credential := range credentials {
+		if credential.TokenFile == "" || seen[credential.TokenFile] {
+			t.Fatalf("aggregate evidence credentials are not distinct: %#v", credentials)
+		}
+		seen[credential.TokenFile] = true
+	}
+	var preparation aggregateEvidenceLaunchPreparation
+	if err := json.Unmarshal(stdout.Bytes(), &preparation); err != nil {
+		t.Fatal(err)
+	}
+	if preparation.State != "PREPARED" || preparation.MutationAllowed || preparation.Material.MutationAllowed || preparation.Candidate.MutationAllowed {
+		t.Fatalf("unsafe aggregate evidence preparation: %#v", preparation)
+	}
+
+	invalid := removeArgumentWithValue(aggregateEvidenceLaunchPrepareArguments(paths), "--argo-observer-job-token-file")
+	stdout.Reset()
+	if err := run(invalid, &stdout, &stderr); err == nil || stdout.Len() != 0 {
+		t.Fatal("incomplete aggregate evidence material reached preparation")
+	}
+}
+
+func TestAggregateEvidenceLaunchExecuteUsesExactBoundary(t *testing.T) {
+	previous := executeAggregateEvidenceStageLaunch
+	defer func() { executeAggregateEvidenceStageLaunch = previous }()
+	var calls int
+	var candidate string
+	executeAggregateEvidenceStageLaunch = func(ctx context.Context, config runner.AggregateEvidenceStageLaunchMaterialConfig, authority runner.KubernetesAuthorityConfig, expectedCandidateDigest string) (runner.AggregateEvidenceStageLaunchReceipt, error) {
+		calls++
+		candidate = expectedCandidateDigest
+		deadline, bounded := ctx.Deadline()
+		if !bounded || time.Until(deadline) <= 0 || time.Until(deadline) > stageLaunchTimeout {
+			t.Fatal("aggregate evidence launch context is not bounded")
+		}
+		if config.Package.RunID != "ok147-aggregate-evidence-20260817-01" || authority.Endpoint != "https://192.0.2.12:6443" || authority.TokenFile != "/private/tmp/aggregate-installer-token" {
+			t.Fatalf("aggregate evidence execute boundary differs: %#v %#v", config, authority)
+		}
+		return runner.AggregateEvidenceStageLaunchReceipt{
+			Format: runner.AggregateEvidenceStageLaunchReceiptFormat, StageID: "aggregate-evidence", Authority: "ok-mgmt",
+			State: "LAUNCHED", MutationState: "ATTEMPTED", Results: []runner.SubmissionStageLaunchResult{},
+		}, nil
+	}
+	paths := aggregateEvidenceLaunchTestFiles(t)
+	var stdout, stderr bytes.Buffer
+	if err := run(aggregateEvidenceLaunchExecuteArguments(paths), &stdout, &stderr); err != nil {
+		t.Fatalf("run: %v; stderr=%s", err, stderr.String())
+	}
+	if calls != 1 || candidate != testSHA("9") {
+		t.Fatalf("exact aggregate evidence candidate not used: calls=%d digest=%q", calls, candidate)
+	}
+	var receipt runner.AggregateEvidenceStageLaunchReceipt
+	if err := json.Unmarshal(stdout.Bytes(), &receipt); err != nil || receipt.State != "LAUNCHED" {
+		t.Fatalf("unexpected aggregate evidence launch receipt: %#v %v", receipt, err)
+	}
+
+	valid := aggregateEvidenceLaunchExecuteArguments(paths)
+	for name, arguments := range map[string][]string{
+		"missing execute":         removeArgument(valid, "--execute"),
+		"missing candidate":       removeArgumentWithValue(valid, "--expected-candidate-digest"),
+		"malformed candidate":     replaceArgument(valid, "--expected-candidate-digest", "sha256:ABC"),
+		"missing installer token": removeArgumentWithValue(valid, "--installer-token-file"),
+		"missing runtime binding": removeArgumentWithValue(valid, "--runtime-binding-material"),
+	} {
+		t.Run(name, func(t *testing.T) {
+			before := calls
+			stdout.Reset()
+			if err := run(arguments, &stdout, &stderr); err == nil || stdout.Len() != 0 || calls != before {
+				t.Fatal("unsafe aggregate evidence input reached executor")
+			}
+		})
+	}
+}
+
+type aggregateEvidenceLaunchPaths struct {
+	template, runtimeManifest, runtimeBinding, runtimeReceipt, capability string
+}
+
+func aggregateEvidenceLaunchTestFiles(t *testing.T) aggregateEvidenceLaunchPaths {
+	t.Helper()
+	root := t.TempDir()
+	paths := aggregateEvidenceLaunchPaths{
+		template: filepath.Join(root, "aggregate.yaml.tpl"), runtimeManifest: filepath.Join(root, "runtime.yaml"),
+		runtimeBinding: filepath.Join(root, "runtime-binding.json"), runtimeReceipt: filepath.Join(root, "runtime-binding-receipt.json"),
+		capability: filepath.Join(root, "platform-capability.json"),
+	}
+	for path, content := range map[string]string{
+		paths.template: "bounded-aggregate-template", paths.runtimeManifest: "bounded-runtime",
+		paths.runtimeBinding: "private-runtime-binding", paths.runtimeReceipt: "private-runtime-receipt",
+		paths.capability: "private-platform-capability",
+	} {
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return paths
+}
+
+func aggregateEvidenceLaunchPrepareArguments(paths aggregateEvidenceLaunchPaths) []string {
+	resume := stageResumeArguments()
+	arguments := append([]string{"cluster", "stage", "run", "aggregate-evidence", "launch", "prepare"}, resume[3:]...)
+	for index := 1; index <= 11; index++ {
+		arguments = append(arguments, "--receipt", "/tmp/stage-"+string(rune('a'+index-1))+".json@"+testSHA(string(rune('0'+index%10))))
+	}
+	arguments = append(arguments,
+		"--aggregate-profile", "/tmp/aggregate-profile.json", "--aggregate-profile-digest", testSHA("1"),
+		"--network-profile", "/tmp/network-profile.json", "--network-profile-digest", testSHA("2"),
+		"--platform-profile", "/tmp/platform-profile.json", "--platform-profile-digest", testSHA("3"),
+		"--input-configmap", "ok147-aggregate-evidence-input",
+		"--job-template", paths.template, "--job-template-digest", digest.SHA256([]byte("bounded-aggregate-template")),
+		"--run-id", "ok147-aggregate-evidence-20260817-01", "--image", "ghcr.io/openkubes/ok-cluster@"+testSHA("a"),
+		"--ledger-api-url", "https://192.0.2.12:6443", "--ledger-api-cidr", "192.0.2.12/32", "--ledger-credential-secret", "ok147-ledger-aggregate",
+		"--management-api-url", "https://192.0.2.12:6443", "--management-api-cidr", "192.0.2.12/32", "--management-credential-secret", "ok147-management-aggregate",
+		"--workload-api-url", "https://192.0.2.20:6443", "--workload-api-cidr", "192.0.2.20/32", "--workload-credential-secret", "ok147-workload-aggregate",
+		"--argo-api-url", "https://192.0.2.30:6443", "--argo-api-cidr", "192.0.2.30/32", "--argo-credential-secret", "ok147-argo-aggregate",
+		"--runtime-binding-secret", "ok147-runtime-binding-run-01", "--runtime-binding-material", paths.runtimeBinding, "--runtime-binding-receipt", paths.runtimeReceipt,
+		"--platform-capability-secret", "ok147-platform-capability-01", "--platform-capability", paths.capability, "--platform-capability-digest", testSHA("4"),
+		"--credential-materialized-at", "2026-08-17T08:00:00Z",
+	)
+	for index, credential := range []struct{ prefix, authority, subject string }{
+		{"ledger-job", "ok-mgmt", "system:serviceaccount:openkubes-execution-system:ok147-ledger-writer"},
+		{"management-observer-job", "ok-mgmt", "system:serviceaccount:openkubes-execution-system:ok147-management-observer"},
+		{"workload-observer-job", testSHA("b"), "system:serviceaccount:openkubes-execution-system:ok147-workload-observer"},
+		{"argo-observer-job", "ok-shared", "system:serviceaccount:openkubes-execution-system:ok147-argo-observer"},
+	} {
+		marker := string(rune('5' + index))
+		arguments = append(arguments,
+			"--"+credential.prefix+"-authority", credential.authority,
+			"--"+credential.prefix+"-token-file", "/private/tmp/"+credential.prefix+"-token", "--"+credential.prefix+"-token-digest", testSHA(marker),
+			"--"+credential.prefix+"-ca-file", "/private/tmp/"+credential.prefix+"-ca", "--"+credential.prefix+"-ca-digest", testSHA("c"),
+			"--"+credential.prefix+"-tokenrequest-evidence-digest", testSHA(marker),
+			"--"+credential.prefix+"-issuer", "https://kubernetes.default.svc.cluster.local", "--"+credential.prefix+"-subject", credential.subject,
+			"--"+credential.prefix+"-audiences", "https://kubernetes.default.svc",
+			"--"+credential.prefix+"-issued-at", "2026-08-17T07:59:00Z", "--"+credential.prefix+"-expires-at", "2026-08-17T08:30:00Z",
+		)
+	}
+	return append(arguments,
+		"--runtime-manifest", paths.runtimeManifest, "--runtime-manifest-digest", digest.SHA256([]byte("bounded-runtime")),
+		"--installer-api-endpoint", "https://192.0.2.12:6443", "--installer-ca-digest", testSHA("c"),
+		"--installer-token-digest", testSHA("d"), "--installer-tokenrequest-evidence-digest", testSHA("e"),
+		"--prepared-at", "2026-08-17T08:01:00Z",
+	)
+}
+
+func aggregateEvidenceLaunchExecuteArguments(paths aggregateEvidenceLaunchPaths) []string {
+	arguments := aggregateEvidenceLaunchPrepareArguments(paths)
+	arguments[5] = "execute"
+	return append(arguments,
+		"--execute", "--expected-candidate-digest", testSHA("9"),
+		"--installer-token-file", "/private/tmp/aggregate-installer-token", "--installer-ca-file", "/private/tmp/aggregate-installer-ca",
+	)
+}

--- a/cmd/ok/main.go
+++ b/cmd/ok/main.go
@@ -672,6 +672,12 @@ func runContext(ctx context.Context, arguments []string, stdout, stderr io.Write
 	if len(arguments) >= 4 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "run" && arguments[3] == "target-access" {
 		return runClusterStageRunTargetAccess(ctx, arguments[4:], stdout, stderr)
 	}
+	if len(arguments) >= 6 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "run" && arguments[3] == "aggregate-evidence" && arguments[4] == "launch" && arguments[5] == "prepare" {
+		return runClusterStageRunAggregateEvidenceLaunchPrepare(arguments[6:], stdout, stderr)
+	}
+	if len(arguments) >= 6 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "run" && arguments[3] == "aggregate-evidence" && arguments[4] == "launch" && arguments[5] == "execute" {
+		return runClusterStageRunAggregateEvidenceLaunchExecute(ctx, arguments[6:], stdout, stderr)
+	}
 	if len(arguments) >= 3 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "run" {
 		return runClusterStageRun(ctx, arguments[3:], stdout, stderr)
 	}
@@ -684,7 +690,7 @@ func runContext(ctx context.Context, arguments []string, stdout, stderr io.Write
 	if len(arguments) >= 4 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "launch" && arguments[3] == "execute" {
 		return runClusterStageLaunchExecute(ctx, arguments[4:], stdout, stderr)
 	}
-	return errors.New("usage: ok cluster create ... | ok cluster stage inspect ... | ok cluster stage resume ... | ok cluster stage observe lifecycle ... | ok cluster stage observe network ... | ok cluster stage bind runtime ... | ok cluster stage bind runtime launch prepare ... | ok cluster stage bind runtime launch execute ... | ok cluster stage observe network package ... | ok cluster stage observe network launch prepare ... | ok cluster stage observe network launch execute ... | ok cluster stage observe lifecycle package ... | ok cluster stage observe lifecycle launch prepare ... | ok cluster stage observe lifecycle launch execute ... | ok cluster stage run ... | ok cluster stage run enablement ... | ok cluster stage run target-access ... | ok cluster stage run enablement package ... | ok cluster stage run enablement launch prepare ... | ok cluster stage run enablement launch execute ... | ok cluster stage package ... | ok cluster stage launch prepare ... | ok cluster stage launch execute ...")
+	return errors.New("usage: ok cluster create ... | ok cluster stage inspect ... | ok cluster stage resume ... | ok cluster stage observe lifecycle ... | ok cluster stage observe network ... | ok cluster stage bind runtime ... | ok cluster stage bind runtime launch prepare ... | ok cluster stage bind runtime launch execute ... | ok cluster stage observe network package ... | ok cluster stage observe network launch prepare ... | ok cluster stage observe network launch execute ... | ok cluster stage observe lifecycle package ... | ok cluster stage observe lifecycle launch prepare ... | ok cluster stage observe lifecycle launch execute ... | ok cluster stage run ... | ok cluster stage run enablement ... | ok cluster stage run target-access ... | ok cluster stage run aggregate-evidence launch prepare ... | ok cluster stage run aggregate-evidence launch execute ... | ok cluster stage run enablement package ... | ok cluster stage run enablement launch prepare ... | ok cluster stage run enablement launch execute ... | ok cluster stage package ... | ok cluster stage launch prepare ... | ok cluster stage launch execute ...")
 }
 
 func runClusterCreate(arguments []string, stdout, stderr io.Writer) error {


### PR DESCRIPTION
## Scope

- expose Stage 12 through `ok cluster stage run aggregate-evidence launch prepare|execute`
- map the complete public profiles, private runtime/capability inputs, four distinct observer credentials, runtime prerequisite, and installer binding into verified launch material
- keep `prepare` strictly non-mutating and emit the material plus candidate receipts
- require explicit `--execute`, the exact candidate digest, and separate installer token/CA files before invoking the bounded launcher
- bound execution with the existing five-minute stage-launch timeout
- reject incomplete private inputs and malformed candidate identities before execution

## Boundaries

- CLI wiring and fake-boundary tests only
- no live infrastructure execution
- no automatic token materialization
- no retry, rollback, or cleanup command added

## Verification

- `go test -ldflags=-linkmode=external ./...`
- `go vet ./...`
- `go test -race -ldflags=-linkmode=external ./internal/runner`

All passed. The macOS external-linker warnings are unchanged and non-fatal.

## OK-147 status

The OK-147 MVP now exposes the complete twelve-stage happy-run path, including the final aggregate-evidence launch boundary. Live execution remains a separate decision.
