### PR TITLE
feat(cli): evaluate aggregate evidence stage (OK-147)

### DIFF
--- a/cmd/ok/aggregate_evidence.go
+++ b/cmd/ok/aggregate_evidence.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/execution"
+	"github.com/openkubes/ok-cluster/internal/runner"
+)
+
+var executeAggregateEvidenceStage = func(ctx context.Context, bundleConfig runner.AggregateEvidenceStageBundleConfig, fileRuntime runner.AggregateEvidenceStageFileRuntimeConfig) (execution.EvaluationStageRunReceipt, error) {
+	bundle, err := runner.LoadAggregateEvidenceStageBundle(bundleConfig)
+	if err != nil {
+		return execution.EvaluationStageRunReceipt{}, err
+	}
+	runtimeConfig, err := runner.LoadAggregateEvidenceStageFileRuntime(fileRuntime)
+	if err != nil {
+		return execution.EvaluationStageRunReceipt{}, err
+	}
+	opened, err := bundle.Open(runtimeConfig)
+	if err != nil {
+		return execution.EvaluationStageRunReceipt{}, err
+	}
+	return opened.Run(ctx)
+}
+
+func runClusterStageEvaluateAggregate(ctx context.Context, arguments []string, stdout, stderr io.Writer) error {
+	flags := flag.NewFlagSet("ok cluster stage evaluate aggregate", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	resumeFlags := addStageResumeFlags(flags)
+	execute := flags.Bool("execute", false, "perform the exact read-only aggregate evaluation and persist its receipt")
+	aggregateProfile := flags.String("aggregate-profile", "", "path to the aggregate evidence profile")
+	aggregateProfileDigest := flags.String("aggregate-profile-digest", "", "expected aggregate evidence profile digest")
+	networkProfile := flags.String("network-profile", "", "path to the NetworkReady profile")
+	networkProfileDigest := flags.String("network-profile-digest", "", "expected NetworkReady profile digest")
+	platformProfile := flags.String("platform-profile", "", "path to the PlatformReady profile")
+	platformProfileDigest := flags.String("platform-profile-digest", "", "expected PlatformReady profile digest")
+	runtimeBinding := flags.String("runtime-binding", "", "path to private canonical runtime-binding material")
+	runtimeBindingReceipt := flags.String("runtime-binding-receipt", "", "path to the verified runtime-binding material receipt")
+	platformCapability := flags.String("platform-capability", "", "path to private platform capability evidence")
+	platformCapabilityDigest := flags.String("platform-capability-digest", "", "expected platform capability evidence digest")
+	ledgerEndpoint := flags.String("ledger-api-endpoint", "", "TLS Kubernetes API endpoint for the durable ledger")
+	ledgerToken := flags.String("ledger-token-file", "", "path to the short-lived ledger token")
+	ledgerCA := flags.String("ledger-ca-file", "", "path to the ledger Kubernetes API CA bundle")
+	managementEndpoint := flags.String("management-api-endpoint", "", "TLS Kubernetes API endpoint for exact CAPI and HCP/HRP reads")
+	managementToken := flags.String("management-token-file", "", "path to the short-lived management observer token")
+	managementCA := flags.String("management-ca-file", "", "path to the management Kubernetes API CA bundle")
+	workloadEndpoint := flags.String("workload-api-endpoint", "", "expected runtime-bound workload Kubernetes API endpoint")
+	workloadToken := flags.String("workload-token-file", "", "path to the short-lived workload observer token")
+	workloadCA := flags.String("workload-ca-file", "", "path to the workload Kubernetes API CA bundle")
+	argoEndpoint := flags.String("argo-api-endpoint", "", "TLS Kubernetes API endpoint for exact Argo Application reads")
+	argoToken := flags.String("argo-token-file", "", "path to the short-lived Argo observer token")
+	argoCA := flags.String("argo-ca-file", "", "path to the Argo Kubernetes API CA bundle")
+	if err := flags.Parse(arguments); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return errors.New("positional arguments are not accepted")
+	}
+	if !*execute {
+		return errors.New("aggregate evidence evaluation requires explicit --execute")
+	}
+	resume, err := resumeFlags.config()
+	if err != nil {
+		return err
+	}
+	for _, input := range []struct{ name, value string }{
+		{"--aggregate-profile", *aggregateProfile}, {"--aggregate-profile-digest", *aggregateProfileDigest},
+		{"--network-profile", *networkProfile}, {"--network-profile-digest", *networkProfileDigest},
+		{"--platform-profile", *platformProfile}, {"--platform-profile-digest", *platformProfileDigest},
+		{"--runtime-binding", *runtimeBinding}, {"--runtime-binding-receipt", *runtimeBindingReceipt},
+		{"--platform-capability", *platformCapability}, {"--platform-capability-digest", *platformCapabilityDigest},
+		{"--ledger-api-endpoint", *ledgerEndpoint}, {"--ledger-token-file", *ledgerToken}, {"--ledger-ca-file", *ledgerCA},
+		{"--management-api-endpoint", *managementEndpoint}, {"--management-token-file", *managementToken}, {"--management-ca-file", *managementCA},
+		{"--workload-api-endpoint", *workloadEndpoint}, {"--workload-token-file", *workloadToken}, {"--workload-ca-file", *workloadCA},
+		{"--argo-api-endpoint", *argoEndpoint}, {"--argo-token-file", *argoToken}, {"--argo-ca-file", *argoCA},
+	} {
+		if input.value == "" {
+			return fmt.Errorf("%s is required", input.name)
+		}
+	}
+	for _, value := range []string{*aggregateProfileDigest, *networkProfileDigest, *platformProfileDigest, *platformCapabilityDigest} {
+		if !sha256DigestPattern.MatchString(value) {
+			return errors.New("aggregate evidence digests must be lowercase SHA-256 identities")
+		}
+	}
+	loadedAggregate, err := runner.LoadAggregateEvidenceProfileFile(runner.AggregateEvidenceProfileFileConfig{
+		Path: *aggregateProfile, ExpectedProfileDigest: *aggregateProfileDigest,
+		ExpectedIntentRevision: resume.PlanExpected.IntentRevision, ExpectedEnablementRevision: resume.PlanExpected.EnablementRevision,
+		ExpectedPlatformRevision: resume.PlanExpected.PlatformRevision, ExpectedExecutionFixture: resume.PlanExpected.ExecutionFixture,
+	})
+	if err != nil {
+		return err
+	}
+	loadedNetwork, err := runner.LoadNetworkProfileFile(runner.NetworkProfileFileConfig{
+		Path: *networkProfile, ExpectedProfileDigest: *networkProfileDigest,
+		ExpectedIntentRevision: resume.PlanExpected.IntentRevision, ExpectedEnablementRevision: resume.PlanExpected.EnablementRevision,
+	})
+	if err != nil {
+		return err
+	}
+	loadedPlatform, err := runner.LoadPlatformProfileFile(runner.PlatformProfileFileConfig{
+		Path: *platformProfile, ExpectedProfileDigest: *platformProfileDigest,
+		ExpectedIntentRevision: resume.PlanExpected.IntentRevision, ExpectedPlatformRevision: resume.PlanExpected.PlatformRevision,
+		ExpectedExecutionFixture: resume.PlanExpected.ExecutionFixture,
+	})
+	if err != nil {
+		return err
+	}
+	bundleConfig := runner.AggregateEvidenceStageBundleConfig{
+		StageResumeConfig: resume, Profile: loadedAggregate.Profile, ExpectedProfileDigest: loadedAggregate.Digest,
+	}
+	fileRuntime := runner.AggregateEvidenceStageFileRuntimeConfig{
+		Bundle: resume, NetworkProfile: loadedNetwork.Profile, PlatformProfile: loadedPlatform.Profile,
+		Ledger: runner.KubernetesLedgerConfig{Endpoint: *ledgerEndpoint, Namespace: ledgerNamespace, TokenFile: *ledgerToken, CAFile: *ledgerCA},
+		Management: runner.KubernetesAuthorityConfig{
+			Endpoint: *managementEndpoint, AuthorityIdentity: resume.PlanExpected.ManagementAuthority,
+			TokenFile: *managementToken, CAFile: *managementCA,
+		},
+		Argo: runner.KubernetesAuthorityConfig{
+			Endpoint: *argoEndpoint, AuthorityIdentity: resume.PlanExpected.GitOpsAuthority,
+			TokenFile: *argoToken, CAFile: *argoCA,
+		},
+		ExpectedWorkloadEndpoint: *workloadEndpoint, WorkloadTokenFile: *workloadToken, WorkloadCAFile: *workloadCA,
+		RuntimeMaterialPath: *runtimeBinding, RuntimeReceiptPath: *runtimeBindingReceipt,
+		CapabilityPath: *platformCapability, ExpectedCapabilityDigest: *platformCapabilityDigest,
+		Clock: func() time.Time { return time.Now().UTC() },
+	}
+	boundedContext, cancel := context.WithTimeout(ctx, stageRunTimeout)
+	defer cancel()
+	receipt, runErr := executeAggregateEvidenceStage(boundedContext, bundleConfig, fileRuntime)
+	if receipt.Format != "" {
+		encoder := json.NewEncoder(stdout)
+		encoder.SetEscapeHTML(false)
+		encoder.SetIndent("", "  ")
+		if err := encoder.Encode(receipt); err != nil {
+			return err
+		}
+	}
+	return runErr
+}

