### PR TITLE
OK-147: Activate receipt-bound runner recovery

### DIFF
--- a/cmd/ok/post_runtime_test.go
+++ b/cmd/ok/post_runtime_test.go
@@ -45,6 +45,22 @@ func TestPostRuntimePrepareVerifiesWithoutExecution(t *testing.T) {
 	}
 }
 
+func TestPostRuntimePrepareReportsRecoveryBoundaryWithoutExecution(t *testing.T) {
+	fake := &fakePostRuntimeExecutor{}
+	manifestReceipt := testPostRuntimeManifestReceipt(testSHA("1"))
+	manifestReceipt.RecoveryMode = "target-registration"
+	restore := stubPostRuntimeExecutor(t, fake, manifestReceipt)
+	defer restore()
+	var stdout bytes.Buffer
+	if err := run([]string{"cluster", "stage", "run", "post-runtime", "prepare", "--manifest", "/private/tmp/post-runtime.json"}, &stdout, &bytes.Buffer{}); err != nil {
+		t.Fatal(err)
+	}
+	var receipt postRuntimeCLIReceipt
+	if err := json.Unmarshal(stdout.Bytes(), &receipt); err != nil || receipt.Manifest.RecoveryMode != "target-registration" || fake.calls != 0 {
+		t.Fatalf("recovery prepare crossed the mutation boundary: %#v calls=%d err=%v", receipt, fake.calls, err)
+	}
+}
+
 func TestPostRuntimeMaterializeRequiresExplicitBoundIdentity(t *testing.T) {
 	previous := materializePostRuntimeBundle
 	defer func() { materializePostRuntimeBundle = previous }()

--- a/deploy/contract-executor-post-runtime-job.yaml.tpl
+++ b/deploy/contract-executor-post-runtime-job.yaml.tpl
@@ -137,6 +137,7 @@ spec:
               - {key: input.05-network-observation.json, path: input/05-network-observation.json}
               - {key: input.06-runtime-binding.json, path: input/06-runtime-binding.json}
               - {key: input.07-target-access.json, path: input/07-target-access.json}
+${OK147_RECOVERY_RECEIPT_ITEMS}
               - {key: input.aggregate-profile.json, path: input/aggregate-profile.json}
               - {key: input.authorization-authority.pub, path: input/authorization-authority.pub}
               - {key: input.network-profile.json, path: input/network-profile.json}

--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -2781,7 +2781,9 @@ and pinned public key. A failed request, invalid response or invalid grant is
 preserved as a stopped single-use attempt; the resolver exposes no automatic
 retry or overwrite path. This client is not the policy authority or grant
 issuer: deployment and operation of that external authority remain outside
-this checkpoint.
+this checkpoint. Credential and registration crash recovery use the same
+bounded endpoint but distinct canonical request media types, so the authority
+cannot confuse a normal stage grant with either recovery decision.
 
 The concrete post-runtime execution adapter now composes those boundaries into
 one single-use Stage 8-12 library path. It normally starts from the exact
@@ -2805,7 +2807,7 @@ cleanup. The adapter itself does not own a CLI or Job activation surface; the
 activation layer composes it without widening this library boundary.
 
 The private post-runtime execution manifest now provides the local activation
-boundary for that adapter. One strict `0600` JSON document binds the verified
+boundary for that adapter. The baseline v1 form binds the verified
 Plan and seven-receipt prefix, Stage-8 grant and policy, predecessor-bound TLS
 authority, runtime binding, exact registration and Application projections,
 Network/Platform/Aggregate profiles, one shared capability assertion, isolated
@@ -2815,6 +2817,15 @@ artifact or capability divergence before opening the execution suffix. Its
 redaction-safe receipt exposes only semantic digests and explicitly grants no
 mutation. Loading remains verification-only; every activation surface must
 bind that verified identity separately.
+
+The additive v2 form activates crash recovery without changing historical
+evidence. It requires the exact successful Stage-8 receipt and may additionally
+bind the exact successful Stage-9 receipt. Both paths and digests are strict,
+private inputs. Stage 8 selects credential recovery; Stage 8 plus Stage 9
+selects registration refresh and continuation at Stage 10. A v1 manifest that
+carries recovery state, a v2 manifest without Stage 8, a relative path, a
+changed digest or a failed historical receipt stops before authority or
+Kubernetes contact.
 
 The local post-runtime CLI now keeps verification and mutation as two explicit
 operations. `post-runtime prepare` opens and verifies the private manifest and
@@ -2831,11 +2842,13 @@ The first ephemeral post-runtime Job envelope binds that same command to one
 immutable activation Secret, one canonical bundle-index digest and one
 semantic manifest digest. Because Kubernetes projected Secret entries are
 symlinks while the runner deliberately accepts only regular private files, a
-non-networked init invocation copies exactly 34 allowlisted, individually
-hashed inputs into one new `0700` memory-backed workspace as `0600` files. It
-also creates the private create-only authorization and receipt directories.
-The executor container can see only that workspace, not the original Secret
-projection.
+non-networked init invocation copies exactly 34 baseline inputs, plus the one
+or two recovery receipts selected by the v2 manifest, into one new `0700`
+memory-backed workspace as individually hashed `0600` files. The bundle index,
+Secret projection and rewritten manifest all bind the same recovery mode. The
+initializer also creates the private create-only authorization and receipt
+directories. The executor container can see only that workspace, not the
+original Secret projection.
 
 The Job has no automounted ServiceAccount token, no retry and a deadline around
 the CLI's three-hour bound. Its deny-all NetworkPolicy permits only four exact
@@ -2855,12 +2868,13 @@ therefore receives its own digest without changing R, E, P or the execution
 fixture.
 
 The builder emits exactly one immutable opaque Secret followed by the already
-verified NetworkPolicy and Job. The Secret's 34 private files and canonical
-index are individually digest-bound. The CLI writes this credential-bearing
-package create-only as `0600` and emits only a redaction-safe package receipt
-containing component digests. Source and rewritten manifest identities are
-both retained. Package construction remains offline and grants no installation
-or launch authority.
+verified NetworkPolicy and Job. Its 34 baseline files and any selected
+historical recovery receipts are individually digest-bound by a canonical
+index. The CLI writes this credential-bearing package create-only as `0600`
+and emits only a redaction-safe package receipt containing component digests
+and the recovery mode. Source and rewritten manifest identities are both
+retained. Package construction remains offline and grants no installation or
+launch authority.
 
 The final activation boundary derives an exact credential-free installation
 plan from that private package. It permits only this order:
@@ -2901,7 +2915,10 @@ The twelve-stage Go library and its durable replay semantics are complete and
 covered by unit, negative, local TLS integration and race tests. The complete
 Stage 8-12 suffix now has a local prepare/execute command, a bounded ephemeral
 Job, a deterministic private activation package, an exact installation plan
-and a single-use CLI launcher. This is not yet the OK-147 Definition of Done:
+and a single-use CLI launcher. Successful Stage-8 and Stage-9 crash boundaries
+can be reactivated through the same manifest, authority, package, Job and CLI
+chain without rewriting their durable receipts. This is not yet the OK-147
+Definition of Done:
 
 - the legacy `ok cluster create` command remains dry-run-only;
 - the standalone Stage-12 launcher has not yet been executed as part of the

--- a/internal/runner/post_runtime_activation_installation_plan.go
+++ b/internal/runner/post_runtime_activation_installation_plan.go
@@ -111,7 +111,7 @@ func PlanPostRuntimeExecutionActivationInstallation(packaged VerifiedPostRuntime
 			annotations, _ := metadata["annotations"].(map[string]any)
 			if name != runID || spec["backoffLimit"] != 0 || podSpec["serviceAccountName"] != "ok147-contract-executor-runtime" ||
 				podSpec["automountServiceAccountToken"] != false || annotations["openkubes.io/bundle-digest"] != receipt.BundleDigest ||
-				annotations["openkubes.io/manifest-digest"] != receipt.ManifestDigest || !postRuntimeJobMountsActivationSecret(podSpec, receipt.ActivationSecret) {
+				annotations["openkubes.io/manifest-digest"] != receipt.ManifestDigest || !postRuntimeJobMountsActivationSecret(podSpec, receipt.ActivationSecret, receipt.PrivateFileCount) {
 				return PostRuntimeExecutionActivationInstallationPlan{}, errors.New("post-runtime activation Job binding differs")
 			}
 		}
@@ -131,7 +131,7 @@ func postRuntimeActivationCreatePaths(apiVersion, kind, namespace, name string) 
 	return submissionStageCreatePaths(apiVersion, kind, namespace, name)
 }
 
-func postRuntimeJobMountsActivationSecret(podSpec map[string]any, name string) bool {
+func postRuntimeJobMountsActivationSecret(podSpec map[string]any, name string, fileCount int) bool {
 	volumes, ok := podSpec["volumes"].([]any)
 	if !ok {
 		return false
@@ -143,7 +143,7 @@ func postRuntimeJobMountsActivationSecret(podSpec map[string]any, name string) b
 		}
 		secret, _ := volume["secret"].(map[string]any)
 		items, _ := secret["items"].([]any)
-		return secret["secretName"] == name && len(items) == len(postRuntimeExecutionBundleFiles)+1
+		return secret["secretName"] == name && len(items) == fileCount+1
 	}
 	return false
 }

--- a/internal/runner/post_runtime_activation_package.go
+++ b/internal/runner/post_runtime_activation_package.go
@@ -56,6 +56,7 @@ type PostRuntimeExecutionActivationPackageReceipt struct {
 	ManagementAuthority  string   `json:"managementAuthority"`
 	PlanDigest           string   `json:"planDigest"`
 	TargetIdentityDigest string   `json:"targetIdentityDigest"`
+	RecoveryMode         string   `json:"recoveryMode,omitempty"`
 	PrivateFileCount     int      `json:"privateFileCount"`
 	ObjectKinds          []string `json:"objectKinds"`
 	MutationAllowed      bool     `json:"mutationAllowed"`
@@ -117,15 +118,23 @@ func BuildPostRuntimeExecutionActivationPackage(config PostRuntimeExecutionActiv
 	if err != nil {
 		return VerifiedPostRuntimeExecutionActivationPackage{}, err
 	}
-	index := postRuntimeExecutionBundleIndex{Format: PostRuntimeExecutionBundleFormat, ManifestDigest: manifestDigest}
-	for _, path := range postRuntimeExecutionBundleFiles {
+	bundleFormat, recoveryMode, err := postRuntimeExecutionBundleIdentity(document)
+	if err != nil || (sourceReceipt.RecoveryMode != "none" && sourceReceipt.RecoveryMode != recoveryMode) {
+		return VerifiedPostRuntimeExecutionActivationPackage{}, errors.New("post-runtime activation recovery identity differs")
+	}
+	bundleFiles, err := postRuntimeExecutionBundleFilesFor(bundleFormat, recoveryMode)
+	if err != nil {
+		return VerifiedPostRuntimeExecutionActivationPackage{}, err
+	}
+	index := postRuntimeExecutionBundleIndex{Format: bundleFormat, ManifestDigest: manifestDigest, RecoveryMode: recoveryMode}
+	for _, path := range bundleFiles {
 		raw, ok := files[path]
 		if !ok || len(raw) == 0 {
 			return VerifiedPostRuntimeExecutionActivationPackage{}, errors.New("post-runtime activation file set is incomplete")
 		}
 		index.Files = append(index.Files, postRuntimeExecutionBundleIndexFile{Path: path, Digest: digest.SHA256(raw)})
 	}
-	if err := validatePostRuntimeExecutionBundleFiles(index.Files); err != nil {
+	if err := validatePostRuntimeExecutionBundleFiles(index.Files, bundleFiles); err != nil {
 		return VerifiedPostRuntimeExecutionActivationPackage{}, err
 	}
 	bundleDigest, err := canonicalPostRuntimeExecutionBundleIndexDigest(index)
@@ -137,7 +146,7 @@ func BuildPostRuntimeExecutionActivationPackage(config PostRuntimeExecutionActiv
 		return VerifiedPostRuntimeExecutionActivationPackage{}, errors.New("encode post-runtime activation bundle index")
 	}
 	binaryData := map[string]string{postRuntimeExecutionBundleIndexName: base64.StdEncoding.EncodeToString(indexRaw)}
-	for _, path := range postRuntimeExecutionBundleFiles {
+	for _, path := range bundleFiles {
 		binaryData[strings.ReplaceAll(path, "/", ".")] = base64.StdEncoding.EncodeToString(files[path])
 	}
 	secret := postRuntimeActivationSecret{
@@ -163,6 +172,7 @@ func BuildPostRuntimeExecutionActivationPackage(config PostRuntimeExecutionActiv
 		WorkloadAPIURL: executor.runtime.material.Target.WorkloadAPIEndpoint, WorkloadAPICIDR: config.WorkloadAPICIDR,
 		ArgoAPIURL: document.TargetRegistration.GitOps.Endpoint, ArgoAPICIDR: config.ArgoAPICIDR,
 		AuthorizationAPIURL: document.Authorization.Endpoint, AuthorizationAPICIDR: config.AuthorizationAPICIDR,
+		RecoveryMode: recoveryMode,
 	})
 	if err != nil {
 		return VerifiedPostRuntimeExecutionActivationPackage{}, err
@@ -178,7 +188,7 @@ func BuildPostRuntimeExecutionActivationPackage(config PostRuntimeExecutionActiv
 		ManifestDigest:       manifestDigest, JobTemplateDigest: config.JobTemplateDigest, JobEnvelopeDigest: digest.SHA256(jobRaw),
 		ManagementAuthority: document.Plan.Expected.ManagementAuthority, PlanDigest: sourceReceipt.PlanDigest,
 		TargetIdentityDigest: sourceReceipt.TargetIdentityDigest,
-		PrivateFileCount:     len(postRuntimeExecutionBundleFiles), ObjectKinds: []string{"Secret", "NetworkPolicy", "Job"}, MutationAllowed: false,
+		RecoveryMode:         recoveryMode, PrivateFileCount: len(bundleFiles), ObjectKinds: []string{"Secret", "NetworkPolicy", "Job"}, MutationAllowed: false,
 	}
 	return VerifiedPostRuntimeExecutionActivationPackage{
 		raw: packageRaw, receipt: receipt, managementAuthority: document.Plan.Expected.ManagementAuthority, verified: true,
@@ -210,9 +220,16 @@ func verifyPostRuntimeExecutionActivationPackage(packaged VerifiedPostRuntimeExe
 		!stageReceiptPrefixDigestPattern.MatchString(packaged.receipt.SourceManifestDigest) ||
 		!stageReceiptPrefixDigestPattern.MatchString(packaged.receipt.SecretObjectDigest) || !stageReceiptPrefixDigestPattern.MatchString(packaged.receipt.JobEnvelopeDigest) ||
 		!stageReceiptPrefixDigestPattern.MatchString(packaged.receipt.PlanDigest) || !stageReceiptPrefixDigestPattern.MatchString(packaged.receipt.TargetIdentityDigest) ||
-		packaged.receipt.ManagementAuthority == "" || packaged.receipt.ManagementAuthority != packaged.managementAuthority ||
-		packaged.receipt.PrivateFileCount != len(postRuntimeExecutionBundleFiles) {
+		packaged.receipt.ManagementAuthority == "" || packaged.receipt.ManagementAuthority != packaged.managementAuthority {
 		return errors.New("post-runtime activation package identity is incomplete")
+	}
+	bundleFormat := PostRuntimeExecutionBundleFormat
+	if packaged.receipt.RecoveryMode != "" {
+		bundleFormat = PostRuntimeExecutionRecoveryBundleFormat
+	}
+	expectedFiles, err := postRuntimeExecutionBundleFilesFor(bundleFormat, packaged.receipt.RecoveryMode)
+	if err != nil || packaged.receipt.PrivateFileCount != len(expectedFiles) {
+		return errors.New("post-runtime activation package file identity is incomplete")
 	}
 	parts := bytes.SplitN(packaged.raw, []byte("\n---\n"), 2)
 	if len(parts) != 2 || digest.SHA256(parts[0]) != packaged.receipt.SecretObjectDigest || digest.SHA256(parts[1]) != packaged.receipt.JobEnvelopeDigest {
@@ -267,6 +284,12 @@ func collectPostRuntimeActivationSources(document postRuntimeExecutionManifestDo
 	for index, receipt := range receipts {
 		paths[postRuntimeReceiptBundlePaths[index]] = receipt.Path
 	}
+	if document.Recovery != nil {
+		paths[postRuntimeExecutionRecoveryReceiptFiles[0]] = document.Recovery.TargetCredential.Path
+		if document.Recovery.TargetRegistration != nil {
+			paths[postRuntimeExecutionRecoveryReceiptFiles[1]] = document.Recovery.TargetRegistration.Path
+		}
+	}
 	result := make(map[string][]byte, len(paths))
 	total := 0
 	for relative, source := range paths {
@@ -319,7 +342,7 @@ func collectPostRuntimeActivationSources(document postRuntimeExecutionManifestDo
 }
 
 func rewritePostRuntimeActivation(document postRuntimeExecutionManifestDocument, sources map[string][]byte) (map[string][]byte, string, error) {
-	files := make(map[string][]byte, len(postRuntimeExecutionBundleFiles))
+	files := make(map[string][]byte, len(sources)+2)
 	for path, raw := range sources {
 		files[path] = append([]byte(nil), raw...)
 	}
@@ -353,6 +376,14 @@ func rewritePostRuntimeActivation(document postRuntimeExecutionManifestDocument,
 	document.AggregateEvidence.Ledger, document.AggregateEvidence.Management, document.AggregateEvidence.Argo = ledger, management, gitOps
 	document.AggregateEvidence.WorkloadTokenFile, document.AggregateEvidence.WorkloadCAFile = path("credentials/workload-token"), path("credentials/workload-ca.crt")
 	document.AggregateEvidence.CapabilityPath = path("input/platform-capability.json")
+	if document.Recovery != nil {
+		document.Recovery.TargetCredential.Path = path(postRuntimeExecutionRecoveryReceiptFiles[0])
+		document.Recovery.TargetCredential.Digest = digest.SHA256(files[postRuntimeExecutionRecoveryReceiptFiles[0]])
+		if document.Recovery.TargetRegistration != nil {
+			document.Recovery.TargetRegistration.Path = path(postRuntimeExecutionRecoveryReceiptFiles[1])
+			document.Recovery.TargetRegistration.Digest = digest.SHA256(files[postRuntimeExecutionRecoveryReceiptFiles[1]])
+		}
+	}
 	document.ReceiptDirectory = path("work/receipts")
 	manifestRaw, err := json.Marshal(document)
 	if err != nil {
@@ -370,7 +401,14 @@ func rewritePostRuntimeActivation(document postRuntimeExecutionManifestDocument,
 	}
 	manifestDigest := digest.SHA256(canonical)
 	files[postRuntimeExecutionManifestRelativePath] = manifestRaw
-	if len(files) != len(postRuntimeExecutionBundleFiles) {
+	expectedCount := len(postRuntimeExecutionBundleFiles)
+	if document.Recovery != nil {
+		expectedCount++
+		if document.Recovery.TargetRegistration != nil {
+			expectedCount++
+		}
+	}
+	if len(files) != expectedCount {
 		return nil, "", errors.New("rewritten post-runtime activation file set differs")
 	}
 	return files, manifestDigest, nil

--- a/internal/runner/post_runtime_activation_package_test.go
+++ b/internal/runner/post_runtime_activation_package_test.go
@@ -117,6 +117,79 @@ func TestPostRuntimeExecutionActivationPackageMaterializesExactSecret(t *testing
 	}
 }
 
+func TestPostRuntimeExecutionRecoveryActivationCarriesHistoricalReceipts(t *testing.T) {
+	config, cleanup := postRuntimeActivationPackageFixture(t)
+	defer cleanup()
+	config.ManifestPath = postRuntimeRecoveryManifestFixture(t, config.ManifestPath, true)
+	packaged, err := BuildPostRuntimeExecutionActivationPackage(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := packaged.Receipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if receipt.RecoveryMode != "target-registration" || receipt.PrivateFileCount != len(postRuntimeExecutionBundleFiles)+2 {
+		t.Fatalf("recovery activation identity is incomplete: %#v", receipt)
+	}
+	raw, err := packaged.PrivateBytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	parts := bytes.SplitN(raw, []byte("\n---\n"), 2)
+	var secret postRuntimeActivationSecret
+	if len(parts) != 2 || json.Unmarshal(parts[0], &secret) != nil {
+		t.Fatal("decode recovery activation Secret")
+	}
+	indexRaw, err := base64.StdEncoding.DecodeString(secret.BinaryData[postRuntimeExecutionBundleIndexName])
+	if err != nil {
+		t.Fatal(err)
+	}
+	var index postRuntimeExecutionBundleIndex
+	if json.Unmarshal(indexRaw, &index) != nil || index.Format != PostRuntimeExecutionRecoveryBundleFormat ||
+		index.RecoveryMode != "target-registration" || len(index.Files) != receipt.PrivateFileCount {
+		t.Fatalf("unexpected recovery bundle index: %#v", index)
+	}
+	for _, relative := range postRuntimeExecutionRecoveryReceiptFiles {
+		if secret.BinaryData[strings.ReplaceAll(relative, "/", ".")] == "" {
+			t.Fatalf("recovery receipt %s is absent from private activation", relative)
+		}
+	}
+	plan, err := PlanPostRuntimeExecutionActivationInstallation(packaged)
+	if err != nil || plan.State != "VERIFIED" || plan.MutationAllowed {
+		t.Fatalf("recovery activation installation plan failed: %#v %v", plan, err)
+	}
+
+	root := t.TempDir()
+	source := filepath.Join(root, "projection")
+	if err := os.Mkdir(source, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(source, postRuntimeExecutionBundleIndexName), indexRaw, 0o440); err != nil {
+		t.Fatal(err)
+	}
+	for _, file := range index.Files {
+		encoded := secret.BinaryData[strings.ReplaceAll(file.Path, "/", ".")]
+		content, err := base64.StdEncoding.DecodeString(encoded)
+		if err != nil {
+			t.Fatal(err)
+		}
+		target := filepath.Join(source, file.Path)
+		if err := os.MkdirAll(filepath.Dir(target), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(target, content, 0o440); err != nil {
+			t.Fatal(err)
+		}
+	}
+	materialized, err := MaterializePostRuntimeExecutionBundle(PostRuntimeExecutionBundleMaterializationConfig{
+		SourceDirectory: source, DestinationDirectory: filepath.Join(root, "workspace"), ExpectedBundleDigest: receipt.BundleDigest,
+	})
+	if err != nil || materialized.State != "MATERIALIZED_VERIFIED" || materialized.FileCount != receipt.PrivateFileCount {
+		t.Fatalf("recovery activation did not materialize exactly: %#v %v", materialized, err)
+	}
+}
+
 func TestBuildPostRuntimeExecutionActivationPackageFailsClosed(t *testing.T) {
 	for name, mutate := range map[string]func(*testing.T, *PostRuntimeExecutionActivationPackageConfig){
 		"wrong template digest": func(_ *testing.T, config *PostRuntimeExecutionActivationPackageConfig) {

--- a/internal/runner/post_runtime_execution_manifest.go
+++ b/internal/runner/post_runtime_execution_manifest.go
@@ -17,9 +17,10 @@ import (
 )
 
 const (
-	PostRuntimeExecutionManifestFormat        = "ok147-post-runtime-execution-manifest/v1"
-	PostRuntimeExecutionManifestReceiptFormat = "ok147-post-runtime-execution-manifest-receipt/v1"
-	maximumPostRuntimeExecutionManifestBytes  = 512 * 1024
+	PostRuntimeExecutionManifestFormat         = "ok147-post-runtime-execution-manifest/v1"
+	PostRuntimeExecutionRecoveryManifestFormat = "ok147-post-runtime-execution-manifest/v2"
+	PostRuntimeExecutionManifestReceiptFormat  = "ok147-post-runtime-execution-manifest-receipt/v1"
+	maximumPostRuntimeExecutionManifestBytes   = 512 * 1024
 )
 
 type postRuntimePlanExpectedDocument struct {
@@ -120,6 +121,16 @@ type postRuntimeBindingDocument struct {
 	ReceiptPath  string `json:"receiptPath"`
 }
 
+type postRuntimeRecoveryReceiptDocument struct {
+	Path   string `json:"path"`
+	Digest string `json:"digest"`
+}
+
+type postRuntimeRecoveryDocument struct {
+	TargetCredential   *postRuntimeRecoveryReceiptDocument `json:"targetCredential,omitempty"`
+	TargetRegistration *postRuntimeRecoveryReceiptDocument `json:"targetRegistration,omitempty"`
+}
+
 type postRuntimePlatformObservationDocument struct {
 	Ledger                   postRuntimeLedgerDocument    `json:"ledger"`
 	Argo                     postRuntimeAuthorityDocument `json:"argo"`
@@ -150,6 +161,7 @@ type postRuntimeExecutionManifestDocument struct {
 	RuntimeBinding       postRuntimeBindingDocument              `json:"runtimeBinding"`
 	PlatformObservation  postRuntimePlatformObservationDocument  `json:"platformObservation"`
 	AggregateEvidence    postRuntimeAggregateEvidenceDocument    `json:"aggregateEvidence"`
+	Recovery             *postRuntimeRecoveryDocument            `json:"recovery,omitempty"`
 	ReceiptDirectory     string                                  `json:"receiptDirectory"`
 }
 
@@ -164,6 +176,7 @@ type PostRuntimeExecutionManifestReceipt struct {
 	PlatformProfileDigest  string `json:"platformProfileDigest"`
 	AggregateProfileDigest string `json:"aggregateProfileDigest"`
 	AuthorizationMode      string `json:"authorizationMode"`
+	RecoveryMode           string `json:"recoveryMode,omitempty"`
 	MutationAllowed        bool   `json:"mutationAllowed"`
 }
 
@@ -258,6 +271,13 @@ func openPostRuntimeExecutionManifest(path string, factories postRuntimeExecutio
 		return nil, receipt, errors.New("open post-runtime authorization resolver")
 	}
 	receipt.AuthorizationMode = "predecessor-bound-tls/v1"
+	if document.Recovery == nil {
+		receipt.RecoveryMode = "none"
+	} else if document.Recovery.TargetRegistration == nil {
+		receipt.RecoveryMode = "target-credential"
+	} else {
+		receipt.RecoveryMode = "target-registration"
+	}
 
 	targetRegistrationStage, _, err := plan.Stage("target-registration")
 	if err != nil || len(targetRegistrationStage.Inputs) != 1 {
@@ -366,6 +386,16 @@ func openPostRuntimeExecutionManifest(path string, factories postRuntimeExecutio
 		},
 		RuntimeBinding: runtimeBinding, ReceiptDirectory: document.ReceiptDirectory,
 	}
+	if document.Recovery != nil {
+		config.TargetCredentialRecovery = &PostRuntimeTargetCredentialRecoveryConfig{
+			StageReceipt: recoveryStageReceiptSource(document.Recovery.TargetCredential), Authorization: authorization,
+		}
+		if document.Recovery.TargetRegistration != nil {
+			config.TargetRegistrationRecovery = &PostRuntimeTargetRegistrationRecoveryConfig{
+				StageReceipt: recoveryStageReceiptSource(document.Recovery.TargetRegistration), Authorization: authorization,
+			}
+		}
+	}
 	executor, err := openPostRuntimeExecution(config, factories)
 	if err != nil {
 		return nil, receipt, errors.New("open verified post-runtime execution")
@@ -386,12 +416,19 @@ func loadPostRuntimeExecutionManifest(path string) (postRuntimeExecutionManifest
 	if err != nil {
 		return postRuntimeExecutionManifestDocument{}, "", errors.New("read bounded post-runtime execution manifest")
 	}
+	return decodePostRuntimeExecutionManifest(raw)
+}
+
+func decodePostRuntimeExecutionManifest(raw []byte) (postRuntimeExecutionManifestDocument, string, error) {
 	var document postRuntimeExecutionManifestDocument
 	if err := jsonstrict.Decode(raw, &document); err != nil {
 		return postRuntimeExecutionManifestDocument{}, "", errors.New("decode strict post-runtime execution manifest")
 	}
-	if document.Format != PostRuntimeExecutionManifestFormat {
+	if document.Format != PostRuntimeExecutionManifestFormat && document.Format != PostRuntimeExecutionRecoveryManifestFormat {
 		return postRuntimeExecutionManifestDocument{}, "", errors.New("post-runtime execution manifest format is not supported")
+	}
+	if err := validatePostRuntimeRecoveryDocument(document); err != nil {
+		return postRuntimeExecutionManifestDocument{}, "", err
 	}
 	encoded, err := json.Marshal(document)
 	if err != nil {
@@ -408,6 +445,35 @@ func loadPostRuntimeExecutionManifest(path string) (postRuntimeExecutionManifest
 		return postRuntimeExecutionManifestDocument{}, "", errors.New("canonicalize post-runtime execution manifest")
 	}
 	return document, digest.SHA256(canonical), nil
+}
+
+func validatePostRuntimeRecoveryDocument(document postRuntimeExecutionManifestDocument) error {
+	if document.Recovery == nil {
+		if document.Format != PostRuntimeExecutionManifestFormat {
+			return errors.New("post-runtime recovery manifest requires recovery receipts")
+		}
+		return nil
+	}
+	if document.Format != PostRuntimeExecutionRecoveryManifestFormat || document.Recovery.TargetCredential == nil {
+		return errors.New("post-runtime recovery manifest requires a target-credential receipt")
+	}
+	for _, source := range []*postRuntimeRecoveryReceiptDocument{document.Recovery.TargetCredential, document.Recovery.TargetRegistration} {
+		if source == nil {
+			continue
+		}
+		if source.Path == "" || !filepath.IsAbs(source.Path) || filepath.Clean(source.Path) != source.Path ||
+			!stageReceiptPrefixDigestPattern.MatchString(source.Digest) {
+			return errors.New("post-runtime recovery receipt source is invalid")
+		}
+	}
+	return nil
+}
+
+func recoveryStageReceiptSource(document *postRuntimeRecoveryReceiptDocument) StageReceiptSource {
+	if document == nil {
+		return StageReceiptSource{}
+	}
+	return StageReceiptSource{Path: document.Path, Digest: document.Digest}
 }
 
 func bindPostRuntimeProfileInputs(plan stageplan.Binding, receipt PostRuntimeExecutionManifestReceipt) error {

--- a/internal/runner/post_runtime_execution_manifest_test.go
+++ b/internal/runner/post_runtime_execution_manifest_test.go
@@ -115,6 +115,124 @@ func TestPostRuntimeExecutionManifestDigestIsFormattingIndependent(t *testing.T)
 	}
 }
 
+func TestOpenPostRuntimeExecutionRecoveryManifestResumesFromDurableReceipts(t *testing.T) {
+	for _, test := range []struct {
+		name                string
+		registrationReceipt bool
+		wantMode            string
+	}{
+		{name: "target credential", wantMode: "target-credential"},
+		{name: "target registration", registrationReceipt: true, wantMode: "target-registration"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			manifest, factories, cleanup := postRuntimeManifestFixture(t)
+			defer cleanup()
+			manifest = postRuntimeRecoveryManifestFixture(t, manifest, test.registrationReceipt)
+			if test.registrationReceipt {
+				factories.registrationRecovery = func(context.Context, TargetRegistrationRecoveryConfig) (TargetRegistrationRecoveryReceipt, error) {
+					return TargetRegistrationRecoveryReceipt{}, errors.New("not executed")
+				}
+			}
+
+			executor, receipt, err := openPostRuntimeExecutionManifest(manifest, factories)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if executor == nil || receipt.State != "VERIFIED" || receipt.RecoveryMode != test.wantMode ||
+				executor.config.TargetCredentialRecovery == nil ||
+				(executor.config.TargetRegistrationRecovery != nil) != test.registrationReceipt {
+				t.Fatalf("unexpected recovery activation: receipt=%#v executor=%#v", receipt, executor)
+			}
+		})
+	}
+}
+
+func TestPostRuntimeExecutionRecoveryManifestFailsClosed(t *testing.T) {
+	manifest, factories, cleanup := postRuntimeManifestFixture(t)
+	defer cleanup()
+	recoveryManifest := postRuntimeRecoveryManifestFixture(t, manifest, true)
+	raw, err := os.ReadFile(recoveryManifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root := filepath.Dir(manifest)
+	for name, mutate := range map[string]func(map[string]any){
+		"v1 carries recovery": func(value map[string]any) {
+			value["format"] = PostRuntimeExecutionManifestFormat
+		},
+		"v2 omits recovery": func(value map[string]any) {
+			delete(value, "recovery")
+		},
+		"registration without credential": func(value map[string]any) {
+			delete(value["recovery"].(map[string]any), "targetCredential")
+		},
+		"wrong receipt digest": func(value map[string]any) {
+			value["recovery"].(map[string]any)["targetCredential"].(map[string]any)["digest"] = runnerStageSHA("f")
+		},
+		"relative receipt path": func(value map[string]any) {
+			value["recovery"].(map[string]any)["targetCredential"].(map[string]any)["path"] = "08-target-credential.json"
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			var value map[string]any
+			if err := json.Unmarshal(raw, &value); err != nil {
+				t.Fatal(err)
+			}
+			mutate(value)
+			path := writeBundleFile(t, root, "unsafe-recovery-"+strings.ReplaceAll(name, " ", "-")+".json", mustJSON(t, value))
+			if _, _, err := openPostRuntimeExecutionManifest(path, factories); err == nil {
+				t.Fatal("unsafe recovery manifest was accepted")
+			}
+		})
+	}
+}
+
+func postRuntimeRecoveryManifestFixture(t *testing.T, manifest string, includeRegistration bool) string {
+	t.Helper()
+	document, _, err := loadPostRuntimeExecutionManifest(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := stageplan.Expected{
+		ContractIdentity: document.Plan.Expected.ContractIdentity,
+		IntentRevision:   document.Plan.Expected.IntentRevision, EnablementRevision: document.Plan.Expected.EnablementRevision,
+		PlatformRevision: document.Plan.Expected.PlatformRevision, ExecutionFixture: document.Plan.Expected.ExecutionFixture,
+		InfrastructureAuthority: document.Plan.Expected.InfrastructureAuthority, ManagementAuthority: document.Plan.Expected.ManagementAuthority,
+		GitOpsAuthority: document.Plan.Expected.GitOpsAuthority,
+	}
+	receipts, err := LoadStageReceiptPrefix(document.Plan.ReceiptPrefixPath, document.Plan.ReceiptPrefixDigest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan, cursor, prefix, err := loadStageResumeWithPrefix(StageResumeConfig{PlanPath: document.Plan.Path, PlanExpected: expected, Receipts: receipts})
+	if err != nil {
+		t.Fatal(err)
+	}
+	predecessors, err := cursor.Predecessors()
+	if err != nil {
+		t.Fatal(err)
+	}
+	at := time.Date(2026, 8, 18, 8, 2, 0, 0, time.UTC)
+	stageEight, err := stagereceipt.New(plan, "target-credential", predecessors, "SUCCEEDED", "ATTEMPTED", runnerStageSHA("a"), runnerStageSHA("b"), at)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root := filepath.Dir(manifest)
+	stageEightSource := appendStageReceipt(t, root, nil, stageEight, "08-target-credential.json")[0]
+	document.Format = PostRuntimeExecutionRecoveryManifestFormat
+	document.Recovery = &postRuntimeRecoveryDocument{TargetCredential: &postRuntimeRecoveryReceiptDocument{Path: stageEightSource.Path, Digest: stageEightSource.Digest}}
+	if includeRegistration {
+		stageNine, err := stagereceipt.New(plan, "target-registration", []stagereceipt.Verified{stageEight}, "SUCCEEDED", "ATTEMPTED", runnerStageSHA("c"), runnerStageSHA("d"), at.Add(time.Minute))
+		if err != nil {
+			t.Fatal(err)
+		}
+		stageNineSource := appendStageReceipt(t, root, nil, stageNine, "09-target-registration.json")[0]
+		document.Recovery.TargetRegistration = &postRuntimeRecoveryReceiptDocument{Path: stageNineSource.Path, Digest: stageNineSource.Digest}
+	}
+	_ = prefix // retained here to make the exact seven-receipt recovery boundary explicit.
+	return writeBundleFile(t, root, "post-runtime-recovery-manifest.json", mustJSON(t, document))
+}
+
 func postRuntimeManifestFixture(t *testing.T) (string, postRuntimeExecutionFactories, func()) {
 	t.Helper()
 	root := t.TempDir()

--- a/internal/runner/post_runtime_job.go
+++ b/internal/runner/post_runtime_job.go
@@ -24,6 +24,7 @@ type PostRuntimeExecutionJobValues struct {
 	ArgoAPICIDR          string
 	AuthorizationAPIURL  string
 	AuthorizationAPICIDR string
+	RecoveryMode         string
 }
 
 // RenderPostRuntimeExecutionJobTemplate binds the complete Stage 8-12 process
@@ -72,6 +73,16 @@ func RenderPostRuntimeExecutionJobTemplate(template []byte, values PostRuntimeEx
 		"${OK147_WORKLOAD_API_CIDR}": values.WorkloadAPICIDR, "${OK147_WORKLOAD_API_PORT}": workloadPort,
 		"${OK147_ARGO_API_CIDR}": values.ArgoAPICIDR, "${OK147_ARGO_API_PORT}": argoPort,
 		"${OK147_AUTHORIZATION_API_CIDR}": values.AuthorizationAPICIDR, "${OK147_AUTHORIZATION_API_PORT}": authorizationPort,
+	}
+	switch values.RecoveryMode {
+	case "":
+		replacements["${OK147_RECOVERY_RECEIPT_ITEMS}"] = ""
+	case "target-credential":
+		replacements["${OK147_RECOVERY_RECEIPT_ITEMS}"] = "              - {key: input.08-target-credential.json, path: input/08-target-credential.json}"
+	case "target-registration":
+		replacements["${OK147_RECOVERY_RECEIPT_ITEMS}"] = "              - {key: input.08-target-credential.json, path: input/08-target-credential.json}\n              - {key: input.09-target-registration.json, path: input/09-target-registration.json}"
+	default:
+		return nil, errors.New("post-runtime Job recovery mode is invalid")
 	}
 	result := string(template)
 	for placeholder, value := range replacements {

--- a/internal/runner/post_runtime_job_test.go
+++ b/internal/runner/post_runtime_job_test.go
@@ -82,6 +82,26 @@ func TestRenderPostRuntimeExecutionJobTemplateBindsPrivateInitAndSingleExecution
 	}
 }
 
+func TestRenderPostRuntimeExecutionJobTemplateProjectsRecoveryReceipts(t *testing.T) {
+	values := validPostRuntimeExecutionJobValues()
+	values.RecoveryMode = "target-registration"
+	raw, err := RenderPostRuntimeExecutionJobTemplate(postRuntimeExecutionJobTemplate(t), values)
+	if err != nil {
+		t.Fatal(err)
+	}
+	job := decodeJobObjects(t, raw)["Job"]
+	podSpec := objectAt(t, objectAt(t, objectAt(t, job, "spec"), "template"), "spec")
+	secret := objectAt(t, arrayAt(t, podSpec, "volumes")[0].(map[string]any), "secret")
+	paths := make(map[string]bool)
+	for _, item := range arrayAt(t, secret, "items") {
+		paths[item.(map[string]any)["path"].(string)] = true
+	}
+	if len(paths) != len(postRuntimeExecutionBundleFiles)+len(postRuntimeExecutionRecoveryReceiptFiles)+1 ||
+		!paths[postRuntimeExecutionRecoveryReceiptFiles[0]] || !paths[postRuntimeExecutionRecoveryReceiptFiles[1]] {
+		t.Fatalf("recovery receipts are not projected exactly: %#v", paths)
+	}
+}
+
 func TestRenderPostRuntimeExecutionJobTemplateFailsClosed(t *testing.T) {
 	valid := validPostRuntimeExecutionJobValues()
 	for name, mutate := range map[string]func(*PostRuntimeExecutionJobValues){
@@ -96,6 +116,7 @@ func TestRenderPostRuntimeExecutionJobTemplateFailsClosed(t *testing.T) {
 			values.ArgoAPIURL, values.ArgoAPICIDR = values.WorkloadAPIURL, values.WorkloadAPICIDR
 		},
 		"authority without path": func(values *PostRuntimeExecutionJobValues) { values.AuthorizationAPIURL = "https://192.0.2.40:8443" },
+		"unknown recovery mode":  func(values *PostRuntimeExecutionJobValues) { values.RecoveryMode = "retry-everything" },
 	} {
 		t.Run(name, func(t *testing.T) {
 			candidate := valid

--- a/internal/runner/post_runtime_materializer.go
+++ b/internal/runner/post_runtime_materializer.go
@@ -17,6 +17,7 @@ import (
 
 const (
 	PostRuntimeExecutionBundleFormat         = "ok147-post-runtime-execution-bundle/v1"
+	PostRuntimeExecutionRecoveryBundleFormat = "ok147-post-runtime-execution-bundle/v2"
 	PostRuntimeExecutionBundleReceiptFormat  = "ok147-post-runtime-execution-bundle-receipt/v1"
 	postRuntimeExecutionBundleIndexName      = "bundle-index.json"
 	postRuntimeExecutionManifestRelativePath = "activation/post-runtime-manifest.json"
@@ -61,6 +62,11 @@ var postRuntimeExecutionBundleFiles = []string{
 	"input/workload-authority.json",
 }
 
+var postRuntimeExecutionRecoveryReceiptFiles = []string{
+	"input/08-target-credential.json",
+	"input/09-target-registration.json",
+}
+
 type postRuntimeExecutionBundleIndexFile struct {
 	Path   string `json:"path"`
 	Digest string `json:"digest"`
@@ -69,6 +75,7 @@ type postRuntimeExecutionBundleIndexFile struct {
 type postRuntimeExecutionBundleIndex struct {
 	Format         string                                `json:"format"`
 	ManifestDigest string                                `json:"manifestDigest"`
+	RecoveryMode   string                                `json:"recoveryMode,omitempty"`
 	Files          []postRuntimeExecutionBundleIndexFile `json:"files"`
 }
 
@@ -109,7 +116,7 @@ func MaterializePostRuntimeExecutionBundle(config PostRuntimeExecutionBundleMate
 		return receipt, errors.New("read post-runtime bundle index")
 	}
 	var index postRuntimeExecutionBundleIndex
-	if err := jsonstrict.Decode(indexRaw, &index); err != nil || index.Format != PostRuntimeExecutionBundleFormat ||
+	if err := jsonstrict.Decode(indexRaw, &index); err != nil ||
 		!stageReceiptPrefixDigestPattern.MatchString(index.ManifestDigest) {
 		return receipt, errors.New("post-runtime bundle index is invalid")
 	}
@@ -118,7 +125,11 @@ func MaterializePostRuntimeExecutionBundle(config PostRuntimeExecutionBundleMate
 		return receipt, errors.New("post-runtime bundle index differs from expected identity")
 	}
 	receipt.BundleDigest, receipt.ManifestDigest = indexDigest, index.ManifestDigest
-	if err := validatePostRuntimeExecutionBundleFiles(index.Files); err != nil {
+	expectedFiles, err := postRuntimeExecutionBundleFilesFor(index.Format, index.RecoveryMode)
+	if err != nil {
+		return receipt, err
+	}
+	if err := validatePostRuntimeExecutionBundleFiles(index.Files, expectedFiles); err != nil {
 		return receipt, err
 	}
 
@@ -133,6 +144,14 @@ func MaterializePostRuntimeExecutionBundle(config PostRuntimeExecutionBundleMate
 			return receipt, errors.New("post-runtime bundle exceeds size limit")
 		}
 		contents[file.Path] = raw
+	}
+	sourceDocument, sourceManifestDigest, err := decodePostRuntimeExecutionManifest(contents[postRuntimeExecutionManifestRelativePath])
+	if err != nil || sourceManifestDigest != index.ManifestDigest {
+		return receipt, errors.New("projected post-runtime manifest differs from bundle identity")
+	}
+	sourceBundleFormat, sourceRecoveryMode, err := postRuntimeExecutionBundleIdentity(sourceDocument)
+	if err != nil || sourceBundleFormat != index.Format || sourceRecoveryMode != index.RecoveryMode {
+		return receipt, errors.New("projected post-runtime recovery identity differs from bundle index")
 	}
 
 	parentInfo, err := os.Lstat(filepath.Dir(config.DestinationDirectory))
@@ -154,9 +173,13 @@ func MaterializePostRuntimeExecutionBundle(config PostRuntimeExecutionBundleMate
 		}
 	}
 	manifestPath := filepath.Join(config.DestinationDirectory, postRuntimeExecutionManifestRelativePath)
-	_, manifestDigest, err := loadPostRuntimeExecutionManifest(manifestPath)
+	document, manifestDigest, err := loadPostRuntimeExecutionManifest(manifestPath)
 	if err != nil || manifestDigest != index.ManifestDigest {
 		return receipt, errors.New("materialized post-runtime manifest differs from bundle identity")
+	}
+	manifestBundleFormat, manifestRecoveryMode, err := postRuntimeExecutionBundleIdentity(document)
+	if err != nil || manifestBundleFormat != index.Format || manifestRecoveryMode != index.RecoveryMode {
+		return receipt, errors.New("materialized post-runtime recovery identity differs from bundle index")
 	}
 	receipt.State, receipt.FileCount = "MATERIALIZED_VERIFIED", len(index.Files)
 	return receipt, nil
@@ -180,11 +203,11 @@ func canonicalPostRuntimeExecutionBundleIndexDigest(index postRuntimeExecutionBu
 	return digest.SHA256(canonical), nil
 }
 
-func validatePostRuntimeExecutionBundleFiles(files []postRuntimeExecutionBundleIndexFile) error {
-	if len(files) != len(postRuntimeExecutionBundleFiles) || len(files) > maximumPostRuntimeExecutionBundleFiles {
+func validatePostRuntimeExecutionBundleFiles(files []postRuntimeExecutionBundleIndexFile, expected []string) error {
+	if len(files) != len(expected) || len(files) > maximumPostRuntimeExecutionBundleFiles {
 		return errors.New("post-runtime bundle file set is incomplete")
 	}
-	want := append([]string(nil), postRuntimeExecutionBundleFiles...)
+	want := append([]string(nil), expected...)
 	sort.Strings(want)
 	for index, file := range files {
 		if file.Path != want[index] || !stageReceiptPrefixDigestPattern.MatchString(file.Digest) {
@@ -192,6 +215,34 @@ func validatePostRuntimeExecutionBundleFiles(files []postRuntimeExecutionBundleI
 		}
 	}
 	return nil
+}
+
+func postRuntimeExecutionBundleFilesFor(format, recoveryMode string) ([]string, error) {
+	files := append([]string(nil), postRuntimeExecutionBundleFiles...)
+	switch {
+	case format == PostRuntimeExecutionBundleFormat && recoveryMode == "":
+	case format == PostRuntimeExecutionRecoveryBundleFormat && recoveryMode == "target-credential":
+		files = append(files, postRuntimeExecutionRecoveryReceiptFiles[0])
+	case format == PostRuntimeExecutionRecoveryBundleFormat && recoveryMode == "target-registration":
+		files = append(files, postRuntimeExecutionRecoveryReceiptFiles...)
+	default:
+		return nil, errors.New("post-runtime bundle recovery schema is invalid")
+	}
+	sort.Strings(files)
+	return files, nil
+}
+
+func postRuntimeExecutionBundleIdentity(document postRuntimeExecutionManifestDocument) (string, string, error) {
+	switch {
+	case document.Format == PostRuntimeExecutionManifestFormat && document.Recovery == nil:
+		return PostRuntimeExecutionBundleFormat, "", nil
+	case document.Format == PostRuntimeExecutionRecoveryManifestFormat && document.Recovery != nil && document.Recovery.TargetCredential != nil && document.Recovery.TargetRegistration == nil:
+		return PostRuntimeExecutionRecoveryBundleFormat, "target-credential", nil
+	case document.Format == PostRuntimeExecutionRecoveryManifestFormat && document.Recovery != nil && document.Recovery.TargetCredential != nil && document.Recovery.TargetRegistration != nil:
+		return PostRuntimeExecutionRecoveryBundleFormat, "target-registration", nil
+	default:
+		return "", "", errors.New("post-runtime execution manifest recovery identity is invalid")
+	}
 }
 
 func readProjectedPostRuntimeBundleFile(root, relative string, maximum int64) ([]byte, error) {

--- a/internal/runner/stage_authorization_http_resolver.go
+++ b/internal/runner/stage_authorization_http_resolver.go
@@ -18,6 +18,13 @@ import (
 
 const maximumStageAuthorizationHTTPResponseBytes = 128 * 1024
 
+const (
+	stageAuthorizationRequestMediaType                      = "application/vnd.openkubes.stage-authorization-request+json"
+	targetCredentialRecoveryAuthorizationRequestMediaType   = "application/vnd.openkubes.target-credential-recovery-authorization-request+json"
+	targetRegistrationRecoveryAuthorizationRequestMediaType = "application/vnd.openkubes.target-registration-recovery-authorization-request+json"
+	stageAuthorizationResponseMediaType                     = "application/vnd.openkubes.stage-authorization+json"
+)
+
 type StageAuthorizationHTTPResolverConfig struct {
 	Endpoint        string
 	TokenFile       string
@@ -86,21 +93,41 @@ func newStageAuthorizationHTTPResolver(config StageAuthorizationHTTPResolverConf
 // that independent verification against the current cursor immediately after
 // this method returns.
 func (resolver *StageAuthorizationHTTPResolver) ResolveStageAuthorization(ctx context.Context, request StageAuthorizationRequest) (StageAuthorizationSource, error) {
-	if resolver == nil || resolver.client == nil || resolver.clock == nil {
-		return StageAuthorizationSource{}, errors.New("stage authorization HTTP resolver is required")
-	}
 	requestRaw, err := request.Bytes()
 	if err != nil {
 		return StageAuthorizationSource{}, err
 	}
+	return resolver.resolve(ctx, request.RequestDigest, requestRaw, stageAuthorizationRequestMediaType)
+}
+
+func (resolver *StageAuthorizationHTTPResolver) ResolveTargetCredentialRecoveryAuthorization(ctx context.Context, request TargetCredentialRecoveryAuthorizationRequest) (StageAuthorizationSource, error) {
+	requestRaw, err := request.Bytes()
+	if err != nil {
+		return StageAuthorizationSource{}, err
+	}
+	return resolver.resolve(ctx, request.RequestDigest, requestRaw, targetCredentialRecoveryAuthorizationRequestMediaType)
+}
+
+func (resolver *StageAuthorizationHTTPResolver) ResolveTargetRegistrationRecoveryAuthorization(ctx context.Context, request TargetRegistrationRecoveryAuthorizationRequest) (StageAuthorizationSource, error) {
+	requestRaw, err := request.Bytes()
+	if err != nil {
+		return StageAuthorizationSource{}, err
+	}
+	return resolver.resolve(ctx, request.RequestDigest, requestRaw, targetRegistrationRecoveryAuthorizationRequestMediaType)
+}
+
+func (resolver *StageAuthorizationHTTPResolver) resolve(ctx context.Context, requestDigest string, requestRaw []byte, contentType string) (StageAuthorizationSource, error) {
+	if resolver == nil || resolver.client == nil || resolver.clock == nil {
+		return StageAuthorizationSource{}, errors.New("stage authorization HTTP resolver is required")
+	}
 	resolver.mu.Lock()
-	if _, exists := resolver.used[request.RequestDigest]; exists {
+	if _, exists := resolver.used[requestDigest]; exists {
 		resolver.mu.Unlock()
 		return StageAuthorizationSource{}, errors.New("stage authorization request is single-use")
 	}
-	resolver.used[request.RequestDigest] = struct{}{}
+	resolver.used[requestDigest] = struct{}{}
 	resolver.mu.Unlock()
-	outputPath := filepath.Join(resolver.outputDirectory, strings.TrimPrefix(request.RequestDigest, "sha256:")+".json")
+	outputPath := filepath.Join(resolver.outputDirectory, strings.TrimPrefix(requestDigest, "sha256:")+".json")
 	if err := validateRuntimeBindingOutputPath(outputPath); err != nil {
 		return StageAuthorizationSource{}, errors.New("stage authorization grant destination is invalid")
 	}
@@ -109,8 +136,8 @@ func (resolver *StageAuthorizationHTTPResolver) ResolveStageAuthorization(ctx co
 		return StageAuthorizationSource{}, errors.New("create stage authorization request")
 	}
 	httpRequest.Header.Set("Authorization", "Bearer "+resolver.token)
-	httpRequest.Header.Set("Content-Type", "application/vnd.openkubes.stage-authorization-request+json")
-	httpRequest.Header.Set("Accept", "application/vnd.openkubes.stage-authorization+json")
+	httpRequest.Header.Set("Content-Type", contentType)
+	httpRequest.Header.Set("Accept", stageAuthorizationResponseMediaType)
 	response, err := resolver.client.Do(httpRequest)
 	if err != nil {
 		return StageAuthorizationSource{}, errors.New("perform stage authorization request")
@@ -118,7 +145,7 @@ func (resolver *StageAuthorizationHTTPResolver) ResolveStageAuthorization(ctx co
 	defer response.Body.Close()
 	grantRaw, readErr := io.ReadAll(io.LimitReader(response.Body, maximumStageAuthorizationHTTPResponseBytes+1))
 	if readErr != nil || len(grantRaw) == 0 || len(grantRaw) > maximumStageAuthorizationHTTPResponseBytes ||
-		response.StatusCode != http.StatusCreated || response.Header.Get("Content-Type") != "application/vnd.openkubes.stage-authorization+json" {
+		response.StatusCode != http.StatusCreated || response.Header.Get("Content-Type") != stageAuthorizationResponseMediaType {
 		return StageAuthorizationSource{}, errors.New("stage authorization authority response is not accepted")
 	}
 	file, err := os.OpenFile(outputPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
@@ -154,3 +181,5 @@ func (resolver *StageAuthorizationHTTPResolver) ResolveStageAuthorization(ctx co
 }
 
 var _ StageAuthorizationResolver = (*StageAuthorizationHTTPResolver)(nil)
+var _ TargetCredentialRecoveryAuthorizationResolver = (*StageAuthorizationHTTPResolver)(nil)
+var _ TargetRegistrationRecoveryAuthorizationResolver = (*StageAuthorizationHTTPResolver)(nil)

--- a/internal/runner/stage_authorization_http_resolver_test.go
+++ b/internal/runner/stage_authorization_http_resolver_test.go
@@ -142,6 +142,124 @@ func TestStageAuthorizationHTTPResolverRejectsRedirectAndUnsafeConfiguration(t *
 	}
 }
 
+func TestStageAuthorizationHTTPResolverCarriesRecoveryEvidenceToAuthority(t *testing.T) {
+	credentialFixture := targetCredentialBundleFixture(t)
+	plan, cursor, _, err := loadStageResumeWithPrefix(StageResumeConfig{
+		PlanPath: credentialFixture.config.PlanPath, PlanExpected: credentialFixture.config.PlanExpected, Receipts: credentialFixture.config.Receipts,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	decision, err := cursor.Decision()
+	if err != nil {
+		t.Fatal(err)
+	}
+	credentialStage, err := newStageAuthorizationRequest(plan, decision)
+	if err != nil {
+		t.Fatal(err)
+	}
+	credentialRequest := TargetCredentialRecoveryAuthorizationRequest{
+		Format: TargetCredentialRecoveryAuthorizationRequestFormat, Stage: credentialStage,
+		PriorStageReceiptDigest: runnerStageSHA("1"), OriginalAuthorizationDigest: runnerStageSHA("2"),
+	}
+	credentialRequest.RequestDigest, err = targetCredentialRecoveryAuthorizationRequestDigest(credentialRequest)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	registrationFixture := targetRegistrationRecoveryFixture(t)
+	registrationPlan, registrationCursor, _, err := registrationFixture.handoff.registrationContext()
+	if err != nil {
+		t.Fatal(err)
+	}
+	registrationDecision, err := registrationCursor.Decision()
+	if err != nil {
+		t.Fatal(err)
+	}
+	registrationStage, err := newStageAuthorizationRequest(registrationPlan, registrationDecision)
+	if err != nil {
+		t.Fatal(err)
+	}
+	registrationRequest := TargetRegistrationRecoveryAuthorizationRequest{
+		Format: TargetRegistrationRecoveryAuthorizationRequestFormat, Stage: registrationStage,
+		PriorStageReceiptDigest:         registrationFixture.prior.Digest,
+		CredentialRecoveryRequestDigest: registrationFixture.recoveryRequest,
+		CredentialIssueReceiptDigest:    registrationFixture.credentialEvidence,
+	}
+	registrationRequest.RequestDigest, err = targetRegistrationRecoveryAuthorizationRequestDigest(registrationRequest)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var mu sync.Mutex
+	mediaTypes := []string{}
+	server := httptest.NewTLSServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		var stage StageAuthorizationRequest
+		switch mediaType := request.Header.Get("Content-Type"); mediaType {
+		case targetCredentialRecoveryAuthorizationRequestMediaType:
+			var recovery TargetCredentialRecoveryAuthorizationRequest
+			if json.NewDecoder(request.Body).Decode(&recovery) != nil || recovery.RequestDigest != credentialRequest.RequestDigest {
+				response.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			stage = recovery.Stage
+		case targetRegistrationRecoveryAuthorizationRequestMediaType:
+			var recovery TargetRegistrationRecoveryAuthorizationRequest
+			if json.NewDecoder(request.Body).Decode(&recovery) != nil || recovery.RequestDigest != registrationRequest.RequestDigest {
+				response.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			stage = recovery.Stage
+		default:
+			response.WriteHeader(http.StatusUnsupportedMediaType)
+			return
+		}
+		mu.Lock()
+		mediaTypes = append(mediaTypes, request.Header.Get("Content-Type"))
+		mu.Unlock()
+		response.Header().Set("Content-Type", stageAuthorizationResponseMediaType)
+		response.WriteHeader(http.StatusCreated)
+		_, _ = response.Write(stageAuthorizationEnvelopeForRequest(t, stage, publicKey, privateKey))
+	}))
+	defer server.Close()
+	root := t.TempDir()
+	if err := os.Chmod(root, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	resolver, err := OpenStageAuthorizationHTTPResolver(StageAuthorizationHTTPResolverConfig{
+		Endpoint: server.URL + "/v1/stage-authorizations", TokenFile: writeBundleFile(t, root, "token", []byte("authority-token")),
+		CAFile:          writeRuntimeBindingServerCA(t, root, "ca.crt", server),
+		PublicKeyPath:   writeBundleFile(t, root, "authority.pub", []byte(base64.StdEncoding.EncodeToString(publicKey)+"\n")),
+		OutputDirectory: root, Clock: func() time.Time { return time.Date(2026, 8, 18, 8, 5, 0, 0, time.UTC) },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	credentialSource, err := resolver.ResolveTargetCredentialRecoveryAuthorization(context.Background(), credentialRequest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	registrationSource, err := resolver.ResolveTargetRegistrationRecoveryAuthorization(context.Background(), registrationRequest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if credentialSource.GrantPath == registrationSource.GrantPath || credentialSource.PublicKeyPath != registrationSource.PublicKeyPath {
+		t.Fatalf("recovery grant sources are not independently persisted: %#v %#v", credentialSource, registrationSource)
+	}
+	if _, err := resolver.ResolveTargetCredentialRecoveryAuthorization(context.Background(), credentialRequest); err == nil {
+		t.Fatal("same credential-recovery request was sent twice")
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(mediaTypes) != 2 || mediaTypes[0] != targetCredentialRecoveryAuthorizationRequestMediaType || mediaTypes[1] != targetRegistrationRecoveryAuthorizationRequestMediaType {
+		t.Fatalf("recovery request media types differ: %v", mediaTypes)
+	}
+}
+
 func stageAuthorizationEnvelopeForRequest(t *testing.T, request StageAuthorizationRequest, publicKey ed25519.PublicKey, privateKey ed25519.PrivateKey) []byte {
 	t.Helper()
 	payload := authorization.StagePayload{


### PR DESCRIPTION
## Outcome

Activates the existing Stage 8/9 crash-recovery semantics through the concrete post-runtime manifest, authorization, private bundle, Job projection, materializer, installation-plan and CLI boundaries.

## Scope

- adds strict post-runtime recovery manifest v2 with immutable Stage 8/9 receipt bindings
- carries distinct credential- and registration-recovery requests through the bounded TLS authority
- binds recovery mode and historical receipts into the immutable activation Secret and canonical bundle index
- projects and materializes the exact recovery receipts for the ephemeral Job
- reports the recovery boundary through CLI prepare without executing it
- documents the additive fail-closed recovery activation path

## Safety boundary

- historical Stage 8/9 receipts remain unchanged
- no automatic retry, rollback or cleanup
- no infrastructure mutation performed by this checkpoint
- v1 activation remains supported unchanged

## Verification

- go test ./... -count=1 (Linux, Go 1.21.13): PASS
- focused recovery race tests: PASS
- go vet ./... (Linux, Go 1.21.13): PASS