### PR TITLE
feat(runner): orchestrate post-runtime stages once (OK-147)

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -2683,6 +2683,14 @@ orchestrator checkpoint must either execute those steps within one bounded
 process lifetime or obtain a fresh independently authorized credential after a
 pre-registration stop.
 
+The in-process post-runtime orchestrator now fixes the Stage 8-12 call order
+and passes the one-use credential handoff only from Stage 8 to Stage 9. It
+validates every redaction-safe run receipt against one Plan digest, stops at
+the first error or malformed receipt, invokes no later stage and discards an
+unconsumed credential. It deliberately exposes no retry, rollback or cleanup
+method. This core still needs a concrete CLI and Job adapter before it is an
+executable end-to-end runner path.
+
 ## Current OK-147 implementation boundary
 
 The twelve-stage Go library and its durable replay semantics are complete and

--- a/internal/runner/post_runtime_orchestrator.go
+++ b/internal/runner/post_runtime_orchestrator.go
@@ -1,0 +1,137 @@
+package runner
+
+import (
+	"context"
+	"errors"
+
+	"github.com/openkubes/ok-cluster/internal/execution"
+)
+
+const PostRuntimeOrchestrationReceiptFormat = "ok147-post-runtime-orchestration-receipt/v1"
+
+var postRuntimeStageOrder = []string{
+	"target-credential",
+	"target-registration",
+	"platform-applications",
+	"platform-observation",
+	"aggregate-evidence",
+}
+
+type PostRuntimeStageCheckpoint struct {
+	StageID            string `json:"stageId"`
+	State              string `json:"state"`
+	StageReceiptDigest string `json:"stageReceiptDigest"`
+}
+
+// PostRuntimeOrchestrationReceipt is a redaction-safe summary. It contains no
+// credential, endpoint, target UID, CA or local path.
+type PostRuntimeOrchestrationReceipt struct {
+	Format      string                       `json:"format"`
+	State       string                       `json:"state"`
+	PlanDigest  string                       `json:"planDigest,omitempty"`
+	StoppedAt   string                       `json:"stoppedAt,omitempty"`
+	Checkpoints []PostRuntimeStageCheckpoint `json:"checkpoints"`
+}
+
+// PostRuntimeOrchestration composes only the already bounded Stage 8-12
+// operations. Each callback may perform exactly one stage invocation. The
+// Stage-8 credential is passed only to Stage 9 and is never exposed in the
+// public receipt or to a later callback.
+type PostRuntimeOrchestration struct {
+	RunTargetCredential     func(context.Context) (execution.StagedOperationReceipt, *VerifiedTargetCredentialStageHandoff, error)
+	RunTargetRegistration   func(context.Context, *VerifiedTargetCredentialStageHandoff, execution.StagedOperationReceipt) (execution.StagedOperationReceipt, error)
+	RunPlatformApplications func(context.Context, execution.StagedOperationReceipt) (execution.StagedOperationReceipt, error)
+	RunPlatformObservation  func(context.Context, execution.StagedOperationReceipt) (execution.ObservationStageRunReceipt, error)
+	RunAggregateEvidence    func(context.Context, execution.ObservationStageRunReceipt) (execution.EvaluationStageRunReceipt, error)
+}
+
+// Run executes the five-stage suffix once, in order, and stops on the first
+// malformed receipt or error. It has no retry, rollback or cleanup path.
+func (orchestration PostRuntimeOrchestration) Run(ctx context.Context) (PostRuntimeOrchestrationReceipt, error) {
+	receipt := PostRuntimeOrchestrationReceipt{
+		Format: PostRuntimeOrchestrationReceiptFormat, State: "RUNNING",
+		Checkpoints: []PostRuntimeStageCheckpoint{},
+	}
+	if orchestration.RunTargetCredential == nil || orchestration.RunTargetRegistration == nil ||
+		orchestration.RunPlatformApplications == nil || orchestration.RunPlatformObservation == nil ||
+		orchestration.RunAggregateEvidence == nil {
+		receipt.State, receipt.StoppedAt = "STOPPED", postRuntimeStageOrder[0]
+		return receipt, errors.New("post-runtime orchestration is incomplete")
+	}
+	if err := ctx.Err(); err != nil {
+		receipt.State, receipt.StoppedAt = "STOPPED", postRuntimeStageOrder[0]
+		return receipt, errors.New("post-runtime orchestration context is unavailable")
+	}
+
+	credentialReceipt, handoff, runErr := orchestration.RunTargetCredential(ctx)
+	if err := appendPostRuntimeCheckpoint(&receipt, postRuntimeStageOrder[0], execution.StagedReceiptFormat, credentialReceipt.Format, credentialReceipt.State, credentialReceipt.PlanDigest, credentialReceipt.StageID, credentialReceipt.StageReceiptDigest); err != nil || runErr != nil || handoff == nil {
+		discardTargetCredentialHandoff(handoff)
+		return stopPostRuntimeOrchestration(receipt, postRuntimeStageOrder[0])
+	}
+	defer discardTargetCredentialHandoff(handoff)
+
+	if err := ctx.Err(); err != nil {
+		return stopPostRuntimeOrchestration(receipt, postRuntimeStageOrder[1])
+	}
+	registrationReceipt, runErr := orchestration.RunTargetRegistration(ctx, handoff, credentialReceipt)
+	if err := appendPostRuntimeCheckpoint(&receipt, postRuntimeStageOrder[1], execution.StagedReceiptFormat, registrationReceipt.Format, registrationReceipt.State, registrationReceipt.PlanDigest, registrationReceipt.StageID, registrationReceipt.StageReceiptDigest); err != nil || runErr != nil {
+		return stopPostRuntimeOrchestration(receipt, postRuntimeStageOrder[1])
+	}
+	if err := ctx.Err(); err != nil {
+		return stopPostRuntimeOrchestration(receipt, postRuntimeStageOrder[2])
+	}
+	applicationReceipt, runErr := orchestration.RunPlatformApplications(ctx, registrationReceipt)
+	if err := appendPostRuntimeCheckpoint(&receipt, postRuntimeStageOrder[2], execution.StagedReceiptFormat, applicationReceipt.Format, applicationReceipt.State, applicationReceipt.PlanDigest, applicationReceipt.StageID, applicationReceipt.StageReceiptDigest); err != nil || runErr != nil {
+		return stopPostRuntimeOrchestration(receipt, postRuntimeStageOrder[2])
+	}
+	if err := ctx.Err(); err != nil {
+		return stopPostRuntimeOrchestration(receipt, postRuntimeStageOrder[3])
+	}
+	observationReceipt, runErr := orchestration.RunPlatformObservation(ctx, applicationReceipt)
+	if err := appendPostRuntimeCheckpoint(&receipt, postRuntimeStageOrder[3], execution.ObservationStageReceiptFormat, observationReceipt.Format, observationReceipt.State, observationReceipt.PlanDigest, observationReceipt.StageID, observationReceipt.StageReceiptDigest); err != nil || runErr != nil {
+		return stopPostRuntimeOrchestration(receipt, postRuntimeStageOrder[3])
+	}
+	if err := ctx.Err(); err != nil {
+		return stopPostRuntimeOrchestration(receipt, postRuntimeStageOrder[4])
+	}
+	evaluationReceipt, runErr := orchestration.RunAggregateEvidence(ctx, observationReceipt)
+	if err := appendPostRuntimeCheckpoint(&receipt, postRuntimeStageOrder[4], execution.EvaluationStageReceiptFormat, evaluationReceipt.Format, evaluationReceipt.State, evaluationReceipt.PlanDigest, evaluationReceipt.StageID, evaluationReceipt.StageReceiptDigest); err != nil || runErr != nil {
+		return stopPostRuntimeOrchestration(receipt, postRuntimeStageOrder[4])
+	}
+	receipt.State = "SUCCEEDED"
+	return receipt, nil
+}
+
+func appendPostRuntimeCheckpoint(receipt *PostRuntimeOrchestrationReceipt, expectedStage, expectedFormat, format, state, planDigest, stageID, stageReceiptDigest string) error {
+	if receipt == nil || format != expectedFormat || state != "COMPLETED_SUCCEEDED" || stageID != expectedStage ||
+		!stageReceiptPrefixDigestPattern.MatchString(planDigest) || !stageReceiptPrefixDigestPattern.MatchString(stageReceiptDigest) {
+		return errors.New("post-runtime stage receipt is invalid")
+	}
+	if receipt.PlanDigest == "" {
+		receipt.PlanDigest = planDigest
+	} else if receipt.PlanDigest != planDigest {
+		return errors.New("post-runtime stage plan identity changed")
+	}
+	receipt.Checkpoints = append(receipt.Checkpoints, PostRuntimeStageCheckpoint{
+		StageID: stageID, State: state, StageReceiptDigest: stageReceiptDigest,
+	})
+	return nil
+}
+
+func stopPostRuntimeOrchestration(receipt PostRuntimeOrchestrationReceipt, stageID string) (PostRuntimeOrchestrationReceipt, error) {
+	receipt.State, receipt.StoppedAt = "STOPPED", stageID
+	return receipt, errors.New("post-runtime orchestration stopped at " + stageID)
+}
+
+func discardTargetCredentialHandoff(handoff *VerifiedTargetCredentialStageHandoff) {
+	if handoff == nil {
+		return
+	}
+	handoff.mu.Lock()
+	defer handoff.mu.Unlock()
+	if handoff.consumed {
+		return
+	}
+	handoff.consumed = true
+	handoff.credential = VerifiedTargetCredentialMaterial{}
+}

