### PR TITLE
feat(cli): activate post-runtime execution suffix (OK-147)

### DIFF
--- a/cmd/ok/main.go
+++ b/cmd/ok/main.go
@@ -681,6 +681,12 @@ func runContext(ctx context.Context, arguments []string, stdout, stderr io.Write
 	if len(arguments) >= 4 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "run" && arguments[3] == "platform-applications" {
 		return runClusterStageRunPlatformApplications(ctx, arguments[4:], stdout, stderr)
 	}
+	if len(arguments) >= 5 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "run" && arguments[3] == "post-runtime" && arguments[4] == "prepare" {
+		return runClusterStageRunPostRuntimePrepare(arguments[5:], stdout, stderr)
+	}
+	if len(arguments) >= 5 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "run" && arguments[3] == "post-runtime" && arguments[4] == "execute" {
+		return runClusterStageRunPostRuntimeExecute(ctx, arguments[5:], stdout, stderr)
+	}
 	if len(arguments) >= 6 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "run" && arguments[3] == "aggregate-evidence" && arguments[4] == "launch" && arguments[5] == "prepare" {
 		return runClusterStageRunAggregateEvidenceLaunchPrepare(arguments[6:], stdout, stderr)
 	}
@@ -699,7 +705,7 @@ func runContext(ctx context.Context, arguments []string, stdout, stderr io.Write
 	if len(arguments) >= 4 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "launch" && arguments[3] == "execute" {
 		return runClusterStageLaunchExecute(ctx, arguments[4:], stdout, stderr)
 	}
-	return errors.New("usage: ok cluster create ... | ok cluster stage inspect ... | ok cluster stage resume ... | ok cluster stage observe lifecycle ... | ok cluster stage observe network ... | ok cluster stage observe platform ... | ok cluster stage evaluate aggregate ... | ok cluster stage bind runtime ... | ok cluster stage bind runtime launch prepare ... | ok cluster stage bind runtime launch execute ... | ok cluster stage observe network package ... | ok cluster stage observe network launch prepare ... | ok cluster stage observe network launch execute ... | ok cluster stage observe lifecycle package ... | ok cluster stage observe lifecycle launch prepare ... | ok cluster stage observe lifecycle launch execute ... | ok cluster stage run ... | ok cluster stage run enablement ... | ok cluster stage run target-access ... | ok cluster stage run platform-applications ... | ok cluster stage run aggregate-evidence launch prepare ... | ok cluster stage run aggregate-evidence launch execute ... | ok cluster stage run enablement package ... | ok cluster stage run enablement launch prepare ... | ok cluster stage run enablement launch execute ... | ok cluster stage package ... | ok cluster stage launch prepare ... | ok cluster stage launch execute ...")
+	return errors.New("usage: ok cluster create ... | ok cluster stage inspect ... | ok cluster stage resume ... | ok cluster stage observe lifecycle ... | ok cluster stage observe network ... | ok cluster stage observe platform ... | ok cluster stage evaluate aggregate ... | ok cluster stage bind runtime ... | ok cluster stage bind runtime launch prepare ... | ok cluster stage bind runtime launch execute ... | ok cluster stage observe network package ... | ok cluster stage observe network launch prepare ... | ok cluster stage observe network launch execute ... | ok cluster stage observe lifecycle package ... | ok cluster stage observe lifecycle launch prepare ... | ok cluster stage observe lifecycle launch execute ... | ok cluster stage run ... | ok cluster stage run enablement ... | ok cluster stage run target-access ... | ok cluster stage run platform-applications ... | ok cluster stage run post-runtime prepare ... | ok cluster stage run post-runtime execute ... | ok cluster stage run aggregate-evidence launch prepare ... | ok cluster stage run aggregate-evidence launch execute ... | ok cluster stage run enablement package ... | ok cluster stage run enablement launch prepare ... | ok cluster stage run enablement launch execute ... | ok cluster stage package ... | ok cluster stage launch prepare ... | ok cluster stage launch execute ...")
 }
 
 func runClusterCreate(arguments []string, stdout, stderr io.Writer) error {

--- a/cmd/ok/post_runtime.go
+++ b/cmd/ok/post_runtime.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"io"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/runner"
+)
+
+const (
+	postRuntimeCLIReceiptFormat = "ok147-post-runtime-cli-receipt/v1"
+	postRuntimeExecutionTimeout = 3 * time.Hour
+)
+
+type postRuntimeExecutor interface {
+	Run(context.Context) (runner.PostRuntimeExecutionReceipt, error)
+}
+
+var openPostRuntimeExecutor = func(path string) (postRuntimeExecutor, runner.PostRuntimeExecutionManifestReceipt, error) {
+	return runner.OpenPostRuntimeExecutionManifest(path)
+}
+
+type postRuntimeCLIReceipt struct {
+	Format    string                                     `json:"format"`
+	State     string                                     `json:"state"`
+	Manifest  runner.PostRuntimeExecutionManifestReceipt `json:"manifest"`
+	Execution *runner.PostRuntimeExecutionReceipt        `json:"execution,omitempty"`
+}
+
+func runClusterStageRunPostRuntimePrepare(arguments []string, stdout, stderr io.Writer) error {
+	flags := flag.NewFlagSet("ok cluster stage run post-runtime prepare", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	manifestPath := flags.String("manifest", "", "path to the private 0600 post-runtime execution manifest")
+	if err := flags.Parse(arguments); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return errors.New("positional arguments are not accepted")
+	}
+	if *manifestPath == "" {
+		return errors.New("--manifest is required")
+	}
+	_, receipt, err := openPostRuntimeExecutor(*manifestPath)
+	if err != nil {
+		return err
+	}
+	return writePostRuntimeCLIReceipt(stdout, postRuntimeCLIReceipt{
+		Format: postRuntimeCLIReceiptFormat, State: "PREPARED", Manifest: receipt,
+	})
+}
+
+func runClusterStageRunPostRuntimeExecute(ctx context.Context, arguments []string, stdout, stderr io.Writer) error {
+	flags := flag.NewFlagSet("ok cluster stage run post-runtime execute", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	manifestPath := flags.String("manifest", "", "path to the private 0600 post-runtime execution manifest")
+	expectedManifestDigest := flags.String("expected-manifest-digest", "", "exact semantic digest emitted by prepare")
+	execute := flags.Bool("execute", false, "perform the exact single-use Stage 8-12 execution suffix")
+	if err := flags.Parse(arguments); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return errors.New("positional arguments are not accepted")
+	}
+	if !*execute {
+		return errors.New("post-runtime mutation requires explicit --execute")
+	}
+	if *manifestPath == "" || !sha256DigestPattern.MatchString(*expectedManifestDigest) {
+		return errors.New("--manifest and a lowercase SHA-256 --expected-manifest-digest are required")
+	}
+	executor, manifestReceipt, err := openPostRuntimeExecutor(*manifestPath)
+	if err != nil {
+		return err
+	}
+	if executor == nil || manifestReceipt.State != "VERIFIED" || manifestReceipt.MutationAllowed || manifestReceipt.ManifestDigest != *expectedManifestDigest {
+		return errors.New("post-runtime manifest differs from the prepared identity")
+	}
+	bounded, cancel := context.WithTimeout(ctx, postRuntimeExecutionTimeout)
+	defer cancel()
+	executionReceipt, runErr := executor.Run(bounded)
+	outputErr := writePostRuntimeCLIReceipt(stdout, postRuntimeCLIReceipt{
+		Format: postRuntimeCLIReceiptFormat, State: executionReceipt.State,
+		Manifest: manifestReceipt, Execution: &executionReceipt,
+	})
+	if outputErr != nil {
+		return outputErr
+	}
+	return runErr
+}
+
+func writePostRuntimeCLIReceipt(output io.Writer, receipt postRuntimeCLIReceipt) error {
+	encoder := json.NewEncoder(output)
+	encoder.SetEscapeHTML(false)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(receipt)
+}

--- a/cmd/ok/post_runtime_test.go
+++ b/cmd/ok/post_runtime_test.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/openkubes/ok-cluster/internal/runner"
+)
+
+type fakePostRuntimeExecutor struct {
+	calls         int
+	deadlineBound bool
+	receipt       runner.PostRuntimeExecutionReceipt
+	err           error
+}
+
+func (executor *fakePostRuntimeExecutor) Run(ctx context.Context) (runner.PostRuntimeExecutionReceipt, error) {
+	executor.calls++
+	_, executor.deadlineBound = ctx.Deadline()
+	return executor.receipt, executor.err
+}
+
+func TestPostRuntimePrepareVerifiesWithoutExecution(t *testing.T) {
+	fake := &fakePostRuntimeExecutor{}
+	restore := stubPostRuntimeExecutor(t, fake, testPostRuntimeManifestReceipt(testSHA("1")))
+	defer restore()
+	var stdout, stderr bytes.Buffer
+	if err := run([]string{"cluster", "stage", "run", "post-runtime", "prepare", "--manifest", "/private/tmp/post-runtime.json"}, &stdout, &stderr); err != nil {
+		t.Fatal(err)
+	}
+	if fake.calls != 0 {
+		t.Fatal("post-runtime prepare executed the suffix")
+	}
+	var receipt postRuntimeCLIReceipt
+	if err := json.Unmarshal(stdout.Bytes(), &receipt); err != nil || receipt.Format != postRuntimeCLIReceiptFormat || receipt.State != "PREPARED" ||
+		receipt.Manifest.ManifestDigest != testSHA("1") || receipt.Execution != nil {
+		t.Fatalf("unexpected prepare receipt: %#v %v", receipt, err)
+	}
+}
+
+func TestPostRuntimeExecuteRequiresPreparedIdentityAndRunsOnce(t *testing.T) {
+	fake := &fakePostRuntimeExecutor{receipt: runner.PostRuntimeExecutionReceipt{
+		Format: runner.PostRuntimeExecutionReceiptFormat, State: "SUCCEEDED", PlanDigest: testSHA("2"),
+	}}
+	restore := stubPostRuntimeExecutor(t, fake, testPostRuntimeManifestReceipt(testSHA("1")))
+	defer restore()
+	var stdout, stderr bytes.Buffer
+	err := runContext(context.Background(), []string{
+		"cluster", "stage", "run", "post-runtime", "execute",
+		"--manifest", "/private/tmp/post-runtime.json", "--expected-manifest-digest", testSHA("1"), "--execute",
+	}, &stdout, &stderr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fake.calls != 1 || !fake.deadlineBound {
+		t.Fatalf("post-runtime execution was not exact and bounded: calls=%d deadline=%v", fake.calls, fake.deadlineBound)
+	}
+	var receipt postRuntimeCLIReceipt
+	if err := json.Unmarshal(stdout.Bytes(), &receipt); err != nil || receipt.State != "SUCCEEDED" || receipt.Execution == nil || receipt.Execution.PlanDigest != testSHA("2") {
+		t.Fatalf("unexpected execution receipt: %#v %v", receipt, err)
+	}
+}
+
+func TestPostRuntimeExecuteFailsClosedBeforeRun(t *testing.T) {
+	for name, arguments := range map[string][]string{
+		"no execute":   {"cluster", "stage", "run", "post-runtime", "execute", "--manifest", "/private/tmp/post-runtime.json", "--expected-manifest-digest", testSHA("1")},
+		"bad digest":   {"cluster", "stage", "run", "post-runtime", "execute", "--manifest", "/private/tmp/post-runtime.json", "--expected-manifest-digest", "sha256:no", "--execute"},
+		"wrong digest": {"cluster", "stage", "run", "post-runtime", "execute", "--manifest", "/private/tmp/post-runtime.json", "--expected-manifest-digest", testSHA("2"), "--execute"},
+		"positional":   {"cluster", "stage", "run", "post-runtime", "execute", "--manifest", "/private/tmp/post-runtime.json", "--expected-manifest-digest", testSHA("1"), "--execute", "extra"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			fake := &fakePostRuntimeExecutor{}
+			restore := stubPostRuntimeExecutor(t, fake, testPostRuntimeManifestReceipt(testSHA("1")))
+			defer restore()
+			if err := run(arguments, &bytes.Buffer{}, &bytes.Buffer{}); err == nil || fake.calls != 0 {
+				t.Fatalf("unsafe execution reached runner: calls=%d err=%v", fake.calls, err)
+			}
+		})
+	}
+}
+
+func TestPostRuntimeExecuteEmitsStoppedReceiptOnRunFailure(t *testing.T) {
+	fake := &fakePostRuntimeExecutor{
+		receipt: runner.PostRuntimeExecutionReceipt{Format: runner.PostRuntimeExecutionReceiptFormat, State: "STOPPED", StoppedAt: "target-registration"},
+		err:     errors.New("private authority failure"),
+	}
+	restore := stubPostRuntimeExecutor(t, fake, testPostRuntimeManifestReceipt(testSHA("1")))
+	defer restore()
+	var stdout bytes.Buffer
+	err := run([]string{
+		"cluster", "stage", "run", "post-runtime", "execute", "--manifest", "/private/tmp/post-runtime.json",
+		"--expected-manifest-digest", testSHA("1"), "--execute",
+	}, &stdout, &bytes.Buffer{})
+	if err == nil || strings.Contains(stdout.String(), "private authority failure") {
+		t.Fatalf("failed execution was not redaction-safe: output=%q err=%v", stdout.String(), err)
+	}
+	var receipt postRuntimeCLIReceipt
+	if decodeErr := json.Unmarshal(stdout.Bytes(), &receipt); decodeErr != nil || receipt.State != "STOPPED" || receipt.Execution == nil || receipt.Execution.StoppedAt != "target-registration" {
+		t.Fatalf("stopped execution receipt was not emitted: %#v %v", receipt, decodeErr)
+	}
+}
+
+func stubPostRuntimeExecutor(t *testing.T, executor postRuntimeExecutor, receipt runner.PostRuntimeExecutionManifestReceipt) func() {
+	t.Helper()
+	previous := openPostRuntimeExecutor
+	openPostRuntimeExecutor = func(path string) (postRuntimeExecutor, runner.PostRuntimeExecutionManifestReceipt, error) {
+		if path != "/private/tmp/post-runtime.json" {
+			return nil, runner.PostRuntimeExecutionManifestReceipt{}, errors.New("unexpected private path")
+		}
+		return executor, receipt, nil
+	}
+	return func() { openPostRuntimeExecutor = previous }
+}
+
+func testPostRuntimeManifestReceipt(manifestDigest string) runner.PostRuntimeExecutionManifestReceipt {
+	return runner.PostRuntimeExecutionManifestReceipt{
+		Format: runner.PostRuntimeExecutionManifestReceiptFormat, State: "VERIFIED", ManifestDigest: manifestDigest,
+		PlanDigest: testSHA("3"), InitialReceiptCount: 7, TargetIdentityDigest: testSHA("4"),
+		NetworkProfileDigest: testSHA("5"), PlatformProfileDigest: testSHA("6"), AggregateProfileDigest: testSHA("7"),
+		AuthorizationMode: "predecessor-bound-tls/v1", MutationAllowed: false,
+	}
+}

