### PR TITLE
feat(runner): launch post-runtime activation (OK-147)

### DIFF
--- a/internal/runner/post_runtime_activation_installation_plan.go
+++ b/internal/runner/post_runtime_activation_installation_plan.go
@@ -1,0 +1,174 @@
+package runner
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"gopkg.in/yaml.v3"
+)
+
+const PostRuntimeExecutionActivationInstallationPlanFormat = "ok147-post-runtime-execution-activation-installation-plan/v1"
+
+// PostRuntimeExecutionActivationInstallationPlan is a credential-free exact
+// description of the three creates that activate the verified post-runtime
+// suffix. It is evidence, not create authority.
+type PostRuntimeExecutionActivationInstallationPlan struct {
+	Format               string                      `json:"format"`
+	State                string                      `json:"state"`
+	RunID                string                      `json:"runId"`
+	PackageDigest        string                      `json:"packageDigest"`
+	PlanDigest           string                      `json:"planDigest"`
+	TargetIdentityDigest string                      `json:"targetIdentityDigest"`
+	Authority            string                      `json:"authority"`
+	Creates              []SubmissionStageCreatePlan `json:"creates"`
+	MutationAllowed      bool                        `json:"mutationAllowed"`
+}
+
+// PlanPostRuntimeExecutionActivationInstallation derives the exact
+// Secret -> NetworkPolicy -> Job absence/create sequence without opening a
+// credential or contacting Kubernetes.
+func PlanPostRuntimeExecutionActivationInstallation(packaged VerifiedPostRuntimeExecutionActivationPackage) (PostRuntimeExecutionActivationInstallationPlan, error) {
+	receipt, err := packaged.Receipt()
+	if err != nil {
+		return PostRuntimeExecutionActivationInstallationPlan{}, err
+	}
+	expectedKinds := []string{"Secret", "NetworkPolicy", "Job"}
+	if !equalStringList(receipt.ObjectKinds, expectedKinds) || packaged.managementAuthority == "" {
+		return PostRuntimeExecutionActivationInstallationPlan{}, errors.New("post-runtime activation package inventory or authority is invalid")
+	}
+	decoder := yaml.NewDecoder(bytes.NewReader(packaged.raw))
+	objects := make([]map[string]any, 0, len(expectedKinds))
+	for {
+		var object map[string]any
+		err := decoder.Decode(&object)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil || len(object) == 0 {
+			return PostRuntimeExecutionActivationInstallationPlan{}, errors.New("decode post-runtime activation package")
+		}
+		objects = append(objects, object)
+	}
+	if len(objects) != len(expectedKinds) {
+		return PostRuntimeExecutionActivationInstallationPlan{}, errors.New("post-runtime activation package object count is invalid")
+	}
+
+	runID := ""
+	creates := make([]SubmissionStageCreatePlan, 0, len(objects))
+	for index, object := range objects {
+		apiVersion, _ := object["apiVersion"].(string)
+		kind, _ := object["kind"].(string)
+		if kind != expectedKinds[index] {
+			return PostRuntimeExecutionActivationInstallationPlan{}, errors.New("post-runtime activation create order is invalid")
+		}
+		metadata, ok := object["metadata"].(map[string]any)
+		if !ok {
+			return PostRuntimeExecutionActivationInstallationPlan{}, errors.New("post-runtime activation object metadata is invalid")
+		}
+		name, _ := metadata["name"].(string)
+		namespace, _ := metadata["namespace"].(string)
+		if !submissionStageInputNamePattern.MatchString(name) || len(name) > 63 || namespace != submissionStageInputNamespace || metadata["generateName"] != nil {
+			return PostRuntimeExecutionActivationInstallationPlan{}, errors.New("post-runtime activation object identity is invalid")
+		}
+		collectionPath, objectPath, err := postRuntimeActivationCreatePaths(apiVersion, kind, namespace, name)
+		if err != nil {
+			return PostRuntimeExecutionActivationInstallationPlan{}, err
+		}
+		canonical, err := json.Marshal(object)
+		if err != nil {
+			return PostRuntimeExecutionActivationInstallationPlan{}, errors.New("encode post-runtime activation object")
+		}
+		creates = append(creates, SubmissionStageCreatePlan{
+			Order: index + 1, APIVersion: apiVersion, Kind: kind, Namespace: namespace, Name: name,
+			PreflightMethod: "GET", ObjectPath: objectPath, CreateMethod: "POST", CollectionPath: collectionPath,
+			ObjectDigest: digest.SHA256(canonical),
+		})
+		switch kind {
+		case "Secret":
+			annotations, _ := metadata["annotations"].(map[string]any)
+			labels, _ := metadata["labels"].(map[string]any)
+			binaryData, _ := object["binaryData"].(map[string]any)
+			if name != receipt.ActivationSecret || object["immutable"] != true || object["type"] != "Opaque" ||
+				labels["openkubes.io/stage-id"] != "post-runtime" || annotations["openkubes.io/bundle-digest"] != receipt.BundleDigest ||
+				annotations["openkubes.io/manifest-digest"] != receipt.ManifestDigest || len(binaryData) != receipt.PrivateFileCount+1 {
+				return PostRuntimeExecutionActivationInstallationPlan{}, errors.New("post-runtime activation Secret semantics differ")
+			}
+		case "NetworkPolicy":
+			runID = name
+			spec, _ := object["spec"].(map[string]any)
+			selector, _ := spec["podSelector"].(map[string]any)
+			matchLabels, _ := selector["matchLabels"].(map[string]any)
+			if matchLabels["openkubes.io/execution-id"] != runID {
+				return PostRuntimeExecutionActivationInstallationPlan{}, errors.New("post-runtime activation NetworkPolicy selector differs")
+			}
+		case "Job":
+			spec, _ := object["spec"].(map[string]any)
+			template, _ := spec["template"].(map[string]any)
+			podSpec, _ := template["spec"].(map[string]any)
+			annotations, _ := metadata["annotations"].(map[string]any)
+			if name != runID || spec["backoffLimit"] != 0 || podSpec["serviceAccountName"] != "ok147-contract-executor-runtime" ||
+				podSpec["automountServiceAccountToken"] != false || annotations["openkubes.io/bundle-digest"] != receipt.BundleDigest ||
+				annotations["openkubes.io/manifest-digest"] != receipt.ManifestDigest || !postRuntimeJobMountsActivationSecret(podSpec, receipt.ActivationSecret) {
+				return PostRuntimeExecutionActivationInstallationPlan{}, errors.New("post-runtime activation Job binding differs")
+			}
+		}
+	}
+	return PostRuntimeExecutionActivationInstallationPlan{
+		Format: PostRuntimeExecutionActivationInstallationPlanFormat, State: "VERIFIED", RunID: runID,
+		PackageDigest: receipt.PackageDigest, PlanDigest: receipt.PlanDigest, TargetIdentityDigest: receipt.TargetIdentityDigest,
+		Authority: packaged.managementAuthority, Creates: creates, MutationAllowed: false,
+	}, nil
+}
+
+func postRuntimeActivationCreatePaths(apiVersion, kind, namespace, name string) (string, string, error) {
+	if apiVersion == "v1" && kind == "Secret" {
+		collection := "/api/v1/namespaces/" + namespace + "/secrets"
+		return collection, collection + "/" + name, nil
+	}
+	return submissionStageCreatePaths(apiVersion, kind, namespace, name)
+}
+
+func postRuntimeJobMountsActivationSecret(podSpec map[string]any, name string) bool {
+	volumes, ok := podSpec["volumes"].([]any)
+	if !ok {
+		return false
+	}
+	for _, value := range volumes {
+		volume, _ := value.(map[string]any)
+		if volume["name"] != "activation-source" {
+			continue
+		}
+		secret, _ := volume["secret"].(map[string]any)
+		items, _ := secret["items"].([]any)
+		return secret["secretName"] == name && len(items) == len(postRuntimeExecutionBundleFiles)+1
+	}
+	return false
+}
+
+func preparePostRuntimeExecutionActivationInstallation(packaged VerifiedPostRuntimeExecutionActivationPackage) (PostRuntimeExecutionActivationInstallationPlan, []submissionStageInstallObject, error) {
+	plan, err := PlanPostRuntimeExecutionActivationInstallation(packaged)
+	if err != nil {
+		return PostRuntimeExecutionActivationInstallationPlan{}, nil, err
+	}
+	decoder := yaml.NewDecoder(bytes.NewReader(packaged.raw))
+	objects := make([]submissionStageInstallObject, 0, len(plan.Creates))
+	for index := range plan.Creates {
+		var value map[string]any
+		if err := decoder.Decode(&value); err != nil || len(value) == 0 {
+			return PostRuntimeExecutionActivationInstallationPlan{}, nil, errors.New("decode verified post-runtime activation object")
+		}
+		raw, err := json.Marshal(value)
+		if err != nil || digest.SHA256(raw) != plan.Creates[index].ObjectDigest {
+			return PostRuntimeExecutionActivationInstallationPlan{}, nil, errors.New("post-runtime activation object differs from plan")
+		}
+		objects = append(objects, submissionStageInstallObject{plan: plan.Creates[index], raw: raw})
+	}
+	var trailing map[string]any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		return PostRuntimeExecutionActivationInstallationPlan{}, nil, errors.New("post-runtime activation package contains trailing object")
+	}
+	return plan, objects, nil
+}

