### PR TITLE
docs(runner): define phase-one operating boundary (OK-147)

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -2840,8 +2840,10 @@ and a single-use CLI launcher. This is not yet the OK-147 Definition of Done:
 - no ephemeral `ok-mgmt` Job has executed the complete current implementation;
 - the disposable-cluster create conformance and executor-termination failure
   conformance have not yet been repeated through this MVP;
-- the final operator runbook, security boundary summary and ADR-030 amendment
-  proposal remain to be reviewed.
+- the final [operator runbook](ok147-operator-runbook.md),
+  [security boundary summary](ok147-security-boundary.md) and
+  [ADR-030 amendment proposal](ok147-adr-030-amendment-proposal.md) are defined
+  and remain to be reviewed with the live evidence.
 
 The remaining work is execution evidence and operational closure, not another
 runner component. A live checkpoint must publish the current image, construct

--- a/docs/ok147-adr-030-amendment-proposal.md
+++ b/docs/ok147-adr-030-amendment-proposal.md
@@ -1,0 +1,104 @@
+# OK-147 evidence-based ADR-030 amendment proposal
+
+This document proposes review changes to the still-`Proposed` ADR-030. It does
+not edit or accept that ADR. The proposal is based on the OK-141 execution
+evidence and the OK-147 bounded-runner implementation.
+
+## Evidence conclusion
+
+The spike has not proven a need for a broad OpenKubes-owned lifecycle
+reconciler. The smallest supported model is:
+
+```text
+Contracts / Profiles
+        -> external policy and authorization
+        -> bounded, replaceable Contract Executor
+        -> CAPI/CAPK and existing controllers
+        -> selected Enablement controller
+        -> selected GitOps controller
+        -> generation- and revision-aware bounded evaluator
+        -> durable evidence
+```
+
+The executor may run locally or as an ephemeral Job. Its termination does not
+stop controller reconciliation, and its exit status is not readiness.
+
+## Proposed changes before ADR acceptance
+
+### 1. Specify an aggregate-result invariant, not a mandatory component
+
+Replace the mandatory continuously running **OpenKubes Status Aggregator** with
+a requirement for one deterministic, profile-aware aggregate result. A bounded
+read-only evaluator is sufficient while the known consumers are CLI status,
+wait, execution completion, evidence collection and troubleshooting.
+
+If a future real consumer requires continuously updated Kubernetes Watch,
+transition history or a durable normalized status API, a small single-writer
+status adapter may be introduced through separate evidence and review. It must
+only observe, correlate, normalize and publish; it must not repair source
+resources.
+
+For any persisted normalized status surface, the ADR's single-writer rule
+continues to apply. Without such a surface there is no aggregate-status writer,
+but every source Condition still has exactly one authoritative owner.
+
+### 2. Describe Enablement as a responsibility, not a preselected controller
+
+Replace wording that requires a new **Cluster Enablement Controller** with a
+requirement that one selected existing mechanism own E convergence and expose
+current, revision-correlated evidence. The spike's CAAPH/Helm path demonstrates
+that existing controllers can own desired package convergence while Cilium and
+Kubernetes provide runtime NetworkReady observations.
+
+OpenKubes deterministically constructs E and evaluates its proof. It does not
+need to duplicate Helm/CNI correction in a new package reconciler.
+
+### 3. Make the bounded executor the implementation-neutral requirement
+
+ADR-030 should require the executor properties rather than one deployment
+shape: typed operations, external authorization, single-use consumption,
+least privilege, durable evidence, stop-on-partial behavior and no independent
+lifecycle truth. A CLI, CI process or ephemeral Job may implement those
+properties. A continuously running OpenKubes operator is not required by the
+current evidence.
+
+### 4. Align Condition naming with authoritative sources
+
+Use current CAPI `ControlPlaneAvailable` semantics rather than freezing the
+historical `ControlPlaneReady` name. Normalized results must preserve source
+reason/message detail and reject stale, missing, conflicting or wrong-revision
+evidence. `Ready` remains derived and must never be asserted independently.
+
+### 5. Preserve ownership and recovery boundaries
+
+The amendment must retain these constraints:
+
+- CAPI/CAPK own infrastructure and cluster lifecycle convergence;
+- the selected Enablement mechanism owns E convergence;
+- GitOps owns P convergence, drift detection, retry, prune and self-heal;
+- the evaluator never remediates those sources;
+- at most one management plane holds lifecycle write authority; and
+- ADR-031 separately owns fencing, restore, promotion and orphan recovery.
+
+Any proposal in which OpenKubes repairs CAPI, Helm/CNI or GitOps state in
+parallel with its existing owner is a duplicated-writer architecture and must
+be rejected.
+
+## Acceptance impact
+
+ADR-030 must not move to `Accepted` merely because the bounded runner compiles
+or one happy path succeeds. Acceptance still requires reviewed evidence for:
+
+- exact R/E/P and authority correlation through the complete forcing workflow;
+- current-generation lifecycle, NetworkReady and PlatformReady results;
+- executor termination/restart without loss of convergence or evidence;
+- stale, missing, wrong-revision and conflicting-authority negative controls;
+- controlled deletion with independently retained terminal evidence;
+- security/RBAC and credential-lifetime conformance; and
+- the management-plane-outage scenario, while ADR-031's fencing proof remains
+  separate.
+
+The status-aggregator and dedicated-enablement-controller acceptance clauses
+should therefore become evidence invariants rather than mandatory component
+checks. This keeps ADR-030 about contracts and ownership while allowing the
+implementation spike to determine the minimum required components.