--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -2740,8 +2740,18 @@ runtime credentials and private receipt destinations. Loading derives target
 identity from durable lifecycle evidence and rejects identity, profile,
 artifact or capability divergence before opening the execution suffix. Its
 redaction-safe receipt exposes only semantic digests and explicitly grants no
-mutation. The manifest loader still is not a CLI command or Kubernetes Job;
-those activation surfaces remain separate checkpoints.
+mutation. Loading remains verification-only; every activation surface must
+bind that verified identity separately.
+
+The local post-runtime CLI now keeps verification and mutation as two explicit
+operations. `post-runtime prepare` opens and verifies the private manifest and
+emits its redaction-safe semantic digest without executing any stage.
+`post-runtime execute` reopens the manifest, requires that exact prepared
+digest plus an explicit `--execute` flag, and runs the Stage 8-12 suffix once
+inside a fixed three-hour context. A stopped execution still emits its bounded
+composite receipt before the command returns the failure. Neither operation
+adds automatic retry, rollback or cleanup. This closes the local activation
+surface; an ephemeral Kubernetes Job remains a separate checkpoint.
 
 ## Current OK-147 implementation boundary
 
@@ -2751,8 +2761,9 @@ Stage-12 launch boundary and the direct command executed by its Job are exposed
 through the local CLI. This is not yet the OK-147 Definition of Done:
 
 - the legacy `ok cluster create` command remains dry-run-only;
