### PR TITLE
feat(runner): bind post-runtime execution manifest (OK-147)

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -2731,6 +2731,18 @@ cursor. A missing grant, failed stage, malformed receipt, unsafe destination
 or cancelled context stops the suffix without retry, rollback or cleanup. The
 adapter itself still has no CLI or Job activation surface.
 
+The private post-runtime execution manifest now provides the local activation
+boundary for that adapter. One strict `0600` JSON document binds the verified
+Plan and seven-receipt prefix, Stage-8 grant and policy, predecessor-bound TLS
+authority, runtime binding, exact registration and Application projections,
+Network/Platform/Aggregate profiles, one shared capability assertion, isolated
+runtime credentials and private receipt destinations. Loading derives target
+identity from durable lifecycle evidence and rejects identity, profile,
+artifact or capability divergence before opening the execution suffix. Its
+redaction-safe receipt exposes only semantic digests and explicitly grants no
+mutation. The manifest loader still is not a CLI command or Kubernetes Job;
+those activation surfaces remain separate checkpoints.
+
 ## Current OK-147 implementation boundary
 
 The twelve-stage Go library and its durable replay semantics are complete and
@@ -2739,8 +2751,8 @@ Stage-12 launch boundary and the direct command executed by its Job are exposed
 through the local CLI. This is not yet the OK-147 Definition of Done:
 
 - the legacy `ok cluster create` command remains dry-run-only;
-- the Stage 8-12 execution adapter is not yet exposed through one coherent
-  local CLI and Job orchestration path;
+- the Stage 8-12 execution adapter has one coherent private manifest loader but
+  is not yet exposed through a local CLI and Job orchestration path;
 - the standalone Stage-12 launcher has not yet been executed as part of the
   complete predecessor-bound stage chain;
 - the previously published runner image predates this staged-library closure;

