### PR TITLE
fix(runner): resume verified stage prefixes

### DIFF
--- a/internal/runner/submission_stage_installer.go
+++ b/internal/runner/submission_stage_installer.go
@@ -266,7 +266,11 @@ func verifySubmissionStageCreatedObject(raw []byte, expected submissionStageInst
 		return "", "", err
 	}
 	desired, err := decodeCapabilityJSONObject(expected.raw)
-	if err != nil || !capabilitySubset(desired, observed) {
+	if err != nil {
+		return "", "", errors.New("observed object does not contain exact package fields")
+	}
+	normalizeSubmissionStageAPIDefaults(desired, observed)
+	if !capabilitySubset(desired, observed) {
 		return "", "", errors.New("observed object does not contain exact package fields")
 	}
 	metadata, _ := observed["metadata"].(map[string]any)
@@ -276,6 +280,39 @@ func verifySubmissionStageCreatedObject(raw []byte, expected submissionStageInst
 		return "", "", errors.New("created object lacks bounded runtime identity")
 	}
 	return uid, resourceVersion, nil
+}
+
+// normalizeSubmissionStageAPIDefaults restores only API-server omissions that
+// are semantically identical to the verified package. Kubernetes may omit an
+// explicitly empty NetworkPolicy ingress list. With policyTypes containing
+// Ingress, both an omitted ingress field and ingress: [] mean deny all ingress.
+func normalizeSubmissionStageAPIDefaults(desired, observed map[string]any) {
+	if desired["apiVersion"] != "networking.k8s.io/v1" || desired["kind"] != "NetworkPolicy" || observed["apiVersion"] != desired["apiVersion"] || observed["kind"] != desired["kind"] {
+		return
+	}
+	desiredSpec, desiredOK := desired["spec"].(map[string]any)
+	observedSpec, observedOK := observed["spec"].(map[string]any)
+	if !desiredOK || !observedOK {
+		return
+	}
+	desiredIngress, desiredIngressOK := desiredSpec["ingress"].([]any)
+	_, observedIngressExists := observedSpec["ingress"]
+	if desiredIngressOK && len(desiredIngress) == 0 && !observedIngressExists && stringArrayContains(desiredSpec["policyTypes"], "Ingress") && stringArrayContains(observedSpec["policyTypes"], "Ingress") {
+		observedSpec["ingress"] = []any{}
+	}
+}
+
+func stringArrayContains(value any, expected string) bool {
+	items, ok := value.([]any)
+	if !ok {
+		return false
+	}
+	for _, item := range items {
+		if item == expected {
+			return true
+		}
+	}
+	return false
 }
 
 func stageInstallationStatusError(method string, status int) error {

--- a/internal/runner/submission_stage_launcher.go
+++ b/internal/runner/submission_stage_launcher.go
@@ -227,14 +227,23 @@ func (launcher *KubernetesSubmissionStageLauncher) Launch(ctx context.Context) (
 		}
 		return receipt, nil
 	}
