### PR TITLE
feat(runner): bridge durable stage receipts (OK-147)

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -2691,6 +2691,13 @@ unconsumed credential. It deliberately exposes no retry, rollback or cleanup
 method. This core still needs a concrete CLI and Job adapter before it is an
 executable end-to-end runner path.
 
+The accompanying receipt bridge can reload only the independently
+digest-bound, already durable public receipt selected by the current cursor.
+It writes canonical receipt bytes create-only as `0600` below an existing
+private directory, re-verifies the stored digest and returns the exact
+`StageReceiptSource` for the next bundle. Private credentials, endpoints and
+runtime identity never enter this bridge.
+
 ## Current OK-147 implementation boundary
 
 The twelve-stage Go library and its durable replay semantics are complete and

--- a/internal/runner/stage_receipt_bridge.go
+++ b/internal/runner/stage_receipt_bridge.go
@@ -1,0 +1,139 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"os"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/execution"
+	"github.com/openkubes/ok-cluster/internal/ledger"
+)
+
+type StageRunReceiptReference struct {
+	Format             string
+	State              string
+	PlanDigest         string
+	StageID            string
+	StageReceiptDigest string
+}
+
+type StageReceiptBridgeConfig struct {
+	Bundle StageResumeConfig
+	Ledger *ledger.Ledger
+	Run    StageRunReceiptReference
+}
+
+type VerifiedStageReceiptMaterial struct {
+	raw      []byte
+	digest   string
+	stageID  string
+	verified bool
+}
+
+func StagedOperationReceiptReference(receipt execution.StagedOperationReceipt) StageRunReceiptReference {
+	return StageRunReceiptReference{
+		Format: receipt.Format, State: receipt.State, PlanDigest: receipt.PlanDigest,
+		StageID: receipt.StageID, StageReceiptDigest: receipt.StageReceiptDigest,
+	}
+}
+
+func ObservationStageReceiptReference(receipt execution.ObservationStageRunReceipt) StageRunReceiptReference {
+	return StageRunReceiptReference{
+		Format: receipt.Format, State: receipt.State, PlanDigest: receipt.PlanDigest,
+		StageID: receipt.StageID, StageReceiptDigest: receipt.StageReceiptDigest,
+	}
+}
+
+// LoadStageReceiptMaterial reads exactly one independently digest-bound,
+// already durable redaction-safe stage receipt. It never reconstructs private
+// credential material and performs no source-authority request.
+func LoadStageReceiptMaterial(ctx context.Context, config StageReceiptBridgeConfig) (VerifiedStageReceiptMaterial, error) {
+	if config.Ledger == nil || config.Run.State != "COMPLETED_SUCCEEDED" ||
+		!stageReceiptPrefixDigestPattern.MatchString(config.Run.PlanDigest) ||
+		!stageReceiptPrefixDigestPattern.MatchString(config.Run.StageReceiptDigest) {
+		return VerifiedStageReceiptMaterial{}, errors.New("stage receipt bridge input is invalid")
+	}
+	plan, cursor, _, err := loadStageResumeWithPrefix(config.Bundle)
+	if err != nil {
+		return VerifiedStageReceiptMaterial{}, errors.New("verify stage receipt bridge prefix")
+	}
+	decision, err := cursor.Decision()
+	if err != nil || decision.State != "NEXT" || decision.StageID != config.Run.StageID || config.Run.PlanDigest != plan.PlanDigest {
+		return VerifiedStageReceiptMaterial{}, errors.New("stage receipt bridge differs from verified cursor")
+	}
+	if config.Run.Format != runReceiptFormatForStageKind(decision.Kind) {
+		return VerifiedStageReceiptMaterial{}, errors.New("stage receipt bridge run format differs from stage kind")
+	}
+	predecessors, err := cursor.Predecessors()
+	if err != nil {
+		return VerifiedStageReceiptMaterial{}, errors.New("load stage receipt bridge predecessors")
+	}
+	verified, err := config.Ledger.LoadStageReceipt(ctx, plan, decision.StageID, config.Run.StageReceiptDigest, predecessors)
+	if err != nil {
+		return VerifiedStageReceiptMaterial{}, errors.New("load durable stage receipt for bridge")
+	}
+	raw, err := verified.Bytes()
+	if err != nil || digest.SHA256(raw) != config.Run.StageReceiptDigest {
+		return VerifiedStageReceiptMaterial{}, errors.New("durable stage receipt bridge identity changed")
+	}
+	return VerifiedStageReceiptMaterial{
+		raw: append([]byte(nil), raw...), digest: config.Run.StageReceiptDigest,
+		stageID: decision.StageID, verified: true,
+	}, nil
+}
+
+func runReceiptFormatForStageKind(kind string) string {
+	switch kind {
+	case "Submission", "Credential":
+		return execution.StagedReceiptFormat
+	case "Observation":
+		return execution.ObservationStageReceiptFormat
+	case "Binding":
+		return execution.BindingStageReceiptFormat
+	case "Evaluation":
+		return execution.EvaluationStageReceiptFormat
+	default:
+		return ""
+	}
+}
+
+func (material VerifiedStageReceiptMaterial) Bytes() ([]byte, error) {
+	if !material.verified || material.stageID == "" || !stageReceiptPrefixDigestPattern.MatchString(material.digest) || digest.SHA256(material.raw) != material.digest {
+		return nil, errors.New("stage receipt bridge material is unverified")
+	}
+	return append([]byte(nil), material.raw...), nil
+}
+
+// Persist creates one exclusive 0600 redaction-safe receipt file below an
+// existing private directory and returns the exact source for the next bundle.
+// It has no overwrite or cleanup path.
+func (material VerifiedStageReceiptMaterial) Persist(path string) (StageReceiptSource, error) {
+	raw, err := material.Bytes()
+	if err != nil {
+		return StageReceiptSource{}, err
+	}
+	if err := validateRuntimeBindingOutputPath(path); err != nil {
+		return StageReceiptSource{}, errors.New("stage receipt bridge output path is invalid")
+	}
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return StageReceiptSource{}, errors.New("create exclusive stage receipt bridge output")
+	}
+	if _, err := file.Write(raw); err != nil {
+		file.Close()
+		return StageReceiptSource{}, errors.New("write stage receipt bridge output")
+	}
+	if err := file.Sync(); err != nil {
+		file.Close()
+		return StageReceiptSource{}, errors.New("sync stage receipt bridge output")
+	}
+	if err := file.Close(); err != nil {
+		return StageReceiptSource{}, errors.New("close stage receipt bridge output")
+	}
+	stored, err := readBoundedRegular(path, int64(len(raw)))
+	if err != nil || digest.SHA256(stored) != material.digest {
+		return StageReceiptSource{}, errors.New("persisted stage receipt bridge output differs")
+	}
+	return StageReceiptSource{Path: path, Digest: material.digest}, nil
+}

