### PR TITLE
feat(runner): resolve stage grants over bounded TLS (OK-147)

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -2710,6 +2710,16 @@ not sign, persist or widen a grant and performs no ledger or Kubernetes
 request. This keeps the future in-process adapter from becoming its own policy
 authority.
 
+The concrete HTTP resolver posts that canonical request exactly once to the
+bound TLS authority endpoint, rejects redirects and unexpected media types,
+and stores the signed response create-only as a private `0600` file. The
+existing verifier then binds that grant independently to the current cursor
+and pinned public key. A failed request, invalid response or invalid grant is
+preserved as a stopped single-use attempt; the resolver exposes no automatic
+retry or overwrite path. This client is not the policy authority or grant
+issuer: deployment and operation of that external authority remain outside
+this checkpoint.
+
 The concrete post-runtime execution adapter now composes those boundaries into
 one single-use Stage 8-12 library path. It starts from the exact seven-receipt
 cursor, reuses one verified runtime binding, executes the memory-only

--- a/internal/runner/stage_authorization_http_resolver.go
+++ b/internal/runner/stage_authorization_http_resolver.go
@@ -1,0 +1,156 @@
+package runner
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+const maximumStageAuthorizationHTTPResponseBytes = 128 * 1024
+
+type StageAuthorizationHTTPResolverConfig struct {
+	Endpoint        string
+	TokenFile       string
+	CAFile          string
+	PublicKeyPath   string
+	OutputDirectory string
+	Clock           func() time.Time
+}
+
+type StageAuthorizationHTTPResolver struct {
+	endpoint        *url.URL
+	token           string
+	publicKeyPath   string
+	outputDirectory string
+	client          *http.Client
+	clock           func() time.Time
+	mu              sync.Mutex
+	used            map[string]struct{}
+}
+
+// OpenStageAuthorizationHTTPResolver binds one TLS authority endpoint and a
+// private create-only grant directory. Opening reads bounded local credential
+// files but performs no network request.
+func OpenStageAuthorizationHTTPResolver(config StageAuthorizationHTTPResolverConfig) (*StageAuthorizationHTTPResolver, error) {
+	token, client, err := openBoundedKubernetesHTTP(config.TokenFile, config.CAFile)
+	if err != nil {
+		return nil, errors.New("open stage authorization authority credential")
+	}
+	return newStageAuthorizationHTTPResolver(config, token, client)
+}
+
+func newStageAuthorizationHTTPResolver(config StageAuthorizationHTTPResolverConfig, token string, client *http.Client) (*StageAuthorizationHTTPResolver, error) {
+	endpoint, err := url.Parse(config.Endpoint)
+	if err != nil || endpoint.Scheme == "" || endpoint.Host == "" || endpoint.Port() == "" || endpoint.User != nil || endpoint.RawQuery != "" || endpoint.Fragment != "" || endpoint.Path != "/v1/stage-authorizations" {
+		return nil, errors.New("stage authorization endpoint is invalid")
+	}
+	if endpoint.Scheme != "https" && !(endpoint.Scheme == "http" && endpoint.Hostname() == "127.0.0.1") {
+		return nil, errors.New("stage authorization endpoint must use HTTPS")
+	}
+	if token == "" || strings.TrimSpace(token) != token || strings.ContainsAny(token, "\r\n") || config.PublicKeyPath == "" || config.OutputDirectory == "" || config.Clock == nil || client == nil {
+		return nil, errors.New("stage authorization HTTP resolver configuration is incomplete")
+	}
+	keyInfo, err := os.Lstat(config.PublicKeyPath)
+	if err != nil || !keyInfo.Mode().IsRegular() || keyInfo.Mode()&os.ModeSymlink != 0 {
+		return nil, errors.New("stage authorization trust key metadata is invalid")
+	}
+	directoryInfo, err := os.Lstat(config.OutputDirectory)
+	if err != nil || !directoryInfo.IsDir() || directoryInfo.Mode()&os.ModeSymlink != 0 || directoryInfo.Mode().Perm()&0o077 != 0 || !filepath.IsAbs(config.OutputDirectory) || filepath.Clean(config.OutputDirectory) != config.OutputDirectory {
+		return nil, errors.New("stage authorization output directory is not private")
+	}
+	bounded := *client
+	bounded.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+	if bounded.Timeout == 0 || bounded.Timeout > 30*time.Second {
+		bounded.Timeout = 15 * time.Second
+	}
+	return &StageAuthorizationHTTPResolver{
+		endpoint: endpoint, token: token, publicKeyPath: config.PublicKeyPath,
+		outputDirectory: config.OutputDirectory, client: &bounded, clock: config.Clock,
+		used: map[string]struct{}{},
+	}, nil
+}
+
+// ResolveStageAuthorization performs exactly one POST for one canonical
+// request digest and persists the returned signed grant create-only as 0600.
+// It does not verify or broaden the grant; ResolveStageAuthorization performs
+// that independent verification against the current cursor immediately after
+// this method returns.
+func (resolver *StageAuthorizationHTTPResolver) ResolveStageAuthorization(ctx context.Context, request StageAuthorizationRequest) (StageAuthorizationSource, error) {
+	if resolver == nil || resolver.client == nil || resolver.clock == nil {
+		return StageAuthorizationSource{}, errors.New("stage authorization HTTP resolver is required")
+	}
+	requestRaw, err := request.Bytes()
+	if err != nil {
+		return StageAuthorizationSource{}, err
+	}
+	resolver.mu.Lock()
+	if _, exists := resolver.used[request.RequestDigest]; exists {
+		resolver.mu.Unlock()
+		return StageAuthorizationSource{}, errors.New("stage authorization request is single-use")
+	}
+	resolver.used[request.RequestDigest] = struct{}{}
+	resolver.mu.Unlock()
+	outputPath := filepath.Join(resolver.outputDirectory, strings.TrimPrefix(request.RequestDigest, "sha256:")+".json")
+	if err := validateRuntimeBindingOutputPath(outputPath); err != nil {
+		return StageAuthorizationSource{}, errors.New("stage authorization grant destination is invalid")
+	}
+	httpRequest, err := http.NewRequestWithContext(ctx, http.MethodPost, resolver.endpoint.String(), bytes.NewReader(requestRaw))
+	if err != nil {
+		return StageAuthorizationSource{}, errors.New("create stage authorization request")
+	}
+	httpRequest.Header.Set("Authorization", "Bearer "+resolver.token)
+	httpRequest.Header.Set("Content-Type", "application/vnd.openkubes.stage-authorization-request+json")
+	httpRequest.Header.Set("Accept", "application/vnd.openkubes.stage-authorization+json")
+	response, err := resolver.client.Do(httpRequest)
+	if err != nil {
+		return StageAuthorizationSource{}, errors.New("perform stage authorization request")
+	}
+	defer response.Body.Close()
+	grantRaw, readErr := io.ReadAll(io.LimitReader(response.Body, maximumStageAuthorizationHTTPResponseBytes+1))
+	if readErr != nil || len(grantRaw) == 0 || len(grantRaw) > maximumStageAuthorizationHTTPResponseBytes ||
+		response.StatusCode != http.StatusCreated || response.Header.Get("Content-Type") != "application/vnd.openkubes.stage-authorization+json" {
+		return StageAuthorizationSource{}, errors.New("stage authorization authority response is not accepted")
+	}
+	file, err := os.OpenFile(outputPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return StageAuthorizationSource{}, errors.New("create exclusive stage authorization grant")
+	}
+	if _, err := file.Write(grantRaw); err != nil {
+		file.Close()
+		return StageAuthorizationSource{}, errors.New("write stage authorization grant")
+	}
+	if err := file.Sync(); err != nil {
+		file.Close()
+		return StageAuthorizationSource{}, errors.New("sync stage authorization grant")
+	}
+	if err := file.Close(); err != nil {
+		return StageAuthorizationSource{}, errors.New("close stage authorization grant")
+	}
+	info, err := os.Lstat(outputPath)
+	if err != nil || !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 || info.Mode().Perm() != 0o600 || info.Size() != int64(len(grantRaw)) {
+		return StageAuthorizationSource{}, errors.New("persisted stage authorization grant metadata differs")
+	}
+	stored, err := readBoundedRegular(outputPath, maximumStageAuthorizationHTTPResponseBytes)
+	if err != nil || digest.SHA256(stored) != digest.SHA256(grantRaw) {
+		return StageAuthorizationSource{}, errors.New("persisted stage authorization grant differs")
+	}
+	evaluationTime := resolver.clock().UTC()
+	if evaluationTime.IsZero() {
+		return StageAuthorizationSource{}, errors.New("stage authorization evaluation time is invalid")
+	}
+	return StageAuthorizationSource{
+		GrantPath: outputPath, PublicKeyPath: resolver.publicKeyPath, EvaluationTime: evaluationTime,
+	}, nil
+}
+
+var _ StageAuthorizationResolver = (*StageAuthorizationHTTPResolver)(nil)