--- a/cmd/ok/aggregate_evidence_test.go
+++ b/cmd/ok/aggregate_evidence_test.go
@@ -1,0 +1,149 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/execution"
+	"github.com/openkubes/ok-cluster/internal/observation"
+	"github.com/openkubes/ok-cluster/internal/runner"
+)
+
+func aggregateEvidenceStageArguments(t *testing.T) []string {
+	t.Helper()
+	platformArguments := platformApplicationsStageRunArguments(t)
+	platformPath := testFlagValue(t, platformArguments, "--platform-profile")
+	platformDigest := testFlagValue(t, platformArguments, "--platform-profile-digest")
+	networkProfile := observation.NetworkProfile{
+		Format: observation.NetworkProfileFormat, IntentRevision: testSHA("a"), EnablementRevision: testSHA("b"),
+		ExpectedNodeCount: 2, ExpectedHCPSpecDigest: testSHA("4"), ExpectedHRPSpecDigest: testSHA("5"),
+		ExpectedImages: observation.NetworkImages{
+			CiliumAgent: "example.invalid/cilium@" + testSHA("1"), CiliumEnvoy: "example.invalid/envoy@" + testSHA("2"), CiliumOperator: "example.invalid/operator@" + testSHA("3"),
+		},
+		MinimumProbeFreshnessSeconds: 60, MaximumProbeIntervalSeconds: 60, CacheExposureSeconds: 30,
+	}
+	networkDigest, err := observation.NetworkProfileDigest(networkProfile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	aggregateProfile := runner.AggregateEvidenceProfile{
+		Format: runner.AggregateEvidenceProfileFormat, IntentRevision: testSHA("a"), EnablementRevision: testSHA("b"),
+		PlatformRevision: testSHA("c"), ExecutionFixture: testSHA("d"),
+		Required: []string{"InfrastructureReady", "ControlPlaneAvailable", "NetworkReady", "PlatformReady"},
+	}
+	aggregateDigest, err := runner.AggregateEvidenceProfileDigest(aggregateProfile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root := t.TempDir()
+	networkPath := writeAggregateEvidenceCLIJSON(t, root, "network-profile.json", networkProfile)
+	aggregatePath := writeAggregateEvidenceCLIJSON(t, root, "aggregate-profile.json", aggregateProfile)
+	resume := stageResumeArguments()
+	arguments := append([]string{"cluster", "stage", "evaluate", "aggregate"}, resume[3:]...)
+	receiptNames := []string{
+		"provider", "lifecycle", "lifecycle-observation", "enablement", "network-observation", "runtime-binding",
+		"target-access", "target-credential", "target-registration", "platform-applications", "platform-observation",
+	}
+	receiptDigests := []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "0", "e"}
+	for index, name := range receiptNames {
+		arguments = append(arguments, "--receipt", "/tmp/"+name+".json@"+testSHA(receiptDigests[index]))
+	}
+	return append(arguments,
+		"--aggregate-profile", aggregatePath, "--aggregate-profile-digest", aggregateDigest,
+		"--network-profile", networkPath, "--network-profile-digest", networkDigest,
+		"--platform-profile", platformPath, "--platform-profile-digest", platformDigest,
+		"--runtime-binding", "/private/tmp/runtime-binding.json", "--runtime-binding-receipt", "/private/tmp/runtime-binding-receipt.json",
+		"--platform-capability", "/private/tmp/platform-capability.json", "--platform-capability-digest", testSHA("6"),
+		"--execute",
+		"--ledger-api-endpoint", "https://192.0.2.12:6443", "--ledger-token-file", "/private/tmp/ledger-token", "--ledger-ca-file", "/private/tmp/ledger-ca",
+		"--management-api-endpoint", "https://192.0.2.12:6443", "--management-token-file", "/private/tmp/management-token", "--management-ca-file", "/private/tmp/management-ca",
+		"--workload-api-endpoint", "https://192.0.2.20:6443", "--workload-token-file", "/private/tmp/workload-token", "--workload-ca-file", "/private/tmp/workload-ca",
+		"--argo-api-endpoint", "https://192.0.2.13:6443", "--argo-token-file", "/private/tmp/argo-token", "--argo-ca-file", "/private/tmp/argo-ca",
+	)
+}
+
+func TestAggregateEvidenceStageBindsExactProfilesAuthoritiesAndPrivateEvidence(t *testing.T) {
+	previous := executeAggregateEvidenceStage
+	defer func() { executeAggregateEvidenceStage = previous }()
+	var calls int
+	executeAggregateEvidenceStage = func(ctx context.Context, bundle runner.AggregateEvidenceStageBundleConfig, runtime runner.AggregateEvidenceStageFileRuntimeConfig) (execution.EvaluationStageRunReceipt, error) {
+		calls++
+		deadline, bounded := ctx.Deadline()
+		if !bounded || time.Until(deadline) > stageRunTimeout || time.Until(deadline) < stageRunTimeout-time.Minute {
+			t.Fatalf("aggregate evidence context is not bounded: %s %t", deadline, bounded)
+		}
+		if len(bundle.Receipts) != 11 || bundle.ExpectedProfileDigest == "" || len(bundle.Profile.Required) != 4 {
+			t.Fatalf("aggregate evidence bundle differs: %#v", bundle)
+		}
+		if runtime.Bundle.PlanExpected.IntentRevision != testSHA("a") || runtime.NetworkProfile.EnablementRevision != testSHA("b") || runtime.PlatformProfile.PlatformRevision != testSHA("c") {
+			t.Fatalf("aggregate profile binding differs: %#v", runtime)
+		}
+		if runtime.Ledger.Namespace != ledgerNamespace || runtime.Management.AuthorityIdentity != "ok-mgmt" || runtime.Argo.AuthorityIdentity != "ok-shared" || runtime.ExpectedWorkloadEndpoint != "https://192.0.2.20:6443" {
+			t.Fatalf("aggregate authority binding differs: %#v", runtime)
+		}
+		if runtime.RuntimeMaterialPath != "/private/tmp/runtime-binding.json" || runtime.RuntimeReceiptPath != "/private/tmp/runtime-binding-receipt.json" || runtime.CapabilityPath != "/private/tmp/platform-capability.json" || runtime.ExpectedCapabilityDigest != testSHA("6") || runtime.Clock == nil {
+			t.Fatalf("aggregate private input binding differs: %#v", runtime)
+		}
+		return execution.EvaluationStageRunReceipt{Format: execution.EvaluationStageReceiptFormat, State: "COMPLETED_SUCCEEDED", StageID: "aggregate-evidence", StageReceiptDigest: testSHA("9")}, nil
+	}
+	var stdout, stderr bytes.Buffer
+	if err := run(aggregateEvidenceStageArguments(t), &stdout, &stderr); err != nil {
+		t.Fatalf("run: %v; stderr=%s", err, stderr.String())
+	}
+	if calls != 1 {
+		t.Fatalf("aggregate evidence runner calls = %d", calls)
+	}
+	var receipt execution.EvaluationStageRunReceipt
+	if err := json.Unmarshal(stdout.Bytes(), &receipt); err != nil || receipt.StageID != "aggregate-evidence" {
+		t.Fatalf("unexpected aggregate evidence receipt: %#v %v", receipt, err)
+	}
+}
+
+func TestAggregateEvidenceStageFailsClosedBeforeExecution(t *testing.T) {
+	previous := executeAggregateEvidenceStage
+	defer func() { executeAggregateEvidenceStage = previous }()
+	calls := 0
+	executeAggregateEvidenceStage = func(context.Context, runner.AggregateEvidenceStageBundleConfig, runner.AggregateEvidenceStageFileRuntimeConfig) (execution.EvaluationStageRunReceipt, error) {
+		calls++
+		return execution.EvaluationStageRunReceipt{}, nil
+	}
+	valid := aggregateEvidenceStageArguments(t)
+	for name, arguments := range map[string][]string{
+		"missing execute":           removeArgument(valid, "--execute"),
+		"missing aggregate profile": removeArgumentWithValue(valid, "--aggregate-profile"),
+		"missing runtime binding":   removeArgumentWithValue(valid, "--runtime-binding"),
+		"missing capability digest": removeArgumentWithValue(valid, "--platform-capability-digest"),
+		"invalid network digest":    replaceArgument(valid, "--network-profile-digest", "not-a-digest"),
+		"missing workload endpoint": removeArgumentWithValue(valid, "--workload-api-endpoint"),
+		"missing Argo credential":   removeArgumentWithValue(valid, "--argo-token-file"),
+		"positional":                append(append([]string{}, valid...), "unexpected"),
+	} {
+		t.Run(name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			if err := run(arguments, &stdout, &stderr); err == nil || stdout.Len() != 0 {
+				t.Fatalf("unsafe aggregate evidence run was accepted: %v %s", err, stdout.String())
+			}
+		})
+	}
+	if calls != 0 {
+		t.Fatalf("aggregate evidence runner reached %d times for invalid input", calls)
+	}
+}
+
+func writeAggregateEvidenceCLIJSON(t *testing.T, root, name string, value any) string {
+	t.Helper()
+	raw, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(root, name)
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}

