### PR TITLE
feat(runner): durably execute target credentials (OK-147)

### DIFF
--- a/internal/runner/target_credential_stage_bundle.go
+++ b/internal/runner/target_credential_stage_bundle.go
@@ -1,6 +1,8 @@
 package runner
 
 import (
+	"context"
+	"crypto/subtle"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -9,6 +11,7 @@ import (
 
 	"github.com/openkubes/ok-cluster/internal/authorization"
 	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/execution"
 	"github.com/openkubes/ok-cluster/internal/jsonstrict"
 	"github.com/openkubes/ok-cluster/internal/projection"
 	"github.com/openkubes/ok-cluster/internal/stagecursor"
@@ -82,6 +85,21 @@ type VerifiedTargetCredentialStageBundle struct {
 	policy   targetCredentialPolicyDocument
 	receipt  TargetCredentialStageBundleReceipt
 	verified bool
+}
+
+type TargetCredentialStageRuntimeConfig struct {
+	Ledger   KubernetesLedgerConfig
+	Workload WorkloadAuthorityFileResolverConfig
+	Clock    func() time.Time
+}
+
+type BoundTargetCredentialStage struct {
+	operation execution.StagedOperation
+	mutator   *TargetCredentialStageMutator
+	plan      stageplan.Binding
+	cursor    stagecursor.Cursor
+	grant     authorization.VerifiedStageGrant
+	verified  bool
 }
 
 // LoadTargetCredentialStageBundle proves that the credential request is for
@@ -208,6 +226,51 @@ func (bundle VerifiedTargetCredentialStageBundle) Receipt() (TargetCredentialSta
 		return TargetCredentialStageBundleReceipt{}, err
 	}
 	return bundle.receipt, nil
+}
+
+// Open binds the verified credential policy to the workload authority and
+// durable ledger without contacting either Kubernetes API.
+func (bundle VerifiedTargetCredentialStageBundle) Open(config TargetCredentialStageRuntimeConfig) (BoundTargetCredentialStage, error) {
+	if err := verifyTargetCredentialStageBundle(bundle); err != nil || config.Clock == nil {
+		return BoundTargetCredentialStage{}, errors.New("verified target-credential bundle and clock are required")
+	}
+	issuer, err := OpenTargetCredentialIssuer(bundle, TargetCredentialIssuerConfig{Workload: config.Workload, Clock: config.Clock})
+	if err != nil {
+		return BoundTargetCredentialStage{}, err
+	}
+	ledgerStore, ledgerToken, err := openKubernetesLedger(config.Ledger)
+	if err != nil {
+		return BoundTargetCredentialStage{}, errors.New("open target-credential stage ledger")
+	}
+	if len(ledgerToken) == len(issuer.authorityToken) && subtle.ConstantTimeCompare([]byte(ledgerToken), []byte(issuer.authorityToken)) == 1 {
+		return BoundTargetCredentialStage{}, errors.New("ledger and target-credential authority credentials must be distinct")
+	}
+	mutator, err := NewTargetCredentialStageMutator(bundle.plan, bundle.receipt, issuer)
+	if err != nil {
+		return BoundTargetCredentialStage{}, err
+	}
+	return BoundTargetCredentialStage{
+		operation: execution.StagedOperation{Ledger: ledgerStore, Mutator: mutator, Clock: config.Clock},
+		mutator:   mutator, plan: bundle.plan, cursor: bundle.cursor, grant: bundle.grant, verified: true,
+	}, nil
+}
+
+// Run durably completes Stage 8 and transfers the verified credential exactly
+// once to the immediately following in-process registration step. A replay can
+// recover the public receipt but deliberately cannot recreate private material.
+func (stage BoundTargetCredentialStage) Run(ctx context.Context) (execution.StagedOperationReceipt, VerifiedTargetCredentialMaterial, error) {
+	if !stage.verified || stage.mutator == nil {
+		return execution.StagedOperationReceipt{}, VerifiedTargetCredentialMaterial{}, errors.New("target-credential stage runtime was not produced by verification")
+	}
+	receipt, err := stage.operation.Run(ctx, stage.plan, stage.cursor, stage.grant)
+	if err != nil {
+		return receipt, VerifiedTargetCredentialMaterial{}, err
+	}
+	material, err := stage.mutator.TakeMaterial()
+	if err != nil {
+		return receipt, VerifiedTargetCredentialMaterial{}, errors.New("durable target-credential outcome has no in-memory credential; registration must stop")
+	}
+	return receipt, material, nil
 }
 
 func verifyTargetCredentialStageBundle(bundle VerifiedTargetCredentialStageBundle) error {

--- a/internal/runner/target_credential_stage_execution_test.go
+++ b/internal/runner/target_credential_stage_execution_test.go
@@ -1,0 +1,124 @@
+package runner
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/execution"
+)
+
+func TestTargetCredentialStageRunsOnceAndHandsOffMaterialOnce(t *testing.T) {
+	fixture := targetCredentialBundleFixture(t)
+	bundle, err := LoadTargetCredentialStageBundle(fixture.config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2026, 8, 17, 16, 1, 0, 0, time.UTC)
+	credentialAPI, requests := newTargetCredentialExecutionAPI(t, now, http.StatusCreated)
+	defer credentialAPI.Close()
+	ledgerAPI := newRuntimeBindingLedgerAPI(t)
+	defer ledgerAPI.Close()
+	runtime := targetCredentialExecutionRuntime(t, fixture, ledgerAPI.Server, credentialAPI, now)
+	bound, err := bundle.Open(runtime)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if requests.Load() != 0 || ledgerAPI.RequestCount() != 0 {
+		t.Fatal("opening target-credential stage contacted Kubernetes")
+	}
+	receipt, material, err := bound.Run(context.Background())
+	if err != nil || receipt.State != "COMPLETED_SUCCEEDED" || receipt.StageID != "target-credential" || receipt.StageReceiptDigest == "" || requests.Load() != 1 {
+		t.Fatalf("target-credential stage did not complete: %#v requests=%d err=%v", receipt, requests.Load(), err)
+	}
+	issued, err := material.Receipt()
+	if err != nil || issued.State != "ISSUED" || issued.CredentialBytesInReceipt || issued.PolicyDigest != fixture.policyDigest {
+		t.Fatalf("in-memory handoff differs: %#v %v", issued, err)
+	}
+	if replay, replayMaterial, err := bound.Run(context.Background()); err == nil || replay.State != "COMPLETED_SUCCEEDED" || requests.Load() != 1 {
+		t.Fatalf("durable replay recreated credential: %#v %#v requests=%d err=%v", replay, replayMaterial, requests.Load(), err)
+	}
+}
+
+func TestTargetCredentialStageDurablyStopsFailedIssuance(t *testing.T) {
+	fixture := targetCredentialBundleFixture(t)
+	bundle, err := LoadTargetCredentialStageBundle(fixture.config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2026, 8, 17, 16, 1, 0, 0, time.UTC)
+	credentialAPI, requests := newTargetCredentialExecutionAPI(t, now, http.StatusForbidden)
+	defer credentialAPI.Close()
+	ledgerAPI := newRuntimeBindingLedgerAPI(t)
+	defer ledgerAPI.Close()
+	bound, err := bundle.Open(targetCredentialExecutionRuntime(t, fixture, ledgerAPI.Server, credentialAPI, now))
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, material, runErr := bound.Run(context.Background())
+	var resultErr *execution.StageResultError
+	if !errors.As(runErr, &resultErr) || receipt.State != "COMPLETED_STOPPED" || receipt.StageReceiptDigest == "" || requests.Load() != 1 {
+		t.Fatalf("failed issuance was not durably stopped: %#v %#v requests=%d err=%v", receipt, material, requests.Load(), runErr)
+	}
+	if replay, _, err := bound.Run(context.Background()); !errors.As(err, &resultErr) || replay.State != "COMPLETED_STOPPED" || requests.Load() != 1 {
+		t.Fatalf("durable stop retried TokenRequest: %#v requests=%d err=%v", replay, requests.Load(), err)
+	}
+}
+
+func TestTargetCredentialStageRejectsSharedLedgerAndAuthorityCredential(t *testing.T) {
+	fixture := targetCredentialBundleFixture(t)
+	bundle, err := LoadTargetCredentialStageBundle(fixture.config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2026, 8, 17, 16, 1, 0, 0, time.UTC)
+	credentialAPI, requests := newTargetCredentialExecutionAPI(t, now, http.StatusCreated)
+	defer credentialAPI.Close()
+	ledgerAPI := newRuntimeBindingLedgerAPI(t)
+	defer ledgerAPI.Close()
+	runtime := targetCredentialExecutionRuntime(t, fixture, ledgerAPI.Server, credentialAPI, now)
+	if err := os.WriteFile(runtime.Workload.TokenFile, []byte("ledger-token"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := bundle.Open(runtime); err == nil || requests.Load() != 0 || ledgerAPI.RequestCount() != 0 {
+		t.Fatal("shared ledger/authority credential opened target-credential stage")
+	}
+}
+
+func targetCredentialExecutionRuntime(t *testing.T, fixture targetCredentialBundleTestFixture, ledgerServer, credentialServer *httptest.Server, now time.Time) TargetCredentialStageRuntimeConfig {
+	t.Helper()
+	base := targetAccessExecutionRuntime(t, fixture.plan, ledgerServer, credentialServer)
+	return TargetCredentialStageRuntimeConfig{Ledger: base.Ledger, Workload: base.Workload, Clock: func() time.Time { return now }}
+}
+
+func newTargetCredentialExecutionAPI(t *testing.T, now time.Time, status int) (*httptest.Server, *atomic.Int32) {
+	t.Helper()
+	var requests atomic.Int32
+	server := httptest.NewTLSServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		requests.Add(1)
+		response.Header().Set("Content-Type", "application/json")
+		if request.Method != http.MethodPost || request.URL.Path != "/api/v1/namespaces/kube-system/serviceaccounts/ok147-argocd-manager/token" || request.Header.Get("Authorization") != "Bearer workload-token" {
+			response.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if status != http.StatusCreated {
+			response.WriteHeader(status)
+			return
+		}
+		token := targetCredentialTestJWT(t, now, now.Add(3*time.Hour), "system:serviceaccount:kube-system:ok147-argocd-manager")
+		result := map[string]any{
+			"apiVersion": "authentication.k8s.io/v1", "kind": "TokenRequest", "metadata": map[string]any{},
+			"spec":   map[string]any{"audiences": []string{"https://kubernetes.default.svc"}, "expirationSeconds": 10800},
+			"status": map[string]any{"token": token, "expirationTimestamp": now.Add(3 * time.Hour).Format(time.RFC3339)},
+		}
+		response.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(response).Encode(result)
+	}))
+	return server, &requests
+}

--- a/internal/runner/target_credential_stage_mutator.go
+++ b/internal/runner/target_credential_stage_mutator.go
@@ -1,0 +1,111 @@
+package runner
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+
+	"github.com/openkubes/ok-cluster/internal/contract"
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/execution"
+	"github.com/openkubes/ok-cluster/internal/stageplan"
+)
+
+type targetCredentialStoppedEvidence struct {
+	Format               string `json:"format"`
+	StageID              string `json:"stageId"`
+	PlanDigest           string `json:"planDigest"`
+	PolicyDigest         string `json:"policyDigest"`
+	TargetIdentityDigest string `json:"targetIdentityDigest"`
+	State                string `json:"state"`
+	CredentialRetained   bool   `json:"credentialRetained"`
+}
+
+// TargetCredentialStageMutator adapts one TokenRequest issuer to the durable
+// staged-operation protocol while retaining successful credential bytes only
+// for one in-process handoff.
+type TargetCredentialStageMutator struct {
+	mu       sync.Mutex
+	binding  execution.StageMutationBinding
+	identity contract.Identity
+	bundle   TargetCredentialStageBundleReceipt
+	issuer   *KubernetesTargetCredentialIssuer
+	material VerifiedTargetCredentialMaterial
+	ready    bool
+}
+
+var _ execution.StageMutator = (*TargetCredentialStageMutator)(nil)
+
+func NewTargetCredentialStageMutator(plan stageplan.Binding, bundle TargetCredentialStageBundleReceipt, issuer *KubernetesTargetCredentialIssuer) (*TargetCredentialStageMutator, error) {
+	stage, stageDigest, err := plan.Stage("target-credential")
+	if err != nil {
+		return nil, err
+	}
+	if issuer == nil || bundle.Format != TargetCredentialStageBundleReceiptFormat || bundle.State != "VERIFIED" ||
+		bundle.PlanDigest != plan.PlanDigest || bundle.StageID != stage.ID || bundle.TargetIdentityDigest != issuer.targetIdentity ||
+		stage.Kind != "Credential" || stage.Authority != "workload" || stage.GrantOperation != "IssueTargetCredential" {
+		return nil, errors.New("target-credential mutator requires the exact verified stage and issuer")
+	}
+	return &TargetCredentialStageMutator{
+		binding: execution.StageMutationBinding{
+			PlanDigest: plan.PlanDigest, StageID: stage.ID, StageDigest: stageDigest,
+			Operation: stage.GrantOperation, Authority: stage.Authority, ContractRevision: plan.IntentRevision,
+		},
+		identity: plan.ContractIdentity, bundle: bundle, issuer: issuer,
+	}, nil
+}
+
+func (mutator *TargetCredentialStageMutator) Binding() execution.StageMutationBinding {
+	if mutator == nil {
+		return execution.StageMutationBinding{}
+	}
+	return mutator.binding
+}
+
+func (mutator *TargetCredentialStageMutator) Mutate(ctx context.Context, request execution.StageMutationRequest) (execution.StageMutationResult, error) {
+	if mutator == nil || request.StageMutationBinding != mutator.binding || request.ContractIdentity != mutator.identity ||
+		request.GrantID == "" || !stageReceiptPrefixDigestPattern.MatchString(request.PredecessorDigest) {
+		return execution.StageMutationResult{}, errors.New("target-credential mutation request differs from the preconstructed stage")
+	}
+	material, issueErr := mutator.issuer.Issue(ctx)
+	if issueErr != nil {
+		evidence, _ := json.Marshal(targetCredentialStoppedEvidence{
+			Format: "ok147-target-credential-stopped-evidence/v1", StageID: "target-credential",
+			PlanDigest: mutator.bundle.PlanDigest, PolicyDigest: mutator.bundle.PolicyDigest,
+			TargetIdentityDigest: mutator.bundle.TargetIdentityDigest, State: "STOPPED", CredentialRetained: false,
+		})
+		return execution.StageMutationResult{Outcome: "STOPPED", MutationState: "UNKNOWN", EvidenceDigest: digest.SHA256(evidence)}, errors.New("bounded target-credential issuance stopped")
+	}
+	receipt, err := material.Receipt()
+	if err != nil || receipt.PolicyDigest != mutator.bundle.PolicyDigest || receipt.TargetIdentityDigest != mutator.bundle.TargetIdentityDigest || receipt.ServiceAccountIdentityDigest != mutator.bundle.ServiceAccountIdentityDigest {
+		return execution.StageMutationResult{}, errors.New("issued target credential differs from verified stage")
+	}
+	evidence, err := json.Marshal(receipt)
+	if err != nil {
+		return execution.StageMutationResult{}, errors.New("derive bounded target-credential evidence")
+	}
+	mutator.mu.Lock()
+	mutator.material = material
+	mutator.ready = true
+	mutator.mu.Unlock()
+	return execution.StageMutationResult{Outcome: "SUCCEEDED", MutationState: "ATTEMPTED", EvidenceDigest: digest.SHA256(evidence)}, nil
+}
+
+func (mutator *TargetCredentialStageMutator) TakeMaterial() (VerifiedTargetCredentialMaterial, error) {
+	if mutator == nil {
+		return VerifiedTargetCredentialMaterial{}, errors.New("target-credential mutator is required")
+	}
+	mutator.mu.Lock()
+	defer mutator.mu.Unlock()
+	if !mutator.ready {
+		return VerifiedTargetCredentialMaterial{}, errors.New("target-credential material is unavailable")
+	}
+	material := mutator.material
+	mutator.material = VerifiedTargetCredentialMaterial{}
+	mutator.ready = false
+	if _, err := material.Receipt(); err != nil {
+		return VerifiedTargetCredentialMaterial{}, err
+	}
+	return material, nil
+}


### PR DESCRIPTION
## Summary

- bind Stage 8 TokenRequest issuance to the durable claim/outcome/receipt protocol
- retain the verified target credential for exactly one in-process handoff
- stop replay when the public durable outcome exists but private credential material is no longer available
- reject shared ledger and workload-authority credentials before any API request

## Verification

- `GOCACHE=/private/tmp/ok147-go-build go test -ldflags=-linkmode=external ./...`
- `GOCACHE=/private/tmp/ok147-go-vet go vet ./...`
- `GOCACHE=/private/tmp/ok147-go-race go test -race -ldflags=-linkmode=external ./internal/runner`
- `git diff --check`
- local TLS integration only; no live cluster contact or infrastructure mutation

## Review question

Does this execution boundary durably account for exactly one TokenRequest while preserving the memory-only credential invariant needed by the subsequent registration stage?
