### PR TITLE
feat(runner): open registration from credential handoff (OK-147)

### DIFF
--- a/internal/runner/target_credential_stage_bundle.go
+++ b/internal/runner/target_credential_stage_bundle.go
@@ -98,6 +98,7 @@ type BoundTargetCredentialStage struct {
 	mutator   *TargetCredentialStageMutator
 	plan      stageplan.Binding
 	cursor    stagecursor.Cursor
+	prefix    []stagereceipt.Verified
 	previous  []stagereceipt.Verified
 	grant     authorization.VerifiedStageGrant
 	verified  bool
@@ -256,7 +257,7 @@ func (bundle VerifiedTargetCredentialStageBundle) Open(config TargetCredentialSt
 	}
 	return BoundTargetCredentialStage{
 		operation: execution.StagedOperation{Ledger: ledgerStore, Mutator: mutator, Clock: config.Clock},
-		mutator:   mutator, plan: bundle.plan, cursor: bundle.cursor, previous: previous,
+		mutator:   mutator, plan: bundle.plan, cursor: bundle.cursor, prefix: bundle.prefix, previous: previous,
 		grant: bundle.grant, verified: true,
 	}, nil
 }
@@ -294,7 +295,7 @@ func (stage BoundTargetCredentialStage) RunHandoff(ctx context.Context) (executi
 	if err != nil {
 		return receipt, nil, errors.New("durable target-credential outcome has no in-memory credential; registration must stop")
 	}
-	handoff, err := newVerifiedTargetCredentialStageHandoff(verified, material)
+	handoff, err := newVerifiedTargetCredentialStageHandoff(stage.plan, stage.prefix, verified, material)
 	if err != nil {
 		return receipt, nil, err
 	}

--- a/internal/runner/target_credential_stage_handoff.go
+++ b/internal/runner/target_credential_stage_handoff.go
@@ -1,11 +1,12 @@
 package runner
 
 import (
-	"encoding/json"
 	"errors"
 	"sync"
 
 	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/stagecursor"
+	"github.com/openkubes/ok-cluster/internal/stageplan"
 	"github.com/openkubes/ok-cluster/internal/stagereceipt"
 )
 
@@ -14,13 +15,18 @@ import (
 // are publicly readable; the credential can be consumed once inside runner.
 type VerifiedTargetCredentialStageHandoff struct {
 	mu         sync.Mutex
+	plan       stageplan.Binding
+	prefix     []stagereceipt.Verified
 	receipt    stagereceipt.Verified
 	credential VerifiedTargetCredentialMaterial
 	consumed   bool
 	verified   bool
 }
 
-func newVerifiedTargetCredentialStageHandoff(receipt stagereceipt.Verified, credential VerifiedTargetCredentialMaterial) (*VerifiedTargetCredentialStageHandoff, error) {
+func newVerifiedTargetCredentialStageHandoff(plan stageplan.Binding, prefix []stagereceipt.Verified, receipt stagereceipt.Verified, credential VerifiedTargetCredentialMaterial) (*VerifiedTargetCredentialStageHandoff, error) {
+	if len(prefix) != 7 {
+		return nil, errors.New("target-credential handoff requires the exact seven-stage prefix")
+	}
 	stage, err := receipt.Receipt()
 	if err != nil {
 		return nil, err
@@ -29,16 +35,25 @@ func newVerifiedTargetCredentialStageHandoff(receipt stagereceipt.Verified, cred
 	if err != nil {
 		return nil, err
 	}
-	issuedRaw, err := json.Marshal(issued)
+	issuedRaw, err := canonicalTargetRegistrationValue(issued)
 	if err != nil {
 		return nil, errors.New("encode target-credential handoff evidence")
 	}
 	if stage.StageID != "target-credential" || stage.State != "SUCCEEDED" || stage.MutationState != "ATTEMPTED" ||
-		stage.EvidenceDigest != digest.SHA256(issuedRaw) || stage.TargetClusterUIDDigest != "" ||
+		stage.PlanDigest != plan.PlanDigest || stage.EvidenceDigest != digest.SHA256(issuedRaw) || stage.TargetClusterUIDDigest != "" ||
 		issued.StageID != stage.StageID || issued.TargetIdentityDigest != credential.targetIdentity {
 		return nil, errors.New("target-credential handoff differs from durable Stage-8 receipt")
 	}
-	return &VerifiedTargetCredentialStageHandoff{receipt: receipt, credential: credential, verified: true}, nil
+	combined := append(append([]stagereceipt.Verified(nil), prefix...), receipt)
+	cursor, err := stagecursor.Evaluate(plan, combined)
+	if err != nil {
+		return nil, err
+	}
+	decision, err := cursor.Decision()
+	if err != nil || decision.State != "NEXT" || decision.StageID != "target-registration" {
+		return nil, errors.New("target-credential handoff does not select target registration")
+	}
+	return &VerifiedTargetCredentialStageHandoff{plan: plan, prefix: combined, receipt: receipt, credential: credential, verified: true}, nil
 }
 
 func (handoff *VerifiedTargetCredentialStageHandoff) StageReceipt() (stagereceipt.Receipt, error) {
@@ -63,8 +78,13 @@ func (handoff *VerifiedTargetCredentialStageHandoff) StageReceiptDigest() (strin
 }
 
 func (handoff *VerifiedTargetCredentialStageHandoff) CredentialReceipt() (TargetCredentialIssueReceipt, error) {
-	if handoff == nil || !handoff.verified {
+	if handoff == nil {
 		return TargetCredentialIssueReceipt{}, errors.New("target-credential handoff was not produced by verification")
+	}
+	handoff.mu.Lock()
+	defer handoff.mu.Unlock()
+	if !handoff.verified || handoff.consumed {
+		return TargetCredentialIssueReceipt{}, errors.New("target-credential handoff is unavailable or already consumed")
 	}
 	return handoff.credential.Receipt()
 }
@@ -85,4 +105,21 @@ func (handoff *VerifiedTargetCredentialStageHandoff) takeCredential() (VerifiedT
 	credential := handoff.credential
 	handoff.credential = VerifiedTargetCredentialMaterial{}
 	return credential, nil
+}
+
+func (handoff *VerifiedTargetCredentialStageHandoff) registrationContext() (stageplan.Binding, stagecursor.Cursor, []stagereceipt.Verified, error) {
+	if handoff == nil {
+		return stageplan.Binding{}, stagecursor.Cursor{}, nil, errors.New("target-credential handoff is required")
+	}
+	handoff.mu.Lock()
+	defer handoff.mu.Unlock()
+	if !handoff.verified || handoff.consumed || len(handoff.prefix) != 8 {
+		return stageplan.Binding{}, stagecursor.Cursor{}, nil, errors.New("target-credential handoff is unavailable or already consumed")
+	}
+	prefix := append([]stagereceipt.Verified(nil), handoff.prefix...)
+	cursor, err := stagecursor.Evaluate(handoff.plan, prefix)
+	if err != nil {
+		return stageplan.Binding{}, stagecursor.Cursor{}, nil, err
+	}
+	return handoff.plan, cursor, prefix, nil
 }

--- a/internal/runner/target_credential_stage_mutator.go
+++ b/internal/runner/target_credential_stage_mutator.go
@@ -81,7 +81,7 @@ func (mutator *TargetCredentialStageMutator) Mutate(ctx context.Context, request
 	if err != nil || receipt.PolicyDigest != mutator.bundle.PolicyDigest || receipt.TargetIdentityDigest != mutator.bundle.TargetIdentityDigest || receipt.ServiceAccountIdentityDigest != mutator.bundle.ServiceAccountIdentityDigest {
 		return execution.StageMutationResult{}, errors.New("issued target credential differs from verified stage")
 	}
-	evidence, err := json.Marshal(receipt)
+	evidence, err := canonicalTargetRegistrationValue(receipt)
 	if err != nil {
 		return execution.StageMutationResult{}, errors.New("derive bounded target-credential evidence")
 	}

--- a/internal/runner/target_registration_material_test.go
+++ b/internal/runner/target_registration_material_test.go
@@ -123,10 +123,11 @@ func TestBuildTargetRegistrationMaterialFailsClosed(t *testing.T) {
 }
 
 type targetRegistrationMaterialTestFixture struct {
-	bundle     VerifiedTargetRegistrationStageBundle
-	runtime    VerifiedRuntimeBindingMaterial
-	credential VerifiedTargetCredentialMaterial
-	config     TargetRegistrationMaterializeConfig
+	bundle       VerifiedTargetRegistrationStageBundle
+	bundleConfig TargetRegistrationStageBundleConfig
+	runtime      VerifiedRuntimeBindingMaterial
+	credential   VerifiedTargetCredentialMaterial
+	config       TargetRegistrationMaterializeConfig
 }
 
 func targetRegistrationMaterialFixture(t *testing.T) targetRegistrationMaterialTestFixture {
@@ -165,7 +166,7 @@ func targetRegistrationMaterialFixture(t *testing.T) targetRegistrationMaterialT
 		t.Fatal(err)
 	}
 	config := TargetRegistrationMaterializeConfig{Bundle: bundle, Runtime: runtime, Credential: credential, MaterializationTime: now}
-	return targetRegistrationMaterialTestFixture{bundle: bundle, runtime: runtime, credential: credential, config: config}
+	return targetRegistrationMaterialTestFixture{bundle: bundle, bundleConfig: bundleFixture.config, runtime: runtime, credential: credential, config: config}
 }
 
 func refreshTargetRegistrationRuntime(t *testing.T, runtime *VerifiedRuntimeBindingMaterial) {

--- a/internal/runner/target_registration_stage_bundle.go
+++ b/internal/runner/target_registration_stage_bundle.go
@@ -28,6 +28,15 @@ type TargetRegistrationStageBundleConfig struct {
 	Expected           submission.TargetRegistrationExpected
 }
 
+type TargetRegistrationStageHandoffConfig struct {
+	Handoff            *VerifiedTargetCredentialStageHandoff
+	GrantPath          string
+	GrantPublicKeyPath string
+	EvaluationTime     time.Time
+	ArtifactPath       string
+	Expected           submission.TargetRegistrationExpected
+}
+
 type TargetRegistrationStageBundleReceipt struct {
 	Format                     string `json:"format"`
 	State                      string `json:"state"`
@@ -50,6 +59,7 @@ type VerifiedTargetRegistrationStageBundle struct {
 	grant      authorization.VerifiedStageGrant
 	projection submission.TargetRegistrationPlan
 	receipt    TargetRegistrationStageBundleReceipt
+	handoff    *VerifiedTargetCredentialStageHandoff
 	verified   bool
 }
 
@@ -58,6 +68,14 @@ type TargetRegistrationStageRuntimeConfig struct {
 	GitOps              KubernetesAuthorityConfig
 	Runtime             VerifiedRuntimeBindingMaterial
 	Credential          VerifiedTargetCredentialMaterial
+	MaterializationTime time.Time
+	Clock               func() time.Time
+}
+
+type TargetRegistrationStageHandoffRuntimeConfig struct {
+	Ledger              KubernetesLedgerConfig
+	GitOps              KubernetesAuthorityConfig
+	Runtime             VerifiedRuntimeBindingMaterial
 	MaterializationTime time.Time
 	Clock               func() time.Time
 }
@@ -83,6 +101,43 @@ func LoadTargetRegistrationStageBundle(config TargetRegistrationStageBundleConfi
 	if err != nil {
 		return VerifiedTargetRegistrationStageBundle{}, err
 	}
+	return loadTargetRegistrationStageBundle(plan, cursor, prefix, targetRegistrationStageLoadConfig{
+		GrantPath: config.GrantPath, GrantPublicKeyPath: config.GrantPublicKeyPath, EvaluationTime: config.EvaluationTime,
+		ArtifactPath: config.ArtifactPath, Expected: config.Expected,
+	})
+}
+
+// LoadTargetRegistrationStageBundleFromHandoff consumes no credential. It
+// verifies a newly available Stage-9 grant against the exact durable Stage-8
+// receipt retained by the same process.
+func LoadTargetRegistrationStageBundleFromHandoff(config TargetRegistrationStageHandoffConfig) (VerifiedTargetRegistrationStageBundle, error) {
+	if config.Handoff == nil || config.EvaluationTime.IsZero() {
+		return VerifiedTargetRegistrationStageBundle{}, errors.New("target-registration handoff and authorization evaluation time are required")
+	}
+	plan, cursor, prefix, err := config.Handoff.registrationContext()
+	if err != nil {
+		return VerifiedTargetRegistrationStageBundle{}, err
+	}
+	bundle, err := loadTargetRegistrationStageBundle(plan, cursor, prefix, targetRegistrationStageLoadConfig{
+		GrantPath: config.GrantPath, GrantPublicKeyPath: config.GrantPublicKeyPath, EvaluationTime: config.EvaluationTime,
+		ArtifactPath: config.ArtifactPath, Expected: config.Expected,
+	})
+	if err != nil {
+		return VerifiedTargetRegistrationStageBundle{}, err
+	}
+	bundle.handoff = config.Handoff
+	return bundle, nil
+}
+
+type targetRegistrationStageLoadConfig struct {
+	GrantPath          string
+	GrantPublicKeyPath string
+	EvaluationTime     time.Time
+	ArtifactPath       string
+	Expected           submission.TargetRegistrationExpected
+}
+
+func loadTargetRegistrationStageBundle(plan stageplan.Binding, cursor stagecursor.Cursor, prefix []stagereceipt.Verified, config targetRegistrationStageLoadConfig) (VerifiedTargetRegistrationStageBundle, error) {
 	decision, err := cursor.Decision()
 	if err != nil || decision.State != "NEXT" || decision.StageID != "target-registration" || decision.Kind != "Submission" || decision.Authority != "gitops" || !decision.RequiresAuthorization || decision.Operation != "RegisterTarget" {
 		return VerifiedTargetRegistrationStageBundle{}, errors.New("verified prefix does not select target registration")
@@ -179,6 +234,22 @@ func (bundle VerifiedTargetRegistrationStageBundle) Open(config TargetRegistrati
 		operation: execution.StagedOperation{Ledger: ledgerStore, Mutator: mutator, Clock: config.Clock},
 		plan:      bundle.plan, cursor: bundle.cursor, grant: bundle.grant, verified: true,
 	}, nil
+}
+
+// OpenHandoff consumes the memory-only credential exactly once and binds it to
+// the already verified Stage-9 projection, writer and durable ledger.
+func (bundle VerifiedTargetRegistrationStageBundle) OpenHandoff(config TargetRegistrationStageHandoffRuntimeConfig) (BoundTargetRegistrationStage, error) {
+	if err := verifyTargetRegistrationStageBundle(bundle); err != nil || bundle.handoff == nil || config.Clock == nil || config.MaterializationTime.IsZero() {
+		return BoundTargetRegistrationStage{}, errors.New("target-registration bundle was not loaded from an in-process handoff")
+	}
+	credential, err := bundle.handoff.takeCredential()
+	if err != nil {
+		return BoundTargetRegistrationStage{}, err
+	}
+	return bundle.Open(TargetRegistrationStageRuntimeConfig{
+		Ledger: config.Ledger, GitOps: config.GitOps, Runtime: config.Runtime, Credential: credential,
+		MaterializationTime: config.MaterializationTime, Clock: config.Clock,
+	})
 }
 
 func (stage BoundTargetRegistrationStage) Run(ctx context.Context) (execution.StagedOperationReceipt, error) {

--- a/internal/runner/target_registration_stage_execution_test.go
+++ b/internal/runner/target_registration_stage_execution_test.go
@@ -94,6 +94,73 @@ func TestTargetRegistrationStageRejectsSharedLedgerAndWriterCredentialBeforeAPI(
 	}
 }
 
+func TestTargetRegistrationStageLoadsAndRunsFromCredentialHandoff(t *testing.T) {
+	fixture := targetRegistrationMaterialFixture(t)
+	handoff, err := newVerifiedTargetCredentialStageHandoff(
+		fixture.bundle.plan, fixture.bundle.prefix[:7], fixture.bundle.prefix[7], fixture.credential,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bundle, err := LoadTargetRegistrationStageBundleFromHandoff(TargetRegistrationStageHandoffConfig{
+		Handoff: handoff, GrantPath: fixture.bundleConfig.GrantPath, GrantPublicKeyPath: fixture.bundleConfig.GrantPublicKeyPath,
+		EvaluationTime: fixture.bundleConfig.EvaluationTime, ArtifactPath: fixture.bundleConfig.ArtifactPath, Expected: fixture.bundleConfig.Expected,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	public, err := bundle.Receipt()
+	if err != nil || public.CredentialMaterialPresent || public.MutationAllowed {
+		t.Fatalf("handoff-loaded bundle exposed credential: %#v %v", public, err)
+	}
+	ledgerAPI := newRuntimeBindingLedgerAPI(t)
+	defer ledgerAPI.Close()
+	gitopsAPI := newTargetRegistrationExecutionAPI(t, 0)
+	defer gitopsAPI.Close()
+	base := targetRegistrationExecutionRuntime(t, fixture, ledgerAPI.Server, gitopsAPI.Server)
+	bound, err := bundle.OpenHandoff(TargetRegistrationStageHandoffRuntimeConfig{
+		Ledger: base.Ledger, GitOps: base.GitOps, Runtime: base.Runtime,
+		MaterializationTime: base.MaterializationTime, Clock: base.Clock,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ledgerAPI.RequestCount() != 0 || gitopsAPI.RequestCount() != 0 {
+		t.Fatal("opening handoff-loaded target registration contacted Kubernetes")
+	}
+	receipt, err := bound.Run(context.Background())
+	if err != nil || receipt.State != "COMPLETED_SUCCEEDED" || receipt.StageID != "target-registration" || gitopsAPI.RequestCount() != 4 {
+		t.Fatalf("handoff-loaded target registration did not complete: %#v requests=%v err=%v", receipt, gitopsAPI.Requests(), err)
+	}
+	if _, err := bundle.OpenHandoff(TargetRegistrationStageHandoffRuntimeConfig{}); err == nil {
+		t.Fatal("memory-only target credential was consumed twice")
+	}
+}
+
+func TestTargetRegistrationHandoffRejectsForeignOrConsumedContext(t *testing.T) {
+	fixture := targetRegistrationMaterialFixture(t)
+	if _, err := newVerifiedTargetCredentialStageHandoff(
+		fixture.bundle.plan, fixture.bundle.prefix[:6], fixture.bundle.prefix[7], fixture.credential,
+	); err == nil {
+		t.Fatal("incomplete predecessor prefix produced a target-credential handoff")
+	}
+	handoff, err := newVerifiedTargetCredentialStageHandoff(
+		fixture.bundle.plan, fixture.bundle.prefix[:7], fixture.bundle.prefix[7], fixture.credential,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := handoff.takeCredential(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadTargetRegistrationStageBundleFromHandoff(TargetRegistrationStageHandoffConfig{
+		Handoff: handoff, GrantPath: fixture.bundleConfig.GrantPath, GrantPublicKeyPath: fixture.bundleConfig.GrantPublicKeyPath,
+		EvaluationTime: fixture.bundleConfig.EvaluationTime, ArtifactPath: fixture.bundleConfig.ArtifactPath, Expected: fixture.bundleConfig.Expected,
+	}); err == nil {
+		t.Fatal("consumed target credential handoff loaded target registration")
+	}
+}
+
 func targetRegistrationExecutionRuntime(t *testing.T, fixture targetRegistrationMaterialTestFixture, ledgerServer, gitopsServer *httptest.Server) TargetRegistrationStageRuntimeConfig {
 	t.Helper()
 	root := t.TempDir()


### PR DESCRIPTION
## Summary

- retain the verified eight-receipt prefix inside the memory-only Stage-8 handoff
- load a newly supplied Stage-9 grant against the exact runtime-created Stage-8 receipt
- keep bundle verification read-only and credential-free
- consume the target credential exactly once only when opening the verified registration runtime
- canonicalize credential evidence consistently across the Stage-8/9 boundary

## Verification

- `GOCACHE=/private/tmp/ok147-go-build go test -ldflags=-linkmode=external ./...`
- `GOCACHE=/private/tmp/ok147-go-vet go vet ./...`
- `GOCACHE=/private/tmp/ok147-go-race go test -race -ldflags=-linkmode=external ./internal/runner`
- `git diff --check`
- local TLS integration only; no live cluster contact or infrastructure mutation

## Review question

Does this preserve predecessor-bound per-stage authorization while allowing Stage 9 to continue in the same process without persisting target credentials?
