### PR TITLE
fix(runner): package complete stage projection

### DIFF
--- a/internal/runner/staged_submission_bundle.go
+++ b/internal/runner/staged_submission_bundle.go
@@ -38,12 +38,13 @@ type SubmissionStageBundleConfig struct {
 // VerifiedSubmissionStageBundle retains only values produced by verification.
 // Its internals are consumed by the shared local/Job runtime below.
 type VerifiedSubmissionStageBundle struct {
-	plan       stageplan.Binding
-	cursor     stagecursor.Cursor
-	grant      authorization.VerifiedStageGrant
-	projection submission.Plan
-	stageID    string
-	verified   bool
+	plan              stageplan.Binding
+	cursor            stagecursor.Cursor
+	grant             authorization.VerifiedStageGrant
+	projectionBinding projection.Binding
+	projection        submission.Plan
+	stageID           string
+	verified          bool
 }
 
 type SubmissionStageRuntimeConfig struct {
@@ -135,7 +136,15 @@ func LoadSubmissionStageBundle(config SubmissionStageBundleConfig) (VerifiedSubm
 	if _, err := authorization.BindStageGrant(grant, plan, decision.StageID, directPredecessors); err != nil {
 		return VerifiedSubmissionStageBundle{}, err
 	}
-	return VerifiedSubmissionStageBundle{plan: plan, cursor: cursor, grant: grant, projection: projected, stageID: decision.StageID, verified: true}, nil
+	return VerifiedSubmissionStageBundle{
+		plan:              plan,
+		cursor:            cursor,
+		grant:             grant,
+		projectionBinding: projectionBinding,
+		projection:        projected,
+		stageID:           decision.StageID,
+		verified:          true,
+	}, nil
 }
 
 func (bundle VerifiedSubmissionStageBundle) Decision() (stagecursor.Decision, error) {

--- a/internal/runner/submission_stage_input.go
+++ b/internal/runner/submission_stage_input.go
@@ -64,7 +64,8 @@ func BuildSubmissionStageInput(config SubmissionStageBundleConfig, configMapName
 	if !submissionStageInputNamePattern.MatchString(configMapName) || len(configMapName) > 63 || !strings.HasPrefix(configMapName, "ok147-") {
 		return VerifiedSubmissionStageInput{}, errors.New("submission stage input ConfigMap name is invalid")
 	}
-	if _, err := LoadSubmissionStageBundle(config); err != nil {
+	bundle, err := LoadSubmissionStageBundle(config)
+	if err != nil {
 		return VerifiedSubmissionStageInput{}, err
 	}
 
@@ -80,6 +81,18 @@ func BuildSubmissionStageInput(config SubmissionStageBundleConfig, configMapName
 		"authority-map.json":          filepath.Join(root, "authority-map.json"),
 		"ok-infra-prerequisites.yaml": filepath.Join(root, "ok-infra-prerequisites.yaml"),
 		"ok-mgmt-lifecycle.yaml":      filepath.Join(root, "ok-mgmt-lifecycle.yaml"),
+	}
+	projectionBaseKeys := map[string]bool{
+		"authority-map.json": true, "ok-infra-prerequisites.yaml": true, "ok-mgmt-lifecycle.yaml": true,
+	}
+	for _, artifact := range bundle.projectionBinding.Artifacts {
+		if _, exists := paths[artifact.Name]; exists {
+			if !projectionBaseKeys[artifact.Name] {
+				return VerifiedSubmissionStageInput{}, errors.New("projection artifact collides with reserved stage input key")
+			}
+			continue
+		}
+		paths[artifact.Name] = filepath.Join(root, artifact.Name)
 	}
 	prefix := stageReceiptPrefixDocument{Format: StageReceiptPrefixFormat, Receipts: []stageReceiptPrefixEntry{}}
 	switch config.ExpectedStageID {

--- a/internal/runner/submission_stage_input_test.go
+++ b/internal/runner/submission_stage_input_test.go
@@ -160,3 +160,49 @@ func TestBuildSubmissionStageInputFailsClosed(t *testing.T) {
 		t.Fatalf("oversized input was accepted: %v", err)
 	}
 }
+
+func TestBuildSubmissionStageInputIncludesCompleteProjectionClosure(t *testing.T) {
+	fixture := submissionBundleFixture(t, false, "")
+	root := filepath.Dir(fixture.config.ProjectionManifestPath)
+	extraName := "renderer-input.yaml"
+	extraRaw := []byte("profile: datacenter-isolated-v1\n")
+	if err := os.WriteFile(filepath.Join(root, extraName), extraRaw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	manifestRaw, err := os.ReadFile(fixture.config.ProjectionManifestPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var manifest map[string]any
+	if err := json.Unmarshal(manifestRaw, &manifest); err != nil {
+		t.Fatal(err)
+	}
+	manifest["artifacts"].(map[string]any)[extraName] = digest.SHA256(extraRaw)
+	updated, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(fixture.config.ProjectionManifestPath, updated, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	verified, err := BuildSubmissionStageInput(fixture.config, "ok147-projection-closure-input")
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := verified.Receipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := verified.Bytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var configMap submissionStageInputConfigMap
+	if err := json.Unmarshal(raw, &configMap); err != nil {
+		t.Fatal(err)
+	}
+	if configMap.Data[extraName] != string(extraRaw) || !contains(receipt.DataKeys, extraName) {
+		t.Fatalf("projection closure artifact was not packaged: keys=%v", receipt.DataKeys)
+	}
+}


### PR DESCRIPTION
## Summary

- retain the already verified projection binding in the submission-stage bundle
- package every manifest-bound projection artifact into the immutable Job input ConfigMap
- add a regression test for the complete projection closure discovered by OK-141 Stage 1

## Evidence

- `go test -ldflags='-linkmode=external' ./internal/runner`
- `go test -ldflags='-linkmode=external' ./...`

This closes the Stage-1 packaging defect that caused the v3 Job to fail before ledger claim or provider mutation. No infrastructure mutation is included in this PR.