### PR TITLE
feat(cli): observe platform readiness stage (OK-147)

### DIFF
--- a/cmd/ok/main.go
+++ b/cmd/ok/main.go
@@ -639,6 +639,9 @@ func runContext(ctx context.Context, arguments []string, stdout, stderr io.Write
 	if len(arguments) >= 4 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "observe" && arguments[3] == "network" {
 		return runClusterStageObserveNetwork(ctx, arguments[4:], stdout, stderr)
 	}
+	if len(arguments) >= 4 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "observe" && arguments[3] == "platform" {
+		return runClusterStageObservePlatform(ctx, arguments[4:], stdout, stderr)
+	}
 	if len(arguments) >= 6 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "bind" && arguments[3] == "runtime" && arguments[4] == "launch" && arguments[5] == "prepare" {
 		return runClusterStageBindRuntimeLaunchPrepare(arguments[6:], stdout, stderr)
 	}
@@ -693,7 +696,7 @@ func runContext(ctx context.Context, arguments []string, stdout, stderr io.Write
 	if len(arguments) >= 4 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "launch" && arguments[3] == "execute" {
 		return runClusterStageLaunchExecute(ctx, arguments[4:], stdout, stderr)
 	}
-	return errors.New("usage: ok cluster create ... | ok cluster stage inspect ... | ok cluster stage resume ... | ok cluster stage observe lifecycle ... | ok cluster stage observe network ... | ok cluster stage bind runtime ... | ok cluster stage bind runtime launch prepare ... | ok cluster stage bind runtime launch execute ... | ok cluster stage observe network package ... | ok cluster stage observe network launch prepare ... | ok cluster stage observe network launch execute ... | ok cluster stage observe lifecycle package ... | ok cluster stage observe lifecycle launch prepare ... | ok cluster stage observe lifecycle launch execute ... | ok cluster stage run ... | ok cluster stage run enablement ... | ok cluster stage run target-access ... | ok cluster stage run platform-applications ... | ok cluster stage run aggregate-evidence launch prepare ... | ok cluster stage run aggregate-evidence launch execute ... | ok cluster stage run enablement package ... | ok cluster stage run enablement launch prepare ... | ok cluster stage run enablement launch execute ... | ok cluster stage package ... | ok cluster stage launch prepare ... | ok cluster stage launch execute ...")
+	return errors.New("usage: ok cluster create ... | ok cluster stage inspect ... | ok cluster stage resume ... | ok cluster stage observe lifecycle ... | ok cluster stage observe network ... | ok cluster stage observe platform ... | ok cluster stage bind runtime ... | ok cluster stage bind runtime launch prepare ... | ok cluster stage bind runtime launch execute ... | ok cluster stage observe network package ... | ok cluster stage observe network launch prepare ... | ok cluster stage observe network launch execute ... | ok cluster stage observe lifecycle package ... | ok cluster stage observe lifecycle launch prepare ... | ok cluster stage observe lifecycle launch execute ... | ok cluster stage run ... | ok cluster stage run enablement ... | ok cluster stage run target-access ... | ok cluster stage run platform-applications ... | ok cluster stage run aggregate-evidence launch prepare ... | ok cluster stage run aggregate-evidence launch execute ... | ok cluster stage run enablement package ... | ok cluster stage run enablement launch prepare ... | ok cluster stage run enablement launch execute ... | ok cluster stage package ... | ok cluster stage launch prepare ... | ok cluster stage launch execute ...")
 }
 
 func runClusterCreate(arguments []string, stdout, stderr io.Writer) error {

--- a/cmd/ok/platform_observation.go
+++ b/cmd/ok/platform_observation.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/execution"
+	"github.com/openkubes/ok-cluster/internal/runner"
+)
+
+var executePlatformObservationStage = func(ctx context.Context, bundleConfig runner.PlatformObservationStageBundleConfig, fileRuntime runner.PlatformObservationStageFileRuntimeConfig) (execution.ObservationStageRunReceipt, error) {
+	bundle, err := runner.LoadPlatformObservationStageBundle(bundleConfig)
+	if err != nil {
+		return execution.ObservationStageRunReceipt{}, err
+	}
+	runtimeConfig, err := runner.LoadPlatformObservationStageFileRuntime(fileRuntime)
+	if err != nil {
+		return execution.ObservationStageRunReceipt{}, err
+	}
+	opened, err := bundle.Open(runtimeConfig)
+	if err != nil {
+		return execution.ObservationStageRunReceipt{}, err
+	}
+	return opened.Run(ctx)
+}
+
+func runClusterStageObservePlatform(ctx context.Context, arguments []string, stdout, stderr io.Writer) error {
+	flags := flag.NewFlagSet("ok cluster stage observe platform", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	resumeFlags := addStageResumeFlags(flags)
+	execute := flags.Bool("execute", false, "perform exactly the selected read-only platform observation and persist its receipt")
+	profilePath := flags.String("platform-profile", "", "path to the immutable PlatformReady profile")
+	profileDigest := flags.String("platform-profile-digest", "", "expected PlatformReady profile digest")
+	runtimeMaterial := flags.String("runtime-binding-material", "", "path to the private canonical runtime-binding material")
+	runtimeReceipt := flags.String("runtime-binding-receipt", "", "path to the verified runtime-binding material receipt")
+	capabilityPath := flags.String("platform-capability", "", "path to the redacted platform capability evidence")
+	capabilityDigest := flags.String("platform-capability-digest", "", "expected platform capability evidence digest")
+	ledgerEndpoint := flags.String("ledger-api-endpoint", "", "TLS Kubernetes API endpoint for the durable ledger")
+	ledgerToken := flags.String("ledger-token-file", "", "path to the short-lived ledger token")
+	ledgerCA := flags.String("ledger-ca-file", "", "path to the ledger Kubernetes API CA bundle")
+	argoEndpoint := flags.String("argo-api-endpoint", "", "TLS Kubernetes API endpoint for exact Argo Application observation")
+	argoToken := flags.String("argo-token-file", "", "path to the short-lived read-only Argo token")
+	argoCA := flags.String("argo-ca-file", "", "path to the Argo Kubernetes API CA bundle")
+	argoCADigest := flags.String("argo-ca-digest", "", "expected Argo Kubernetes API CA digest")
+	pollInterval := flags.Duration("poll-interval", 0, "bounded interval between verified Unknown observations")
+	pollTimeout := flags.Duration("poll-timeout", 0, "maximum bounded platform observation duration")
+	if err := flags.Parse(arguments); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return errors.New("positional arguments are not accepted")
+	}
+	if !*execute {
+		return errors.New("platform observation requires explicit --execute")
+	}
+	resume, err := resumeFlags.config()
+	if err != nil {
+		return err
+	}
+	for _, input := range []struct{ name, value string }{
+		{"--platform-profile", *profilePath}, {"--platform-profile-digest", *profileDigest},
+		{"--runtime-binding-material", *runtimeMaterial}, {"--runtime-binding-receipt", *runtimeReceipt},
+		{"--platform-capability", *capabilityPath}, {"--platform-capability-digest", *capabilityDigest},
+		{"--ledger-api-endpoint", *ledgerEndpoint}, {"--ledger-token-file", *ledgerToken}, {"--ledger-ca-file", *ledgerCA},
+		{"--argo-api-endpoint", *argoEndpoint}, {"--argo-token-file", *argoToken}, {"--argo-ca-file", *argoCA}, {"--argo-ca-digest", *argoCADigest},
+	} {
+		if input.value == "" {
+			return fmt.Errorf("%s is required", input.name)
+		}
+	}
+	for _, value := range []string{*profileDigest, *capabilityDigest, *argoCADigest} {
+		if !sha256DigestPattern.MatchString(value) {
+			return errors.New("platform observation digests must be lowercase SHA-256 identities")
+		}
+	}
+	if *pollInterval < time.Second || *pollInterval > 5*time.Minute || *pollTimeout < *pollInterval || *pollTimeout > 6*time.Hour {
+		return errors.New("--poll-interval and --poll-timeout must define a valid bounded observation of at most 6h")
+	}
+	loadedProfile, err := runner.LoadPlatformProfileFile(runner.PlatformProfileFileConfig{
+		Path: *profilePath, ExpectedProfileDigest: *profileDigest,
+		ExpectedIntentRevision: resume.PlanExpected.IntentRevision, ExpectedPlatformRevision: resume.PlanExpected.PlatformRevision,
+		ExpectedExecutionFixture: resume.PlanExpected.ExecutionFixture,
+	})
+	if err != nil {
+		return err
+	}
+	bundleConfig := runner.PlatformObservationStageBundleConfig{
+		StageResumeConfig: resume, Profile: loadedProfile.Profile, ExpectedProfileDigest: loadedProfile.Digest,
+	}
+	fileRuntime := runner.PlatformObservationStageFileRuntimeConfig{
+		Bundle: resume, Profile: loadedProfile.Profile,
+		Ledger: runner.KubernetesLedgerConfig{Endpoint: *ledgerEndpoint, Namespace: ledgerNamespace, TokenFile: *ledgerToken, CAFile: *ledgerCA},
+		Argo: runner.KubernetesAuthorityConfig{
+			Endpoint: *argoEndpoint, AuthorityIdentity: resume.PlanExpected.GitOpsAuthority,
+			TokenFile: *argoToken, CAFile: *argoCA, CABundleDigest: *argoCADigest,
+		},
+		RuntimeMaterialPath: *runtimeMaterial, RuntimeReceiptPath: *runtimeReceipt,
+		CapabilityPath: *capabilityPath, ExpectedCapabilityDigest: *capabilityDigest,
+		PollInterval: *pollInterval, PollTimeout: *pollTimeout,
+		Clock: func() time.Time { return time.Now().UTC() }, Wait: runner.WaitWithTimer,
+	}
+	boundedContext, cancel := context.WithTimeout(ctx, *pollTimeout+lifecycleObservationRunOverhead)
+	defer cancel()
+	receipt, runErr := executePlatformObservationStage(boundedContext, bundleConfig, fileRuntime)
+	if receipt.Format != "" {
+		encoder := json.NewEncoder(stdout)
+		encoder.SetEscapeHTML(false)
+		encoder.SetIndent("", "  ")
+		if err := encoder.Encode(receipt); err != nil {
+			return err
+		}
+	}
+	return runErr
+}

--- a/cmd/ok/platform_observation_test.go
+++ b/cmd/ok/platform_observation_test.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/execution"
+	"github.com/openkubes/ok-cluster/internal/runner"
+)
+
+func platformObservationStageArguments(t *testing.T) []string {
+	t.Helper()
+	platformArguments := platformApplicationsStageRunArguments(t)
+	profilePath := testFlagValue(t, platformArguments, "--platform-profile")
+	profileDigest := testFlagValue(t, platformArguments, "--platform-profile-digest")
+	resume := stageResumeArguments()
+	arguments := append([]string{"cluster", "stage", "observe", "platform"}, resume[3:]...)
+	return append(arguments,
+		"--receipt", "/tmp/provider.json@"+testSHA("1"),
+		"--receipt", "/tmp/lifecycle.json@"+testSHA("2"),
+		"--receipt", "/tmp/lifecycle-observation.json@"+testSHA("3"),
+		"--receipt", "/tmp/enablement.json@"+testSHA("4"),
+		"--receipt", "/tmp/network-observation.json@"+testSHA("5"),
+		"--receipt", "/tmp/runtime-binding.json@"+testSHA("6"),
+		"--receipt", "/tmp/target-access.json@"+testSHA("7"),
+		"--receipt", "/tmp/target-credential.json@"+testSHA("8"),
+		"--receipt", "/tmp/target-registration.json@"+testSHA("9"),
+		"--receipt", "/tmp/platform-applications.json@"+testSHA("0"),
+		"--platform-profile", profilePath, "--platform-profile-digest", profileDigest,
+		"--runtime-binding-material", "/private/tmp/runtime-binding.json", "--runtime-binding-receipt", "/private/tmp/runtime-binding-receipt.json",
+		"--platform-capability", "/private/tmp/platform-capability.json", "--platform-capability-digest", testSHA("6"),
+		"--execute",
+		"--ledger-api-endpoint", "https://192.0.2.12:6443", "--ledger-token-file", "/private/tmp/ledger-token", "--ledger-ca-file", "/private/tmp/ledger-ca",
+		"--argo-api-endpoint", "https://192.0.2.13:6443", "--argo-token-file", "/private/tmp/argo-token", "--argo-ca-file", "/private/tmp/argo-ca", "--argo-ca-digest", testSHA("8"),
+		"--poll-interval", "15s", "--poll-timeout", "5m",
+	)
+}
+
+func TestPlatformObservationStageBindsPrivateRuntimeCapabilityAndArgo(t *testing.T) {
+	previous := executePlatformObservationStage
+	defer func() { executePlatformObservationStage = previous }()
+	var calls int
+	executePlatformObservationStage = func(ctx context.Context, bundle runner.PlatformObservationStageBundleConfig, runtime runner.PlatformObservationStageFileRuntimeConfig) (execution.ObservationStageRunReceipt, error) {
+		calls++
+		deadline, bounded := ctx.Deadline()
+		if !bounded || time.Until(deadline) > 6*time.Minute || time.Until(deadline) < 4*time.Minute {
+			t.Fatalf("platform observation context is not bounded: %s %t", deadline, bounded)
+		}
+		if len(bundle.Receipts) != 10 || bundle.ExpectedProfileDigest == "" || len(bundle.Profile.RequiredApplications) != 3 {
+			t.Fatalf("platform observation bundle differs: %#v", bundle)
+		}
+		if runtime.RuntimeMaterialPath != "/private/tmp/runtime-binding.json" || runtime.RuntimeReceiptPath != "/private/tmp/runtime-binding-receipt.json" || runtime.CapabilityPath != "/private/tmp/platform-capability.json" || runtime.ExpectedCapabilityDigest != testSHA("6") {
+			t.Fatalf("platform observation private inputs differ: %#v", runtime)
+		}
+		if runtime.Ledger.Namespace != ledgerNamespace || runtime.Argo.AuthorityIdentity != "ok-shared" || runtime.Argo.CABundleDigest != testSHA("8") || runtime.PollInterval != 15*time.Second || runtime.PollTimeout != 5*time.Minute || runtime.Clock == nil || runtime.Wait == nil {
+			t.Fatalf("platform observation authority differs: %#v", runtime)
+		}
+		return execution.ObservationStageRunReceipt{Format: execution.ObservationStageReceiptFormat, State: "COMPLETED_TRUE", StageID: "platform-observation", StageReceiptDigest: testSHA("9")}, nil
+	}
+	var stdout, stderr bytes.Buffer
+	if err := run(platformObservationStageArguments(t), &stdout, &stderr); err != nil {
+		t.Fatalf("run: %v; stderr=%s", err, stderr.String())
+	}
+	if calls != 1 {
+		t.Fatalf("platform observation calls = %d", calls)
+	}
+	var receipt execution.ObservationStageRunReceipt
+	if err := json.Unmarshal(stdout.Bytes(), &receipt); err != nil || receipt.StageID != "platform-observation" {
+		t.Fatalf("unexpected platform observation receipt: %#v %v", receipt, err)
+	}
+}
+
+func TestPlatformObservationStageFailsClosedBeforeExecution(t *testing.T) {
+	previous := executePlatformObservationStage
+	defer func() { executePlatformObservationStage = previous }()
+	calls := 0
+	executePlatformObservationStage = func(context.Context, runner.PlatformObservationStageBundleConfig, runner.PlatformObservationStageFileRuntimeConfig) (execution.ObservationStageRunReceipt, error) {
+		calls++
+		return execution.ObservationStageRunReceipt{}, nil
+	}
+	valid := platformObservationStageArguments(t)
+	for name, arguments := range map[string][]string{
+		"missing execute":          removeArgument(valid, "--execute"),
+		"missing runtime material": removeArgumentWithValue(valid, "--runtime-binding-material"),
+		"missing capability":       removeArgumentWithValue(valid, "--platform-capability"),
+		"invalid capability":       replaceArgument(valid, "--platform-capability-digest", "not-a-digest"),
+		"missing Argo credential":  removeArgumentWithValue(valid, "--argo-token-file"),
+		"unbounded polling":        replaceArgument(valid, "--poll-timeout", "7h"),
+		"positional":               append(append([]string{}, valid...), "unexpected"),
+	} {
+		t.Run(name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			if err := run(arguments, &stdout, &stderr); err == nil || stdout.Len() != 0 {
+				t.Fatalf("unsafe platform observation was accepted: %v %s", err, stdout.String())
+			}
+		})
+	}
+	if calls != 0 {
+		t.Fatalf("platform observation runner reached %d times for invalid input", calls)
+	}
+}
+
+func testFlagValue(t *testing.T, arguments []string, name string) string {
+	t.Helper()
+	for index := 0; index+1 < len(arguments); index++ {
+		if arguments[index] == name {
+			return arguments[index+1]
+		}
+	}
+	t.Fatalf("missing test flag %s", name)
+	return ""
+}