-- the Stage 8-12 execution adapter has one coherent private manifest loader but
-  is not yet exposed through a local CLI and Job orchestration path;
+- the Stage 8-12 execution adapter and private manifest are exposed through one
+  local prepare/execute CLI, but not yet through an ephemeral Job orchestration
+  path;
 - the standalone Stage-12 launcher has not yet been executed as part of the
   complete predecessor-bound stage chain;
 - the previously published runner image predates this staged-library closure;


### PR DESCRIPTION
## Summary

- expose the verified Stage 8-12 post-runtime execution suffix through separate local `prepare` and `execute` commands
- bind execution to the exact prepared manifest digest and an explicit `--execute` flag
- preserve stopped, redaction-safe receipts without adding retry, rollback, or cleanup
- document the remaining ephemeral Job activation boundary

## Verification

- `GOCACHE=/private/tmp/ok147-go-build go test -count=1 -ldflags=-linkmode=external ./...`
- `GOCACHE=/private/tmp/ok147-go-vet go vet ./...`
- `GOCACHE=/private/tmp/ok147-go-race go test -race -count=1 -ldflags=-linkmode=external ./internal/runner ./cmd/ok`

## Boundary

This checkpoint adds no Kubernetes Job and performs no live infrastructure mutation. The CLI executes only after the private manifest is independently reverified and its semantic digest matches the explicitly supplied prepared identity.
