### PR TITLE
fix(cli): clarify staged submission boundary (OK-147)

### DIFF
--- a/cmd/ok/main.go
+++ b/cmd/ok/main.go
@@ -715,7 +715,7 @@ func runClusterCreate(arguments []string, stdout, stderr io.Writer) error {
 		return errors.New("positional arguments are not accepted")
 	}
 	if !*dryRun {
-		return errors.New("the OK-147 MVP currently requires --dry-run; submission is not implemented")
+		return errors.New("ok cluster create remains dry-run-only; mutating submission is available only through explicitly authorized ok cluster stage commands")
 	}
 	if *contractPath == "" || *schemaPath == "" {
 		return errors.New("--contract and --schema are required")

--- a/cmd/ok/main_test.go
+++ b/cmd/ok/main_test.go
@@ -68,7 +68,7 @@ func TestCreateWithoutDryRunFailsClosed(t *testing.T) {
 		"--contract", fixturePath(t, "ok141-contract-v5.yaml"),
 		"--schema", fixturePath(t, "ok141-contract-v3.schema.json"),
 	}, &stdout, &stderr)
-	if err == nil || !strings.Contains(err.Error(), "requires --dry-run") {
+	if err == nil || !strings.Contains(err.Error(), "cluster create remains dry-run-only") || !strings.Contains(err.Error(), "explicitly authorized ok cluster stage commands") {
 		t.Fatalf("error = %v", err)
 	}
 	if stdout.Len() != 0 {


### PR DESCRIPTION
## Summary

- keep the legacy `ok cluster create` boundary explicitly dry-run-only
- stop claiming that submission is wholly unimplemented now that authorized staged commands exist
- direct operators to the explicit `ok cluster stage` mutation surface

## Verification

- `GOCACHE=/private/tmp/ok147-go-build go test -ldflags=-linkmode=external ./cmd/ok`
- `git diff --check`
- no cluster contact or infrastructure mutation

## Review question

Does this fail-closed message accurately distinguish the legacy dry-run command from the separately authorized staged submission surface?