--- a/internal/runner/post_runtime_orchestrator_test.go
+++ b/internal/runner/post_runtime_orchestrator_test.go
@@ -1,0 +1,241 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/openkubes/ok-cluster/internal/execution"
+)
+
+func TestPostRuntimeOrchestrationRunsExactFiveStageSuffixOnce(t *testing.T) {
+	var calls []string
+	handoff := &VerifiedTargetCredentialStageHandoff{verified: true}
+	orchestration := PostRuntimeOrchestration{
+		RunTargetCredential: func(context.Context) (execution.StagedOperationReceipt, *VerifiedTargetCredentialStageHandoff, error) {
+			calls = append(calls, "target-credential")
+			return postRuntimeStagedReceipt("target-credential", "1"), handoff, nil
+		},
+		RunTargetRegistration: func(_ context.Context, got *VerifiedTargetCredentialStageHandoff, predecessor execution.StagedOperationReceipt) (execution.StagedOperationReceipt, error) {
+			calls = append(calls, "target-registration")
+			if got != handoff || predecessor.StageID != "target-credential" {
+				t.Fatal("target-credential handoff was not passed only to registration")
+			}
+			return postRuntimeStagedReceipt("target-registration", "2"), nil
+		},
+		RunPlatformApplications: func(_ context.Context, predecessor execution.StagedOperationReceipt) (execution.StagedOperationReceipt, error) {
+			calls = append(calls, "platform-applications")
+			if predecessor.StageID != "target-registration" {
+				t.Fatal("registration receipt was not passed to platform Applications")
+			}
+			return postRuntimeStagedReceipt("platform-applications", "3"), nil
+		},
+		RunPlatformObservation: func(_ context.Context, predecessor execution.StagedOperationReceipt) (execution.ObservationStageRunReceipt, error) {
+			calls = append(calls, "platform-observation")
+			if predecessor.StageID != "platform-applications" {
+				t.Fatal("Application receipt was not passed to platform observation")
+			}
+			return postRuntimeObservationReceipt("4"), nil
+		},
+		RunAggregateEvidence: func(_ context.Context, predecessor execution.ObservationStageRunReceipt) (execution.EvaluationStageRunReceipt, error) {
+			calls = append(calls, "aggregate-evidence")
+			if predecessor.StageID != "platform-observation" {
+				t.Fatal("platform observation receipt was not passed to aggregate evidence")
+			}
+			return postRuntimeEvaluationReceipt("5"), nil
+		},
+	}
+	receipt, err := orchestration.Run(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if receipt.Format != PostRuntimeOrchestrationReceiptFormat || receipt.State != "SUCCEEDED" || receipt.StoppedAt != "" || receipt.PlanDigest != runnerStageSHA("a") || len(receipt.Checkpoints) != 5 {
+		t.Fatalf("unexpected post-runtime receipt: %#v", receipt)
+	}
+	if !reflect.DeepEqual(calls, postRuntimeStageOrder) {
+		t.Fatalf("post-runtime order differs: %v", calls)
+	}
+	if !handoff.consumed {
+		t.Fatal("unused in-memory credential handoff survived orchestration")
+	}
+	for index, checkpoint := range receipt.Checkpoints {
+		if checkpoint.StageID != postRuntimeStageOrder[index] || checkpoint.State != "COMPLETED_SUCCEEDED" || checkpoint.StageReceiptDigest == "" {
+			t.Fatalf("unexpected checkpoint %d: %#v", index, checkpoint)
+		}
+	}
+}
+
+func TestPostRuntimeOrchestrationStopsWithoutRetryAndDiscardsCredential(t *testing.T) {
+	for name, stopStage := range map[string]string{
+		"credential error":   "target-credential",
+		"registration error": "target-registration",
+		"application error":  "platform-applications",
+		"observation error":  "platform-observation",
+		"evaluation error":   "aggregate-evidence",
+	} {
+		t.Run(name, func(t *testing.T) {
+			calls := map[string]int{}
+			handoff := &VerifiedTargetCredentialStageHandoff{verified: true}
+			orchestration := PostRuntimeOrchestration{
+				RunTargetCredential: func(context.Context) (execution.StagedOperationReceipt, *VerifiedTargetCredentialStageHandoff, error) {
+					calls["target-credential"]++
+					if stopStage == "target-credential" {
+						return execution.StagedOperationReceipt{}, handoff, errors.New("private failure")
+					}
+					return postRuntimeStagedReceipt("target-credential", "1"), handoff, nil
+				},
+				RunTargetRegistration: func(context.Context, *VerifiedTargetCredentialStageHandoff, execution.StagedOperationReceipt) (execution.StagedOperationReceipt, error) {
+					calls["target-registration"]++
+					if stopStage == "target-registration" {
+						return execution.StagedOperationReceipt{}, errors.New("private failure")
+					}
+					return postRuntimeStagedReceipt("target-registration", "2"), nil
+				},
+				RunPlatformApplications: func(context.Context, execution.StagedOperationReceipt) (execution.StagedOperationReceipt, error) {
+					calls["platform-applications"]++
+					if stopStage == "platform-applications" {
+						return execution.StagedOperationReceipt{}, errors.New("private failure")
+					}
+					return postRuntimeStagedReceipt("platform-applications", "3"), nil
+				},
+				RunPlatformObservation: func(context.Context, execution.StagedOperationReceipt) (execution.ObservationStageRunReceipt, error) {
+					calls["platform-observation"]++
+					if stopStage == "platform-observation" {
+						return execution.ObservationStageRunReceipt{}, errors.New("private failure")
+					}
+					return postRuntimeObservationReceipt("4"), nil
+				},
+				RunAggregateEvidence: func(context.Context, execution.ObservationStageRunReceipt) (execution.EvaluationStageRunReceipt, error) {
+					calls["aggregate-evidence"]++
+					if stopStage == "aggregate-evidence" {
+						return execution.EvaluationStageRunReceipt{}, errors.New("private failure")
+					}
+					return postRuntimeEvaluationReceipt("5"), nil
+				},
+			}
+			receipt, err := orchestration.Run(context.Background())
+			if err == nil || receipt.State != "STOPPED" || receipt.StoppedAt != stopStage {
+				t.Fatalf("orchestration did not stop at %s: %#v %v", stopStage, receipt, err)
+			}
+			stopIndex := -1
+			for index, stage := range postRuntimeStageOrder {
+				if stage == stopStage {
+					stopIndex = index
+					break
+				}
+			}
+			for index, stage := range postRuntimeStageOrder {
+				want := 0
+				if index <= stopIndex {
+					want = 1
+				}
+				if calls[stage] != want {
+					t.Fatalf("stage %s calls=%d want=%d; all=%v", stage, calls[stage], want, calls)
+				}
+			}
+			if !handoff.consumed {
+				t.Fatal("credential handoff survived stopped orchestration")
+			}
+		})
+	}
+}
+
+func TestPostRuntimeOrchestrationRejectsMalformedOrForeignReceipts(t *testing.T) {
+	for name, mutate := range map[string]func(*execution.StagedOperationReceipt){
+		"wrong format": func(receipt *execution.StagedOperationReceipt) {
+			receipt.Format = execution.ObservationStageReceiptFormat
+		},
+		"wrong stage":  func(receipt *execution.StagedOperationReceipt) { receipt.StageID = "platform-applications" },
+		"foreign plan": func(receipt *execution.StagedOperationReceipt) { receipt.PlanDigest = runnerStageSHA("f") },
+		"failed state": func(receipt *execution.StagedOperationReceipt) { receipt.State = "COMPLETED_FAILED" },
+		"bad digest":   func(receipt *execution.StagedOperationReceipt) { receipt.StageReceiptDigest = "bad" },
+	} {
+		t.Run(name, func(t *testing.T) {
+			orchestration := successfulPostRuntimeOrchestration()
+			base := orchestration.RunTargetRegistration
+			orchestration.RunTargetRegistration = func(ctx context.Context, handoff *VerifiedTargetCredentialStageHandoff, predecessor execution.StagedOperationReceipt) (execution.StagedOperationReceipt, error) {
+				receipt, err := base(ctx, handoff, predecessor)
+				mutate(&receipt)
+				return receipt, err
+			}
+			receipt, err := orchestration.Run(context.Background())
+			if err == nil || receipt.State != "STOPPED" || receipt.StoppedAt != "target-registration" || len(receipt.Checkpoints) != 1 {
+				t.Fatalf("malformed receipt was accepted: %#v %v", receipt, err)
+			}
+		})
+	}
+}
+
+func TestPostRuntimeOrchestrationRequiresCompleteLiveContext(t *testing.T) {
+	if receipt, err := (PostRuntimeOrchestration{}).Run(context.Background()); err == nil || receipt.State != "STOPPED" {
+		t.Fatalf("incomplete orchestration was accepted: %#v %v", receipt, err)
+	}
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+	calls := 0
+	orchestration := successfulPostRuntimeOrchestration()
+	orchestration.RunTargetCredential = func(context.Context) (execution.StagedOperationReceipt, *VerifiedTargetCredentialStageHandoff, error) {
+		calls++
+		return postRuntimeStagedReceipt("target-credential", "1"), &VerifiedTargetCredentialStageHandoff{verified: true}, nil
+	}
+	if receipt, err := orchestration.Run(cancelled); err == nil || receipt.StoppedAt != "target-credential" || calls != 0 {
+		t.Fatalf("cancelled orchestration invoked a stage: %#v calls=%d err=%v", receipt, calls, err)
+	}
+
+	runtimeContext, stop := context.WithCancel(context.Background())
+	orchestration = successfulPostRuntimeOrchestration()
+	registrationCalls := 0
+	orchestration.RunTargetCredential = func(context.Context) (execution.StagedOperationReceipt, *VerifiedTargetCredentialStageHandoff, error) {
+		stop()
+		return postRuntimeStagedReceipt("target-credential", "1"), &VerifiedTargetCredentialStageHandoff{verified: true}, nil
+	}
+	orchestration.RunTargetRegistration = func(context.Context, *VerifiedTargetCredentialStageHandoff, execution.StagedOperationReceipt) (execution.StagedOperationReceipt, error) {
+		registrationCalls++
+		return postRuntimeStagedReceipt("target-registration", "2"), nil
+	}
+	if receipt, err := orchestration.Run(runtimeContext); err == nil || receipt.StoppedAt != "target-registration" || len(receipt.Checkpoints) != 1 || registrationCalls != 0 {
+		t.Fatalf("cancelled suffix invoked a later stage: %#v registrationCalls=%d err=%v", receipt, registrationCalls, err)
+	}
+}
+
+func successfulPostRuntimeOrchestration() PostRuntimeOrchestration {
+	return PostRuntimeOrchestration{
+		RunTargetCredential: func(context.Context) (execution.StagedOperationReceipt, *VerifiedTargetCredentialStageHandoff, error) {
+			return postRuntimeStagedReceipt("target-credential", "1"), &VerifiedTargetCredentialStageHandoff{verified: true}, nil
+		},
+		RunTargetRegistration: func(context.Context, *VerifiedTargetCredentialStageHandoff, execution.StagedOperationReceipt) (execution.StagedOperationReceipt, error) {
+			return postRuntimeStagedReceipt("target-registration", "2"), nil
+		},
+		RunPlatformApplications: func(context.Context, execution.StagedOperationReceipt) (execution.StagedOperationReceipt, error) {
+			return postRuntimeStagedReceipt("platform-applications", "3"), nil
+		},
+		RunPlatformObservation: func(context.Context, execution.StagedOperationReceipt) (execution.ObservationStageRunReceipt, error) {
+			return postRuntimeObservationReceipt("4"), nil
+		},
+		RunAggregateEvidence: func(context.Context, execution.ObservationStageRunReceipt) (execution.EvaluationStageRunReceipt, error) {
+			return postRuntimeEvaluationReceipt("5"), nil
+		},
+	}
+}
+
+func postRuntimeStagedReceipt(stageID, digestValue string) execution.StagedOperationReceipt {
+	return execution.StagedOperationReceipt{
+		Format: execution.StagedReceiptFormat, State: "COMPLETED_SUCCEEDED", PlanDigest: runnerStageSHA("a"),
+		StageID: stageID, StageReceiptDigest: runnerStageSHA(digestValue),
+	}
+}
+
+func postRuntimeObservationReceipt(digestValue string) execution.ObservationStageRunReceipt {
+	return execution.ObservationStageRunReceipt{
+		Format: execution.ObservationStageReceiptFormat, State: "COMPLETED_SUCCEEDED", PlanDigest: runnerStageSHA("a"),
+		StageID: "platform-observation", StageReceiptDigest: runnerStageSHA(digestValue),
+	}
+}
+
+func postRuntimeEvaluationReceipt(digestValue string) execution.EvaluationStageRunReceipt {
+	return execution.EvaluationStageRunReceipt{
+		Format: execution.EvaluationStageReceiptFormat, State: "COMPLETED_SUCCEEDED", PlanDigest: runnerStageSHA("a"),
+		StageID: "aggregate-evidence", StageReceiptDigest: runnerStageSHA(digestValue),
+	}
+}


### PR DESCRIPTION
## Outcome

Adds the in-process Stage 8-12 orchestration core required to keep the short-lived target credential memory-only between issuance and Argo registration.

## Scope

- invokes target credential, target registration, platform Applications, platform observation and aggregate evidence exactly once and in order
- passes the one-use credential handoff only from Stage 8 to Stage 9
- validates all redaction-safe stage receipts against one Plan digest
- stops before every later stage on error, malformed receipt or context cancellation
- discards an unconsumed in-memory credential on every exit path
- exposes no retry, rollback or cleanup operation

## Verification

- `GOCACHE=/private/tmp/ok147-go-build go test -ldflags=-linkmode=external ./...`
- `GOCACHE=/private/tmp/ok147-go-vet go vet ./...`
- `GOCACHE=/private/tmp/ok147-go-race go test -race -ldflags=-linkmode=external ./internal/runner ./cmd/ok`

This is the orchestration core only; concrete CLI/Job adapters remain a follow-up. No DEV-cluster contact or infrastructure mutation was performed.
