### PR TITLE
fix(runner): preserve empty first-stage predecessors

### DIFF
--- a/internal/runner/stage_authorization_resolver.go
+++ b/internal/runner/stage_authorization_resolver.go
@@ -233,7 +233,7 @@ func newStageAuthorizationRequest(plan stageplan.Binding, decision stagecursor.D
 		PlatformRevision: plan.PlatformRevision, ExecutionFixture: plan.ExecutionFixture,
 		StageID: stage.ID, StageOrder: stage.Order, StageDigest: stageDigest,
 		Operation: stage.GrantOperation, Authority: stage.Authority,
-		Predecessors: append([]stagecursor.Predecessor(nil), decision.Predecessors...), MaxUses: 1,
+		Predecessors: append([]stagecursor.Predecessor{}, decision.Predecessors...), MaxUses: 1,
 	}
 	request.RequestDigest, err = stageAuthorizationRequestDigest(request)
 	if err != nil {
@@ -243,7 +243,7 @@ func newStageAuthorizationRequest(plan stageplan.Binding, decision stagecursor.D
 }
 
 func cloneStageAuthorizationRequest(request StageAuthorizationRequest) StageAuthorizationRequest {
-	request.Predecessors = append([]stagecursor.Predecessor(nil), request.Predecessors...)
+	request.Predecessors = append([]stagecursor.Predecessor{}, request.Predecessors...)
 	return request
 }
 
@@ -277,7 +277,7 @@ func stageAuthorizationRequestDigest(request StageAuthorizationRequest) (string,
 		EnablementRevision: request.EnablementRevision, PlatformRevision: request.PlatformRevision,
 		ExecutionFixture: request.ExecutionFixture, StageID: request.StageID, StageOrder: request.StageOrder,
 		StageDigest: request.StageDigest, Operation: request.Operation, Authority: request.Authority,
-		Predecessors: append([]stagecursor.Predecessor(nil), request.Predecessors...), MaxUses: request.MaxUses,
+		Predecessors: append([]stagecursor.Predecessor{}, request.Predecessors...), MaxUses: request.MaxUses,
 	}
 	raw, err := json.Marshal(payload)
 	if err != nil {

--- a/internal/runner/stage_authorization_resolver_test.go
+++ b/internal/runner/stage_authorization_resolver_test.go
@@ -66,6 +66,35 @@ func TestStageAuthorizationResolverBindsExactCurrentCursor(t *testing.T) {
 	}
 }
 
+func TestStageAuthorizationResolverPreservesExplicitEmptyFirstStagePredecessors(t *testing.T) {
+	fixture := submissionBundleFixture(t, false, "")
+	resume := StageResumeConfig{
+		PlanPath: fixture.config.PlanPath, PlanExpected: fixture.config.PlanExpected,
+		Receipts: []StageReceiptSource{},
+	}
+	resolved, err := ResolveStageAuthorization(context.Background(), resume, StageAuthorizationResolverFunc(
+		func(_ context.Context, request StageAuthorizationRequest) (StageAuthorizationSource, error) {
+			if request.StageID != "provider-prerequisites" || request.Predecessors == nil || len(request.Predecessors) != 0 {
+				t.Fatalf("first-stage predecessors are not an explicit empty set: %#v", request.Predecessors)
+			}
+			if _, err := request.Bytes(); err != nil {
+				t.Fatalf("first-stage request is not serializable: %v", err)
+			}
+			return StageAuthorizationSource{
+				GrantPath: fixture.config.GrantPath, PublicKeyPath: fixture.config.GrantPublicKeyPath,
+				EvaluationTime: fixture.config.EvaluationTime,
+			}, nil
+		},
+	))
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := resolved.Receipt()
+	if err != nil || receipt.StageID != "provider-prerequisites" {
+		t.Fatalf("unexpected first-stage authorization receipt: %#v %v", receipt, err)
+	}
+}
+
 func TestStageAuthorizationResolverRejectsWrongGrantAndReadOnlyCursor(t *testing.T) {
 	fixture := targetCredentialBundleFixture(t)
 	resume := StageResumeConfig{PlanPath: fixture.config.PlanPath, PlanExpected: fixture.config.PlanExpected, Receipts: fixture.config.Receipts}


### PR DESCRIPTION
## What changed

- preserves an explicit empty predecessor slice while deriving, cloning and digesting a Stage 1 authorization request
- adds a regression test that exercises the complete first-stage authorization resolver path

## Root cause

The first mutating stage has an explicit empty predecessor set. `append(nil, empty...)` converted that set to a nil slice, which serializes as `null`; the request boundary correctly rejects nil predecessors, so the HTTP authority path could never authorize Stage 1.

## Impact

The first Stage 1 authorization request now remains `predecessors: []`, is serializable, digest-stable and resolvable. Later stages with actual predecessors are unchanged.

## Validation

- focused StageAuthorizationResolver tests: PASS
- full `go test -ldflags=-linkmode=external ./...`: PASS
- cross-repository OK-141 Stage-1 candidate vs runner-generated request: exact match