--- a/internal/runner/stage_receipt_bridge_test.go
+++ b/internal/runner/stage_receipt_bridge_test.go
@@ -1,0 +1,181 @@
+package runner
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/execution"
+	"github.com/openkubes/ok-cluster/internal/ledger"
+	"github.com/openkubes/ok-cluster/internal/stagereceipt"
+)
+
+func TestStageReceiptBridgeLoadsDurableReceiptAndPersistsExactSource(t *testing.T) {
+	fixture := targetCredentialBundleFixture(t)
+	plan, _, prefix, err := loadStageResumeWithPrefix(StageResumeConfig{
+		PlanPath: fixture.config.PlanPath, PlanExpected: fixture.config.PlanExpected, Receipts: fixture.config.Receipts,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := ledger.Open(filepath.Join(t.TempDir(), "ledger"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	verified, err := stagereceipt.New(plan, "target-credential", []stagereceipt.Verified{prefix[6]}, "SUCCEEDED", "ATTEMPTED", runnerStageSHA("1"), runnerStageSHA("2"), time.Date(2026, 8, 17, 23, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatal(err)
+	}
+	receiptDigest, err := store.StoreStageReceipt(context.Background(), plan, verified, []stagereceipt.Verified{prefix[6]})
+	if err != nil {
+		t.Fatal(err)
+	}
+	runReceipt := execution.StagedOperationReceipt{
+		Format: execution.StagedReceiptFormat, State: "COMPLETED_SUCCEEDED", PlanDigest: plan.PlanDigest,
+		StageID: "target-credential", StageReceiptDigest: receiptDigest,
+	}
+	material, err := LoadStageReceiptMaterial(context.Background(), StageReceiptBridgeConfig{
+		Bundle: StageResumeConfig{PlanPath: fixture.config.PlanPath, PlanExpected: fixture.config.PlanExpected, Receipts: fixture.config.Receipts},
+		Ledger: store, Run: StagedOperationReceiptReference(runReceipt),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := material.Bytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantRaw, _ := verified.Bytes()
+	if string(raw) != string(wantRaw) {
+		t.Fatal("stage receipt bridge changed canonical bytes")
+	}
+	outputRoot := t.TempDir()
+	if err := os.Chmod(outputRoot, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	output := filepath.Join(outputRoot, "target-credential.json")
+	source, err := material.Persist(output)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if source.Path != output || source.Digest != receiptDigest {
+		t.Fatalf("unexpected stage receipt source: %#v", source)
+	}
+	info, err := os.Lstat(output)
+	if err != nil || !info.Mode().IsRegular() || info.Mode().Perm() != 0o600 {
+		t.Fatalf("stage receipt output metadata differs: %#v %v", info, err)
+	}
+	combined := append(append([]StageReceiptSource{}, fixture.config.Receipts...), source)
+	decision, err := InspectStageResume(StageResumeConfig{PlanPath: fixture.config.PlanPath, PlanExpected: fixture.config.PlanExpected, Receipts: combined})
+	if err != nil || decision.StageID != "target-registration" {
+		t.Fatalf("persisted receipt did not advance exact cursor: %#v %v", decision, err)
+	}
+	if _, err := material.Persist(output); err == nil {
+		t.Fatal("existing receipt output was overwritten")
+	}
+	raw[0] ^= 1
+	again, _ := material.Bytes()
+	if string(again) != string(wantRaw) {
+		t.Fatal("caller mutated verified stage receipt material")
+	}
+}
+
+func TestStageReceiptBridgeFailsClosedOnForeignOrMalformedRunReference(t *testing.T) {
+	fixture := targetCredentialBundleFixture(t)
+	plan, _, prefix, err := loadStageResumeWithPrefix(StageResumeConfig{
+		PlanPath: fixture.config.PlanPath, PlanExpected: fixture.config.PlanExpected, Receipts: fixture.config.Receipts,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := ledger.Open(filepath.Join(t.TempDir(), "ledger"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	verified, _ := stagereceipt.New(plan, "target-credential", []stagereceipt.Verified{prefix[6]}, "SUCCEEDED", "ATTEMPTED", runnerStageSHA("1"), runnerStageSHA("2"), time.Now().UTC())
+	receiptDigest, _ := store.StoreStageReceipt(context.Background(), plan, verified, []stagereceipt.Verified{prefix[6]})
+	valid := StageReceiptBridgeConfig{
+		Bundle: StageResumeConfig{PlanPath: fixture.config.PlanPath, PlanExpected: fixture.config.PlanExpected, Receipts: fixture.config.Receipts},
+		Ledger: store,
+		Run:    StageRunReceiptReference{Format: execution.StagedReceiptFormat, State: "COMPLETED_SUCCEEDED", PlanDigest: plan.PlanDigest, StageID: "target-credential", StageReceiptDigest: receiptDigest},
+	}
+	for name, mutate := range map[string]func(*StageReceiptBridgeConfig){
+		"missing ledger":    func(config *StageReceiptBridgeConfig) { config.Ledger = nil },
+		"wrong format":      func(config *StageReceiptBridgeConfig) { config.Run.Format = execution.ObservationStageReceiptFormat },
+		"failed state":      func(config *StageReceiptBridgeConfig) { config.Run.State = "COMPLETED_FAILED" },
+		"foreign plan":      func(config *StageReceiptBridgeConfig) { config.Run.PlanDigest = runnerStageSHA("f") },
+		"foreign stage":     func(config *StageReceiptBridgeConfig) { config.Run.StageID = "target-registration" },
+		"foreign digest":    func(config *StageReceiptBridgeConfig) { config.Run.StageReceiptDigest = runnerStageSHA("f") },
+		"incomplete prefix": func(config *StageReceiptBridgeConfig) { config.Bundle.Receipts = config.Bundle.Receipts[:6] },
+	} {
+		t.Run(name, func(t *testing.T) {
+			config := valid
+			mutate(&config)
+			if _, err := LoadStageReceiptMaterial(context.Background(), config); err == nil {
+				t.Fatal("unsafe stage receipt bridge input was accepted")
+			}
+		})
+	}
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := LoadStageReceiptMaterial(cancelled, valid); err == nil {
+		t.Fatal("cancelled stage receipt bridge load was accepted")
+	}
+	if _, err := (VerifiedStageReceiptMaterial{}).Bytes(); err == nil {
+		t.Fatal("unverified stage receipt material exposed bytes")
+	}
+}
+
+func TestStageReceiptBridgeAcceptsObservationReceiptForObservationCursor(t *testing.T) {
+	fixture := aggregateEvidenceBundleFixture(t)
+	beforeObservation := StageResumeConfig{
+		PlanPath: fixture.PlanPath, PlanExpected: fixture.PlanExpected,
+		Receipts: append([]StageReceiptSource(nil), fixture.Receipts[:10]...),
+	}
+	plan, _, prefix, err := loadStageResumeWithPrefix(beforeObservation)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := ledger.Open(filepath.Join(t.TempDir(), "ledger"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	verified, err := stagereceipt.New(plan, "platform-observation", []stagereceipt.Verified{prefix[9]}, "SUCCEEDED", "NOT_APPLICABLE", "", runnerStageSHA("e"), time.Now().UTC())
+	if err != nil {
+		t.Fatal(err)
+	}
+	receiptDigest, err := store.StoreStageReceipt(context.Background(), plan, verified, []stagereceipt.Verified{prefix[9]})
+	if err != nil {
+		t.Fatal(err)
+	}
+	reference := ObservationStageReceiptReference(execution.ObservationStageRunReceipt{
+		Format: execution.ObservationStageReceiptFormat, State: "COMPLETED_SUCCEEDED", PlanDigest: plan.PlanDigest,
+		StageID: "platform-observation", StageReceiptDigest: receiptDigest,
+	})
+	material, err := LoadStageReceiptMaterial(context.Background(), StageReceiptBridgeConfig{Bundle: beforeObservation, Ledger: store, Run: reference})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if raw, err := material.Bytes(); err != nil || digest.SHA256(raw) != receiptDigest {
+		t.Fatalf("observation receipt bridge differs: %v", err)
+	}
+}
+
+func TestStageReceiptBridgePersistenceRequiresPrivateAbsoluteDestination(t *testing.T) {
+	material := VerifiedStageReceiptMaterial{raw: []byte("{}"), digest: runnerStageSHA("a"), stageID: "target-credential", verified: true}
+	// Refresh the digest so this deliberately minimal material reaches path validation.
+	material.digest = digest.SHA256(material.raw)
+	if _, err := material.Persist("relative.json"); err == nil {
+		t.Fatal("relative stage receipt output was accepted")
+	}
+	root := t.TempDir()
+	if err := os.Chmod(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := material.Persist(filepath.Join(root, "receipt.json")); err == nil {
+		t.Fatal("broad stage receipt output directory was accepted")
+	}
+}


### PR DESCRIPTION
## Outcome

Adds the durable public-receipt bridge required by the in-process Stage 8-12 adapter.

## Scope

- reloads only the exact receipt selected by the current verified cursor
- requires an independently supplied successful run-receipt digest and matching receipt format
- verifies the canonical receipt again against the Plan and predecessor chain
- supports both mutating and observation stages needed by the suffix
- persists only redaction-safe canonical receipt bytes, create-only and mode `0600`
- returns the exact digest-bound `StageReceiptSource` for the next bundle
- rejects foreign Plan, stage, format, digest, incomplete prefix and broad output directories

## Verification

- `GOCACHE=/private/tmp/ok147-go-build go test -ldflags=-linkmode=external ./...`
- `GOCACHE=/private/tmp/ok147-go-vet go vet ./...`
- `GOCACHE=/private/tmp/ok147-go-race go test -race -ldflags=-linkmode=external ./internal/runner ./cmd/ok`

Private credentials, endpoints and runtime identity never enter this bridge. Concrete CLI/Job adapters remain a follow-up. No DEV-cluster contact or infrastructure mutation was performed.