--- a/internal/runner/platform_observation_files.go
+++ b/internal/runner/platform_observation_files.go
@@ -1,0 +1,51 @@
+package runner
+
+import (
+	"errors"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/observation"
+)
+
+// PlatformObservationStageFileRuntimeConfig binds restart-safe private runtime
+// material and one already produced capability assertion to the exact
+// execution history. Target identity is derived inside the runner and is not
+// accepted as a second CLI-provided source of truth.
+type PlatformObservationStageFileRuntimeConfig struct {
+	Bundle                   StageResumeConfig
+	Profile                  observation.PlatformProfile
+	Ledger                   KubernetesLedgerConfig
+	Argo                     KubernetesAuthorityConfig
+	RuntimeMaterialPath      string
+	RuntimeReceiptPath       string
+	CapabilityPath           string
+	ExpectedCapabilityDigest string
+	PollInterval             time.Duration
+	PollTimeout              time.Duration
+	Clock                    func() time.Time
+	Wait                     ObservationWaiter
+}
+
+// LoadPlatformObservationStageFileRuntime performs only bounded local file
+// reads. It does not open credentials or contact any Kubernetes API.
+func LoadPlatformObservationStageFileRuntime(config PlatformObservationStageFileRuntimeConfig) (PlatformObservationStageRuntimeConfig, error) {
+	runtime, err := LoadRuntimeBindingMaterialFiles(RuntimeBindingMaterialFileConfig{
+		Bundle: config.Bundle, MaterialPath: config.RuntimeMaterialPath, ReceiptPath: config.RuntimeReceiptPath,
+	})
+	if err != nil {
+		return PlatformObservationStageRuntimeConfig{}, errors.New("load verified platform observation runtime binding")
+	}
+	capability, err := LoadPlatformCapabilityFile(PlatformCapabilityFileConfig{
+		Path: config.CapabilityPath, ExpectedEvidenceDigest: config.ExpectedCapabilityDigest,
+		ExpectedIntentRevision: config.Bundle.PlanExpected.IntentRevision, ExpectedPlatformRevision: config.Bundle.PlanExpected.PlatformRevision,
+		ExpectedExecutionFixture: config.Bundle.PlanExpected.ExecutionFixture, ExpectedTargetClusterUID: runtime.material.Target.CAPIClusterUID,
+		ExpectedContractDigest: config.Profile.CapabilityContractDigest, ExpectedExecutableDigest: config.Profile.CapabilityExecutableDigest,
+	})
+	if err != nil {
+		return PlatformObservationStageRuntimeConfig{}, errors.New("load runtime-bound platform capability evidence")
+	}
+	return PlatformObservationStageRuntimeConfig{
+		Ledger: config.Ledger, Argo: config.Argo, Runtime: runtime, Capability: capability,
+		PollInterval: config.PollInterval, PollTimeout: config.PollTimeout, Clock: config.Clock, Wait: config.Wait,
+	}, nil
+}