--- a/internal/runner/post_runtime_execution_manifest.go
+++ b/internal/runner/post_runtime_execution_manifest.go
@@ -1,0 +1,445 @@
+package runner
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/contract"
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/jsonstrict"
+	"github.com/openkubes/ok-cluster/internal/projection"
+	"github.com/openkubes/ok-cluster/internal/stageplan"
+	"github.com/openkubes/ok-cluster/internal/submission"
+)
+
+const (
+	PostRuntimeExecutionManifestFormat        = "ok147-post-runtime-execution-manifest/v1"
+	PostRuntimeExecutionManifestReceiptFormat = "ok147-post-runtime-execution-manifest-receipt/v1"
+	maximumPostRuntimeExecutionManifestBytes  = 512 * 1024
+)
+
+type postRuntimePlanExpectedDocument struct {
+	ContractIdentity        contract.Identity `json:"contractIdentity"`
+	IntentRevision          string            `json:"intentRevision"`
+	EnablementRevision      string            `json:"enablementRevision"`
+	PlatformRevision        string            `json:"platformRevision"`
+	ExecutionFixture        string            `json:"executionFixture"`
+	InfrastructureAuthority string            `json:"infrastructureAuthority"`
+	ManagementAuthority     string            `json:"managementAuthority"`
+	GitOpsAuthority         string            `json:"gitOpsAuthority"`
+}
+
+type postRuntimePlanDocument struct {
+	Path                string                          `json:"path"`
+	Expected            postRuntimePlanExpectedDocument `json:"expected"`
+	ReceiptPrefixPath   string                          `json:"receiptPrefixPath"`
+	ReceiptPrefixDigest string                          `json:"receiptPrefixDigest"`
+}
+
+type postRuntimeLedgerDocument struct {
+	Endpoint  string `json:"endpoint"`
+	Namespace string `json:"namespace"`
+	TokenFile string `json:"tokenFile"`
+	CAFile    string `json:"caFile"`
+}
+
+type postRuntimeAuthorityDocument struct {
+	Endpoint          string `json:"endpoint"`
+	AuthorityIdentity string `json:"authorityIdentity"`
+	TokenFile         string `json:"tokenFile"`
+	CAFile            string `json:"caFile"`
+	CABundleDigest    string `json:"caBundleDigest"`
+}
+
+type postRuntimeWorkloadDocument struct {
+	Path                  string `json:"path"`
+	ExpectedBindingDigest string `json:"expectedBindingDigest"`
+	TokenFile             string `json:"tokenFile"`
+	CAFile                string `json:"caFile"`
+}
+
+type postRuntimeTargetCredentialDocument struct {
+	GrantPath                   string                        `json:"grantPath"`
+	GrantPublicKeyPath          string                        `json:"grantPublicKeyPath"`
+	EvaluationTime              string                        `json:"evaluationTime"`
+	PolicyPath                  string                        `json:"policyPath"`
+	TargetAccessArtifactPath    string                        `json:"targetAccessArtifactPath"`
+	TargetAccessExpectedObjects []projection.ResourceIdentity `json:"targetAccessExpectedObjects"`
+	Ledger                      postRuntimeLedgerDocument     `json:"ledger"`
+	Workload                    postRuntimeWorkloadDocument   `json:"workload"`
+}
+
+type postRuntimeAuthorizationDocument struct {
+	Endpoint        string `json:"endpoint"`
+	TokenFile       string `json:"tokenFile"`
+	CAFile          string `json:"caFile"`
+	PublicKeyPath   string `json:"publicKeyPath"`
+	OutputDirectory string `json:"outputDirectory"`
+}
+
+type postRuntimeTargetRegistrationDocument struct {
+	ArtifactPath        string                       `json:"artifactPath"`
+	ArgoNamespace       string                       `json:"argoNamespace"`
+	ProjectName         string                       `json:"projectName"`
+	RegistrationName    string                       `json:"registrationName"`
+	TargetName          string                       `json:"targetName"`
+	SourceRepository    string                       `json:"sourceRepository"`
+	TargetNamespaces    []string                     `json:"targetNamespaces"`
+	Ledger              postRuntimeLedgerDocument    `json:"ledger"`
+	GitOps              postRuntimeAuthorityDocument `json:"gitOps"`
+	MaterializationTime string                       `json:"materializationTime"`
+}
+
+type postRuntimePlatformApplicationsDocument struct {
+	ArtifactPath     string                       `json:"artifactPath"`
+	ArgoNamespace    string                       `json:"argoNamespace"`
+	ProjectName      string                       `json:"projectName"`
+	RegistrationName string                       `json:"registrationName"`
+	SourceRepository string                       `json:"sourceRepository"`
+	Ledger           postRuntimeLedgerDocument    `json:"ledger"`
+	GitOps           postRuntimeAuthorityDocument `json:"gitOps"`
+}
+
+type postRuntimeProfileReferenceDocument struct {
+	Path   string `json:"path"`
+	Digest string `json:"digest"`
+}
+
+type postRuntimeProfilesDocument struct {
+	Network   postRuntimeProfileReferenceDocument `json:"network"`
+	Platform  postRuntimeProfileReferenceDocument `json:"platform"`
+	Aggregate postRuntimeProfileReferenceDocument `json:"aggregate"`
+}
+
+type postRuntimeBindingDocument struct {
+	MaterialPath string `json:"materialPath"`
+	ReceiptPath  string `json:"receiptPath"`
+}
+
+type postRuntimePlatformObservationDocument struct {
+	Ledger                   postRuntimeLedgerDocument    `json:"ledger"`
+	Argo                     postRuntimeAuthorityDocument `json:"argo"`
+	CapabilityPath           string                       `json:"capabilityPath"`
+	ExpectedCapabilityDigest string                       `json:"expectedCapabilityDigest"`
+	PollInterval             string                       `json:"pollInterval"`
+	PollTimeout              string                       `json:"pollTimeout"`
+}
+
+type postRuntimeAggregateEvidenceDocument struct {
+	Ledger                   postRuntimeLedgerDocument    `json:"ledger"`
+	Management               postRuntimeAuthorityDocument `json:"management"`
+	Argo                     postRuntimeAuthorityDocument `json:"argo"`
+	WorkloadTokenFile        string                       `json:"workloadTokenFile"`
+	WorkloadCAFile           string                       `json:"workloadCAFile"`
+	CapabilityPath           string                       `json:"capabilityPath"`
+	ExpectedCapabilityDigest string                       `json:"expectedCapabilityDigest"`
+}
+
+type postRuntimeExecutionManifestDocument struct {
+	Format               string                                  `json:"format"`
+	Plan                 postRuntimePlanDocument                 `json:"plan"`
+	TargetCredential     postRuntimeTargetCredentialDocument     `json:"targetCredential"`
+	Authorization        postRuntimeAuthorizationDocument        `json:"authorization"`
+	TargetRegistration   postRuntimeTargetRegistrationDocument   `json:"targetRegistration"`
+	PlatformApplications postRuntimePlatformApplicationsDocument `json:"platformApplications"`
+	Profiles             postRuntimeProfilesDocument             `json:"profiles"`
+	RuntimeBinding       postRuntimeBindingDocument              `json:"runtimeBinding"`
+	PlatformObservation  postRuntimePlatformObservationDocument  `json:"platformObservation"`
+	AggregateEvidence    postRuntimeAggregateEvidenceDocument    `json:"aggregateEvidence"`
+	ReceiptDirectory     string                                  `json:"receiptDirectory"`
+}
+
+type PostRuntimeExecutionManifestReceipt struct {
+	Format                 string `json:"format"`
+	State                  string `json:"state"`
+	ManifestDigest         string `json:"manifestDigest"`
+	PlanDigest             string `json:"planDigest"`
+	InitialReceiptCount    int    `json:"initialReceiptCount"`
+	TargetIdentityDigest   string `json:"targetIdentityDigest"`
+	NetworkProfileDigest   string `json:"networkProfileDigest"`
+	PlatformProfileDigest  string `json:"platformProfileDigest"`
+	AggregateProfileDigest string `json:"aggregateProfileDigest"`
+	AuthorizationMode      string `json:"authorizationMode"`
+	MutationAllowed        bool   `json:"mutationAllowed"`
+}
+
+// OpenPostRuntimeExecutionManifest loads one private strict-JSON activation
+// manifest and composes the existing Stage 8-12 executor. It performs bounded
+// local reads and opens credential clients, but makes no network or ledger
+// request and performs no mutation.
+func OpenPostRuntimeExecutionManifest(path string) (*PostRuntimeExecution, PostRuntimeExecutionManifestReceipt, error) {
+	return openPostRuntimeExecutionManifest(path, defaultPostRuntimeExecutionFactories())
+}
+
+func openPostRuntimeExecutionManifest(path string, factories postRuntimeExecutionFactories) (*PostRuntimeExecution, PostRuntimeExecutionManifestReceipt, error) {
+	receipt := PostRuntimeExecutionManifestReceipt{Format: PostRuntimeExecutionManifestReceiptFormat, State: "STOPPED", MutationAllowed: false}
+	document, manifestDigest, err := loadPostRuntimeExecutionManifest(path)
+	if err != nil {
+		return nil, receipt, err
+	}
+	receipt.ManifestDigest = manifestDigest
+	expected := stageplan.Expected{
+		ContractIdentity: document.Plan.Expected.ContractIdentity,
+		IntentRevision:   document.Plan.Expected.IntentRevision, EnablementRevision: document.Plan.Expected.EnablementRevision,
+		PlatformRevision: document.Plan.Expected.PlatformRevision, ExecutionFixture: document.Plan.Expected.ExecutionFixture,
+		InfrastructureAuthority: document.Plan.Expected.InfrastructureAuthority, ManagementAuthority: document.Plan.Expected.ManagementAuthority,
+		GitOpsAuthority: document.Plan.Expected.GitOpsAuthority,
+	}
+	receipts, err := LoadStageReceiptPrefix(document.Plan.ReceiptPrefixPath, document.Plan.ReceiptPrefixDigest)
+	if err != nil {
+		return nil, receipt, errors.New("load post-runtime receipt prefix")
+	}
+	resume := StageResumeConfig{PlanPath: document.Plan.Path, PlanExpected: expected, Receipts: receipts}
+	plan, cursor, prefix, err := loadStageResumeWithPrefix(resume)
+	if err != nil {
+		return nil, receipt, errors.New("verify post-runtime manifest plan")
+	}
+	decision, err := cursor.Decision()
+	if err != nil || decision.State != "NEXT" || decision.StageID != "target-credential" || len(prefix) != 7 {
+		return nil, receipt, errors.New("post-runtime manifest does not select the exact Stage-8 cursor")
+	}
+	receipt.PlanDigest, receipt.InitialReceiptCount = plan.PlanDigest, len(prefix)
+	lifecycle, err := prefix[1].Receipt()
+	if err != nil || !stageReceiptPrefixDigestPattern.MatchString(lifecycle.TargetClusterUIDDigest) {
+		return nil, receipt, errors.New("post-runtime manifest lacks durable target identity")
+	}
+	receipt.TargetIdentityDigest = lifecycle.TargetClusterUIDDigest
+
+	loadedNetwork, err := LoadNetworkProfileFile(NetworkProfileFileConfig{
+		Path: document.Profiles.Network.Path, ExpectedProfileDigest: document.Profiles.Network.Digest,
+		ExpectedIntentRevision: plan.IntentRevision, ExpectedEnablementRevision: plan.EnablementRevision,
+	})
+	if err != nil {
+		return nil, receipt, errors.New("load post-runtime Network profile")
+	}
+	loadedPlatform, err := LoadPlatformProfileFile(PlatformProfileFileConfig{
+		Path: document.Profiles.Platform.Path, ExpectedProfileDigest: document.Profiles.Platform.Digest,
+		ExpectedIntentRevision: plan.IntentRevision, ExpectedPlatformRevision: plan.PlatformRevision,
+		ExpectedExecutionFixture: plan.ExecutionFixture,
+	})
+	if err != nil {
+		return nil, receipt, errors.New("load post-runtime Platform profile")
+	}
+	loadedAggregate, err := LoadAggregateEvidenceProfileFile(AggregateEvidenceProfileFileConfig{
+		Path: document.Profiles.Aggregate.Path, ExpectedProfileDigest: document.Profiles.Aggregate.Digest,
+		ExpectedIntentRevision: plan.IntentRevision, ExpectedEnablementRevision: plan.EnablementRevision,
+		ExpectedPlatformRevision: plan.PlatformRevision, ExpectedExecutionFixture: plan.ExecutionFixture,
+	})
+	if err != nil {
+		return nil, receipt, errors.New("load post-runtime aggregate profile")
+	}
+	receipt.NetworkProfileDigest, receipt.PlatformProfileDigest, receipt.AggregateProfileDigest = loadedNetwork.Digest, loadedPlatform.Digest, loadedAggregate.Digest
+	if err := bindPostRuntimeProfileInputs(plan, receipt); err != nil {
+		return nil, receipt, err
+	}
+
+	evaluationTime, err := time.Parse(time.RFC3339, document.TargetCredential.EvaluationTime)
+	if err != nil {
+		return nil, receipt, errors.New("post-runtime target credential evaluation time is invalid")
+	}
+	materializationTime, err := time.Parse(time.RFC3339, document.TargetRegistration.MaterializationTime)
+	if err != nil {
+		return nil, receipt, errors.New("post-runtime registration materialization time is invalid")
+	}
+	pollInterval, pollTimeout, err := parsePostRuntimePolling(document.PlatformObservation.PollInterval, document.PlatformObservation.PollTimeout)
+	if err != nil {
+		return nil, receipt, err
+	}
+	clock := func() time.Time { return time.Now().UTC() }
+	authorization, err := OpenStageAuthorizationHTTPResolver(StageAuthorizationHTTPResolverConfig{
+		Endpoint: document.Authorization.Endpoint, TokenFile: document.Authorization.TokenFile, CAFile: document.Authorization.CAFile,
+		PublicKeyPath: document.Authorization.PublicKeyPath, OutputDirectory: document.Authorization.OutputDirectory, Clock: clock,
+	})
+	if err != nil {
+		return nil, receipt, errors.New("open post-runtime authorization resolver")
+	}
+	receipt.AuthorizationMode = "predecessor-bound-tls/v1"
+
+	targetRegistrationStage, _, err := plan.Stage("target-registration")
+	if err != nil || len(targetRegistrationStage.Inputs) != 1 {
+		return nil, receipt, errors.New("post-runtime target-registration input is invalid")
+	}
+	platformApplicationsStage, _, err := plan.Stage("platform-applications")
+	if err != nil || len(platformApplicationsStage.Inputs) != 1 {
+		return nil, receipt, errors.New("post-runtime platform-applications input is invalid")
+	}
+	if document.TargetRegistration.TargetName != plan.ContractIdentity.Name {
+		return nil, receipt, errors.New("post-runtime target name differs from Contract identity")
+	}
+	runtimeBinding := RuntimeBindingMaterialFileConfig{Bundle: resume, MaterialPath: document.RuntimeBinding.MaterialPath, ReceiptPath: document.RuntimeBinding.ReceiptPath}
+	verifiedRuntime, err := LoadRuntimeBindingMaterialFiles(runtimeBinding)
+	if err != nil {
+		return nil, receipt, errors.New("load post-runtime manifest runtime binding")
+	}
+	if digest.SHA256([]byte(verifiedRuntime.material.Target.CAPIClusterUID)) != lifecycle.TargetClusterUIDDigest {
+		return nil, receipt, errors.New("post-runtime runtime target differs from lifecycle identity")
+	}
+	registrationExpected := submission.TargetRegistrationExpected{
+		ArtifactDigest: targetRegistrationStage.Inputs[0].Digest, ContractIdentity: plan.ContractIdentity,
+		IntentRevision: plan.IntentRevision, PlatformRevision: plan.PlatformRevision, ExecutionFixture: plan.ExecutionFixture,
+		TargetIdentityDigest: lifecycle.TargetClusterUIDDigest, ArgoAuthority: plan.Authorities.GitOps,
+		ArgoNamespace: document.TargetRegistration.ArgoNamespace, ProjectName: document.TargetRegistration.ProjectName,
+		RegistrationName: document.TargetRegistration.RegistrationName, TargetName: document.TargetRegistration.TargetName,
+		SourceRepository: document.TargetRegistration.SourceRepository, TargetNamespaces: append([]string(nil), document.TargetRegistration.TargetNamespaces...),
+	}
+	if _, err := submission.LoadTargetRegistration(document.TargetRegistration.ArtifactPath, registrationExpected); err != nil {
+		return nil, receipt, errors.New("verify post-runtime target-registration artifact")
+	}
+	applicationsExpected := submission.PlatformApplicationsExpected{
+		ArtifactDigest: platformApplicationsStage.Inputs[0].Digest, ContractIdentity: plan.ContractIdentity,
+		IntentRevision: plan.IntentRevision, PlatformRevision: plan.PlatformRevision, ExecutionFixture: plan.ExecutionFixture,
+		TargetIdentityDigest: lifecycle.TargetClusterUIDDigest, ArgoAuthority: plan.Authorities.GitOps,
+		ArgoNamespace: document.PlatformApplications.ArgoNamespace, ProjectName: document.PlatformApplications.ProjectName,
+		RegistrationName: document.PlatformApplications.RegistrationName, SourceRepository: document.PlatformApplications.SourceRepository,
+		Profile: loadedPlatform.Profile,
+	}
+	if _, err := submission.LoadPlatformApplications(document.PlatformApplications.ArtifactPath, applicationsExpected); err != nil {
+		return nil, receipt, errors.New("verify post-runtime platform Applications artifact")
+	}
+	if document.PlatformObservation.CapabilityPath != document.AggregateEvidence.CapabilityPath ||
+		document.PlatformObservation.ExpectedCapabilityDigest != document.AggregateEvidence.ExpectedCapabilityDigest {
+		return nil, receipt, errors.New("post-runtime stages must share one capability assertion")
+	}
+	if _, err := LoadPlatformCapabilityFile(PlatformCapabilityFileConfig{
+		Path: document.PlatformObservation.CapabilityPath, ExpectedEvidenceDigest: document.PlatformObservation.ExpectedCapabilityDigest,
+		ExpectedIntentRevision: plan.IntentRevision, ExpectedPlatformRevision: plan.PlatformRevision,
+		ExpectedExecutionFixture: plan.ExecutionFixture, ExpectedTargetClusterUID: verifiedRuntime.material.Target.CAPIClusterUID,
+		ExpectedContractDigest:   loadedPlatform.Profile.CapabilityContractDigest,
+		ExpectedExecutableDigest: loadedPlatform.Profile.CapabilityExecutableDigest,
+	}); err != nil {
+		return nil, receipt, errors.New("verify post-runtime platform capability assertion")
+	}
+
+	config := PostRuntimeExecutionConfig{
+		TargetCredential: TargetCredentialStageBundleConfig{
+			PlanPath: document.Plan.Path, PlanExpected: expected, Receipts: receipts,
+			GrantPath: document.TargetCredential.GrantPath, GrantPublicKeyPath: document.TargetCredential.GrantPublicKeyPath,
+			EvaluationTime: evaluationTime, PolicyPath: document.TargetCredential.PolicyPath,
+			TargetAccessArtifactPath:    document.TargetCredential.TargetAccessArtifactPath,
+			TargetAccessExpectedObjects: append([]projection.ResourceIdentity(nil), document.TargetCredential.TargetAccessExpectedObjects...),
+		},
+		TargetCredentialRun: TargetCredentialStageRuntimeConfig{
+			Ledger: ledgerConfig(document.TargetCredential.Ledger),
+			Workload: WorkloadAuthorityFileResolverConfig{
+				Path: document.TargetCredential.Workload.Path, ExpectedBindingDigest: document.TargetCredential.Workload.ExpectedBindingDigest,
+				TokenFile: document.TargetCredential.Workload.TokenFile, CAFile: document.TargetCredential.Workload.CAFile,
+			},
+			Clock: clock,
+		},
+		Authorization: authorization,
+		TargetRegistration: PostRuntimeTargetRegistrationConfig{
+			ArtifactPath: document.TargetRegistration.ArtifactPath,
+			Expected:     registrationExpected,
+			Runtime: TargetRegistrationStageHandoffRuntimeConfig{
+				Ledger: ledgerConfig(document.TargetRegistration.Ledger), GitOps: authorityConfig(document.TargetRegistration.GitOps),
+				MaterializationTime: materializationTime, Clock: clock,
+			},
+		},
+		PlatformApplications: PostRuntimePlatformApplicationsConfig{
+			ArtifactPath: document.PlatformApplications.ArtifactPath,
+			Expected:     applicationsExpected,
+			Runtime: PlatformApplicationsStageRuntimeConfig{
+				Ledger: ledgerConfig(document.PlatformApplications.Ledger), GitOps: authorityConfig(document.PlatformApplications.GitOps), Clock: clock,
+			},
+		},
+		PlatformObservation: PostRuntimePlatformObservationConfig{
+			Profile: loadedPlatform.Profile,
+			Runtime: PlatformObservationStageFileRuntimeConfig{
+				Ledger: ledgerConfig(document.PlatformObservation.Ledger), Argo: authorityConfig(document.PlatformObservation.Argo),
+				CapabilityPath: document.PlatformObservation.CapabilityPath, ExpectedCapabilityDigest: document.PlatformObservation.ExpectedCapabilityDigest,
+				PollInterval: pollInterval, PollTimeout: pollTimeout, Clock: clock, Wait: WaitWithTimer,
+			},
+		},
+		AggregateEvidence: PostRuntimeAggregateEvidenceConfig{
+			Profile: loadedAggregate.Profile,
+			Runtime: AggregateEvidenceStageFileRuntimeConfig{
+				NetworkProfile: loadedNetwork.Profile, PlatformProfile: loadedPlatform.Profile,
+				Ledger: ledgerConfig(document.AggregateEvidence.Ledger), Management: authorityConfig(document.AggregateEvidence.Management),
+				Argo: authorityConfig(document.AggregateEvidence.Argo), WorkloadTokenFile: document.AggregateEvidence.WorkloadTokenFile,
+				WorkloadCAFile: document.AggregateEvidence.WorkloadCAFile, CapabilityPath: document.AggregateEvidence.CapabilityPath,
+				ExpectedCapabilityDigest: document.AggregateEvidence.ExpectedCapabilityDigest, Clock: clock,
+			},
+		},
+		RuntimeBinding: runtimeBinding, ReceiptDirectory: document.ReceiptDirectory,
+	}
+	executor, err := openPostRuntimeExecution(config, factories)
+	if err != nil {
+		return nil, receipt, errors.New("open verified post-runtime execution")
+	}
+	receipt.State = "VERIFIED"
+	return executor, receipt, nil
+}
+
+func loadPostRuntimeExecutionManifest(path string) (postRuntimeExecutionManifestDocument, string, error) {
+	if path == "" || !filepath.IsAbs(path) || filepath.Clean(path) != path {
+		return postRuntimeExecutionManifestDocument{}, "", errors.New("post-runtime execution manifest path is invalid")
+	}
+	info, err := os.Lstat(path)
+	if err != nil || !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 || info.Mode().Perm()&0o077 != 0 || info.Size() <= 0 || info.Size() > maximumPostRuntimeExecutionManifestBytes {
+		return postRuntimeExecutionManifestDocument{}, "", errors.New("post-runtime execution manifest metadata is invalid")
+	}
+	raw, err := readBoundedRegular(path, maximumPostRuntimeExecutionManifestBytes)
+	if err != nil {
+		return postRuntimeExecutionManifestDocument{}, "", errors.New("read bounded post-runtime execution manifest")
+	}
+	var document postRuntimeExecutionManifestDocument
+	if err := jsonstrict.Decode(raw, &document); err != nil {
+		return postRuntimeExecutionManifestDocument{}, "", errors.New("decode strict post-runtime execution manifest")
+	}
+	if document.Format != PostRuntimeExecutionManifestFormat {
+		return postRuntimeExecutionManifestDocument{}, "", errors.New("post-runtime execution manifest format is not supported")
+	}
+	encoded, err := json.Marshal(document)
+	if err != nil {
+		return postRuntimeExecutionManifestDocument{}, "", errors.New("encode post-runtime execution manifest")
+	}
+	decoder := json.NewDecoder(bytes.NewReader(encoded))
+	decoder.UseNumber()
+	var value any
+	if err := decoder.Decode(&value); err != nil {
+		return postRuntimeExecutionManifestDocument{}, "", errors.New("decode post-runtime execution manifest identity")
+	}
+	canonical, err := contract.JCS(value)
+	if err != nil {
+		return postRuntimeExecutionManifestDocument{}, "", errors.New("canonicalize post-runtime execution manifest")
+	}
+	return document, digest.SHA256(canonical), nil
+}
+
+func bindPostRuntimeProfileInputs(plan stageplan.Binding, receipt PostRuntimeExecutionManifestReceipt) error {
+	for stageID, expected := range map[string]struct{ name, digest string }{
+		"network-observation":  {"stage.network-observation", receipt.NetworkProfileDigest},
+		"platform-observation": {"stage.platform-observation", receipt.PlatformProfileDigest},
+		"aggregate-evidence":   {"stage.aggregate-evidence", receipt.AggregateProfileDigest},
+	} {
+		stage, _, err := plan.Stage(stageID)
+		if err != nil || len(stage.Inputs) != 1 || stage.Inputs[0].Name != expected.name || stage.Inputs[0].Digest != expected.digest {
+			return errors.New("post-runtime profile differs from staged input")
+		}
+	}
+	return nil
+}
+
+func parsePostRuntimePolling(intervalValue, timeoutValue string) (time.Duration, time.Duration, error) {
+	interval, intervalErr := time.ParseDuration(intervalValue)
+	timeout, timeoutErr := time.ParseDuration(timeoutValue)
+	if intervalErr != nil || timeoutErr != nil || interval < time.Second || interval > 5*time.Minute || timeout < interval || timeout > 6*time.Hour {
+		return 0, 0, errors.New("post-runtime polling bounds are invalid")
+	}
+	return interval, timeout, nil
+}
+
+func ledgerConfig(document postRuntimeLedgerDocument) KubernetesLedgerConfig {
+	return KubernetesLedgerConfig{Endpoint: document.Endpoint, Namespace: document.Namespace, TokenFile: document.TokenFile, CAFile: document.CAFile}
+}
+
+func authorityConfig(document postRuntimeAuthorityDocument) KubernetesAuthorityConfig {
+	return KubernetesAuthorityConfig{
+		Endpoint: document.Endpoint, AuthorityIdentity: document.AuthorityIdentity,
+		TokenFile: document.TokenFile, CAFile: document.CAFile, CABundleDigest: document.CABundleDigest,
+	}
+}