--- a/internal/runner/post_runtime_activation_launcher.go
+++ b/internal/runner/post_runtime_activation_launcher.go
@@ -1,0 +1,215 @@
+package runner
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+const PostRuntimeExecutionActivationLaunchReceiptFormat = "ok147-post-runtime-execution-activation-launch-receipt/v1"
+
+type PostRuntimeExecutionActivationLauncherConfig struct {
+	Authority             KubernetesAuthorityConfig
+	ExpectedPackageDigest string
+}
+
+// PostRuntimeExecutionActivationLaunchReceipt contains only redaction-safe
+// identities. The private activation package and bearer credential are never
+// retained in the receipt.
+type PostRuntimeExecutionActivationLaunchReceipt struct {
+	Format        string                           `json:"format"`
+	RunID         string                           `json:"runId"`
+	PackageDigest string                           `json:"packageDigest"`
+	PlanDigest    string                           `json:"planDigest"`
+	Authority     string                           `json:"authority"`
+	State         string                           `json:"state"`
+	MutationState string                           `json:"mutationState"`
+	Results       []SubmissionStageInstalledObject `json:"results"`
+}
+
+// KubernetesPostRuntimeExecutionActivationLauncher is a single-use bounded
+// installer for one verified private activation package.
+type KubernetesPostRuntimeExecutionActivationLauncher struct {
+	mu       sync.Mutex
+	used     bool
+	endpoint *url.URL
+	token    string
+	client   *http.Client
+	plan     PostRuntimeExecutionActivationInstallationPlan
+	objects  []submissionStageInstallObject
+}
+
+// OpenKubernetesPostRuntimeExecutionActivationLauncher opens the exact
+// management credential but performs no API request.
+func OpenKubernetesPostRuntimeExecutionActivationLauncher(config PostRuntimeExecutionActivationLauncherConfig, packaged VerifiedPostRuntimeExecutionActivationPackage) (*KubernetesPostRuntimeExecutionActivationLauncher, error) {
+	receipt, err := packaged.Receipt()
+	if err != nil || config.ExpectedPackageDigest != receipt.PackageDigest {
+		return nil, errors.New("post-runtime activation package differs from expected identity")
+	}
+	if config.Authority.AuthorityIdentity == "" || config.Authority.AuthorityIdentity != packaged.managementAuthority || !stageReceiptPrefixDigestPattern.MatchString(config.Authority.CABundleDigest) {
+		return nil, errors.New("post-runtime activation authority differs from verified management authority")
+	}
+	endpoint, err := normalizeSubmissionStageLaunchEndpoint(config.Authority.Endpoint)
+	if err != nil {
+		return nil, errors.New("post-runtime activation endpoint is invalid")
+	}
+	token, ca, client, err := openBoundedKubernetesMaterial(config.Authority.TokenFile, config.Authority.CAFile)
+	if err != nil {
+		return nil, errors.New("open bounded post-runtime activation credential")
+	}
+	if digest.SHA256(ca) != config.Authority.CABundleDigest {
+		return nil, errors.New("post-runtime activation CA differs from bound identity")
+	}
+	return newKubernetesPostRuntimeExecutionActivationLauncher(submissionStageInstallerClientConfig{
+		Endpoint: endpoint, BearerToken: token, AuthorityIdentity: config.Authority.AuthorityIdentity, Client: client,
+	}, packaged)
+}
+
+func newKubernetesPostRuntimeExecutionActivationLauncher(config submissionStageInstallerClientConfig, packaged VerifiedPostRuntimeExecutionActivationPackage) (*KubernetesPostRuntimeExecutionActivationLauncher, error) {
+	plan, objects, err := preparePostRuntimeExecutionActivationInstallation(packaged)
+	if err != nil {
+		return nil, err
+	}
+	if config.AuthorityIdentity == "" || config.AuthorityIdentity != plan.Authority {
+		return nil, errors.New("post-runtime activation authority differs from verified management authority")
+	}
+	endpoint, err := url.Parse(config.Endpoint)
+	if err != nil || endpoint.Host == "" || endpoint.User != nil || endpoint.RawQuery != "" || endpoint.Fragment != "" ||
+		endpoint.Path != "" && endpoint.Path != "/" || endpoint.Port() == "" || net.ParseIP(endpoint.Hostname()) == nil {
+		return nil, errors.New("post-runtime activation Kubernetes endpoint is invalid")
+	}
+	if endpoint.Scheme != "https" && !(endpoint.Scheme == "http" && endpoint.Hostname() == "127.0.0.1") {
+		return nil, errors.New("post-runtime activation Kubernetes endpoint must use HTTPS")
+	}
+	if config.BearerToken == "" || strings.TrimSpace(config.BearerToken) != config.BearerToken ||
+		strings.ContainsAny(config.BearerToken, "\r\n") || config.Client == nil {
+		return nil, errors.New("post-runtime activation credential or client is invalid")
+	}
+	client := *config.Client
+	client.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+	if client.Timeout == 0 {
+		client.Timeout = 15 * time.Second
+	}
+	endpoint.Path, endpoint.RawPath = "", ""
+	return &KubernetesPostRuntimeExecutionActivationLauncher{
+		endpoint: endpoint, token: config.BearerToken, client: &client, plan: plan, objects: objects,
+	}, nil
+}
+
+// Launch completes all three exact-name GETs before the first POST, then
+// creates Secret, NetworkPolicy and Job exactly once in that order. It has no
+// update, patch, apply, delete, list, watch, retry, rollback or cleanup path.
+func (launcher *KubernetesPostRuntimeExecutionActivationLauncher) Launch(ctx context.Context) (PostRuntimeExecutionActivationLaunchReceipt, error) {
+	receipt := launcher.newReceipt()
+	if launcher == nil || launcher.client == nil {
+		return receipt, errors.New("post-runtime activation launcher is required")
+	}
+	launcher.mu.Lock()
+	if launcher.used {
+		launcher.mu.Unlock()
+		return stopPostRuntimeExecutionActivation(receipt, "STOPPED_ZERO_WRITE", errors.New("post-runtime activation launcher is single-use"))
+	}
+	launcher.used = true
+	launcher.mu.Unlock()
+
+	for _, object := range launcher.objects {
+		_, status, err := launcher.request(ctx, http.MethodGet, object.plan.ObjectPath, nil)
+		if err != nil {
+			return stopPostRuntimeExecutionActivation(receipt, "STOPPED_ZERO_WRITE", err)
+		}
+		switch status {
+		case http.StatusNotFound:
+		case http.StatusOK:
+			return stopPostRuntimeExecutionActivation(receipt, "STOPPED_ZERO_WRITE", errors.New("post-runtime activation object already exists; zero-write preflight stopped"))
+		default:
+			return stopPostRuntimeExecutionActivation(receipt, "STOPPED_ZERO_WRITE", postRuntimeActivationStatusError(http.MethodGet, status))
+		}
+	}
+
+	receipt.State = "ACTIVATING"
+	for _, object := range launcher.objects {
+		receipt.MutationState = "ATTEMPTED_UNKNOWN"
+		raw, status, err := launcher.request(ctx, http.MethodPost, object.plan.CollectionPath, object.raw)
+		if err != nil {
+			return stopPostRuntimeExecutionActivation(receipt, "STOPPED_PARTIAL_OR_UNKNOWN", err)
+		}
+		if status != http.StatusCreated {
+			receipt.MutationState = "ATTEMPTED"
+			return stopPostRuntimeExecutionActivation(receipt, "STOPPED_PARTIAL_OR_UNKNOWN", postRuntimeActivationStatusError(http.MethodPost, status))
+		}
+		uid, resourceVersion, err := verifySubmissionStageCreatedObject(raw, object)
+		if err != nil {
+			return stopPostRuntimeExecutionActivation(receipt, "STOPPED_PARTIAL_OR_UNKNOWN", errors.New("created post-runtime activation object differs from verified package"))
+		}
+		receipt.MutationState = "ATTEMPTED"
+		receipt.Results = append(receipt.Results, SubmissionStageInstalledObject{
+			Order: object.plan.Order, APIVersion: object.plan.APIVersion, Kind: object.plan.Kind,
+			Namespace: object.plan.Namespace, Name: object.plan.Name, ObjectDigest: object.plan.ObjectDigest,
+			UIDDigest: digest.SHA256([]byte(uid)), ResourceVersionDigest: digest.SHA256([]byte(resourceVersion)), State: "CREATED",
+		})
+	}
+	receipt.State = "ACTIVATED"
+	return receipt, nil
+}
+
+func (launcher *KubernetesPostRuntimeExecutionActivationLauncher) newReceipt() PostRuntimeExecutionActivationLaunchReceipt {
+	receipt := PostRuntimeExecutionActivationLaunchReceipt{
+		Format: PostRuntimeExecutionActivationLaunchReceiptFormat, State: "PREFLIGHT", MutationState: "NOT_ATTEMPTED",
+		Results: []SubmissionStageInstalledObject{},
+	}
+	if launcher != nil {
+		receipt.RunID, receipt.PackageDigest, receipt.PlanDigest, receipt.Authority =
+			launcher.plan.RunID, launcher.plan.PackageDigest, launcher.plan.PlanDigest, launcher.plan.Authority
+	}
+	return receipt
+}
+
+func stopPostRuntimeExecutionActivation(receipt PostRuntimeExecutionActivationLaunchReceipt, state string, err error) (PostRuntimeExecutionActivationLaunchReceipt, error) {
+	receipt.State = state
+	return receipt, err
+}
+
+func (launcher *KubernetesPostRuntimeExecutionActivationLauncher) request(ctx context.Context, method, path string, body []byte) ([]byte, int, error) {
+	endpoint := *launcher.endpoint
+	endpoint.Path = path
+	request, err := http.NewRequestWithContext(ctx, method, endpoint.String(), bytes.NewReader(body))
+	if err != nil {
+		return nil, 0, errors.New("construct bounded post-runtime activation request")
+	}
+	request.Header.Set("Accept", "application/json")
+	request.Header.Set("Authorization", "Bearer "+launcher.token)
+	if body != nil {
+		request.Header.Set("Content-Type", "application/json")
+	}
+	response, err := launcher.client.Do(request)
+	if err != nil {
+		return nil, 0, fmt.Errorf("bounded post-runtime activation %s request failed", method)
+	}
+	defer response.Body.Close()
+	raw, readErr := io.ReadAll(io.LimitReader(response.Body, maximumStageInstallationResponseBytes+1))
+	if readErr != nil || len(raw) > maximumStageInstallationResponseBytes {
+		return nil, 0, errors.New("bounded post-runtime activation response exceeds accepted size")
+	}
+	if len(raw) > 0 {
+		mediaType, _, err := mime.ParseMediaType(response.Header.Get("Content-Type"))
+		if err != nil || mediaType != "application/json" {
+			return nil, 0, errors.New("bounded post-runtime activation response is not JSON")
+		}
+	}
+	return raw, response.StatusCode, nil
+}
+
+func postRuntimeActivationStatusError(method string, status int) error {
+	return fmt.Errorf("bounded post-runtime activation %s returned HTTP %d", method, status)
+}

