### PR TITLE
OK-147: defer Stage 8 target identity binding

### DIFF
--- a/internal/runner/post_runtime_execution_manifest_test.go
+++ b/internal/runner/post_runtime_execution_manifest_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/openkubes/ok-cluster/internal/observation"
 	"github.com/openkubes/ok-cluster/internal/stageplan"
 	"github.com/openkubes/ok-cluster/internal/stagereceipt"
+	"github.com/openkubes/ok-cluster/internal/submission"
 )
 
 func TestOpenPostRuntimeExecutionManifestBindsExactPrivateActivation(t *testing.T) {
@@ -126,7 +127,7 @@ func postRuntimeManifestFixture(t *testing.T) (string, postRuntimeExecutionFacto
 	}
 	targetAccess := runnerTargetAccessYAML()
 	policy := targetCredentialPolicyDocument{
-		Format: TargetCredentialPolicyFormat, TargetIdentityDigest: digest.SHA256([]byte(targetAccessRuntimeUID)),
+		Format: TargetCredentialPolicyFormat, TargetIdentityDigest: submission.RuntimeTargetIdentityDigestPlaceholder,
 		ServiceAccount:     targetCredentialServiceAccount{Namespace: "kube-system", Name: "ok147-argocd-manager"},
 		RequestedAudiences: []string{}, ExpirationSeconds: 10800, CredentialUse: "argocd-target-registration",
 		Retention: "memory-only", NativeRotation: false, ProductionSuitable: false,

--- a/internal/runner/target_credential_stage_bundle.go
+++ b/internal/runner/target_credential_stage_bundle.go
@@ -168,6 +168,11 @@ func LoadTargetCredentialStageBundle(config TargetCredentialStageBundleConfig) (
 	if err := validateTargetCredentialPolicy(policy, lifecycle.TargetClusterUIDDigest, serviceAccount); err != nil {
 		return VerifiedTargetCredentialStageBundle{}, err
 	}
+	// The public pre-runtime policy is digest-bound before Kubernetes assigns
+	// the CAPI Cluster UID. Materialize only that lifecycle-derived identity in
+	// memory after both the policy digest and receipt prefix have been verified.
+	// This keeps Stage 8 deterministic without weakening target correlation.
+	policy.TargetIdentityDigest = lifecycle.TargetClusterUIDDigest
 	directPredecessors, err := cursor.Predecessors()
 	if err != nil {
 		return VerifiedTargetCredentialStageBundle{}, err
@@ -195,8 +200,8 @@ func LoadTargetCredentialStageBundle(config TargetCredentialStageBundleConfig) (
 }
 
 func validateTargetCredentialPolicy(policy targetCredentialPolicyDocument, targetIdentity string, serviceAccount projection.ResourceIdentity) error {
-	if policy.Format != TargetCredentialPolicyFormat || policy.TargetIdentityDigest != targetIdentity {
-		return errors.New("target-credential policy target identity differs from verified workload")
+	if policy.Format != TargetCredentialPolicyFormat || !stageReceiptPrefixDigestPattern.MatchString(targetIdentity) || policy.TargetIdentityDigest != submission.RuntimeTargetIdentityDigestPlaceholder {
+		return errors.New("target-credential policy target identity placeholder or verified workload identity is invalid")
 	}
 	if policy.ServiceAccount.Namespace != serviceAccount.Namespace || policy.ServiceAccount.Name != serviceAccount.Name || serviceAccount.APIVersion != "v1" || serviceAccount.Kind != "ServiceAccount" {
 		return errors.New("target-credential ServiceAccount differs from target-access artifact")

--- a/internal/runner/target_credential_stage_bundle_test.go
+++ b/internal/runner/target_credential_stage_bundle_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/openkubes/ok-cluster/internal/projection"
 	"github.com/openkubes/ok-cluster/internal/stageplan"
 	"github.com/openkubes/ok-cluster/internal/stagereceipt"
+	"github.com/openkubes/ok-cluster/internal/submission"
 )
 
 func TestLoadTargetCredentialStageBundleBindsPrefixPolicyGrantAndAccessIdentity(t *testing.T) {
@@ -25,6 +26,9 @@ func TestLoadTargetCredentialStageBundleBindsPrefixPolicyGrantAndAccessIdentity(
 	receipt, err := bundle.Receipt()
 	if err != nil || receipt.Format != TargetCredentialStageBundleReceiptFormat || receipt.State != "VERIFIED" || receipt.PlanDigest != fixture.plan.PlanDigest || receipt.PolicyDigest != fixture.policyDigest || receipt.TargetAccessArtifactDigest != fixture.accessDigest || receipt.TargetIdentityDigest != digest.SHA256([]byte(targetAccessRuntimeUID)) || receipt.AuthorizationDigest == "" || receipt.ServiceAccountIdentityDigest == "" || receipt.AudienceMode != "server-default" || receipt.ExpirationSeconds != 10800 || receipt.CredentialRetention != "memory-only" || receipt.NativeRotationClaimed || receipt.ProductionSuitableClaimed || receipt.MutationAllowed {
 		t.Fatalf("unexpected target-credential receipt: %#v %v", receipt, err)
+	}
+	if bundle.policy.TargetIdentityDigest != receipt.TargetIdentityDigest {
+		t.Fatal("verified lifecycle target was not materialized into the private in-memory policy")
 	}
 }
 
@@ -64,7 +68,7 @@ func TestValidateTargetCredentialPolicyFailsClosed(t *testing.T) {
 	serviceAccount := projection.ResourceIdentity{APIVersion: "v1", Kind: "ServiceAccount", Namespace: "kube-system", Name: "ok147-argocd-manager"}
 	valid := func() targetCredentialPolicyDocument {
 		return targetCredentialPolicyDocument{
-			Format: TargetCredentialPolicyFormat, TargetIdentityDigest: target,
+			Format: TargetCredentialPolicyFormat, TargetIdentityDigest: submission.RuntimeTargetIdentityDigestPlaceholder,
 			ServiceAccount:     targetCredentialServiceAccount{Namespace: serviceAccount.Namespace, Name: serviceAccount.Name},
 			RequestedAudiences: []string{}, ExpirationSeconds: 10800,
 			CredentialUse: "argocd-target-registration", Retention: "memory-only",
@@ -74,7 +78,7 @@ func TestValidateTargetCredentialPolicyFailsClosed(t *testing.T) {
 		t.Fatal(err)
 	}
 	policyTests := map[string]func(*targetCredentialPolicyDocument){
-		"foreign target":          func(p *targetCredentialPolicyDocument) { p.TargetIdentityDigest = runnerStageSHA("f") },
+		"prefilled target":        func(p *targetCredentialPolicyDocument) { p.TargetIdentityDigest = target },
 		"foreign service account": func(p *targetCredentialPolicyDocument) { p.ServiceAccount.Name = "foreign-manager" },
 		"guessed audience":        func(p *targetCredentialPolicyDocument) { p.RequestedAudiences = []string{"https://guessed.invalid"} },
 		"long lifetime":           func(p *targetCredentialPolicyDocument) { p.ExpirationSeconds++ },
@@ -112,7 +116,7 @@ func targetCredentialBundleFixture(t *testing.T) targetCredentialBundleTestFixtu
 	access := runnerTargetAccessYAML()
 	accessDigest := digest.SHA256(access)
 	policy := targetCredentialPolicyDocument{
-		Format: TargetCredentialPolicyFormat, TargetIdentityDigest: digest.SHA256([]byte(targetAccessRuntimeUID)),
+		Format: TargetCredentialPolicyFormat, TargetIdentityDigest: submission.RuntimeTargetIdentityDigestPlaceholder,
 		ServiceAccount:     targetCredentialServiceAccount{Namespace: "kube-system", Name: "ok147-argocd-manager"},
 		RequestedAudiences: []string{}, ExpirationSeconds: 10800, CredentialUse: "argocd-target-registration",
 		Retention: "memory-only", NativeRotation: false, ProductionSuitable: false,


### PR DESCRIPTION
## Outcome

Closes the remaining pre-runtime circular dependency in Stage 8. The public target-credential policy now carries an explicit runtime target-identity placeholder; after the policy digest and lifecycle receipt prefix are verified, the CAPI-UID-derived digest is materialized only in memory.

## Safety boundary

- concrete prefilled target identities fail closed
- policy bytes and staged input digest remain immutable
- lifecycle-derived target correlation remains mandatory
- no cluster contact or infrastructure mutation

## Verification

`GOCACHE=/private/tmp/ok141-go-cache go test -ldflags=-linkmode=external ./...`

All packages pass.