### PR TITLE
feat(runner): execute post-runtime stage suffix (OK-147)

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -2710,6 +2710,17 @@ not sign, persist or widen a grant and performs no ledger or Kubernetes
 request. This keeps the future in-process adapter from becoming its own policy
 authority.
 
+The concrete post-runtime execution adapter now composes those boundaries into
+one single-use Stage 8-12 library path. It starts from the exact seven-receipt
+cursor, reuses one verified runtime binding, executes the memory-only
+credential handoff, resolves Stage 9 and Stage 10 authorization only after the
+current predecessor receipt is durable, and opens the existing registration,
+Application, observation and aggregate operations. Canonical Stage 8-11
+receipts are persisted create-only as private `0600` files for the next
+cursor. A missing grant, failed stage, malformed receipt, unsafe destination
+or cancelled context stops the suffix without retry, rollback or cleanup. The
+adapter itself still has no CLI or Job activation surface.
+
 ## Current OK-147 implementation boundary
 
 The twelve-stage Go library and its durable replay semantics are complete and
@@ -2718,8 +2729,8 @@ Stage-12 launch boundary and the direct command executed by its Job are exposed
 through the local CLI. This is not yet the OK-147 Definition of Done:
 
 - the legacy `ok cluster create` command remains dry-run-only;
-- stages 8–11 are not yet composed with Stage 12 through one coherent local
-  CLI and Job orchestration path;
+- the Stage 8-12 execution adapter is not yet exposed through one coherent
+  local CLI and Job orchestration path;
 - the standalone Stage-12 launcher has not yet been executed as part of the
   complete predecessor-bound stage chain;
 - the previously published runner image predates this staged-library closure;

