### PR TITLE
fix(runner): mount complete stage input closure

### DIFF
--- a/deploy/contract-executor-stage-job.yaml.tpl
+++ b/deploy/contract-executor-stage-job.yaml.tpl
@@ -127,14 +127,7 @@ spec:
             capabilities:
               drop: ["ALL"]
           volumeMounts:
-            - {name: input, mountPath: /var/run/openkubes/input/staged-plan.json, subPath: staged-plan.json, readOnly: true}
-            - {name: input, mountPath: /var/run/openkubes/input/receipt-prefix.json, subPath: receipt-prefix.json, readOnly: true}
-            - {name: input, mountPath: /var/run/openkubes/input/stage-grant.json, subPath: stage-grant.json, readOnly: true}
-            - {name: input, mountPath: /var/run/openkubes/input/stage-authority.pub, subPath: stage-authority.pub, readOnly: true}
-            - {name: input, mountPath: /var/run/openkubes/input/projection-manifest.json, subPath: projection-manifest.json, readOnly: true}
-            - {name: input, mountPath: /var/run/openkubes/input/authority-map.json, subPath: authority-map.json, readOnly: true}
-            - {name: input, mountPath: /var/run/openkubes/input/ok-infra-prerequisites.yaml, subPath: ok-infra-prerequisites.yaml, readOnly: true}
-            - {name: input, mountPath: /var/run/openkubes/input/ok-mgmt-lifecycle.yaml, subPath: ok-mgmt-lifecycle.yaml, readOnly: true}
+            - {name: input, mountPath: /var/run/openkubes/input, readOnly: true}
 ${OK147_RECEIPT_VOLUME_MOUNT}            - {name: ledger-credential, mountPath: /var/run/openkubes/ledger/token, subPath: token, readOnly: true}
             - {name: ledger-credential, mountPath: /var/run/openkubes/ledger/ca.crt, subPath: ca.crt, readOnly: true}
             - {name: authority-credential, mountPath: /var/run/openkubes/authority/token, subPath: token, readOnly: true}
@@ -144,15 +137,6 @@ ${OK147_RECEIPT_VOLUME_MOUNT}            - {name: ledger-credential, mountPath: 
           configMap:
             name: "${OK147_INPUT_CONFIGMAP}"
             defaultMode: 0444
-            items:
-              - {key: staged-plan.json, path: staged-plan.json}
-              - {key: receipt-prefix.json, path: receipt-prefix.json}
-              - {key: stage-grant.json, path: stage-grant.json}
-              - {key: stage-authority.pub, path: stage-authority.pub}
-              - {key: projection-manifest.json, path: projection-manifest.json}
-              - {key: authority-map.json, path: authority-map.json}
-              - {key: ok-infra-prerequisites.yaml, path: ok-infra-prerequisites.yaml}
-              - {key: ok-mgmt-lifecycle.yaml, path: ok-mgmt-lifecycle.yaml}
 ${OK147_RECEIPT_CONFIGMAP_ITEM}        - name: ledger-credential
           secret:
             secretName: "${OK147_LEDGER_CREDENTIAL_SECRET}"

--- a/internal/runner/submission_stage_job.go
+++ b/internal/runner/submission_stage_job.go
@@ -79,8 +79,6 @@ func RenderSubmissionStageJobTemplate(template []byte, values SubmissionStageJob
 		if authorityEndpoint != ledgerEndpoint {
 			return nil, errors.New("cluster lifecycle authority must use the management ledger endpoint")
 		}
-		receiptMount = "            - name: input\n              mountPath: /var/run/openkubes/input/provider-receipt.json\n              subPath: provider-receipt.json\n              readOnly: true\n"
-		receiptItem = "              - key: provider-receipt.json\n                path: provider-receipt.json\n"
 	default:
 		return nil, errors.New("submission stage Job supports only Contract-to-CAPI stages")
 	}

--- a/internal/runner/submission_stage_job_test.go
+++ b/internal/runner/submission_stage_job_test.go
@@ -61,23 +61,27 @@ func TestSubmissionStageJobIsBoundedToStageCredentialsAndEndpoints(t *testing.T)
 				}
 			}
 			mounts := arrayAt(t, container, "volumeMounts")
-			wantMounts := 12
-			if stageID == "cluster-lifecycle" {
-				wantMounts = 13
-			}
+			wantMounts := 5
 			if len(mounts) != wantMounts {
 				t.Fatalf("volumeMounts=%d, want %d", len(mounts), wantMounts)
 			}
-			providerMounted := false
+			inputMounted := false
 			for _, rawMount := range mounts {
 				mount := rawMount.(map[string]any)
-				if mount["subPath"] == nil || mount["readOnly"] != true {
-					t.Fatalf("input/credential is not a read-only subPath mount: %#v", mount)
+				if mount["readOnly"] != true {
+					t.Fatalf("input/credential is not read-only: %#v", mount)
 				}
-				providerMounted = providerMounted || mount["subPath"] == "provider-receipt.json"
+				if mount["name"] == "input" {
+					if mount["mountPath"] != "/var/run/openkubes/input" || mount["subPath"] != nil {
+						t.Fatalf("verified input closure is not mounted as a directory: %#v", mount)
+					}
+					inputMounted = true
+				} else if mount["subPath"] == nil {
+					t.Fatalf("credential is not a bounded subPath mount: %#v", mount)
+				}
 			}
-			if providerMounted != (stageID == "cluster-lifecycle") {
-				t.Fatalf("provider receipt mount differs for %s", stageID)
+			if !inputMounted {
+				t.Fatalf("verified input closure is not mounted for %s", stageID)
 			}
 			policySpec := objectAt(t, policy, "spec")
 			if ingress := arrayAt(t, policySpec, "ingress"); len(ingress) != 0 {


### PR DESCRIPTION
## Summary

- mount the immutable, credential-free submission input ConfigMap as one read-only directory
- remove the historical fixed `subPath` allow-list that dropped newly manifest-bound projection artifacts
- verify both Contract-to-CAPI stages receive the full projection closure while credentials remain bounded subPath mounts

## Evidence

- `go test -ldflags='-linkmode=external' ./internal/runner`
- `go test -ldflags='-linkmode=external' ./...`
- OK-141 v4 live diagnostic: ConfigMap contained all manifest artifacts, while the Pod lacked `renderer-input.yaml`

No infrastructure mutation is included in this PR.