### PR TITLE
feat(runner): resolve predecessor-bound stage grants (OK-147)

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -2698,6 +2698,18 @@ private directory, re-verifies the stored digest and returns the exact
 `StageReceiptSource` for the next bundle. Private credentials, endpoints and
 runtime identity never enter this bridge.
 
+The post-runtime authorization resolver closes the next authority boundary.
+After a predecessor receipt is durable, it derives one canonical,
+redaction-safe request from the verified cursor, including the exact Plan,
+stage, operation, authority and predecessor receipt digest. An external
+authority resolves that request to one signed grant source; the runner reloads
+and verifies the grant before exposing it to the selected stage bundle. The
+request digest changes with its predecessor, so Stage 9 and Stage 10 grants
+cannot be safely precomputed from an earlier receipt prefix. The resolver does
+not sign, persist or widen a grant and performs no ledger or Kubernetes
+request. This keeps the future in-process adapter from becoming its own policy
+authority.
+
 ## Current OK-147 implementation boundary
 
 The twelve-stage Go library and its durable replay semantics are complete and

--- a/internal/runner/stage_authorization_resolver.go
+++ b/internal/runner/stage_authorization_resolver.go
@@ -1,0 +1,256 @@
+package runner
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/authorization"
+	"github.com/openkubes/ok-cluster/internal/contract"
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/stagecursor"
+	"github.com/openkubes/ok-cluster/internal/stageplan"
+)
+
+const (
+	StageAuthorizationRequestFormat         = "ok147-stage-authorization-request/v1"
+	ResolvedStageAuthorizationReceiptFormat = "ok147-resolved-stage-authorization/v1"
+)
+
+// StageAuthorizationRequest is the redaction-safe, canonical input supplied
+// to an authority after the direct predecessor receipt exists. It contains no
+// credential, endpoint, local path or grant material.
+type StageAuthorizationRequest struct {
+	Format             string                    `json:"format"`
+	RequestDigest      string                    `json:"requestDigest"`
+	Audience           string                    `json:"audience"`
+	PlanDigest         string                    `json:"planDigest"`
+	ContractIdentity   contract.Identity         `json:"contractIdentity"`
+	ContractRevision   string                    `json:"contractRevision"`
+	EnablementRevision string                    `json:"enablementRevision"`
+	PlatformRevision   string                    `json:"platformRevision"`
+	ExecutionFixture   string                    `json:"executionFixture"`
+	StageID            string                    `json:"stageId"`
+	StageOrder         int                       `json:"stageOrder"`
+	StageDigest        string                    `json:"stageDigest"`
+	Operation          string                    `json:"operation"`
+	Authority          string                    `json:"authority"`
+	Predecessors       []stagecursor.Predecessor `json:"predecessors"`
+	MaxUses            int                       `json:"maxUses"`
+}
+
+type stageAuthorizationRequestPayload struct {
+	Format             string                    `json:"format"`
+	Audience           string                    `json:"audience"`
+	PlanDigest         string                    `json:"planDigest"`
+	ContractIdentity   contract.Identity         `json:"contractIdentity"`
+	ContractRevision   string                    `json:"contractRevision"`
+	EnablementRevision string                    `json:"enablementRevision"`
+	PlatformRevision   string                    `json:"platformRevision"`
+	ExecutionFixture   string                    `json:"executionFixture"`
+	StageID            string                    `json:"stageId"`
+	StageOrder         int                       `json:"stageOrder"`
+	StageDigest        string                    `json:"stageDigest"`
+	Operation          string                    `json:"operation"`
+	Authority          string                    `json:"authority"`
+	Predecessors       []stagecursor.Predecessor `json:"predecessors"`
+	MaxUses            int                       `json:"maxUses"`
+}
+
+// StageAuthorizationSource points at one bounded signed grant and its trust
+// key. Paths remain private runtime input and never enter the public receipt.
+type StageAuthorizationSource struct {
+	GrantPath      string
+	PublicKeyPath  string
+	EvaluationTime time.Time
+}
+
+type StageAuthorizationResolver interface {
+	ResolveStageAuthorization(context.Context, StageAuthorizationRequest) (StageAuthorizationSource, error)
+}
+
+type StageAuthorizationResolverFunc func(context.Context, StageAuthorizationRequest) (StageAuthorizationSource, error)
+
+func (resolve StageAuthorizationResolverFunc) ResolveStageAuthorization(ctx context.Context, request StageAuthorizationRequest) (StageAuthorizationSource, error) {
+	return resolve(ctx, request)
+}
+
+type ResolvedStageAuthorizationReceipt struct {
+	Format              string `json:"format"`
+	State               string `json:"state"`
+	RequestDigest       string `json:"requestDigest"`
+	AuthorizationDigest string `json:"authorizationDigest"`
+	GrantID             string `json:"grantId"`
+	KeyID               string `json:"keyId"`
+	PlanDigest          string `json:"planDigest"`
+	StageID             string `json:"stageId"`
+	StageDigest         string `json:"stageDigest"`
+	Operation           string `json:"operation"`
+	Authority           string `json:"authority"`
+	PredecessorDigest   string `json:"predecessorDigest"`
+	NotAfter            string `json:"notAfter"`
+	MaxUses             int    `json:"maxUses"`
+}
+
+type ResolvedStageAuthorization struct {
+	request  StageAuthorizationRequest
+	source   StageAuthorizationSource
+	receipt  ResolvedStageAuthorizationReceipt
+	verified bool
+}
+
+// ResolveStageAuthorization derives the only acceptable authorization
+// request from the current cursor, invokes the external authority once and
+// re-verifies the returned grant before exposing its private file source to a
+// stage bundle. It performs no ledger or Kubernetes request.
+func ResolveStageAuthorization(ctx context.Context, resume StageResumeConfig, resolver StageAuthorizationResolver) (ResolvedStageAuthorization, error) {
+	if resolver == nil {
+		return ResolvedStageAuthorization{}, errors.New("stage authorization resolver is required")
+	}
+	if err := ctx.Err(); err != nil {
+		return ResolvedStageAuthorization{}, errors.New("stage authorization context is unavailable")
+	}
+	plan, cursor, _, err := loadStageResumeWithPrefix(resume)
+	if err != nil {
+		return ResolvedStageAuthorization{}, errors.New("verify stage authorization cursor")
+	}
+	decision, err := cursor.Decision()
+	if err != nil || decision.State != "NEXT" || !decision.RequiresAuthorization || decision.Operation == "" {
+		return ResolvedStageAuthorization{}, errors.New("verified cursor does not select a mutating stage")
+	}
+	request, err := newStageAuthorizationRequest(plan, decision)
+	if err != nil {
+		return ResolvedStageAuthorization{}, err
+	}
+	source, err := resolver.ResolveStageAuthorization(ctx, cloneStageAuthorizationRequest(request))
+	if err != nil {
+		return ResolvedStageAuthorization{}, errors.New("resolve stage authorization")
+	}
+	if err := ctx.Err(); err != nil {
+		return ResolvedStageAuthorization{}, errors.New("stage authorization context became unavailable")
+	}
+	if source.GrantPath == "" || source.PublicKeyPath == "" || source.EvaluationTime.IsZero() {
+		return ResolvedStageAuthorization{}, errors.New("resolved stage authorization source is incomplete")
+	}
+	predecessors, err := cursor.Predecessors()
+	if err != nil {
+		return ResolvedStageAuthorization{}, errors.New("load stage authorization predecessors")
+	}
+	grant, err := authorization.LoadStage(source.GrantPath, source.PublicKeyPath, plan, decision.StageID, predecessors, source.EvaluationTime)
+	if err != nil {
+		return ResolvedStageAuthorization{}, errors.New("verify resolved stage authorization")
+	}
+	if _, err := authorization.BindStageGrant(grant, plan, decision.StageID, predecessors); err != nil {
+		return ResolvedStageAuthorization{}, errors.New("bind resolved stage authorization")
+	}
+	grantReceipt := grant.Receipt()
+	receipt := ResolvedStageAuthorizationReceipt{
+		Format: ResolvedStageAuthorizationReceiptFormat, State: "VERIFIED",
+		RequestDigest: request.RequestDigest, AuthorizationDigest: grantReceipt.AuthorizationDigest,
+		GrantID: grantReceipt.GrantID, KeyID: grantReceipt.KeyID, PlanDigest: grantReceipt.PlanDigest,
+		StageID: grantReceipt.StageID, StageDigest: grantReceipt.StageDigest,
+		Operation: grantReceipt.Operation, Authority: grantReceipt.Authority,
+		PredecessorDigest: grantReceipt.PredecessorDigest, NotAfter: grantReceipt.NotAfter,
+		MaxUses: grantReceipt.MaxUses,
+	}
+	return ResolvedStageAuthorization{request: request, source: source, receipt: receipt, verified: true}, nil
+}
+
+func (resolved ResolvedStageAuthorization) Receipt() (ResolvedStageAuthorizationReceipt, error) {
+	if err := verifyResolvedStageAuthorization(resolved); err != nil {
+		return ResolvedStageAuthorizationReceipt{}, err
+	}
+	return resolved.receipt, nil
+}
+
+func (resolved ResolvedStageAuthorization) Source() (StageAuthorizationSource, error) {
+	if err := verifyResolvedStageAuthorization(resolved); err != nil {
+		return StageAuthorizationSource{}, err
+	}
+	return resolved.source, nil
+}
+
+func newStageAuthorizationRequest(plan stageplan.Binding, decision stagecursor.Decision) (StageAuthorizationRequest, error) {
+	stage, stageDigest, err := plan.Stage(decision.StageID)
+	if err != nil || !stageplan.IsMutating(stage) || decision.Format != stagecursor.DecisionFormat ||
+		decision.State != "NEXT" || !decision.RequiresAuthorization || decision.PlanDigest != plan.PlanDigest ||
+		decision.StageOrder != stage.Order || decision.StageDigest != stageDigest || decision.Operation != stage.GrantOperation ||
+		decision.Authority != stage.Authority || len(decision.Predecessors) != len(stage.Requires) {
+		return StageAuthorizationRequest{}, errors.New("stage authorization request cursor is invalid")
+	}
+	for index, predecessor := range decision.Predecessors {
+		if predecessor.StageID != stage.Requires[index] || !stageReceiptPrefixDigestPattern.MatchString(predecessor.ReceiptDigest) {
+			return StageAuthorizationRequest{}, errors.New("stage authorization request predecessor is invalid")
+		}
+	}
+	request := StageAuthorizationRequest{
+		Format: StageAuthorizationRequestFormat, Audience: authorization.StageAudience,
+		PlanDigest: plan.PlanDigest, ContractIdentity: plan.ContractIdentity,
+		ContractRevision: plan.IntentRevision, EnablementRevision: plan.EnablementRevision,
+		PlatformRevision: plan.PlatformRevision, ExecutionFixture: plan.ExecutionFixture,
+		StageID: stage.ID, StageOrder: stage.Order, StageDigest: stageDigest,
+		Operation: stage.GrantOperation, Authority: stage.Authority,
+		Predecessors: append([]stagecursor.Predecessor(nil), decision.Predecessors...), MaxUses: 1,
+	}
+	request.RequestDigest, err = stageAuthorizationRequestDigest(request)
+	if err != nil {
+		return StageAuthorizationRequest{}, errors.New("canonicalize stage authorization request")
+	}
+	return request, nil
+}
+
+func cloneStageAuthorizationRequest(request StageAuthorizationRequest) StageAuthorizationRequest {
+	request.Predecessors = append([]stagecursor.Predecessor(nil), request.Predecessors...)
+	return request
+}
+
+func verifyResolvedStageAuthorization(resolved ResolvedStageAuthorization) error {
+	if !resolved.verified || resolved.receipt.Format != ResolvedStageAuthorizationReceiptFormat || resolved.receipt.State != "VERIFIED" ||
+		resolved.receipt.RequestDigest != resolved.request.RequestDigest || resolved.receipt.PlanDigest != resolved.request.PlanDigest ||
+		resolved.receipt.StageID != resolved.request.StageID || resolved.receipt.StageDigest != resolved.request.StageDigest ||
+		resolved.receipt.Operation != resolved.request.Operation || resolved.receipt.Authority != resolved.request.Authority ||
+		resolved.receipt.MaxUses != 1 || resolved.source.GrantPath == "" || resolved.source.PublicKeyPath == "" || resolved.source.EvaluationTime.IsZero() {
+		return errors.New("stage authorization resolution was not produced by verification")
+	}
+	for _, value := range []string{
+		resolved.receipt.RequestDigest, resolved.receipt.AuthorizationDigest, resolved.receipt.PlanDigest,
+		resolved.receipt.StageDigest, resolved.receipt.PredecessorDigest,
+	} {
+		if !stageReceiptPrefixDigestPattern.MatchString(value) {
+			return errors.New("resolved stage authorization digest identity is invalid")
+		}
+	}
+	requestDigest, err := stageAuthorizationRequestDigest(resolved.request)
+	if err != nil || requestDigest != resolved.request.RequestDigest {
+		return errors.New("stage authorization request identity changed after verification")
+	}
+	return nil
+}
+
+func stageAuthorizationRequestDigest(request StageAuthorizationRequest) (string, error) {
+	payload := stageAuthorizationRequestPayload{
+		Format: request.Format, Audience: request.Audience, PlanDigest: request.PlanDigest,
+		ContractIdentity: request.ContractIdentity, ContractRevision: request.ContractRevision,
+		EnablementRevision: request.EnablementRevision, PlatformRevision: request.PlatformRevision,
+		ExecutionFixture: request.ExecutionFixture, StageID: request.StageID, StageOrder: request.StageOrder,
+		StageDigest: request.StageDigest, Operation: request.Operation, Authority: request.Authority,
+		Predecessors: append([]stagecursor.Predecessor(nil), request.Predecessors...), MaxUses: request.MaxUses,
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return "", err
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	var value any
+	if err := decoder.Decode(&value); err != nil {
+		return "", err
+	}
+	canonical, err := contract.JCS(value)
+	if err != nil {
+		return "", err
+	}
+	return digest.SHA256(canonical), nil
+}

--- a/internal/runner/stage_authorization_resolver_test.go
+++ b/internal/runner/stage_authorization_resolver_test.go
@@ -1,0 +1,154 @@
+package runner
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/openkubes/ok-cluster/internal/authorization"
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+func TestStageAuthorizationResolverBindsExactCurrentCursor(t *testing.T) {
+	fixture := targetCredentialBundleFixture(t)
+	resume := StageResumeConfig{
+		PlanPath: fixture.config.PlanPath, PlanExpected: fixture.config.PlanExpected,
+		Receipts: fixture.config.Receipts,
+	}
+	calls := 0
+	resolved, err := ResolveStageAuthorization(context.Background(), resume, StageAuthorizationResolverFunc(
+		func(_ context.Context, request StageAuthorizationRequest) (StageAuthorizationSource, error) {
+			calls++
+			if request.Format != StageAuthorizationRequestFormat || request.Audience != authorization.StageAudience ||
+				request.PlanDigest != fixture.plan.PlanDigest || request.ContractIdentity != fixture.plan.ContractIdentity ||
+				request.ContractRevision != fixture.plan.IntentRevision || request.EnablementRevision != fixture.plan.EnablementRevision ||
+				request.PlatformRevision != fixture.plan.PlatformRevision || request.ExecutionFixture != fixture.plan.ExecutionFixture ||
+				request.StageID != "target-credential" || request.StageOrder != 8 || request.Operation != "IssueTargetCredential" ||
+				request.Authority != "workload" || len(request.Predecessors) != 1 || request.Predecessors[0].StageID != "target-access" ||
+				request.MaxUses != 1 || !stageReceiptPrefixDigestPattern.MatchString(request.RequestDigest) {
+				t.Fatalf("unexpected authorization request: %#v", request)
+			}
+			request.Predecessors[0].ReceiptDigest = runnerStageSHA("f")
+			return StageAuthorizationSource{
+				GrantPath: fixture.config.GrantPath, PublicKeyPath: fixture.config.GrantPublicKeyPath,
+				EvaluationTime: fixture.config.EvaluationTime,
+			}, nil
+		},
+	))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if calls != 1 {
+		t.Fatalf("resolver calls=%d, want 1", calls)
+	}
+	receipt, err := resolved.Receipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if receipt.Format != "ok147-resolved-stage-authorization/v1" || receipt.State != "VERIFIED" ||
+		receipt.RequestDigest == "" || receipt.AuthorizationDigest == "" || receipt.PlanDigest != fixture.plan.PlanDigest ||
+		receipt.StageID != "target-credential" || receipt.Operation != "IssueTargetCredential" || receipt.Authority != "workload" || receipt.MaxUses != 1 {
+		t.Fatalf("unexpected resolved authorization receipt: %#v", receipt)
+	}
+	source, err := resolved.Source()
+	if err != nil || source.GrantPath != fixture.config.GrantPath || source.PublicKeyPath != fixture.config.GrantPublicKeyPath || source.EvaluationTime != fixture.config.EvaluationTime {
+		t.Fatalf("unexpected verified source: %#v %v", source, err)
+	}
+	raw, err := json.Marshal(receipt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range []string{fixture.config.GrantPath, fixture.config.GrantPublicKeyPath, "endpoint", "token"} {
+		if strings.Contains(string(raw), forbidden) {
+			t.Fatalf("public receipt exposed private runtime input %q", forbidden)
+		}
+	}
+}
+
+func TestStageAuthorizationResolverRejectsWrongGrantAndReadOnlyCursor(t *testing.T) {
+	fixture := targetCredentialBundleFixture(t)
+	resume := StageResumeConfig{PlanPath: fixture.config.PlanPath, PlanExpected: fixture.config.PlanExpected, Receipts: fixture.config.Receipts}
+	foreign := targetRegistrationBundleFixture(t)
+	if _, err := ResolveStageAuthorization(context.Background(), resume, StageAuthorizationResolverFunc(
+		func(context.Context, StageAuthorizationRequest) (StageAuthorizationSource, error) {
+			return StageAuthorizationSource{
+				GrantPath: foreign.config.GrantPath, PublicKeyPath: foreign.config.GrantPublicKeyPath,
+				EvaluationTime: foreign.config.EvaluationTime,
+			}, nil
+		},
+	)); err == nil {
+		t.Fatal("foreign stage grant was accepted")
+	}
+
+	aggregate := aggregateEvidenceBundleFixture(t)
+	readOnly := StageResumeConfig{
+		PlanPath: aggregate.PlanPath, PlanExpected: aggregate.PlanExpected,
+		Receipts: append([]StageReceiptSource(nil), aggregate.Receipts[:10]...),
+	}
+	calls := 0
+	if _, err := ResolveStageAuthorization(context.Background(), readOnly, StageAuthorizationResolverFunc(
+		func(context.Context, StageAuthorizationRequest) (StageAuthorizationSource, error) {
+			calls++
+			return StageAuthorizationSource{}, nil
+		},
+	)); err == nil || calls != 0 {
+		t.Fatalf("read-only cursor reached authority resolver: calls=%d err=%v", calls, err)
+	}
+}
+
+func TestStageAuthorizationResolverFailsClosedBeforeAndAfterResolution(t *testing.T) {
+	fixture := targetCredentialBundleFixture(t)
+	resume := StageResumeConfig{PlanPath: fixture.config.PlanPath, PlanExpected: fixture.config.PlanExpected, Receipts: fixture.config.Receipts}
+	if _, err := ResolveStageAuthorization(context.Background(), resume, nil); err == nil {
+		t.Fatal("nil resolver was accepted")
+	}
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+	calls := 0
+	if _, err := ResolveStageAuthorization(cancelled, resume, StageAuthorizationResolverFunc(
+		func(context.Context, StageAuthorizationRequest) (StageAuthorizationSource, error) {
+			calls++
+			return StageAuthorizationSource{}, nil
+		},
+	)); err == nil || calls != 0 {
+		t.Fatalf("cancelled request reached resolver: calls=%d err=%v", calls, err)
+	}
+
+	ctx, stop := context.WithCancel(context.Background())
+	if _, err := ResolveStageAuthorization(ctx, resume, StageAuthorizationResolverFunc(
+		func(context.Context, StageAuthorizationRequest) (StageAuthorizationSource, error) {
+			stop()
+			return StageAuthorizationSource{
+				GrantPath: fixture.config.GrantPath, PublicKeyPath: fixture.config.GrantPublicKeyPath,
+				EvaluationTime: fixture.config.EvaluationTime,
+			}, nil
+		},
+	)); err == nil {
+		t.Fatal("authorization returned after context cancellation")
+	}
+	if _, err := (ResolvedStageAuthorization{}).Source(); err == nil {
+		t.Fatal("unverified authorization exposed its source")
+	}
+}
+
+func TestStageAuthorizationRequestDigestChangesWithPredecessor(t *testing.T) {
+	fixture := targetCredentialBundleFixture(t)
+	plan, cursor, _, err := loadStageResumeWithPrefix(StageResumeConfig{
+		PlanPath: fixture.config.PlanPath, PlanExpected: fixture.config.PlanExpected, Receipts: fixture.config.Receipts,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	decision, _ := cursor.Decision()
+	request, err := newStageAuthorizationRequest(plan, decision)
+	if err != nil {
+		t.Fatal(err)
+	}
+	original := request.RequestDigest
+	request.Predecessors[0].ReceiptDigest = digest.SHA256([]byte("different predecessor"))
+	changed, err := stageAuthorizationRequestDigest(request)
+	if err != nil || changed == original {
+		t.Fatalf("predecessor change did not change request identity: %s %s %v", original, changed, err)
+	}
+}


### PR DESCRIPTION
## What changed

- derive a canonical, redaction-safe authorization request from the current verified stage cursor
- resolve exactly one external grant source and re-verify it against the Plan, stage and predecessor receipt
- expose only a redacted verification receipt while keeping grant paths private
- document why Stage 9 and Stage 10 grants cannot be safely precomputed

## Why

The concrete Stage 8–12 adapter must obtain downstream grants only after the preceding durable receipt exists. This boundary prevents the runner from becoming its own policy authority while preserving one-process credential handoff.

## Validation

- `go test -ldflags=-linkmode=external ./...`
- `go test -count=1 -ldflags=-linkmode=external ./internal/runner`
- `go vet ./...`
- `go test -race -ldflags=-linkmode=external ./internal/runner ./cmd/ok`

No cluster contact or infrastructure mutation was performed.