--- a/internal/runner/post_runtime_activation_launcher_test.go
+++ b/internal/runner/post_runtime_activation_launcher_test.go
@@ -1,0 +1,179 @@
+package runner
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+func TestPlanPostRuntimeExecutionActivationInstallationBindsExactOrder(t *testing.T) {
+	packaged, cleanup := postRuntimeActivationLauncherPackage(t)
+	defer cleanup()
+	plan, err := PlanPostRuntimeExecutionActivationInstallation(packaged)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plan.Format != PostRuntimeExecutionActivationInstallationPlanFormat || plan.State != "VERIFIED" || plan.RunID != "ok147-post-runtime-01" ||
+		plan.Authority != "ok-mgmt" || plan.MutationAllowed || len(plan.Creates) != 3 {
+		t.Fatalf("unexpected post-runtime activation plan: %#v", plan)
+	}
+	for index, kind := range []string{"Secret", "NetworkPolicy", "Job"} {
+		create := plan.Creates[index]
+		if create.Order != index+1 || create.Kind != kind || create.Namespace != submissionStageInputNamespace ||
+			create.PreflightMethod != http.MethodGet || create.CreateMethod != http.MethodPost ||
+			create.ObjectPath == "" || create.CollectionPath == "" || !stageReceiptPrefixDigestPattern.MatchString(create.ObjectDigest) {
+			t.Fatalf("create %d differs: %#v", index, create)
+		}
+	}
+	public, err := json.Marshal(plan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range []string{"bearer", "token", "certificate", "/private/"} {
+		if strings.Contains(strings.ToLower(string(public)), forbidden) {
+			t.Fatalf("installation plan exposed %q", forbidden)
+		}
+	}
+}
+
+func TestPlanPostRuntimeExecutionActivationInstallationFailsClosed(t *testing.T) {
+	packaged, cleanup := postRuntimeActivationLauncherPackage(t)
+	defer cleanup()
+	for name, mutate := range map[string]func(*VerifiedPostRuntimeExecutionActivationPackage){
+		"raw":       func(value *VerifiedPostRuntimeExecutionActivationPackage) { value.raw[0] ^= 0xff },
+		"authority": func(value *VerifiedPostRuntimeExecutionActivationPackage) { value.managementAuthority = "ok-infra" },
+		"inventory": func(value *VerifiedPostRuntimeExecutionActivationPackage) { value.receipt.ObjectKinds[0] = "ConfigMap" },
+	} {
+		t.Run(name, func(t *testing.T) {
+			candidate := packaged
+			candidate.raw = append([]byte(nil), packaged.raw...)
+			candidate.receipt.ObjectKinds = append([]string(nil), packaged.receipt.ObjectKinds...)
+			mutate(&candidate)
+			if _, err := PlanPostRuntimeExecutionActivationInstallation(candidate); err == nil {
+				t.Fatal("changed activation package produced an installation plan")
+			}
+		})
+	}
+}
+
+func TestPostRuntimeExecutionActivationLauncherPreflightsThenCreates(t *testing.T) {
+	packaged, cleanup := postRuntimeActivationLauncherPackage(t)
+	defer cleanup()
+	api := newSubmissionStageInstallerAPI(t)
+	launcher := newPostRuntimeActivationLauncher(t, packaged, api.client())
+	receipt, err := launcher.Launch(context.Background())
+	if err != nil || receipt.State != "ACTIVATED" || receipt.MutationState != "ATTEMPTED" || len(receipt.Results) != 3 {
+		t.Fatalf("post-runtime activation failed: %#v %v", receipt, err)
+	}
+	plan, _ := PlanPostRuntimeExecutionActivationInstallation(packaged)
+	if receipt.Format != PostRuntimeExecutionActivationLaunchReceiptFormat || receipt.PackageDigest != plan.PackageDigest ||
+		receipt.PlanDigest != plan.PlanDigest || receipt.RunID != plan.RunID || receipt.Authority != "ok-mgmt" {
+		t.Fatalf("activation receipt identity differs: %#v", receipt)
+	}
+	if len(api.requests) != 6 {
+		t.Fatalf("requests=%d, want three GETs then three POSTs: %#v", len(api.requests), api.requests)
+	}
+	for index, create := range plan.Creates {
+		preflight, submission := api.requests[index], api.requests[index+3]
+		if preflight.method != http.MethodGet || preflight.path != create.ObjectPath || len(preflight.body) != 0 {
+			t.Fatalf("preflight %d differs: %#v", index, preflight)
+		}
+		if submission.method != http.MethodPost || submission.path != create.CollectionPath || digest.SHA256(submission.body) != create.ObjectDigest {
+			t.Fatalf("submission %d differs: %#v", index, submission)
+		}
+	}
+	public, err := json.Marshal(receipt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(public, []byte("short-lived-installer-token")) || bytes.Contains(public, []byte("created-stage-uid")) {
+		t.Fatal("activation receipt disclosed credential or raw runtime identity")
+	}
+}
+
+func TestPostRuntimeExecutionActivationLauncherStopsZeroWriteOnExistingObject(t *testing.T) {
+	packaged, cleanup := postRuntimeActivationLauncherPackage(t)
+	defer cleanup()
+	api := newSubmissionStageInstallerAPI(t)
+	plan, _ := PlanPostRuntimeExecutionActivationInstallation(packaged)
+	api.objects[plan.Creates[2].ObjectPath] = map[string]any{"kind": "Job"}
+	launcher := newPostRuntimeActivationLauncher(t, packaged, api.client())
+	receipt, err := launcher.Launch(context.Background())
+	if err == nil || receipt.State != "STOPPED_ZERO_WRITE" || receipt.MutationState != "NOT_ATTEMPTED" || api.posts != 0 || len(api.requests) != 3 {
+		t.Fatalf("existing activation object did not stop zero-write: %#v requests=%d posts=%d err=%v", receipt, len(api.requests), api.posts, err)
+	}
+}
+
+func TestPostRuntimeExecutionActivationLauncherPreservesPartialStateAndCannotRetry(t *testing.T) {
+	packaged, cleanup := postRuntimeActivationLauncherPackage(t)
+	defer cleanup()
+	api := newSubmissionStageInstallerAPI(t)
+	api.failPost = 2
+	launcher := newPostRuntimeActivationLauncher(t, packaged, api.client())
+	receipt, err := launcher.Launch(context.Background())
+	if err == nil || receipt.State != "STOPPED_PARTIAL_OR_UNKNOWN" || receipt.MutationState != "ATTEMPTED" ||
+		len(receipt.Results) != 1 || receipt.Results[0].Kind != "Secret" {
+		t.Fatalf("partial activation prefix differs: %#v %v", receipt, err)
+	}
+	requestCount := len(api.requests)
+	retry, retryErr := launcher.Launch(context.Background())
+	if retryErr == nil || retry.State != "STOPPED_ZERO_WRITE" || retry.MutationState != "NOT_ATTEMPTED" || len(api.requests) != requestCount {
+		t.Fatalf("single-use activation boundary failed: %#v requests=%d/%d err=%v", retry, len(api.requests), requestCount, retryErr)
+	}
+}
+
+func TestPostRuntimeExecutionActivationLauncherRejectsForeignAuthorityAndUnboundedEndpoint(t *testing.T) {
+	packaged, cleanup := postRuntimeActivationLauncherPackage(t)
+	defer cleanup()
+	api := newSubmissionStageInstallerAPI(t)
+	for _, test := range []submissionStageInstallerClientConfig{
+		{Endpoint: "http://127.0.0.1:12345", BearerToken: "short-lived-installer-token", AuthorityIdentity: "ok-infra", Client: api.client()},
+		{Endpoint: "https://ok-mgmt.example:6443", BearerToken: "short-lived-installer-token", AuthorityIdentity: "ok-mgmt", Client: api.client()},
+		{Endpoint: "https://192.0.2.10:6443/path", BearerToken: "short-lived-installer-token", AuthorityIdentity: "ok-mgmt", Client: api.client()},
+	} {
+		if _, err := newKubernetesPostRuntimeExecutionActivationLauncher(test, packaged); err == nil {
+			t.Fatalf("unsafe activation launcher config accepted: %#v", test)
+		}
+	}
+}
+
+func TestOpenPostRuntimeExecutionActivationLauncherRequiresExactPackageDigestBeforeCredentialRead(t *testing.T) {
+	packaged, cleanup := postRuntimeActivationLauncherPackage(t)
+	defer cleanup()
+	if _, err := OpenKubernetesPostRuntimeExecutionActivationLauncher(PostRuntimeExecutionActivationLauncherConfig{
+		Authority: KubernetesAuthorityConfig{
+			Endpoint: "https://192.0.2.10:6443", AuthorityIdentity: "ok-mgmt",
+			TokenFile: "/private/tmp/must-not-open-token", CAFile: "/private/tmp/must-not-open-ca", CABundleDigest: bundleSHA("a"),
+		},
+		ExpectedPackageDigest: bundleSHA("f"),
+	}, packaged); err == nil || !strings.Contains(err.Error(), "expected identity") {
+		t.Fatalf("foreign activation package identity reached credential opening: %v", err)
+	}
+}
+
+func postRuntimeActivationLauncherPackage(t *testing.T) (VerifiedPostRuntimeExecutionActivationPackage, func()) {
+	t.Helper()
+	config, cleanup := postRuntimeActivationPackageFixture(t)
+	packaged, err := BuildPostRuntimeExecutionActivationPackage(config)
+	if err != nil {
+		cleanup()
+		t.Fatal(err)
+	}
+	return packaged, cleanup
+}
+
+func newPostRuntimeActivationLauncher(t *testing.T, packaged VerifiedPostRuntimeExecutionActivationPackage, client *http.Client) *KubernetesPostRuntimeExecutionActivationLauncher {
+	t.Helper()
+	launcher, err := newKubernetesPostRuntimeExecutionActivationLauncher(submissionStageInstallerClientConfig{
+		Endpoint: "http://127.0.0.1:12345", BearerToken: "short-lived-installer-token", AuthorityIdentity: "ok-mgmt", Client: client,
+	}, packaged)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return launcher
+}

--- a/internal/runner/post_runtime_activation_package.go
+++ b/internal/runner/post_runtime_activation_package.go
@@ -53,15 +53,19 @@ type PostRuntimeExecutionActivationPackageReceipt struct {
 	ManifestDigest       string   `json:"manifestDigest"`
 	JobTemplateDigest    string   `json:"jobTemplateDigest"`
 	JobEnvelopeDigest    string   `json:"jobEnvelopeDigest"`
+	ManagementAuthority  string   `json:"managementAuthority"`
+	PlanDigest           string   `json:"planDigest"`
+	TargetIdentityDigest string   `json:"targetIdentityDigest"`
 	PrivateFileCount     int      `json:"privateFileCount"`
 	ObjectKinds          []string `json:"objectKinds"`
 	MutationAllowed      bool     `json:"mutationAllowed"`
 }
 
 type VerifiedPostRuntimeExecutionActivationPackage struct {
-	raw      []byte
-	receipt  PostRuntimeExecutionActivationPackageReceipt
-	verified bool
+	raw                 []byte
+	receipt             PostRuntimeExecutionActivationPackageReceipt
+	managementAuthority string
+	verified            bool
 }
 
 type postRuntimeActivationSecret struct {
@@ -172,9 +176,13 @@ func BuildPostRuntimeExecutionActivationPackage(config PostRuntimeExecutionActiv
 		ActivationSecret: config.ActivationSecret, SecretObjectDigest: digest.SHA256(secretRaw), BundleDigest: bundleDigest,
 		SourceManifestDigest: sourceReceipt.ManifestDigest,
 		ManifestDigest:       manifestDigest, JobTemplateDigest: config.JobTemplateDigest, JobEnvelopeDigest: digest.SHA256(jobRaw),
-		PrivateFileCount: len(postRuntimeExecutionBundleFiles), ObjectKinds: []string{"Secret", "NetworkPolicy", "Job"}, MutationAllowed: false,
+		ManagementAuthority: document.Plan.Expected.ManagementAuthority, PlanDigest: sourceReceipt.PlanDigest,
+		TargetIdentityDigest: sourceReceipt.TargetIdentityDigest,
+		PrivateFileCount:     len(postRuntimeExecutionBundleFiles), ObjectKinds: []string{"Secret", "NetworkPolicy", "Job"}, MutationAllowed: false,
 	}
-	return VerifiedPostRuntimeExecutionActivationPackage{raw: packageRaw, receipt: receipt, verified: true}, nil
+	return VerifiedPostRuntimeExecutionActivationPackage{
+		raw: packageRaw, receipt: receipt, managementAuthority: document.Plan.Expected.ManagementAuthority, verified: true,
+	}, nil
 }
 
 // PrivateBytes returns the credential-bearing installation package. Callers
@@ -201,6 +209,8 @@ func verifyPostRuntimeExecutionActivationPackage(packaged VerifiedPostRuntimeExe
 		!stageReceiptPrefixDigestPattern.MatchString(packaged.receipt.BundleDigest) || !stageReceiptPrefixDigestPattern.MatchString(packaged.receipt.ManifestDigest) ||
 		!stageReceiptPrefixDigestPattern.MatchString(packaged.receipt.SourceManifestDigest) ||
 		!stageReceiptPrefixDigestPattern.MatchString(packaged.receipt.SecretObjectDigest) || !stageReceiptPrefixDigestPattern.MatchString(packaged.receipt.JobEnvelopeDigest) ||
+		!stageReceiptPrefixDigestPattern.MatchString(packaged.receipt.PlanDigest) || !stageReceiptPrefixDigestPattern.MatchString(packaged.receipt.TargetIdentityDigest) ||
+		packaged.receipt.ManagementAuthority == "" || packaged.receipt.ManagementAuthority != packaged.managementAuthority ||
 		packaged.receipt.PrivateFileCount != len(postRuntimeExecutionBundleFiles) {
 		return errors.New("post-runtime activation package identity is incomplete")
 	}

--- a/internal/runner/post_runtime_activation_package_test.go
+++ b/internal/runner/post_runtime_activation_package_test.go
@@ -24,7 +24,9 @@ func TestBuildPostRuntimeExecutionActivationPackageBindsPrivateSecretAndJob(t *t
 		t.Fatal(err)
 	}
 	if receipt.Format != PostRuntimeExecutionActivationPackageFormat || receipt.State != "VERIFIED" || receipt.ActivationSecret != config.ActivationSecret ||
-		receipt.PrivateFileCount != len(postRuntimeExecutionBundleFiles) || receipt.MutationAllowed || len(receipt.ObjectKinds) != 3 {
+		receipt.ManagementAuthority != "ok-mgmt" || !stageReceiptPrefixDigestPattern.MatchString(receipt.PlanDigest) ||
+		!stageReceiptPrefixDigestPattern.MatchString(receipt.TargetIdentityDigest) || receipt.PrivateFileCount != len(postRuntimeExecutionBundleFiles) ||
+		receipt.MutationAllowed || len(receipt.ObjectKinds) != 3 {
 		t.Fatalf("unexpected activation package receipt: %#v", receipt)
 	}
 	public, err := json.Marshal(receipt)


### PR DESCRIPTION
## Summary
- bind the private post-runtime package to management authority, plan and target identities
- derive an exact Secret -> NetworkPolicy -> Job create-only plan
- add a single-use launcher with complete absence preflight and STOP-PRESERVE-NO-RETRY partial-state semantics

## Safety boundary
- expected package digest is checked before credential files are opened
- no update, patch, apply, delete, list, watch, retry, rollback or cleanup path
- receipts retain only digested runtime identities; private package and credentials remain excluded
- no live infrastructure mutation in this PR

## Verification
- go test ./...
- go vet ./...
- go test -race ./internal/runner ./cmd/ok