### PR TITLE
OK-147: close receipt-bound runner recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ Powered by [Cluster API (CAPI)](https://cluster-api.sigs.k8s.io/), [CAPK (KubeVi
   explicit canonical receipt prefix and reports only the next, completed or
   stopped cursor state; it has no grant, credential, endpoint or execution
   capability and can safely select the next read-only stage after a restart.
+  Lifecycle/Network observation and runtime binding additionally permit one
+  explicit retry only when the caller supplies the exact immutable terminal
+  receipt digest. The first receipt remains unchanged and every different
+  result is retained in a digest-addressed attempt slot. A generic receipt
+  materializer can copy one independently selected successful ledger receipt
+  to an absent private `0600` path without executing a stage.
   Successful Cluster-lifecycle submission also carries a SHA-256 binding of
   the exact CAPI Cluster UID through the durable outcome and stage receipt;
   the raw UID is not emitted in redaction-safe evidence. The next typed

--- a/README.md
+++ b/README.md
@@ -209,7 +209,11 @@ Powered by [Cluster API (CAPI)](https://cluster-api.sigs.k8s.io/), [CAPK (KubeVi
   supports an explicit receipt-bound continuation: a separately signed grant
   with a new GrantID is claimed once in the existing ledger before a new
   TokenRequest. The original Stage-8 receipt remains unchanged and automatic
-  mutation retry is still prohibited.
+  mutation retry is still prohibited. A package-private registration refresh
+  primitive additionally verifies the complete existing AppProject and static
+  cluster-Secret binding before one UID/resourceVersion-protected token update;
+  it remains unusable until a separate Stage-9 recovery grant and ledger claim
+  are composed around it.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -204,7 +204,12 @@ Powered by [Cluster API (CAPI)](https://cluster-api.sigs.k8s.io/), [CAPK (KubeVi
   bounded `ok-mgmt` installer credential, completes three exact-name GETs
   before any write, then can create only Secret, NetworkPolicy and Job in that
   order. This complete Job path is tested offline and against fake APIs but is
-  not yet live-proven on DEV.
+  not yet live-proven on DEV. If the process loses its memory-only target
+  credential after a durable successful Stage-8 receipt, the library now
+  supports an explicit receipt-bound continuation: a separately signed grant
+  with a new GrantID is claimed once in the existing ledger before a new
+  TokenRequest. The original Stage-8 receipt remains unchanged and automatic
+  mutation retry is still prohibited.
 
 </details>
 

--- a/cmd/ok/main.go
+++ b/cmd/ok/main.go
@@ -530,6 +530,19 @@ var executeLifecycleObservationStage = func(ctx context.Context, bundleConfig ru
 	return opened.Run(ctx)
 }
 
+var executeLifecycleObservationStageRetry = func(ctx context.Context, bundleConfig runner.StageResumeConfig, runtimeConfig runner.LifecycleObservationStageRuntimeConfig, failedReceiptDigest string) (execution.ObservationStageRunReceipt, error) {
+	bundle, err := runner.LoadLifecycleObservationStageBundle(bundleConfig)
+	if err != nil {
+		return execution.ObservationStageRunReceipt{}, err
+	}
+	runtimeConfig.Management.AuthorityIdentity = bundleConfig.PlanExpected.ManagementAuthority
+	opened, err := bundle.Open(runtimeConfig)
+	if err != nil {
+		return execution.ObservationStageRunReceipt{}, err
+	}
+	return opened.Retry(ctx, failedReceiptDigest)
+}
+
 var executeNetworkObservationStage = func(ctx context.Context, bundleConfig runner.StageResumeConfig, runtimeConfig runner.NetworkObservationStageRuntimeConfig) (execution.ObservationStageRunReceipt, error) {
 	bundle, err := runner.LoadNetworkObservationStageBundle(bundleConfig)
 	if err != nil {
@@ -541,6 +554,19 @@ var executeNetworkObservationStage = func(ctx context.Context, bundleConfig runn
 		return execution.ObservationStageRunReceipt{}, err
 	}
 	return opened.Run(ctx)
+}
+
+var executeNetworkObservationStageRetry = func(ctx context.Context, bundleConfig runner.StageResumeConfig, runtimeConfig runner.NetworkObservationStageRuntimeConfig, failedReceiptDigest string) (execution.ObservationStageRunReceipt, error) {
+	bundle, err := runner.LoadNetworkObservationStageBundle(bundleConfig)
+	if err != nil {
+		return execution.ObservationStageRunReceipt{}, err
+	}
+	runtimeConfig.Management.AuthorityIdentity = bundleConfig.PlanExpected.ManagementAuthority
+	opened, err := bundle.Open(runtimeConfig)
+	if err != nil {
+		return execution.ObservationStageRunReceipt{}, err
+	}
+	return opened.Retry(ctx, failedReceiptDigest)
 }
 
 var executeRuntimeBindingStage = func(ctx context.Context, bundleConfig runner.StageResumeConfig, runtimeConfig runner.RuntimeBindingStageRuntimeConfig) (execution.BindingStageRunReceipt, *runner.RuntimeBindingStageEvidenceReceipt, error) {
@@ -570,6 +596,40 @@ var executeKubernetesRuntimeBindingStage = func(ctx context.Context, bundleConfi
 		return execution.BindingStageRunReceipt{}, nil, err
 	}
 	receipt, runErr := opened.Run(ctx)
+	evidence, evidenceErr := opened.EvidenceReceipt()
+	if evidenceErr == nil {
+		return receipt, &evidence, runErr
+	}
+	return receipt, nil, runErr
+}
+
+var executeRuntimeBindingStageRetry = func(ctx context.Context, bundleConfig runner.StageResumeConfig, runtimeConfig runner.RuntimeBindingStageRuntimeConfig, terminalReceiptDigest string) (execution.BindingStageRunReceipt, *runner.RuntimeBindingStageEvidenceReceipt, error) {
+	bundle, err := runner.LoadRuntimeBindingStageBundle(bundleConfig)
+	if err != nil {
+		return execution.BindingStageRunReceipt{}, nil, err
+	}
+	opened, err := bundle.Open(runtimeConfig)
+	if err != nil {
+		return execution.BindingStageRunReceipt{}, nil, err
+	}
+	receipt, runErr := opened.Retry(ctx, terminalReceiptDigest)
+	evidence, evidenceErr := opened.EvidenceReceipt()
+	if evidenceErr == nil {
+		return receipt, &evidence, runErr
+	}
+	return receipt, nil, runErr
+}
+
+var executeKubernetesRuntimeBindingStageRetry = func(ctx context.Context, bundleConfig runner.StageResumeConfig, runtimeConfig runner.RuntimeBindingStageKubernetesRuntimeConfig, terminalReceiptDigest string) (execution.BindingStageRunReceipt, *runner.RuntimeBindingStageEvidenceReceipt, error) {
+	bundle, err := runner.LoadRuntimeBindingStageBundle(bundleConfig)
+	if err != nil {
+		return execution.BindingStageRunReceipt{}, nil, err
+	}
+	opened, err := bundle.OpenKubernetes(runtimeConfig)
+	if err != nil {
+		return execution.BindingStageRunReceipt{}, nil, err
+	}
+	receipt, runErr := opened.Retry(ctx, terminalReceiptDigest)
 	evidence, evidenceErr := opened.EvidenceReceipt()
 	if evidenceErr == nil {
 		return receipt, &evidence, runErr
@@ -614,6 +674,9 @@ func runContext(ctx context.Context, arguments []string, stdout, stderr io.Write
 	}
 	if len(arguments) >= 3 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "resume" {
 		return runClusterStageResume(arguments[3:], stdout, stderr)
+	}
+	if len(arguments) >= 4 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "receipt" && arguments[3] == "materialize" {
+		return runClusterStageReceiptMaterialize(ctx, arguments[4:], stdout, stderr)
 	}
 	if len(arguments) >= 5 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "observe" && arguments[3] == "lifecycle" && arguments[4] == "package" {
 		return runClusterStageObserveLifecyclePackage(arguments[5:], stdout, stderr)
@@ -717,7 +780,7 @@ func runContext(ctx context.Context, arguments []string, stdout, stderr io.Write
 	if len(arguments) >= 4 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "launch" && arguments[3] == "execute" {
 		return runClusterStageLaunchExecute(ctx, arguments[4:], stdout, stderr)
 	}
-	return errors.New("usage: ok cluster create ... | ok cluster stage inspect ... | ok cluster stage resume ... | ok cluster stage observe lifecycle ... | ok cluster stage observe network ... | ok cluster stage observe platform ... | ok cluster stage evaluate aggregate ... | ok cluster stage bind runtime ... | ok cluster stage bind runtime launch prepare ... | ok cluster stage bind runtime launch execute ... | ok cluster stage observe network package ... | ok cluster stage observe network launch prepare ... | ok cluster stage observe network launch execute ... | ok cluster stage observe lifecycle package ... | ok cluster stage observe lifecycle launch prepare ... | ok cluster stage observe lifecycle launch execute ... | ok cluster stage run ... | ok cluster stage run enablement ... | ok cluster stage run target-access ... | ok cluster stage run platform-applications ... | ok cluster stage run post-runtime package ... | ok cluster stage run post-runtime materialize ... | ok cluster stage run post-runtime launch prepare ... | ok cluster stage run post-runtime launch execute ... | ok cluster stage run post-runtime prepare ... | ok cluster stage run post-runtime execute ... | ok cluster stage run aggregate-evidence launch prepare ... | ok cluster stage run aggregate-evidence launch execute ... | ok cluster stage run enablement package ... | ok cluster stage run enablement launch prepare ... | ok cluster stage run enablement launch execute ... | ok cluster stage package ... | ok cluster stage launch prepare ... | ok cluster stage launch execute ...")
+	return errors.New("usage: ok cluster create ... | ok cluster stage inspect ... | ok cluster stage resume ... | ok cluster stage receipt materialize ... | ok cluster stage observe lifecycle ... | ok cluster stage observe network ... | ok cluster stage observe platform ... | ok cluster stage evaluate aggregate ... | ok cluster stage bind runtime ... | ok cluster stage bind runtime launch prepare ... | ok cluster stage bind runtime launch execute ... | ok cluster stage observe network package ... | ok cluster stage observe network launch prepare ... | ok cluster stage observe network launch execute ... | ok cluster stage observe lifecycle package ... | ok cluster stage observe lifecycle launch prepare ... | ok cluster stage observe lifecycle launch execute ... | ok cluster stage run ... | ok cluster stage run enablement ... | ok cluster stage run target-access ... | ok cluster stage run platform-applications ... | ok cluster stage run post-runtime package ... | ok cluster stage run post-runtime materialize ... | ok cluster stage run post-runtime launch prepare ... | ok cluster stage run post-runtime launch execute ... | ok cluster stage run post-runtime prepare ... | ok cluster stage run post-runtime execute ... | ok cluster stage run aggregate-evidence launch prepare ... | ok cluster stage run aggregate-evidence launch execute ... | ok cluster stage run enablement package ... | ok cluster stage run enablement launch prepare ... | ok cluster stage run enablement launch execute ... | ok cluster stage package ... | ok cluster stage launch prepare ... | ok cluster stage launch execute ...")
 }
 
 func runClusterCreate(arguments []string, stdout, stderr io.Writer) error {
@@ -898,6 +961,78 @@ func runClusterStageResume(arguments []string, stdout, stderr io.Writer) error {
 	return encoder.Encode(inspection)
 }
 
+func runClusterStageReceiptMaterialize(ctx context.Context, arguments []string, stdout, stderr io.Writer) error {
+	flags := flag.NewFlagSet("ok cluster stage receipt materialize", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	resumeFlags := addStageResumeFlags(flags)
+	execute := flags.Bool("execute", false, "materialize exactly one verified durable stage receipt")
+	runFormat := flags.String("run-format", "", "exact successful stage run receipt format")
+	planDigest := flags.String("plan-digest", "", "exact staged plan digest from the successful run")
+	stageID := flags.String("stage-id", "", "exact successful stage ID selected by the cursor")
+	stageReceiptDigest := flags.String("stage-receipt-digest", "", "exact durable successful stage receipt digest")
+	ledgerAPIEndpoint := flags.String("ledger-api-endpoint", "", "TLS Kubernetes API endpoint for the durable ledger")
+	ledgerTokenFile := flags.String("ledger-token-file", "", "path to the short-lived ledger token")
+	ledgerCAFile := flags.String("ledger-ca-file", "", "path to the ledger Kubernetes API CA bundle")
+	output := flags.String("output", "", "exclusive private absolute output path for the verified receipt")
+	if err := flags.Parse(arguments); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return errors.New("positional arguments are not accepted")
+	}
+	if !*execute {
+		return errors.New("stage receipt materialization requires explicit --execute")
+	}
+	resume, err := resumeFlags.config()
+	if err != nil {
+		return err
+	}
+	for _, input := range []struct{ name, value string }{
+		{"--run-format", *runFormat}, {"--plan-digest", *planDigest}, {"--stage-id", *stageID},
+		{"--stage-receipt-digest", *stageReceiptDigest}, {"--ledger-api-endpoint", *ledgerAPIEndpoint},
+		{"--ledger-token-file", *ledgerTokenFile}, {"--ledger-ca-file", *ledgerCAFile}, {"--output", *output},
+	} {
+		if input.value == "" {
+			return fmt.Errorf("%s is required", input.name)
+		}
+	}
+	if !sha256DigestPattern.MatchString(*planDigest) || !sha256DigestPattern.MatchString(*stageReceiptDigest) {
+		return errors.New("stage receipt materialization requires exact SHA-256 identities")
+	}
+	boundedContext, cancel := context.WithTimeout(ctx, runtimeBindingRunTimeout)
+	defer cancel()
+	store, err := runner.OpenKubernetesLedger(runner.KubernetesLedgerConfig{
+		Endpoint: *ledgerAPIEndpoint, Namespace: ledgerNamespace, TokenFile: *ledgerTokenFile, CAFile: *ledgerCAFile,
+	})
+	if err != nil {
+		return errors.New("open durable stage receipt ledger")
+	}
+	material, err := runner.LoadStageReceiptMaterial(boundedContext, runner.StageReceiptBridgeConfig{
+		Bundle: resume, Ledger: store,
+		Run: runner.StageRunReceiptReference{
+			Format: *runFormat, State: "COMPLETED_SUCCEEDED", PlanDigest: *planDigest,
+			StageID: *stageID, StageReceiptDigest: *stageReceiptDigest,
+		},
+	})
+	if err != nil {
+		return err
+	}
+	source, err := material.Persist(*output)
+	if err != nil {
+		return err
+	}
+	return json.NewEncoder(stdout).Encode(struct {
+		Format string `json:"format"`
+		State  string `json:"state"`
+		Stage  string `json:"stageId"`
+		Path   string `json:"path"`
+		Digest string `json:"digest"`
+	}{
+		Format: "ok147-stage-receipt-materialization/v1", State: "MATERIALIZED",
+		Stage: *stageID, Path: source.Path, Digest: source.Digest,
+	})
+}
+
 func runClusterStageObserveLifecycle(ctx context.Context, arguments []string, stdout, stderr io.Writer) error {
 	flags := flag.NewFlagSet("ok cluster stage observe lifecycle", flag.ContinueOnError)
 	flags.SetOutput(stderr)
@@ -911,6 +1046,7 @@ func runClusterStageObserveLifecycle(ctx context.Context, arguments []string, st
 	managementCAFile := flags.String("management-ca-file", "", "path to the management Kubernetes API CA bundle")
 	pollInterval := flags.Duration("poll-interval", 0, "bounded interval between verified Unknown observations")
 	pollTimeout := flags.Duration("poll-timeout", 0, "maximum bounded lifecycle observation duration")
+	retryAfterReceipt := flags.String("retry-after-failed-receipt-digest", "", "retry only after the exact immutable FAILED observation receipt")
 	if err := flags.Parse(arguments); err != nil {
 		return err
 	}
@@ -935,10 +1071,13 @@ func runClusterStageObserveLifecycle(ctx context.Context, arguments []string, st
 	if *pollInterval < time.Second || *pollInterval > 5*time.Minute || *pollTimeout < *pollInterval || *pollTimeout > 6*time.Hour {
 		return errors.New("--poll-interval and --poll-timeout must define a valid bounded observation of at most 6h")
 	}
+	if *retryAfterReceipt != "" && !sha256DigestPattern.MatchString(*retryAfterReceipt) {
+		return errors.New("--retry-after-failed-receipt-digest must be an exact SHA-256 identity")
+	}
 	runTimeout := *pollTimeout + lifecycleObservationRunOverhead
 	boundedContext, cancel := context.WithTimeout(ctx, runTimeout)
 	defer cancel()
-	receipt, runErr := executeLifecycleObservationStage(boundedContext, bundleConfig, runner.LifecycleObservationStageRuntimeConfig{
+	runtimeConfig := runner.LifecycleObservationStageRuntimeConfig{
 		Ledger: runner.KubernetesLedgerConfig{
 			Endpoint: *ledgerAPIEndpoint, Namespace: ledgerNamespace, TokenFile: *ledgerTokenFile, CAFile: *ledgerCAFile,
 		},
@@ -947,7 +1086,14 @@ func runClusterStageObserveLifecycle(ctx context.Context, arguments []string, st
 		},
 		PollInterval: *pollInterval, PollTimeout: *pollTimeout,
 		Clock: func() time.Time { return time.Now().UTC() }, Wait: runner.WaitWithTimer,
-	})
+	}
+	var receipt execution.ObservationStageRunReceipt
+	var runErr error
+	if *retryAfterReceipt == "" {
+		receipt, runErr = executeLifecycleObservationStage(boundedContext, bundleConfig, runtimeConfig)
+	} else {
+		receipt, runErr = executeLifecycleObservationStageRetry(boundedContext, bundleConfig, runtimeConfig, *retryAfterReceipt)
+	}
 	if receipt.Format != "" {
 		encoder := json.NewEncoder(stdout)
 		encoder.SetEscapeHTML(false)
@@ -978,6 +1124,7 @@ func runClusterStageObserveNetwork(ctx context.Context, arguments []string, stdo
 	networkProfileDigest := flags.String("network-profile-digest", "", "expected NetworkReady profile digest")
 	pollInterval := flags.Duration("poll-interval", 0, "bounded interval between verified Unknown observations")
 	pollTimeout := flags.Duration("poll-timeout", 0, "maximum bounded network observation duration")
+	retryAfterReceipt := flags.String("retry-after-failed-receipt-digest", "", "retry only after the exact immutable FAILED observation receipt")
 	if err := flags.Parse(arguments); err != nil {
 		return err
 	}
@@ -1008,9 +1155,12 @@ func runClusterStageObserveNetwork(ctx context.Context, arguments []string, stdo
 	if *pollInterval < time.Second || *pollInterval > 5*time.Minute || *pollTimeout < *pollInterval || *pollTimeout > 6*time.Hour {
 		return errors.New("--poll-interval and --poll-timeout must define a valid bounded observation of at most 6h")
 	}
+	if *retryAfterReceipt != "" && !sha256DigestPattern.MatchString(*retryAfterReceipt) {
+		return errors.New("--retry-after-failed-receipt-digest must be an exact SHA-256 identity")
+	}
 	boundedContext, cancel := context.WithTimeout(ctx, *pollTimeout+lifecycleObservationRunOverhead)
 	defer cancel()
-	receipt, runErr := executeNetworkObservationStage(boundedContext, bundleConfig, runner.NetworkObservationStageRuntimeConfig{
+	runtimeConfig := runner.NetworkObservationStageRuntimeConfig{
 		Ledger: runner.KubernetesLedgerConfig{
 			Endpoint: *ledgerAPIEndpoint, Namespace: ledgerNamespace, TokenFile: *ledgerTokenFile, CAFile: *ledgerCAFile,
 		},
@@ -1024,7 +1174,14 @@ func runClusterStageObserveNetwork(ctx context.Context, arguments []string, stdo
 		NetworkProfilePath: *networkProfile, ExpectedNetworkProfileDigest: *networkProfileDigest,
 		PollInterval: *pollInterval, PollTimeout: *pollTimeout,
 		Clock: func() time.Time { return time.Now().UTC() }, Wait: runner.WaitWithTimer,
-	})
+	}
+	var receipt execution.ObservationStageRunReceipt
+	var runErr error
+	if *retryAfterReceipt == "" {
+		receipt, runErr = executeNetworkObservationStage(boundedContext, bundleConfig, runtimeConfig)
+	} else {
+		receipt, runErr = executeNetworkObservationStageRetry(boundedContext, bundleConfig, runtimeConfig, *retryAfterReceipt)
+	}
 	if receipt.Format != "" {
 		encoder := json.NewEncoder(stdout)
 		encoder.SetEscapeHTML(false)
@@ -1052,6 +1209,7 @@ func runClusterStageBindRuntime(ctx context.Context, arguments []string, stdout,
 	persistenceTokenFile := flags.String("persistence-token-file", "", "path to the distinct short-lived runtime-binding Secret writer token")
 	persistenceCAFile := flags.String("persistence-ca-file", "", "path to the runtime-binding Secret writer Kubernetes API CA bundle")
 	output := flags.String("output", "", "absent absolute path in a private directory for the runtime binding")
+	retryAfterReceipt := flags.String("retry-after-terminal-receipt-digest", "", "retry only after the exact immutable FAILED or STOPPED binding receipt")
 	if err := flags.Parse(arguments); err != nil {
 		return err
 	}
@@ -1076,6 +1234,9 @@ func runClusterStageBindRuntime(ctx context.Context, arguments []string, stdout,
 	}
 	if !sha256DigestPattern.MatchString(*workloadBindingDigest) {
 		return errors.New("workload binding digest must be a lowercase SHA-256 identity")
+	}
+	if *retryAfterReceipt != "" && !sha256DigestPattern.MatchString(*retryAfterReceipt) {
+		return errors.New("--retry-after-terminal-receipt-digest must be an exact SHA-256 identity")
 	}
 	switch *persistenceMode {
 	case "local-file":
@@ -1108,19 +1269,29 @@ func runClusterStageBindRuntime(ctx context.Context, arguments []string, stdout,
 	outputFormat := "ok147-runtime-binding-execution/v1"
 	if *persistenceMode == "immutable-secret" {
 		outputFormat = "ok147-runtime-binding-execution/v2"
-		receipt, evidence, runErr = executeKubernetesRuntimeBindingStage(boundedContext, bundleConfig, runner.RuntimeBindingStageKubernetesRuntimeConfig{
+		runtimeConfig := runner.RuntimeBindingStageKubernetesRuntimeConfig{
 			Ledger: ledgerConfig, Workload: workloadConfig,
 			Persistence: runner.KubernetesAuthorityConfig{
 				Endpoint: *ledgerAPIEndpoint, AuthorityIdentity: bundleConfig.PlanExpected.ManagementAuthority,
 				TokenFile: *persistenceTokenFile, CAFile: *persistenceCAFile,
 			},
 			Clock: func() time.Time { return time.Now().UTC() },
-		})
+		}
+		if *retryAfterReceipt == "" {
+			receipt, evidence, runErr = executeKubernetesRuntimeBindingStage(boundedContext, bundleConfig, runtimeConfig)
+		} else {
+			receipt, evidence, runErr = executeKubernetesRuntimeBindingStageRetry(boundedContext, bundleConfig, runtimeConfig, *retryAfterReceipt)
+		}
 	} else {
-		receipt, evidence, runErr = executeRuntimeBindingStage(boundedContext, bundleConfig, runner.RuntimeBindingStageRuntimeConfig{
+		runtimeConfig := runner.RuntimeBindingStageRuntimeConfig{
 			Ledger: ledgerConfig, Workload: workloadConfig, OutputPath: *output,
 			Clock: func() time.Time { return time.Now().UTC() },
-		})
+		}
+		if *retryAfterReceipt == "" {
+			receipt, evidence, runErr = executeRuntimeBindingStage(boundedContext, bundleConfig, runtimeConfig)
+		} else {
+			receipt, evidence, runErr = executeRuntimeBindingStageRetry(boundedContext, bundleConfig, runtimeConfig, *retryAfterReceipt)
+		}
 	}
 	if receipt.Format != "" {
 		encoder := json.NewEncoder(stdout)

--- a/cmd/ok/main_test.go
+++ b/cmd/ok/main_test.go
@@ -255,6 +255,25 @@ func TestStageResumeRequiresCompleteUnambiguousInputs(t *testing.T) {
 	}
 }
 
+func TestStageReceiptMaterializeFailsClosedBeforeLedgerContact(t *testing.T) {
+	valid := stageReceiptMaterializeArguments()
+	for name, arguments := range map[string][]string{
+		"missing execute":     removeArgument(valid, "--execute"),
+		"bad plan digest":     replaceArgument(valid, "--plan-digest", "sha256:ABC"),
+		"bad receipt digest":  replaceArgument(valid, "--stage-receipt-digest", "invalid"),
+		"missing run format":  removeArgumentWithValue(valid, "--run-format"),
+		"missing output":      removeArgumentWithValue(valid, "--output"),
+		"positional argument": append(append([]string{}, valid...), "unexpected"),
+	} {
+		t.Run(name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			if err := run(arguments, &stdout, &stderr); err == nil || stdout.Len() != 0 {
+				t.Fatalf("unsafe receipt materialization input was accepted: err=%v stdout=%s", err, stdout.String())
+			}
+		})
+	}
+}
+
 func TestStageObserveLifecycleRequiresExplicitExecutionAndBindsRuntime(t *testing.T) {
 	previous := executeLifecycleObservationStage
 	defer func() { executeLifecycleObservationStage = previous }()
@@ -295,6 +314,38 @@ func TestStageObserveLifecycleRequiresExplicitExecutionAndBindsRuntime(t *testin
 	}
 }
 
+func TestStageObserveLifecycleRoutesExactFailedReceiptRetry(t *testing.T) {
+	previousRun := executeLifecycleObservationStage
+	previousRetry := executeLifecycleObservationStageRetry
+	defer func() {
+		executeLifecycleObservationStage = previousRun
+		executeLifecycleObservationStageRetry = previousRetry
+	}()
+	runCalls, retryCalls := 0, 0
+	executeLifecycleObservationStage = func(context.Context, runner.StageResumeConfig, runner.LifecycleObservationStageRuntimeConfig) (execution.ObservationStageRunReceipt, error) {
+		runCalls++
+		return execution.ObservationStageRunReceipt{}, nil
+	}
+	executeLifecycleObservationStageRetry = func(_ context.Context, _ runner.StageResumeConfig, _ runner.LifecycleObservationStageRuntimeConfig, digest string) (execution.ObservationStageRunReceipt, error) {
+		retryCalls++
+		if digest != testSHA("4") {
+			t.Fatalf("unexpected failed receipt binding: %s", digest)
+		}
+		return execution.ObservationStageRunReceipt{
+			Format: execution.ObservationStageReceiptFormat, State: "COMPLETED_SUCCEEDED",
+			PlanDigest: testSHA("9"), StageID: "lifecycle-observation", StageReceiptDigest: testSHA("8"),
+		}, nil
+	}
+	arguments := append(stageObserveLifecycleArguments(), "--retry-after-failed-receipt-digest", testSHA("4"))
+	var stdout, stderr bytes.Buffer
+	if err := run(arguments, &stdout, &stderr); err != nil {
+		t.Fatalf("retry run: %v; stderr=%s", err, stderr.String())
+	}
+	if runCalls != 0 || retryCalls != 1 {
+		t.Fatalf("retry routing differs: run=%d retry=%d", runCalls, retryCalls)
+	}
+}
+
 func TestStageObserveLifecycleFailsClosedBeforeExecution(t *testing.T) {
 	previous := executeLifecycleObservationStage
 	defer func() { executeLifecycleObservationStage = previous }()
@@ -312,6 +363,7 @@ func TestStageObserveLifecycleFailsClosedBeforeExecution(t *testing.T) {
 		"too frequent":             replaceArgument(valid, "--poll-interval", "500ms"),
 		"interval exceeds timeout": replaceArgument(valid, "--poll-interval", "6m"),
 		"too long":                 replaceArgument(valid, "--poll-timeout", "7h"),
+		"invalid retry receipt":    append(append([]string{}, valid...), "--retry-after-failed-receipt-digest", "invalid"),
 		"positional":               append(append([]string{}, valid...), "unexpected"),
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -388,6 +440,38 @@ func TestStageObserveNetworkRequiresExplicitExecutionAndBindsRuntime(t *testing.
 	}
 }
 
+func TestStageObserveNetworkRoutesExactFailedReceiptRetry(t *testing.T) {
+	previousRun := executeNetworkObservationStage
+	previousRetry := executeNetworkObservationStageRetry
+	defer func() {
+		executeNetworkObservationStage = previousRun
+		executeNetworkObservationStageRetry = previousRetry
+	}()
+	runCalls, retryCalls := 0, 0
+	executeNetworkObservationStage = func(context.Context, runner.StageResumeConfig, runner.NetworkObservationStageRuntimeConfig) (execution.ObservationStageRunReceipt, error) {
+		runCalls++
+		return execution.ObservationStageRunReceipt{}, nil
+	}
+	executeNetworkObservationStageRetry = func(_ context.Context, _ runner.StageResumeConfig, _ runner.NetworkObservationStageRuntimeConfig, receiptDigest string) (execution.ObservationStageRunReceipt, error) {
+		retryCalls++
+		if receiptDigest != testSHA("6") {
+			t.Fatalf("unexpected failed receipt binding: %s", receiptDigest)
+		}
+		return execution.ObservationStageRunReceipt{
+			Format: execution.ObservationStageReceiptFormat, State: "COMPLETED_SUCCEEDED",
+			PlanDigest: testSHA("9"), StageID: "network-observation", StageReceiptDigest: testSHA("8"),
+		}, nil
+	}
+	arguments := append(stageObserveNetworkArguments(), "--retry-after-failed-receipt-digest", testSHA("6"))
+	var stdout, stderr bytes.Buffer
+	if err := run(arguments, &stdout, &stderr); err != nil {
+		t.Fatalf("retry run: %v; stderr=%s", err, stderr.String())
+	}
+	if runCalls != 0 || retryCalls != 1 {
+		t.Fatalf("retry routing differs: run=%d retry=%d", runCalls, retryCalls)
+	}
+}
+
 func TestStageObserveNetworkFailsClosedBeforeExecution(t *testing.T) {
 	previous := executeNetworkObservationStage
 	defer func() { executeNetworkObservationStage = previous }()
@@ -407,6 +491,7 @@ func TestStageObserveNetworkFailsClosedBeforeExecution(t *testing.T) {
 		"too frequent":             replaceArgument(valid, "--poll-interval", "500ms"),
 		"interval exceeds timeout": replaceArgument(valid, "--poll-interval", "6m"),
 		"too long":                 replaceArgument(valid, "--poll-timeout", "7h"),
+		"invalid retry receipt":    append(append([]string{}, valid...), "--retry-after-failed-receipt-digest", "invalid"),
 		"positional":               append(append([]string{}, valid...), "unexpected"),
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -542,6 +627,7 @@ func TestStageBindRuntimeFailsClosedBeforeExecution(t *testing.T) {
 		"missing workload token":   removeArgumentWithValue(valid, "--workload-token-file"),
 		"relative output":          replaceArgument(valid, "--output", "runtime-binding.json"),
 		"unclean output":           replaceArgument(valid, "--output", "/private/tmp/../tmp/runtime-binding.json"),
+		"invalid retry receipt":    append(append([]string{}, valid...), "--retry-after-terminal-receipt-digest", "invalid"),
 		"positional":               append(append([]string{}, valid...), "unexpected"),
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -1538,6 +1624,18 @@ func stageResumeArguments() []string {
 		"--intent-revision", testSHA("a"), "--enablement-revision", testSHA("b"), "--platform-revision", testSHA("c"),
 		"--execution-fixture", testSHA("d"), "--infrastructure-authority", "ok-infra", "--management-authority", "ok-mgmt", "--gitops-authority", "ok-shared",
 	}
+}
+
+func stageReceiptMaterializeArguments() []string {
+	resume := stageResumeArguments()
+	arguments := append([]string{"cluster", "stage", "receipt", "materialize"}, resume[3:]...)
+	return append(arguments,
+		"--execute", "--run-format", execution.ObservationStageReceiptFormat,
+		"--plan-digest", testSHA("9"), "--stage-id", "lifecycle-observation",
+		"--stage-receipt-digest", testSHA("8"),
+		"--ledger-api-endpoint", "https://192.0.2.12:6443", "--ledger-token-file", "/tmp/ledger-token", "--ledger-ca-file", "/tmp/ledger-ca",
+		"--output", "/private/tmp/lifecycle-observation.json",
+	)
 }
 
 func stageRunArguments() []string {

--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -873,6 +873,27 @@ not sufficient. This checkpoint only persists evidence: it does not execute a
 stage, consume a grant, select a retry, contact a cluster during construction,
 or activate the CLI/Job path.
 
+## Explicit terminal-receipt retry boundary
+
+Lifecycle and Network observation plus runtime binding now expose one
+deliberate retry boundary. A caller must supply the exact digest of an
+immutable `FAILED` observation receipt or `FAILED`/`STOPPED` binding receipt.
+The runner reloads and reverifies that receipt against the same Plan and direct
+predecessor chain before invoking the bounded operation again. A missing,
+successful, foreign or malformed receipt stops before source access.
+
+The original deterministic receipt is never replaced. A different result is
+stored in its digest-addressed attempt slot, so both failure and recovery remain
+auditable. The CLI routes this boundary only through explicit
+`--retry-after-failed-receipt-digest` or
+`--retry-after-terminal-receipt-digest` flags. It never chooses a latest
+attempt, infers retry authority from elapsed time or retries a mutating stage.
+
+For process handoff, `ok cluster stage receipt materialize --execute` can load
+one independently digest-bound successful receipt from the durable ledger and
+write its canonical bytes create-only to an absent private path. The command
+does not run a stage or convert a terminal receipt into success.
+
 ## Durable mutating-stage outcome finalization
 
 A completed mutating-stage ledger outcome can now be transformed into the
@@ -2632,6 +2653,12 @@ Local TLS integration tests prove the final operation performs exactly one
 CAPI read, one Network source pass, three exact Argo Application reads and one
 capability read. Once the Stage-12 receipt is durable, replay performs no
 additional authoritative-source access.
+
+Network source correlation also normalizes CAAPH's semantic default for
+`spec.options.enableClientCache`: an omitted field and an API-defaulted
+`false` are equivalent. Other option differences remain revision-significant.
+This prevents API defaulting from manufacturing a false E mismatch without
+weakening the exact HelmChartProxy/HelmReleaseProxy identity checks.
 
 Stage 12 also has an explicit local launch surface:
 

--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -2717,10 +2717,15 @@ only normalized, revision-correlated evidence.
 
 The memory-only target credential intentionally creates a narrow process-crash
 boundary between successful credential issuance and durable registration. The
-runner must not solve that boundary by persisting the bearer token. A later
-orchestrator checkpoint must either execute those steps within one bounded
-process lifetime or obtain a fresh independently authorized credential after a
-pre-registration stop.
+runner does not solve that boundary by persisting the bearer token. It normally
+executes both steps within one bounded process lifetime. If that process stops
+after the immutable successful Stage-8 receipt, the recovery path first binds a
+redaction-safe recovery request to that exact receipt and the original Stage-8
+authorization. An external authority must return a new signed Stage-8 grant
+with a different authorization digest and GrantID. The existing durable ledger
+claims that grant before one new TokenRequest and records its outcome, while
+the authoritative Stage-8 receipt is neither finalized again nor overwritten.
+Only a successful recovery recreates the one-use in-memory handoff for Stage 9.
 
 The in-process post-runtime orchestrator now fixes the Stage 8-12 call order
 and passes the one-use credential handoff only from Stage 8 to Stage 9. It
@@ -2760,15 +2765,19 @@ issuer: deployment and operation of that external authority remain outside
 this checkpoint.
 
 The concrete post-runtime execution adapter now composes those boundaries into
-one single-use Stage 8-12 library path. It starts from the exact seven-receipt
-cursor, reuses one verified runtime binding, executes the memory-only
-credential handoff, resolves Stage 9 and Stage 10 authorization only after the
-current predecessor receipt is durable, and opens the existing registration,
-Application, observation and aggregate operations. Canonical Stage 8-11
-receipts are persisted create-only as private `0600` files for the next
-cursor. A missing grant, failed stage, malformed receipt, unsafe destination
-or cancelled context stops the suffix without retry, rollback or cleanup. The
-adapter itself does not own a CLI or Job activation surface; the later
+one single-use Stage 8-12 library path. It normally starts from the exact
+seven-receipt cursor, reuses one verified runtime binding, executes the
+memory-only credential handoff, resolves Stage 9 and Stage 10 authorization
+only after the current predecessor receipt is durable, and opens the existing
+registration, Application, observation and aggregate operations. An explicit
+recovery configuration may instead supply the exact successful Stage-8 receipt
+and the separate recovery authority described above; after the new grant is
+durably consumed, execution continues at Stage 9 using that unchanged receipt
+as the authoritative predecessor. Canonical Stage 8-11 receipts are persisted
+create-only as private `0600` files for the next cursor. A missing grant,
+consumed recovery grant, failed stage, malformed receipt, unsafe destination or
+cancelled context stops the suffix without automatic retry, rollback or
+cleanup. The adapter itself does not own a CLI or Job activation surface; the
 activation layer composes it without widening this library boundary.
 
 The private post-runtime execution manifest now provides the local activation

--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -2727,6 +2727,19 @@ claims that grant before one new TokenRequest and records its outcome, while
 the authoritative Stage-8 receipt is neither finalized again nor overwritten.
 Only a successful recovery recreates the one-use in-memory handoff for Stage 9.
 
+The registration-side refresh primitive is narrower than a general adoption
+or update path. It first requires the existing AppProject to have the exact
+bound spec, labels and annotations. It then accepts only the exact bound Argo
+cluster Secret: the target name, server, namespaces, project, cluster-resource
+mode, CA configuration and all non-expiration annotations must match. The old
+bearer token must be structurally present and different from the newly issued
+one. A single `PUT` carries the observed UID and resourceVersion and changes
+only the new credential configuration plus its bound expiration; the response
+is reverified byte-for-byte at the data boundary. Drift stops before mutation,
+and an unknown `PUT` outcome is preserved without retry. This package-private
+primitive grants no authority by itself; composition still requires a fresh
+Stage-9 recovery authorization and durable ledger claim.
+
 The in-process post-runtime orchestrator now fixes the Stage 8-12 call order
 and passes the one-use credential handoff only from Stage 8 to Stage 9. It
 validates every redaction-safe run receipt against one Plan digest, stops at

--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -2736,9 +2736,15 @@ bearer token must be structurally present and different from the newly issued
 one. A single `PUT` carries the observed UID and resourceVersion and changes
 only the new credential configuration plus its bound expiration; the response
 is reverified byte-for-byte at the data boundary. Drift stops before mutation,
-and an unknown `PUT` outcome is preserved without retry. This package-private
-primitive grants no authority by itself; composition still requires a fresh
-Stage-9 recovery authorization and durable ledger claim.
+and an unknown `PUT` outcome is preserved without retry. The recovery
+coordinator now places a separate redaction-safe Stage-9 authorization request
+and durable ledger claim around this package-private primitive. That request
+binds the immutable successful Stage-9 receipt, the Stage-8 credential-recovery
+request and the new credential evidence. It accepts only a fresh signed
+Stage-9 grant, claims it before the first registration read and records a
+durable `SUCCEEDED` or `STOPPED` outcome without finalizing or rewriting the
+historical Stage-9 receipt. A consumed recovery grant cannot reach a second
+`PUT`.
 
 The in-process post-runtime orchestrator now fixes the Stage 8-12 call order
 and passes the one-use credential handoff only from Stage 8 to Stage 9. It
@@ -2786,8 +2792,13 @@ registration, Application, observation and aggregate operations. An explicit
 recovery configuration may instead supply the exact successful Stage-8 receipt
 and the separate recovery authority described above; after the new grant is
 durably consumed, execution continues at Stage 9 using that unchanged receipt
-as the authoritative predecessor. Canonical Stage 8-11 receipts are persisted
-create-only as private `0600` files for the next cursor. A missing grant,
+as the authoritative predecessor. If Stage 9 had also completed before the
+process stopped, a second explicit recovery configuration must provide its
+exact successful receipt and an independent Stage-9 recovery authority. The
+adapter then refreshes only the bound registration credential, retains both
+historical Stage-8 and Stage-9 receipts unchanged, and resumes at Stage 10.
+Canonical receipts produced by the normal path are persisted create-only as
+private `0600` files for the next cursor. A missing grant,
 consumed recovery grant, failed stage, malformed receipt, unsafe destination or
 cancelled context stops the suffix without automatic retry, rollback or
 cleanup. The adapter itself does not own a CLI or Job activation surface; the

--- a/internal/execution/staged_binding.go
+++ b/internal/execution/staged_binding.go
@@ -63,6 +63,19 @@ func (err *BindingStageResultError) Error() string {
 // is returned without opening the binder again, so a process restart cannot
 // silently regenerate a different runtime identity.
 func (operation BindingStageOperation) Run(ctx context.Context, plan stageplan.Binding, cursor stagecursor.Cursor) (BindingStageRunReceipt, error) {
+	return operation.run(ctx, plan, cursor, "")
+}
+
+// Retry invokes the binder again only when the caller binds the exact digest
+// of an immutable FAILED or STOPPED receipt. Earlier receipts remain intact.
+func (operation BindingStageOperation) Retry(ctx context.Context, plan stageplan.Binding, cursor stagecursor.Cursor, terminalReceiptDigest string) (BindingStageRunReceipt, error) {
+	if !stagedDigestPattern.MatchString(terminalReceiptDigest) {
+		return BindingStageRunReceipt{Format: BindingStageReceiptFormat, State: "PREBINDING"}, errors.New("terminal binding receipt digest is invalid")
+	}
+	return operation.run(ctx, plan, cursor, terminalReceiptDigest)
+}
+
+func (operation BindingStageOperation) run(ctx context.Context, plan stageplan.Binding, cursor stagecursor.Cursor, terminalReceiptDigest string) (BindingStageRunReceipt, error) {
 	receipt := BindingStageRunReceipt{Format: BindingStageReceiptFormat, State: "PREBINDING"}
 	if operation.Ledger == nil || operation.Binder == nil {
 		return receipt, errors.New("binding stage ledger and binder are required")
@@ -89,7 +102,19 @@ func (operation BindingStageOperation) Run(ctx context.Context, plan stageplan.B
 	if existing, found, err := operation.Ledger.InspectStageReceipt(ctx, plan, decision.StageID, predecessors); err != nil {
 		return receipt, err
 	} else if found {
-		return finalizeBindingRunReceipt(receipt, existing)
+		if terminalReceiptDigest == "" {
+			return finalizeBindingRunReceipt(receipt, existing)
+		}
+		terminal, loadErr := operation.Ledger.LoadStageReceipt(ctx, plan, decision.StageID, terminalReceiptDigest, predecessors)
+		if loadErr != nil {
+			return receipt, errors.New("binding retry does not bind an existing terminal receipt")
+		}
+		terminalReceipt, receiptErr := terminal.Receipt()
+		if receiptErr != nil || terminalReceipt.State != "FAILED" && terminalReceipt.State != "STOPPED" {
+			return receipt, errors.New("binding retry does not bind an existing terminal receipt")
+		}
+	} else if terminalReceiptDigest != "" {
+		return receipt, errors.New("binding retry requires an existing terminal receipt")
 	}
 
 	result, bindErr := operation.Binder.Bind(ctx)

--- a/internal/execution/staged_binding_test.go
+++ b/internal/execution/staged_binding_test.go
@@ -46,6 +46,28 @@ func TestBindingStagePersistsTerminalResultWithoutRawError(t *testing.T) {
 	}
 }
 
+func TestBindingStageRetriesOnlyExactTerminalReceipt(t *testing.T) {
+	plan, cursor, at := runtimeBindingCursor(t)
+	store, _ := ledger.Open(filepath.Join(t.TempDir(), "ledger"))
+	binder := &fakeStageBinder{binding: binderBinding(t, plan, "runtime-binding"), result: StageBindingResult{Outcome: "STOPPED", EvidenceDigest: stagedSHA("f"), CompletedAt: at}}
+	operation := BindingStageOperation{Ledger: store, Binder: binder}
+	stopped, err := operation.Run(context.Background(), plan, cursor)
+	var resultErr *BindingStageResultError
+	if !errors.As(err, &resultErr) || stopped.State != "COMPLETED_STOPPED" || binder.calls != 1 {
+		t.Fatalf("terminal binding was not retained: %#v calls=%d err=%v", stopped, binder.calls, err)
+	}
+	for _, value := range []string{"invalid", stagedSHA("0")} {
+		if retried, retryErr := operation.Retry(context.Background(), plan, cursor, value); retryErr == nil || retried.StageReceiptDigest != "" || binder.calls != 1 {
+			t.Fatalf("unsafe retry reached binder: %#v calls=%d err=%v", retried, binder.calls, retryErr)
+		}
+	}
+	binder.result = StageBindingResult{Outcome: "SUCCEEDED", EvidenceDigest: stagedSHA("e"), CompletedAt: at.Add(time.Second)}
+	retried, err := operation.Retry(context.Background(), plan, cursor, stopped.StageReceiptDigest)
+	if err != nil || retried.State != "COMPLETED_SUCCEEDED" || retried.StageReceiptDigest == stopped.StageReceiptDigest || binder.calls != 2 {
+		t.Fatalf("exact terminal retry did not succeed: %#v calls=%d err=%v", retried, binder.calls, err)
+	}
+}
+
 func TestBindingStageFailsClosedBeforePersistence(t *testing.T) {
 	plan, cursor, at := runtimeBindingCursor(t)
 	for name, mutate := range map[string]func(*fakeStageBinder){

--- a/internal/execution/staged_observation.go
+++ b/internal/execution/staged_observation.go
@@ -57,6 +57,21 @@ func (err *ObservationStageResultError) Error() string {
 // receipt is returned without observing again, making process termination
 // after receipt persistence safe to resume.
 func (operation ObservationStageOperation) Run(ctx context.Context, plan stageplan.Binding, cursor stagecursor.Cursor) (ObservationStageRunReceipt, error) {
+	return operation.run(ctx, plan, cursor, "")
+}
+
+// Retry invokes the observer again only when the caller binds the exact
+// immutable digest of an already persisted FAILED receipt. The original
+// deterministic receipt remains untouched; StoreStageReceipt persists the
+// new result in its digest-addressed attempt slot.
+func (operation ObservationStageOperation) Retry(ctx context.Context, plan stageplan.Binding, cursor stagecursor.Cursor, failedReceiptDigest string) (ObservationStageRunReceipt, error) {
+	if !stagedDigestPattern.MatchString(failedReceiptDigest) {
+		return ObservationStageRunReceipt{Format: ObservationStageReceiptFormat, State: "PREOBSERVATION"}, errors.New("failed observation receipt digest is invalid")
+	}
+	return operation.run(ctx, plan, cursor, failedReceiptDigest)
+}
+
+func (operation ObservationStageOperation) run(ctx context.Context, plan stageplan.Binding, cursor stagecursor.Cursor, failedReceiptDigest string) (ObservationStageRunReceipt, error) {
 	receipt := ObservationStageRunReceipt{Format: ObservationStageReceiptFormat, State: "PREOBSERVATION"}
 	if operation.Ledger == nil || operation.Observer == nil {
 		return receipt, errors.New("observation stage ledger and observer are required")
@@ -83,7 +98,19 @@ func (operation ObservationStageOperation) Run(ctx context.Context, plan stagepl
 	if existing, found, err := operation.Ledger.InspectStageReceipt(ctx, plan, decision.StageID, predecessors); err != nil {
 		return receipt, err
 	} else if found {
-		return finalizeObservationRunReceipt(receipt, existing)
+		if failedReceiptDigest == "" {
+			return finalizeObservationRunReceipt(receipt, existing)
+		}
+		failed, loadErr := operation.Ledger.LoadStageReceipt(ctx, plan, decision.StageID, failedReceiptDigest, predecessors)
+		if loadErr != nil {
+			return receipt, errors.New("observation retry does not bind an existing FAILED receipt")
+		}
+		failedReceipt, receiptErr := failed.Receipt()
+		if receiptErr != nil || failedReceipt.State != "FAILED" {
+			return receipt, errors.New("observation retry does not bind an existing FAILED receipt")
+		}
+	} else if failedReceiptDigest != "" {
+		return receipt, errors.New("observation retry requires an existing FAILED receipt")
 	}
 
 	result, observeErr := operation.Observer.Observe(ctx)

--- a/internal/execution/staged_observation_test.go
+++ b/internal/execution/staged_observation_test.go
@@ -46,6 +46,59 @@ func TestObservationStagePersistsTerminalResultWithoutRawError(t *testing.T) {
 	}
 }
 
+func TestObservationStageRetriesOnlyExactFailedReceipt(t *testing.T) {
+	plan, cursor, at := lifecycleObservationCursor(t)
+	store, _ := ledger.Open(filepath.Join(t.TempDir(), "ledger"))
+	observer := &fakeStageObserver{
+		binding: observationBinding(t, plan, "lifecycle-observation"),
+		result:  StageObservationResult{Outcome: "FAILED", EvidenceDigest: stagedSHA("f"), CompletedAt: at},
+	}
+	operation := ObservationStageOperation{Ledger: store, Observer: observer}
+	failed, err := operation.Run(context.Background(), plan, cursor)
+	var resultErr *ObservationStageResultError
+	if !errors.As(err, &resultErr) || failed.State != "COMPLETED_FAILED" || observer.calls != 1 {
+		t.Fatalf("failed observation was not retained: %#v calls=%d err=%v", failed, observer.calls, err)
+	}
+	observer.result = StageObservationResult{Outcome: "FAILED", EvidenceDigest: stagedSHA("d"), CompletedAt: at.Add(time.Second)}
+	for name, digest := range map[string]string{"invalid": "invalid", "wrong": stagedSHA("0")} {
+		t.Run(name, func(t *testing.T) {
+			if receipt, err := operation.Retry(context.Background(), plan, cursor, digest); err == nil || receipt.StageReceiptDigest != "" || observer.calls != 1 {
+				t.Fatalf("unsafe retry reached observer: %#v calls=%d err=%v", receipt, observer.calls, err)
+			}
+		})
+	}
+	failedAttempt, err := operation.Retry(context.Background(), plan, cursor, failed.StageReceiptDigest)
+	if !errors.As(err, &resultErr) || failedAttempt.State != "COMPLETED_FAILED" || failedAttempt.StageReceiptDigest == failed.StageReceiptDigest || observer.calls != 2 {
+		t.Fatalf("exact failed receipt retry was not retained: %#v calls=%d err=%v", failedAttempt, observer.calls, err)
+	}
+	observer.result = StageObservationResult{Outcome: "SUCCEEDED", EvidenceDigest: stagedSHA("e"), CompletedAt: at.Add(2 * time.Second)}
+	retried, err := operation.Retry(context.Background(), plan, cursor, failedAttempt.StageReceiptDigest)
+	if err != nil || retried.State != "COMPLETED_SUCCEEDED" || retried.StageReceiptDigest == failedAttempt.StageReceiptDigest || observer.calls != 3 {
+		t.Fatalf("digest-addressed failed attempt retry did not succeed: %#v calls=%d err=%v", retried, observer.calls, err)
+	}
+	replayed, err := operation.Run(context.Background(), plan, cursor)
+	if !errors.As(err, &resultErr) || replayed != failed || observer.calls != 3 {
+		t.Fatalf("legacy deterministic receipt changed after retry: %#v calls=%d err=%v", replayed, observer.calls, err)
+	}
+	loaded, err := store.LoadStageReceipt(context.Background(), plan, "lifecycle-observation", retried.StageReceiptDigest, cursorMustPredecessors(t, cursor))
+	if err != nil {
+		t.Fatalf("retry attempt receipt is not addressable: %v", err)
+	}
+	loadedReceipt, _ := loaded.Receipt()
+	if loadedReceipt.State != "SUCCEEDED" {
+		t.Fatalf("unexpected retry attempt receipt: %#v", loadedReceipt)
+	}
+}
+
+func cursorMustPredecessors(t *testing.T, cursor stagecursor.Cursor) []stagereceipt.Verified {
+	t.Helper()
+	items, err := cursor.Predecessors()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return items
+}
+
 func TestObservationStageFailsClosedBeforePersistence(t *testing.T) {
 	plan, cursor, at := lifecycleObservationCursor(t)
 	for name, mutate := range map[string]func(*fakeStageObserver){

--- a/internal/observation/network_collector.go
+++ b/internal/observation/network_collector.go
@@ -258,7 +258,24 @@ func addonSpecDigest(spec map[string]any, includeClusterRef bool) (string, error
 	}
 	semantic := make(map[string]any, len(keys))
 	for _, key := range keys {
-		semantic[key] = spec[key]
+		value := spec[key]
+		// CAAPH defaults an omitted enableClientCache to false when persisting
+		// HelmChartProxy objects. The API-defaulted representation and the
+		// submitted representation have identical Helm semantics, so their
+		// revision identity must not diverge.
+		if key == "options" {
+			if options, ok := value.(map[string]any); ok {
+				normalized := make(map[string]any, len(options))
+				for option, optionValue := range options {
+					if option == "enableClientCache" && optionValue == false {
+						continue
+					}
+					normalized[option] = optionValue
+				}
+				value = normalized
+			}
+		}
+		semantic[key] = value
 	}
 	return canonicalDigest(semantic)
 }

--- a/internal/observation/network_collector_test.go
+++ b/internal/observation/network_collector_test.go
@@ -61,6 +61,38 @@ func TestNetworkSourceCollectorNormalizesOrderDeterministically(t *testing.T) {
 	}
 }
 
+func TestAddonSpecDigestNormalizesCAAPHDefaultedFalse(t *testing.T) {
+	requested := map[string]any{
+		"chartName": "cilium", "repoURL": "oci://quay.io/cilium/charts", "version": "1.19.6",
+		"releaseName": "cilium", "namespace": "kube-system", "reconcileStrategy": "Continuous",
+		"valuesTemplate": "pinned-values", "options": map[string]any{"wait": true},
+	}
+	defaulted := map[string]any{}
+	for key, value := range requested {
+		defaulted[key] = value
+	}
+	defaulted["options"] = map[string]any{"wait": true, "enableClientCache": false}
+	want, err := addonSpecDigest(requested, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := addonSpecDigest(defaulted, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Fatalf("CAAPH false default changed HCP semantics: got %s want %s", got, want)
+	}
+	defaulted["options"] = map[string]any{"wait": true, "enableClientCache": true}
+	changed, err := addonSpecDigest(defaulted, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changed == want {
+		t.Fatal("explicit enableClientCache=true did not change HCP semantics")
+	}
+}
+
 func TestNetworkSourceCollectorRejectsDifferentRuntimeAuthorityBeforeReads(t *testing.T) {
 	policy, _, management, workload, probe := collectorFixture(t)
 	collector := mustNetworkCollector(t, policy, management, workload, probe)

--- a/internal/runner/lifecycle_observation_bundle.go
+++ b/internal/runner/lifecycle_observation_bundle.go
@@ -113,3 +113,12 @@ func (stage OpenedLifecycleObservationStage) Run(ctx context.Context) (execution
 	}
 	return stage.operation.Run(ctx, stage.plan, stage.cursor)
 }
+
+// Retry performs one explicitly bound read-only retry after an immutable
+// FAILED lifecycle observation receipt.
+func (stage OpenedLifecycleObservationStage) Retry(ctx context.Context, failedReceiptDigest string) (execution.ObservationStageRunReceipt, error) {
+	if !stage.verified {
+		return execution.ObservationStageRunReceipt{}, errors.New("lifecycle observation stage is not opened")
+	}
+	return stage.operation.Retry(ctx, stage.plan, stage.cursor, failedReceiptDigest)
+}

--- a/internal/runner/network_observation_bundle.go
+++ b/internal/runner/network_observation_bundle.go
@@ -129,6 +129,15 @@ func (stage OpenedNetworkObservationStage) Run(ctx context.Context) (execution.O
 	return stage.operation.Run(ctx, stage.plan, stage.cursor)
 }
 
+// Retry performs one explicitly bound read-only retry after an immutable
+// FAILED network observation receipt.
+func (stage OpenedNetworkObservationStage) Retry(ctx context.Context, failedReceiptDigest string) (execution.ObservationStageRunReceipt, error) {
+	if !stage.verified {
+		return execution.ObservationStageRunReceipt{}, errors.New("network observation stage is not opened")
+	}
+	return stage.operation.Retry(ctx, stage.plan, stage.cursor, failedReceiptDigest)
+}
+
 func sameSecret(first, second string) bool {
 	return len(first) == len(second) && subtle.ConstantTimeCompare([]byte(first), []byte(second)) == 1
 }

--- a/internal/runner/post_runtime_execution.go
+++ b/internal/runner/post_runtime_execution.go
@@ -9,6 +9,8 @@ import (
 	"github.com/openkubes/ok-cluster/internal/execution"
 	"github.com/openkubes/ok-cluster/internal/ledger"
 	"github.com/openkubes/ok-cluster/internal/observation"
+	"github.com/openkubes/ok-cluster/internal/stagecursor"
+	"github.com/openkubes/ok-cluster/internal/stagereceipt"
 	"github.com/openkubes/ok-cluster/internal/submission"
 )
 
@@ -51,32 +53,44 @@ type PostRuntimeTargetCredentialRecoveryConfig struct {
 	Authorization TargetCredentialRecoveryAuthorizationResolver
 }
 
+// PostRuntimeTargetRegistrationRecoveryConfig selects the explicit crash-only
+// continuation path after Stage 9 succeeded durably but the short-lived target
+// credential embedded in the Argo registration has expired. It is valid only
+// together with target-credential recovery and never replaces a first attempt.
+type PostRuntimeTargetRegistrationRecoveryConfig struct {
+	StageReceipt  StageReceiptSource
+	Authorization TargetRegistrationRecoveryAuthorizationResolver
+}
+
 // PostRuntimeExecutionConfig supplies immutable artifacts and private runtime
 // bindings for exactly Stage 8-12. The Stage-8 grant is already part of its
 // verified bundle; later mutating grants are resolved only after their direct
 // predecessor receipt is durable.
 type PostRuntimeExecutionConfig struct {
-	TargetCredential         TargetCredentialStageBundleConfig
-	TargetCredentialRun      TargetCredentialStageRuntimeConfig
-	TargetCredentialRecovery *PostRuntimeTargetCredentialRecoveryConfig
-	Authorization            StageAuthorizationResolver
-	TargetRegistration       PostRuntimeTargetRegistrationConfig
-	PlatformApplications     PostRuntimePlatformApplicationsConfig
-	PlatformObservation      PostRuntimePlatformObservationConfig
-	AggregateEvidence        PostRuntimeAggregateEvidenceConfig
-	RuntimeBinding           RuntimeBindingMaterialFileConfig
-	ReceiptDirectory         string
+	TargetCredential           TargetCredentialStageBundleConfig
+	TargetCredentialRun        TargetCredentialStageRuntimeConfig
+	TargetCredentialRecovery   *PostRuntimeTargetCredentialRecoveryConfig
+	TargetRegistrationRecovery *PostRuntimeTargetRegistrationRecoveryConfig
+	Authorization              StageAuthorizationResolver
+	TargetRegistration         PostRuntimeTargetRegistrationConfig
+	PlatformApplications       PostRuntimePlatformApplicationsConfig
+	PlatformObservation        PostRuntimePlatformObservationConfig
+	AggregateEvidence          PostRuntimeAggregateEvidenceConfig
+	RuntimeBinding             RuntimeBindingMaterialFileConfig
+	ReceiptDirectory           string
 }
 
 type PostRuntimeExecutionReceipt struct {
-	Format                        string                                                `json:"format"`
-	State                         string                                                `json:"state"`
-	PlanDigest                    string                                                `json:"planDigest,omitempty"`
-	StoppedAt                     string                                                `json:"stoppedAt,omitempty"`
-	Checkpoints                   []PostRuntimeStageCheckpoint                          `json:"checkpoints"`
-	ResolvedAuthorizations        []ResolvedStageAuthorizationReceipt                   `json:"resolvedAuthorizations"`
-	ResolvedRecoveryAuthorization *ResolvedTargetCredentialRecoveryAuthorizationReceipt `json:"resolvedRecoveryAuthorization,omitempty"`
-	TargetCredentialRecovery      *TargetCredentialRecoveryReceipt                      `json:"targetCredentialRecovery,omitempty"`
+	Format                                    string                                                  `json:"format"`
+	State                                     string                                                  `json:"state"`
+	PlanDigest                                string                                                  `json:"planDigest,omitempty"`
+	StoppedAt                                 string                                                  `json:"stoppedAt,omitempty"`
+	Checkpoints                               []PostRuntimeStageCheckpoint                            `json:"checkpoints"`
+	ResolvedAuthorizations                    []ResolvedStageAuthorizationReceipt                     `json:"resolvedAuthorizations"`
+	ResolvedRecoveryAuthorization             *ResolvedTargetCredentialRecoveryAuthorizationReceipt   `json:"resolvedRecoveryAuthorization,omitempty"`
+	TargetCredentialRecovery                  *TargetCredentialRecoveryReceipt                        `json:"targetCredentialRecovery,omitempty"`
+	ResolvedRegistrationRecoveryAuthorization *ResolvedTargetRegistrationRecoveryAuthorizationReceipt `json:"resolvedRegistrationRecoveryAuthorization,omitempty"`
+	TargetRegistrationRecovery                *TargetRegistrationRecoveryReceipt                      `json:"targetRegistrationRecovery,omitempty"`
 }
 
 type postRuntimeCredentialInvocation struct {
@@ -99,23 +113,25 @@ type postRuntimeEvaluationInvocation struct {
 }
 
 type postRuntimeExecutionFactories struct {
-	credential   func(TargetCredentialStageBundleConfig, TargetCredentialStageRuntimeConfig) (postRuntimeCredentialInvocation, error)
-	registration func(StageResumeConfig, *VerifiedTargetCredentialStageHandoff, StageAuthorizationSource, PostRuntimeTargetRegistrationConfig, VerifiedRuntimeBindingMaterial) (postRuntimeStagedInvocation, error)
-	applications func(StageResumeConfig, StageAuthorizationSource, PostRuntimePlatformApplicationsConfig) (postRuntimeStagedInvocation, error)
-	observation  func(StageResumeConfig, PostRuntimePlatformObservationConfig) (postRuntimeObservationInvocation, error)
-	aggregate    func(StageResumeConfig, PostRuntimeAggregateEvidenceConfig, VerifiedRuntimeBindingMaterial) (postRuntimeEvaluationInvocation, error)
+	credential           func(TargetCredentialStageBundleConfig, TargetCredentialStageRuntimeConfig) (postRuntimeCredentialInvocation, error)
+	registration         func(StageResumeConfig, *VerifiedTargetCredentialStageHandoff, StageAuthorizationSource, PostRuntimeTargetRegistrationConfig, VerifiedRuntimeBindingMaterial) (postRuntimeStagedInvocation, error)
+	applications         func(StageResumeConfig, StageAuthorizationSource, PostRuntimePlatformApplicationsConfig) (postRuntimeStagedInvocation, error)
+	observation          func(StageResumeConfig, PostRuntimePlatformObservationConfig) (postRuntimeObservationInvocation, error)
+	aggregate            func(StageResumeConfig, PostRuntimeAggregateEvidenceConfig, VerifiedRuntimeBindingMaterial) (postRuntimeEvaluationInvocation, error)
+	registrationRecovery func(context.Context, TargetRegistrationRecoveryConfig) (TargetRegistrationRecoveryReceipt, error)
 }
 
 type PostRuntimeExecution struct {
-	config         PostRuntimeExecutionConfig
-	initial        StageResumeConfig
-	runtime        VerifiedRuntimeBindingMaterial
-	credential     postRuntimeCredentialInvocation
-	recoveryBundle *VerifiedTargetCredentialStageBundle
-	recovery       *PostRuntimeTargetCredentialRecoveryConfig
-	factories      postRuntimeExecutionFactories
-	mu             sync.Mutex
-	used           bool
+	config               PostRuntimeExecutionConfig
+	initial              StageResumeConfig
+	runtime              VerifiedRuntimeBindingMaterial
+	credential           postRuntimeCredentialInvocation
+	recoveryBundle       *VerifiedTargetCredentialStageBundle
+	recovery             *PostRuntimeTargetCredentialRecoveryConfig
+	registrationRecovery *PostRuntimeTargetRegistrationRecoveryConfig
+	factories            postRuntimeExecutionFactories
+	mu                   sync.Mutex
+	used                 bool
 }
 
 // OpenPostRuntimeExecution performs bounded local loading only. It opens
@@ -141,6 +157,9 @@ func openPostRuntimeExecution(config PostRuntimeExecutionConfig, factories postR
 	persistedStages := postRuntimeStageOrder[:4]
 	if config.TargetCredentialRecovery != nil {
 		persistedStages = postRuntimeStageOrder[1:4]
+	}
+	if config.TargetRegistrationRecovery != nil {
+		persistedStages = postRuntimeStageOrder[2:4]
 	}
 	for _, stageID := range persistedStages {
 		if err := validateRuntimeBindingOutputPath(filepath.Join(config.ReceiptDirectory, postRuntimeReceiptFiles[stageID])); err != nil {
@@ -175,6 +194,27 @@ func openPostRuntimeExecution(config PostRuntimeExecutionConfig, factories postR
 		}
 		recoveryBundle = &bundle
 	}
+	var registrationRecovery *PostRuntimeTargetRegistrationRecoveryConfig
+	if config.TargetRegistrationRecovery != nil {
+		if config.TargetCredentialRecovery == nil || config.TargetRegistrationRecovery.Authorization == nil || recoveryBundle == nil || factories.registrationRecovery == nil {
+			return nil, errors.New("post-runtime target-registration recovery requires credential recovery and independent authorization")
+		}
+		retained := *config.TargetRegistrationRecovery
+		config.TargetRegistrationRecovery = &retained
+		stageEight, loadErr := loadSuccessfulTargetCredentialReceipt(*recoveryBundle, config.TargetCredentialRecovery.StageReceipt)
+		if loadErr != nil {
+			return nil, errors.New("verify post-runtime target-credential recovery receipt for registration recovery")
+		}
+		prefix := append(append([]stagereceipt.Verified(nil), recoveryBundle.prefix...), stageEight)
+		cursor, loadErr := stagecursor.Evaluate(recoveryBundle.plan, prefix)
+		if loadErr != nil {
+			return nil, errors.New("evaluate post-runtime target-registration recovery prefix")
+		}
+		if _, loadErr = loadSuccessfulTargetRegistrationReceipt(recoveryBundle.plan, cursor, prefix, retained.StageReceipt); loadErr != nil {
+			return nil, errors.New("verify post-runtime target-registration recovery receipt")
+		}
+		registrationRecovery = config.TargetRegistrationRecovery
+	}
 	config.TargetCredential.Receipts = append([]StageReceiptSource(nil), initial.Receipts...)
 	config.PlatformObservation.Profile.RequiredApplications = append([]observation.PlatformApplicationExpectation(nil), config.PlatformObservation.Profile.RequiredApplications...)
 	config.PlatformObservation.Runtime.RuntimeMaterialPath = config.RuntimeBinding.MaterialPath
@@ -185,6 +225,7 @@ func openPostRuntimeExecution(config PostRuntimeExecutionConfig, factories postR
 	return &PostRuntimeExecution{
 		config: config, initial: initial, runtime: runtime, credential: credential,
 		recoveryBundle: recoveryBundle, recovery: config.TargetCredentialRecovery, factories: factories,
+		registrationRecovery: registrationRecovery,
 	}, nil
 }
 
@@ -207,6 +248,8 @@ func (executor *PostRuntimeExecution) Run(ctx context.Context) (PostRuntimeExecu
 	authorizations := []ResolvedStageAuthorizationReceipt{}
 	var recoveryAuthorization *ResolvedTargetCredentialRecoveryAuthorizationReceipt
 	var recoveryReceipt *TargetCredentialRecoveryReceipt
+	var registrationRecoveryAuthorization *ResolvedTargetRegistrationRecoveryAuthorizationReceipt
+	var registrationRecoveryReceipt *TargetRegistrationRecoveryReceipt
 	orchestration := PostRuntimeOrchestration{}
 	orchestration.RunTargetCredential = func(ctx context.Context) (execution.StagedOperationReceipt, *VerifiedTargetCredentialStageHandoff, error) {
 		if executor.recovery != nil {
@@ -250,6 +293,33 @@ func (executor *PostRuntimeExecution) Run(ctx context.Context) (PostRuntimeExecu
 		return runReceipt, handoff, nil
 	}
 	orchestration.RunTargetRegistration = func(ctx context.Context, handoff *VerifiedTargetCredentialStageHandoff, _ execution.StagedOperationReceipt) (execution.StagedOperationReceipt, error) {
+		if executor.registrationRecovery != nil {
+			resolved, err := ResolveTargetRegistrationRecoveryAuthorization(ctx, handoff, executor.registrationRecovery.StageReceipt, executor.registrationRecovery.Authorization)
+			if err != nil {
+				return execution.StagedOperationReceipt{}, err
+			}
+			resolvedReceipt, err := resolved.Receipt()
+			if err != nil {
+				return execution.StagedOperationReceipt{}, err
+			}
+			recovered, err := executor.factories.registrationRecovery(ctx, TargetRegistrationRecoveryConfig{
+				Handoff: handoff, PriorStageReceipt: executor.registrationRecovery.StageReceipt, Authorization: resolved,
+				ArtifactPath: executor.config.TargetRegistration.ArtifactPath, Expected: executor.config.TargetRegistration.Expected,
+				Ledger: executor.config.TargetRegistration.Runtime.Ledger, GitOps: executor.config.TargetRegistration.Runtime.GitOps,
+				Runtime: executor.runtime, MaterializationTime: executor.config.TargetRegistration.Runtime.MaterializationTime,
+				Clock: executor.config.TargetRegistration.Runtime.Clock,
+			})
+			registrationRecoveryAuthorization, registrationRecoveryReceipt = &resolvedReceipt, &recovered
+			runReceipt := execution.StagedOperationReceipt{
+				Format: execution.StagedReceiptFormat, State: "COMPLETED_SUCCEEDED", PlanDigest: executor.recoveryBundle.plan.PlanDigest,
+				StageID: "target-registration", StageReceiptDigest: executor.registrationRecovery.StageReceipt.Digest,
+			}
+			if err != nil {
+				return runReceipt, err
+			}
+			receipts = append(receipts, executor.registrationRecovery.StageReceipt)
+			return runReceipt, nil
+		}
 		resolved, err := ResolveStageAuthorization(ctx, executor.resume(receipts), executor.config.Authorization)
 		if err != nil {
 			return execution.StagedOperationReceipt{}, err
@@ -332,6 +402,8 @@ func (executor *PostRuntimeExecution) Run(ctx context.Context) (PostRuntimeExecu
 		Checkpoints:                   append([]PostRuntimeStageCheckpoint(nil), orchestrationReceipt.Checkpoints...),
 		ResolvedAuthorizations:        append([]ResolvedStageAuthorizationReceipt(nil), authorizations...),
 		ResolvedRecoveryAuthorization: recoveryAuthorization, TargetCredentialRecovery: recoveryReceipt,
+		ResolvedRegistrationRecoveryAuthorization: registrationRecoveryAuthorization,
+		TargetRegistrationRecovery:                registrationRecoveryReceipt,
 	}
 	return result, err
 }
@@ -462,5 +534,6 @@ func defaultPostRuntimeExecutionFactories() postRuntimeExecutionFactories {
 			}
 			return postRuntimeEvaluationInvocation{run: opened.Run}, nil
 		},
+		registrationRecovery: RecoverTargetRegistration,
 	}
 }

--- a/internal/runner/post_runtime_execution.go
+++ b/internal/runner/post_runtime_execution.go
@@ -43,29 +43,40 @@ type PostRuntimeAggregateEvidenceConfig struct {
 	Runtime AggregateEvidenceStageFileRuntimeConfig
 }
 
+// PostRuntimeTargetCredentialRecoveryConfig selects the explicit crash-only
+// continuation path after Stage 8 succeeded durably but its memory-only
+// credential handoff was lost. It never replaces the normal first attempt.
+type PostRuntimeTargetCredentialRecoveryConfig struct {
+	StageReceipt  StageReceiptSource
+	Authorization TargetCredentialRecoveryAuthorizationResolver
+}
+
 // PostRuntimeExecutionConfig supplies immutable artifacts and private runtime
 // bindings for exactly Stage 8-12. The Stage-8 grant is already part of its
 // verified bundle; later mutating grants are resolved only after their direct
 // predecessor receipt is durable.
 type PostRuntimeExecutionConfig struct {
-	TargetCredential     TargetCredentialStageBundleConfig
-	TargetCredentialRun  TargetCredentialStageRuntimeConfig
-	Authorization        StageAuthorizationResolver
-	TargetRegistration   PostRuntimeTargetRegistrationConfig
-	PlatformApplications PostRuntimePlatformApplicationsConfig
-	PlatformObservation  PostRuntimePlatformObservationConfig
-	AggregateEvidence    PostRuntimeAggregateEvidenceConfig
-	RuntimeBinding       RuntimeBindingMaterialFileConfig
-	ReceiptDirectory     string
+	TargetCredential         TargetCredentialStageBundleConfig
+	TargetCredentialRun      TargetCredentialStageRuntimeConfig
+	TargetCredentialRecovery *PostRuntimeTargetCredentialRecoveryConfig
+	Authorization            StageAuthorizationResolver
+	TargetRegistration       PostRuntimeTargetRegistrationConfig
+	PlatformApplications     PostRuntimePlatformApplicationsConfig
+	PlatformObservation      PostRuntimePlatformObservationConfig
+	AggregateEvidence        PostRuntimeAggregateEvidenceConfig
+	RuntimeBinding           RuntimeBindingMaterialFileConfig
+	ReceiptDirectory         string
 }
 
 type PostRuntimeExecutionReceipt struct {
-	Format                 string                              `json:"format"`
-	State                  string                              `json:"state"`
-	PlanDigest             string                              `json:"planDigest,omitempty"`
-	StoppedAt              string                              `json:"stoppedAt,omitempty"`
-	Checkpoints            []PostRuntimeStageCheckpoint        `json:"checkpoints"`
-	ResolvedAuthorizations []ResolvedStageAuthorizationReceipt `json:"resolvedAuthorizations"`
+	Format                        string                                                `json:"format"`
+	State                         string                                                `json:"state"`
+	PlanDigest                    string                                                `json:"planDigest,omitempty"`
+	StoppedAt                     string                                                `json:"stoppedAt,omitempty"`
+	Checkpoints                   []PostRuntimeStageCheckpoint                          `json:"checkpoints"`
+	ResolvedAuthorizations        []ResolvedStageAuthorizationReceipt                   `json:"resolvedAuthorizations"`
+	ResolvedRecoveryAuthorization *ResolvedTargetCredentialRecoveryAuthorizationReceipt `json:"resolvedRecoveryAuthorization,omitempty"`
+	TargetCredentialRecovery      *TargetCredentialRecoveryReceipt                      `json:"targetCredentialRecovery,omitempty"`
 }
 
 type postRuntimeCredentialInvocation struct {
@@ -96,13 +107,15 @@ type postRuntimeExecutionFactories struct {
 }
 
 type PostRuntimeExecution struct {
-	config     PostRuntimeExecutionConfig
-	initial    StageResumeConfig
-	runtime    VerifiedRuntimeBindingMaterial
-	credential postRuntimeCredentialInvocation
-	factories  postRuntimeExecutionFactories
-	mu         sync.Mutex
-	used       bool
+	config         PostRuntimeExecutionConfig
+	initial        StageResumeConfig
+	runtime        VerifiedRuntimeBindingMaterial
+	credential     postRuntimeCredentialInvocation
+	recoveryBundle *VerifiedTargetCredentialStageBundle
+	recovery       *PostRuntimeTargetCredentialRecoveryConfig
+	factories      postRuntimeExecutionFactories
+	mu             sync.Mutex
+	used           bool
 }
 
 // OpenPostRuntimeExecution performs bounded local loading only. It opens
@@ -125,7 +138,11 @@ func openPostRuntimeExecution(config PostRuntimeExecutionConfig, factories postR
 	if err != nil || decision.State != "NEXT" || decision.StageID != "target-credential" || len(initial.Receipts) != 7 {
 		return nil, errors.New("post-runtime execution requires the exact Stage-8 cursor")
 	}
-	for _, stageID := range postRuntimeStageOrder[:4] {
+	persistedStages := postRuntimeStageOrder[:4]
+	if config.TargetCredentialRecovery != nil {
+		persistedStages = postRuntimeStageOrder[1:4]
+	}
+	for _, stageID := range persistedStages {
 		if err := validateRuntimeBindingOutputPath(filepath.Join(config.ReceiptDirectory, postRuntimeReceiptFiles[stageID])); err != nil {
 			return nil, errors.New("post-runtime receipt destination is invalid")
 		}
@@ -136,9 +153,27 @@ func openPostRuntimeExecution(config PostRuntimeExecutionConfig, factories postR
 	if err != nil {
 		return nil, errors.New("load post-runtime execution binding")
 	}
-	credential, err := factories.credential(config.TargetCredential, config.TargetCredentialRun)
-	if err != nil || credential.run == nil || credential.ledger == nil {
-		return nil, errors.New("open post-runtime target credential stage")
+	var credential postRuntimeCredentialInvocation
+	var recoveryBundle *VerifiedTargetCredentialStageBundle
+	if config.TargetCredentialRecovery == nil {
+		credential, err = factories.credential(config.TargetCredential, config.TargetCredentialRun)
+		if err != nil || credential.run == nil || credential.ledger == nil {
+			return nil, errors.New("open post-runtime target credential stage")
+		}
+	} else {
+		retainedRecovery := *config.TargetCredentialRecovery
+		config.TargetCredentialRecovery = &retainedRecovery
+		if config.TargetCredentialRecovery.Authorization == nil {
+			return nil, errors.New("post-runtime target-credential recovery authorization is required")
+		}
+		bundle, loadErr := LoadTargetCredentialStageBundle(config.TargetCredential)
+		if loadErr != nil {
+			return nil, errors.New("load post-runtime target-credential recovery bundle")
+		}
+		if _, loadErr = loadSuccessfulTargetCredentialReceipt(bundle, config.TargetCredentialRecovery.StageReceipt); loadErr != nil {
+			return nil, errors.New("verify post-runtime target-credential recovery receipt")
+		}
+		recoveryBundle = &bundle
 	}
 	config.TargetCredential.Receipts = append([]StageReceiptSource(nil), initial.Receipts...)
 	config.PlatformObservation.Profile.RequiredApplications = append([]observation.PlatformApplicationExpectation(nil), config.PlatformObservation.Profile.RequiredApplications...)
@@ -148,7 +183,8 @@ func openPostRuntimeExecution(config PostRuntimeExecutionConfig, factories postR
 	config.AggregateEvidence.Runtime.RuntimeMaterialPath = config.RuntimeBinding.MaterialPath
 	config.AggregateEvidence.Runtime.RuntimeReceiptPath = config.RuntimeBinding.ReceiptPath
 	return &PostRuntimeExecution{
-		config: config, initial: initial, runtime: runtime, credential: credential, factories: factories,
+		config: config, initial: initial, runtime: runtime, credential: credential,
+		recoveryBundle: recoveryBundle, recovery: config.TargetCredentialRecovery, factories: factories,
 	}, nil
 }
 
@@ -169,8 +205,39 @@ func (executor *PostRuntimeExecution) Run(ctx context.Context) (PostRuntimeExecu
 
 	receipts := append([]StageReceiptSource(nil), executor.initial.Receipts...)
 	authorizations := []ResolvedStageAuthorizationReceipt{}
+	var recoveryAuthorization *ResolvedTargetCredentialRecoveryAuthorizationReceipt
+	var recoveryReceipt *TargetCredentialRecoveryReceipt
 	orchestration := PostRuntimeOrchestration{}
 	orchestration.RunTargetCredential = func(ctx context.Context) (execution.StagedOperationReceipt, *VerifiedTargetCredentialStageHandoff, error) {
+		if executor.recovery != nil {
+			if executor.recoveryBundle == nil {
+				return execution.StagedOperationReceipt{}, nil, errors.New("post-runtime recovery bundle is unavailable")
+			}
+			resolved, err := ResolveTargetCredentialRecoveryAuthorization(ctx, *executor.recoveryBundle, executor.recovery.StageReceipt, executor.recovery.Authorization)
+			if err != nil {
+				return execution.StagedOperationReceipt{}, nil, err
+			}
+			resolvedReceipt, err := resolved.Receipt()
+			if err != nil {
+				return execution.StagedOperationReceipt{}, nil, err
+			}
+			recovered, handoff, err := RecoverTargetCredential(ctx, TargetCredentialRecoveryConfig{
+				Bundle: *executor.recoveryBundle, StageReceipt: executor.recovery.StageReceipt, Authorization: resolved,
+				Ledger: executor.config.TargetCredentialRun.Ledger, Workload: executor.config.TargetCredentialRun.Workload,
+				Clock: executor.config.TargetCredentialRun.Clock,
+			})
+			recoveryAuthorization, recoveryReceipt = &resolvedReceipt, &recovered
+			runReceipt := execution.StagedOperationReceipt{
+				Format: execution.StagedReceiptFormat, State: "COMPLETED_SUCCEEDED",
+				PlanDigest: executor.recoveryBundle.plan.PlanDigest, StageID: "target-credential",
+				StageReceiptDigest: executor.recovery.StageReceipt.Digest,
+			}
+			if err != nil {
+				return runReceipt, nil, err
+			}
+			receipts = append(receipts, executor.recovery.StageReceipt)
+			return runReceipt, handoff, nil
+		}
 		runReceipt, handoff, err := executor.credential.run(ctx)
 		if err != nil {
 			return runReceipt, handoff, err
@@ -262,8 +329,9 @@ func (executor *PostRuntimeExecution) Run(ctx context.Context) (PostRuntimeExecu
 	result := PostRuntimeExecutionReceipt{
 		Format: PostRuntimeExecutionReceiptFormat, State: orchestrationReceipt.State,
 		PlanDigest: orchestrationReceipt.PlanDigest, StoppedAt: orchestrationReceipt.StoppedAt,
-		Checkpoints:            append([]PostRuntimeStageCheckpoint(nil), orchestrationReceipt.Checkpoints...),
-		ResolvedAuthorizations: append([]ResolvedStageAuthorizationReceipt(nil), authorizations...),
+		Checkpoints:                   append([]PostRuntimeStageCheckpoint(nil), orchestrationReceipt.Checkpoints...),
+		ResolvedAuthorizations:        append([]ResolvedStageAuthorizationReceipt(nil), authorizations...),
+		ResolvedRecoveryAuthorization: recoveryAuthorization, TargetCredentialRecovery: recoveryReceipt,
 	}
 	return result, err
 }

--- a/internal/runner/post_runtime_execution_test.go
+++ b/internal/runner/post_runtime_execution_test.go
@@ -103,6 +103,68 @@ func TestPostRuntimeExecutionStopsAfterDurableReceiptWhenNextGrantIsUnavailable(
 	}
 }
 
+func TestPostRuntimeExecutionContinuesFromReceiptBoundCredentialRecovery(t *testing.T) {
+	config, factories, calls, _ := postRuntimeExecutionFixture(t)
+	bundle, err := LoadTargetCredentialStageBundle(config.TargetCredential)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := config.TargetCredential.EvaluationTime.Add(time.Minute)
+	credentialAPI, requests := newTargetCredentialExecutionAPI(t, now, 201)
+	defer credentialAPI.Close()
+	ledgerAPI := newRuntimeBindingLedgerAPI(t)
+	defer ledgerAPI.Close()
+	runtime := targetCredentialExecutionRuntime(t, targetCredentialBundleTestFixture{
+		config: config.TargetCredential, plan: bundle.plan, policyDigest: bundle.receipt.PolicyDigest,
+		accessDigest: bundle.receipt.TargetAccessArtifactDigest,
+	}, ledgerAPI.Server, credentialAPI, now)
+	original, err := bundle.Open(runtime)
+	if err != nil {
+		t.Fatal(err)
+	}
+	run, handoff, err := original.RunHandoff(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := handoff.StageReceiptBytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	priorPath := filepath.Join(config.ReceiptDirectory, postRuntimeReceiptFiles["target-credential"])
+	if err := os.WriteFile(priorPath, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	prior := StageReceiptSource{Path: priorPath, Digest: run.StageReceiptDigest}
+	recoveryGrantRoot := t.TempDir()
+	config.TargetCredentialRun = runtime
+	config.TargetCredentialRecovery = &PostRuntimeTargetCredentialRecoveryConfig{
+		StageReceipt: prior,
+		Authorization: TargetCredentialRecoveryAuthorizationResolverFunc(func(_ context.Context, request TargetCredentialRecoveryAuthorizationRequest) (StageAuthorizationSource, error) {
+			return writeTargetCredentialRecoveryGrant(t, recoveryGrantRoot, request, now), nil
+		}),
+	}
+	executor, err := openPostRuntimeExecution(config, factories)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := executor.Run(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if receipt.State != "SUCCEEDED" || receipt.ResolvedRecoveryAuthorization == nil || receipt.TargetCredentialRecovery == nil ||
+		receipt.TargetCredentialRecovery.State != "REISSUED" || receipt.Checkpoints[0].StageReceiptDigest != prior.Digest ||
+		len(receipt.ResolvedAuthorizations) != 2 || requests.Load() != 2 {
+		t.Fatalf("post-runtime recovery did not continue exact suffix: %#v requests=%d", receipt, requests.Load())
+	}
+	if !reflect.DeepEqual(*calls, postRuntimeStageOrder[1:]) {
+		t.Fatalf("normal Stage-8 factory ran during recovery: calls=%v", *calls)
+	}
+	stored, err := os.ReadFile(priorPath)
+	if err != nil || digest.SHA256(stored) != prior.Digest {
+		t.Fatalf("recovery changed prior Stage-8 receipt: %v", err)
+	}
+}
+
 func postRuntimeExecutionFixture(t *testing.T) (PostRuntimeExecutionConfig, postRuntimeExecutionFactories, *[]string, *[]StageAuthorizationRequest) {
 	t.Helper()
 	credential := targetCredentialBundleFixture(t)

--- a/internal/runner/post_runtime_execution_test.go
+++ b/internal/runner/post_runtime_execution_test.go
@@ -165,6 +165,118 @@ func TestPostRuntimeExecutionContinuesFromReceiptBoundCredentialRecovery(t *test
 	}
 }
 
+func TestPostRuntimeExecutionContinuesFromReceiptBoundRegistrationRecovery(t *testing.T) {
+	config, factories, calls, requests := postRuntimeExecutionFixture(t)
+	bundle, err := LoadTargetCredentialStageBundle(config.TargetCredential)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := config.TargetCredential.EvaluationTime.Add(time.Minute)
+	credentialAPI, tokenRequests := newTargetCredentialExecutionAPI(t, now, 201)
+	defer credentialAPI.Close()
+	ledgerAPI := newRuntimeBindingLedgerAPI(t)
+	defer ledgerAPI.Close()
+	runtime := targetCredentialExecutionRuntime(t, targetCredentialBundleTestFixture{
+		config: config.TargetCredential, plan: bundle.plan, policyDigest: bundle.receipt.PolicyDigest,
+		accessDigest: bundle.receipt.TargetAccessArtifactDigest,
+	}, ledgerAPI.Server, credentialAPI, now)
+	original, err := bundle.Open(runtime)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stageEightRun, stageEightHandoff, err := original.RunHandoff(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	stageEightRaw, err := stageEightHandoff.StageReceiptBytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	stageEightPath := filepath.Join(config.ReceiptDirectory, postRuntimeReceiptFiles["target-credential"])
+	if err := os.WriteFile(stageEightPath, stageEightRaw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	stageEight := StageReceiptSource{Path: stageEightPath, Digest: stageEightRun.StageReceiptDigest}
+
+	resume := StageResumeConfig{PlanPath: config.TargetCredential.PlanPath, PlanExpected: config.TargetCredential.PlanExpected,
+		Receipts: append(append([]StageReceiptSource(nil), config.TargetCredential.Receipts...), stageEight)}
+	plan, cursor, _, err := loadStageResumeWithPrefix(resume)
+	if err != nil {
+		t.Fatal(err)
+	}
+	predecessors, err := cursor.Predecessors()
+	if err != nil {
+		t.Fatal(err)
+	}
+	stageNine, err := stagereceipt.New(plan, "target-registration", predecessors, "SUCCEEDED", "ATTEMPTED",
+		digest.SHA256([]byte("original-registration-outcome")), digest.SHA256([]byte("original-registration-evidence")), now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stageNineRaw, err := stageNine.Bytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	stageNineDigest, err := stageNine.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	stageNinePath := filepath.Join(config.ReceiptDirectory, postRuntimeReceiptFiles["target-registration"])
+	if err := os.WriteFile(stageNinePath, stageNineRaw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	stageNineSource := StageReceiptSource{Path: stageNinePath, Digest: stageNineDigest}
+
+	grantRoot := t.TempDir()
+	config.TargetCredentialRun = runtime
+	config.TargetCredentialRecovery = &PostRuntimeTargetCredentialRecoveryConfig{
+		StageReceipt: stageEight,
+		Authorization: TargetCredentialRecoveryAuthorizationResolverFunc(func(_ context.Context, request TargetCredentialRecoveryAuthorizationRequest) (StageAuthorizationSource, error) {
+			return writeTargetCredentialRecoveryGrant(t, grantRoot, request, now), nil
+		}),
+	}
+	config.TargetRegistrationRecovery = &PostRuntimeTargetRegistrationRecoveryConfig{
+		StageReceipt: stageNineSource,
+		Authorization: TargetRegistrationRecoveryAuthorizationResolverFunc(func(_ context.Context, request TargetRegistrationRecoveryAuthorizationRequest) (StageAuthorizationSource, error) {
+			return writeTargetRegistrationRecoveryGrant(t, grantRoot, request, now), nil
+		}),
+	}
+	factories.registrationRecovery = func(_ context.Context, recovery TargetRegistrationRecoveryConfig) (TargetRegistrationRecoveryReceipt, error) {
+		*calls = append(*calls, "target-registration")
+		if recovery.PriorStageReceipt.Digest != stageNineDigest || recovery.Handoff == nil || !recovery.Authorization.verified {
+			t.Fatalf("registration recovery config differs: %#v", recovery)
+		}
+		return TargetRegistrationRecoveryReceipt{
+			Format: TargetRegistrationRecoveryReceiptFormat, State: "REFRESHED", PlanDigest: plan.PlanDigest,
+			PriorStageReceiptDigest: stageNineDigest, RecoveryRequestDigest: recovery.Authorization.request.RequestDigest,
+		}, nil
+	}
+
+	executor, err := openPostRuntimeExecution(config, factories)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := executor.Run(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if receipt.State != "SUCCEEDED" || receipt.ResolvedRecoveryAuthorization == nil || receipt.TargetCredentialRecovery == nil ||
+		receipt.ResolvedRegistrationRecoveryAuthorization == nil || receipt.TargetRegistrationRecovery == nil ||
+		receipt.TargetRegistrationRecovery.State != "REFRESHED" || len(receipt.ResolvedAuthorizations) != 1 || len(receipt.Checkpoints) != 5 ||
+		receipt.Checkpoints[0].StageReceiptDigest != stageEight.Digest || receipt.Checkpoints[1].StageReceiptDigest != stageNineDigest ||
+		tokenRequests.Load() != 2 {
+		t.Fatalf("post-runtime registration recovery did not continue exact suffix: %#v tokenRequests=%d", receipt, tokenRequests.Load())
+	}
+	if !reflect.DeepEqual(*calls, postRuntimeStageOrder[1:]) || len(*requests) != 1 || (*requests)[0].StageID != "platform-applications" {
+		t.Fatalf("normal registration path ran during recovery: calls=%v requests=%#v", *calls, *requests)
+	}
+	storedEight, errEight := os.ReadFile(stageEightPath)
+	storedNine, errNine := os.ReadFile(stageNinePath)
+	if errEight != nil || errNine != nil || digest.SHA256(storedEight) != stageEight.Digest || digest.SHA256(storedNine) != stageNineDigest {
+		t.Fatalf("registration recovery changed historical receipts: stage8=%v stage9=%v", errEight, errNine)
+	}
+}
+
 func postRuntimeExecutionFixture(t *testing.T) (PostRuntimeExecutionConfig, postRuntimeExecutionFactories, *[]string, *[]StageAuthorizationRequest) {
 	t.Helper()
 	credential := targetCredentialBundleFixture(t)

--- a/internal/runner/runtime_binding_stage.go
+++ b/internal/runner/runtime_binding_stage.go
@@ -177,6 +177,15 @@ func (stage OpenedRuntimeBindingStage) Run(ctx context.Context) (execution.Bindi
 	return stage.operation.Run(ctx, stage.plan, stage.cursor)
 }
 
+// Retry performs one digest-bound retry after an immutable terminal binding
+// receipt while preserving every prior attempt.
+func (stage OpenedRuntimeBindingStage) Retry(ctx context.Context, terminalReceiptDigest string) (execution.BindingStageRunReceipt, error) {
+	if !stage.verified {
+		return execution.BindingStageRunReceipt{}, errors.New("runtime binding stage is not opened")
+	}
+	return stage.operation.Retry(ctx, stage.plan, stage.cursor, terminalReceiptDigest)
+}
+
 // EvidenceReceipt exposes only the redaction-safe receipt from a binding call
 // made by this opened stage. Private material and runtime identities remain in
 // the selected private persistence implementation.

--- a/internal/runner/target_credential_recovery.go
+++ b/internal/runner/target_credential_recovery.go
@@ -308,7 +308,7 @@ func RecoverTargetCredential(ctx context.Context, config TargetCredentialRecover
 		return receipt, nil, errors.New("complete target-credential recovery outcome")
 	}
 	receipt.Outcome, receipt.State = &outcome, "REISSUED"
-	handoff, err := newVerifiedTargetCredentialStageHandoff(config.Bundle.plan, config.Bundle.prefix, prior, credential)
+	handoff, err := newVerifiedRecoveredTargetCredentialStageHandoff(config.Bundle.plan, config.Bundle.prefix, prior, credential, receipt)
 	if err != nil {
 		return receipt, nil, err
 	}

--- a/internal/runner/target_credential_recovery.go
+++ b/internal/runner/target_credential_recovery.go
@@ -1,0 +1,341 @@
+package runner
+
+import (
+	"context"
+	"crypto/subtle"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/authorization"
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/ledger"
+	"github.com/openkubes/ok-cluster/internal/stagecursor"
+	"github.com/openkubes/ok-cluster/internal/stagereceipt"
+)
+
+const (
+	TargetCredentialRecoveryAuthorizationRequestFormat  = "ok147-target-credential-recovery-authorization-request/v1"
+	ResolvedTargetCredentialRecoveryAuthorizationFormat = "ok147-resolved-target-credential-recovery-authorization/v1"
+	TargetCredentialRecoveryReceiptFormat               = "ok147-target-credential-recovery/v2"
+)
+
+// TargetCredentialRecoveryAuthorizationRequest tells the external authority
+// that a new single-use Stage-8 grant is requested only because the original
+// successful Stage-8 receipt can no longer hand private material to Stage 9.
+// It is redaction-safe and binds both the old receipt and old authorization.
+type TargetCredentialRecoveryAuthorizationRequest struct {
+	Format                      string                    `json:"format"`
+	RequestDigest               string                    `json:"requestDigest"`
+	Stage                       StageAuthorizationRequest `json:"stage"`
+	PriorStageReceiptDigest     string                    `json:"priorStageReceiptDigest"`
+	OriginalAuthorizationDigest string                    `json:"originalAuthorizationDigest"`
+}
+
+type targetCredentialRecoveryAuthorizationRequestPayload struct {
+	Format                      string                    `json:"format"`
+	Stage                       StageAuthorizationRequest `json:"stage"`
+	PriorStageReceiptDigest     string                    `json:"priorStageReceiptDigest"`
+	OriginalAuthorizationDigest string                    `json:"originalAuthorizationDigest"`
+}
+
+type TargetCredentialRecoveryAuthorizationResolver interface {
+	ResolveTargetCredentialRecoveryAuthorization(context.Context, TargetCredentialRecoveryAuthorizationRequest) (StageAuthorizationSource, error)
+}
+
+type TargetCredentialRecoveryAuthorizationResolverFunc func(context.Context, TargetCredentialRecoveryAuthorizationRequest) (StageAuthorizationSource, error)
+
+func (resolve TargetCredentialRecoveryAuthorizationResolverFunc) ResolveTargetCredentialRecoveryAuthorization(ctx context.Context, request TargetCredentialRecoveryAuthorizationRequest) (StageAuthorizationSource, error) {
+	return resolve(ctx, request)
+}
+
+type ResolvedTargetCredentialRecoveryAuthorization struct {
+	request  TargetCredentialRecoveryAuthorizationRequest
+	source   StageAuthorizationSource
+	grant    authorization.VerifiedStageGrant
+	verified bool
+}
+
+type ResolvedTargetCredentialRecoveryAuthorizationReceipt struct {
+	Format                      string `json:"format"`
+	State                       string `json:"state"`
+	RequestDigest               string `json:"requestDigest"`
+	PriorStageReceiptDigest     string `json:"priorStageReceiptDigest"`
+	OriginalAuthorizationDigest string `json:"originalAuthorizationDigest"`
+	RecoveryAuthorizationDigest string `json:"recoveryAuthorizationDigest"`
+	GrantID                     string `json:"grantId"`
+	KeyID                       string `json:"keyId"`
+	PlanDigest                  string `json:"planDigest"`
+	StageID                     string `json:"stageId"`
+	NotAfter                    string `json:"notAfter"`
+	MaxUses                     int    `json:"maxUses"`
+}
+
+func (request TargetCredentialRecoveryAuthorizationRequest) Bytes() ([]byte, error) {
+	digestValue, err := targetCredentialRecoveryAuthorizationRequestDigest(request)
+	if err != nil || request.Format != TargetCredentialRecoveryAuthorizationRequestFormat || request.RequestDigest != digestValue ||
+		!stageReceiptPrefixDigestPattern.MatchString(request.PriorStageReceiptDigest) || !stageReceiptPrefixDigestPattern.MatchString(request.OriginalAuthorizationDigest) {
+		return nil, errors.New("target-credential recovery authorization request was not produced by verification")
+	}
+	raw, err := json.Marshal(request)
+	if err != nil {
+		return nil, err
+	}
+	return canonicalTargetRegistrationValue(json.RawMessage(raw))
+}
+
+func (resolved ResolvedTargetCredentialRecoveryAuthorization) Receipt() (ResolvedTargetCredentialRecoveryAuthorizationReceipt, error) {
+	if !resolved.verified {
+		return ResolvedTargetCredentialRecoveryAuthorizationReceipt{}, errors.New("target-credential recovery authorization was not produced by verification")
+	}
+	grant := resolved.grant.Receipt()
+	if grant.AuthorizationDigest == resolved.request.OriginalAuthorizationDigest || grant.GrantID == "" {
+		return ResolvedTargetCredentialRecoveryAuthorizationReceipt{}, errors.New("target-credential recovery authorization is not independent")
+	}
+	return ResolvedTargetCredentialRecoveryAuthorizationReceipt{
+		Format: ResolvedTargetCredentialRecoveryAuthorizationFormat, State: "VERIFIED",
+		RequestDigest: resolved.request.RequestDigest, PriorStageReceiptDigest: resolved.request.PriorStageReceiptDigest,
+		OriginalAuthorizationDigest: resolved.request.OriginalAuthorizationDigest, RecoveryAuthorizationDigest: grant.AuthorizationDigest,
+		GrantID: grant.GrantID, KeyID: grant.KeyID, PlanDigest: grant.PlanDigest, StageID: grant.StageID,
+		NotAfter: grant.NotAfter, MaxUses: grant.MaxUses,
+	}, nil
+}
+
+// ResolveTargetCredentialRecoveryAuthorization verifies the already durable
+// successful Stage-8 receipt before asking an external authority for a fresh
+// grant. The new grant must have a different authorization digest and GrantID.
+func ResolveTargetCredentialRecoveryAuthorization(ctx context.Context, bundle VerifiedTargetCredentialStageBundle, prior StageReceiptSource, resolver TargetCredentialRecoveryAuthorizationResolver) (ResolvedTargetCredentialRecoveryAuthorization, error) {
+	if err := verifyTargetCredentialStageBundle(bundle); err != nil || resolver == nil {
+		return ResolvedTargetCredentialRecoveryAuthorization{}, errors.New("verified target-credential bundle and recovery resolver are required")
+	}
+	if err := ctx.Err(); err != nil {
+		return ResolvedTargetCredentialRecoveryAuthorization{}, errors.New("target-credential recovery authorization context is unavailable")
+	}
+	verifiedPrior, err := loadSuccessfulTargetCredentialReceipt(bundle, prior)
+	if err != nil {
+		return ResolvedTargetCredentialRecoveryAuthorization{}, err
+	}
+	decision, err := bundle.cursor.Decision()
+	if err != nil {
+		return ResolvedTargetCredentialRecoveryAuthorization{}, err
+	}
+	stageRequest, err := newStageAuthorizationRequest(bundle.plan, decision)
+	if err != nil {
+		return ResolvedTargetCredentialRecoveryAuthorization{}, err
+	}
+	request := TargetCredentialRecoveryAuthorizationRequest{
+		Format: TargetCredentialRecoveryAuthorizationRequestFormat, Stage: stageRequest,
+		PriorStageReceiptDigest: prior.Digest, OriginalAuthorizationDigest: bundle.receipt.AuthorizationDigest,
+	}
+	request.RequestDigest, err = targetCredentialRecoveryAuthorizationRequestDigest(request)
+	if err != nil {
+		return ResolvedTargetCredentialRecoveryAuthorization{}, errors.New("canonicalize target-credential recovery authorization request")
+	}
+	source, err := resolver.ResolveTargetCredentialRecoveryAuthorization(ctx, cloneTargetCredentialRecoveryAuthorizationRequest(request))
+	if err != nil {
+		return ResolvedTargetCredentialRecoveryAuthorization{}, errors.New("resolve target-credential recovery authorization")
+	}
+	if err := ctx.Err(); err != nil {
+		return ResolvedTargetCredentialRecoveryAuthorization{}, errors.New("target-credential recovery authorization context became unavailable")
+	}
+	if source.GrantPath == "" || source.PublicKeyPath == "" || source.EvaluationTime.IsZero() {
+		return ResolvedTargetCredentialRecoveryAuthorization{}, errors.New("resolved target-credential recovery authorization source is incomplete")
+	}
+	predecessors, err := bundle.cursor.Predecessors()
+	if err != nil {
+		return ResolvedTargetCredentialRecoveryAuthorization{}, err
+	}
+	grant, err := authorization.LoadStage(source.GrantPath, source.PublicKeyPath, bundle.plan, "target-credential", predecessors, source.EvaluationTime)
+	if err != nil {
+		return ResolvedTargetCredentialRecoveryAuthorization{}, errors.New("verify target-credential recovery authorization")
+	}
+	newReceipt, originalReceipt := grant.Receipt(), bundle.grant.Receipt()
+	if newReceipt.AuthorizationDigest == originalReceipt.AuthorizationDigest || newReceipt.GrantID == originalReceipt.GrantID {
+		return ResolvedTargetCredentialRecoveryAuthorization{}, errors.New("target-credential recovery requires an independent authorization and GrantID")
+	}
+	if _, err := verifiedPrior.Digest(); err != nil {
+		return ResolvedTargetCredentialRecoveryAuthorization{}, err
+	}
+	return ResolvedTargetCredentialRecoveryAuthorization{request: request, source: source, grant: grant, verified: true}, nil
+}
+
+func cloneTargetCredentialRecoveryAuthorizationRequest(request TargetCredentialRecoveryAuthorizationRequest) TargetCredentialRecoveryAuthorizationRequest {
+	request.Stage = cloneStageAuthorizationRequest(request.Stage)
+	return request
+}
+
+func targetCredentialRecoveryAuthorizationRequestDigest(request TargetCredentialRecoveryAuthorizationRequest) (string, error) {
+	payload := targetCredentialRecoveryAuthorizationRequestPayload{
+		Format: request.Format, Stage: request.Stage, PriorStageReceiptDigest: request.PriorStageReceiptDigest,
+		OriginalAuthorizationDigest: request.OriginalAuthorizationDigest,
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return "", err
+	}
+	canonical, err := canonicalTargetRegistrationValue(json.RawMessage(raw))
+	if err != nil {
+		return "", err
+	}
+	return digest.SHA256(canonical), nil
+}
+
+func verifyResolvedTargetCredentialRecoveryAuthorization(resolved ResolvedTargetCredentialRecoveryAuthorization, bundle VerifiedTargetCredentialStageBundle, prior StageReceiptSource) error {
+	if !resolved.verified || resolved.request.Format != TargetCredentialRecoveryAuthorizationRequestFormat || resolved.request.PriorStageReceiptDigest != prior.Digest ||
+		resolved.request.OriginalAuthorizationDigest != bundle.receipt.AuthorizationDigest || resolved.request.Stage.StageID != "target-credential" {
+		return errors.New("target-credential recovery authorization was not produced by verification")
+	}
+	digestValue, err := targetCredentialRecoveryAuthorizationRequestDigest(resolved.request)
+	if err != nil || digestValue != resolved.request.RequestDigest {
+		return errors.New("target-credential recovery authorization request identity changed")
+	}
+	predecessors, err := bundle.cursor.Predecessors()
+	if err != nil {
+		return err
+	}
+	if _, err := authorization.BindStageGrant(resolved.grant, bundle.plan, "target-credential", predecessors); err != nil {
+		return errors.New("target-credential recovery authorization binding changed")
+	}
+	current, original := resolved.grant.Receipt(), bundle.grant.Receipt()
+	if current.AuthorizationDigest == original.AuthorizationDigest || current.GrantID == original.GrantID {
+		return errors.New("target-credential recovery authorization is not independent")
+	}
+	return nil
+}
+
+type TargetCredentialRecoveryConfig struct {
+	Bundle        VerifiedTargetCredentialStageBundle
+	StageReceipt  StageReceiptSource
+	Authorization ResolvedTargetCredentialRecoveryAuthorization
+	Ledger        KubernetesLedgerConfig
+	Workload      WorkloadAuthorityFileResolverConfig
+	Clock         func() time.Time
+}
+
+type TargetCredentialRecoveryReceipt struct {
+	Format                       string                      `json:"format"`
+	State                        string                      `json:"state"`
+	PlanDigest                   string                      `json:"planDigest"`
+	PriorStageReceiptDigest      string                      `json:"priorStageReceiptDigest"`
+	RecoveryRequestDigest        string                      `json:"recoveryRequestDigest"`
+	OriginalAuthorizationDigest  string                      `json:"originalAuthorizationDigest"`
+	RecoveryAuthorizationDigest  string                      `json:"recoveryAuthorizationDigest"`
+	TargetIdentityDigest         string                      `json:"targetIdentityDigest"`
+	Claim                        *ledger.StageClaimReceipt   `json:"claim,omitempty"`
+	Outcome                      *ledger.StageOutcomeReceipt `json:"outcome,omitempty"`
+	CredentialIssueReceiptDigest string                      `json:"credentialIssueReceiptDigest,omitempty"`
+	IssuedAt                     string                      `json:"issuedAt,omitempty"`
+	ExpiresAt                    string                      `json:"expiresAt,omitempty"`
+	CredentialBytesInReceipt     bool                        `json:"credentialBytesInReceipt"`
+	StageReceiptRewritten        bool                        `json:"stageReceiptRewritten"`
+}
+
+// RecoverTargetCredential claims the fresh recovery grant before making one
+// TokenRequest. It records a durable outcome but deliberately never finalizes
+// or overwrites the authoritative successful Stage-8 receipt.
+func RecoverTargetCredential(ctx context.Context, config TargetCredentialRecoveryConfig) (TargetCredentialRecoveryReceipt, *VerifiedTargetCredentialStageHandoff, error) {
+	receipt := TargetCredentialRecoveryReceipt{Format: TargetCredentialRecoveryReceiptFormat, State: "PRECLAIM"}
+	if err := verifyTargetCredentialStageBundle(config.Bundle); err != nil || config.Clock == nil {
+		return receipt, nil, errors.New("verified target-credential recovery config and clock are required")
+	}
+	if err := verifyResolvedTargetCredentialRecoveryAuthorization(config.Authorization, config.Bundle, config.StageReceipt); err != nil {
+		return receipt, nil, err
+	}
+	prior, err := loadSuccessfulTargetCredentialReceipt(config.Bundle, config.StageReceipt)
+	if err != nil {
+		return receipt, nil, err
+	}
+	recoveryGrant := config.Authorization.grant
+	recoveryGrantReceipt := recoveryGrant.Receipt()
+	receipt.PlanDigest = config.Bundle.plan.PlanDigest
+	receipt.PriorStageReceiptDigest = config.StageReceipt.Digest
+	receipt.RecoveryRequestDigest = config.Authorization.request.RequestDigest
+	receipt.OriginalAuthorizationDigest = config.Bundle.receipt.AuthorizationDigest
+	receipt.RecoveryAuthorizationDigest = recoveryGrantReceipt.AuthorizationDigest
+	receipt.TargetIdentityDigest = config.Bundle.receipt.TargetIdentityDigest
+
+	issuer, err := OpenTargetCredentialIssuer(config.Bundle, TargetCredentialIssuerConfig{Workload: config.Workload, Clock: config.Clock})
+	if err != nil {
+		return receipt, nil, err
+	}
+	store, ledgerToken, err := openKubernetesLedger(config.Ledger)
+	if err != nil {
+		return receipt, nil, errors.New("open target-credential recovery ledger")
+	}
+	if len(ledgerToken) == len(issuer.authorityToken) && subtle.ConstantTimeCompare([]byte(ledgerToken), []byte(issuer.authorityToken)) == 1 {
+		return receipt, nil, errors.New("ledger and target-credential recovery authority credentials must be distinct")
+	}
+	inspection, err := store.InspectStage(ctx, recoveryGrant)
+	if err != nil {
+		return receipt, nil, err
+	}
+	if inspection.State != "AVAILABLE" || !inspection.ClaimAllowed {
+		return receipt, nil, errors.New("target-credential recovery authorization is not available")
+	}
+	claim, err := store.ClaimStage(ctx, recoveryGrant, config.Clock())
+	if err != nil {
+		return receipt, nil, err
+	}
+	receipt.Claim = &claim
+	receipt.State = "CLAIMED_INDETERMINATE_STOP"
+
+	credential, issueErr := issuer.Issue(ctx)
+	if issueErr != nil {
+		stoppedRaw, _ := canonicalTargetRegistrationValue(targetCredentialStoppedEvidence{
+			Format: "ok147-target-credential-recovery-stopped-evidence/v1", StageID: "target-credential",
+			PlanDigest: config.Bundle.plan.PlanDigest, PolicyDigest: config.Bundle.receipt.PolicyDigest,
+			TargetIdentityDigest: config.Bundle.receipt.TargetIdentityDigest, State: "STOPPED", CredentialRetained: false,
+		})
+		outcome, completeErr := store.CompleteStage(ctx, claim, "STOPPED", "UNKNOWN", digest.SHA256(stoppedRaw), config.Clock())
+		if completeErr != nil {
+			return receipt, nil, errors.New("target-credential recovery stopped before durable completion")
+		}
+		receipt.Outcome, receipt.State = &outcome, "COMPLETED_STOPPED"
+		return receipt, nil, errors.New("bounded target-credential recovery issuance stopped")
+	}
+	issued, err := credential.Receipt()
+	if err != nil || issued.TargetIdentityDigest != receipt.TargetIdentityDigest {
+		return receipt, nil, errors.New("recovered target credential differs from bound target")
+	}
+	issuedRaw, err := canonicalTargetRegistrationValue(issued)
+	if err != nil {
+		return receipt, nil, errors.New("canonicalize recovered target credential evidence")
+	}
+	receipt.CredentialIssueReceiptDigest = digest.SHA256(issuedRaw)
+	receipt.IssuedAt, receipt.ExpiresAt = issued.IssuedAt, issued.ExpiresAt
+	outcome, err := store.CompleteStage(ctx, claim, "SUCCEEDED", "ATTEMPTED", receipt.CredentialIssueReceiptDigest, config.Clock())
+	if err != nil {
+		return receipt, nil, errors.New("complete target-credential recovery outcome")
+	}
+	receipt.Outcome, receipt.State = &outcome, "REISSUED"
+	handoff, err := newVerifiedTargetCredentialStageHandoff(config.Bundle.plan, config.Bundle.prefix, prior, credential)
+	if err != nil {
+		return receipt, nil, err
+	}
+	return receipt, handoff, nil
+}
+
+func loadSuccessfulTargetCredentialReceipt(bundle VerifiedTargetCredentialStageBundle, source StageReceiptSource) (stagereceipt.Verified, error) {
+	predecessors, err := bundle.cursor.Predecessors()
+	if err != nil {
+		return stagereceipt.Verified{}, err
+	}
+	verified, err := stagereceipt.Load(source.Path, source.Digest, bundle.plan, predecessors)
+	if err != nil {
+		return stagereceipt.Verified{}, errors.New("load durable target-credential receipt for recovery")
+	}
+	receipt, err := verified.Receipt()
+	if err != nil || receipt.StageID != "target-credential" || receipt.State != "SUCCEEDED" || receipt.MutationState != "ATTEMPTED" || receipt.EvidenceDigest == "" {
+		return stagereceipt.Verified{}, errors.New("target-credential recovery requires a successful durable Stage-8 receipt")
+	}
+	prefix := append(append([]stagereceipt.Verified(nil), bundle.prefix...), verified)
+	cursor, err := stagecursor.Evaluate(bundle.plan, prefix)
+	if err != nil {
+		return stagereceipt.Verified{}, err
+	}
+	decision, err := cursor.Decision()
+	if err != nil || decision.State != "NEXT" || decision.StageID != "target-registration" {
+		return stagereceipt.Verified{}, errors.New("durable receipt chain does not select target registration")
+	}
+	return verified, nil
+}

--- a/internal/runner/target_credential_recovery_test.go
+++ b/internal/runner/target_credential_recovery_test.go
@@ -21,12 +21,12 @@ func TestTargetCredentialRecoveryRequiresIndependentGrantAndClaimsBeforeIssuance
 		t.Fatal(err)
 	}
 	now := time.Date(2026, 8, 17, 16, 1, 0, 0, time.UTC)
-	credentialAPI, requests := newTargetCredentialExecutionAPI(t, now, http.StatusCreated)
-	defer credentialAPI.Close()
+	originalAPI, originalRequests := newTargetCredentialExecutionAPI(t, now, http.StatusCreated)
+	defer originalAPI.Close()
 	ledgerAPI := newRuntimeBindingLedgerAPI(t)
 	defer ledgerAPI.Close()
-	runtime := targetCredentialExecutionRuntime(t, fixture, ledgerAPI.Server, credentialAPI, now)
-	bound, err := bundle.Open(runtime)
+	originalRuntime := targetCredentialExecutionRuntime(t, fixture, ledgerAPI.Server, originalAPI, now)
+	bound, err := bundle.Open(originalRuntime)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -39,6 +39,10 @@ func TestTargetCredentialRecoveryRequiresIndependentGrantAndClaimsBeforeIssuance
 		t.Fatal(err)
 	}
 	prior := StageReceiptSource{Path: writeBundleFile(t, t.TempDir(), "stage-8.json", priorRaw), Digest: stageRun.StageReceiptDigest}
+	recoveryTime := now.Add(15 * time.Minute)
+	recoveryAPI, recoveryRequests := newTargetCredentialExecutionAPI(t, recoveryTime, http.StatusCreated)
+	defer recoveryAPI.Close()
+	recoveryRuntime := targetCredentialExecutionRuntime(t, fixture, ledgerAPI.Server, recoveryAPI, recoveryTime)
 
 	if _, err := ResolveTargetCredentialRecoveryAuthorization(context.Background(), bundle, prior,
 		TargetCredentialRecoveryAuthorizationResolverFunc(func(context.Context, TargetCredentialRecoveryAuthorizationRequest) (StageAuthorizationSource, error) {
@@ -52,7 +56,7 @@ func TestTargetCredentialRecoveryRequiresIndependentGrantAndClaimsBeforeIssuance
 	resolved, err := ResolveTargetCredentialRecoveryAuthorization(context.Background(), bundle, prior,
 		TargetCredentialRecoveryAuthorizationResolverFunc(func(_ context.Context, request TargetCredentialRecoveryAuthorizationRequest) (StageAuthorizationSource, error) {
 			observed = request
-			return writeTargetCredentialRecoveryGrant(t, root, request, now), nil
+			return writeTargetCredentialRecoveryGrant(t, root, request, recoveryTime), nil
 		}))
 	if err != nil {
 		t.Fatal(err)
@@ -64,13 +68,13 @@ func TestTargetCredentialRecoveryRequiresIndependentGrantAndClaimsBeforeIssuance
 	}
 
 	recovery, recoveredHandoff, err := RecoverTargetCredential(context.Background(), TargetCredentialRecoveryConfig{
-		Bundle: bundle, StageReceipt: prior, Authorization: resolved, Ledger: runtime.Ledger, Workload: runtime.Workload,
-		Clock: func() time.Time { return now },
+		Bundle: bundle, StageReceipt: prior, Authorization: resolved, Ledger: recoveryRuntime.Ledger, Workload: recoveryRuntime.Workload,
+		Clock: func() time.Time { return recoveryTime },
 	})
 	if err != nil || recovery.State != "REISSUED" || recovery.Claim == nil || recovery.Outcome == nil ||
 		recovery.Outcome.Outcome != "SUCCEEDED" || recovery.RecoveryAuthorizationDigest == recovery.OriginalAuthorizationDigest ||
-		recovery.CredentialBytesInReceipt || recovery.StageReceiptRewritten || recoveredHandoff == nil || requests.Load() != 2 {
-		t.Fatalf("recovery did not complete safely: %#v requests=%d err=%v", recovery, requests.Load(), err)
+		recovery.CredentialBytesInReceipt || recovery.StageReceiptRewritten || recoveredHandoff == nil || originalRequests.Load() != 1 || recoveryRequests.Load() != 1 {
+		t.Fatalf("recovery did not complete safely: %#v original=%d recovery=%d err=%v", recovery, originalRequests.Load(), recoveryRequests.Load(), err)
 	}
 	if recoveredHandoffDigest, err := recoveredHandoff.StageReceiptDigest(); err != nil || recoveredHandoffDigest != prior.Digest {
 		t.Fatalf("recovery rewrote authoritative Stage-8 receipt: %q %v", recoveredHandoffDigest, err)
@@ -79,10 +83,10 @@ func TestTargetCredentialRecoveryRequiresIndependentGrantAndClaimsBeforeIssuance
 		t.Fatalf("recovery created another Stage-8 receipt: count=%d", got)
 	}
 	if _, _, err := RecoverTargetCredential(context.Background(), TargetCredentialRecoveryConfig{
-		Bundle: bundle, StageReceipt: prior, Authorization: resolved, Ledger: runtime.Ledger, Workload: runtime.Workload,
-		Clock: func() time.Time { return now },
-	}); err == nil || requests.Load() != 2 {
-		t.Fatalf("consumed recovery grant was reused: requests=%d err=%v", requests.Load(), err)
+		Bundle: bundle, StageReceipt: prior, Authorization: resolved, Ledger: recoveryRuntime.Ledger, Workload: recoveryRuntime.Workload,
+		Clock: func() time.Time { return recoveryTime },
+	}); err == nil || recoveryRequests.Load() != 1 {
+		t.Fatalf("consumed recovery grant was reused: requests=%d err=%v", recoveryRequests.Load(), err)
 	}
 }
 
@@ -115,12 +119,13 @@ func TestTargetCredentialRecoveryDurablyStopsFailedIssuance(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	failureAPI, requests := newTargetCredentialExecutionAPI(t, now, http.StatusForbidden)
+	recoveryTime := now.Add(15 * time.Minute)
+	failureAPI, requests := newTargetCredentialExecutionAPI(t, recoveryTime, http.StatusForbidden)
 	defer failureAPI.Close()
-	failureRuntime := targetCredentialExecutionRuntime(t, fixture, ledgerAPI.Server, failureAPI, now)
+	failureRuntime := targetCredentialExecutionRuntime(t, fixture, ledgerAPI.Server, failureAPI, recoveryTime)
 	receipt, recovered, recoveryErr := RecoverTargetCredential(context.Background(), TargetCredentialRecoveryConfig{
 		Bundle: bundle, StageReceipt: prior, Authorization: resolved, Ledger: failureRuntime.Ledger, Workload: failureRuntime.Workload,
-		Clock: func() time.Time { return now },
+		Clock: func() time.Time { return recoveryTime },
 	})
 	if recoveryErr == nil || receipt.State != "COMPLETED_STOPPED" || receipt.Claim == nil || receipt.Outcome == nil ||
 		receipt.Outcome.Outcome != "STOPPED" || receipt.Outcome.MutationState != "UNKNOWN" || recovered != nil || requests.Load() != 1 {
@@ -128,7 +133,7 @@ func TestTargetCredentialRecoveryDurablyStopsFailedIssuance(t *testing.T) {
 	}
 	if _, _, err := RecoverTargetCredential(context.Background(), TargetCredentialRecoveryConfig{
 		Bundle: bundle, StageReceipt: prior, Authorization: resolved, Ledger: failureRuntime.Ledger, Workload: failureRuntime.Workload,
-		Clock: func() time.Time { return now },
+		Clock: func() time.Time { return recoveryTime },
 	}); err == nil || requests.Load() != 1 {
 		t.Fatalf("durably stopped recovery was retried: requests=%d err=%v", requests.Load(), err)
 	}

--- a/internal/runner/target_credential_recovery_test.go
+++ b/internal/runner/target_credential_recovery_test.go
@@ -1,0 +1,202 @@
+package runner
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/authorization"
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+func TestTargetCredentialRecoveryRequiresIndependentGrantAndClaimsBeforeIssuance(t *testing.T) {
+	fixture := targetCredentialBundleFixture(t)
+	bundle, err := LoadTargetCredentialStageBundle(fixture.config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2026, 8, 17, 16, 1, 0, 0, time.UTC)
+	credentialAPI, requests := newTargetCredentialExecutionAPI(t, now, http.StatusCreated)
+	defer credentialAPI.Close()
+	ledgerAPI := newRuntimeBindingLedgerAPI(t)
+	defer ledgerAPI.Close()
+	runtime := targetCredentialExecutionRuntime(t, fixture, ledgerAPI.Server, credentialAPI, now)
+	bound, err := bundle.Open(runtime)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stageRun, handoff, err := bound.RunHandoff(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	priorRaw, err := handoff.StageReceiptBytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	prior := StageReceiptSource{Path: writeBundleFile(t, t.TempDir(), "stage-8.json", priorRaw), Digest: stageRun.StageReceiptDigest}
+
+	if _, err := ResolveTargetCredentialRecoveryAuthorization(context.Background(), bundle, prior,
+		TargetCredentialRecoveryAuthorizationResolverFunc(func(context.Context, TargetCredentialRecoveryAuthorizationRequest) (StageAuthorizationSource, error) {
+			return StageAuthorizationSource{GrantPath: fixture.config.GrantPath, PublicKeyPath: fixture.config.GrantPublicKeyPath, EvaluationTime: fixture.config.EvaluationTime}, nil
+		})); err == nil {
+		t.Fatal("original Stage-8 grant was accepted as independent recovery authorization")
+	}
+
+	root := t.TempDir()
+	var observed TargetCredentialRecoveryAuthorizationRequest
+	resolved, err := ResolveTargetCredentialRecoveryAuthorization(context.Background(), bundle, prior,
+		TargetCredentialRecoveryAuthorizationResolverFunc(func(_ context.Context, request TargetCredentialRecoveryAuthorizationRequest) (StageAuthorizationSource, error) {
+			observed = request
+			return writeTargetCredentialRecoveryGrant(t, root, request, now), nil
+		}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if observed.Format != TargetCredentialRecoveryAuthorizationRequestFormat || observed.PriorStageReceiptDigest != prior.Digest ||
+		observed.OriginalAuthorizationDigest != bundle.receipt.AuthorizationDigest || observed.Stage.StageID != "target-credential" ||
+		observed.Stage.Predecessors[0].StageID != "target-access" || observed.RequestDigest == "" {
+		t.Fatalf("recovery authority request is incomplete: %#v", observed)
+	}
+
+	recovery, recoveredHandoff, err := RecoverTargetCredential(context.Background(), TargetCredentialRecoveryConfig{
+		Bundle: bundle, StageReceipt: prior, Authorization: resolved, Ledger: runtime.Ledger, Workload: runtime.Workload,
+		Clock: func() time.Time { return now },
+	})
+	if err != nil || recovery.State != "REISSUED" || recovery.Claim == nil || recovery.Outcome == nil ||
+		recovery.Outcome.Outcome != "SUCCEEDED" || recovery.RecoveryAuthorizationDigest == recovery.OriginalAuthorizationDigest ||
+		recovery.CredentialBytesInReceipt || recovery.StageReceiptRewritten || recoveredHandoff == nil || requests.Load() != 2 {
+		t.Fatalf("recovery did not complete safely: %#v requests=%d err=%v", recovery, requests.Load(), err)
+	}
+	if recoveredHandoffDigest, err := recoveredHandoff.StageReceiptDigest(); err != nil || recoveredHandoffDigest != prior.Digest {
+		t.Fatalf("recovery rewrote authoritative Stage-8 receipt: %q %v", recoveredHandoffDigest, err)
+	}
+	if got := countLedgerRecordType(ledgerAPI, "stage-receipt"); got != 1 {
+		t.Fatalf("recovery created another Stage-8 receipt: count=%d", got)
+	}
+	if _, _, err := RecoverTargetCredential(context.Background(), TargetCredentialRecoveryConfig{
+		Bundle: bundle, StageReceipt: prior, Authorization: resolved, Ledger: runtime.Ledger, Workload: runtime.Workload,
+		Clock: func() time.Time { return now },
+	}); err == nil || requests.Load() != 2 {
+		t.Fatalf("consumed recovery grant was reused: requests=%d err=%v", requests.Load(), err)
+	}
+}
+
+func TestTargetCredentialRecoveryDurablyStopsFailedIssuance(t *testing.T) {
+	fixture := targetCredentialBundleFixture(t)
+	bundle, err := LoadTargetCredentialStageBundle(fixture.config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2026, 8, 17, 16, 1, 0, 0, time.UTC)
+	successAPI, _ := newTargetCredentialExecutionAPI(t, now, http.StatusCreated)
+	defer successAPI.Close()
+	ledgerAPI := newRuntimeBindingLedgerAPI(t)
+	defer ledgerAPI.Close()
+	originalRuntime := targetCredentialExecutionRuntime(t, fixture, ledgerAPI.Server, successAPI, now)
+	bound, err := bundle.Open(originalRuntime)
+	if err != nil {
+		t.Fatal(err)
+	}
+	run, handoff, err := bound.RunHandoff(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, _ := handoff.StageReceiptBytes()
+	prior := StageReceiptSource{Path: writeBundleFile(t, t.TempDir(), "stage-8.json", raw), Digest: run.StageReceiptDigest}
+	resolved, err := ResolveTargetCredentialRecoveryAuthorization(context.Background(), bundle, prior,
+		TargetCredentialRecoveryAuthorizationResolverFunc(func(_ context.Context, request TargetCredentialRecoveryAuthorizationRequest) (StageAuthorizationSource, error) {
+			return writeTargetCredentialRecoveryGrant(t, t.TempDir(), request, now), nil
+		}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	failureAPI, requests := newTargetCredentialExecutionAPI(t, now, http.StatusForbidden)
+	defer failureAPI.Close()
+	failureRuntime := targetCredentialExecutionRuntime(t, fixture, ledgerAPI.Server, failureAPI, now)
+	receipt, recovered, recoveryErr := RecoverTargetCredential(context.Background(), TargetCredentialRecoveryConfig{
+		Bundle: bundle, StageReceipt: prior, Authorization: resolved, Ledger: failureRuntime.Ledger, Workload: failureRuntime.Workload,
+		Clock: func() time.Time { return now },
+	})
+	if recoveryErr == nil || receipt.State != "COMPLETED_STOPPED" || receipt.Claim == nil || receipt.Outcome == nil ||
+		receipt.Outcome.Outcome != "STOPPED" || receipt.Outcome.MutationState != "UNKNOWN" || recovered != nil || requests.Load() != 1 {
+		t.Fatalf("failed recovery was not durably stopped: %#v requests=%d err=%v", receipt, requests.Load(), recoveryErr)
+	}
+	if _, _, err := RecoverTargetCredential(context.Background(), TargetCredentialRecoveryConfig{
+		Bundle: bundle, StageReceipt: prior, Authorization: resolved, Ledger: failureRuntime.Ledger, Workload: failureRuntime.Workload,
+		Clock: func() time.Time { return now },
+	}); err == nil || requests.Load() != 1 {
+		t.Fatalf("durably stopped recovery was retried: requests=%d err=%v", requests.Load(), err)
+	}
+}
+
+func TestTargetCredentialRecoveryFailsClosedOnChangedReceiptAndResolution(t *testing.T) {
+	fixture := targetCredentialBundleFixture(t)
+	bundle, err := LoadTargetCredentialStageBundle(fixture.config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	missing := StageReceiptSource{Path: t.TempDir() + "/missing.json", Digest: runnerStageSHA("1")}
+	calls := 0
+	if _, err := ResolveTargetCredentialRecoveryAuthorization(context.Background(), bundle, missing,
+		TargetCredentialRecoveryAuthorizationResolverFunc(func(context.Context, TargetCredentialRecoveryAuthorizationRequest) (StageAuthorizationSource, error) {
+			calls++
+			return StageAuthorizationSource{}, errors.New("unexpected")
+		})); err == nil || calls != 0 {
+		t.Fatalf("invalid prior receipt reached recovery authority: calls=%d err=%v", calls, err)
+	}
+	if _, _, err := RecoverTargetCredential(context.Background(), TargetCredentialRecoveryConfig{}); err == nil {
+		t.Fatal("empty recovery config was accepted")
+	}
+}
+
+func writeTargetCredentialRecoveryGrant(t *testing.T, root string, request TargetCredentialRecoveryAuthorizationRequest, at time.Time) StageAuthorizationSource {
+	t.Helper()
+	payload := authorization.StagePayload{
+		Audience: request.Stage.Audience, GrantID: "ok147-target-credential-recovery-01", Decision: "ALLOW",
+		PlanDigest: request.Stage.PlanDigest, ContractIdentity: request.Stage.ContractIdentity,
+		ContractRevision: request.Stage.ContractRevision, EnablementRevision: request.Stage.EnablementRevision,
+		PlatformRevision: request.Stage.PlatformRevision, ExecutionFixture: request.Stage.ExecutionFixture,
+		StageID: request.Stage.StageID, StageOrder: request.Stage.StageOrder, StageDigest: request.Stage.StageDigest,
+		Operation: request.Stage.Operation, Authority: request.Stage.Authority, MaxUses: 1,
+		NotBefore: at.Add(-time.Minute).Format(time.RFC3339), NotAfter: at.Add(20 * time.Minute).Format(time.RFC3339),
+	}
+	for _, predecessor := range request.Stage.Predecessors {
+		payload.Predecessors = append(payload.Predecessors, authorization.StagePredecessor{StageID: predecessor.StageID, OutcomeDigest: predecessor.ReceiptDigest})
+	}
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	signed, err := authorization.StageSigningBytes(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	envelope := mustJSON(t, map[string]any{
+		"format": authorization.StageFormat, "payload": payload,
+		"signature": map[string]any{"algorithm": "Ed25519", "keyId": digest.SHA256(publicKey), "value": base64.StdEncoding.EncodeToString(ed25519.Sign(privateKey, signed))},
+	})
+	return StageAuthorizationSource{
+		GrantPath:      writeBundleFile(t, root, "recovery-grant.json", envelope),
+		PublicKeyPath:  writeBundleFile(t, root, "recovery-authority.pub", []byte(base64.StdEncoding.EncodeToString(publicKey)+"\n")),
+		EvaluationTime: at,
+	}
+}
+
+func countLedgerRecordType(api *runtimeBindingLedgerAPI, recordType string) int {
+	api.mu.Lock()
+	defer api.mu.Unlock()
+	count := 0
+	for _, object := range api.objects {
+		metadata, _ := object["metadata"].(map[string]any)
+		labels, _ := metadata["labels"].(map[string]any)
+		if labels["openkubes.io/ledger-record"] == recordType {
+			count++
+		}
+	}
+	return count
+}

--- a/internal/runner/target_credential_stage_handoff.go
+++ b/internal/runner/target_credential_stage_handoff.go
@@ -14,13 +14,15 @@ import (
 // receipt to one private, memory-only credential. Only the redacted receipts
 // are publicly readable; the credential can be consumed once inside runner.
 type VerifiedTargetCredentialStageHandoff struct {
-	mu         sync.Mutex
-	plan       stageplan.Binding
-	prefix     []stagereceipt.Verified
-	receipt    stagereceipt.Verified
-	credential VerifiedTargetCredentialMaterial
-	consumed   bool
-	verified   bool
+	mu                       sync.Mutex
+	plan                     stageplan.Binding
+	prefix                   []stagereceipt.Verified
+	receipt                  stagereceipt.Verified
+	credential               VerifiedTargetCredentialMaterial
+	credentialEvidenceDigest string
+	recoveryRequestDigest    string
+	consumed                 bool
+	verified                 bool
 }
 
 func newVerifiedTargetCredentialStageHandoff(plan stageplan.Binding, prefix []stagereceipt.Verified, receipt stagereceipt.Verified, credential VerifiedTargetCredentialMaterial) (*VerifiedTargetCredentialStageHandoff, error) {
@@ -53,7 +55,63 @@ func newVerifiedTargetCredentialStageHandoff(plan stageplan.Binding, prefix []st
 	if err != nil || decision.State != "NEXT" || decision.StageID != "target-registration" {
 		return nil, errors.New("target-credential handoff does not select target registration")
 	}
-	return &VerifiedTargetCredentialStageHandoff{plan: plan, prefix: combined, receipt: receipt, credential: credential, verified: true}, nil
+	return &VerifiedTargetCredentialStageHandoff{
+		plan: plan, prefix: combined, receipt: receipt, credential: credential,
+		credentialEvidenceDigest: digest.SHA256(issuedRaw), verified: true,
+	}, nil
+}
+
+func newVerifiedRecoveredTargetCredentialStageHandoff(plan stageplan.Binding, prefix []stagereceipt.Verified, prior stagereceipt.Verified, credential VerifiedTargetCredentialMaterial, recovery TargetCredentialRecoveryReceipt) (*VerifiedTargetCredentialStageHandoff, error) {
+	if len(prefix) != 7 || recovery.Format != TargetCredentialRecoveryReceiptFormat || recovery.State != "REISSUED" ||
+		recovery.Outcome == nil || recovery.Outcome.Outcome != "SUCCEEDED" || recovery.Outcome.MutationState != "ATTEMPTED" ||
+		recovery.CredentialBytesInReceipt || recovery.StageReceiptRewritten || recovery.PlanDigest != plan.PlanDigest {
+		return nil, errors.New("recovered target-credential handoff requires exact successful recovery evidence")
+	}
+	priorDigest, err := prior.Digest()
+	if err != nil || priorDigest != recovery.PriorStageReceiptDigest {
+		return nil, errors.New("recovered target-credential handoff prior receipt differs")
+	}
+	stage, err := prior.Receipt()
+	if err != nil || stage.StageID != "target-credential" || stage.State != "SUCCEEDED" || stage.MutationState != "ATTEMPTED" || stage.PlanDigest != plan.PlanDigest {
+		return nil, errors.New("recovered target-credential handoff lacks successful Stage-8 receipt")
+	}
+	issued, err := credential.Receipt()
+	if err != nil || issued.TargetIdentityDigest != recovery.TargetIdentityDigest {
+		return nil, errors.New("recovered target-credential handoff target differs")
+	}
+	issuedRaw, err := canonicalTargetRegistrationValue(issued)
+	if err != nil || digest.SHA256(issuedRaw) != recovery.CredentialIssueReceiptDigest || recovery.Outcome.EvidenceDigest != recovery.CredentialIssueReceiptDigest {
+		return nil, errors.New("recovered target-credential handoff evidence differs")
+	}
+	combined := append(append([]stagereceipt.Verified(nil), prefix...), prior)
+	cursor, err := stagecursor.Evaluate(plan, combined)
+	if err != nil {
+		return nil, err
+	}
+	decision, err := cursor.Decision()
+	if err != nil || decision.State != "NEXT" || decision.StageID != "target-registration" {
+		return nil, errors.New("recovered target-credential handoff does not select target registration")
+	}
+	return &VerifiedTargetCredentialStageHandoff{
+		plan: plan, prefix: combined, receipt: prior, credential: credential,
+		credentialEvidenceDigest: recovery.CredentialIssueReceiptDigest,
+		recoveryRequestDigest:    recovery.RecoveryRequestDigest, verified: true,
+	}, nil
+}
+
+func (handoff *VerifiedTargetCredentialStageHandoff) credentialEvidence() (string, string, error) {
+	if handoff == nil {
+		return "", "", errors.New("target-credential handoff is required")
+	}
+	handoff.mu.Lock()
+	defer handoff.mu.Unlock()
+	if !handoff.verified || handoff.consumed || !stageReceiptPrefixDigestPattern.MatchString(handoff.credentialEvidenceDigest) {
+		return "", "", errors.New("target-credential handoff evidence is unavailable")
+	}
+	if handoff.recoveryRequestDigest != "" && !stageReceiptPrefixDigestPattern.MatchString(handoff.recoveryRequestDigest) {
+		return "", "", errors.New("target-credential recovery request identity is invalid")
+	}
+	return handoff.credentialEvidenceDigest, handoff.recoveryRequestDigest, nil
 }
 
 func (handoff *VerifiedTargetCredentialStageHandoff) StageReceipt() (stagereceipt.Receipt, error) {

--- a/internal/runner/target_registration_material.go
+++ b/internal/runner/target_registration_material.go
@@ -154,7 +154,11 @@ func BuildTargetRegistrationMaterial(config TargetRegistrationMaterializeConfig)
 		return VerifiedTargetRegistrationMaterial{}, errors.New("canonicalize target-credential receipt")
 	}
 	credentialStageReceipt, err := bundle.prefix[7].Receipt()
-	if err != nil || credentialStageReceipt.StageID != "target-credential" || credentialStageReceipt.EvidenceDigest != digest.SHA256(credentialReceiptRaw) {
+	wantCredentialEvidence := credentialStageReceipt.EvidenceDigest
+	if bundle.credentialEvidenceDigest != "" {
+		wantCredentialEvidence = bundle.credentialEvidenceDigest
+	}
+	if err != nil || credentialStageReceipt.StageID != "target-credential" || wantCredentialEvidence != digest.SHA256(credentialReceiptRaw) {
 		return VerifiedTargetRegistrationMaterial{}, errors.New("target-credential material differs from durable stage evidence")
 	}
 	binding := targetRegistrationSafeBinding{

--- a/internal/runner/target_registration_recovery.go
+++ b/internal/runner/target_registration_recovery.go
@@ -1,0 +1,354 @@
+package runner
+
+import (
+	"context"
+	"crypto/subtle"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/authorization"
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/ledger"
+	"github.com/openkubes/ok-cluster/internal/stagecursor"
+	"github.com/openkubes/ok-cluster/internal/stageplan"
+	"github.com/openkubes/ok-cluster/internal/stagereceipt"
+	"github.com/openkubes/ok-cluster/internal/submission"
+)
+
+const (
+	TargetRegistrationRecoveryAuthorizationRequestFormat  = "ok147-target-registration-recovery-authorization-request/v1"
+	ResolvedTargetRegistrationRecoveryAuthorizationFormat = "ok147-resolved-target-registration-recovery-authorization/v1"
+	TargetRegistrationRecoveryReceiptFormat               = "ok147-target-registration-recovery/v1"
+)
+
+type TargetRegistrationRecoveryAuthorizationRequest struct {
+	Format                          string                    `json:"format"`
+	RequestDigest                   string                    `json:"requestDigest"`
+	Stage                           StageAuthorizationRequest `json:"stage"`
+	PriorStageReceiptDigest         string                    `json:"priorStageReceiptDigest"`
+	CredentialRecoveryRequestDigest string                    `json:"credentialRecoveryRequestDigest"`
+	CredentialIssueReceiptDigest    string                    `json:"credentialIssueReceiptDigest"`
+}
+
+type targetRegistrationRecoveryAuthorizationRequestPayload struct {
+	Format                          string                    `json:"format"`
+	Stage                           StageAuthorizationRequest `json:"stage"`
+	PriorStageReceiptDigest         string                    `json:"priorStageReceiptDigest"`
+	CredentialRecoveryRequestDigest string                    `json:"credentialRecoveryRequestDigest"`
+	CredentialIssueReceiptDigest    string                    `json:"credentialIssueReceiptDigest"`
+}
+
+type TargetRegistrationRecoveryAuthorizationResolver interface {
+	ResolveTargetRegistrationRecoveryAuthorization(context.Context, TargetRegistrationRecoveryAuthorizationRequest) (StageAuthorizationSource, error)
+}
+
+type TargetRegistrationRecoveryAuthorizationResolverFunc func(context.Context, TargetRegistrationRecoveryAuthorizationRequest) (StageAuthorizationSource, error)
+
+func (resolve TargetRegistrationRecoveryAuthorizationResolverFunc) ResolveTargetRegistrationRecoveryAuthorization(ctx context.Context, request TargetRegistrationRecoveryAuthorizationRequest) (StageAuthorizationSource, error) {
+	return resolve(ctx, request)
+}
+
+type ResolvedTargetRegistrationRecoveryAuthorization struct {
+	request  TargetRegistrationRecoveryAuthorizationRequest
+	source   StageAuthorizationSource
+	grant    authorization.VerifiedStageGrant
+	verified bool
+}
+
+type ResolvedTargetRegistrationRecoveryAuthorizationReceipt struct {
+	Format                          string `json:"format"`
+	State                           string `json:"state"`
+	RequestDigest                   string `json:"requestDigest"`
+	PriorStageReceiptDigest         string `json:"priorStageReceiptDigest"`
+	CredentialRecoveryRequestDigest string `json:"credentialRecoveryRequestDigest"`
+	CredentialIssueReceiptDigest    string `json:"credentialIssueReceiptDigest"`
+	AuthorizationDigest             string `json:"authorizationDigest"`
+	GrantID                         string `json:"grantId"`
+	KeyID                           string `json:"keyId"`
+	PlanDigest                      string `json:"planDigest"`
+	StageID                         string `json:"stageId"`
+	NotAfter                        string `json:"notAfter"`
+	MaxUses                         int    `json:"maxUses"`
+}
+
+func ResolveTargetRegistrationRecoveryAuthorization(ctx context.Context, handoff *VerifiedTargetCredentialStageHandoff, prior StageReceiptSource, resolver TargetRegistrationRecoveryAuthorizationResolver) (ResolvedTargetRegistrationRecoveryAuthorization, error) {
+	if handoff == nil || resolver == nil {
+		return ResolvedTargetRegistrationRecoveryAuthorization{}, errors.New("recovered target-credential handoff and registration recovery resolver are required")
+	}
+	if err := ctx.Err(); err != nil {
+		return ResolvedTargetRegistrationRecoveryAuthorization{}, errors.New("target-registration recovery authorization context is unavailable")
+	}
+	plan, cursor, prefix, err := handoff.registrationContext()
+	if err != nil {
+		return ResolvedTargetRegistrationRecoveryAuthorization{}, err
+	}
+	credentialEvidence, recoveryRequest, err := handoff.credentialEvidence()
+	if err != nil || recoveryRequest == "" {
+		return ResolvedTargetRegistrationRecoveryAuthorization{}, errors.New("target-registration recovery requires an independently recovered credential")
+	}
+	if _, err := loadSuccessfulTargetRegistrationReceipt(plan, cursor, prefix, prior); err != nil {
+		return ResolvedTargetRegistrationRecoveryAuthorization{}, err
+	}
+	decision, err := cursor.Decision()
+	if err != nil {
+		return ResolvedTargetRegistrationRecoveryAuthorization{}, err
+	}
+	stageRequest, err := newStageAuthorizationRequest(plan, decision)
+	if err != nil {
+		return ResolvedTargetRegistrationRecoveryAuthorization{}, err
+	}
+	request := TargetRegistrationRecoveryAuthorizationRequest{
+		Format: TargetRegistrationRecoveryAuthorizationRequestFormat, Stage: stageRequest,
+		PriorStageReceiptDigest: prior.Digest, CredentialRecoveryRequestDigest: recoveryRequest,
+		CredentialIssueReceiptDigest: credentialEvidence,
+	}
+	request.RequestDigest, err = targetRegistrationRecoveryAuthorizationRequestDigest(request)
+	if err != nil {
+		return ResolvedTargetRegistrationRecoveryAuthorization{}, errors.New("canonicalize target-registration recovery authorization request")
+	}
+	source, err := resolver.ResolveTargetRegistrationRecoveryAuthorization(ctx, cloneTargetRegistrationRecoveryAuthorizationRequest(request))
+	if err != nil {
+		return ResolvedTargetRegistrationRecoveryAuthorization{}, errors.New("resolve target-registration recovery authorization")
+	}
+	if err := ctx.Err(); err != nil {
+		return ResolvedTargetRegistrationRecoveryAuthorization{}, errors.New("target-registration recovery authorization context became unavailable")
+	}
+	if source.GrantPath == "" || source.PublicKeyPath == "" || source.EvaluationTime.IsZero() {
+		return ResolvedTargetRegistrationRecoveryAuthorization{}, errors.New("resolved target-registration recovery authorization source is incomplete")
+	}
+	predecessors, err := cursor.Predecessors()
+	if err != nil {
+		return ResolvedTargetRegistrationRecoveryAuthorization{}, err
+	}
+	grant, err := authorization.LoadStage(source.GrantPath, source.PublicKeyPath, plan, "target-registration", predecessors, source.EvaluationTime)
+	if err != nil {
+		return ResolvedTargetRegistrationRecoveryAuthorization{}, errors.New("verify target-registration recovery authorization")
+	}
+	return ResolvedTargetRegistrationRecoveryAuthorization{request: request, source: source, grant: grant, verified: true}, nil
+}
+
+func (request TargetRegistrationRecoveryAuthorizationRequest) Bytes() ([]byte, error) {
+	digestValue, err := targetRegistrationRecoveryAuthorizationRequestDigest(request)
+	if err != nil || request.Format != TargetRegistrationRecoveryAuthorizationRequestFormat || request.RequestDigest != digestValue ||
+		request.Stage.StageID != "target-registration" ||
+		!stageReceiptPrefixDigestPattern.MatchString(request.PriorStageReceiptDigest) ||
+		!stageReceiptPrefixDigestPattern.MatchString(request.CredentialRecoveryRequestDigest) ||
+		!stageReceiptPrefixDigestPattern.MatchString(request.CredentialIssueReceiptDigest) {
+		return nil, errors.New("target-registration recovery authorization request was not produced by verification")
+	}
+	if _, err := request.Stage.Bytes(); err != nil {
+		return nil, errors.New("target-registration recovery stage request was not produced by verification")
+	}
+	raw, err := json.Marshal(request)
+	if err != nil {
+		return nil, err
+	}
+	return canonicalTargetRegistrationValue(json.RawMessage(raw))
+}
+
+func (resolved ResolvedTargetRegistrationRecoveryAuthorization) Receipt() (ResolvedTargetRegistrationRecoveryAuthorizationReceipt, error) {
+	if !resolved.verified {
+		return ResolvedTargetRegistrationRecoveryAuthorizationReceipt{}, errors.New("target-registration recovery authorization was not produced by verification")
+	}
+	grant := resolved.grant.Receipt()
+	return ResolvedTargetRegistrationRecoveryAuthorizationReceipt{
+		Format: ResolvedTargetRegistrationRecoveryAuthorizationFormat, State: "VERIFIED",
+		RequestDigest: resolved.request.RequestDigest, PriorStageReceiptDigest: resolved.request.PriorStageReceiptDigest,
+		CredentialRecoveryRequestDigest: resolved.request.CredentialRecoveryRequestDigest,
+		CredentialIssueReceiptDigest:    resolved.request.CredentialIssueReceiptDigest,
+		AuthorizationDigest:             grant.AuthorizationDigest, GrantID: grant.GrantID, KeyID: grant.KeyID,
+		PlanDigest: grant.PlanDigest, StageID: grant.StageID, NotAfter: grant.NotAfter, MaxUses: grant.MaxUses,
+	}, nil
+}
+
+func cloneTargetRegistrationRecoveryAuthorizationRequest(request TargetRegistrationRecoveryAuthorizationRequest) TargetRegistrationRecoveryAuthorizationRequest {
+	request.Stage = cloneStageAuthorizationRequest(request.Stage)
+	return request
+}
+
+func targetRegistrationRecoveryAuthorizationRequestDigest(request TargetRegistrationRecoveryAuthorizationRequest) (string, error) {
+	payload := targetRegistrationRecoveryAuthorizationRequestPayload{
+		Format: request.Format, Stage: request.Stage, PriorStageReceiptDigest: request.PriorStageReceiptDigest,
+		CredentialRecoveryRequestDigest: request.CredentialRecoveryRequestDigest,
+		CredentialIssueReceiptDigest:    request.CredentialIssueReceiptDigest,
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return "", err
+	}
+	canonical, err := canonicalTargetRegistrationValue(json.RawMessage(raw))
+	if err != nil {
+		return "", err
+	}
+	return digest.SHA256(canonical), nil
+}
+
+type TargetRegistrationRecoveryConfig struct {
+	Handoff             *VerifiedTargetCredentialStageHandoff
+	PriorStageReceipt   StageReceiptSource
+	Authorization       ResolvedTargetRegistrationRecoveryAuthorization
+	ArtifactPath        string
+	Expected            submission.TargetRegistrationExpected
+	Ledger              KubernetesLedgerConfig
+	GitOps              KubernetesAuthorityConfig
+	Runtime             VerifiedRuntimeBindingMaterial
+	MaterializationTime time.Time
+	Clock               func() time.Time
+}
+
+type TargetRegistrationRecoveryReceipt struct {
+	Format                          string                            `json:"format"`
+	State                           string                            `json:"state"`
+	PlanDigest                      string                            `json:"planDigest"`
+	PriorStageReceiptDigest         string                            `json:"priorStageReceiptDigest"`
+	RecoveryRequestDigest           string                            `json:"recoveryRequestDigest"`
+	CredentialRecoveryRequestDigest string                            `json:"credentialRecoveryRequestDigest"`
+	CredentialIssueReceiptDigest    string                            `json:"credentialIssueReceiptDigest"`
+	AuthorizationDigest             string                            `json:"authorizationDigest"`
+	Claim                           *ledger.StageClaimReceipt         `json:"claim,omitempty"`
+	Outcome                         *ledger.StageOutcomeReceipt       `json:"outcome,omitempty"`
+	Refresh                         *TargetRegistrationRefreshReceipt `json:"refresh,omitempty"`
+	StageReceiptRewritten           bool                              `json:"stageReceiptRewritten"`
+}
+
+func RecoverTargetRegistration(ctx context.Context, config TargetRegistrationRecoveryConfig) (TargetRegistrationRecoveryReceipt, error) {
+	receipt := TargetRegistrationRecoveryReceipt{Format: TargetRegistrationRecoveryReceiptFormat, State: "PRECLAIM"}
+	if config.Handoff == nil || config.Clock == nil || config.MaterializationTime.IsZero() || !config.Authorization.verified {
+		return receipt, errors.New("verified target-registration recovery config is required")
+	}
+	plan, cursor, prefix, err := config.Handoff.registrationContext()
+	if err != nil {
+		return receipt, err
+	}
+	if _, err := loadSuccessfulTargetRegistrationReceipt(plan, cursor, prefix, config.PriorStageReceipt); err != nil {
+		return receipt, err
+	}
+	if err := verifyResolvedTargetRegistrationRecoveryAuthorization(config.Authorization, plan, cursor, config.PriorStageReceipt, config.Handoff); err != nil {
+		return receipt, err
+	}
+	resolvedReceipt, _ := config.Authorization.Receipt()
+	receipt.PlanDigest, receipt.PriorStageReceiptDigest = plan.PlanDigest, config.PriorStageReceipt.Digest
+	receipt.RecoveryRequestDigest = resolvedReceipt.RequestDigest
+	receipt.CredentialRecoveryRequestDigest = resolvedReceipt.CredentialRecoveryRequestDigest
+	receipt.CredentialIssueReceiptDigest = resolvedReceipt.CredentialIssueReceiptDigest
+	receipt.AuthorizationDigest = resolvedReceipt.AuthorizationDigest
+
+	bundle, err := LoadTargetRegistrationStageBundleFromHandoff(TargetRegistrationStageHandoffConfig{
+		Handoff: config.Handoff, GrantPath: config.Authorization.source.GrantPath,
+		GrantPublicKeyPath: config.Authorization.source.PublicKeyPath, EvaluationTime: config.Authorization.source.EvaluationTime,
+		ArtifactPath: config.ArtifactPath, Expected: config.Expected,
+	})
+	if err != nil {
+		return receipt, err
+	}
+	credential, err := bundle.handoff.takeCredential()
+	if err != nil {
+		return receipt, err
+	}
+	material, err := BuildTargetRegistrationMaterial(TargetRegistrationMaterializeConfig{
+		Bundle: bundle, Runtime: config.Runtime, Credential: credential, MaterializationTime: config.MaterializationTime,
+	})
+	if err != nil {
+		return receipt, err
+	}
+	writerToken, ca, client, err := openBoundedKubernetesMaterial(config.GitOps.TokenFile, config.GitOps.CAFile)
+	if err != nil || digest.SHA256(ca) != config.GitOps.CABundleDigest || config.GitOps.AuthorityIdentity != plan.Authorities.GitOps {
+		return receipt, errors.New("open bounded target-registration recovery writer")
+	}
+	refresher, err := newKubernetesTargetRegistrationRefresher(targetRegistrationLauncherClientConfig{
+		Endpoint: config.GitOps.Endpoint, BearerToken: writerToken, AuthorityIdentity: config.GitOps.AuthorityIdentity,
+		Client: client, Clock: config.Clock,
+	}, material)
+	if err != nil {
+		return receipt, err
+	}
+	store, ledgerToken, err := openKubernetesLedger(config.Ledger)
+	if err != nil {
+		return receipt, errors.New("open target-registration recovery ledger")
+	}
+	if len(ledgerToken) == len(writerToken) && subtle.ConstantTimeCompare([]byte(ledgerToken), []byte(writerToken)) == 1 {
+		return receipt, errors.New("ledger and target-registration recovery writer credentials must be distinct")
+	}
+	inspection, err := store.InspectStage(ctx, config.Authorization.grant)
+	if err != nil || inspection.State != "AVAILABLE" || !inspection.ClaimAllowed {
+		return receipt, errors.New("target-registration recovery authorization is not available")
+	}
+	claim, err := store.ClaimStage(ctx, config.Authorization.grant, config.Clock())
+	if err != nil {
+		return receipt, err
+	}
+	receipt.Claim, receipt.State = &claim, "CLAIMED_INDETERMINATE_STOP"
+	refresh, refreshErr := refresher.Refresh(ctx)
+	receipt.Refresh = &refresh
+	refreshRaw, canonicalErr := canonicalTargetRegistrationValue(refresh)
+	if canonicalErr != nil {
+		return receipt, errors.New("canonicalize target-registration recovery evidence")
+	}
+	if refreshErr != nil {
+		mutationState := refresh.MutationState
+		if mutationState != "UNKNOWN" && mutationState != "ATTEMPTED" {
+			mutationState = "NOT_ATTEMPTED"
+		}
+		outcome, completeErr := store.CompleteStage(ctx, claim, "STOPPED", mutationState, digest.SHA256(refreshRaw), config.Clock())
+		if completeErr != nil {
+			return receipt, errors.New("target-registration recovery stopped before durable completion")
+		}
+		receipt.Outcome, receipt.State = &outcome, "COMPLETED_STOPPED"
+		return receipt, errors.New("bounded target-registration recovery stopped")
+	}
+	outcome, err := store.CompleteStage(ctx, claim, "SUCCEEDED", "ATTEMPTED", digest.SHA256(refreshRaw), config.Clock())
+	if err != nil {
+		return receipt, errors.New("complete target-registration recovery outcome")
+	}
+	receipt.Outcome, receipt.State = &outcome, "REFRESHED"
+	return receipt, nil
+}
+
+func verifyResolvedTargetRegistrationRecoveryAuthorization(resolved ResolvedTargetRegistrationRecoveryAuthorization, plan stageplan.Binding, cursor stagecursor.Cursor, prior StageReceiptSource, handoff *VerifiedTargetCredentialStageHandoff) error {
+	if !resolved.verified || resolved.request.PriorStageReceiptDigest != prior.Digest {
+		return errors.New("target-registration recovery authorization was not produced by verification")
+	}
+	if _, err := resolved.request.Bytes(); err != nil {
+		return err
+	}
+	credentialEvidence, recoveryRequest, err := handoff.credentialEvidence()
+	if err != nil || resolved.request.CredentialIssueReceiptDigest != credentialEvidence || resolved.request.CredentialRecoveryRequestDigest != recoveryRequest {
+		return errors.New("target-registration recovery credential binding changed")
+	}
+	digestValue, err := targetRegistrationRecoveryAuthorizationRequestDigest(resolved.request)
+	if err != nil || digestValue != resolved.request.RequestDigest {
+		return errors.New("target-registration recovery request identity changed")
+	}
+	predecessors, err := cursor.Predecessors()
+	if err != nil {
+		return err
+	}
+	_, err = authorization.BindStageGrant(resolved.grant, plan, "target-registration", predecessors)
+	return err
+}
+
+func loadSuccessfulTargetRegistrationReceipt(plan stageplan.Binding, cursor stagecursor.Cursor, prefix []stagereceipt.Verified, source StageReceiptSource) (stagereceipt.Verified, error) {
+	predecessors, err := cursor.Predecessors()
+	if err != nil {
+		return stagereceipt.Verified{}, err
+	}
+	verified, err := stagereceipt.Load(source.Path, source.Digest, plan, predecessors)
+	if err != nil {
+		return stagereceipt.Verified{}, errors.New("load durable target-registration receipt for recovery")
+	}
+	stage, err := verified.Receipt()
+	if err != nil || stage.StageID != "target-registration" || stage.State != "SUCCEEDED" || stage.MutationState != "ATTEMPTED" {
+		return stagereceipt.Verified{}, errors.New("target-registration recovery requires successful durable Stage-9 receipt")
+	}
+	combined := append(append([]stagereceipt.Verified(nil), prefix...), verified)
+	next, err := stagecursor.Evaluate(plan, combined)
+	if err != nil {
+		return stagereceipt.Verified{}, err
+	}
+	decision, err := next.Decision()
+	if err != nil || decision.State != "NEXT" || decision.StageID != "platform-applications" {
+		return stagereceipt.Verified{}, errors.New("durable receipt chain does not select platform Applications")
+	}
+	return verified, nil
+}

--- a/internal/runner/target_registration_recovery_test.go
+++ b/internal/runner/target_registration_recovery_test.go
@@ -1,0 +1,318 @@
+package runner
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/authorization"
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/ledger"
+	"github.com/openkubes/ok-cluster/internal/stagereceipt"
+)
+
+func TestTargetRegistrationRecoveryClaimsIndependentGrantBeforeExactRefresh(t *testing.T) {
+	fixture := targetRegistrationRecoveryFixture(t)
+	ledgerAPI := newRuntimeBindingLedgerAPI(t)
+	defer ledgerAPI.Close()
+	refreshAPI, gitopsAPI := newTargetRegistrationRecoveryAPI(t, fixture.material)
+	defer gitopsAPI.Close()
+	runtime := targetRegistrationRecoveryRuntime(t, fixture, ledgerAPI.Server, gitopsAPI)
+
+	var observed TargetRegistrationRecoveryAuthorizationRequest
+	resolved, err := ResolveTargetRegistrationRecoveryAuthorization(context.Background(), fixture.handoff, fixture.prior,
+		TargetRegistrationRecoveryAuthorizationResolverFunc(func(_ context.Context, request TargetRegistrationRecoveryAuthorizationRequest) (StageAuthorizationSource, error) {
+			observed = request
+			return writeTargetRegistrationRecoveryGrant(t, t.TempDir(), request, fixture.now), nil
+		}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if observed.Stage.StageID != "target-registration" || observed.PriorStageReceiptDigest != fixture.prior.Digest ||
+		observed.CredentialRecoveryRequestDigest != fixture.recoveryRequest || observed.CredentialIssueReceiptDigest != fixture.credentialEvidence ||
+		observed.RequestDigest == "" {
+		t.Fatalf("registration recovery request is incomplete: %#v", observed)
+	}
+	if raw, err := observed.Bytes(); err != nil || len(raw) == 0 {
+		t.Fatalf("registration recovery request is not canonical: %v", err)
+	}
+
+	receipt, err := RecoverTargetRegistration(context.Background(), TargetRegistrationRecoveryConfig{
+		Handoff: fixture.handoff, PriorStageReceipt: fixture.prior, Authorization: resolved,
+		ArtifactPath: fixture.registration.bundleConfig.ArtifactPath, Expected: fixture.registration.bundleConfig.Expected,
+		Ledger: runtime.Ledger, GitOps: runtime.GitOps, Runtime: fixture.registration.runtime,
+		MaterializationTime: fixture.registration.config.MaterializationTime, Clock: func() time.Time { return fixture.now },
+	})
+	if err != nil || receipt.State != "REFRESHED" || receipt.Claim == nil || receipt.Outcome == nil || receipt.Refresh == nil ||
+		receipt.Outcome.Outcome != "SUCCEEDED" || receipt.Outcome.MutationState != "ATTEMPTED" || receipt.StageReceiptRewritten ||
+		!receipt.Refresh.StaticRegistrationPreserved || receipt.Refresh.CredentialBytesInReceipt {
+		t.Fatalf("target-registration recovery did not complete safely: %#v err=%v", receipt, err)
+	}
+	if got := refreshAPI.requestSummary(); !equalStringSlices(got, []string{"GET project", "GET registration", "PUT registration"}) {
+		t.Fatalf("registration refresh request boundary differs: %v", got)
+	}
+	if got := countLedgerRecordType(ledgerAPI, "stage-receipt"); got != 0 {
+		t.Fatalf("registration recovery rewrote Stage-9 receipt: count=%d", got)
+	}
+	public, err := json.Marshal(receipt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range []string{string(fixture.registration.credential.token), fixture.registration.credential.endpoint, runtime.GitOps.Endpoint, "short-lived-gitops-token"} {
+		if bytes.Contains(public, []byte(forbidden)) {
+			t.Fatalf("registration recovery receipt leaked private value %q", forbidden)
+		}
+	}
+
+	secondHandoff := newRecoveredTargetRegistrationHandoff(t, fixture.registration, fixture.recoveryRequest)
+	if _, err := RecoverTargetRegistration(context.Background(), TargetRegistrationRecoveryConfig{
+		Handoff: secondHandoff, PriorStageReceipt: fixture.prior, Authorization: resolved,
+		ArtifactPath: fixture.registration.bundleConfig.ArtifactPath, Expected: fixture.registration.bundleConfig.Expected,
+		Ledger: runtime.Ledger, GitOps: runtime.GitOps, Runtime: fixture.registration.runtime,
+		MaterializationTime: fixture.registration.config.MaterializationTime, Clock: func() time.Time { return fixture.now },
+	}); err == nil || refreshAPI.puts != 1 {
+		t.Fatalf("consumed recovery grant reached a second replacement: puts=%d err=%v", refreshAPI.puts, err)
+	}
+}
+
+func TestTargetRegistrationRecoveryDurablyStopsBeforeWriteOnDrift(t *testing.T) {
+	fixture := targetRegistrationRecoveryFixture(t)
+	ledgerAPI := newRuntimeBindingLedgerAPI(t)
+	defer ledgerAPI.Close()
+	refreshAPI, gitopsAPI := newTargetRegistrationRecoveryAPI(t, fixture.material)
+	defer gitopsAPI.Close()
+	refreshAPI.objects["project"].(map[string]any)["spec"].(map[string]any)["description"] = "foreign"
+	runtime := targetRegistrationRecoveryRuntime(t, fixture, ledgerAPI.Server, gitopsAPI)
+	resolved, err := ResolveTargetRegistrationRecoveryAuthorization(context.Background(), fixture.handoff, fixture.prior,
+		TargetRegistrationRecoveryAuthorizationResolverFunc(func(_ context.Context, request TargetRegistrationRecoveryAuthorizationRequest) (StageAuthorizationSource, error) {
+			return writeTargetRegistrationRecoveryGrant(t, t.TempDir(), request, fixture.now), nil
+		}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, recoveryErr := RecoverTargetRegistration(context.Background(), TargetRegistrationRecoveryConfig{
+		Handoff: fixture.handoff, PriorStageReceipt: fixture.prior, Authorization: resolved,
+		ArtifactPath: fixture.registration.bundleConfig.ArtifactPath, Expected: fixture.registration.bundleConfig.Expected,
+		Ledger: runtime.Ledger, GitOps: runtime.GitOps, Runtime: fixture.registration.runtime,
+		MaterializationTime: fixture.registration.config.MaterializationTime, Clock: func() time.Time { return fixture.now },
+	})
+	if recoveryErr == nil || receipt.State != "COMPLETED_STOPPED" || receipt.Outcome == nil || receipt.Refresh == nil ||
+		receipt.Outcome.Outcome != "STOPPED" || receipt.Outcome.MutationState != "NOT_ATTEMPTED" || receipt.Refresh.MutationState != "NOT_ATTEMPTED" ||
+		refreshAPI.puts != 0 {
+		t.Fatalf("registration drift was not durably stopped before write: %#v puts=%d err=%v", receipt, refreshAPI.puts, recoveryErr)
+	}
+}
+
+func TestTargetRegistrationRecoveryDurablyPreservesUnknownReplaceOutcome(t *testing.T) {
+	fixture := targetRegistrationRecoveryFixture(t)
+	ledgerAPI := newRuntimeBindingLedgerAPI(t)
+	defer ledgerAPI.Close()
+	refreshAPI, gitopsAPI := newTargetRegistrationRecoveryAPI(t, fixture.material)
+	defer gitopsAPI.Close()
+	refreshAPI.failPut = true
+	runtime := targetRegistrationRecoveryRuntime(t, fixture, ledgerAPI.Server, gitopsAPI)
+	resolved, err := ResolveTargetRegistrationRecoveryAuthorization(context.Background(), fixture.handoff, fixture.prior,
+		TargetRegistrationRecoveryAuthorizationResolverFunc(func(_ context.Context, request TargetRegistrationRecoveryAuthorizationRequest) (StageAuthorizationSource, error) {
+			return writeTargetRegistrationRecoveryGrant(t, t.TempDir(), request, fixture.now), nil
+		}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, recoveryErr := RecoverTargetRegistration(context.Background(), TargetRegistrationRecoveryConfig{
+		Handoff: fixture.handoff, PriorStageReceipt: fixture.prior, Authorization: resolved,
+		ArtifactPath: fixture.registration.bundleConfig.ArtifactPath, Expected: fixture.registration.bundleConfig.Expected,
+		Ledger: runtime.Ledger, GitOps: runtime.GitOps, Runtime: fixture.registration.runtime,
+		MaterializationTime: fixture.registration.config.MaterializationTime, Clock: func() time.Time { return fixture.now },
+	})
+	if recoveryErr == nil || receipt.State != "COMPLETED_STOPPED" || receipt.Outcome == nil || receipt.Refresh == nil ||
+		receipt.Outcome.Outcome != "STOPPED" || receipt.Outcome.MutationState != "UNKNOWN" || receipt.Refresh.MutationState != "UNKNOWN" ||
+		refreshAPI.puts != 1 {
+		t.Fatalf("unknown registration outcome was not durably preserved: %#v puts=%d err=%v", receipt, refreshAPI.puts, recoveryErr)
+	}
+}
+
+func TestTargetRegistrationRecoveryRejectsMissingHistoryAndNormalHandoffBeforeAuthority(t *testing.T) {
+	registration := targetRegistrationMaterialFixture(t)
+	normal, err := newVerifiedTargetCredentialStageHandoff(registration.bundle.plan, registration.bundle.prefix[:7], registration.bundle.prefix[7], registration.credential)
+	if err != nil {
+		t.Fatal(err)
+	}
+	calls := 0
+	resolver := TargetRegistrationRecoveryAuthorizationResolverFunc(func(context.Context, TargetRegistrationRecoveryAuthorizationRequest) (StageAuthorizationSource, error) {
+		calls++
+		return StageAuthorizationSource{}, errors.New("unexpected")
+	})
+	missing := StageReceiptSource{Path: t.TempDir() + "/missing.json", Digest: runnerStageSHA("7")}
+	if _, err := ResolveTargetRegistrationRecoveryAuthorization(context.Background(), normal, missing, resolver); err == nil || calls != 0 {
+		t.Fatalf("normal handoff or missing receipt reached recovery authority: calls=%d err=%v", calls, err)
+	}
+	recovered := newRecoveredTargetRegistrationHandoff(t, registration, runnerStageSHA("8"))
+	if _, err := ResolveTargetRegistrationRecoveryAuthorization(context.Background(), recovered, missing, resolver); err == nil || calls != 0 {
+		t.Fatalf("missing Stage-9 history reached recovery authority: calls=%d err=%v", calls, err)
+	}
+}
+
+type targetRegistrationRecoveryTestFixture struct {
+	registration       targetRegistrationMaterialTestFixture
+	handoff            *VerifiedTargetCredentialStageHandoff
+	prior              StageReceiptSource
+	material           VerifiedTargetRegistrationMaterial
+	recoveryRequest    string
+	credentialEvidence string
+	now                time.Time
+}
+
+func targetRegistrationRecoveryFixture(t *testing.T) targetRegistrationRecoveryTestFixture {
+	t.Helper()
+	registration := targetRegistrationMaterialFixture(t)
+	recoveryRequest := runnerStageSHA("8")
+	handoff := newRecoveredTargetRegistrationHandoff(t, registration, recoveryRequest)
+	predecessors, err := registration.bundle.cursor.Predecessors()
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := registration.config.MaterializationTime.Add(time.Minute)
+	stage, err := stagereceipt.New(registration.bundle.plan, "target-registration", predecessors, "SUCCEEDED", "ATTEMPTED",
+		runnerStageSHA("9"), runnerStageSHA("a"), now.Add(-time.Minute))
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := stage.Bytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	stageDigest, err := stage.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	prior := StageReceiptSource{Path: writeBundleFile(t, t.TempDir(), "stage-9.json", raw), Digest: stageDigest}
+	material, err := BuildTargetRegistrationMaterial(registration.config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	credentialEvidence, _, err := handoff.credentialEvidence()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return targetRegistrationRecoveryTestFixture{
+		registration: registration, handoff: handoff, prior: prior, material: material,
+		recoveryRequest: recoveryRequest, credentialEvidence: credentialEvidence, now: now,
+	}
+}
+
+func newRecoveredTargetRegistrationHandoff(t *testing.T, registration targetRegistrationMaterialTestFixture, recoveryRequest string) *VerifiedTargetCredentialStageHandoff {
+	t.Helper()
+	issued, err := registration.credential.Receipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := canonicalTargetRegistrationValue(issued)
+	if err != nil {
+		t.Fatal(err)
+	}
+	credentialEvidence := digest.SHA256(raw)
+	priorDigest, err := registration.bundle.prefix[7].Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	recovery := TargetCredentialRecoveryReceipt{
+		Format: TargetCredentialRecoveryReceiptFormat, State: "REISSUED", PlanDigest: registration.bundle.plan.PlanDigest,
+		PriorStageReceiptDigest: priorDigest, RecoveryRequestDigest: recoveryRequest,
+		TargetIdentityDigest: registration.bundle.receipt.TargetIdentityDigest, CredentialIssueReceiptDigest: credentialEvidence,
+		Outcome: &ledger.StageOutcomeReceipt{Outcome: "SUCCEEDED", MutationState: "ATTEMPTED", EvidenceDigest: credentialEvidence},
+	}
+	handoff, err := newVerifiedRecoveredTargetCredentialStageHandoff(
+		registration.bundle.plan, registration.bundle.prefix[:7], registration.bundle.prefix[7], registration.credential, recovery,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return handoff
+}
+
+func writeTargetRegistrationRecoveryGrant(t *testing.T, root string, request TargetRegistrationRecoveryAuthorizationRequest, at time.Time) StageAuthorizationSource {
+	t.Helper()
+	payload := authorization.StagePayload{
+		Audience: request.Stage.Audience, GrantID: "ok147-target-registration-recovery-01", Decision: "ALLOW",
+		PlanDigest: request.Stage.PlanDigest, ContractIdentity: request.Stage.ContractIdentity,
+		ContractRevision: request.Stage.ContractRevision, EnablementRevision: request.Stage.EnablementRevision,
+		PlatformRevision: request.Stage.PlatformRevision, ExecutionFixture: request.Stage.ExecutionFixture,
+		StageID: request.Stage.StageID, StageOrder: request.Stage.StageOrder, StageDigest: request.Stage.StageDigest,
+		Operation: request.Stage.Operation, Authority: request.Stage.Authority, MaxUses: 1,
+		NotBefore: at.Add(-time.Minute).Format(time.RFC3339), NotAfter: at.Add(20 * time.Minute).Format(time.RFC3339),
+	}
+	for _, predecessor := range request.Stage.Predecessors {
+		payload.Predecessors = append(payload.Predecessors, authorization.StagePredecessor{StageID: predecessor.StageID, OutcomeDigest: predecessor.ReceiptDigest})
+	}
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	signed, err := authorization.StageSigningBytes(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	envelope := mustJSON(t, map[string]any{
+		"format": authorization.StageFormat, "payload": payload,
+		"signature": map[string]any{"algorithm": "Ed25519", "keyId": digest.SHA256(publicKey), "value": base64.StdEncoding.EncodeToString(ed25519.Sign(privateKey, signed))},
+	})
+	return StageAuthorizationSource{
+		GrantPath:      writeBundleFile(t, root, "registration-recovery-grant.json", envelope),
+		PublicKeyPath:  writeBundleFile(t, root, "registration-recovery-authority.pub", []byte(base64.StdEncoding.EncodeToString(publicKey)+"\n")),
+		EvaluationTime: at,
+	}
+}
+
+func newTargetRegistrationRecoveryAPI(t *testing.T, material VerifiedTargetRegistrationMaterial) (*targetRegistrationRefreshAPI, *httptest.Server) {
+	t.Helper()
+	api := newTargetRegistrationRefreshAPI(t, material)
+	server := httptest.NewTLSServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		result, err := api.client().Transport.RoundTrip(request)
+		if err != nil {
+			return
+		}
+		defer result.Body.Close()
+		for key, values := range result.Header {
+			for _, value := range values {
+				response.Header().Add(key, value)
+			}
+		}
+		response.WriteHeader(result.StatusCode)
+		_, _ = io.Copy(response, result.Body)
+	}))
+	return api, server
+}
+
+func targetRegistrationRecoveryRuntime(t *testing.T, fixture targetRegistrationRecoveryTestFixture, ledgerServer, gitopsServer *httptest.Server) TargetRegistrationStageRuntimeConfig {
+	t.Helper()
+	root := t.TempDir()
+	ledgerCA := writeRuntimeBindingServerCA(t, root, "ledger-ca.crt", ledgerServer)
+	gitopsCA := writeRuntimeBindingServerCA(t, root, "gitops-ca.crt", gitopsServer)
+	gitopsCABytes, err := os.ReadFile(gitopsCA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return TargetRegistrationStageRuntimeConfig{
+		Ledger: KubernetesLedgerConfig{
+			Endpoint: ledgerServer.URL, Namespace: "openkubes-execution-system",
+			TokenFile: writeBundleFile(t, root, "ledger-token", []byte("ledger-token")), CAFile: ledgerCA,
+		},
+		GitOps: KubernetesAuthorityConfig{
+			Endpoint: gitopsServer.URL, AuthorityIdentity: "ok-shared",
+			TokenFile: writeBundleFile(t, root, "gitops-token", []byte("short-lived-gitops-token")), CAFile: gitopsCA,
+			CABundleDigest: digest.SHA256(gitopsCABytes),
+		},
+		Runtime: fixture.registration.runtime, MaterializationTime: fixture.registration.config.MaterializationTime,
+		Clock: func() time.Time { return fixture.now },
+	}
+}

--- a/internal/runner/target_registration_refresh.go
+++ b/internal/runner/target_registration_refresh.go
@@ -35,8 +35,8 @@ type TargetRegistrationRefreshReceipt struct {
 	StaticRegistrationPreserved  bool   `json:"staticRegistrationPreserved"`
 }
 
-// kubernetesTargetRegistrationRefresher is deliberately package-private. A
-// later recovery coordinator must place a fresh independently authorized and
+// kubernetesTargetRegistrationRefresher is deliberately package-private. The
+// recovery coordinator places a fresh independently authorized and
 // ledger-claimed Stage-9 operation around this single exact replacement.
 type kubernetesTargetRegistrationRefresher struct {
 	mu             sync.Mutex

--- a/internal/runner/target_registration_refresh.go
+++ b/internal/runner/target_registration_refresh.go
@@ -1,0 +1,347 @@
+package runner
+
+import (
+	"bytes"
+	"context"
+	"crypto/subtle"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+const TargetRegistrationRefreshReceiptFormat = "ok147-target-registration-refresh/v1"
+
+type TargetRegistrationRefreshReceipt struct {
+	Format                       string `json:"format"`
+	State                        string `json:"state"`
+	PlanDigest                   string `json:"planDigest"`
+	TargetIdentityDigest         string `json:"targetIdentityDigest"`
+	MaterializationBindingDigest string `json:"materializationBindingDigest"`
+	ProjectUIDDigest             string `json:"projectUidDigest,omitempty"`
+	RegistrationUIDDigest        string `json:"registrationUidDigest,omitempty"`
+	ResourceVersionDigest        string `json:"resourceVersionDigest,omitempty"`
+	MutationState                string `json:"mutationState"`
+	CredentialBytesInReceipt     bool   `json:"credentialBytesInReceipt"`
+	StaticRegistrationPreserved  bool   `json:"staticRegistrationPreserved"`
+}
+
+// kubernetesTargetRegistrationRefresher is deliberately package-private. A
+// later recovery coordinator must place a fresh independently authorized and
+// ledger-claimed Stage-9 operation around this single exact replacement.
+type kubernetesTargetRegistrationRefresher struct {
+	mu             sync.Mutex
+	used           bool
+	endpoint       *url.URL
+	token          string
+	client         *http.Client
+	clock          func() time.Time
+	expiresAt      time.Time
+	materializedAt time.Time
+	receipt        TargetRegistrationMaterialReceipt
+	project        targetRegistrationLaunchObject
+	registration   targetRegistrationLaunchObject
+}
+
+func newKubernetesTargetRegistrationRefresher(config targetRegistrationLauncherClientConfig, material VerifiedTargetRegistrationMaterial) (*kubernetesTargetRegistrationRefresher, error) {
+	receipt, objects, err := prepareTargetRegistrationLaunchMaterial(material)
+	if err != nil || len(objects) != 2 || objects[0].role != "project" || objects[1].role != "registration" {
+		return nil, errors.New("target-registration refresh requires exact verified material")
+	}
+	if config.AuthorityIdentity != material.authority || config.BearerToken == "" || strings.TrimSpace(config.BearerToken) != config.BearerToken ||
+		strings.ContainsAny(config.BearerToken, "\r\n") || config.Client == nil || config.Clock == nil {
+		return nil, errors.New("target-registration refresh writer boundary is invalid")
+	}
+	if len(config.BearerToken) == len(objects[1].credentialToken) && subtle.ConstantTimeCompare([]byte(config.BearerToken), objects[1].credentialToken) == 1 {
+		return nil, errors.New("GitOps writer and refreshed workload credential must be distinct")
+	}
+	endpoint, err := normalizeSubmissionStageLaunchEndpoint(config.Endpoint)
+	if err != nil {
+		return nil, errors.New("target-registration refresh endpoint is invalid")
+	}
+	parsed, err := url.Parse(endpoint)
+	if err != nil {
+		return nil, errors.New("target-registration refresh endpoint is invalid")
+	}
+	expiresAt, err := time.Parse(time.RFC3339, receipt.ExpiresAt)
+	if err != nil {
+		return nil, errors.New("target-registration refresh expiration is invalid")
+	}
+	client := *config.Client
+	client.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+	if client.Timeout == 0 {
+		client.Timeout = 15 * time.Second
+	}
+	return &kubernetesTargetRegistrationRefresher{
+		endpoint: parsed, token: config.BearerToken, client: &client, clock: config.Clock,
+		expiresAt: expiresAt, materializedAt: material.materializedAt, receipt: receipt,
+		project: objects[0], registration: objects[1],
+	}, nil
+}
+
+func (refresher *kubernetesTargetRegistrationRefresher) Refresh(ctx context.Context) (TargetRegistrationRefreshReceipt, error) {
+	receipt := TargetRegistrationRefreshReceipt{Format: TargetRegistrationRefreshReceiptFormat, State: "PREFLIGHT", MutationState: "NOT_ATTEMPTED"}
+	if refresher == nil || refresher.client == nil || refresher.clock == nil {
+		return receipt, errors.New("target-registration refresher is required")
+	}
+	receipt.PlanDigest = refresher.receipt.PlanDigest
+	receipt.TargetIdentityDigest = refresher.receipt.TargetIdentityDigest
+	receipt.MaterializationBindingDigest = refresher.receipt.MaterializationBindingDigest
+	refresher.mu.Lock()
+	if refresher.used {
+		refresher.mu.Unlock()
+		return receipt, errors.New("target-registration refresher is single-use")
+	}
+	refresher.used = true
+	refresher.mu.Unlock()
+	now := refresher.clock().UTC()
+	if now.Before(refresher.materializedAt) || refresher.expiresAt.Sub(now) < minimumTargetRegistrationCredentialRemaining {
+		return receipt, errors.New("target-registration refresh credential has insufficient remaining lifetime")
+	}
+	projectRaw, status, err := refresher.request(ctx, http.MethodGet, refresher.project.objectPath, nil)
+	if err != nil || status != http.StatusOK {
+		return receipt, targetRegistrationRefreshError(http.MethodGet, status, err)
+	}
+	projectUID, err := verifyExactExistingTargetRegistrationProject(projectRaw, refresher.project)
+	if err != nil {
+		return receipt, errors.New("existing target-registration project differs from exact material")
+	}
+	receipt.ProjectUIDDigest = digest.SHA256([]byte(projectUID))
+	existingRaw, status, err := refresher.request(ctx, http.MethodGet, refresher.registration.objectPath, nil)
+	if err != nil || status != http.StatusOK {
+		return receipt, targetRegistrationRefreshError(http.MethodGet, status, err)
+	}
+	replacement, uid, err := prepareExactTargetRegistrationRefresh(existingRaw, refresher.registration)
+	if err != nil {
+		return receipt, err
+	}
+	receipt.RegistrationUIDDigest = digest.SHA256([]byte(uid))
+	receipt.State, receipt.MutationState = "REPLACING", "UNKNOWN"
+	updatedRaw, status, err := refresher.request(ctx, http.MethodPut, refresher.registration.objectPath, replacement)
+	if err != nil || status != http.StatusOK {
+		return receipt, targetRegistrationRefreshError(http.MethodPut, status, err)
+	}
+	updatedUID, resourceVersion, err := verifyExactTargetRegistrationRefresh(updatedRaw, refresher.registration, uid)
+	if err != nil {
+		return receipt, errors.New("refreshed target-registration Secret differs from exact material")
+	}
+	receipt.State, receipt.MutationState = "REFRESHED", "ATTEMPTED"
+	receipt.RegistrationUIDDigest = digest.SHA256([]byte(updatedUID))
+	receipt.ResourceVersionDigest = digest.SHA256([]byte(resourceVersion))
+	receipt.StaticRegistrationPreserved = true
+	return receipt, nil
+}
+
+func prepareExactTargetRegistrationRefresh(existingRaw []byte, desired targetRegistrationLaunchObject) ([]byte, string, error) {
+	existing, err := decodeCapabilityJSONObject(existingRaw)
+	if err != nil {
+		return nil, "", errors.New("existing target-registration Secret is invalid")
+	}
+	wanted, err := decodeCapabilityJSONObject(desired.raw)
+	if err != nil {
+		return nil, "", errors.New("desired target-registration Secret is invalid")
+	}
+	existingMetadata, _ := existing["metadata"].(map[string]any)
+	wantedMetadata, _ := wanted["metadata"].(map[string]any)
+	uid, _ := existingMetadata["uid"].(string)
+	resourceVersion, _ := existingMetadata["resourceVersion"].(string)
+	if existing["apiVersion"] != "v1" || existing["kind"] != "Secret" || existing["type"] != wanted["type"] ||
+		existingMetadata["name"] != desired.name || existingMetadata["namespace"] != desired.namespace ||
+		!runtimeInputUIDPattern.MatchString(uid) || !runtimeInputUIDPattern.MatchString(resourceVersion) {
+		return nil, "", errors.New("existing target-registration Secret identity is invalid")
+	}
+	for _, field := range []string{"labels", "annotations"} {
+		if !equalTargetRegistrationMetadata(field, existingMetadata[field], wantedMetadata[field], field == "annotations") {
+			return nil, "", errors.New("existing target-registration Secret metadata differs")
+		}
+	}
+	existingStrings, err := decodeTargetRegistrationSecretData(existing["data"])
+	if err != nil {
+		return nil, "", err
+	}
+	wantedStrings, _ := wanted["stringData"].(map[string]any)
+	if len(existingStrings) != len(wantedStrings) {
+		return nil, "", errors.New("existing target-registration Secret data membership differs")
+	}
+	for _, key := range []string{"name", "server", "namespaces", "clusterResources", "project"} {
+		if existingStrings[key] != wantedStrings[key] {
+			return nil, "", errors.New("existing target-registration Secret target binding differs")
+		}
+	}
+	var existingConfig, wantedConfig targetRegistrationSecretConfig
+	existingConfigRaw, existingOK := existingStrings["config"].(string)
+	wantedConfigRaw, wantedOK := wantedStrings["config"].(string)
+	if !existingOK || !wantedOK || json.Unmarshal([]byte(existingConfigRaw), &existingConfig) != nil || json.Unmarshal([]byte(wantedConfigRaw), &wantedConfig) != nil ||
+		existingConfig.TLSClientConfig != wantedConfig.TLSClientConfig || len(existingConfig.BearerToken) < 80 || len(wantedConfig.BearerToken) < 80 ||
+		len(existingConfig.BearerToken) == len(wantedConfig.BearerToken) && subtle.ConstantTimeCompare([]byte(existingConfig.BearerToken), []byte(wantedConfig.BearerToken)) == 1 {
+		return nil, "", errors.New("existing target-registration Secret credential boundary is invalid")
+	}
+	existingAnnotations, _ := existingMetadata["annotations"].(map[string]any)
+	existingExpiration, _ := existingAnnotations["openkubes.io/token-expiration"].(string)
+	if _, err := time.Parse(time.RFC3339, existingExpiration); err != nil {
+		return nil, "", errors.New("existing target-registration Secret expiration is invalid")
+	}
+	wantedMetadata["uid"], wantedMetadata["resourceVersion"] = uid, resourceVersion
+	replacement, err := canonicalTargetRegistrationValue(wanted)
+	if err != nil {
+		return nil, "", errors.New("canonicalize target-registration Secret refresh")
+	}
+	return replacement, uid, nil
+}
+
+func equalTargetRegistrationMetadata(field string, existing, wanted any, allowTokenExpirationDifference bool) bool {
+	if existing == nil && wanted == nil {
+		return true
+	}
+	existingMap, existingOK := existing.(map[string]any)
+	wantedMap, wantedOK := wanted.(map[string]any)
+	if !existingOK || !wantedOK || len(existingMap) != len(wantedMap) {
+		return false
+	}
+	for key, value := range wantedMap {
+		if field == "annotations" && key == "openkubes.io/token-expiration" && allowTokenExpirationDifference {
+			if _, ok := existingMap[key].(string); !ok {
+				return false
+			}
+			continue
+		}
+		if existingMap[key] != value {
+			return false
+		}
+	}
+	return true
+}
+
+func decodeTargetRegistrationSecretData(value any) (map[string]any, error) {
+	data, ok := value.(map[string]any)
+	if !ok {
+		return nil, errors.New("existing target-registration Secret data is invalid")
+	}
+	decoded := make(map[string]any, len(data))
+	for key, value := range data {
+		encoded, ok := value.(string)
+		if !ok {
+			return nil, errors.New("existing target-registration Secret data is invalid")
+		}
+		raw, err := base64.StdEncoding.Strict().DecodeString(encoded)
+		if err != nil {
+			return nil, errors.New("existing target-registration Secret data is invalid")
+		}
+		decoded[key] = string(raw)
+	}
+	return decoded, nil
+}
+
+func verifyExactTargetRegistrationRefresh(raw []byte, desired targetRegistrationLaunchObject, expectedUID string) (string, string, error) {
+	observed, err := decodeCapabilityJSONObject(raw)
+	if err != nil {
+		return "", "", err
+	}
+	metadata, _ := observed["metadata"].(map[string]any)
+	uid, _ := metadata["uid"].(string)
+	resourceVersion, _ := metadata["resourceVersion"].(string)
+	if uid != expectedUID || !runtimeInputUIDPattern.MatchString(resourceVersion) {
+		return "", "", errors.New("refreshed target-registration Secret server identity differs")
+	}
+	wanted, err := decodeCapabilityJSONObject(desired.raw)
+	if err != nil {
+		return "", "", err
+	}
+	wantedMetadata, _ := wanted["metadata"].(map[string]any)
+	if observed["apiVersion"] != "v1" || observed["kind"] != "Secret" || observed["type"] != wanted["type"] ||
+		metadata["name"] != desired.name || metadata["namespace"] != desired.namespace ||
+		!equalTargetRegistrationMetadata("labels", metadata["labels"], wantedMetadata["labels"], false) ||
+		!equalTargetRegistrationMetadata("annotations", metadata["annotations"], wantedMetadata["annotations"], false) {
+		return "", "", errors.New("refreshed target-registration Secret metadata differs")
+	}
+	observedStrings, err := decodeTargetRegistrationSecretData(observed["data"])
+	if err != nil {
+		return "", "", err
+	}
+	wantedStrings, _ := wanted["stringData"].(map[string]any)
+	if len(observedStrings) != len(wantedStrings) {
+		return "", "", errors.New("refreshed target-registration Secret data membership differs")
+	}
+	for key, wantedValue := range wantedStrings {
+		if observedStrings[key] != wantedValue {
+			return "", "", errors.New("refreshed target-registration Secret data differs")
+		}
+	}
+	return uid, resourceVersion, nil
+}
+
+func verifyExactExistingTargetRegistrationProject(raw []byte, desired targetRegistrationLaunchObject) (string, error) {
+	observed, err := decodeCapabilityJSONObject(raw)
+	if err != nil {
+		return "", err
+	}
+	wanted, err := decodeCapabilityJSONObject(desired.raw)
+	if err != nil {
+		return "", err
+	}
+	observedMetadata, _ := observed["metadata"].(map[string]any)
+	wantedMetadata, _ := wanted["metadata"].(map[string]any)
+	uid, _ := observedMetadata["uid"].(string)
+	resourceVersion, _ := observedMetadata["resourceVersion"].(string)
+	if observed["apiVersion"] != wanted["apiVersion"] || observed["kind"] != wanted["kind"] ||
+		observedMetadata["name"] != desired.name || observedMetadata["namespace"] != desired.namespace ||
+		!runtimeInputUIDPattern.MatchString(uid) || !runtimeInputUIDPattern.MatchString(resourceVersion) ||
+		!equalTargetRegistrationMetadata("labels", observedMetadata["labels"], wantedMetadata["labels"], false) ||
+		!equalTargetRegistrationMetadata("annotations", observedMetadata["annotations"], wantedMetadata["annotations"], false) {
+		return "", errors.New("existing target-registration project identity differs")
+	}
+	observedSpec, observedOK := observed["spec"]
+	wantedSpec, wantedOK := wanted["spec"]
+	observedRaw, observedErr := canonicalTargetRegistrationValue(observedSpec)
+	wantedRaw, wantedErr := canonicalTargetRegistrationValue(wantedSpec)
+	if !observedOK || !wantedOK || observedErr != nil || wantedErr != nil || !bytes.Equal(observedRaw, wantedRaw) {
+		return "", errors.New("existing target-registration project spec differs")
+	}
+	return uid, nil
+}
+
+func (refresher *kubernetesTargetRegistrationRefresher) request(ctx context.Context, method, path string, body []byte) ([]byte, int, error) {
+	endpoint := *refresher.endpoint
+	endpoint.Path = path
+	request, err := http.NewRequestWithContext(ctx, method, endpoint.String(), bytes.NewReader(body))
+	if err != nil {
+		return nil, 0, errors.New("construct bounded target-registration refresh request")
+	}
+	request.Header.Set("Accept", "application/json")
+	request.Header.Set("Authorization", "Bearer "+refresher.token)
+	if body != nil {
+		request.Header.Set("Content-Type", "application/json")
+	}
+	response, err := refresher.client.Do(request)
+	if err != nil {
+		return nil, 0, fmt.Errorf("bounded target-registration refresh %s request failed", method)
+	}
+	defer response.Body.Close()
+	raw, err := io.ReadAll(io.LimitReader(response.Body, maximumStageInstallationResponseBytes+1))
+	if err != nil || len(raw) > maximumStageInstallationResponseBytes {
+		return nil, 0, errors.New("bounded target-registration refresh response exceeds accepted size")
+	}
+	if len(raw) > 0 {
+		mediaType, _, parseErr := mime.ParseMediaType(response.Header.Get("Content-Type"))
+		if parseErr != nil || mediaType != "application/json" {
+			return nil, 0, errors.New("bounded target-registration refresh response is not JSON")
+		}
+	}
+	return raw, response.StatusCode, nil
+}
+
+func targetRegistrationRefreshError(method string, status int, err error) error {
+	if err != nil {
+		return err
+	}
+	return fmt.Errorf("bounded target-registration refresh %s returned status %d", method, status)
+}

--- a/internal/runner/target_registration_refresh_test.go
+++ b/internal/runner/target_registration_refresh_test.go
@@ -1,0 +1,211 @@
+package runner
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestTargetRegistrationRefresherReplacesOnlyExactBoundSecret(t *testing.T) {
+	fixture := targetRegistrationMaterialFixture(t)
+	material, err := BuildTargetRegistrationMaterial(fixture.config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	api := newTargetRegistrationRefreshAPI(t, material)
+	refresher, err := newKubernetesTargetRegistrationRefresher(targetRegistrationLauncherClientConfig{
+		Endpoint: "https://127.0.0.1:12345", BearerToken: "short-lived-gitops-token", AuthorityIdentity: "ok-shared",
+		Client: api.client(), Clock: func() time.Time { return fixture.config.MaterializationTime.Add(time.Minute) },
+	}, material)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := refresher.Refresh(context.Background())
+	if err != nil || receipt.State != "REFRESHED" || receipt.MutationState != "ATTEMPTED" || !receipt.StaticRegistrationPreserved ||
+		receipt.CredentialBytesInReceipt || receipt.ProjectUIDDigest == "" || receipt.RegistrationUIDDigest == "" || receipt.ResourceVersionDigest == "" {
+		t.Fatalf("target-registration refresh failed: %#v %v", receipt, err)
+	}
+	want := []string{"GET project", "GET registration", "PUT registration"}
+	if got := api.requestSummary(); !equalStringSlices(got, want) {
+		t.Fatalf("refresh request boundary differs: got=%v want=%v", got, want)
+	}
+	public, _ := json.Marshal(receipt)
+	for _, forbidden := range []string{string(fixture.credential.token), fixture.credential.endpoint, "old-target-token"} {
+		if bytes.Contains(public, []byte(forbidden)) {
+			t.Fatalf("refresh receipt leaked private value %q", forbidden)
+		}
+	}
+	if _, err := refresher.Refresh(context.Background()); err == nil || len(api.requestSummary()) != 3 {
+		t.Fatal("single-use target-registration refresher ran twice")
+	}
+}
+
+func TestTargetRegistrationRefresherStopsBeforeWriteOnDrift(t *testing.T) {
+	for name, mutate := range map[string]func(map[string]any){
+		"project drift": func(objects map[string]any) {
+			project := objects["project"].(map[string]any)
+			project["spec"].(map[string]any)["description"] = "foreign"
+		},
+		"target drift": func(objects map[string]any) {
+			secret := objects["registration"].(map[string]any)
+			data := secret["data"].(map[string]any)
+			data["server"] = base64.StdEncoding.EncodeToString([]byte("https://foreign.invalid"))
+		},
+		"metadata drift": func(objects map[string]any) {
+			secret := objects["registration"].(map[string]any)
+			secret["metadata"].(map[string]any)["annotations"].(map[string]any)["foreign"] = "value"
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			fixture := targetRegistrationMaterialFixture(t)
+			material, _ := BuildTargetRegistrationMaterial(fixture.config)
+			api := newTargetRegistrationRefreshAPI(t, material)
+			mutate(api.objects)
+			refresher, err := newKubernetesTargetRegistrationRefresher(targetRegistrationLauncherClientConfig{
+				Endpoint: "https://127.0.0.1:12345", BearerToken: "short-lived-gitops-token", AuthorityIdentity: "ok-shared",
+				Client: api.client(), Clock: func() time.Time { return fixture.config.MaterializationTime.Add(time.Minute) },
+			}, material)
+			if err != nil {
+				t.Fatal(err)
+			}
+			receipt, err := refresher.Refresh(context.Background())
+			if err == nil || receipt.MutationState != "NOT_ATTEMPTED" || api.puts != 0 {
+				t.Fatalf("drift reached registration replacement: %#v puts=%d err=%v", receipt, api.puts, err)
+			}
+		})
+	}
+}
+
+func TestTargetRegistrationRefresherPreservesUnknownPutOutcome(t *testing.T) {
+	fixture := targetRegistrationMaterialFixture(t)
+	material, _ := BuildTargetRegistrationMaterial(fixture.config)
+	api := newTargetRegistrationRefreshAPI(t, material)
+	api.failPut = true
+	refresher, err := newKubernetesTargetRegistrationRefresher(targetRegistrationLauncherClientConfig{
+		Endpoint: "https://127.0.0.1:12345", BearerToken: "short-lived-gitops-token", AuthorityIdentity: "ok-shared",
+		Client: api.client(), Clock: func() time.Time { return fixture.config.MaterializationTime.Add(time.Minute) },
+	}, material)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := refresher.Refresh(context.Background())
+	if err == nil || receipt.State != "REPLACING" || receipt.MutationState != "UNKNOWN" || api.puts != 1 {
+		t.Fatalf("unknown replacement outcome was not preserved: %#v %v", receipt, err)
+	}
+}
+
+type targetRegistrationRefreshAPI struct {
+	t        *testing.T
+	mu       sync.Mutex
+	objects  map[string]any
+	requests []string
+	puts     int
+	failPut  bool
+}
+
+func newTargetRegistrationRefreshAPI(t *testing.T, material VerifiedTargetRegistrationMaterial) *targetRegistrationRefreshAPI {
+	t.Helper()
+	project := decodeRefreshObject(t, material.project)
+	projectMetadata := project["metadata"].(map[string]any)
+	projectMetadata["uid"], projectMetadata["resourceVersion"] = "project-runtime-uid", "7"
+	registration := decodeRefreshObject(t, material.registration)
+	registrationMetadata := registration["metadata"].(map[string]any)
+	registrationMetadata["uid"], registrationMetadata["resourceVersion"] = "registration-runtime-uid", "11"
+	stringData := registration["stringData"].(map[string]any)
+	var config targetRegistrationSecretConfig
+	if err := json.Unmarshal([]byte(stringData["config"].(string)), &config); err != nil {
+		t.Fatal(err)
+	}
+	config.BearerToken = strings.Repeat("old-target-token-", 8)
+	configRaw, _ := json.Marshal(config)
+	stringData["config"] = string(configRaw)
+	registration["data"] = encodeRefreshData(t, stringData)
+	delete(registration, "stringData")
+	return &targetRegistrationRefreshAPI{t: t, objects: map[string]any{"project": project, "registration": registration}}
+}
+
+func (api *targetRegistrationRefreshAPI) client() *http.Client {
+	return &http.Client{Transport: targetRegistrationRoundTripFunc(func(request *http.Request) (*http.Response, error) {
+		api.mu.Lock()
+		defer api.mu.Unlock()
+		if request.Header.Get("Authorization") != "Bearer short-lived-gitops-token" || request.Header.Get("Accept") != "application/json" {
+			return targetRegistrationJSONResponse(http.StatusUnauthorized, nil, nil), nil
+		}
+		switch request.Method {
+		case http.MethodGet:
+			if strings.Contains(request.URL.Path, "appprojects") {
+				api.requests = append(api.requests, "GET project")
+				return targetRegistrationJSONResponse(http.StatusOK, api.objects["project"], nil), nil
+			}
+			api.requests = append(api.requests, "GET registration")
+			return targetRegistrationJSONResponse(http.StatusOK, api.objects["registration"], nil), nil
+		case http.MethodPut:
+			api.requests = append(api.requests, "PUT registration")
+			api.puts++
+			if api.failPut {
+				return nil, errors.New("simulated unknown PUT outcome")
+			}
+			body, _ := io.ReadAll(request.Body)
+			updated := decodeRefreshObject(api.t, body)
+			metadata := updated["metadata"].(map[string]any)
+			if metadata["uid"] != "registration-runtime-uid" || metadata["resourceVersion"] != "11" {
+				return targetRegistrationJSONResponse(http.StatusConflict, nil, nil), nil
+			}
+			updated["data"] = encodeRefreshData(api.t, updated["stringData"].(map[string]any))
+			delete(updated, "stringData")
+			metadata["resourceVersion"] = "12"
+			api.objects["registration"] = updated
+			return targetRegistrationJSONResponse(http.StatusOK, updated, nil), nil
+		default:
+			return targetRegistrationJSONResponse(http.StatusMethodNotAllowed, nil, nil), nil
+		}
+	})}
+}
+
+func (api *targetRegistrationRefreshAPI) requestSummary() []string {
+	api.mu.Lock()
+	defer api.mu.Unlock()
+	return append([]string(nil), api.requests...)
+}
+
+func decodeRefreshObject(t *testing.T, raw []byte) map[string]any {
+	t.Helper()
+	var object map[string]any
+	if err := json.Unmarshal(raw, &object); err != nil {
+		t.Fatal(err)
+	}
+	return object
+}
+
+func encodeRefreshData(t *testing.T, values map[string]any) map[string]any {
+	t.Helper()
+	encoded := make(map[string]any, len(values))
+	for key, value := range values {
+		text, ok := value.(string)
+		if !ok {
+			t.Fatalf("non-string Secret value %s", key)
+		}
+		encoded[key] = base64.StdEncoding.EncodeToString([]byte(text))
+	}
+	return encoded
+}
+
+func equalStringSlices(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for index := range left {
+		if left[index] != right[index] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/runner/target_registration_stage_bundle.go
+++ b/internal/runner/target_registration_stage_bundle.go
@@ -53,14 +53,16 @@ type TargetRegistrationStageBundleReceipt struct {
 }
 
 type VerifiedTargetRegistrationStageBundle struct {
-	plan       stageplan.Binding
-	cursor     stagecursor.Cursor
-	prefix     []stagereceipt.Verified
-	grant      authorization.VerifiedStageGrant
-	projection submission.TargetRegistrationPlan
-	receipt    TargetRegistrationStageBundleReceipt
-	handoff    *VerifiedTargetCredentialStageHandoff
-	verified   bool
+	plan                     stageplan.Binding
+	cursor                   stagecursor.Cursor
+	prefix                   []stagereceipt.Verified
+	grant                    authorization.VerifiedStageGrant
+	projection               submission.TargetRegistrationPlan
+	receipt                  TargetRegistrationStageBundleReceipt
+	handoff                  *VerifiedTargetCredentialStageHandoff
+	credentialEvidenceDigest string
+	recoveryRequestDigest    string
+	verified                 bool
 }
 
 type TargetRegistrationStageRuntimeConfig struct {
@@ -125,7 +127,13 @@ func LoadTargetRegistrationStageBundleFromHandoff(config TargetRegistrationStage
 	if err != nil {
 		return VerifiedTargetRegistrationStageBundle{}, err
 	}
+	credentialEvidence, recoveryRequest, err := config.Handoff.credentialEvidence()
+	if err != nil {
+		return VerifiedTargetRegistrationStageBundle{}, err
+	}
 	bundle.handoff = config.Handoff
+	bundle.credentialEvidenceDigest = credentialEvidence
+	bundle.recoveryRequestDigest = recoveryRequest
 	return bundle, nil
 }
 
@@ -262,6 +270,12 @@ func (stage BoundTargetRegistrationStage) Run(ctx context.Context) (execution.St
 func verifyTargetRegistrationStageBundle(bundle VerifiedTargetRegistrationStageBundle) error {
 	if !bundle.verified || bundle.receipt.Format != TargetRegistrationStageBundleReceiptFormat || bundle.receipt.State != "VERIFIED" || bundle.receipt.StageID != "target-registration" || bundle.receipt.CredentialMaterialPresent || bundle.receipt.MutationAllowed || len(bundle.prefix) != 8 {
 		return errors.New("target-registration stage bundle was not produced by verification")
+	}
+	if bundle.handoff != nil && !stageReceiptPrefixDigestPattern.MatchString(bundle.credentialEvidenceDigest) {
+		return errors.New("target-registration handoff credential evidence is invalid")
+	}
+	if bundle.recoveryRequestDigest != "" && !stageReceiptPrefixDigestPattern.MatchString(bundle.recoveryRequestDigest) {
+		return errors.New("target-registration recovery request identity is invalid")
 	}
 	for _, value := range []string{
 		bundle.receipt.PlanDigest, bundle.receipt.AuthorizationDigest, bundle.receipt.ArtifactDigest,


### PR DESCRIPTION
## Summary

- resume terminal read and binding stages from verified durable receipts
- normalize the omitted CAAPH client-cache default without weakening explicit drift checks
- recover an expired Stage-8 target credential through a new independently authorized, ledger-claimed operation
- verify and refresh the exact existing Stage-9 Argo target registration without rewriting historical stage receipts
- continue the post-runtime suffix at Stage 10 after receipt-bound credential and registration recovery

## Safety boundary

- no controller, reconciler, retry loop, rollback, cleanup, or infrastructure mutation is introduced
- recovery requires the exact successful Stage-8 and Stage-9 receipts
- fresh signed recovery grants are claimed before TokenRequest or registration mutation
- target-registration drift stops before write
- unknown PUT outcomes remain fail-closed and durable
- consumed grants cannot reach a second mutation
- credentials, endpoints, and private paths remain absent from public receipts

## Verification

- `git diff --check`
- `go test ./... -count=1` in `golang:1.21.13` as unprivileged UID 65532

## Review question

Does this checkpoint provide a bounded receipt-based crash recovery path for Stages 8 and 9 while preserving the existing ownership, authorization, ledger, and no-automatic-retry boundaries?
