### PR TITLE
fix(ledger): preserve immutable retry receipts

### DIFF
--- a/internal/ledger/stage_receipt.go
+++ b/internal/ledger/stage_receipt.go
@@ -12,13 +12,17 @@ import (
 	"github.com/openkubes/ok-cluster/internal/stagereceipt"
 )
 
-const stageReceiptSlotFormat = "ok147-stage-receipt-slot/v1"
+const (
+	stageReceiptSlotFormat        = "ok147-stage-receipt-slot/v1"
+	stageReceiptAttemptSlotFormat = "ok147-stage-receipt-attempt-slot/v1"
+)
 
 var ErrStageReceiptConflict = errors.New("a different stage receipt already occupies the immutable slot")
 
-// StoreStageReceipt persists one verified receipt in the deterministic slot
-// for its plan and stage. An exact replay is idempotent; different content for
-// the same slot fails closed.
+// StoreStageReceipt persists one verified receipt without replacing a prior
+// attempt. The first receipt occupies the deterministic stage slot for legacy
+// crash inspection; a different retry receipt occupies a digest-addressed
+// immutable attempt slot. Exact replays are idempotent in either slot.
 func (ledger *Ledger) StoreStageReceipt(ctx context.Context, plan stageplan.Binding, verified stagereceipt.Verified, predecessors []stagereceipt.Verified) (string, error) {
 	receipt, err := verified.Receipt()
 	if err != nil {
@@ -48,11 +52,30 @@ func (ledger *Ledger) StoreStageReceipt(ctx context.Context, plan stageplan.Bind
 	if err != nil {
 		return "", fmt.Errorf("read existing stage receipt: %w", err)
 	}
-	if !bytes.Equal(existing, raw) {
+	if bytes.Equal(existing, raw) {
+		if _, err := stagereceipt.Verify(existing, receiptDigest, plan, predecessors); err != nil {
+			return "", fmt.Errorf("verify existing stage receipt: %w", err)
+		}
+		return receiptDigest, nil
+	}
+	attemptKey, err := stageReceiptAttemptKey(plan, receipt.StageID, receiptDigest)
+	if err != nil {
+		return "", err
+	}
+	if err := ledger.store.Create(ctx, "stage-receipts", attemptKey, raw); err == nil {
+		return receiptDigest, nil
+	} else if !errors.Is(err, ErrRecordExists) {
+		return "", fmt.Errorf("write immutable retry stage receipt: %w", err)
+	}
+	attempt, err := ledger.store.Get(ctx, "stage-receipts", attemptKey)
+	if err != nil {
+		return "", fmt.Errorf("read existing retry stage receipt: %w", err)
+	}
+	if !bytes.Equal(attempt, raw) {
 		return "", ErrStageReceiptConflict
 	}
-	if _, err := stagereceipt.Verify(existing, receiptDigest, plan, predecessors); err != nil {
-		return "", fmt.Errorf("verify existing stage receipt: %w", err)
+	if _, err := stagereceipt.Verify(attempt, receiptDigest, plan, predecessors); err != nil {
+		return "", fmt.Errorf("verify existing retry stage receipt: %w", err)
 	}
 	return receiptDigest, nil
 }
@@ -84,17 +107,33 @@ func (ledger *Ledger) InspectStageReceipt(ctx context.Context, plan stageplan.Bi
 	return verified, true, nil
 }
 
-// LoadStageReceipt reads one deterministic slot and requires the receipt
-// identity to be supplied independently by the caller.
+// LoadStageReceipt requires an independently supplied receipt identity. It
+// first checks the legacy deterministic slot, then the digest-addressed retry
+// slot. It never lists or chooses a latest attempt.
 func (ledger *Ledger) LoadStageReceipt(ctx context.Context, plan stageplan.Binding, stageID, expectedDigest string, predecessors []stagereceipt.Verified) (stagereceipt.Verified, error) {
 	key, err := stageReceiptKey(plan, stageID)
 	if err != nil {
 		return stagereceipt.Verified{}, err
 	}
 	raw, err := ledger.store.Get(ctx, "stage-receipts", key)
+	if err == nil && digest.SHA256(raw) == expectedDigest {
+		return verifyLoadedStageReceipt(raw, expectedDigest, plan, stageID, predecessors)
+	}
+	if err != nil && !errors.Is(err, ErrRecordNotFound) {
+		return stagereceipt.Verified{}, err
+	}
+	attemptKey, err := stageReceiptAttemptKey(plan, stageID, expectedDigest)
 	if err != nil {
 		return stagereceipt.Verified{}, err
 	}
+	raw, err = ledger.store.Get(ctx, "stage-receipts", attemptKey)
+	if err != nil {
+		return stagereceipt.Verified{}, err
+	}
+	return verifyLoadedStageReceipt(raw, expectedDigest, plan, stageID, predecessors)
+}
+
+func verifyLoadedStageReceipt(raw []byte, expectedDigest string, plan stageplan.Binding, stageID string, predecessors []stagereceipt.Verified) (stagereceipt.Verified, error) {
 	verified, err := stagereceipt.Verify(raw, expectedDigest, plan, predecessors)
 	if err != nil {
 		return stagereceipt.Verified{}, fmt.Errorf("verify persisted stage receipt: %w", err)
@@ -115,6 +154,26 @@ func stageReceiptKey(plan stageplan.Binding, stageID string) (string, error) {
 		PlanDigest string `json:"planDigest"`
 		StageID    string `json:"stageId"`
 	}{Format: stageReceiptSlotFormat, PlanDigest: plan.PlanDigest, StageID: stageID}
+	_, identityDigest, err := canonicalRecord(identity)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimPrefix(identityDigest, "sha256:"), nil
+}
+
+func stageReceiptAttemptKey(plan stageplan.Binding, stageID, receiptDigest string) (string, error) {
+	if _, _, err := plan.Stage(stageID); err != nil {
+		return "", err
+	}
+	if !validDigest(receiptDigest) {
+		return "", errors.New("retry stage receipt digest is invalid")
+	}
+	identity := struct {
+		Format        string `json:"format"`
+		PlanDigest    string `json:"planDigest"`
+		StageID       string `json:"stageId"`
+		ReceiptDigest string `json:"receiptDigest"`
+	}{Format: stageReceiptAttemptSlotFormat, PlanDigest: plan.PlanDigest, StageID: stageID, ReceiptDigest: receiptDigest}
 	_, identityDigest, err := canonicalRecord(identity)
 	if err != nil {
 		return "", err

--- a/internal/ledger/stage_receipt_test.go
+++ b/internal/ledger/stage_receipt_test.go
@@ -2,7 +2,6 @@ package ledger
 
 import (
 	"context"
-	"errors"
 	"path/filepath"
 	"testing"
 	"time"
@@ -69,7 +68,7 @@ func TestStageReceiptSurvivesLedgerRecreation(t *testing.T) {
 	}
 }
 
-func TestStageReceiptSlotRejectsConflictingOutcome(t *testing.T) {
+func TestStageReceiptSlotPreservesRetryOutcome(t *testing.T) {
 	store, err := Open(filepath.Join(t.TempDir(), "ledger"))
 	if err != nil {
 		t.Fatal(err)
@@ -81,8 +80,19 @@ func TestStageReceiptSlotRejectsConflictingOutcome(t *testing.T) {
 	if _, err := store.StoreStageReceipt(context.Background(), plan, first, []stagereceipt.Verified{}); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := store.StoreStageReceipt(context.Background(), plan, conflict, []stagereceipt.Verified{}); !errors.Is(err, ErrStageReceiptConflict) {
-		t.Fatalf("conflicting receipt = %v, want ErrStageReceiptConflict", err)
+	firstDigest, _ := first.Digest()
+	conflictDigest, _ := conflict.Digest()
+	if _, err := store.StoreStageReceipt(context.Background(), plan, conflict, []stagereceipt.Verified{}); err != nil {
+		t.Fatalf("retry receipt was not preserved: %v", err)
+	}
+	for _, expected := range []string{firstDigest, conflictDigest} {
+		loaded, err := store.LoadStageReceipt(context.Background(), plan, "provider-prerequisites", expected, []stagereceipt.Verified{})
+		if err != nil {
+			t.Fatalf("load immutable attempt %s: %v", expected, err)
+		}
+		if got, _ := loaded.Digest(); got != expected {
+			t.Fatalf("loaded retry digest = %s, want %s", got, expected)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- keep the first plan/stage receipt in its deterministic immutable slot
- preserve a different retry receipt in a digest-addressed immutable attempt slot
- load retries only by an independently supplied exact receipt digest
- retain zero-list, zero-overwrite and idempotent exact-replay behavior

## Evidence

- `go test -ldflags='-linkmode=external' ./internal/ledger ./internal/execution ./internal/runner`
- `go test -ldflags='-linkmode=external' ./...`
- OK-141 v7 reached a durable `SUCCEEDED` operation outcome after an earlier immutable `STOPPED` receipt occupied the legacy slot

No ledger record is overwritten or deleted by this change.