### PR TITLE
fix(runner): defer runtime target identity binding (OK-147)

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -2671,6 +2671,16 @@ target identity and the selected project boundary. The registration launcher
 uses exact-name preflights and create-only submission; unexpected existing or
 partial state stops without retry.
 
+The staged plan binds pre-runtime templates for target registration and the
+three Platform Applications. Those templates must carry the literal
+`RUNTIME-TARGET-IDENTITY-DIGEST-REQUIRED` placeholder; a prefilled digest is
+rejected. After lifecycle submission, the loader takes the target digest only
+from the verified `cluster-lifecycle` receipt, substitutes that one carrier in
+memory and records the resulting concrete object digests. This avoids a
+causality cycle in which the plan would otherwise have to hash the
+Kubernetes-assigned CAPI Cluster UID before Stage 1. It also prevents a caller
+from predicting or selecting a different runtime target identity.
+
 Platform application submission verifies exactly three externally rendered
 Applications and their immutable profile membership. Argo CD remains the sole
 owner of Platform convergence. The runner neither renders an alternative

--- a/internal/runner/platform_applications_stage_bundle_test.go
+++ b/internal/runner/platform_applications_stage_bundle_test.go
@@ -207,7 +207,7 @@ func runnerPlatformApplications(t *testing.T, expected stageplan.Expected) ([]by
 	paths := []string{"profiles/minimal-observability/alerting", "profiles/minimal-observability/core", "profiles/minimal-observability/dashboards"}
 	annotations := map[string]any{
 		"openkubes.io/intent-revision": expected.IntentRevision, "openkubes.io/platform-revision": expected.PlatformRevision,
-		"openkubes.io/execution-fixture": expected.ExecutionFixture, "openkubes.io/target-identity-digest": digest.SHA256([]byte(targetAccessRuntimeUID)),
+		"openkubes.io/execution-fixture": expected.ExecutionFixture, "openkubes.io/target-identity-digest": submission.RuntimeTargetIdentityDigestPlaceholder,
 	}
 	documents := make([][]byte, 0, len(names))
 	expectations := make([]observation.PlatformApplicationExpectation, 0, len(names))

--- a/internal/runner/target_registration_stage_bundle_test.go
+++ b/internal/runner/target_registration_stage_bundle_test.go
@@ -157,7 +157,7 @@ func targetRegistrationCredentialReceipt(at time.Time, policy targetCredentialPo
 func runnerTargetRegistrationYAML(expected stageplan.Expected) []byte {
 	annotations := map[string]any{
 		"openkubes.io/intent-revision": expected.IntentRevision, "openkubes.io/platform-revision": expected.PlatformRevision,
-		"openkubes.io/execution-fixture": expected.ExecutionFixture, "openkubes.io/target-identity-digest": digest.SHA256([]byte(targetAccessRuntimeUID)),
+		"openkubes.io/execution-fixture": expected.ExecutionFixture, "openkubes.io/target-identity-digest": submission.RuntimeTargetIdentityDigestPlaceholder,
 	}
 	project := map[string]any{
 		"apiVersion": "argoproj.io/v1alpha1", "kind": "AppProject",

--- a/internal/submission/platform_applications.go
+++ b/internal/submission/platform_applications.go
@@ -194,7 +194,7 @@ func validatePlatformApplication(value map[string]any, expected PlatformApplicat
 	annotations, ok := metadata["annotations"].(map[string]any)
 	wantAnnotations := map[string]string{
 		"openkubes.io/intent-revision": expected.IntentRevision, "openkubes.io/platform-revision": expected.PlatformRevision,
-		"openkubes.io/execution-fixture": expected.ExecutionFixture, "openkubes.io/target-identity-digest": expected.TargetIdentityDigest,
+		"openkubes.io/execution-fixture": expected.ExecutionFixture, "openkubes.io/target-identity-digest": RuntimeTargetIdentityDigestPlaceholder,
 	}
 	if !ok || len(annotations) != len(wantAnnotations) {
 		return Object{}, "", errors.New("platform Application annotations differ from exact revision carriers")
@@ -204,6 +204,9 @@ func validatePlatformApplication(value map[string]any, expected PlatformApplicat
 			return Object{}, "", errors.New("platform Application revision carrier differs")
 		}
 	}
+	// The plan binds this static template. The concrete CAPI UID digest is
+	// inserted only after the lifecycle receipt has established it.
+	annotations["openkubes.io/target-identity-digest"] = expected.TargetIdentityDigest
 	spec, ok := value["spec"].(map[string]any)
 	if !ok || text(spec["project"]) != expected.ProjectName {
 		return Object{}, "", errors.New("platform Application project differs")

--- a/internal/submission/platform_applications_test.go
+++ b/internal/submission/platform_applications_test.go
@@ -33,6 +33,23 @@ func TestLoadPlatformApplicationsBindsExactProfileSet(t *testing.T) {
 	}
 }
 
+func TestPlatformApplicationsTemplateIsIndependentOfRuntimeTargetIdentity(t *testing.T) {
+	fixture := platformApplicationsFixture(t)
+	first, err := LoadPlatformApplications(fixture.path, fixture.expected)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondExpected := fixture.expected
+	secondExpected.TargetIdentityDigest = platformApplicationsSHA("9")
+	second, err := LoadPlatformApplications(fixture.path, secondExpected)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.ArtifactDigest != second.ArtifactDigest || first.Applications[0].Digest == second.Applications[0].Digest {
+		t.Fatal("static platform Applications template did not materialize a distinct runtime target identity")
+	}
+}
+
 func TestPlatformApplicationSpecIdentityIncludesIgnoreDifferences(t *testing.T) {
 	fixture := platformApplicationsFixture(t)
 	spec := fixture.documents[0]["spec"].(map[string]any)
@@ -61,6 +78,9 @@ func TestLoadPlatformApplicationsFailsClosed(t *testing.T) {
 		},
 		"wrong revision carrier": func(f *platformApplicationsTestFixture) {
 			f.documents[0]["metadata"].(map[string]any)["annotations"].(map[string]any)["openkubes.io/platform-revision"] = platformApplicationsSHA("f")
+		},
+		"runtime target digest prefilled": func(f *platformApplicationsTestFixture) {
+			f.documents[0]["metadata"].(map[string]any)["annotations"].(map[string]any)["openkubes.io/target-identity-digest"] = f.expected.TargetIdentityDigest
 		},
 		"unprofiled semantic change": func(f *platformApplicationsTestFixture) {
 			f.documents[0]["spec"].(map[string]any)["syncPolicy"] = map[string]any{"automated": map[string]any{"enabled": true, "prune": false, "selfHeal": true, "allowEmpty": false}}
@@ -116,7 +136,7 @@ func platformApplicationsFixture(t *testing.T) platformApplicationsTestFixture {
 				"name": name, "namespace": "argocd",
 				"annotations": map[string]any{
 					"openkubes.io/intent-revision": intent, "openkubes.io/platform-revision": platform,
-					"openkubes.io/execution-fixture": execution, "openkubes.io/target-identity-digest": target,
+					"openkubes.io/execution-fixture": execution, "openkubes.io/target-identity-digest": RuntimeTargetIdentityDigestPlaceholder,
 				},
 			},
 			"spec": spec,

--- a/internal/submission/target_registration.go
+++ b/internal/submission/target_registration.go
@@ -25,6 +25,11 @@ const (
 	RegistrationExpirationPlaceholder  = "RUNTIME-TOKEN-EXPIRATION-REQUIRED"
 	RegistrationEndpointPlaceholder    = "RUNTIME-HTTPS-ENDPOINT-REQUIRED"
 	RegistrationConfigPlaceholder      = "RUNTIME-IN-MEMORY-MATERIALIZATION-ONLY"
+	// RuntimeTargetIdentityDigestPlaceholder keeps the pre-runtime projection
+	// independent of the CAPI Cluster UID, which Kubernetes assigns only after
+	// the lifecycle stage. The verified lifecycle receipt supplies the concrete
+	// digest before any target-registration object can be submitted.
+	RuntimeTargetIdentityDigestPlaceholder = "RUNTIME-TARGET-IDENTITY-DIGEST-REQUIRED"
 )
 
 type TargetRegistrationExpected struct {
@@ -270,7 +275,7 @@ func validateTargetRegistrationAnnotations(metadata map[string]any, expected Tar
 		"openkubes.io/intent-revision":        expected.IntentRevision,
 		"openkubes.io/platform-revision":      expected.PlatformRevision,
 		"openkubes.io/execution-fixture":      expected.ExecutionFixture,
-		"openkubes.io/target-identity-digest": expected.TargetIdentityDigest,
+		"openkubes.io/target-identity-digest": RuntimeTargetIdentityDigestPlaceholder,
 	}
 	if runtime {
 		want["openkubes.io/capi-cluster-uid"] = RegistrationCAPIUIDPlaceholder
@@ -286,6 +291,10 @@ func validateTargetRegistrationAnnotations(metadata map[string]any, expected Tar
 			return errors.New("registration annotation differs from verified identity")
 		}
 	}
+	// Materialize only the lifecycle-derived identity carrier. All other
+	// runtime Secret fields retain their explicit placeholders until the
+	// credential-bearing in-memory materialization step.
+	annotations["openkubes.io/target-identity-digest"] = expected.TargetIdentityDigest
 	return nil
 }
 

--- a/internal/submission/target_registration_test.go
+++ b/internal/submission/target_registration_test.go
@@ -29,6 +29,24 @@ func TestLoadTargetRegistrationBindsProjectAndCredentialFreeTemplate(t *testing.
 	}
 }
 
+func TestTargetRegistrationTemplateIsIndependentOfRuntimeTargetIdentity(t *testing.T) {
+	raw, firstExpected := targetRegistrationFixture(t)
+	path := writeTargetRegistrationFixture(t, raw)
+	first, err := LoadTargetRegistration(path, firstExpected)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondExpected := firstExpected
+	secondExpected.TargetIdentityDigest = targetRegistrationSHA("e")
+	second, err := LoadTargetRegistration(path, secondExpected)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.ArtifactDigest != second.ArtifactDigest || first.Project.Digest == second.Project.Digest || first.Registration.Digest == second.Registration.Digest {
+		t.Fatal("static target-registration template did not materialize distinct runtime target identities")
+	}
+}
+
 func TestLoadTargetRegistrationFailsClosed(t *testing.T) {
 	t.Run("changed artifact", func(t *testing.T) {
 		raw, expected := targetRegistrationFixture(t)
@@ -56,6 +74,9 @@ func TestLoadTargetRegistrationFailsClosed(t *testing.T) {
 		},
 		"runtime UID prefilled": func(values []map[string]any) {
 			values[1]["metadata"].(map[string]any)["annotations"].(map[string]any)["openkubes.io/capi-cluster-uid"] = "raw-uid"
+		},
+		"runtime target digest prefilled": func(values []map[string]any) {
+			values[0]["metadata"].(map[string]any)["annotations"].(map[string]any)["openkubes.io/target-identity-digest"] = targetRegistrationSHA("d")
 		},
 		"extra object": func(values []map[string]any) {
 			values = append(values, map[string]any{"apiVersion": "v1", "kind": "ConfigMap"})
@@ -90,7 +111,7 @@ func targetRegistrationFixture(t *testing.T) ([]byte, TargetRegistrationExpected
 	}
 	baseAnnotations := map[string]any{
 		"openkubes.io/intent-revision": expected.IntentRevision, "openkubes.io/platform-revision": expected.PlatformRevision,
-		"openkubes.io/execution-fixture": expected.ExecutionFixture, "openkubes.io/target-identity-digest": expected.TargetIdentityDigest,
+		"openkubes.io/execution-fixture": expected.ExecutionFixture, "openkubes.io/target-identity-digest": RuntimeTargetIdentityDigestPlaceholder,
 	}
 	project := map[string]any{
 		"apiVersion": "argoproj.io/v1alpha1", "kind": "AppProject",


### PR DESCRIPTION
## What changed

- bind pre-runtime target-registration and Platform Application templates with an explicit runtime target identity placeholder
- materialize the concrete target identity digest only from the verified `cluster-lifecycle` receipt
- reject artifacts that prefill a runtime target digest
- document the pre-runtime/runtime causality boundary

## Root cause

The staged plan must be immutable before Stage 1, while the CAPI Cluster UID is assigned only during Stage 2. Target-registration and Platform Application artifacts previously embedded `SHA-256(CAPI Cluster UID)` in their plan-bound bytes, creating an impossible circular dependency that unit tests hid by supplying a synthetic UID in advance.

## Impact

The full twelve-stage plan can now bind static templates before execution without weakening the `capi-cluster-uid/v1` authority model. Concrete Argo objects still carry the verified runtime target digest before submission.

## Validation

- `go test -ldflags=-linkmode=external ./...`
- explicit positive tests: one static artifact materializes distinct runtime target identities
- explicit negative tests: prefilled runtime target identities fail closed
- `git diff --check`

No infrastructure mutation was performed. A new runner image and fresh Happy Run must wait for this fix to merge and publish.