--- a/internal/runner/stage_authorization_http_resolver_test.go
+++ b/internal/runner/stage_authorization_http_resolver_test.go
@@ -1,0 +1,166 @@
+package runner
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/authorization"
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+func TestStageAuthorizationHTTPResolverRequestsAndPersistsExactGrant(t *testing.T) {
+	fixture := targetCredentialBundleFixture(t)
+	resume := StageResumeConfig{PlanPath: fixture.config.PlanPath, PlanExpected: fixture.config.PlanExpected, Receipts: fixture.config.Receipts}
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var mu sync.Mutex
+	requests := 0
+	server := httptest.NewTLSServer(http.HandlerFunc(func(response http.ResponseWriter, httpRequest *http.Request) {
+		mu.Lock()
+		requests++
+		mu.Unlock()
+		if httpRequest.Method != http.MethodPost || httpRequest.URL.Path != "/v1/stage-authorizations" ||
+			httpRequest.Header.Get("Authorization") != "Bearer authority-token" ||
+			httpRequest.Header.Get("Content-Type") != "application/vnd.openkubes.stage-authorization-request+json" ||
+			httpRequest.Header.Get("Accept") != "application/vnd.openkubes.stage-authorization+json" {
+			response.WriteHeader(http.StatusForbidden)
+			return
+		}
+		var request StageAuthorizationRequest
+		if err := json.NewDecoder(httpRequest.Body).Decode(&request); err != nil || request.StageID != "target-credential" || request.RequestDigest == "" {
+			response.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		response.Header().Set("Content-Type", "application/vnd.openkubes.stage-authorization+json")
+		response.WriteHeader(http.StatusCreated)
+		response.Write(stageAuthorizationEnvelopeForRequest(t, request, publicKey, privateKey))
+	}))
+	defer server.Close()
+	root := t.TempDir()
+	if err := os.Chmod(root, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	keyPath := writeBundleFile(t, root, "authority.pub", []byte(base64.StdEncoding.EncodeToString(publicKey)+"\n"))
+	resolver, err := OpenStageAuthorizationHTTPResolver(StageAuthorizationHTTPResolverConfig{
+		Endpoint: server.URL + "/v1/stage-authorizations", TokenFile: writeBundleFile(t, root, "token", []byte("authority-token")),
+		CAFile: writeRuntimeBindingServerCA(t, root, "ca.crt", server), PublicKeyPath: keyPath,
+		OutputDirectory: root, Clock: func() time.Time { return time.Date(2026, 8, 18, 8, 5, 0, 0, time.UTC) },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolved, err := ResolveStageAuthorization(context.Background(), resume, resolver)
+	if err != nil {
+		t.Fatal(err)
+	}
+	source, err := resolved.Source()
+	if err != nil || source.PublicKeyPath != keyPath || source.EvaluationTime != time.Date(2026, 8, 18, 8, 5, 0, 0, time.UTC) {
+		t.Fatalf("unexpected HTTP authorization source: %#v %v", source, err)
+	}
+	info, err := os.Lstat(source.GrantPath)
+	if err != nil || !info.Mode().IsRegular() || info.Mode().Perm() != 0o600 || filepath.Dir(source.GrantPath) != root {
+		t.Fatalf("HTTP grant was not persisted privately: %#v %v", info, err)
+	}
+	if _, err := ResolveStageAuthorization(context.Background(), resume, resolver); err == nil {
+		t.Fatal("same authorization request was sent twice")
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if requests != 1 {
+		t.Fatalf("authority requests=%d, want 1", requests)
+	}
+}
+
+func TestStageAuthorizationHTTPResolverRejectsRedirectAndUnsafeConfiguration(t *testing.T) {
+	fixture := targetCredentialBundleFixture(t)
+	resume := StageResumeConfig{PlanPath: fixture.config.PlanPath, PlanExpected: fixture.config.PlanExpected, Receipts: fixture.config.Receipts}
+	publicKey, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	targetCalls := 0
+	target := httptest.NewTLSServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) { targetCalls++ }))
+	defer target.Close()
+	redirect := httptest.NewTLSServer(http.HandlerFunc(func(response http.ResponseWriter, _ *http.Request) {
+		response.Header().Set("Location", target.URL)
+		response.WriteHeader(http.StatusTemporaryRedirect)
+	}))
+	defer redirect.Close()
+	root := t.TempDir()
+	if err := os.Chmod(root, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	config := StageAuthorizationHTTPResolverConfig{
+		Endpoint: redirect.URL + "/v1/stage-authorizations", TokenFile: writeBundleFile(t, root, "token", []byte("authority-token")),
+		CAFile:          writeRuntimeBindingServerCA(t, root, "ca.crt", redirect),
+		PublicKeyPath:   writeBundleFile(t, root, "authority.pub", []byte(base64.StdEncoding.EncodeToString(publicKey)+"\n")),
+		OutputDirectory: root, Clock: time.Now,
+	}
+	resolver, err := OpenStageAuthorizationHTTPResolver(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan, cursor, _, err := loadStageResumeWithPrefix(resume)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decision, _ := cursor.Decision()
+	unsafeRequest, err := newStageAuthorizationRequest(plan, decision)
+	if err != nil {
+		t.Fatal(err)
+	}
+	unsafeRequest.StageID = "../../escape"
+	unsafeRequest.RequestDigest, _ = stageAuthorizationRequestDigest(unsafeRequest)
+	if _, err := resolver.ResolveStageAuthorization(context.Background(), unsafeRequest); err == nil {
+		t.Fatal("path-capable stage identity reached HTTP resolver")
+	}
+	if _, err := ResolveStageAuthorization(context.Background(), resume, resolver); err == nil || targetCalls != 0 {
+		t.Fatalf("authority redirect was followed: targetCalls=%d err=%v", targetCalls, err)
+	}
+	config.Endpoint = "http://example.invalid:80/v1/stage-authorizations"
+	if _, err := OpenStageAuthorizationHTTPResolver(config); err == nil {
+		t.Fatal("cleartext non-loopback authority was accepted")
+	}
+	if err := os.Chmod(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	config.Endpoint = redirect.URL + "/v1/stage-authorizations"
+	if _, err := OpenStageAuthorizationHTTPResolver(config); err == nil {
+		t.Fatal("broad grant directory was accepted")
+	}
+}
+
+func stageAuthorizationEnvelopeForRequest(t *testing.T, request StageAuthorizationRequest, publicKey ed25519.PublicKey, privateKey ed25519.PrivateKey) []byte {
+	t.Helper()
+	payload := authorization.StagePayload{
+		Audience: request.Audience, GrantID: "ok147-http-" + request.StageID, Decision: "ALLOW",
+		PlanDigest: request.PlanDigest, ContractIdentity: request.ContractIdentity, ContractRevision: request.ContractRevision,
+		EnablementRevision: request.EnablementRevision, PlatformRevision: request.PlatformRevision, ExecutionFixture: request.ExecutionFixture,
+		StageID: request.StageID, StageOrder: request.StageOrder, StageDigest: request.StageDigest,
+		Operation: request.Operation, Authority: request.Authority,
+		NotBefore: "2026-08-18T07:59:00Z", NotAfter: "2026-08-18T08:20:00Z", MaxUses: request.MaxUses,
+	}
+	for _, predecessor := range request.Predecessors {
+		payload.Predecessors = append(payload.Predecessors, authorization.StagePredecessor{StageID: predecessor.StageID, OutcomeDigest: predecessor.ReceiptDigest})
+	}
+	signed, err := authorization.StageSigningBytes(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return mustJSON(t, map[string]any{
+		"format": authorization.StageFormat, "payload": payload,
+		"signature": map[string]any{"algorithm": "Ed25519", "keyId": digest.SHA256(publicKey), "value": base64.StdEncoding.EncodeToString(ed25519.Sign(privateKey, signed))},
+	})
+}

--- a/internal/runner/stage_authorization_resolver.go
+++ b/internal/runner/stage_authorization_resolver.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"regexp"
+	"strings"
 	"time"
 
 	"github.com/openkubes/ok-cluster/internal/authorization"
@@ -18,6 +20,8 @@ const (
 	StageAuthorizationRequestFormat         = "ok147-stage-authorization-request/v1"
 	ResolvedStageAuthorizationReceiptFormat = "ok147-resolved-stage-authorization/v1"
 )
+
+var stageAuthorizationRequestNamePattern = regexp.MustCompile(`^[a-z0-9][a-z0-9.-]{1,127}$`)
 
 // StageAuthorizationRequest is the redaction-safe, canonical input supplied
 // to an authority after the direct predecessor receipt exists. It contains no
@@ -99,6 +103,43 @@ type ResolvedStageAuthorization struct {
 	source   StageAuthorizationSource
 	receipt  ResolvedStageAuthorizationReceipt
 	verified bool
+}
+
+func (request StageAuthorizationRequest) Bytes() ([]byte, error) {
+	requestDigest, err := stageAuthorizationRequestDigest(request)
+	if err != nil || request.RequestDigest != requestDigest || request.Format != StageAuthorizationRequestFormat ||
+		request.Audience != authorization.StageAudience || request.MaxUses != 1 || request.StageOrder < 1 ||
+		!stageAuthorizationRequestNamePattern.MatchString(request.StageID) || strings.TrimSpace(request.Operation) != request.Operation || request.Operation == "" ||
+		!stageAuthorizationRequestNamePattern.MatchString(request.Authority) || request.Predecessors == nil {
+		return nil, errors.New("stage authorization request was not produced by verification")
+	}
+	for _, value := range []string{
+		request.RequestDigest, request.PlanDigest, request.ContractRevision, request.EnablementRevision,
+		request.PlatformRevision, request.ExecutionFixture, request.StageDigest,
+	} {
+		if !stageReceiptPrefixDigestPattern.MatchString(value) {
+			return nil, errors.New("stage authorization request digest identity is invalid")
+		}
+	}
+	if request.ContractIdentity.Name == "" || request.ContractIdentity.Namespace == "" {
+		return nil, errors.New("stage authorization request Contract identity is incomplete")
+	}
+	for _, predecessor := range request.Predecessors {
+		if !stageAuthorizationRequestNamePattern.MatchString(predecessor.StageID) || !stageReceiptPrefixDigestPattern.MatchString(predecessor.ReceiptDigest) {
+			return nil, errors.New("stage authorization request predecessor is invalid")
+		}
+	}
+	raw, err := json.Marshal(request)
+	if err != nil {
+		return nil, err
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	var value any
+	if err := decoder.Decode(&value); err != nil {
+		return nil, err
+	}
+	return contract.JCS(value)
 }
 
 // ResolveStageAuthorization derives the only acceptable authorization


### PR DESCRIPTION
## Outcome

- add a concrete single-use HTTPS resolver for predecessor-bound Stage grants
- POST only the canonical redaction-safe authorization request to the exact authority endpoint
- persist the signed response create-only as a private `0600` file
- independently verify the returned grant against the current cursor and pinned public key
- reject redirects, unsafe endpoints, path-capable identities, broad output directories and unexpected response media types

## Boundary

- this client is not the policy authority or grant issuer
- no automatic retry, overwrite, rollback or cleanup path is introduced
- no ledger request, Kubernetes request or infrastructure mutation is performed
- deployment of the external authorization authority remains a later activation concern

## Verification

- `go test -ldflags=-linkmode=external ./...`
- `go vet ./...`
- `go test -race -ldflags=-linkmode=external ./internal/runner ./cmd/ok`
