### PR TITLE
fix(runner): close OK-141 happy run

### DIFF
--- a/docs/ok141-happy-run-closure-evidence.md
+++ b/docs/ok141-happy-run-closure-evidence.md
@@ -1,0 +1,68 @@
+# OK-141 Happy-Run closure evidence
+
+Date: 2026-08-20
+
+Environment: DEV
+
+Outcome: `HAPPY-RUN-SUCCEEDED`
+
+This checkpoint records only verified, redacted identities and outcomes. Raw
+API objects, endpoints, tokens, Secrets, kubeconfigs, UIDs, resourceVersions,
+logs, and capability output are excluded.
+
+## Bound semantic identities
+
+- `R`: `sha256:47bb651f6bc0bdb3a7a567efcd4ca4c776f872a63496fa55c2a6aed77d6fa995`
+- `E`: `sha256:2a849d69e9c64344e907c1bce3bb1abf3d8f77217377081a5be055d62c213300`
+- `P`: `sha256:2956184005f4860607e91672fce82164095dee6ebcbe57e5af883951a199c427`
+- `FixtureDigest`: `sha256:438a6882d8e22b644c826cb0a6f2856850afd7c7ef71badb44cd66e8db0393ec`
+- Platform source revision: `c09c18759aeb7526d22106ccb001599f5f06bc4e`
+
+## Durable stage results
+
+- Stage 11 `platform-observation`: `SUCCEEDED`, receipt
+  `sha256:92a5811cb8926744655f8f6ee20c91ab426b803fb7912ae35f6f4e9379d1a2b0`
+- Original Stage 12 `aggregate-evidence`: `FAILED`, immutable receipt
+  `sha256:7cc777468a200d32df21633fd010a86deaf14a04f2d30582b44531d488694ea4`
+- Corrected Stage 12 retry: `SUCCEEDED`, digest-addressed attempt receipt
+  `sha256:51c3481ea38b8d41284f4f1d6d9a900c4bf40f86318c7bee4825f10eb08ae3d2`
+- Final redacted Happy-Run summary:
+  `sha256:8945f0c0e84605e432d012ddaef7eb1c7aeac40e6de2899c55e15b74efd592ae`
+
+The original failed receipt remains the deterministic first receipt. The
+successful result is a separate immutable retry attempt; no receipt was
+overwritten or deleted.
+
+## Runtime proofs
+
+- Current Platform convergence: all three required Applications were
+  `Synced/Healthy` at the exact bound Git revision. Redacted evidence digest:
+  `sha256:04913cfb938a1a00fd58af3f946c6929ab7b05000b90e8b6469223323f7a6f66`.
+- Exact synthetic Platform capability test: `PASS-CAPABILITY`; cleanup of its
+  temporary kubeconfig, tools, port-forward logs, and synthetic Kubernetes
+  objects completed. Redacted evidence digest:
+  `sha256:46144f93619c13b1e3c377140c24e51eb70789dbe0a17f9650c45e36e3dafe5e`.
+- The refreshed Argo target credential was never retained outside the bound
+  Secret and was never emitted. Argo convergence after the refresh and a
+  graceful cache restart is the functional proof. Redacted restart evidence:
+  `sha256:abc953dc84b953b516f91aa01e2fd14f5a85f1ed40915cd9b3be06e56bc60bc0`.
+
+## Corrections proven by execution
+
+1. Argo may omit `spec.source.directory.recurse=false` from the observed API
+   representation. The collector now canonicalizes the omitted value to the
+   explicit semantic default before comparing the Application identity.
+2. Cilium health cache freshness follows the previously approved rule:
+   advertised probe interval must be positive and no greater than 300 seconds;
+   maximum accepted age is advertised interval plus 60 seconds publication
+   allowance plus 10 seconds scheduling/clock tolerance.
+3. A failed evaluation may be retried only by binding the exact immutable
+   digest of an existing `FAILED` receipt. The original receipt remains intact.
+
+## Safety boundary
+
+- No failure injection or outage was performed.
+- No cluster, VM, Namespace, PV, or persistent data was deleted.
+- No Force Delete, finalizer mutation, wildcard RBAC expansion, or permanent
+  local credential was used.
+- Raw execution evidence remains outside Git under private local paths.

