### PR TITLE
feat(runner): bind target credential handoff (OK-147)

### DIFF
--- a/internal/runner/target_credential_stage_bundle.go
+++ b/internal/runner/target_credential_stage_bundle.go
@@ -98,6 +98,7 @@ type BoundTargetCredentialStage struct {
 	mutator   *TargetCredentialStageMutator
 	plan      stageplan.Binding
 	cursor    stagecursor.Cursor
+	previous  []stagereceipt.Verified
 	grant     authorization.VerifiedStageGrant
 	verified  bool
 }
@@ -249,9 +250,14 @@ func (bundle VerifiedTargetCredentialStageBundle) Open(config TargetCredentialSt
 	if err != nil {
 		return BoundTargetCredentialStage{}, err
 	}
+	previous, err := bundle.cursor.Predecessors()
+	if err != nil {
+		return BoundTargetCredentialStage{}, err
+	}
 	return BoundTargetCredentialStage{
 		operation: execution.StagedOperation{Ledger: ledgerStore, Mutator: mutator, Clock: config.Clock},
-		mutator:   mutator, plan: bundle.plan, cursor: bundle.cursor, grant: bundle.grant, verified: true,
+		mutator:   mutator, plan: bundle.plan, cursor: bundle.cursor, previous: previous,
+		grant: bundle.grant, verified: true,
 	}, nil
 }
 
