### PR TITLE
fix(runner): render verified stage input mounts

### DIFF
--- a/deploy/contract-executor-stage-job.yaml.tpl
+++ b/deploy/contract-executor-stage-job.yaml.tpl
@@ -127,8 +127,7 @@ spec:
             capabilities:
               drop: ["ALL"]
           volumeMounts:
-            - {name: input, mountPath: /var/run/openkubes/input, readOnly: true}
-${OK147_RECEIPT_VOLUME_MOUNT}            - {name: ledger-credential, mountPath: /var/run/openkubes/ledger/token, subPath: token, readOnly: true}
+${OK147_INPUT_VOLUME_MOUNTS}            - {name: ledger-credential, mountPath: /var/run/openkubes/ledger/token, subPath: token, readOnly: true}
             - {name: ledger-credential, mountPath: /var/run/openkubes/ledger/ca.crt, subPath: ca.crt, readOnly: true}
             - {name: authority-credential, mountPath: /var/run/openkubes/authority/token, subPath: token, readOnly: true}
             - {name: authority-credential, mountPath: /var/run/openkubes/authority/ca.crt, subPath: ca.crt, readOnly: true}
@@ -137,7 +136,8 @@ ${OK147_RECEIPT_VOLUME_MOUNT}            - {name: ledger-credential, mountPath: 
           configMap:
             name: "${OK147_INPUT_CONFIGMAP}"
             defaultMode: 0444
-${OK147_RECEIPT_CONFIGMAP_ITEM}        - name: ledger-credential
+            items:
+${OK147_INPUT_CONFIGMAP_ITEMS}        - name: ledger-credential
           secret:
             secretName: "${OK147_LEDGER_CREDENTIAL_SECRET}"
             defaultMode: 0440

--- a/internal/runner/submission_stage_job.go
+++ b/internal/runner/submission_stage_job.go
@@ -6,6 +6,7 @@ import (
 	"net/netip"
 	"net/url"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -29,6 +30,7 @@ type SubmissionStageJobValues struct {
 	AuthorityAPIURL           string
 	AuthorityAPICIDR          string
 	AuthorityCredentialSecret string
+	InputDataKeys             []string
 }
 
 // RenderSubmissionStageJobTemplate performs only validated literal
@@ -69,7 +71,6 @@ func RenderSubmissionStageJobTemplate(template []byte, values SubmissionStageJob
 	if err != nil {
 		return nil, fmt.Errorf("submission stage Job authority endpoint: %w", err)
 	}
-	receiptMount, receiptItem := "", ""
 	switch values.StageID {
 	case "provider-prerequisites":
 		if authorityEndpoint == ledgerEndpoint {
@@ -81,6 +82,10 @@ func RenderSubmissionStageJobTemplate(template []byte, values SubmissionStageJob
 		}
 	default:
 		return nil, errors.New("submission stage Job supports only Contract-to-CAPI stages")
+	}
+	inputMounts, inputItems, err := submissionStageInputVolumeFragments(values.StageID, values.InputDataKeys)
+	if err != nil {
+		return nil, err
 	}
 	replacements := map[string]string{
 		"${OK147_RUN_ID}": values.RunID, "${OK147_STAGE_ID}": values.StageID,
@@ -95,7 +100,7 @@ func RenderSubmissionStageJobTemplate(template []byte, values SubmissionStageJob
 		"${OK147_LEDGER_API_PORT}": ledgerPort, "${OK147_LEDGER_CREDENTIAL_SECRET}": values.LedgerCredentialSecret,
 		"${OK147_AUTHORITY_API_URL}": values.AuthorityAPIURL, "${OK147_AUTHORITY_API_CIDR}": values.AuthorityAPICIDR,
 		"${OK147_AUTHORITY_API_PORT}": authorityPort, "${OK147_AUTHORITY_CREDENTIAL_SECRET}": values.AuthorityCredentialSecret,
-		"${OK147_RECEIPT_VOLUME_MOUNT}": receiptMount, "${OK147_RECEIPT_CONFIGMAP_ITEM}": receiptItem,
+		"${OK147_INPUT_VOLUME_MOUNTS}": inputMounts, "${OK147_INPUT_CONFIGMAP_ITEMS}": inputItems,
 	}
 	result := string(template)
 	for placeholder, value := range replacements {
@@ -108,6 +113,46 @@ func RenderSubmissionStageJobTemplate(template []byte, values SubmissionStageJob
 		return nil, errors.New("submission stage Job template contains an unknown placeholder")
 	}
 	return []byte(result), nil
+}
+
+func submissionStageInputVolumeFragments(stageID string, dataKeys []string) (string, string, error) {
+	if len(dataKeys) == 0 || len(dataKeys) > 32 {
+		return "", "", errors.New("submission stage input data-key set is invalid")
+	}
+	keys := append([]string(nil), dataKeys...)
+	sort.Strings(keys)
+	keyPattern := regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]{0,252}$`)
+	seen := make(map[string]bool, len(keys))
+	var mounts, items strings.Builder
+	for _, key := range keys {
+		if !keyPattern.MatchString(key) || seen[key] {
+			return "", "", errors.New("submission stage input data key is unsafe or repeated")
+		}
+		seen[key] = true
+		mounts.WriteString("            - {name: input, mountPath: /var/run/openkubes/input/")
+		mounts.WriteString(key)
+		mounts.WriteString(", subPath: ")
+		mounts.WriteString(key)
+		mounts.WriteString(", readOnly: true}\n")
+		items.WriteString("              - {key: ")
+		items.WriteString(key)
+		items.WriteString(", path: ")
+		items.WriteString(key)
+		items.WriteString("}\n")
+	}
+	for _, required := range []string{
+		"staged-plan.json", "receipt-prefix.json", "stage-grant.json", "stage-authority.pub",
+		"projection-manifest.json", "authority-map.json", "ok-infra-prerequisites.yaml", "ok-mgmt-lifecycle.yaml",
+	} {
+		if !seen[required] {
+			return "", "", errors.New("submission stage input data-key set is incomplete")
+		}
+	}
+	providerReceipt := seen[providerReceiptInputKey]
+	if providerReceipt != (stageID == "cluster-lifecycle") {
+		return "", "", errors.New("submission stage provider receipt key differs from stage")
+	}
+	return mounts.String(), items.String(), nil
 }
 
 func exactAPIEndpoint(rawURL, rawCIDR string) (string, string, error) {

--- a/internal/runner/submission_stage_job_test.go
+++ b/internal/runner/submission_stage_job_test.go
@@ -23,6 +23,7 @@ func TestSubmissionStageJobIsBoundedToStageCredentialsAndEndpoints(t *testing.T)
 			values.StageID = stageID
 			if stageID == "cluster-lifecycle" {
 				values.AuthorityAPIURL, values.AuthorityAPICIDR = values.LedgerAPIURL, values.LedgerAPICIDR
+				values.InputDataKeys = append(values.InputDataKeys, providerReceiptInputKey)
 			}
 			materialized, err := RenderSubmissionStageJobTemplate(raw, values)
 			if err != nil {
@@ -61,27 +62,28 @@ func TestSubmissionStageJobIsBoundedToStageCredentialsAndEndpoints(t *testing.T)
 				}
 			}
 			mounts := arrayAt(t, container, "volumeMounts")
-			wantMounts := 5
+			wantMounts := len(values.InputDataKeys) + 4
 			if len(mounts) != wantMounts {
 				t.Fatalf("volumeMounts=%d, want %d", len(mounts), wantMounts)
 			}
-			inputMounted := false
+			inputMounts := 0
 			for _, rawMount := range mounts {
 				mount := rawMount.(map[string]any)
 				if mount["readOnly"] != true {
 					t.Fatalf("input/credential is not read-only: %#v", mount)
 				}
 				if mount["name"] == "input" {
-					if mount["mountPath"] != "/var/run/openkubes/input" || mount["subPath"] != nil {
-						t.Fatalf("verified input closure is not mounted as a directory: %#v", mount)
+					key, ok := mount["subPath"].(string)
+					if !ok || mount["mountPath"] != "/var/run/openkubes/input/"+key || !contains(values.InputDataKeys, key) {
+						t.Fatalf("verified input is not an exact subPath mount: %#v", mount)
 					}
-					inputMounted = true
+					inputMounts++
 				} else if mount["subPath"] == nil {
 					t.Fatalf("credential is not a bounded subPath mount: %#v", mount)
 				}
 			}
-			if !inputMounted {
-				t.Fatalf("verified input closure is not mounted for %s", stageID)
+			if inputMounts != len(values.InputDataKeys) {
+				t.Fatalf("input mounts=%d, want %d for %s", inputMounts, len(values.InputDataKeys), stageID)
 			}
 			policySpec := objectAt(t, policy, "spec")
 			if ingress := arrayAt(t, policySpec, "ingress"); len(ingress) != 0 {
@@ -138,6 +140,11 @@ func validSubmissionStageJobValues() SubmissionStageJobValues {
 		InputConfigMap: "ok147-provider-input", ReceiptPrefixDigest: prefixSHA("e"),
 		LedgerAPIURL: "https://192.0.2.12:6443", LedgerAPICIDR: "192.0.2.12/32", LedgerCredentialSecret: "ok147-ledger-credential",
 		AuthorityAPIURL: "https://192.0.2.11:6443", AuthorityAPICIDR: "192.0.2.11/32", AuthorityCredentialSecret: "ok147-authority-credential",
+		InputDataKeys: []string{
+			"authority-map.json", "ok-infra-prerequisites.yaml", "ok-mgmt-lifecycle.yaml", "projection-manifest.json",
+			"receipt-prefix.json", "renderer-input.yaml", "renderer-source.yaml", "resolved-renderer-input.yaml",
+			"stage-authority.pub", "stage-grant.json", "staged-plan.json",
+		},
 	}
 }
 

--- a/internal/runner/submission_stage_package.go
+++ b/internal/runner/submission_stage_package.go
@@ -86,6 +86,7 @@ func BuildSubmissionStagePackage(config SubmissionStagePackageConfig) (VerifiedS
 		LedgerCredentialSecret: config.LedgerCredentialSecret,
 		AuthorityAPIURL:        config.AuthorityAPIURL, AuthorityAPICIDR: config.AuthorityAPICIDR,
 		AuthorityCredentialSecret: config.AuthorityCredentialSecret,
+		InputDataKeys:             inputReceipt.DataKeys,
 	})
 	if err != nil {
 		return VerifiedSubmissionStagePackage{}, err


### PR DESCRIPTION
## Summary

- derive exact ConfigMap `subPath` mounts from the already verified and sorted stage-input receipt
- preserve the runner's deliberate regular-file/no-symlink boundary
- require the common stage-input closure and stage-correct provider receipt
- reject unsafe, duplicate, incomplete, or oversized key sets

## Evidence

- `go test -ldflags='-linkmode=external' ./internal/runner`
- `go test -ldflags='-linkmode=external' ./...`
- OK-141 v5 live diagnostic proved a whole-directory ConfigMap mount exposes Kubernetes AtomicWriter symlinks, correctly rejected by the runner

No infrastructure mutation is included in this PR.