--- a/internal/execution/staged_evaluation.go
+++ b/internal/execution/staged_evaluation.go
@@ -57,6 +57,21 @@ func (err *EvaluationStageResultError) Error() string {
 // Run invokes at most one prebound evaluator. Once its receipt is durable,
 // replay returns that receipt without re-reading any authoritative source.
 func (operation EvaluationStageOperation) Run(ctx context.Context, plan stageplan.Binding, cursor stagecursor.Cursor) (EvaluationStageRunReceipt, error) {
+	return operation.run(ctx, plan, cursor, "")
+}
+
+// Retry invokes the evaluator again only when the caller binds the exact
+// immutable digest of an already persisted FAILED receipt. The deterministic
+// first receipt remains untouched; the retry is stored as a digest-addressed
+// attempt.
+func (operation EvaluationStageOperation) Retry(ctx context.Context, plan stageplan.Binding, cursor stagecursor.Cursor, failedReceiptDigest string) (EvaluationStageRunReceipt, error) {
+	if !stagedDigestPattern.MatchString(failedReceiptDigest) {
+		return EvaluationStageRunReceipt{Format: EvaluationStageReceiptFormat, State: "PREEVALUATION"}, errors.New("failed evaluation receipt digest is invalid")
+	}
+	return operation.run(ctx, plan, cursor, failedReceiptDigest)
+}
+
+func (operation EvaluationStageOperation) run(ctx context.Context, plan stageplan.Binding, cursor stagecursor.Cursor, failedReceiptDigest string) (EvaluationStageRunReceipt, error) {
 	receipt := EvaluationStageRunReceipt{Format: EvaluationStageReceiptFormat, State: "PREEVALUATION"}
 	if operation.Ledger == nil || operation.Evaluator == nil {
 		return receipt, errors.New("evaluation stage ledger and evaluator are required")
@@ -83,7 +98,19 @@ func (operation EvaluationStageOperation) Run(ctx context.Context, plan stagepla
 	if existing, found, err := operation.Ledger.InspectStageReceipt(ctx, plan, decision.StageID, predecessors); err != nil {
 		return receipt, err
 	} else if found {
-		return finalizeEvaluationRunReceipt(receipt, existing)
+		if failedReceiptDigest == "" {
+			return finalizeEvaluationRunReceipt(receipt, existing)
+		}
+		failed, loadErr := operation.Ledger.LoadStageReceipt(ctx, plan, decision.StageID, failedReceiptDigest, predecessors)
+		if loadErr != nil {
+			return receipt, errors.New("evaluation retry does not bind an existing FAILED receipt")
+		}
+		failedReceipt, receiptErr := failed.Receipt()
+		if receiptErr != nil || failedReceipt.State != "FAILED" {
+			return receipt, errors.New("evaluation retry does not bind an existing FAILED receipt")
+		}
+	} else if failedReceiptDigest != "" {
+		return receipt, errors.New("evaluation retry requires an existing FAILED receipt")
 	}
 
 	result, evaluateErr := operation.Evaluator.Evaluate(ctx)

--- a/internal/execution/staged_evaluation_test.go
+++ b/internal/execution/staged_evaluation_test.go
@@ -40,6 +40,46 @@ func TestEvaluationStagePersistsTerminalResultWithoutRawError(t *testing.T) {
 	}
 }
 
+func TestEvaluationStageRetriesOnlyExactFailedReceipt(t *testing.T) {
+	plan, cursor, at := aggregateEvaluationCursor(t)
+	store, _ := ledger.Open(filepath.Join(t.TempDir(), "ledger"))
+	evaluator := &fakeStageEvaluator{binding: evaluationBinding(t, plan), result: StageEvaluationResult{Outcome: "FAILED", EvidenceDigest: stagedSHA("f"), CompletedAt: at}}
+	operation := EvaluationStageOperation{Ledger: store, Evaluator: evaluator}
+	failed, err := operation.Run(context.Background(), plan, cursor)
+	var resultErr *EvaluationStageResultError
+	if !errors.As(err, &resultErr) || failed.State != "COMPLETED_FAILED" || evaluator.calls != 1 {
+		t.Fatalf("failed evaluation was not retained: %#v calls=%d err=%v", failed, evaluator.calls, err)
+	}
+	for name, receiptDigest := range map[string]string{"invalid": "invalid", "wrong": stagedSHA("0")} {
+		t.Run(name, func(t *testing.T) {
+			if receipt, retryErr := operation.Retry(context.Background(), plan, cursor, receiptDigest); retryErr == nil || receipt.StageReceiptDigest != "" || evaluator.calls != 1 {
+				t.Fatalf("unsafe retry reached evaluator: %#v calls=%d err=%v", receipt, evaluator.calls, retryErr)
+			}
+		})
+	}
+	evaluator.result = StageEvaluationResult{Outcome: "SUCCEEDED", EvidenceDigest: stagedSHA("e"), CompletedAt: at.Add(time.Second)}
+	retried, err := operation.Retry(context.Background(), plan, cursor, failed.StageReceiptDigest)
+	if err != nil || retried.State != "COMPLETED_SUCCEEDED" || retried.StageReceiptDigest == failed.StageReceiptDigest || evaluator.calls != 2 {
+		t.Fatalf("exact failed receipt retry did not succeed: %#v calls=%d err=%v", retried, evaluator.calls, err)
+	}
+	replayed, err := operation.Run(context.Background(), plan, cursor)
+	if !errors.As(err, &resultErr) || replayed != failed || evaluator.calls != 2 {
+		t.Fatalf("legacy deterministic receipt changed after retry: %#v calls=%d err=%v", replayed, evaluator.calls, err)
+	}
+	predecessors, err := cursor.Predecessors()
+	if err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := store.LoadStageReceipt(context.Background(), plan, "aggregate-evidence", retried.StageReceiptDigest, predecessors)
+	if err != nil {
+		t.Fatalf("retry attempt receipt is not addressable: %v", err)
+	}
+	loadedReceipt, _ := loaded.Receipt()
+	if loadedReceipt.State != "SUCCEEDED" {
+		t.Fatalf("unexpected retry attempt receipt: %#v", loadedReceipt)
+	}
+}
+
 func TestEvaluationStageFailsClosedBeforePersistence(t *testing.T) {
 	plan, cursor, at := aggregateEvaluationCursor(t)
 	for name, mutate := range map[string]func(*fakeStageEvaluator){

--- a/internal/observation/network_collector_test.go
+++ b/internal/observation/network_collector_test.go
@@ -227,7 +227,7 @@ func collectorFixture(t *testing.T) (Policy, NetworkProfile, *fakeNetworkGetter,
 		"/apis/apps/v1/namespaces/kube-system/deployments/cilium-operator":   jsonBytes(t, component("Deployment", "cilium-operator", "component-uid-3", "cilium-operator", profile.ExpectedImages.CiliumOperator, 1)),
 		"/api/v1/namespaces/kube-system/pods?labelSelector=k8s-app%3Dcilium": jsonBytes(t, map[string]any{"apiVersion": "v1", "kind": "PodList", "items": []any{pod("cilium-b", "pod-uid-2", "node-b"), pod("cilium-a", "pod-uid-1", "node-a")}}),
 	}}
-	path := func() map[string]any { return map[string]any{"lastProbed": "2026-08-16T09:57:00Z"} }
+	path := func() map[string]any { return map[string]any{"lastProbed": "2026-08-16T09:58:00Z"} }
 	probeNode := func(name string) map[string]any {
 		return map[string]any{"name": name,
 			"host":            map[string]any{"primary-address": map[string]any{"http": path(), "icmp": path()}},

--- a/internal/observation/network_evaluator.go
+++ b/internal/observation/network_evaluator.go
@@ -3,7 +3,6 @@ package observation
 import (
 	"errors"
 	"fmt"
-	"math"
 	"sort"
 	"time"
 )
@@ -11,6 +10,15 @@ import (
 const (
 	NetworkProfileFormat  = "ok147-network-profile/v1"
 	NetworkSnapshotFormat = "ok147-network-snapshot/v1"
+
+	// These bounds are the versioned Cilium cache-freshness semantics proven
+	// by OK-141. The advertised interval is runtime evidence; 60 seconds is
+	// the bounded API publication allowance and 10 seconds covers scheduling
+	// and clock skew. They intentionally do not reinterpret the immutable
+	// network profile identity.
+	maximumAdvertisedProbeIntervalSeconds = 300
+	probePublicationAllowanceSeconds      = 60
+	probeSchedulingClockToleranceSeconds  = 10
 )
 
 // NetworkProfile contains the reviewed, immutable semantics behind E. The
@@ -347,12 +355,12 @@ func evaluateNetworkComponents(profile NetworkProfile, components []NetworkCompo
 func evaluateNetworkProbe(profile NetworkProfile, snapshot NetworkSnapshot, nodeUIDs map[string]struct{}) (string, string) {
 	observedAt, _ := time.Parse(time.RFC3339Nano, snapshot.ObservedAt)
 	responseAt, err := time.Parse(time.RFC3339Nano, snapshot.Probe.ResponseTimestamp)
-	if err != nil || snapshot.Probe.ProbeIntervalMilliseconds <= 0 || snapshot.Probe.ProbeIntervalMilliseconds > profile.MaximumProbeIntervalSeconds*1000 {
+	if err != nil || snapshot.Probe.ProbeIntervalMilliseconds <= 0 || snapshot.Probe.ProbeIntervalMilliseconds > maximumAdvertisedProbeIntervalSeconds*1000 {
 		return "False", "FunctionalProbeInvalid"
 	}
 	probeIntervalSeconds := float64(snapshot.Probe.ProbeIntervalMilliseconds) / 1000
-	maximumAge := math.Max(float64(profile.MinimumProbeFreshnessSeconds), 2*probeIntervalSeconds+float64(profile.CacheExposureSeconds))
-	if age := observedAt.Sub(responseAt).Seconds(); age < -5 || age > maximumAge {
+	maximumAge := probeIntervalSeconds + probePublicationAllowanceSeconds + probeSchedulingClockToleranceSeconds
+	if age := observedAt.Sub(responseAt).Seconds(); age < -probeSchedulingClockToleranceSeconds || age > maximumAge {
 		return "False", "FunctionalProbeStale"
 	}
 	expectedPathCount := len(nodeUIDs) * 4
@@ -376,7 +384,7 @@ func evaluateNetworkProbe(profile NetworkProfile, snapshot NetworkSnapshot, node
 		if err != nil {
 			return "False", "FunctionalProbeInvalid"
 		}
-		if age := observedAt.Sub(lastProbed).Seconds(); age < -5 || age > maximumAge {
+		if age := observedAt.Sub(lastProbed).Seconds(); age < -probeSchedulingClockToleranceSeconds || age > maximumAge {
 			return "False", "FunctionalProbeStale"
 		}
 	}

--- a/internal/observation/network_evaluator_test.go
+++ b/internal/observation/network_evaluator_test.go
@@ -117,14 +117,14 @@ func TestEvaluateNetworkSnapshotFailsClosed(t *testing.T) {
 
 func TestEvaluateNetworkSnapshotUsesBoundedDynamicCacheFreshness(t *testing.T) {
 	policy, profile, snapshot := validNetworkFixture(t)
-	// 2 * 96.566s probe interval + 60s cache exposure = 253.132s.
+	// 96.566s advertised interval + 60s publication + 10s tolerance = 166.566s.
 	snapshot.Probe.ProbeIntervalMilliseconds = 96566
-	snapshot.Probe.Paths[0].LastProbed = "2026-08-16T09:56:00Z" // 240s old.
+	snapshot.Probe.Paths[0].LastProbed = "2026-08-16T09:57:30Z" // 150s old.
 	evidence, err := EvaluateNetworkSnapshot(policy, profile, snapshot)
 	if err != nil || evidence.Status != "True" {
 		t.Fatalf("valid cached Cilium path was rejected: %#v %v", evidence, err)
 	}
-	snapshot.Probe.Paths[0].LastProbed = "2026-08-16T09:55:30Z" // 270s old.
+	snapshot.Probe.Paths[0].LastProbed = "2026-08-16T09:57:00Z" // 180s old.
 	evidence, err = EvaluateNetworkSnapshot(policy, profile, snapshot)
 	if err != nil || evidence.Status != "False" || evidence.Reason != "FunctionalProbeStale" {
 		t.Fatalf("stale cached Cilium path was accepted: %#v %v", evidence, err)
@@ -143,7 +143,7 @@ func TestEvaluateNetworkSnapshotRejectsMalformedUnboundedInput(t *testing.T) {
 			snapshot.Nodes = make([]NetworkNode, 101)
 		},
 		"unbounded probe interval": func(_ *NetworkProfile, snapshot *NetworkSnapshot) {
-			snapshot.Probe.ProbeIntervalMilliseconds = 601000
+			snapshot.Probe.ProbeIntervalMilliseconds = 300001
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -214,7 +214,7 @@ func validNetworkFixture(t *testing.T) (Policy, NetworkProfile, NetworkSnapshot)
 	for _, node := range nodes {
 		for _, scope := range []string{"host", "health-endpoint"} {
 			for _, protocol := range []string{"http", "icmp"} {
-				paths = append(paths, NetworkProbePath{NodeUID: node.UID, Scope: scope, Protocol: protocol, LastProbed: "2026-08-16T09:57:00Z"})
+				paths = append(paths, NetworkProbePath{NodeUID: node.UID, Scope: scope, Protocol: protocol, LastProbed: "2026-08-16T09:58:00Z"})
 			}
 		}
 	}

--- a/internal/observation/platform_collector.go
+++ b/internal/observation/platform_collector.go
@@ -200,11 +200,28 @@ func normalizedPlatformApplicationSpec(spec map[string]any) (map[string]any, str
 	if !validGitCommit(revision) || text(source["repoURL"]) == "" || text(source["path"]) == "" || text(spec["project"]) == "" || text(destination["name"]) == "" || text(destination["namespace"]) == "" {
 		return nil, "", errors.New("Argo Application semantic identity is incomplete or mutable")
 	}
+	// Argo's API representation may omit directory.recurse=false even when the
+	// submitted desired object spells the default explicitly. Bind the semantic
+	// default so the desired and observed forms retain one identity.
+	normalizedSource := make(map[string]any, len(source))
+	for key, value := range source {
+		normalizedSource[key] = value
+	}
+	if directory, ok := source["directory"].(map[string]any); ok {
+		normalizedDirectory := make(map[string]any, len(directory)+1)
+		for key, value := range directory {
+			normalizedDirectory[key] = value
+		}
+		if _, present := normalizedDirectory["recurse"]; !present {
+			normalizedDirectory["recurse"] = false
+		}
+		normalizedSource["directory"] = normalizedDirectory
+	}
 	// Keep all source and sync semantics, but only the stable target fields. The
 	// API may default unrelated destination fields; these cannot change P.
 	normalized := map[string]any{
 		"project":     spec["project"],
-		"source":      source,
+		"source":      normalizedSource,
 		"destination": map[string]any{"name": destination["name"], "namespace": destination["namespace"]},
 	}
 	if syncPolicy, exists := spec["syncPolicy"]; exists {

--- a/internal/observation/platform_collector_test.go
+++ b/internal/observation/platform_collector_test.go
@@ -142,6 +142,38 @@ func TestPlatformCollectorBindsRuntimeTargetAfterSubmission(t *testing.T) {
 	}
 }
 
+func TestPlatformApplicationSpecIdentityDefaultsDirectoryRecurseFalse(t *testing.T) {
+	base := map[string]any{
+		"project": "openkubes-disposable",
+		"source": map[string]any{
+			"repoURL": "https://github.com/openkubes/ok-observability.git",
+			"path":    "alerting", "targetRevision": strings.Repeat("6", 40),
+			"directory": map[string]any{"include": "prometheus-rules.yaml", "recurse": false},
+		},
+		"destination": map[string]any{"name": "disposable-ok141", "namespace": "ok-observability"},
+	}
+	defaulted := map[string]any{
+		"project": base["project"],
+		"source": map[string]any{
+			"repoURL": "https://github.com/openkubes/ok-observability.git",
+			"path":    "alerting", "targetRevision": strings.Repeat("6", 40),
+			"directory": map[string]any{"include": "prometheus-rules.yaml"},
+		},
+		"destination": base["destination"],
+	}
+	want, _, err := PlatformApplicationSpecIdentity(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _, err := PlatformApplicationSpecIdentity(defaulted)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Fatalf("explicit and omitted recurse=false differ: got %s want %s", got, want)
+	}
+}
+
 func platformCollectorFixture(t *testing.T) (Policy, PlatformProfile, PlatformCapabilityState, *fakePlatformRawGetter) {
 	t.Helper()
 	policy, profile, snapshot := validPlatformFixture(t)

--- a/internal/runner/aggregate_evidence_stage_evaluator_test.go
+++ b/internal/runner/aggregate_evidence_stage_evaluator_test.go
@@ -75,6 +75,9 @@ func TestAggregateEvidenceStageBundleOpensWithoutClusterContact(t *testing.T) {
 	if _, err := (OpenedAggregateEvidenceStage{}).Run(context.Background()); err == nil {
 		t.Fatal("unopened aggregate evidence stage could run")
 	}
+	if _, err := (OpenedAggregateEvidenceStage{}).Retry(context.Background(), runnerStageSHA("f")); err == nil {
+		t.Fatal("unopened aggregate evidence stage could retry")
+	}
 
 	runtime = aggregateEvidenceRuntime(t, bundle, "shared-token", "shared-token", "argo-token")
 	if _, err := bundle.Open(runtime); err == nil {

--- a/internal/runner/aggregate_evidence_stage_runtime.go
+++ b/internal/runner/aggregate_evidence_stage_runtime.go
@@ -99,3 +99,12 @@ func (stage OpenedAggregateEvidenceStage) Run(ctx context.Context) (execution.Ev
 	}
 	return stage.operation.Run(ctx, stage.plan, stage.cursor)
 }
+
+// Retry repeats the bounded aggregate evaluation only when the caller binds
+// the exact digest of an existing FAILED Stage-12 receipt.
+func (stage OpenedAggregateEvidenceStage) Retry(ctx context.Context, failedReceiptDigest string) (execution.EvaluationStageRunReceipt, error) {
+	if !stage.verified {
+		return execution.EvaluationStageRunReceipt{}, errors.New("aggregate evidence stage is not opened")
+	}
+	return stage.operation.Retry(ctx, stage.plan, stage.cursor, failedReceiptDigest)
+}


### PR DESCRIPTION
Closes the OK-141 create + converge + observe Happy Run checkpoint.\n\nThis change:\n- canonicalizes Argo directory.recurse=false defaulting\n- restores the approved Cilium cache-freshness semantics\n- permits evaluation retry only against an exact immutable FAILED receipt\n- records the redacted Happy-Run closure evidence\n\nResult: HAPPY-RUN-SUCCEEDED. The original failed Stage-12 receipt remains immutable; the successful result is a separate digest-addressed attempt.\n\nValidation:\n- go test ./internal/observation ./internal/execution\n- go test ./internal/runner\n\nNo raw evidence, credentials, endpoints, UIDs, resourceVersions, or secret material are included.