--- a/internal/runner/post_runtime_execution_manifest_test.go
+++ b/internal/runner/post_runtime_execution_manifest_test.go
@@ -1,0 +1,364 @@
+package runner
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/contract"
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/execution"
+	"github.com/openkubes/ok-cluster/internal/ledger"
+	"github.com/openkubes/ok-cluster/internal/observation"
+	"github.com/openkubes/ok-cluster/internal/stageplan"
+	"github.com/openkubes/ok-cluster/internal/stagereceipt"
+)
+
+func TestOpenPostRuntimeExecutionManifestBindsExactPrivateActivation(t *testing.T) {
+	manifest, _, cleanup := postRuntimeManifestFixture(t)
+	defer cleanup()
+	executor, receipt, err := OpenPostRuntimeExecutionManifest(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if executor == nil || receipt.Format != PostRuntimeExecutionManifestReceiptFormat || receipt.State != "VERIFIED" ||
+		receipt.InitialReceiptCount != 7 || receipt.PlanDigest == "" || receipt.ManifestDigest == "" ||
+		receipt.TargetIdentityDigest != digest.SHA256([]byte(targetAccessRuntimeUID)) ||
+		receipt.AuthorizationMode != "predecessor-bound-tls/v1" || receipt.MutationAllowed {
+		t.Fatalf("unexpected post-runtime manifest receipt: %#v", receipt)
+	}
+	public, err := json.Marshal(receipt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range []string{"/private/", "token", "endpoint", "kubeconfig", "certificate"} {
+		if strings.Contains(strings.ToLower(string(public)), forbidden) {
+			t.Fatalf("public manifest receipt disclosed %q", forbidden)
+		}
+	}
+}
+
+func TestPostRuntimeExecutionManifestFailsClosedBeforeActivation(t *testing.T) {
+	manifest, factories, cleanup := postRuntimeManifestFixture(t)
+	defer cleanup()
+	raw, err := os.ReadFile(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root := filepath.Dir(manifest)
+	for name, mutate := range map[string]func(map[string]any){
+		"unknown field": func(value map[string]any) { value["unexpected"] = true },
+		"wrong target": func(value map[string]any) {
+			value["targetRegistration"].(map[string]any)["targetName"] = "different-target"
+		},
+		"wrong profile": func(value map[string]any) {
+			value["profiles"].(map[string]any)["platform"].(map[string]any)["digest"] = runnerStageSHA("f")
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			var value map[string]any
+			if err := json.Unmarshal(raw, &value); err != nil {
+				t.Fatal(err)
+			}
+			mutate(value)
+			path := writeBundleFile(t, root, strings.ReplaceAll(name, " ", "-")+".json", mustJSON(t, value))
+			if _, _, err := openPostRuntimeExecutionManifest(path, factories); err == nil {
+				t.Fatal("unsafe post-runtime manifest was accepted")
+			}
+		})
+	}
+	if err := os.Chmod(manifest, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := openPostRuntimeExecutionManifest(manifest, factories); err == nil {
+		t.Fatal("broad post-runtime manifest was accepted")
+	}
+	if _, _, err := openPostRuntimeExecutionManifest("relative.json", factories); err == nil {
+		t.Fatal("relative post-runtime manifest was accepted")
+	}
+}
+
+func TestPostRuntimeExecutionManifestDigestIsFormattingIndependent(t *testing.T) {
+	manifest, _, cleanup := postRuntimeManifestFixture(t)
+	defer cleanup()
+	raw, err := os.ReadFile(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var value any
+	if err := json.Unmarshal(raw, &value); err != nil {
+		t.Fatal(err)
+	}
+	pretty, err := json.MarshalIndent(value, "", "    ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	prettyPath := writeBundleFile(t, filepath.Dir(manifest), "pretty.json", pretty)
+	_, firstDigest, err := loadPostRuntimeExecutionManifest(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, secondDigest, err := loadPostRuntimeExecutionManifest(prettyPath)
+	if err != nil || firstDigest != secondDigest {
+		t.Fatalf("semantic manifest identity changed with formatting: %q %q %v", firstDigest, secondDigest, err)
+	}
+}
+
+func postRuntimeManifestFixture(t *testing.T) (string, postRuntimeExecutionFactories, func()) {
+	t.Helper()
+	root := t.TempDir()
+	at := time.Date(2026, 8, 18, 8, 0, 0, 0, time.UTC)
+	expected := stageplan.Expected{
+		ContractIdentity: contract.Identity{Namespace: "disposable-ok147", Name: "disposable-ok147"},
+		IntentRevision:   runnerStageSHA("a"), EnablementRevision: runnerStageSHA("b"),
+		PlatformRevision: runnerStageSHA("c"), ExecutionFixture: runnerStageSHA("d"),
+		InfrastructureAuthority: "ok-infra", ManagementAuthority: "ok-mgmt", GitOpsAuthority: "ok-shared",
+	}
+	targetAccess := runnerTargetAccessYAML()
+	policy := targetCredentialPolicyDocument{
+		Format: TargetCredentialPolicyFormat, TargetIdentityDigest: digest.SHA256([]byte(targetAccessRuntimeUID)),
+		ServiceAccount:     targetCredentialServiceAccount{Namespace: "kube-system", Name: "ok147-argocd-manager"},
+		RequestedAudiences: []string{}, ExpirationSeconds: 10800, CredentialUse: "argocd-target-registration",
+		Retention: "memory-only", NativeRotation: false, ProductionSuitable: false,
+	}
+	policyRaw, err := json.Marshal(policy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	registration := runnerTargetRegistrationYAML(expected)
+	applications, platformProfile := runnerPlatformApplications(t, expected)
+	networkProfile := runnerAggregateNetworkProfile(expected)
+	networkDigest, err := observation.NetworkProfileDigest(networkProfile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	platformDigest, err := observation.PlatformProfileDigest(platformProfile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	aggregateProfile := AggregateEvidenceProfile{
+		Format: AggregateEvidenceProfileFormat, IntentRevision: expected.IntentRevision,
+		EnablementRevision: expected.EnablementRevision, PlatformRevision: expected.PlatformRevision,
+		ExecutionFixture: expected.ExecutionFixture, Required: append([]string(nil), aggregateEvidenceRequiredConditions...),
+	}
+	aggregateDigest, err := AggregateEvidenceProfileDigest(aggregateProfile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	planRaw := submissionBundlePlan(t, expected, runnerStageSHA("1"), runnerStageSHA("2"))
+	var planDocument map[string]any
+	if err := json.Unmarshal(planRaw, &planDocument); err != nil {
+		t.Fatal(err)
+	}
+	stages := planDocument["stages"].([]any)
+	stageInputs := []struct {
+		index  int
+		name   string
+		digest string
+	}{
+		{4, "stage.network-observation", networkDigest},
+		{6, "stage.target-access", digest.SHA256(targetAccess)},
+		{7, "stage.target-credential", digest.SHA256(policyRaw)},
+		{8, "stage.target-registration", digest.SHA256(registration)},
+		{9, "stage.platform-applications", digest.SHA256(applications)},
+		{10, "stage.platform-observation", platformDigest},
+		{11, "stage.aggregate-evidence", aggregateDigest},
+	}
+	for _, input := range stageInputs {
+		stages[input.index].(map[string]any)["inputs"] = []any{map[string]any{"name": input.name, "digest": input.digest}}
+	}
+	planPath := writeBundleFile(t, root, "staged-plan.json", mustJSON(t, planDocument))
+	plan, err := stageplan.Load(planPath, expected)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipts := make([]StageReceiptSource, 0, 7)
+	predecessors := []stagereceipt.Verified{}
+	results := []struct{ id, mutation, operation, evidence string }{
+		{"provider-prerequisites", "ATTEMPTED", runnerStageSHA("1"), runnerStageSHA("2")},
+		{"cluster-lifecycle", "ATTEMPTED", runnerStageSHA("3"), runnerStageSHA("4")},
+		{"lifecycle-observation", "NOT_APPLICABLE", "", runnerStageSHA("5")},
+		{"enablement", "ATTEMPTED", runnerStageSHA("6"), runnerStageSHA("7")},
+		{"network-observation", "NOT_APPLICABLE", "", runnerStageSHA("8")},
+		{"runtime-binding", "NOT_APPLICABLE", "", runnerStageSHA("9")},
+		{"target-access", "ATTEMPTED", runnerStageSHA("0"), runnerStageSHA("e")},
+	}
+	for index, result := range results {
+		var verified stagereceipt.Verified
+		if result.id == "cluster-lifecycle" {
+			verified, err = stagereceipt.NewWithTargetClusterUIDDigest(plan, result.id, predecessors, "SUCCEEDED", result.mutation, result.operation, result.evidence, digest.SHA256([]byte(targetAccessRuntimeUID)), at.Add(time.Duration(index-7)*time.Minute))
+		} else {
+			verified, err = stagereceipt.New(plan, result.id, predecessors, "SUCCEEDED", result.mutation, result.operation, result.evidence, at.Add(time.Duration(index-7)*time.Minute))
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		receipts = appendStageReceipt(t, root, receipts, verified, result.id+".json")
+		predecessors = []stagereceipt.Verified{verified}
+	}
+	grantPath, grantKeyPath := writeSubmissionStageGrant(t, root, plan, "target-credential", predecessors, at)
+	resume := StageResumeConfig{PlanPath: planPath, PlanExpected: expected, Receipts: receipts}
+	plan, _, prefix, err := loadStageResumeWithPrefix(resume)
+	if err != nil {
+		t.Fatal(err)
+	}
+	prefixEntries := make([]map[string]any, 0, len(resume.Receipts))
+	for _, source := range resume.Receipts {
+		prefixEntries = append(prefixEntries, map[string]any{"file": filepath.Base(source.Path), "digest": source.Digest})
+	}
+	prefixPath := writeBundleFile(t, root, "receipt-prefix.json", mustJSON(t, map[string]any{
+		"format": StageReceiptPrefixFormat, "receipts": prefixEntries,
+	}))
+	runtimeMaterial, runtimeReceipt := writePostRuntimeBindingFiles(t, plan, prefix)
+
+	platformProfilePath := writeBundleFile(t, root, "platform-profile.json", mustJSON(t, platformProfile))
+	networkProfilePath := writeBundleFile(t, root, "network-profile.json", mustJSON(t, networkProfile))
+	aggregateProfilePath := writeBundleFile(t, root, "aggregate-profile.json", mustJSON(t, aggregateProfile))
+	registrationPath := writeBundleFile(t, root, "target-registration.yaml", registration)
+	applicationsPath := writeBundleFile(t, root, "platform-applications.yaml", applications)
+	targetAccessPath := writeBundleFile(t, root, "target-access.yaml", targetAccess)
+	policyPath := writeBundleFile(t, root, "target-credential-policy.json", policyRaw)
+	capability := observation.PlatformCapabilityState{
+		Format: observation.PlatformCapabilityFormat, ObservedAt: "2026-08-18T08:00:00Z",
+		TargetClusterUID: targetAccessRuntimeUID, IntentRevision: plan.IntentRevision, PlatformRevision: plan.PlatformRevision,
+		ExecutionFixture: plan.ExecutionFixture, ContractDigest: platformProfile.CapabilityContractDigest,
+		ExecutableDigest: platformProfile.CapabilityExecutableDigest, Passed: true,
+	}
+	capability.EvidenceDigest, err = observation.PlatformCapabilityDigest(capability)
+	if err != nil {
+		t.Fatal(err)
+	}
+	capabilityPath := writeBundleFile(t, root, "platform-capability.json", mustJSON(t, capability))
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	publicKey, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		server.Close()
+		t.Fatal(err)
+	}
+	authorizationDirectory := t.TempDir()
+	if err := os.Chmod(authorizationDirectory, 0o700); err != nil {
+		server.Close()
+		t.Fatal(err)
+	}
+	receiptDirectory := t.TempDir()
+	if err := os.Chmod(receiptDirectory, 0o700); err != nil {
+		server.Close()
+		t.Fatal(err)
+	}
+	caPath := writeRuntimeBindingServerCA(t, root, "authority-ca.crt", server)
+	caRaw, err := os.ReadFile(caPath)
+	if err != nil {
+		server.Close()
+		t.Fatal(err)
+	}
+	ledgerDocument := postRuntimeLedgerDocument{
+		Endpoint: server.URL, Namespace: "openkubes-execution-system",
+		TokenFile: writeBundleFile(t, root, "ledger-token", []byte("ledger-token")), CAFile: caPath,
+	}
+	workloadBinding := WorkloadAuthorityBinding{
+		Format: WorkloadAuthorityBindingFormat, IntentRevision: plan.IntentRevision, TargetClusterUID: targetAccessRuntimeUID,
+		TargetIdentityScheme: "capi-cluster-uid/v1", Endpoint: server.URL, CABundleDigest: digest.SHA256(caRaw),
+	}
+	workloadBindingDigest, err := WorkloadAuthorityBindingDigest(workloadBinding)
+	if err != nil {
+		server.Close()
+		t.Fatal(err)
+	}
+	workloadBindingPath := writeBundleFile(t, root, "workload-authority.json", mustJSON(t, workloadBinding))
+	workloadTokenPath := writeBundleFile(t, root, "workload-token", []byte("workload-token"))
+	gitOpsDocument := postRuntimeAuthorityDocument{Endpoint: "https://192.0.2.11:6443", AuthorityIdentity: "ok-shared", TokenFile: "/private/tmp/argocd-token", CAFile: "/private/tmp/argocd-ca", CABundleDigest: runnerStageSHA("1")}
+	document := postRuntimeExecutionManifestDocument{
+		Format: PostRuntimeExecutionManifestFormat,
+		Plan: postRuntimePlanDocument{
+			Path: planPath, Expected: postRuntimePlanExpectedDocument{
+				ContractIdentity: plan.ContractIdentity, IntentRevision: plan.IntentRevision, EnablementRevision: plan.EnablementRevision,
+				PlatformRevision: plan.PlatformRevision, ExecutionFixture: plan.ExecutionFixture,
+				InfrastructureAuthority: plan.Authorities.Infrastructure, ManagementAuthority: plan.Authorities.Management, GitOpsAuthority: plan.Authorities.GitOps,
+			},
+			ReceiptPrefixPath: prefixPath, ReceiptPrefixDigest: fileSHA(t, prefixPath),
+		},
+		TargetCredential: postRuntimeTargetCredentialDocument{
+			GrantPath: grantPath, GrantPublicKeyPath: grantKeyPath, EvaluationTime: at.Format(time.RFC3339),
+			PolicyPath: policyPath, TargetAccessArtifactPath: targetAccessPath,
+			TargetAccessExpectedObjects: runnerTargetAccessIdentities(), Ledger: ledgerDocument,
+			Workload: postRuntimeWorkloadDocument{Path: workloadBindingPath, ExpectedBindingDigest: workloadBindingDigest, TokenFile: workloadTokenPath, CAFile: caPath},
+		},
+		Authorization: postRuntimeAuthorizationDocument{
+			Endpoint: server.URL + "/v1/stage-authorizations", TokenFile: writeBundleFile(t, root, "authority-token", []byte("authority-token")),
+			CAFile:        caPath,
+			PublicKeyPath: writeBundleFile(t, root, "authority.pub", []byte(base64.StdEncoding.EncodeToString(publicKey)+"\n")), OutputDirectory: authorizationDirectory,
+		},
+		TargetRegistration: postRuntimeTargetRegistrationDocument{
+			ArtifactPath: registrationPath, ArgoNamespace: "argocd", ProjectName: "openkubes-disposable",
+			RegistrationName: "disposable-ok147-cluster", TargetName: plan.ContractIdentity.Name,
+			SourceRepository: "https://github.com/openkubes/ok-observability.git", TargetNamespaces: []string{"ok-observability", "kube-system"},
+			Ledger: ledgerDocument, GitOps: gitOpsDocument, MaterializationTime: "2026-08-18T08:01:00Z",
+		},
+		PlatformApplications: postRuntimePlatformApplicationsDocument{
+			ArtifactPath: applicationsPath, ArgoNamespace: "argocd", ProjectName: "openkubes-disposable",
+			RegistrationName: "disposable-ok147", SourceRepository: "https://github.com/openkubes/ok-observability.git",
+			Ledger: ledgerDocument, GitOps: gitOpsDocument,
+		},
+		Profiles: postRuntimeProfilesDocument{
+			Network:   postRuntimeProfileReferenceDocument{Path: networkProfilePath, Digest: networkDigest},
+			Platform:  postRuntimeProfileReferenceDocument{Path: platformProfilePath, Digest: platformDigest},
+			Aggregate: postRuntimeProfileReferenceDocument{Path: aggregateProfilePath, Digest: aggregateDigest},
+		},
+		RuntimeBinding: postRuntimeBindingDocument{MaterialPath: runtimeMaterial, ReceiptPath: runtimeReceipt},
+		PlatformObservation: postRuntimePlatformObservationDocument{
+			Ledger: ledgerDocument, Argo: gitOpsDocument, CapabilityPath: capabilityPath,
+			ExpectedCapabilityDigest: capability.EvidenceDigest, PollInterval: "1s", PollTimeout: "1m",
+		},
+		AggregateEvidence: postRuntimeAggregateEvidenceDocument{
+			Ledger: ledgerDocument, Management: postRuntimeAuthorityDocument{Endpoint: "https://192.0.2.12:6443", AuthorityIdentity: "ok-mgmt", TokenFile: "/private/tmp/management-token", CAFile: "/private/tmp/management-ca", CABundleDigest: runnerStageSHA("4")},
+			Argo: gitOpsDocument, WorkloadTokenFile: "/private/tmp/aggregate-workload-token", WorkloadCAFile: "/private/tmp/aggregate-workload-ca",
+			CapabilityPath: capabilityPath, ExpectedCapabilityDigest: capability.EvidenceDigest,
+		},
+		ReceiptDirectory: receiptDirectory,
+	}
+	manifest := writeBundleFile(t, root, "post-runtime-manifest.json", mustJSON(t, document))
+	store, err := ledger.Open(filepath.Join(t.TempDir(), "ledger"))
+	if err != nil {
+		server.Close()
+		t.Fatal(err)
+	}
+	factories := postRuntimeExecutionFactories{
+		credential: func(TargetCredentialStageBundleConfig, TargetCredentialStageRuntimeConfig) (postRuntimeCredentialInvocation, error) {
+			return postRuntimeCredentialInvocation{ledger: store, run: func(context.Context) (execution.StagedOperationReceipt, *VerifiedTargetCredentialStageHandoff, error) {
+				return execution.StagedOperationReceipt{}, nil, errors.New("not executed")
+			}}, nil
+		},
+		registration: func(StageResumeConfig, *VerifiedTargetCredentialStageHandoff, StageAuthorizationSource, PostRuntimeTargetRegistrationConfig, VerifiedRuntimeBindingMaterial) (postRuntimeStagedInvocation, error) {
+			return postRuntimeStagedInvocation{ledger: store, run: func(context.Context) (execution.StagedOperationReceipt, error) {
+				return execution.StagedOperationReceipt{}, nil
+			}}, nil
+		},
+		applications: func(StageResumeConfig, StageAuthorizationSource, PostRuntimePlatformApplicationsConfig) (postRuntimeStagedInvocation, error) {
+			return postRuntimeStagedInvocation{ledger: store, run: func(context.Context) (execution.StagedOperationReceipt, error) {
+				return execution.StagedOperationReceipt{}, nil
+			}}, nil
+		},
+		observation: func(StageResumeConfig, PostRuntimePlatformObservationConfig) (postRuntimeObservationInvocation, error) {
+			return postRuntimeObservationInvocation{ledger: store, run: func(context.Context) (execution.ObservationStageRunReceipt, error) {
+				return execution.ObservationStageRunReceipt{}, nil
+			}}, nil
+		},
+		aggregate: func(StageResumeConfig, PostRuntimeAggregateEvidenceConfig, VerifiedRuntimeBindingMaterial) (postRuntimeEvaluationInvocation, error) {
+			return postRuntimeEvaluationInvocation{run: func(context.Context) (execution.EvaluationStageRunReceipt, error) {
+				return execution.EvaluationStageRunReceipt{}, nil
+			}}, nil
+		},
+	}
+	return manifest, factories, server.Close
+}


### PR DESCRIPTION
## Outcome

- add one strict private `0600` manifest as the local Stage 8-12 activation boundary
- bind the verified Plan and exact seven-receipt prefix before execution can open
- derive the immutable target identity from durable lifecycle evidence and the runtime binding
- verify Network, Platform and aggregate profiles against their exact staged inputs
- verify target-registration and Platform Application projections before Stage 8 can run
- require one shared runtime-correlated capability assertion for Stage 11 and Stage 12
- construct the existing predecessor-authorized single-use execution suffix without network contact or mutation
- emit a redaction-safe manifest receipt containing semantic digests only

## Fail-closed boundaries

- unknown fields, relative manifest paths, broad file permissions and unsafe receipt destinations are rejected
- wrong target identity, stale/foreign profile identity, artifact drift and capability divergence are rejected locally
- credentials remain path references in the private manifest and never enter the public receipt
- this checkpoint exposes no CLI command, Job, retry, rollback or cleanup path

## Verification

- `go test -count=1 -ldflags=-linkmode=external ./...`
- `go vet ./...`
- `go test -race -count=1 -ldflags=-linkmode=external ./internal/runner ./cmd/ok`