--- a/cmd/ok/main.go
+++ b/cmd/ok/main.go
@@ -642,6 +642,9 @@ func runContext(ctx context.Context, arguments []string, stdout, stderr io.Write
 	if len(arguments) >= 4 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "observe" && arguments[3] == "platform" {
 		return runClusterStageObservePlatform(ctx, arguments[4:], stdout, stderr)
 	}
+	if len(arguments) >= 4 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "evaluate" && arguments[3] == "aggregate" {
+		return runClusterStageEvaluateAggregate(ctx, arguments[4:], stdout, stderr)
+	}
 	if len(arguments) >= 6 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "bind" && arguments[3] == "runtime" && arguments[4] == "launch" && arguments[5] == "prepare" {
 		return runClusterStageBindRuntimeLaunchPrepare(arguments[6:], stdout, stderr)
 	}
@@ -696,7 +699,7 @@ func runContext(ctx context.Context, arguments []string, stdout, stderr io.Write
 	if len(arguments) >= 4 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "launch" && arguments[3] == "execute" {
 		return runClusterStageLaunchExecute(ctx, arguments[4:], stdout, stderr)
 	}
-	return errors.New("usage: ok cluster create ... | ok cluster stage inspect ... | ok cluster stage resume ... | ok cluster stage observe lifecycle ... | ok cluster stage observe network ... | ok cluster stage observe platform ... | ok cluster stage bind runtime ... | ok cluster stage bind runtime launch prepare ... | ok cluster stage bind runtime launch execute ... | ok cluster stage observe network package ... | ok cluster stage observe network launch prepare ... | ok cluster stage observe network launch execute ... | ok cluster stage observe lifecycle package ... | ok cluster stage observe lifecycle launch prepare ... | ok cluster stage observe lifecycle launch execute ... | ok cluster stage run ... | ok cluster stage run enablement ... | ok cluster stage run target-access ... | ok cluster stage run platform-applications ... | ok cluster stage run aggregate-evidence launch prepare ... | ok cluster stage run aggregate-evidence launch execute ... | ok cluster stage run enablement package ... | ok cluster stage run enablement launch prepare ... | ok cluster stage run enablement launch execute ... | ok cluster stage package ... | ok cluster stage launch prepare ... | ok cluster stage launch execute ...")
+	return errors.New("usage: ok cluster create ... | ok cluster stage inspect ... | ok cluster stage resume ... | ok cluster stage observe lifecycle ... | ok cluster stage observe network ... | ok cluster stage observe platform ... | ok cluster stage evaluate aggregate ... | ok cluster stage bind runtime ... | ok cluster stage bind runtime launch prepare ... | ok cluster stage bind runtime launch execute ... | ok cluster stage observe network package ... | ok cluster stage observe network launch prepare ... | ok cluster stage observe network launch execute ... | ok cluster stage observe lifecycle package ... | ok cluster stage observe lifecycle launch prepare ... | ok cluster stage observe lifecycle launch execute ... | ok cluster stage run ... | ok cluster stage run enablement ... | ok cluster stage run target-access ... | ok cluster stage run platform-applications ... | ok cluster stage run aggregate-evidence launch prepare ... | ok cluster stage run aggregate-evidence launch execute ... | ok cluster stage run enablement package ... | ok cluster stage run enablement launch prepare ... | ok cluster stage run enablement launch execute ... | ok cluster stage package ... | ok cluster stage launch prepare ... | ok cluster stage launch execute ...")
 }
 
 func runClusterCreate(arguments []string, stdout, stderr io.Writer) error {

--- a/deploy/contract-executor-aggregate-evidence-job.yaml.tpl
+++ b/deploy/contract-executor-aggregate-evidence-job.yaml.tpl
@@ -131,6 +131,8 @@ spec:
             - /var/run/openkubes/runtime/runtime-binding-receipt.json
             - --platform-capability
             - /var/run/openkubes/capability/platform-capability.json
+            - --platform-capability-digest
+            - "${OK147_PLATFORM_CAPABILITY_DIGEST}"
           resources:
             requests: {cpu: 50m, memory: 64Mi, ephemeral-storage: 16Mi}
             limits: {cpu: 250m, memory: 128Mi, ephemeral-storage: 32Mi}

--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -2647,6 +2647,19 @@ The durable runtime-binding Secret must already exist and is never created or
 replaced by this launcher. Existing mixed state and any failed create stop
 without update, patch, apply, delete, retry or rollback.
 
+The launched Job now has the matching direct executable boundary:
+
+```text
+ok cluster stage evaluate aggregate --execute ...
+```
+
+It requires the exact eleven-receipt prefix, all three immutable source
+profiles, the verified private runtime binding and the separately digest-bound
+Platform capability assertion. The workload identity and endpoint come from
+the runtime binding rather than an independent CLI identity. The mounted Argo
+CA is re-hashed before any API contact. The command performs no submission or
+status write and emits only the durable Stage-12 evaluation receipt.
+
 ## Target credential and GitOps stages
 
 The target credential stage verifies an exact, short-lived TokenRequest policy
@@ -2674,8 +2687,8 @@ pre-registration stop.
 
 The twelve-stage Go library and its durable replay semantics are complete and
 covered by unit, negative, local TLS integration and race tests. The standalone
-Stage-12 launch boundary is also exposed through the local CLI. This is not yet
-the OK-147 Definition of Done:
+Stage-12 launch boundary and the direct command executed by its Job are exposed
+through the local CLI. This is not yet the OK-147 Definition of Done:
 
 - the legacy `ok cluster create` command remains dry-run-only;
 - stages 8–11 are not yet composed with Stage 12 through one coherent local

--- a/internal/runner/aggregate_evidence_files.go
+++ b/internal/runner/aggregate_evidence_files.go
@@ -1,0 +1,94 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/observation"
+)
+
+type AggregateEvidenceStageFileRuntimeConfig struct {
+	Bundle                   StageResumeConfig
+	NetworkProfile           observation.NetworkProfile
+	PlatformProfile          observation.PlatformProfile
+	Ledger                   KubernetesLedgerConfig
+	Management               KubernetesAuthorityConfig
+	Argo                     KubernetesAuthorityConfig
+	ExpectedWorkloadEndpoint string
+	WorkloadTokenFile        string
+	WorkloadCAFile           string
+	RuntimeMaterialPath      string
+	RuntimeReceiptPath       string
+	CapabilityPath           string
+	ExpectedCapabilityDigest string
+	Clock                    func() time.Time
+}
+
+// LoadAggregateEvidenceStageFileRuntime reconstructs the final evaluator from
+// immutable public profiles and private restart material. It performs bounded
+// local file reads only and contacts no authority.
+func LoadAggregateEvidenceStageFileRuntime(config AggregateEvidenceStageFileRuntimeConfig) (AggregateEvidenceStageRuntimeConfig, error) {
+	runtime, err := LoadRuntimeBindingMaterialFiles(RuntimeBindingMaterialFileConfig{
+		Bundle: config.Bundle, MaterialPath: config.RuntimeMaterialPath, ReceiptPath: config.RuntimeReceiptPath,
+	})
+	if err != nil {
+		return AggregateEvidenceStageRuntimeConfig{}, errors.New("load verified aggregate runtime binding")
+	}
+	if config.ExpectedWorkloadEndpoint == "" || runtime.material.Target.WorkloadAPIEndpoint != config.ExpectedWorkloadEndpoint {
+		return AggregateEvidenceStageRuntimeConfig{}, errors.New("aggregate workload endpoint differs from runtime binding")
+	}
+	if config.WorkloadTokenFile == "" || config.WorkloadCAFile == "" {
+		return AggregateEvidenceStageRuntimeConfig{}, errors.New("aggregate workload credential files are required")
+	}
+	capability, err := OpenPlatformCapabilityFileResolver(PlatformCapabilityFileResolverConfig{
+		Path: config.CapabilityPath, ExpectedEvidenceDigest: config.ExpectedCapabilityDigest,
+	})
+	if err != nil {
+		return AggregateEvidenceStageRuntimeConfig{}, errors.New("open aggregate platform capability resolver")
+	}
+	argoCA, err := readBoundedRegular(config.Argo.CAFile, maximumCABytes)
+	if err != nil {
+		return AggregateEvidenceStageRuntimeConfig{}, errors.New("read bounded aggregate GitOps CA")
+	}
+	config.Argo.CABundleDigest = digest.SHA256(argoCA)
+	workload := &runtimeBindingWorkloadAuthorityResolver{
+		targetUID: runtime.material.Target.CAPIClusterUID, endpoint: runtime.material.Target.WorkloadAPIEndpoint,
+		caDigest: runtime.material.Target.WorkloadAPICADigest, tokenFile: config.WorkloadTokenFile, caFile: config.WorkloadCAFile,
+	}
+	return AggregateEvidenceStageRuntimeConfig{
+		Ledger: config.Ledger,
+		Observer: KubernetesAggregateObserverConfig{
+			Management: config.Management, ExpectedManagementAuthority: config.Bundle.PlanExpected.ManagementAuthority,
+			Argo: config.Argo, ExpectedArgoAuthority: config.Bundle.PlanExpected.GitOpsAuthority,
+			Namespace: config.Bundle.PlanExpected.ContractIdentity.Namespace, Name: config.Bundle.PlanExpected.ContractIdentity.Name,
+			HCPName:        config.Bundle.PlanExpected.ContractIdentity.Name + "-cilium",
+			NetworkProfile: config.NetworkProfile, PlatformProfile: config.PlatformProfile,
+			WorkloadAuthority: workload, PlatformCapability: capability, Clock: config.Clock,
+		},
+		Runtime: runtime,
+	}, nil
+}
+
+type runtimeBindingWorkloadAuthorityResolver struct {
+	targetUID, endpoint, caDigest, tokenFile, caFile string
+}
+
+func (resolver *runtimeBindingWorkloadAuthorityResolver) ResolveWorkloadAuthority(ctx context.Context, policy observation.Policy) (KubernetesAuthorityConfig, error) {
+	if resolver == nil {
+		return KubernetesAuthorityConfig{}, errors.New("runtime-bound workload resolver is required")
+	}
+	if err := ctx.Err(); err != nil {
+		return KubernetesAuthorityConfig{}, errors.New("runtime-bound workload resolution cancelled")
+	}
+	if _, err := observation.PolicyDigest(policy); err != nil || policy.TargetClusterUID != resolver.targetUID {
+		return KubernetesAuthorityConfig{}, errors.New("workload policy differs from runtime-bound target")
+	}
+	return KubernetesAuthorityConfig{
+		Endpoint: resolver.endpoint, AuthorityIdentity: resolver.targetUID,
+		TokenFile: resolver.tokenFile, CAFile: resolver.caFile, CABundleDigest: resolver.caDigest,
+	}, nil
+}
+
+var _ WorkloadAuthorityResolver = (*runtimeBindingWorkloadAuthorityResolver)(nil)

--- a/internal/runner/aggregate_evidence_files_test.go
+++ b/internal/runner/aggregate_evidence_files_test.go
@@ -1,0 +1,147 @@
+package runner
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/observation"
+)
+
+func TestLoadAggregateEvidenceStageFileRuntimeBindsPrivateRuntimeInputs(t *testing.T) {
+	fixture := aggregateEvidenceBundleFixture(t)
+	bundle, err := LoadAggregateEvidenceStageBundle(fixture)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _, prefix, err := loadStageResumeWithPrefix(fixture.StageResumeConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lifecycleReceipt, _ := prefix[1].Receipt()
+	networkReceipt, _ := prefix[4].Receipt()
+	runtime := aggregateRuntimeBindingMaterial(t, bundle)
+	runtime.material.Evidence.LifecycleEvidenceDigest = lifecycleReceipt.EvidenceDigest
+	runtime.material.Evidence.NetworkEvidenceDigest = networkReceipt.EvidenceDigest
+	runtime.receipt.LifecycleEvidenceDigest = lifecycleReceipt.EvidenceDigest
+	runtime.receipt.NetworkEvidenceDigest = networkReceipt.EvidenceDigest
+	runtime.raw, err = canonicalRuntimeBinding(runtime.material)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runtime.receipt.PrivateMaterialDigest = digest.SHA256(runtime.raw)
+	runtimePath, receiptPath := writeRuntimeBindingReplayFiles(t, runtime)
+
+	expected := bundleExpected(bundle)
+	networkProfile := runnerAggregateNetworkProfile(expected)
+	_, platformProfile := runnerPlatformApplications(t, expected)
+	capability := aggregateCapabilityState(t, bundle, platformProfile, time.Date(2026, 8, 17, 22, 1, 0, 0, time.UTC))
+	capabilityRaw, err := json.Marshal(capability)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root := t.TempDir()
+	capabilityPath := writeBundleFile(t, root, "platform-capability.json", capabilityRaw)
+	argoCA := testCA(t)
+	argoCAPath := writeBundleFile(t, root, "argo-ca.crt", argoCA)
+	workloadCAPath := writeBundleFile(t, root, "workload-ca.crt", testCA(t))
+	workloadTokenPath := writeBundleFile(t, root, "workload-token", []byte("short-lived-workload-token"))
+
+	config := AggregateEvidenceStageFileRuntimeConfig{
+		Bundle: fixture.StageResumeConfig, NetworkProfile: networkProfile, PlatformProfile: platformProfile,
+		Ledger:                   KubernetesLedgerConfig{Endpoint: "https://192.0.2.12:6443", Namespace: "openkubes-execution-system", TokenFile: "ledger-token", CAFile: "ledger-ca"},
+		Management:               KubernetesAuthorityConfig{Endpoint: "https://192.0.2.12:6443", AuthorityIdentity: expected.ManagementAuthority, TokenFile: "management-token", CAFile: "management-ca"},
+		Argo:                     KubernetesAuthorityConfig{Endpoint: "https://192.0.2.13:6443", AuthorityIdentity: expected.GitOpsAuthority, TokenFile: "argo-token", CAFile: argoCAPath},
+		ExpectedWorkloadEndpoint: runtime.material.Target.WorkloadAPIEndpoint,
+		WorkloadTokenFile:        workloadTokenPath, WorkloadCAFile: workloadCAPath,
+		RuntimeMaterialPath: runtimePath, RuntimeReceiptPath: receiptPath,
+		CapabilityPath: capabilityPath, ExpectedCapabilityDigest: capability.EvidenceDigest,
+		Clock: func() time.Time { return time.Date(2026, 8, 17, 22, 2, 0, 0, time.UTC) },
+	}
+	loaded, err := LoadAggregateEvidenceStageFileRuntime(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.Observer.Argo.CABundleDigest != digest.SHA256(argoCA) || loaded.Observer.ExpectedManagementAuthority != expected.ManagementAuthority || loaded.Observer.ExpectedArgoAuthority != expected.GitOpsAuthority {
+		t.Fatalf("aggregate authority binding differs: %#v", loaded.Observer)
+	}
+	policy := observation.Policy{
+		Format: observation.PolicyFormat, IntentRevision: expected.IntentRevision,
+		EnablementRevision: expected.EnablementRevision, PlatformRevision: expected.PlatformRevision,
+		TargetClusterUID: runtime.material.Target.CAPIClusterUID,
+		Required:         []string{"InfrastructureReady", "ControlPlaneAvailable", "NetworkReady", "PlatformReady"},
+	}
+	authority, err := loaded.Observer.WorkloadAuthority.ResolveWorkloadAuthority(context.Background(), policy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if authority.Endpoint != runtime.material.Target.WorkloadAPIEndpoint || authority.AuthorityIdentity != runtime.material.Target.CAPIClusterUID || authority.CABundleDigest != runtime.material.Target.WorkloadAPICADigest || authority.TokenFile != workloadTokenPath || authority.CAFile != workloadCAPath {
+		t.Fatalf("runtime-bound workload authority differs: %#v", authority)
+	}
+	source, err := loaded.Observer.PlatformCapability.ResolvePlatformCapability(context.Background(), policy, platformProfile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	observedCapability, err := source.Capability(context.Background())
+	if err != nil || observedCapability != capability {
+		t.Fatalf("runtime-bound platform capability differs: %#v %v", observedCapability, err)
+	}
+
+	foreign := policy
+	foreign.TargetClusterUID = "foreign-target-uid"
+	if _, err := loaded.Observer.WorkloadAuthority.ResolveWorkloadAuthority(context.Background(), foreign); err == nil {
+		t.Fatal("foreign runtime target was accepted")
+	}
+
+	config.ExpectedWorkloadEndpoint = "https://192.0.2.99:6443"
+	if _, err := LoadAggregateEvidenceStageFileRuntime(config); err == nil {
+		t.Fatal("foreign workload endpoint was accepted")
+	}
+	config.ExpectedWorkloadEndpoint = runtime.material.Target.WorkloadAPIEndpoint
+	config.Argo.CAFile = ""
+	if _, err := LoadAggregateEvidenceStageFileRuntime(config); err == nil {
+		t.Fatal("missing GitOps CA was accepted")
+	}
+}
+
+func TestLoadAggregateEvidenceStageFileRuntimeRequiresPrivateCredentials(t *testing.T) {
+	fixture := aggregateEvidenceBundleFixture(t)
+	bundle, err := LoadAggregateEvidenceStageBundle(fixture)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runtime := aggregateRuntimeBindingMaterial(t, bundle)
+	_, _, prefix, err := loadStageResumeWithPrefix(fixture.StageResumeConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lifecycleReceipt, _ := prefix[1].Receipt()
+	networkReceipt, _ := prefix[4].Receipt()
+	runtime.material.Evidence.LifecycleEvidenceDigest = lifecycleReceipt.EvidenceDigest
+	runtime.material.Evidence.NetworkEvidenceDigest = networkReceipt.EvidenceDigest
+	runtime.receipt.LifecycleEvidenceDigest = lifecycleReceipt.EvidenceDigest
+	runtime.receipt.NetworkEvidenceDigest = networkReceipt.EvidenceDigest
+	runtime.raw, _ = canonicalRuntimeBinding(runtime.material)
+	runtime.receipt.PrivateMaterialDigest = digest.SHA256(runtime.raw)
+	runtimePath, receiptPath := writeRuntimeBindingReplayFiles(t, runtime)
+	_, platformProfile := runnerPlatformApplications(t, bundleExpected(bundle))
+	capability := aggregateCapabilityState(t, bundle, platformProfile, time.Now().UTC())
+	capabilityRaw, _ := json.Marshal(capability)
+	root := t.TempDir()
+	config := AggregateEvidenceStageFileRuntimeConfig{
+		Bundle: fixture.StageResumeConfig, NetworkProfile: runnerAggregateNetworkProfile(bundleExpected(bundle)), PlatformProfile: platformProfile,
+		Argo:                     KubernetesAuthorityConfig{CAFile: writeBundleFile(t, root, "argo-ca.crt", testCA(t))},
+		ExpectedWorkloadEndpoint: runtime.material.Target.WorkloadAPIEndpoint,
+		RuntimeMaterialPath:      runtimePath, RuntimeReceiptPath: receiptPath,
+		CapabilityPath: writeBundleFile(t, root, "capability.json", capabilityRaw), ExpectedCapabilityDigest: capability.EvidenceDigest,
+	}
+	if _, err := LoadAggregateEvidenceStageFileRuntime(config); err == nil {
+		t.Fatal("missing workload credential files were accepted")
+	}
+	if _, err := os.Stat(runtimePath); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/runner/aggregate_evidence_stage_job.go
+++ b/internal/runner/aggregate_evidence_stage_job.go
@@ -32,6 +32,7 @@ type AggregateEvidenceStageJobValues struct {
 	ArgoCredentialSecret       string
 	RuntimeBindingSecret       string
 	PlatformCapabilitySecret   string
+	PlatformCapabilityDigest   string
 }
 
 // RenderAggregateEvidenceStageJobTemplate binds the final one-pass evaluator
@@ -63,7 +64,7 @@ func RenderAggregateEvidenceStageJobTemplate(template []byte, values AggregateEv
 	if !regexp.MustCompile(`^[a-z0-9][a-z0-9./:_-]*@sha256:[0-9a-f]{64}$`).MatchString(values.ImageDigest) {
 		return nil, errors.New("aggregate evidence Job image is not digest-bound")
 	}
-	for _, value := range []string{values.ReceiptPrefixDigest, values.AggregateProfileDigest, values.NetworkProfileDigest, values.PlatformProfileDigest} {
+	for _, value := range []string{values.ReceiptPrefixDigest, values.AggregateProfileDigest, values.NetworkProfileDigest, values.PlatformProfileDigest, values.PlatformCapabilityDigest} {
 		if !stageReceiptPrefixDigestPattern.MatchString(value) {
 			return nil, errors.New("aggregate evidence Job semantic digest is invalid")
 		}
@@ -112,6 +113,7 @@ func RenderAggregateEvidenceStageJobTemplate(template []byte, values AggregateEv
 		"${OK147_ARGO_API_PORT}": argoPort, "${OK147_ARGO_CREDENTIAL_SECRET}": values.ArgoCredentialSecret,
 		"${OK147_RUNTIME_BINDING_SECRET}":     values.RuntimeBindingSecret,
 		"${OK147_PLATFORM_CAPABILITY_SECRET}": values.PlatformCapabilitySecret,
+		"${OK147_PLATFORM_CAPABILITY_DIGEST}": values.PlatformCapabilityDigest,
 	}
 	result := string(template)
 	for placeholder, value := range replacements {

--- a/internal/runner/aggregate_evidence_stage_job_test.go
+++ b/internal/runner/aggregate_evidence_stage_job_test.go
@@ -32,13 +32,14 @@ func TestRenderAggregateEvidenceStageJobTemplateBindsExactEnvelope(t *testing.T)
 		t.Fatalf("unexpected aggregate evidence command: %v", args)
 	}
 	for flag, want := range map[string]string{
-		"--receipt-prefix-digest":    values.ReceiptPrefixDigest,
-		"--aggregate-profile-digest": values.AggregateProfileDigest,
-		"--network-profile-digest":   values.NetworkProfileDigest,
-		"--platform-profile-digest":  values.PlatformProfileDigest,
-		"--runtime-binding":          "/var/run/openkubes/runtime/runtime-binding.json",
-		"--runtime-binding-receipt":  "/var/run/openkubes/runtime/runtime-binding-receipt.json",
-		"--platform-capability":      "/var/run/openkubes/capability/platform-capability.json",
+		"--receipt-prefix-digest":      values.ReceiptPrefixDigest,
+		"--aggregate-profile-digest":   values.AggregateProfileDigest,
+		"--network-profile-digest":     values.NetworkProfileDigest,
+		"--platform-profile-digest":    values.PlatformProfileDigest,
+		"--platform-capability-digest": values.PlatformCapabilityDigest,
+		"--runtime-binding":            "/var/run/openkubes/runtime/runtime-binding.json",
+		"--runtime-binding-receipt":    "/var/run/openkubes/runtime/runtime-binding-receipt.json",
+		"--platform-capability":        "/var/run/openkubes/capability/platform-capability.json",
 	} {
 		if got := argumentValue(args, flag); got != want {
 			t.Fatalf("%s=%q, want %q", flag, got, want)
@@ -107,6 +108,7 @@ func validAggregateEvidenceStageJobValues() AggregateEvidenceStageJobValues {
 		WorkloadAPIURL: "https://192.0.2.20:6443", WorkloadAPICIDR: "192.0.2.20/32", WorkloadCredentialSecret: "ok147-workload-aggregate",
 		ArgoAPIURL: "https://192.0.2.30:6443", ArgoAPICIDR: "192.0.2.30/32", ArgoCredentialSecret: "ok147-argo-aggregate",
 		RuntimeBindingSecret: "ok147-runtime-binding-run-01", PlatformCapabilitySecret: "ok147-platform-capability-01",
+		PlatformCapabilityDigest: bundleSHA("f"),
 	}
 }
 

--- a/internal/runner/aggregate_evidence_stage_package.go
+++ b/internal/runner/aggregate_evidence_stage_package.go
@@ -161,6 +161,7 @@ func BuildAggregateEvidenceStagePackage(config AggregateEvidenceStagePackageConf
 		WorkloadAPIURL: config.WorkloadAPIURL, WorkloadAPICIDR: config.WorkloadAPICIDR, WorkloadCredentialSecret: config.WorkloadCredentialSecret,
 		ArgoAPIURL: config.ArgoAPIURL, ArgoAPICIDR: config.ArgoAPICIDR, ArgoCredentialSecret: config.ArgoCredentialSecret,
 		RuntimeBindingSecret: config.RuntimeBindingSecret, PlatformCapabilitySecret: config.PlatformCapabilitySecret,
+		PlatformCapabilityDigest: config.ExpectedPlatformCapabilityDigest,
 	})
 	if err != nil {
 		return VerifiedAggregateEvidenceStagePackage{}, err


### PR DESCRIPTION
## Outcome

Closes the missing executable boundary for Stage 12. The aggregate-evidence Job can now invoke a real `ok cluster stage evaluate aggregate` command instead of failing at CLI dispatch.

## Scope

- requires the exact eleven-receipt predecessor prefix and immutable aggregate, Network and Platform profiles
- reconstructs the evaluator from verified private runtime-binding and capability evidence
- binds the workload endpoint and target UID to the runtime material rather than a free CLI identity
- binds the platform capability digest into the hardened Job envelope
- remains read-only apart from storing the durable Stage-12 receipt
- fails closed on missing, foreign or malformed runtime inputs

## Verification

- `GOCACHE=/private/tmp/ok147-go-build go test -ldflags=-linkmode=external ./...`
- `GOCACHE=/private/tmp/ok147-go-vet go vet ./...`
- `GOCACHE=/private/tmp/ok147-go-race go test -race -ldflags=-linkmode=external ./internal/runner ./cmd/ok`

No DEV-cluster contact or infrastructure mutation was performed.