--- a/internal/runner/post_runtime_execution.go
+++ b/internal/runner/post_runtime_execution.go
@@ -1,0 +1,398 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"sync"
+
+	"github.com/openkubes/ok-cluster/internal/execution"
+	"github.com/openkubes/ok-cluster/internal/ledger"
+	"github.com/openkubes/ok-cluster/internal/observation"
+	"github.com/openkubes/ok-cluster/internal/submission"
+)
+
+const PostRuntimeExecutionReceiptFormat = "ok147-post-runtime-execution-receipt/v1"
+
+var postRuntimeReceiptFiles = map[string]string{
+	"target-credential":     "08-target-credential.json",
+	"target-registration":   "09-target-registration.json",
+	"platform-applications": "10-platform-applications.json",
+	"platform-observation":  "11-platform-observation.json",
+}
+
+type PostRuntimeTargetRegistrationConfig struct {
+	ArtifactPath string
+	Expected     submission.TargetRegistrationExpected
+	Runtime      TargetRegistrationStageHandoffRuntimeConfig
+}
+
+type PostRuntimePlatformApplicationsConfig struct {
+	ArtifactPath string
+	Expected     submission.PlatformApplicationsExpected
+	Runtime      PlatformApplicationsStageRuntimeConfig
+}
+
+type PostRuntimePlatformObservationConfig struct {
+	Profile observation.PlatformProfile
+	Runtime PlatformObservationStageFileRuntimeConfig
+}
+
+type PostRuntimeAggregateEvidenceConfig struct {
+	Profile AggregateEvidenceProfile
+	Runtime AggregateEvidenceStageFileRuntimeConfig
+}
+
+// PostRuntimeExecutionConfig supplies immutable artifacts and private runtime
+// bindings for exactly Stage 8-12. The Stage-8 grant is already part of its
+// verified bundle; later mutating grants are resolved only after their direct
+// predecessor receipt is durable.
+type PostRuntimeExecutionConfig struct {
+	TargetCredential     TargetCredentialStageBundleConfig
+	TargetCredentialRun  TargetCredentialStageRuntimeConfig
+	Authorization        StageAuthorizationResolver
+	TargetRegistration   PostRuntimeTargetRegistrationConfig
+	PlatformApplications PostRuntimePlatformApplicationsConfig
+	PlatformObservation  PostRuntimePlatformObservationConfig
+	AggregateEvidence    PostRuntimeAggregateEvidenceConfig
+	RuntimeBinding       RuntimeBindingMaterialFileConfig
+	ReceiptDirectory     string
+}
+
+type PostRuntimeExecutionReceipt struct {
+	Format                 string                              `json:"format"`
+	State                  string                              `json:"state"`
+	PlanDigest             string                              `json:"planDigest,omitempty"`
+	StoppedAt              string                              `json:"stoppedAt,omitempty"`
+	Checkpoints            []PostRuntimeStageCheckpoint        `json:"checkpoints"`
+	ResolvedAuthorizations []ResolvedStageAuthorizationReceipt `json:"resolvedAuthorizations"`
+}
+
+type postRuntimeCredentialInvocation struct {
+	run    func(context.Context) (execution.StagedOperationReceipt, *VerifiedTargetCredentialStageHandoff, error)
+	ledger *ledger.Ledger
+}
+
+type postRuntimeStagedInvocation struct {
+	run    func(context.Context) (execution.StagedOperationReceipt, error)
+	ledger *ledger.Ledger
+}
+
+type postRuntimeObservationInvocation struct {
+	run    func(context.Context) (execution.ObservationStageRunReceipt, error)
+	ledger *ledger.Ledger
+}
+
+type postRuntimeEvaluationInvocation struct {
+	run func(context.Context) (execution.EvaluationStageRunReceipt, error)
+}
+
+type postRuntimeExecutionFactories struct {
+	credential   func(TargetCredentialStageBundleConfig, TargetCredentialStageRuntimeConfig) (postRuntimeCredentialInvocation, error)
+	registration func(StageResumeConfig, *VerifiedTargetCredentialStageHandoff, StageAuthorizationSource, PostRuntimeTargetRegistrationConfig, VerifiedRuntimeBindingMaterial) (postRuntimeStagedInvocation, error)
+	applications func(StageResumeConfig, StageAuthorizationSource, PostRuntimePlatformApplicationsConfig) (postRuntimeStagedInvocation, error)
+	observation  func(StageResumeConfig, PostRuntimePlatformObservationConfig) (postRuntimeObservationInvocation, error)
+	aggregate    func(StageResumeConfig, PostRuntimeAggregateEvidenceConfig, VerifiedRuntimeBindingMaterial) (postRuntimeEvaluationInvocation, error)
+}
+
+type PostRuntimeExecution struct {
+	config     PostRuntimeExecutionConfig
+	initial    StageResumeConfig
+	runtime    VerifiedRuntimeBindingMaterial
+	credential postRuntimeCredentialInvocation
+	factories  postRuntimeExecutionFactories
+	mu         sync.Mutex
+	used       bool
+}
+
+// OpenPostRuntimeExecution performs bounded local loading only. It opens
+// credential clients but performs no ledger or Kubernetes request and writes
+// no receipt.
+func OpenPostRuntimeExecution(config PostRuntimeExecutionConfig) (*PostRuntimeExecution, error) {
+	return openPostRuntimeExecution(config, defaultPostRuntimeExecutionFactories())
+}
+
+func openPostRuntimeExecution(config PostRuntimeExecutionConfig, factories postRuntimeExecutionFactories) (*PostRuntimeExecution, error) {
+	if config.Authorization == nil || config.ReceiptDirectory == "" || factories.credential == nil || factories.registration == nil ||
+		factories.applications == nil || factories.observation == nil || factories.aggregate == nil {
+		return nil, errors.New("post-runtime execution configuration is incomplete")
+	}
+	initial := StageResumeConfig{
+		PlanPath: config.TargetCredential.PlanPath, PlanExpected: config.TargetCredential.PlanExpected,
+		Receipts: append([]StageReceiptSource(nil), config.TargetCredential.Receipts...),
+	}
+	decision, err := InspectStageResume(initial)
+	if err != nil || decision.State != "NEXT" || decision.StageID != "target-credential" || len(initial.Receipts) != 7 {
+		return nil, errors.New("post-runtime execution requires the exact Stage-8 cursor")
+	}
+	for _, stageID := range postRuntimeStageOrder[:4] {
+		if err := validateRuntimeBindingOutputPath(filepath.Join(config.ReceiptDirectory, postRuntimeReceiptFiles[stageID])); err != nil {
+			return nil, errors.New("post-runtime receipt destination is invalid")
+		}
+	}
+	runtimeConfig := config.RuntimeBinding
+	runtimeConfig.Bundle = initial
+	runtime, err := LoadRuntimeBindingMaterialFiles(runtimeConfig)
+	if err != nil {
+		return nil, errors.New("load post-runtime execution binding")
+	}
+	credential, err := factories.credential(config.TargetCredential, config.TargetCredentialRun)
+	if err != nil || credential.run == nil || credential.ledger == nil {
+		return nil, errors.New("open post-runtime target credential stage")
+	}
+	config.TargetCredential.Receipts = append([]StageReceiptSource(nil), initial.Receipts...)
+	config.PlatformObservation.Profile.RequiredApplications = append([]observation.PlatformApplicationExpectation(nil), config.PlatformObservation.Profile.RequiredApplications...)
+	config.PlatformObservation.Runtime.RuntimeMaterialPath = config.RuntimeBinding.MaterialPath
+	config.PlatformObservation.Runtime.RuntimeReceiptPath = config.RuntimeBinding.ReceiptPath
+	config.AggregateEvidence.Profile.Required = append([]string(nil), config.AggregateEvidence.Profile.Required...)
+	config.AggregateEvidence.Runtime.RuntimeMaterialPath = config.RuntimeBinding.MaterialPath
+	config.AggregateEvidence.Runtime.RuntimeReceiptPath = config.RuntimeBinding.ReceiptPath
+	return &PostRuntimeExecution{
+		config: config, initial: initial, runtime: runtime, credential: credential, factories: factories,
+	}, nil
+}
+
+// Run executes exactly one Stage 8-12 suffix. It persists only canonical
+// redaction-safe Stage 8-11 receipts and has no retry, rollback or cleanup
+// path. A second invocation is rejected before any stage or authority call.
+func (executor *PostRuntimeExecution) Run(ctx context.Context) (PostRuntimeExecutionReceipt, error) {
+	if executor == nil {
+		return stoppedPostRuntimeExecutionReceipt("target-credential", nil, nil), errors.New("post-runtime execution is required")
+	}
+	executor.mu.Lock()
+	if executor.used {
+		executor.mu.Unlock()
+		return stoppedPostRuntimeExecutionReceipt("target-credential", nil, nil), errors.New("post-runtime execution is single-use")
+	}
+	executor.used = true
+	executor.mu.Unlock()
+
+	receipts := append([]StageReceiptSource(nil), executor.initial.Receipts...)
+	authorizations := []ResolvedStageAuthorizationReceipt{}
+	orchestration := PostRuntimeOrchestration{}
+	orchestration.RunTargetCredential = func(ctx context.Context) (execution.StagedOperationReceipt, *VerifiedTargetCredentialStageHandoff, error) {
+		runReceipt, handoff, err := executor.credential.run(ctx)
+		if err != nil {
+			return runReceipt, handoff, err
+		}
+		source, err := executor.bridgeStagedReceipt(ctx, receipts, executor.credential.ledger, runReceipt)
+		if err != nil {
+			return runReceipt, handoff, err
+		}
+		receipts = append(receipts, source)
+		return runReceipt, handoff, nil
+	}
+	orchestration.RunTargetRegistration = func(ctx context.Context, handoff *VerifiedTargetCredentialStageHandoff, _ execution.StagedOperationReceipt) (execution.StagedOperationReceipt, error) {
+		resolved, err := ResolveStageAuthorization(ctx, executor.resume(receipts), executor.config.Authorization)
+		if err != nil {
+			return execution.StagedOperationReceipt{}, err
+		}
+		source, err := resolved.Source()
+		if err != nil {
+			return execution.StagedOperationReceipt{}, err
+		}
+		invocation, err := executor.factories.registration(executor.resume(receipts), handoff, source, executor.config.TargetRegistration, executor.runtime)
+		if err != nil || invocation.run == nil || invocation.ledger == nil {
+			return execution.StagedOperationReceipt{}, errors.New("open post-runtime target registration stage")
+		}
+		runReceipt, err := invocation.run(ctx)
+		if err != nil {
+			return runReceipt, err
+		}
+		persisted, err := executor.bridgeStagedReceipt(ctx, receipts, invocation.ledger, runReceipt)
+		if err != nil {
+			return runReceipt, err
+		}
+		receipt, _ := resolved.Receipt()
+		authorizations = append(authorizations, receipt)
+		receipts = append(receipts, persisted)
+		return runReceipt, nil
+	}
+	orchestration.RunPlatformApplications = func(ctx context.Context, _ execution.StagedOperationReceipt) (execution.StagedOperationReceipt, error) {
+		resolved, err := ResolveStageAuthorization(ctx, executor.resume(receipts), executor.config.Authorization)
+		if err != nil {
+			return execution.StagedOperationReceipt{}, err
+		}
+		source, err := resolved.Source()
+		if err != nil {
+			return execution.StagedOperationReceipt{}, err
+		}
+		invocation, err := executor.factories.applications(executor.resume(receipts), source, executor.config.PlatformApplications)
+		if err != nil || invocation.run == nil || invocation.ledger == nil {
+			return execution.StagedOperationReceipt{}, errors.New("open post-runtime platform Applications stage")
+		}
+		runReceipt, err := invocation.run(ctx)
+		if err != nil {
+			return runReceipt, err
+		}
+		persisted, err := executor.bridgeStagedReceipt(ctx, receipts, invocation.ledger, runReceipt)
+		if err != nil {
+			return runReceipt, err
+		}
+		receipt, _ := resolved.Receipt()
+		authorizations = append(authorizations, receipt)
+		receipts = append(receipts, persisted)
+		return runReceipt, nil
+	}
+	orchestration.RunPlatformObservation = func(ctx context.Context, _ execution.StagedOperationReceipt) (execution.ObservationStageRunReceipt, error) {
+		invocation, err := executor.factories.observation(executor.resume(receipts), executor.config.PlatformObservation)
+		if err != nil || invocation.run == nil || invocation.ledger == nil {
+			return execution.ObservationStageRunReceipt{}, errors.New("open post-runtime platform observation stage")
+		}
+		runReceipt, err := invocation.run(ctx)
+		if err != nil {
+			return runReceipt, err
+		}
+		persisted, err := executor.bridgeObservationReceipt(ctx, receipts, invocation.ledger, runReceipt)
+		if err != nil {
+			return runReceipt, err
+		}
+		receipts = append(receipts, persisted)
+		return runReceipt, nil
+	}
+	orchestration.RunAggregateEvidence = func(ctx context.Context, _ execution.ObservationStageRunReceipt) (execution.EvaluationStageRunReceipt, error) {
+		invocation, err := executor.factories.aggregate(executor.resume(receipts), executor.config.AggregateEvidence, executor.runtime)
+		if err != nil || invocation.run == nil {
+			return execution.EvaluationStageRunReceipt{}, errors.New("open post-runtime aggregate evidence stage")
+		}
+		return invocation.run(ctx)
+	}
+
+	orchestrationReceipt, err := orchestration.Run(ctx)
+	result := PostRuntimeExecutionReceipt{
+		Format: PostRuntimeExecutionReceiptFormat, State: orchestrationReceipt.State,
+		PlanDigest: orchestrationReceipt.PlanDigest, StoppedAt: orchestrationReceipt.StoppedAt,
+		Checkpoints:            append([]PostRuntimeStageCheckpoint(nil), orchestrationReceipt.Checkpoints...),
+		ResolvedAuthorizations: append([]ResolvedStageAuthorizationReceipt(nil), authorizations...),
+	}
+	return result, err
+}
+
+func (executor *PostRuntimeExecution) resume(receipts []StageReceiptSource) StageResumeConfig {
+	return StageResumeConfig{
+		PlanPath: executor.initial.PlanPath, PlanExpected: executor.initial.PlanExpected,
+		Receipts: append([]StageReceiptSource(nil), receipts...),
+	}
+}
+
+func (executor *PostRuntimeExecution) bridgeStagedReceipt(ctx context.Context, receipts []StageReceiptSource, store *ledger.Ledger, receipt execution.StagedOperationReceipt) (StageReceiptSource, error) {
+	return executor.bridgeReceipt(ctx, receipts, store, StagedOperationReceiptReference(receipt))
+}
+
+func (executor *PostRuntimeExecution) bridgeObservationReceipt(ctx context.Context, receipts []StageReceiptSource, store *ledger.Ledger, receipt execution.ObservationStageRunReceipt) (StageReceiptSource, error) {
+	return executor.bridgeReceipt(ctx, receipts, store, ObservationStageReceiptReference(receipt))
+}
+
+func (executor *PostRuntimeExecution) bridgeReceipt(ctx context.Context, receipts []StageReceiptSource, store *ledger.Ledger, reference StageRunReceiptReference) (StageReceiptSource, error) {
+	material, err := LoadStageReceiptMaterial(ctx, StageReceiptBridgeConfig{Bundle: executor.resume(receipts), Ledger: store, Run: reference})
+	if err != nil {
+		return StageReceiptSource{}, err
+	}
+	name, ok := postRuntimeReceiptFiles[reference.StageID]
+	if !ok {
+		return StageReceiptSource{}, errors.New("post-runtime receipt stage is not persistable")
+	}
+	return material.Persist(filepath.Join(executor.config.ReceiptDirectory, name))
+}
+
+func stoppedPostRuntimeExecutionReceipt(stageID string, checkpoints []PostRuntimeStageCheckpoint, authorizations []ResolvedStageAuthorizationReceipt) PostRuntimeExecutionReceipt {
+	return PostRuntimeExecutionReceipt{
+		Format: PostRuntimeExecutionReceiptFormat, State: "STOPPED", StoppedAt: stageID,
+		Checkpoints:            append([]PostRuntimeStageCheckpoint(nil), checkpoints...),
+		ResolvedAuthorizations: append([]ResolvedStageAuthorizationReceipt(nil), authorizations...),
+	}
+}
+
+func defaultPostRuntimeExecutionFactories() postRuntimeExecutionFactories {
+	return postRuntimeExecutionFactories{
+		credential: func(bundleConfig TargetCredentialStageBundleConfig, runtimeConfig TargetCredentialStageRuntimeConfig) (postRuntimeCredentialInvocation, error) {
+			bundle, err := LoadTargetCredentialStageBundle(bundleConfig)
+			if err != nil {
+				return postRuntimeCredentialInvocation{}, err
+			}
+			opened, err := bundle.Open(runtimeConfig)
+			if err != nil {
+				return postRuntimeCredentialInvocation{}, err
+			}
+			return postRuntimeCredentialInvocation{run: opened.RunHandoff, ledger: opened.operation.Ledger}, nil
+		},
+		registration: func(_ StageResumeConfig, handoff *VerifiedTargetCredentialStageHandoff, grant StageAuthorizationSource, config PostRuntimeTargetRegistrationConfig, runtime VerifiedRuntimeBindingMaterial) (postRuntimeStagedInvocation, error) {
+			bundle, err := LoadTargetRegistrationStageBundleFromHandoff(TargetRegistrationStageHandoffConfig{
+				Handoff: handoff, GrantPath: grant.GrantPath, GrantPublicKeyPath: grant.PublicKeyPath, EvaluationTime: grant.EvaluationTime,
+				ArtifactPath: config.ArtifactPath, Expected: config.Expected,
+			})
+			if err != nil {
+				return postRuntimeStagedInvocation{}, err
+			}
+			runtimeConfig := config.Runtime
+			runtimeConfig.Runtime = runtime
+			opened, err := bundle.OpenHandoff(runtimeConfig)
+			if err != nil {
+				return postRuntimeStagedInvocation{}, err
+			}
+			return postRuntimeStagedInvocation{run: opened.Run, ledger: opened.operation.Ledger}, nil
+		},
+		applications: func(resume StageResumeConfig, grant StageAuthorizationSource, config PostRuntimePlatformApplicationsConfig) (postRuntimeStagedInvocation, error) {
+			bundle, err := LoadPlatformApplicationsStageBundle(PlatformApplicationsStageBundleConfig{
+				PlanPath: resume.PlanPath, PlanExpected: resume.PlanExpected, Receipts: resume.Receipts,
+				GrantPath: grant.GrantPath, GrantPublicKeyPath: grant.PublicKeyPath, EvaluationTime: grant.EvaluationTime,
+				ArtifactPath: config.ArtifactPath, Expected: config.Expected,
+			})
+			if err != nil {
+				return postRuntimeStagedInvocation{}, err
+			}
+			opened, err := bundle.Open(config.Runtime)
+			if err != nil {
+				return postRuntimeStagedInvocation{}, err
+			}
+			return postRuntimeStagedInvocation{run: opened.Run, ledger: opened.operation.Ledger}, nil
+		},
+		observation: func(resume StageResumeConfig, config PostRuntimePlatformObservationConfig) (postRuntimeObservationInvocation, error) {
+			profileDigest, err := observation.PlatformProfileDigest(config.Profile)
+			if err != nil {
+				return postRuntimeObservationInvocation{}, err
+			}
+			bundle, err := LoadPlatformObservationStageBundle(PlatformObservationStageBundleConfig{
+				StageResumeConfig: resume, Profile: config.Profile, ExpectedProfileDigest: profileDigest,
+			})
+			if err != nil {
+				return postRuntimeObservationInvocation{}, err
+			}
+			runtimeConfig := config.Runtime
+			runtimeConfig.Bundle, runtimeConfig.Profile = resume, config.Profile
+			runtime, err := LoadPlatformObservationStageFileRuntime(runtimeConfig)
+			if err != nil {
+				return postRuntimeObservationInvocation{}, err
+			}
+			opened, err := bundle.Open(runtime)
+			if err != nil {
+				return postRuntimeObservationInvocation{}, err
+			}
+			return postRuntimeObservationInvocation{run: opened.Run, ledger: opened.operation.Ledger}, nil
+		},
+		aggregate: func(resume StageResumeConfig, config PostRuntimeAggregateEvidenceConfig, runtimeBinding VerifiedRuntimeBindingMaterial) (postRuntimeEvaluationInvocation, error) {
+			profileDigest, err := AggregateEvidenceProfileDigest(config.Profile)
+			if err != nil {
+				return postRuntimeEvaluationInvocation{}, err
+			}
+			bundle, err := LoadAggregateEvidenceStageBundle(AggregateEvidenceStageBundleConfig{
+				StageResumeConfig: resume, Profile: config.Profile, ExpectedProfileDigest: profileDigest,
+			})
+			if err != nil {
+				return postRuntimeEvaluationInvocation{}, err
+			}
+			runtimeConfig := config.Runtime
+			runtimeConfig.Bundle = resume
+			runtimeConfig.ExpectedWorkloadEndpoint = runtimeBinding.material.Target.WorkloadAPIEndpoint
+			runtime, err := LoadAggregateEvidenceStageFileRuntime(runtimeConfig)
+			if err != nil {
+				return postRuntimeEvaluationInvocation{}, err
+			}
+			opened, err := bundle.Open(runtime)
+			if err != nil {
+				return postRuntimeEvaluationInvocation{}, err
+			}
+			return postRuntimeEvaluationInvocation{run: opened.Run}, nil
+		},
+	}
+}