-	runtime, runtimeExists := existing[1]
-	if len(existing) != 0 && !(len(existing) == 1 && runtimeExists) {
-		return stopSubmissionStageLaunch(receipt, "STOPPED_ZERO_WRITE", errors.New("stage launch found an exact partial state; global preflight stopped"))
+	prefixLength := 0
+	for order := 1; order <= len(launcher.plan.Preflights); order++ {
+		if _, ok := existing[order]; !ok {
+			break
+		}
+		prefixLength = order
+	}
+	if len(existing) != prefixLength {
+		return stopSubmissionStageLaunch(receipt, "STOPPED_ZERO_WRITE", errors.New("stage launch found a non-prefix partial state; global preflight stopped"))
 	}
 
 	receipt.State = "LAUNCHING"
-	if runtimeExists {
-		receipt.Results = append(receipt.Results, runtime)
+	for order := 1; order <= prefixLength; order++ {
+		receipt.Results = append(receipt.Results, existing[order])
+	}
+	if prefixLength >= 1 {
+		// The exact runtime prefix was already verified above.
 	} else {
 		receipt.MutationState = "ATTEMPTED_UNKNOWN"
 		result, err := launcher.createRuntime(ctx)
@@ -245,6 +254,9 @@ func (launcher *KubernetesSubmissionStageLauncher) Launch(ctx context.Context) (
 		receipt.Results = append(receipt.Results, result)
 	}
 	for index, secret := range launcher.secrets {
+		if index+2 <= prefixLength {
+			continue
+		}
 		receipt.MutationState = "ATTEMPTED_UNKNOWN"
 		result, err := launcher.createSecret(ctx, index+2, secret)
 		if err != nil {
@@ -254,6 +266,9 @@ func (launcher *KubernetesSubmissionStageLauncher) Launch(ctx context.Context) (
 		receipt.Results = append(receipt.Results, result)
 	}
 	for index, object := range launcher.objects {
+		if index+4 <= prefixLength {
+			continue
+		}
 		receipt.MutationState = "ATTEMPTED_UNKNOWN"
 		result, err := launcher.createStageObject(ctx, index+4, object)
 		if err != nil {

--- a/internal/runner/submission_stage_launcher_test.go
+++ b/internal/runner/submission_stage_launcher_test.go
@@ -155,6 +155,51 @@ func TestSubmissionStageLauncherRejectsExactPartialState(t *testing.T) {
 	}
 }
 
+func TestSubmissionStageLauncherResumesExactVerifiedPrefix(t *testing.T) {
+	stage, credentials, runtime, _, _ := submissionStageLaunchFixture(t)
+	api := newSubmissionStageLauncherAPI(t)
+	now := time.Date(2026, 8, 16, 12, 1, 0, 0, time.UTC)
+	first := newSubmissionStageLauncher(t, stage, credentials, runtime, api, now)
+	if receipt, err := first.Launch(context.Background()); err != nil || receipt.State != "LAUNCHED" {
+		t.Fatalf("first launch failed: %#v %v", receipt, err)
+	}
+	delete(api.objects, first.plan.Preflights[5].ObjectPath)
+	api.requests, api.posts = nil, 0
+
+	resume := newSubmissionStageLauncher(t, stage, credentials, runtime, api, now)
+	receipt, err := resume.Launch(context.Background())
+	if err != nil || receipt.State != "LAUNCHED" || receipt.MutationState != "ATTEMPTED" || len(receipt.Results) != 6 || api.posts != 1 || len(api.requests) != 7 {
+		t.Fatalf("exact prefix was not resumed: receipt=%#v requests=%d posts=%d err=%v", receipt, len(api.requests), api.posts, err)
+	}
+	for index, result := range receipt.Results {
+		wantState := "EXISTING_VERIFIED"
+		if index == 5 {
+			wantState = "CREATED"
+		}
+		if result.Order != index+1 || result.ObjectState != wantState {
+			t.Fatalf("result %d differs: %#v", index+1, result)
+		}
+	}
+}
+
+func TestSubmissionStageCreatedNetworkPolicyAcceptsOmittedEmptyIngress(t *testing.T) {
+	stage, credentials, runtime, _, _ := submissionStageLaunchFixture(t)
+	api := newSubmissionStageLauncherAPI(t)
+	launcher := newSubmissionStageLauncher(t, stage, credentials, runtime, api, time.Date(2026, 8, 16, 12, 1, 0, 0, time.UTC))
+	expected := launcher.objects[1]
+	observed := decodeCapabilityJSONForTest(t, expected.raw)
+	metadata := observed["metadata"].(map[string]any)
+	metadata["uid"], metadata["resourceVersion"] = "network-policy-uid", "17"
+	delete(observed["spec"].(map[string]any), "ingress")
+	raw, err := json.Marshal(observed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := verifySubmissionStageCreatedObject(raw, expected); err != nil {
+		t.Fatalf("semantically identical API-defaulted NetworkPolicy was rejected: %v", err)
+	}
+}
+
 func TestSubmissionStageLauncherPreservesPartialPrefixAndStaleCredentialsStopLocally(t *testing.T) {
 	t.Run("partial prefix", func(t *testing.T) {
 		stage, credentials, runtime, _, _ := submissionStageLaunchFixture(t)


### PR DESCRIPTION
## What changed

- normalize the Kubernetes API omission of an explicitly empty `NetworkPolicy.spec.ingress` only when both desired and observed policies explicitly include `Ingress`
- allow a submission-stage launch to resume only from an exact, verified, gap-free object prefix
- keep non-prefix, altered, or otherwise mixed partial state fail-closed

## Why

The OK-141 Stage-1 live run created the first five launch objects, but the runner rejected the API-server response because Kubernetes omitted `spec.ingress: []` from the stored NetworkPolicy. The Job was therefore not created and no provider prerequisite was written to `ok-infra`.

This change makes the verifier API-normalization-aware and permits the missing Job to be created only after all five predecessors are re-read and verified exactly.

## Validation

- `go test -ldflags='-linkmode=external' ./internal/runner`
- `go test -ldflags='-linkmode=external' ./...`
- live read-only evidence confirmed five exact launch objects on `ok-mgmt`, Job absent, and all three provider prerequisites absent on `ok-infra`

No live mutation or cleanup is included in this PR.