--- a/internal/runner/platform_observation_files_test.go
+++ b/internal/runner/platform_observation_files_test.go
@@ -1,0 +1,80 @@
+package runner
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/observation"
+)
+
+func TestLoadPlatformObservationStageFileRuntimeCorrelatesPrivateTargetAndCapability(t *testing.T) {
+	fixture := platformObservationBundleFixture(t)
+	bundle, err := LoadPlatformObservationStageBundle(fixture.config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runtime := platformObservationRuntimeMaterial(t, bundle)
+	_, _, prefix, err := loadStageResumeWithPrefix(fixture.config.StageResumeConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lifecycle, _ := prefix[1].Receipt()
+	network, _ := prefix[4].Receipt()
+	runtime.material.Evidence.LifecycleEvidenceDigest = lifecycle.EvidenceDigest
+	runtime.material.Evidence.NetworkEvidenceDigest = network.EvidenceDigest
+	runtime.receipt.LifecycleEvidenceDigest = lifecycle.EvidenceDigest
+	runtime.receipt.NetworkEvidenceDigest = network.EvidenceDigest
+	runtime.raw, err = canonicalRuntimeBinding(runtime.material)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runtime.receipt.PrivateMaterialDigest = digest.SHA256(runtime.raw)
+	runtimePath, runtimeReceiptPath := writeRuntimeBindingReplayFiles(t, runtime)
+	capability := observation.PlatformCapabilityState{
+		Format: observation.PlatformCapabilityFormat, ObservedAt: "2026-08-17T20:05:00Z",
+		TargetClusterUID: runtime.material.Target.CAPIClusterUID, IntentRevision: bundle.plan.IntentRevision,
+		PlatformRevision: bundle.plan.PlatformRevision, ExecutionFixture: bundle.plan.ExecutionFixture,
+		ContractDigest: bundle.profile.CapabilityContractDigest, ExecutableDigest: bundle.profile.CapabilityExecutableDigest, Passed: true,
+	}
+	capability.EvidenceDigest, err = observation.PlatformCapabilityDigest(capability)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rawCapability, _ := json.Marshal(capability)
+	capabilityPath := writeBundleFile(t, t.TempDir(), "platform-capability.json", rawCapability)
+	config := PlatformObservationStageFileRuntimeConfig{
+		Bundle: fixture.config.StageResumeConfig, Profile: fixture.config.Profile,
+		Ledger:              KubernetesLedgerConfig{Endpoint: "https://192.0.2.10:6443", Namespace: "openkubes-execution-system", TokenFile: "/private/tmp/ledger-token", CAFile: "/private/tmp/ledger-ca"},
+		Argo:                KubernetesAuthorityConfig{Endpoint: "https://192.0.2.30:6443", AuthorityIdentity: "ok-shared", TokenFile: "/private/tmp/argo-token", CAFile: "/private/tmp/argo-ca", CABundleDigest: runnerStageSHA("8")},
+		RuntimeMaterialPath: runtimePath, RuntimeReceiptPath: runtimeReceiptPath,
+		CapabilityPath: capabilityPath, ExpectedCapabilityDigest: capability.EvidenceDigest,
+		PollInterval: time.Second, PollTimeout: time.Minute, Clock: time.Now,
+		Wait: func(context.Context, time.Duration) error { return nil },
+	}
+	loaded, err := LoadPlatformObservationStageFileRuntime(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	loadedCapability, err := loaded.Capability.Capability(context.Background())
+	if err != nil || loadedCapability != capability {
+		t.Fatalf("capability differs from runtime-bound evidence: %#v %v", loadedCapability, err)
+	}
+	loadedReceipt, err := loaded.Runtime.Receipt()
+	if err != nil || loadedReceipt.TargetClusterUIDDigest != lifecycle.TargetClusterUIDDigest {
+		t.Fatalf("runtime target differs from lifecycle history: %#v %v", loadedReceipt, err)
+	}
+
+	foreign := capability
+	foreign.TargetClusterUID = "replacement-cluster-uid"
+	foreign.EvidenceDigest, _ = observation.PlatformCapabilityDigest(foreign)
+	foreignRaw, _ := json.Marshal(foreign)
+	config.CapabilityPath = writeBundleFile(t, filepath.Dir(capabilityPath), "foreign-capability.json", foreignRaw)
+	config.ExpectedCapabilityDigest = foreign.EvidenceDigest
+	if _, err := LoadPlatformObservationStageFileRuntime(config); err == nil {
+		t.Fatal("capability for a replacement target was accepted")
+	}
+}


### PR DESCRIPTION
## What changed

- add `ok cluster stage observe platform` as the bounded Stage 11 CLI
- reconstruct the private runtime binding from its canonical material and durable receipt
- correlate capability evidence to the runtime-derived workload UID inside the runner
- bind the exact ten-receipt prefix, immutable Platform profile, GitOps authority, and Argo CA identity
- persist only the canonical platform-observation receipt

## Why

Platform observation already existed as a read-only runner stage but lacked an independently executable CLI boundary. The target UID must come from the verified runtime binding rather than becoming another caller-provided identity.

## Safety

- explicit `--execute` and bounded polling are required
- runtime material, capability evidence, profile, credentials, and digests fail closed before observation
- ledger and Argo credentials remain distinct
- the observer has no sync, repair, or status-write path
- no cluster or infrastructure mutation was performed while developing this change

## Validation

- `go test -ldflags=-linkmode=external ./...`
- `go vet ./...`
- `go test -race -ldflags=-linkmode=external ./internal/runner ./cmd/ok`
