### PR TITLE
feat(cli): execute platform applications stage (OK-147)

### DIFF
--- a/cmd/ok/main.go
+++ b/cmd/ok/main.go
@@ -672,6 +672,9 @@ func runContext(ctx context.Context, arguments []string, stdout, stderr io.Write
 	if len(arguments) >= 4 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "run" && arguments[3] == "target-access" {
 		return runClusterStageRunTargetAccess(ctx, arguments[4:], stdout, stderr)
 	}
+	if len(arguments) >= 4 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "run" && arguments[3] == "platform-applications" {
+		return runClusterStageRunPlatformApplications(ctx, arguments[4:], stdout, stderr)
+	}
 	if len(arguments) >= 6 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "run" && arguments[3] == "aggregate-evidence" && arguments[4] == "launch" && arguments[5] == "prepare" {
 		return runClusterStageRunAggregateEvidenceLaunchPrepare(arguments[6:], stdout, stderr)
 	}
@@ -690,7 +693,7 @@ func runContext(ctx context.Context, arguments []string, stdout, stderr io.Write
 	if len(arguments) >= 4 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "launch" && arguments[3] == "execute" {
 		return runClusterStageLaunchExecute(ctx, arguments[4:], stdout, stderr)
 	}
-	return errors.New("usage: ok cluster create ... | ok cluster stage inspect ... | ok cluster stage resume ... | ok cluster stage observe lifecycle ... | ok cluster stage observe network ... | ok cluster stage bind runtime ... | ok cluster stage bind runtime launch prepare ... | ok cluster stage bind runtime launch execute ... | ok cluster stage observe network package ... | ok cluster stage observe network launch prepare ... | ok cluster stage observe network launch execute ... | ok cluster stage observe lifecycle package ... | ok cluster stage observe lifecycle launch prepare ... | ok cluster stage observe lifecycle launch execute ... | ok cluster stage run ... | ok cluster stage run enablement ... | ok cluster stage run target-access ... | ok cluster stage run aggregate-evidence launch prepare ... | ok cluster stage run aggregate-evidence launch execute ... | ok cluster stage run enablement package ... | ok cluster stage run enablement launch prepare ... | ok cluster stage run enablement launch execute ... | ok cluster stage package ... | ok cluster stage launch prepare ... | ok cluster stage launch execute ...")
+	return errors.New("usage: ok cluster create ... | ok cluster stage inspect ... | ok cluster stage resume ... | ok cluster stage observe lifecycle ... | ok cluster stage observe network ... | ok cluster stage bind runtime ... | ok cluster stage bind runtime launch prepare ... | ok cluster stage bind runtime launch execute ... | ok cluster stage observe network package ... | ok cluster stage observe network launch prepare ... | ok cluster stage observe network launch execute ... | ok cluster stage observe lifecycle package ... | ok cluster stage observe lifecycle launch prepare ... | ok cluster stage observe lifecycle launch execute ... | ok cluster stage run ... | ok cluster stage run enablement ... | ok cluster stage run target-access ... | ok cluster stage run platform-applications ... | ok cluster stage run aggregate-evidence launch prepare ... | ok cluster stage run aggregate-evidence launch execute ... | ok cluster stage run enablement package ... | ok cluster stage run enablement launch prepare ... | ok cluster stage run enablement launch execute ... | ok cluster stage package ... | ok cluster stage launch prepare ... | ok cluster stage launch execute ...")
 }
 
 func runClusterCreate(arguments []string, stdout, stderr io.Writer) error {

--- a/cmd/ok/platform_applications.go
+++ b/cmd/ok/platform_applications.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/execution"
+	"github.com/openkubes/ok-cluster/internal/runner"
+	"github.com/openkubes/ok-cluster/internal/submission"
+)
+
+var executePlatformApplicationsStage = func(ctx context.Context, bundleConfig runner.PlatformApplicationsStageBundleConfig, runtimeConfig runner.PlatformApplicationsStageRuntimeConfig) (execution.StagedOperationReceipt, error) {
+	bundle, err := runner.LoadPlatformApplicationsStageBundle(bundleConfig)
+	if err != nil {
+		return execution.StagedOperationReceipt{}, err
+	}
+	stage, err := bundle.Open(runtimeConfig)
+	if err != nil {
+		return execution.StagedOperationReceipt{}, err
+	}
+	return stage.Run(ctx)
+}
+
+func runClusterStageRunPlatformApplications(ctx context.Context, arguments []string, stdout, stderr io.Writer) error {
+	flags := flag.NewFlagSet("ok cluster stage run platform-applications", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	resumeFlags := addStageResumeFlags(flags)
+	grant := flags.String("grant", "", "path to the signed platform-applications grant")
+	grantKey := flags.String("grant-key", "", "path to the trusted stage-authority public key")
+	evaluationTime := flags.String("evaluation-time", "", "explicit RFC3339 grant evaluation time")
+	artifact := flags.String("platform-applications-artifact", "", "path to the exact externally rendered three-Application artifact")
+	artifactDigest := flags.String("platform-applications-digest", "", "expected platform Applications artifact digest")
+	profilePath := flags.String("platform-profile", "", "path to the immutable PlatformReady profile")
+	profileDigest := flags.String("platform-profile-digest", "", "expected PlatformReady profile digest")
+	targetIdentity := flags.String("target-identity-digest", "", "expected immutable workload target identity digest")
+	argoNamespace := flags.String("argo-namespace", "", "expected Argo namespace")
+	projectName := flags.String("project-name", "", "expected Argo AppProject name")
+	registrationName := flags.String("registration-name", "", "expected Argo target registration name")
+	sourceRepository := flags.String("source-repository", "", "expected immutable Platform source repository")
+	ledgerEndpoint := flags.String("ledger-api-endpoint", "", "TLS Kubernetes API endpoint for the durable ledger")
+	ledgerToken := flags.String("ledger-token-file", "", "path to the short-lived ledger token")
+	ledgerCA := flags.String("ledger-ca-file", "", "path to the ledger Kubernetes API CA bundle")
+	gitopsEndpoint := flags.String("gitops-api-endpoint", "", "TLS Kubernetes API endpoint for the GitOps writer")
+	gitopsToken := flags.String("gitops-token-file", "", "path to the short-lived GitOps writer token")
+	gitopsCA := flags.String("gitops-ca-file", "", "path to the GitOps Kubernetes API CA bundle")
+	gitopsCADigest := flags.String("gitops-ca-digest", "", "expected GitOps API CA digest")
+	execute := flags.Bool("execute", false, "claim and execute exactly the platform-applications stage")
+	if err := flags.Parse(arguments); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return errors.New("positional arguments are not accepted")
+	}
+	if !*execute {
+		return errors.New("platform-applications mutation requires explicit --execute")
+	}
+	resume, err := resumeFlags.config()
+	if err != nil {
+		return err
+	}
+	for _, input := range []struct{ name, value string }{
+		{"--grant", *grant}, {"--grant-key", *grantKey}, {"--evaluation-time", *evaluationTime},
+		{"--platform-applications-artifact", *artifact}, {"--platform-applications-digest", *artifactDigest},
+		{"--platform-profile", *profilePath}, {"--platform-profile-digest", *profileDigest}, {"--target-identity-digest", *targetIdentity},
+		{"--argo-namespace", *argoNamespace}, {"--project-name", *projectName}, {"--registration-name", *registrationName}, {"--source-repository", *sourceRepository},
+		{"--ledger-api-endpoint", *ledgerEndpoint}, {"--ledger-token-file", *ledgerToken}, {"--ledger-ca-file", *ledgerCA},
+		{"--gitops-api-endpoint", *gitopsEndpoint}, {"--gitops-token-file", *gitopsToken}, {"--gitops-ca-file", *gitopsCA}, {"--gitops-ca-digest", *gitopsCADigest},
+	} {
+		if input.value == "" {
+			return fmt.Errorf("%s is required", input.name)
+		}
+	}
+	for _, value := range []string{*artifactDigest, *profileDigest, *targetIdentity, *gitopsCADigest} {
+		if !sha256DigestPattern.MatchString(value) {
+			return errors.New("platform-applications digests must be lowercase SHA-256 identities")
+		}
+	}
+	at, err := time.Parse(time.RFC3339, *evaluationTime)
+	if err != nil {
+		return fmt.Errorf("parse evaluation time: %w", err)
+	}
+	loadedProfile, err := runner.LoadPlatformProfileFile(runner.PlatformProfileFileConfig{
+		Path: *profilePath, ExpectedProfileDigest: *profileDigest,
+		ExpectedIntentRevision: resume.PlanExpected.IntentRevision, ExpectedPlatformRevision: resume.PlanExpected.PlatformRevision,
+		ExpectedExecutionFixture: resume.PlanExpected.ExecutionFixture,
+	})
+	if err != nil {
+		return err
+	}
+	bundleConfig := runner.PlatformApplicationsStageBundleConfig{
+		PlanPath: resume.PlanPath, PlanExpected: resume.PlanExpected, Receipts: resume.Receipts,
+		GrantPath: *grant, GrantPublicKeyPath: *grantKey, EvaluationTime: at, ArtifactPath: *artifact,
+		Expected: submission.PlatformApplicationsExpected{
+			ArtifactDigest: *artifactDigest, ContractIdentity: resume.PlanExpected.ContractIdentity,
+			IntentRevision: resume.PlanExpected.IntentRevision, PlatformRevision: resume.PlanExpected.PlatformRevision,
+			ExecutionFixture: resume.PlanExpected.ExecutionFixture, TargetIdentityDigest: *targetIdentity,
+			ArgoAuthority: resume.PlanExpected.GitOpsAuthority, ArgoNamespace: *argoNamespace,
+			ProjectName: *projectName, RegistrationName: *registrationName, SourceRepository: *sourceRepository,
+			Profile: loadedProfile.Profile,
+		},
+	}
+	runtimeConfig := runner.PlatformApplicationsStageRuntimeConfig{
+		Ledger: runner.KubernetesLedgerConfig{Endpoint: *ledgerEndpoint, Namespace: ledgerNamespace, TokenFile: *ledgerToken, CAFile: *ledgerCA},
+		GitOps: runner.KubernetesAuthorityConfig{
+			Endpoint: *gitopsEndpoint, AuthorityIdentity: resume.PlanExpected.GitOpsAuthority,
+			TokenFile: *gitopsToken, CAFile: *gitopsCA, CABundleDigest: *gitopsCADigest,
+		},
+		Clock: func() time.Time { return time.Now().UTC() },
+	}
+	boundedContext, cancel := context.WithTimeout(ctx, stageRunTimeout)
+	defer cancel()
+	receipt, runErr := executePlatformApplicationsStage(boundedContext, bundleConfig, runtimeConfig)
+	if receipt.Format != "" {
+		encoder := json.NewEncoder(stdout)
+		encoder.SetEscapeHTML(false)
+		encoder.SetIndent("", "  ")
+		if err := encoder.Encode(receipt); err != nil {
+			return err
+		}
+	}
+	return runErr
+}

--- a/cmd/ok/platform_applications_test.go
+++ b/cmd/ok/platform_applications_test.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/execution"
+	"github.com/openkubes/ok-cluster/internal/observation"
+	"github.com/openkubes/ok-cluster/internal/runner"
+)
+
+func platformApplicationsStageRunArguments(t *testing.T) []string {
+	t.Helper()
+	profile := observation.PlatformProfile{
+		Format:               observation.PlatformProfileFormat,
+		IntentRevision:       testSHA("a"),
+		PlatformRevision:     testSHA("c"),
+		ExecutionFixture:     testSHA("d"),
+		TargetIdentityScheme: "capi-cluster-uid/v1",
+		ArgoNamespace:        "argocd",
+		RegistrationName:     "disposable-ok147",
+		RequiredApplications: []observation.PlatformApplicationExpectation{
+			{Name: "disposable-ok147-observability-core", SpecDigest: testSHA("1")},
+			{Name: "disposable-ok147-observability-logs", SpecDigest: testSHA("2")},
+			{Name: "disposable-ok147-observability-metrics", SpecDigest: testSHA("3")},
+		},
+		CapabilityContractDigest:    testSHA("4"),
+		CapabilityExecutableDigest:  testSHA("5"),
+		MaximumCapabilityAgeSeconds: 900,
+	}
+	profileDigest, err := observation.PlatformProfileDigest(profile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rawProfile, err := json.Marshal(profile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	profilePath := filepath.Join(t.TempDir(), "platform-profile.json")
+	if err := os.WriteFile(profilePath, rawProfile, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	resume := stageResumeArguments()
+	arguments := append([]string{"cluster", "stage", "run", "platform-applications"}, resume[3:]...)
+	return append(arguments,
+		"--receipt", "/tmp/provider.json@"+testSHA("1"),
+		"--receipt", "/tmp/lifecycle.json@"+testSHA("2"),
+		"--receipt", "/tmp/lifecycle-observation.json@"+testSHA("3"),
+		"--receipt", "/tmp/enablement.json@"+testSHA("4"),
+		"--receipt", "/tmp/network-observation.json@"+testSHA("5"),
+		"--receipt", "/tmp/runtime-binding.json@"+testSHA("6"),
+		"--receipt", "/tmp/target-access.json@"+testSHA("7"),
+		"--receipt", "/tmp/target-credential.json@"+testSHA("8"),
+		"--receipt", "/tmp/target-registration.json@"+testSHA("9"),
+		"--grant", "/tmp/platform-applications-grant.json", "--grant-key", "/tmp/platform-applications-grant.pub",
+		"--evaluation-time", "2026-08-17T16:00:00Z",
+		"--platform-applications-artifact", "/tmp/platform-applications.yaml", "--platform-applications-digest", testSHA("6"),
+		"--platform-profile", profilePath, "--platform-profile-digest", profileDigest,
+		"--target-identity-digest", testSHA("7"),
+		"--argo-namespace", "argocd", "--project-name", "ok147-disposable", "--registration-name", "disposable-ok147",
+		"--source-repository", "https://github.com/openkubes/ok-observability.git",
+		"--execute",
+		"--ledger-api-endpoint", "https://192.0.2.12:6443", "--ledger-token-file", "/private/tmp/ledger-token", "--ledger-ca-file", "/private/tmp/ledger-ca",
+		"--gitops-api-endpoint", "https://192.0.2.13:6443", "--gitops-token-file", "/private/tmp/gitops-token", "--gitops-ca-file", "/private/tmp/gitops-ca", "--gitops-ca-digest", testSHA("8"),
+	)
+}
+
+func TestPlatformApplicationsStageRunBindsExactProfileAndGitOpsRuntime(t *testing.T) {
+	previous := executePlatformApplicationsStage
+	defer func() { executePlatformApplicationsStage = previous }()
+	var calls int
+	executePlatformApplicationsStage = func(ctx context.Context, bundle runner.PlatformApplicationsStageBundleConfig, runtime runner.PlatformApplicationsStageRuntimeConfig) (execution.StagedOperationReceipt, error) {
+		calls++
+		deadline, bounded := ctx.Deadline()
+		if !bounded || time.Until(deadline) > stageRunTimeout || time.Until(deadline) < stageRunTimeout-time.Minute {
+			t.Fatalf("platform-applications context is not bounded: %s %t", deadline, bounded)
+		}
+		if bundle.PlanPath != "/tmp/plan.json" || len(bundle.Receipts) != 9 || bundle.ArtifactPath != "/tmp/platform-applications.yaml" || bundle.Expected.ArtifactDigest != testSHA("6") {
+			t.Fatalf("platform-applications bundle differs: %#v", bundle)
+		}
+		if bundle.Expected.IntentRevision != testSHA("a") || bundle.Expected.PlatformRevision != testSHA("c") || bundle.Expected.ExecutionFixture != testSHA("d") || bundle.Expected.TargetIdentityDigest != testSHA("7") {
+			t.Fatalf("platform-applications revision binding differs: %#v", bundle.Expected)
+		}
+		if bundle.Expected.ArgoAuthority != "ok-shared" || bundle.Expected.ArgoNamespace != "argocd" || bundle.Expected.ProjectName != "ok147-disposable" || bundle.Expected.RegistrationName != "disposable-ok147" || len(bundle.Expected.Profile.RequiredApplications) != 3 {
+			t.Fatalf("platform-applications authority or profile differs: %#v", bundle.Expected)
+		}
+		if runtime.Ledger.Namespace != ledgerNamespace || runtime.GitOps.AuthorityIdentity != "ok-shared" || runtime.GitOps.Endpoint != "https://192.0.2.13:6443" || runtime.GitOps.TokenFile != "/private/tmp/gitops-token" || runtime.GitOps.CABundleDigest != testSHA("8") || runtime.Clock == nil {
+			t.Fatalf("platform-applications runtime differs: %#v", runtime)
+		}
+		return execution.StagedOperationReceipt{Format: execution.StagedReceiptFormat, State: "COMPLETED_SUCCEEDED", StageID: "platform-applications", StageReceiptDigest: testSHA("9")}, nil
+	}
+	var stdout, stderr bytes.Buffer
+	if err := run(platformApplicationsStageRunArguments(t), &stdout, &stderr); err != nil {
+		t.Fatalf("run: %v; stderr=%s", err, stderr.String())
+	}
+	if calls != 1 {
+		t.Fatalf("platform-applications runner calls = %d", calls)
+	}
+	var receipt execution.StagedOperationReceipt
+	if err := json.Unmarshal(stdout.Bytes(), &receipt); err != nil || receipt.StageID != "platform-applications" {
+		t.Fatalf("unexpected platform-applications receipt: %#v %v", receipt, err)
+	}
+}
+
+func TestPlatformApplicationsStageRunFailsClosedBeforeExecution(t *testing.T) {
+	previous := executePlatformApplicationsStage
+	defer func() { executePlatformApplicationsStage = previous }()
+	calls := 0
+	executePlatformApplicationsStage = func(context.Context, runner.PlatformApplicationsStageBundleConfig, runner.PlatformApplicationsStageRuntimeConfig) (execution.StagedOperationReceipt, error) {
+		calls++
+		return execution.StagedOperationReceipt{}, nil
+	}
+	valid := platformApplicationsStageRunArguments(t)
+	for name, arguments := range map[string][]string{
+		"missing execute":         removeArgument(valid, "--execute"),
+		"missing artifact":        removeArgumentWithValue(valid, "--platform-applications-artifact"),
+		"missing profile":         removeArgumentWithValue(valid, "--platform-profile"),
+		"invalid profile digest":  replaceArgument(valid, "--platform-profile-digest", "not-a-digest"),
+		"missing gitops identity": removeArgumentWithValue(valid, "--gitops-ca-digest"),
+		"invalid time":            replaceArgument(valid, "--evaluation-time", "not-time"),
+		"positional":              append(append([]string{}, valid...), "unexpected"),
+	} {
+		t.Run(name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			if err := run(arguments, &stdout, &stderr); err == nil || stdout.Len() != 0 {
+				t.Fatalf("unsafe platform-applications run was accepted: %v %s", err, stdout.String())
+			}
+		})
+	}
+	if calls != 0 {
+		t.Fatalf("platform-applications runner reached %d times for invalid input", calls)
+	}
+}


### PR DESCRIPTION
## What changed

- add `ok cluster stage run platform-applications` as the bounded Stage 10 CLI adapter
- bind the exact nine-receipt prefix, current R/P/fixture identities, immutable Platform profile, target identity, and GitOps authority
- keep ledger and GitOps credentials separated and require explicit `--execute`
- emit only the canonical durable stage receipt

## Why

The Stage 10 runner library was already authoritative, but it had no independently executable CLI boundary. This checkpoint exposes that existing mechanism without adding a renderer, a second Contract-to-Argo translation path, or a new control loop.

## Safety

- missing execution intent, artifacts, profile, identities, credentials, or evaluation time fail closed before runner invocation
- the command runs under the existing five-minute bounded context
- no cluster or infrastructure mutation was performed while developing this change

## Validation

- `go test -ldflags=-linkmode=external ./...`
- `go vet ./...`
- `go test -race -ldflags=-linkmode=external ./internal/runner ./cmd/ok`