--- a/docs/ok147-operator-runbook.md
+++ b/docs/ok147-operator-runbook.md
@@ -1,0 +1,118 @@
+# OK-147 bounded runner operator runbook
+
+This runbook describes the first live execution of the bounded OK-147 runner.
+It is an operational checklist, not standing authorization. Every live run must
+bind one reviewed source revision, one immutable runner image, one activation
+package digest and one separately approved execution window.
+
+## Scope
+
+The runner performs one already-authorized `CreateCluster` transition and the
+bounded post-runtime suffix. It is neither a long-running operator nor a
+lifecycle source of truth. CAPI/CAPK, the selected Enablement mechanism and
+GitOps remain the owners of convergence.
+
+The live activation installs exactly three objects on `ok-mgmt`, in this order:
+
+```text
+immutable activation Secret
+        -> deny-by-default NetworkPolicy
+        -> non-retrying Job
+```
+
+The launcher first reads all three exact names. Any existing object or failed
+read stops before the first write. Once a write has been attempted, an error or
+uncertain response is preserved as `STOPPED_PARTIAL_OR_UNKNOWN`; do not retry,
+update, patch, apply, delete or clean up under the same authorization.
+
+## Required inputs
+
+Before preparation, record and independently review:
+
+- the exact source commit and published runner image digest;
+- the image publication receipt, provenance attestation and pullback result;
+- the private activation manifest and all seven predecessor receipts;
+- the exact R, E, P, execution-fixture, Plan and target-identity digests;
+- one current signed authorization for every externally authorized stage;
+- short-lived, isolated credentials for the ledger, management, workload,
+  GitOps and authorization endpoints;
+- the four exact `/32` egress destinations and ports;
+- the activation namespace, Secret, NetworkPolicy and Job names;
+- independent observers, stop authority, recovery authority and evidence
+  destination; and
+- the tested recovery procedure for the DEV environment.
+
+Secrets, tokens, Kubeconfigs, private keys, endpoints and private local paths
+must never be copied into public receipts, logs, commits or pull requests.
+
+## Preflight
+
+1. Verify that the source commit, image digest, attestation and publication
+   receipt all describe the same build.
+2. Re-run the complete test suite and the offline activation-package tests.
+3. Verify every private input is a regular `0600` file below an existing private
+   directory and that every credential is current and narrowly scoped.
+4. Run `post-runtime launch prepare` without installer credentials. Retain only
+   its redaction-safe package receipt and exact three-object installation plan.
+5. Compare the prepared package digest with the independently reviewed digest.
+6. Verify by exact-name reads that the activation Secret, NetworkPolicy and Job
+   are all absent. A missing observer or ambiguous result is a failed preflight.
+7. Confirm that no unrelated lifecycle change or failure injection is active.
+
+Preparation must not contact a cluster or consume the execution authorization.
+
+## Single-use launch
+
+Only after the preflight and explicit run authorization may the operator invoke
+`post-runtime launch execute --execute` with:
+
+- the exact expected package digest copied from the reviewed preparation;
+- the bound `ok-mgmt` installer endpoint and CA digest;
+- short-lived installer token and CA files; and
+- the same immutable private activation inputs used during preparation.
+
+The command rebuilds the package, verifies its identity before opening the
+installer credential, repeats the complete absence preflight and performs at
+most the three ordered creates. Preserve its public receipt even when it stops.
+
+## Observation and completion
+
+Observe only the exact activation Job and the already-bound lifecycle,
+Enablement and GitOps sources. Completion is not the Job exit code. A successful
+outcome requires:
+
+- the immutable ledger claim and current operation receipts;
+- CAPI/provider observations correlated with R and current generations;
+- Enablement convergence correlated with E and current NetworkReady evidence;
+- GitOps desired/applied revision and capability evidence correlated with P;
+- the bounded aggregate evaluator result; and
+- one independently verifiable, redacted evidence bundle digest.
+
+`Ready=True` is valid only when every profile-required source is current and
+correlated. Missing, stale, conflicting or historical evidence yields
+`Unknown` or `False` and never triggers repair by the evaluator.
+
+## Stop conditions
+
+Stop immediately and preserve state when any of the following occurs:
+
+- an expected-absent object already exists;
+- a digest, identity, authority, generation or revision differs;
+- any create has an error or uncertain outcome;
+- credentials, endpoints or private material appear in public output;
+- an independent observer becomes unavailable;
+- a second failure domain appears; or
+- recovery would require force deletion, finalizer manipulation or an
+  unreviewed mutation.
+
+No automatic retry, rollback or cleanup is part of this run. Cleanup, deletion,
+failure injection and executor-termination conformance require their own
+preflight, digest and authorization.
+
+## Closure record
+
+The final redacted record must bind the source commit, image digest, activation
+package digest, Plan, R/E/P, target identity, grants, stage receipts, source
+observations, aggregate result and evidence-bundle digest. It must also state
+whether the run completed, stopped before mutation or preserved partial/unknown
+state.