--- a/internal/runner/post_runtime_execution_test.go
+++ b/internal/runner/post_runtime_execution_test.go
@@ -1,0 +1,269 @@
+package runner
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/authorization"
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/execution"
+	"github.com/openkubes/ok-cluster/internal/ledger"
+	"github.com/openkubes/ok-cluster/internal/stageplan"
+	"github.com/openkubes/ok-cluster/internal/stagereceipt"
+)
+
+func TestPostRuntimeExecutionComposesExactSuffixWithDynamicAuthorization(t *testing.T) {
+	config, factories, calls, requests := postRuntimeExecutionFixture(t)
+	executor, err := openPostRuntimeExecution(config, factories)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := executor.Run(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if receipt.Format != PostRuntimeExecutionReceiptFormat || receipt.State != "SUCCEEDED" || receipt.StoppedAt != "" ||
+		len(receipt.Checkpoints) != 5 || len(receipt.ResolvedAuthorizations) != 2 {
+		t.Fatalf("unexpected post-runtime execution receipt: %#v", receipt)
+	}
+	if !reflect.DeepEqual(*calls, postRuntimeStageOrder) {
+		t.Fatalf("post-runtime execution order differs: %v", *calls)
+	}
+	if len(*requests) != 2 || (*requests)[0].StageID != "target-registration" || (*requests)[1].StageID != "platform-applications" ||
+		(*requests)[0].Predecessors[0].StageID != "target-credential" || (*requests)[1].Predecessors[0].StageID != "target-registration" ||
+		(*requests)[0].RequestDigest == (*requests)[1].RequestDigest {
+		t.Fatalf("unexpected dynamic authorization sequence: %#v", *requests)
+	}
+	for index, stageID := range postRuntimeStageOrder[:4] {
+		path := filepath.Join(config.ReceiptDirectory, postRuntimeReceiptFiles[stageID])
+		info, statErr := os.Lstat(path)
+		if statErr != nil || !info.Mode().IsRegular() || info.Mode().Perm() != 0o600 {
+			t.Fatalf("receipt %d was not persisted privately: %#v %v", index, info, statErr)
+		}
+	}
+	if second, err := executor.Run(context.Background()); err == nil || second.State != "STOPPED" || second.StoppedAt != "target-credential" || len(*calls) != 5 {
+		t.Fatalf("single-use executor ran twice: %#v calls=%v err=%v", second, *calls, err)
+	}
+	public, err := json.Marshal(receipt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range []string{config.ReceiptDirectory, "token", "endpoint", "kubeconfig"} {
+		if strings.Contains(string(public), forbidden) {
+			t.Fatalf("public execution receipt exposed %q", forbidden)
+		}
+	}
+}
+
+func TestPostRuntimeExecutionRejectsUnsafeReceiptDestinationBeforeExecution(t *testing.T) {
+	config, factories, calls, _ := postRuntimeExecutionFixture(t)
+	if err := os.Chmod(config.ReceiptDirectory, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := openPostRuntimeExecution(config, factories); err == nil || len(*calls) != 0 {
+		t.Fatalf("broad receipt directory was accepted: calls=%v err=%v", *calls, err)
+	}
+}
+
+func TestPostRuntimeExecutionStopsAfterDurableReceiptWhenNextGrantIsUnavailable(t *testing.T) {
+	config, factories, calls, _ := postRuntimeExecutionFixture(t)
+	resolverCalls := 0
+	config.Authorization = StageAuthorizationResolverFunc(func(context.Context, StageAuthorizationRequest) (StageAuthorizationSource, error) {
+		resolverCalls++
+		return StageAuthorizationSource{}, errors.New("authority unavailable with private details")
+	})
+	executor, err := openPostRuntimeExecution(config, factories)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := executor.Run(context.Background())
+	if err == nil || receipt.State != "STOPPED" || receipt.StoppedAt != "target-registration" || len(receipt.Checkpoints) != 1 || len(receipt.ResolvedAuthorizations) != 0 {
+		t.Fatalf("unavailable authority did not stop after Stage 8: %#v %v", receipt, err)
+	}
+	if resolverCalls != 1 || !reflect.DeepEqual(*calls, []string{"target-credential"}) {
+		t.Fatalf("later stage ran after authority failure: resolver=%d calls=%v", resolverCalls, *calls)
+	}
+	if _, err := os.Lstat(filepath.Join(config.ReceiptDirectory, postRuntimeReceiptFiles["target-credential"])); err != nil {
+		t.Fatal("durable Stage-8 receipt was not retained")
+	}
+	for _, stageID := range postRuntimeStageOrder[1:4] {
+		if _, err := os.Lstat(filepath.Join(config.ReceiptDirectory, postRuntimeReceiptFiles[stageID])); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("later receipt %s exists after authorization stop: %v", stageID, err)
+		}
+	}
+}
+
+func postRuntimeExecutionFixture(t *testing.T) (PostRuntimeExecutionConfig, postRuntimeExecutionFactories, *[]string, *[]StageAuthorizationRequest) {
+	t.Helper()
+	credential := targetCredentialBundleFixture(t)
+	resume := StageResumeConfig{
+		PlanPath: credential.config.PlanPath, PlanExpected: credential.config.PlanExpected,
+		Receipts: credential.config.Receipts,
+	}
+	plan, _, prefix, err := loadStageResumeWithPrefix(resume)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := ledger.Open(filepath.Join(t.TempDir(), "ledger"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	runtimeMaterialPath, runtimeReceiptPath := writePostRuntimeBindingFiles(t, plan, prefix)
+	receiptDirectory := t.TempDir()
+	if err := os.Chmod(receiptDirectory, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	grantDirectory := t.TempDir()
+	if err := os.Chmod(grantDirectory, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	calls := []string{}
+	requests := []StageAuthorizationRequest{}
+	sequence := 0
+	stageRun := func(stageResume StageResumeConfig, stageID string) (stagereceipt.Verified, string) {
+		plan, cursor, _, loadErr := loadStageResumeWithPrefix(stageResume)
+		if loadErr != nil {
+			t.Fatal(loadErr)
+		}
+		predecessors, predecessorErr := cursor.Predecessors()
+		if predecessorErr != nil {
+			t.Fatal(predecessorErr)
+		}
+		sequence++
+		mutation := "NOT_APPLICABLE"
+		outcome := ""
+		if stageID == "target-credential" || stageID == "target-registration" || stageID == "platform-applications" {
+			mutation, outcome = "ATTEMPTED", digest.SHA256([]byte("operation-"+stageID))
+		}
+		verified, receiptErr := stagereceipt.New(plan, stageID, predecessors, "SUCCEEDED", mutation, outcome, digest.SHA256([]byte("evidence-"+stageID)), time.Date(2026, 8, 18, 8, sequence, 0, 0, time.UTC))
+		if receiptErr != nil {
+			t.Fatal(receiptErr)
+		}
+		receiptDigest, storeErr := store.StoreStageReceipt(context.Background(), plan, verified, predecessors)
+		if storeErr != nil {
+			t.Fatal(storeErr)
+		}
+		return verified, receiptDigest
+	}
+	resolver := StageAuthorizationResolverFunc(func(_ context.Context, request StageAuthorizationRequest) (StageAuthorizationSource, error) {
+		requests = append(requests, cloneStageAuthorizationRequest(request))
+		return writeResolvedStageGrant(t, grantDirectory, request)
+	})
+	factories := postRuntimeExecutionFactories{
+		credential: func(config TargetCredentialStageBundleConfig, _ TargetCredentialStageRuntimeConfig) (postRuntimeCredentialInvocation, error) {
+			return postRuntimeCredentialInvocation{
+				ledger: store,
+				run: func(context.Context) (execution.StagedOperationReceipt, *VerifiedTargetCredentialStageHandoff, error) {
+					calls = append(calls, "target-credential")
+					_, receiptDigest := stageRun(StageResumeConfig{PlanPath: config.PlanPath, PlanExpected: config.PlanExpected, Receipts: config.Receipts}, "target-credential")
+					return execution.StagedOperationReceipt{Format: execution.StagedReceiptFormat, State: "COMPLETED_SUCCEEDED", PlanDigest: plan.PlanDigest, StageID: "target-credential", StageReceiptDigest: receiptDigest}, &VerifiedTargetCredentialStageHandoff{verified: true}, nil
+				},
+			}, nil
+		},
+		registration: func(stageResume StageResumeConfig, _ *VerifiedTargetCredentialStageHandoff, _ StageAuthorizationSource, _ PostRuntimeTargetRegistrationConfig, _ VerifiedRuntimeBindingMaterial) (postRuntimeStagedInvocation, error) {
+			return postRuntimeStagedInvocation{ledger: store, run: func(context.Context) (execution.StagedOperationReceipt, error) {
+				calls = append(calls, "target-registration")
+				_, receiptDigest := stageRun(stageResume, "target-registration")
+				return execution.StagedOperationReceipt{Format: execution.StagedReceiptFormat, State: "COMPLETED_SUCCEEDED", PlanDigest: plan.PlanDigest, StageID: "target-registration", StageReceiptDigest: receiptDigest}, nil
+			}}, nil
+		},
+		applications: func(stageResume StageResumeConfig, _ StageAuthorizationSource, _ PostRuntimePlatformApplicationsConfig) (postRuntimeStagedInvocation, error) {
+			return postRuntimeStagedInvocation{ledger: store, run: func(context.Context) (execution.StagedOperationReceipt, error) {
+				calls = append(calls, "platform-applications")
+				_, receiptDigest := stageRun(stageResume, "platform-applications")
+				return execution.StagedOperationReceipt{Format: execution.StagedReceiptFormat, State: "COMPLETED_SUCCEEDED", PlanDigest: plan.PlanDigest, StageID: "platform-applications", StageReceiptDigest: receiptDigest}, nil
+			}}, nil
+		},
+		observation: func(stageResume StageResumeConfig, _ PostRuntimePlatformObservationConfig) (postRuntimeObservationInvocation, error) {
+			return postRuntimeObservationInvocation{ledger: store, run: func(context.Context) (execution.ObservationStageRunReceipt, error) {
+				calls = append(calls, "platform-observation")
+				_, receiptDigest := stageRun(stageResume, "platform-observation")
+				return execution.ObservationStageRunReceipt{Format: execution.ObservationStageReceiptFormat, State: "COMPLETED_SUCCEEDED", PlanDigest: plan.PlanDigest, StageID: "platform-observation", StageReceiptDigest: receiptDigest}, nil
+			}}, nil
+		},
+		aggregate: func(stageResume StageResumeConfig, _ PostRuntimeAggregateEvidenceConfig, _ VerifiedRuntimeBindingMaterial) (postRuntimeEvaluationInvocation, error) {
+			return postRuntimeEvaluationInvocation{run: func(context.Context) (execution.EvaluationStageRunReceipt, error) {
+				calls = append(calls, "aggregate-evidence")
+				_, receiptDigest := stageRun(stageResume, "aggregate-evidence")
+				return execution.EvaluationStageRunReceipt{Format: execution.EvaluationStageReceiptFormat, State: "COMPLETED_SUCCEEDED", PlanDigest: plan.PlanDigest, StageID: "aggregate-evidence", StageReceiptDigest: receiptDigest}, nil
+			}}, nil
+		},
+	}
+	config := PostRuntimeExecutionConfig{
+		TargetCredential: credential.config, Authorization: resolver,
+		RuntimeBinding:   RuntimeBindingMaterialFileConfig{MaterialPath: runtimeMaterialPath, ReceiptPath: runtimeReceiptPath},
+		ReceiptDirectory: receiptDirectory,
+	}
+	return config, factories, &calls, &requests
+}
+
+func writePostRuntimeBindingFiles(t *testing.T, binding stageplan.Binding, prefix []stagereceipt.Verified) (string, string) {
+	t.Helper()
+	lifecycle, _ := prefix[1].Receipt()
+	network, _ := prefix[4].Receipt()
+	material := RuntimeBindingMaterial{
+		Format: RuntimeBindingMaterialFormat, State: "CURRENT_RUNTIME_BOUND", PlanDigest: binding.PlanDigest,
+		IntentRevision: binding.IntentRevision, EnablementRevision: binding.EnablementRevision,
+		PlatformRevision: binding.PlatformRevision, ExecutionFixture: binding.ExecutionFixture,
+		Target: RuntimeBindingTarget{
+			Name: binding.ContractIdentity.Name, CAPIClusterUID: targetAccessRuntimeUID,
+			TargetIdentityScheme: "capi-cluster-uid/v1", WorkloadAPIEndpoint: "https://192.0.2.20:6443",
+			WorkloadAPICAData: "Y2E=", WorkloadAPICADigest: digest.SHA256([]byte("ca")), KubeSystemUID: "kube-system-runtime-uid",
+		},
+		Storage:  RuntimeBindingStorage{Name: "local-path", UID: "local-path-runtime-uid", Provisioner: "rancher.io/local-path"},
+		Evidence: RuntimeBindingEvidence{LifecycleEvidenceDigest: lifecycle.EvidenceDigest, NetworkEvidenceDigest: network.EvidenceDigest},
+	}
+	raw, err := canonicalRuntimeBinding(material)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt := RuntimeBindingMaterialReceipt{
+		Format: RuntimeBindingMaterialFormat, State: "VERIFIED", StageID: "runtime-binding", PlanDigest: binding.PlanDigest,
+		IntentRevision: binding.IntentRevision, TargetClusterUIDDigest: digest.SHA256([]byte(material.Target.CAPIClusterUID)),
+		WorkloadAPICADigest: material.Target.WorkloadAPICADigest, KubeSystemUIDDigest: digest.SHA256([]byte(material.Target.KubeSystemUID)),
+		LocalPathStorageUIDDigest: digest.SHA256([]byte(material.Storage.UID)), LifecycleEvidenceDigest: lifecycle.EvidenceDigest,
+		NetworkEvidenceDigest: network.EvidenceDigest, PrivateMaterialDigest: digest.SHA256(raw), PersistentMutationAllowed: false,
+	}
+	root := t.TempDir()
+	return writeBundleFile(t, root, "runtime-binding.json", raw), writeBundleFile(t, root, "runtime-binding-receipt.json", mustJSON(t, receipt))
+}
+
+func writeResolvedStageGrant(t *testing.T, root string, request StageAuthorizationRequest) (StageAuthorizationSource, error) {
+	t.Helper()
+	payload := authorization.StagePayload{
+		Audience: request.Audience, GrantID: "ok147-runtime-" + request.StageID, Decision: "ALLOW",
+		PlanDigest: request.PlanDigest, ContractIdentity: request.ContractIdentity, ContractRevision: request.ContractRevision,
+		EnablementRevision: request.EnablementRevision, PlatformRevision: request.PlatformRevision, ExecutionFixture: request.ExecutionFixture,
+		StageID: request.StageID, StageOrder: request.StageOrder, StageDigest: request.StageDigest,
+		Operation: request.Operation, Authority: request.Authority, MaxUses: request.MaxUses,
+		NotBefore: "2026-08-18T07:59:00Z", NotAfter: "2026-08-18T08:20:00Z",
+	}
+	for _, predecessor := range request.Predecessors {
+		payload.Predecessors = append(payload.Predecessors, authorization.StagePredecessor{StageID: predecessor.StageID, OutcomeDigest: predecessor.ReceiptDigest})
+	}
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return StageAuthorizationSource{}, err
+	}
+	signed, err := authorization.StageSigningBytes(payload)
+	if err != nil {
+		return StageAuthorizationSource{}, err
+	}
+	envelope := mustJSON(t, map[string]any{
+		"format": authorization.StageFormat, "payload": payload,
+		"signature": map[string]any{"algorithm": "Ed25519", "keyId": digest.SHA256(publicKey), "value": base64.StdEncoding.EncodeToString(ed25519.Sign(privateKey, signed))},
+	})
+	grantPath := writeBundleFile(t, root, request.StageID+"-grant.json", envelope)
+	keyPath := writeBundleFile(t, root, request.StageID+"-authority.pub", []byte(base64.StdEncoding.EncodeToString(publicKey)+"\n"))
+	return StageAuthorizationSource{GrantPath: grantPath, PublicKeyPath: keyPath, EvaluationTime: time.Date(2026, 8, 18, 8, 5, 0, 0, time.UTC)}, nil
+}


### PR DESCRIPTION
## What changed

- compose the verified Stage 8–12 operations into one single-use in-process executor
- retain the target credential only across the Stage 8→9 handoff
- resolve Stage 9 and Stage 10 grants only after each predecessor receipt is durable
- persist canonical Stage 8–11 receipts create-only as private `0600` files
- force registration, observation and evaluation to reuse one verified runtime binding
- stop without retry, rollback or cleanup on any failed stage, unavailable authority or unsafe receipt destination

## Why

The runner library had all individual stage operations, the in-process order and the durable receipt bridge, but no concrete composition that could carry the memory-only credential through registration and continue to final evaluation. This adapter closes that internal boundary without adding a renderer, policy authority, controller or cluster activation surface.

## Validation

- `go test -ldflags=-linkmode=external ./...`
- `go test -count=1 -ldflags=-linkmode=external ./internal/runner`
- `go vet ./...`
- `go test -race -ldflags=-linkmode=external ./internal/runner ./cmd/ok`

No cluster contact or infrastructure mutation was performed.