@@ -259,18 +265,40 @@ func (bundle VerifiedTargetCredentialStageBundle) Open(config TargetCredentialSt
 // once to the immediately following in-process registration step. A replay can
 // recover the public receipt but deliberately cannot recreate private material.
 func (stage BoundTargetCredentialStage) Run(ctx context.Context) (execution.StagedOperationReceipt, VerifiedTargetCredentialMaterial, error) {
-	if !stage.verified || stage.mutator == nil {
-		return execution.StagedOperationReceipt{}, VerifiedTargetCredentialMaterial{}, errors.New("target-credential stage runtime was not produced by verification")
-	}
-	receipt, err := stage.operation.Run(ctx, stage.plan, stage.cursor, stage.grant)
+	receipt, handoff, err := stage.RunHandoff(ctx)
 	if err != nil {
 		return receipt, VerifiedTargetCredentialMaterial{}, err
 	}
-	material, err := stage.mutator.TakeMaterial()
+	material, err := handoff.takeCredential()
 	if err != nil {
-		return receipt, VerifiedTargetCredentialMaterial{}, errors.New("durable target-credential outcome has no in-memory credential; registration must stop")
+		return receipt, VerifiedTargetCredentialMaterial{}, err
 	}
 	return receipt, material, nil
+}
+
+// RunHandoff additionally returns the canonical redaction-safe Stage-8 receipt
+// needed by a later authorizer while keeping credential bytes private.
+func (stage BoundTargetCredentialStage) RunHandoff(ctx context.Context) (execution.StagedOperationReceipt, *VerifiedTargetCredentialStageHandoff, error) {
+	if !stage.verified || stage.mutator == nil {
+		return execution.StagedOperationReceipt{}, nil, errors.New("target-credential stage runtime was not produced by verification")
+	}
+	receipt, err := stage.operation.Run(ctx, stage.plan, stage.cursor, stage.grant)
+	if err != nil {
+		return receipt, nil, err
+	}
+	verified, err := stage.operation.Ledger.LoadStageReceipt(ctx, stage.plan, "target-credential", receipt.StageReceiptDigest, stage.previous)
+	if err != nil {
+		return receipt, nil, errors.New("reload durable target-credential receipt for handoff")
+	}
+	material, err := stage.mutator.TakeMaterial()
+	if err != nil {
+		return receipt, nil, errors.New("durable target-credential outcome has no in-memory credential; registration must stop")
+	}
+	handoff, err := newVerifiedTargetCredentialStageHandoff(verified, material)
+	if err != nil {
+		return receipt, nil, err
+	}
+	return receipt, handoff, nil
 }
 
 func verifyTargetCredentialStageBundle(bundle VerifiedTargetCredentialStageBundle) error {

--- a/internal/runner/target_credential_stage_execution_test.go
+++ b/internal/runner/target_credential_stage_execution_test.go
@@ -1,6 +1,7 @@
 package runner
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -33,13 +34,31 @@ func TestTargetCredentialStageRunsOnceAndHandsOffMaterialOnce(t *testing.T) {
 	if requests.Load() != 0 || ledgerAPI.RequestCount() != 0 {
 		t.Fatal("opening target-credential stage contacted Kubernetes")
 	}
-	receipt, material, err := bound.Run(context.Background())
+	receipt, handoff, err := bound.RunHandoff(context.Background())
 	if err != nil || receipt.State != "COMPLETED_SUCCEEDED" || receipt.StageID != "target-credential" || receipt.StageReceiptDigest == "" || requests.Load() != 1 {
 		t.Fatalf("target-credential stage did not complete: %#v requests=%d err=%v", receipt, requests.Load(), err)
 	}
-	issued, err := material.Receipt()
+	stageRaw, err := handoff.StageReceiptBytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	stageDigest, err := handoff.StageReceiptDigest()
+	if err != nil || stageDigest != receipt.StageReceiptDigest {
+		t.Fatalf("handoff receipt digest differs: %q %v", stageDigest, err)
+	}
+	issued, err := handoff.CredentialReceipt()
 	if err != nil || issued.State != "ISSUED" || issued.CredentialBytesInReceipt || issued.PolicyDigest != fixture.policyDigest {
 		t.Fatalf("in-memory handoff differs: %#v %v", issued, err)
+	}
+	material, err := handoff.takeCredential()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(stageRaw, material.token) || bytes.Contains(stageRaw, material.caBundle) || bytes.Contains(stageRaw, []byte(material.endpoint)) {
+		t.Fatal("public Stage-8 handoff receipt leaked private credential material")
+	}
+	if _, err := handoff.takeCredential(); err == nil {
+		t.Fatal("target credential handoff was consumed twice")
 	}
 	if replay, replayMaterial, err := bound.Run(context.Background()); err == nil || replay.State != "COMPLETED_SUCCEEDED" || requests.Load() != 1 {
 		t.Fatalf("durable replay recreated credential: %#v %#v requests=%d err=%v", replay, replayMaterial, requests.Load(), err)

--- a/internal/runner/target_credential_stage_handoff.go
+++ b/internal/runner/target_credential_stage_handoff.go
@@ -1,0 +1,88 @@
+package runner
+
+import (
+	"encoding/json"
+	"errors"
+	"sync"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/stagereceipt"
+)
+
+// VerifiedTargetCredentialStageHandoff binds the canonical public Stage-8
+// receipt to one private, memory-only credential. Only the redacted receipts
+// are publicly readable; the credential can be consumed once inside runner.
+type VerifiedTargetCredentialStageHandoff struct {
+	mu         sync.Mutex
+	receipt    stagereceipt.Verified
+	credential VerifiedTargetCredentialMaterial
+	consumed   bool
+	verified   bool
+}
+
+func newVerifiedTargetCredentialStageHandoff(receipt stagereceipt.Verified, credential VerifiedTargetCredentialMaterial) (*VerifiedTargetCredentialStageHandoff, error) {
+	stage, err := receipt.Receipt()
+	if err != nil {
+		return nil, err
+	}
+	issued, err := credential.Receipt()
+	if err != nil {
+		return nil, err
+	}
+	issuedRaw, err := json.Marshal(issued)
+	if err != nil {
+		return nil, errors.New("encode target-credential handoff evidence")
+	}
+	if stage.StageID != "target-credential" || stage.State != "SUCCEEDED" || stage.MutationState != "ATTEMPTED" ||
+		stage.EvidenceDigest != digest.SHA256(issuedRaw) || stage.TargetClusterUIDDigest != "" ||
+		issued.StageID != stage.StageID || issued.TargetIdentityDigest != credential.targetIdentity {
+		return nil, errors.New("target-credential handoff differs from durable Stage-8 receipt")
+	}
+	return &VerifiedTargetCredentialStageHandoff{receipt: receipt, credential: credential, verified: true}, nil
+}
+
+func (handoff *VerifiedTargetCredentialStageHandoff) StageReceipt() (stagereceipt.Receipt, error) {
+	if handoff == nil || !handoff.verified {
+		return stagereceipt.Receipt{}, errors.New("target-credential handoff was not produced by verification")
+	}
+	return handoff.receipt.Receipt()
+}
+
+func (handoff *VerifiedTargetCredentialStageHandoff) StageReceiptBytes() ([]byte, error) {
+	if handoff == nil || !handoff.verified {
+		return nil, errors.New("target-credential handoff was not produced by verification")
+	}
+	return handoff.receipt.Bytes()
+}
+
+func (handoff *VerifiedTargetCredentialStageHandoff) StageReceiptDigest() (string, error) {
+	if handoff == nil || !handoff.verified {
+		return "", errors.New("target-credential handoff was not produced by verification")
+	}
+	return handoff.receipt.Digest()
+}
+
+func (handoff *VerifiedTargetCredentialStageHandoff) CredentialReceipt() (TargetCredentialIssueReceipt, error) {
+	if handoff == nil || !handoff.verified {
+		return TargetCredentialIssueReceipt{}, errors.New("target-credential handoff was not produced by verification")
+	}
+	return handoff.credential.Receipt()
+}
+
+func (handoff *VerifiedTargetCredentialStageHandoff) takeCredential() (VerifiedTargetCredentialMaterial, error) {
+	if handoff == nil {
+		return VerifiedTargetCredentialMaterial{}, errors.New("target-credential handoff is required")
+	}
+	handoff.mu.Lock()
+	defer handoff.mu.Unlock()
+	if !handoff.verified || handoff.consumed {
+		return VerifiedTargetCredentialMaterial{}, errors.New("target-credential handoff is unavailable or already consumed")
+	}
+	if _, err := handoff.credential.Receipt(); err != nil {
+		return VerifiedTargetCredentialMaterial{}, err
+	}
+	handoff.consumed = true
+	credential := handoff.credential
+	handoff.credential = VerifiedTargetCredentialMaterial{}
+	return credential, nil
+}


### PR DESCRIPTION
## Summary

- reload and verify the canonical durable Stage-8 receipt after credential issuance
- bind that public receipt to the exact redacted issuance evidence
- expose receipt bytes and digest without exposing token, CA or endpoint
- allow the private credential to be consumed exactly once inside the runner process

## Verification

- `GOCACHE=/private/tmp/ok147-go-build go test -ldflags=-linkmode=external ./...`
- `GOCACHE=/private/tmp/ok147-go-vet go vet ./...`
- `GOCACHE=/private/tmp/ok147-go-race go test -race -ldflags=-linkmode=external ./internal/runner`
- `git diff --check`
- local TLS integration only; no live cluster contact or infrastructure mutation

## Review question

Does this handoff provide enough redacted predecessor evidence for Stage 9 authorization while preserving the memory-only, single-consumer credential invariant?