--- a/docs/ok147-security-boundary.md
+++ b/docs/ok147-security-boundary.md
@@ -1,0 +1,103 @@
+# OK-147 bounded runner security boundary
+
+## Trust model
+
+The OK-147 runner is a short-lived, bounded executor. It verifies and consumes
+externally issued decisions; it does not issue its own authorization, render a
+second Contract-to-CAPI projection or become a lifecycle reconciler.
+
+```text
+contract and authoritative projection
+        -> signed, request-bound grants
+        -> single-use runner
+        -> existing reconcilers
+        -> bounded evaluator
+        -> durable redacted evidence
+```
+
+Authority remains split:
+
+- `ok-infra` owns only provider prerequisites;
+- `ok-mgmt` is the sole CAPI lifecycle writer and hosts the durable ledger and
+  ephemeral runner Job;
+- the selected Enablement controller owns Helm/CNI desired-state convergence;
+- Argo CD on `ok-shared` owns Platform convergence for external workload
+  clusters only; and
+- source controllers retain ownership of their own status and Conditions.
+
+The runner may observe, correlate and report those sources. It may not repair
+them outside the exact authorized stage operation.
+
+## Authorization and replay protection
+
+Every mutating stage uses a signed grant bound to its exact operation, request,
+R, projection, audience, validity window and single-use declaration. The
+durable Kubernetes ledger creates an immutable claim before mutation. An
+existing claim, conflicting receipt or indeterminate prior attempt fails
+closed; process replacement does not make a consumed grant reusable.
+
+The runner never accepts generic commands, shell fragments, arbitrary Helm
+arguments or unbounded manifests. A dry-run plan, signed decision or package
+receipt alone grants no mutation authority.
+
+## Credential boundary
+
+The activation Secret contains exactly the allowlisted private inputs for one
+run. A tokenless init container verifies their individual hashes and copies
+them from projected symlinks into a memory-backed `0700` workspace as regular
+`0600` files. The executor sees only that workspace.
+
+The Job:
+
+- has no automounted ServiceAccount token;
+- runs as a fixed non-root UID/GID with a read-only root filesystem;
+- drops all Linux capabilities and forbids privilege escalation;
+- has no retry and a fixed active deadline;
+- uses only short-lived or stage-isolated credentials; and
+- has deny-by-default egress with four exact IP/port exceptions.
+
+The immutable activation Secret retains credentials for the lifetime of the
+Job and Secret. Therefore its lifecycle is part of the operational risk: it
+must not be reused, copied to Git or treated as a durable credential store.
+Cleanup requires separate authority.
+
+## Installation boundary
+
+The launcher can only perform exact-name `GET` and collection `POST` operations
+for one immutable Secret, one NetworkPolicy and one Job. All reads finish
+before the first write. It exposes no update, patch, apply, delete, list, watch,
+retry, rollback or cleanup operation.
+
+Kubernetes RBAC cannot prove create-body equality. The launcher therefore
+verifies the complete package digest before opening the installer credential,
+and admission plus response verification constrain the installed objects. A
+failed or uncertain write is a terminal partial/unknown state for that run.
+
+## Evidence boundary
+
+Public receipts contain semantic identities and digests only. They must not
+contain Secrets, tokens, Kubeconfigs, private keys, certificate payloads,
+private endpoints, private filesystem paths, raw Kubernetes objects, UIDs or
+resourceVersions. Raw evidence stays in the explicitly approved private
+location and is never committed.
+
+An operation is complete only when revision-correlated source evidence and the
+aggregate evaluation have been persisted independently of the executor. Logs
+and process exit status are diagnostic inputs, not the success oracle.
+
+## Explicit non-goals and residual risks
+
+This MVP does not provide:
+
+- a public OpenKubes API;
+- a broad or continuously running OpenKubes lifecycle operator;
+- a persistent aggregate-status controller;
+- automatic retry, rollback, cleanup or disaster recovery;
+- transactional execution across Kubernetes authority domains; or
+- protection against total loss of the DEV infrastructure.
+
+The first deployment is intentionally DEV-only. It accepts non-atomic stage
+boundaries, temporary availability loss and rebuild-on-loss, while preserving
+fail-closed identity checks, single-use authorization and public-evidence
+redaction. ADR-031 remains responsible for management-plane fencing and
+disaster recovery.


### PR DESCRIPTION
## Summary
- add the bounded runner operator runbook and fail-closed launch procedure
- document authority, credential, installation, evidence, and residual-risk boundaries
- propose evidence-based ADR-030 amendments without changing or accepting the ADR
- link the reviewed closure artifacts from the MVP boundary document

## Scope
Documentation only. No ADR mutation, cluster contact, infrastructure mutation, retry, cleanup, or failure injection.

## Review question
Do these artifacts accurately constrain the first live runner activation while replacing preselected components in ADR-030 with evidence invariants?

## Verification
- git diff --check