### PR TITLE
OK-147: compose fail-closed pre-runtime stages

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -5,11 +5,13 @@ and in-cluster Job execution. The current boundary retains non-mutating
 Contract planning and now models the complete twelve-stage bounded execution
 path, including separately authorized mutations, a durable ledger, bounded
 observation and evaluation components and offline Kubernetes workload
-packaging. The complete path is now composed into one local post-runtime
-execution suffix and one bounded ephemeral Job activation path. That Job path
-is fully exercised offline and against fake APIs, but has not yet been run on
-the DEV management plane. It is still an MVP rather than a general lifecycle
-runner or controller.
+packaging. The stages are now composed into a typed in-process Stage 1-7 prefix
+and a separate local Stage 8-12 suffix. Only the post-runtime suffix currently
+has a bounded ephemeral Job activation path. That Job path is fully exercised
+offline and against fake APIs, but has not yet been run on the DEV management
+plane. The two orchestration segments are not yet joined into one CreateCluster
+activation. It is still an MVP rather than a general lifecycle runner or
+controller.
 
 ```text
 versioned contract + test schema
@@ -2746,7 +2748,24 @@ durable `SUCCEEDED` or `STOPPED` outcome without finalizing or rewriting the
 historical Stage-9 receipt. A consumed recovery grant cannot reach a second
 `PUT`.
 
-The in-process post-runtime orchestrator now fixes the Stage 8-12 call order
+The in-process pre-runtime orchestrator fixes the Stage 1-7 call order:
+
+```text
+provider prerequisites -> Cluster lifecycle -> lifecycle observation
+       -> Enablement -> network observation -> runtime binding
+       -> target access
+```
+
+Each callback receives only the redaction-safe receipt of its direct
+predecessor. The orchestrator verifies the receipt format, successful terminal
+state, expected stage, Plan identity and receipt digest at every transition.
+A malformed or foreign receipt, a stage error or context cancellation stops
+the prefix before any later callback. It exposes no retry, rollback or cleanup
+method and contains no dynamic renderer or Kubernetes writer. Concrete stage
+construction, authorization and activation remain outside this composition
+boundary.
+
+The in-process post-runtime orchestrator fixes the Stage 8-12 call order
 and passes the one-use credential handoff only from Stage 8 to Stage 9. It
 validates every redaction-safe run receipt against one Plan digest, stops at
 the first error or malformed receipt, invokes no later stage and discards an
@@ -2912,15 +2931,18 @@ activation implementation; it does not itself prove a live DEV Job run.
 ## Current OK-147 implementation boundary
 
 The twelve-stage Go library and its durable replay semantics are complete and
-covered by unit, negative, local TLS integration and race tests. The complete
-Stage 8-12 suffix now has a local prepare/execute command, a bounded ephemeral
-Job, a deterministic private activation package, an exact installation plan
-and a single-use CLI launcher. Successful Stage-8 and Stage-9 crash boundaries
-can be reactivated through the same manifest, authority, package, Job and CLI
-chain without rewriting their durable receipts. This is not yet the OK-147
-Definition of Done:
+covered by unit, negative, local TLS integration and race tests. Stage 1-7 and
+Stage 8-12 now each have an exact, fail-closed in-process orchestration order.
+The Stage 8-12 suffix additionally has a local prepare/execute command, a
+bounded ephemeral Job, a deterministic private activation package, an exact
+installation plan and a single-use CLI launcher. Successful Stage-8 and
+Stage-9 crash boundaries can be reactivated through the same manifest,
+authority, package, Job and CLI chain without rewriting their durable receipts.
+This is not yet the OK-147 Definition of Done:
 
 - the legacy `ok cluster create` command remains dry-run-only;
+- the two orchestration segments are not yet joined into one typed
+  CreateCluster execution and activation surface;
 - the standalone Stage-12 launcher has not yet been executed as part of the
   complete predecessor-bound stage chain;
 - the current staged-library source is published as the immutable multi-platform
@@ -2935,11 +2957,13 @@ Definition of Done:
   [ADR-030 amendment proposal](ok147-adr-030-amendment-proposal.md) are defined
   and remain to be reviewed with the live evidence.
 
-The remaining work is execution evidence and operational closure, not another
-runner component. A live checkpoint must publish the current image, construct
-fresh short-lived private inputs, run the exact `prepare` / `execute` boundary
-on `ok-mgmt`, preserve a stopped partial state without automatic retry, and
-separately repeat disposable-cluster and executor-termination conformance.
+The remaining implementation work is the narrow receipt-bound seam between the
+two orchestrators and its shared local/Job activation surface; it is not a new
+controller or reconciliation mechanism. After that, live closure must publish
+the current image, construct fresh short-lived private inputs, run the exact
+bounded activation on `ok-mgmt`, preserve a stopped partial state without
+automatic retry, and separately repeat disposable-cluster and
+executor-termination conformance.
 
 These remaining items may compose the verified packages, but must not add a
 second Contract-to-CAPI compiler, persistent aggregate-status controller,

--- a/internal/runner/pre_runtime_orchestrator.go
+++ b/internal/runner/pre_runtime_orchestrator.go
@@ -1,0 +1,145 @@
+package runner
+
+import (
+	"context"
+	"errors"
+
+	"github.com/openkubes/ok-cluster/internal/execution"
+)
+
+const PreRuntimeOrchestrationReceiptFormat = "ok147-pre-runtime-orchestration-receipt/v1"
+
+var preRuntimeStageOrder = []string{
+	"provider-prerequisites",
+	"cluster-lifecycle",
+	"lifecycle-observation",
+	"enablement",
+	"network-observation",
+	"runtime-binding",
+	"target-access",
+}
+
+type PreRuntimeStageCheckpoint struct {
+	StageID            string `json:"stageId"`
+	State              string `json:"state"`
+	StageReceiptDigest string `json:"stageReceiptDigest"`
+}
+
+// PreRuntimeOrchestrationReceipt is a redaction-safe summary. It contains no
+// credential, endpoint, target UID, CA, raw object or local path.
+type PreRuntimeOrchestrationReceipt struct {
+	Format      string                      `json:"format"`
+	State       string                      `json:"state"`
+	PlanDigest  string                      `json:"planDigest,omitempty"`
+	StoppedAt   string                      `json:"stoppedAt,omitempty"`
+	Checkpoints []PreRuntimeStageCheckpoint `json:"checkpoints"`
+}
+
+// PreRuntimeOrchestration composes only the already bounded Stage 1-7
+// operations. Each callback may perform exactly one stage invocation and
+// receives only the redaction-safe receipt of its direct predecessor.
+type PreRuntimeOrchestration struct {
+	RunProviderPrerequisites func(context.Context) (execution.StagedOperationReceipt, error)
+	RunClusterLifecycle      func(context.Context, execution.StagedOperationReceipt) (execution.StagedOperationReceipt, error)
+	RunLifecycleObservation  func(context.Context, execution.StagedOperationReceipt) (execution.ObservationStageRunReceipt, error)
+	RunEnablement            func(context.Context, execution.ObservationStageRunReceipt) (execution.StagedOperationReceipt, error)
+	RunNetworkObservation    func(context.Context, execution.StagedOperationReceipt) (execution.ObservationStageRunReceipt, error)
+	RunRuntimeBinding        func(context.Context, execution.ObservationStageRunReceipt) (execution.BindingStageRunReceipt, error)
+	RunTargetAccess          func(context.Context, execution.BindingStageRunReceipt) (execution.StagedOperationReceipt, error)
+}
+
+// Run executes the seven-stage prefix once, in order, and stops on the first
+// malformed receipt or error. It has no retry, rollback or cleanup path.
+func (orchestration PreRuntimeOrchestration) Run(ctx context.Context) (PreRuntimeOrchestrationReceipt, error) {
+	receipt := PreRuntimeOrchestrationReceipt{
+		Format: PreRuntimeOrchestrationReceiptFormat, State: "RUNNING",
+		Checkpoints: []PreRuntimeStageCheckpoint{},
+	}
+	if orchestration.RunProviderPrerequisites == nil || orchestration.RunClusterLifecycle == nil ||
+		orchestration.RunLifecycleObservation == nil || orchestration.RunEnablement == nil ||
+		orchestration.RunNetworkObservation == nil || orchestration.RunRuntimeBinding == nil ||
+		orchestration.RunTargetAccess == nil {
+		receipt.State, receipt.StoppedAt = "STOPPED", preRuntimeStageOrder[0]
+		return receipt, errors.New("pre-runtime orchestration is incomplete")
+	}
+	if err := ctx.Err(); err != nil {
+		receipt.State, receipt.StoppedAt = "STOPPED", preRuntimeStageOrder[0]
+		return receipt, errors.New("pre-runtime orchestration context is unavailable")
+	}
+
+	providerReceipt, runErr := orchestration.RunProviderPrerequisites(ctx)
+	if err := appendPreRuntimeCheckpoint(&receipt, preRuntimeStageOrder[0], execution.StagedReceiptFormat, providerReceipt.Format, providerReceipt.State, providerReceipt.PlanDigest, providerReceipt.StageID, providerReceipt.StageReceiptDigest); err != nil || runErr != nil {
+		return stopPreRuntimeOrchestration(receipt, preRuntimeStageOrder[0])
+	}
+	if err := ctx.Err(); err != nil {
+		return stopPreRuntimeOrchestration(receipt, preRuntimeStageOrder[1])
+	}
+
+	lifecycleReceipt, runErr := orchestration.RunClusterLifecycle(ctx, providerReceipt)
+	if err := appendPreRuntimeCheckpoint(&receipt, preRuntimeStageOrder[1], execution.StagedReceiptFormat, lifecycleReceipt.Format, lifecycleReceipt.State, lifecycleReceipt.PlanDigest, lifecycleReceipt.StageID, lifecycleReceipt.StageReceiptDigest); err != nil || runErr != nil {
+		return stopPreRuntimeOrchestration(receipt, preRuntimeStageOrder[1])
+	}
+	if err := ctx.Err(); err != nil {
+		return stopPreRuntimeOrchestration(receipt, preRuntimeStageOrder[2])
+	}
+
+	lifecycleObservationReceipt, runErr := orchestration.RunLifecycleObservation(ctx, lifecycleReceipt)
+	if err := appendPreRuntimeCheckpoint(&receipt, preRuntimeStageOrder[2], execution.ObservationStageReceiptFormat, lifecycleObservationReceipt.Format, lifecycleObservationReceipt.State, lifecycleObservationReceipt.PlanDigest, lifecycleObservationReceipt.StageID, lifecycleObservationReceipt.StageReceiptDigest); err != nil || runErr != nil {
+		return stopPreRuntimeOrchestration(receipt, preRuntimeStageOrder[2])
+	}
+	if err := ctx.Err(); err != nil {
+		return stopPreRuntimeOrchestration(receipt, preRuntimeStageOrder[3])
+	}
+
+	enablementReceipt, runErr := orchestration.RunEnablement(ctx, lifecycleObservationReceipt)
+	if err := appendPreRuntimeCheckpoint(&receipt, preRuntimeStageOrder[3], execution.StagedReceiptFormat, enablementReceipt.Format, enablementReceipt.State, enablementReceipt.PlanDigest, enablementReceipt.StageID, enablementReceipt.StageReceiptDigest); err != nil || runErr != nil {
+		return stopPreRuntimeOrchestration(receipt, preRuntimeStageOrder[3])
+	}
+	if err := ctx.Err(); err != nil {
+		return stopPreRuntimeOrchestration(receipt, preRuntimeStageOrder[4])
+	}
+
+	networkObservationReceipt, runErr := orchestration.RunNetworkObservation(ctx, enablementReceipt)
+	if err := appendPreRuntimeCheckpoint(&receipt, preRuntimeStageOrder[4], execution.ObservationStageReceiptFormat, networkObservationReceipt.Format, networkObservationReceipt.State, networkObservationReceipt.PlanDigest, networkObservationReceipt.StageID, networkObservationReceipt.StageReceiptDigest); err != nil || runErr != nil {
+		return stopPreRuntimeOrchestration(receipt, preRuntimeStageOrder[4])
+	}
+	if err := ctx.Err(); err != nil {
+		return stopPreRuntimeOrchestration(receipt, preRuntimeStageOrder[5])
+	}
+
+	runtimeBindingReceipt, runErr := orchestration.RunRuntimeBinding(ctx, networkObservationReceipt)
+	if err := appendPreRuntimeCheckpoint(&receipt, preRuntimeStageOrder[5], execution.BindingStageReceiptFormat, runtimeBindingReceipt.Format, runtimeBindingReceipt.State, runtimeBindingReceipt.PlanDigest, runtimeBindingReceipt.StageID, runtimeBindingReceipt.StageReceiptDigest); err != nil || runErr != nil {
+		return stopPreRuntimeOrchestration(receipt, preRuntimeStageOrder[5])
+	}
+	if err := ctx.Err(); err != nil {
+		return stopPreRuntimeOrchestration(receipt, preRuntimeStageOrder[6])
+	}
+
+	targetAccessReceipt, runErr := orchestration.RunTargetAccess(ctx, runtimeBindingReceipt)
+	if err := appendPreRuntimeCheckpoint(&receipt, preRuntimeStageOrder[6], execution.StagedReceiptFormat, targetAccessReceipt.Format, targetAccessReceipt.State, targetAccessReceipt.PlanDigest, targetAccessReceipt.StageID, targetAccessReceipt.StageReceiptDigest); err != nil || runErr != nil {
+		return stopPreRuntimeOrchestration(receipt, preRuntimeStageOrder[6])
+	}
+	receipt.State = "SUCCEEDED"
+	return receipt, nil
+}
+
+func appendPreRuntimeCheckpoint(receipt *PreRuntimeOrchestrationReceipt, expectedStage, expectedFormat, format, state, planDigest, stageID, stageReceiptDigest string) error {
+	if receipt == nil || format != expectedFormat || state != "COMPLETED_SUCCEEDED" || stageID != expectedStage ||
+		!stageReceiptPrefixDigestPattern.MatchString(planDigest) || !stageReceiptPrefixDigestPattern.MatchString(stageReceiptDigest) {
+		return errors.New("pre-runtime stage receipt is invalid")
+	}
+	if receipt.PlanDigest == "" {
+		receipt.PlanDigest = planDigest
+	} else if receipt.PlanDigest != planDigest {
+		return errors.New("pre-runtime stage plan identity changed")
+	}
+	receipt.Checkpoints = append(receipt.Checkpoints, PreRuntimeStageCheckpoint{
+		StageID: stageID, State: state, StageReceiptDigest: stageReceiptDigest,
+	})
+	return nil
+}
+
+func stopPreRuntimeOrchestration(receipt PreRuntimeOrchestrationReceipt, stageID string) (PreRuntimeOrchestrationReceipt, error) {
+	receipt.State, receipt.StoppedAt = "STOPPED", stageID
+	return receipt, errors.New("pre-runtime orchestration stopped at " + stageID)
+}

--- a/internal/runner/pre_runtime_orchestrator_test.go
+++ b/internal/runner/pre_runtime_orchestrator_test.go
@@ -1,0 +1,246 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/openkubes/ok-cluster/internal/execution"
+)
+
+func TestPreRuntimeOrchestrationRunsExactSevenStagePrefixOnce(t *testing.T) {
+	var calls []string
+	orchestration := successfulPreRuntimeOrchestration(&calls)
+	receipt, err := orchestration.Run(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if receipt.Format != PreRuntimeOrchestrationReceiptFormat || receipt.State != "SUCCEEDED" || receipt.StoppedAt != "" || receipt.PlanDigest != runnerStageSHA("a") || len(receipt.Checkpoints) != 7 {
+		t.Fatalf("unexpected pre-runtime receipt: %#v", receipt)
+	}
+	if !reflect.DeepEqual(calls, preRuntimeStageOrder) {
+		t.Fatalf("pre-runtime order differs: %v", calls)
+	}
+	for index, checkpoint := range receipt.Checkpoints {
+		if checkpoint.StageID != preRuntimeStageOrder[index] || checkpoint.State != "COMPLETED_SUCCEEDED" || checkpoint.StageReceiptDigest == "" {
+			t.Fatalf("unexpected checkpoint %d: %#v", index, checkpoint)
+		}
+	}
+}
+
+func TestPreRuntimeOrchestrationPassesOnlyDirectPredecessor(t *testing.T) {
+	orchestration := successfulPreRuntimeOrchestration(nil)
+	orchestration.RunClusterLifecycle = func(_ context.Context, predecessor execution.StagedOperationReceipt) (execution.StagedOperationReceipt, error) {
+		if predecessor.StageID != "provider-prerequisites" {
+			t.Fatal("provider receipt was not passed to lifecycle")
+		}
+		return preRuntimeStagedReceipt("cluster-lifecycle", "2"), nil
+	}
+	orchestration.RunLifecycleObservation = func(_ context.Context, predecessor execution.StagedOperationReceipt) (execution.ObservationStageRunReceipt, error) {
+		if predecessor.StageID != "cluster-lifecycle" {
+			t.Fatal("lifecycle receipt was not passed to lifecycle observation")
+		}
+		return preRuntimeObservationReceipt("lifecycle-observation", "3"), nil
+	}
+	orchestration.RunEnablement = func(_ context.Context, predecessor execution.ObservationStageRunReceipt) (execution.StagedOperationReceipt, error) {
+		if predecessor.StageID != "lifecycle-observation" {
+			t.Fatal("lifecycle observation receipt was not passed to enablement")
+		}
+		return preRuntimeStagedReceipt("enablement", "4"), nil
+	}
+	orchestration.RunNetworkObservation = func(_ context.Context, predecessor execution.StagedOperationReceipt) (execution.ObservationStageRunReceipt, error) {
+		if predecessor.StageID != "enablement" {
+			t.Fatal("enablement receipt was not passed to network observation")
+		}
+		return preRuntimeObservationReceipt("network-observation", "5"), nil
+	}
+	orchestration.RunRuntimeBinding = func(_ context.Context, predecessor execution.ObservationStageRunReceipt) (execution.BindingStageRunReceipt, error) {
+		if predecessor.StageID != "network-observation" {
+			t.Fatal("network observation receipt was not passed to runtime binding")
+		}
+		return preRuntimeBindingReceipt("6"), nil
+	}
+	orchestration.RunTargetAccess = func(_ context.Context, predecessor execution.BindingStageRunReceipt) (execution.StagedOperationReceipt, error) {
+		if predecessor.StageID != "runtime-binding" {
+			t.Fatal("runtime binding receipt was not passed to target access")
+		}
+		return preRuntimeStagedReceipt("target-access", "7"), nil
+	}
+	if _, err := orchestration.Run(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPreRuntimeOrchestrationStopsWithoutRetry(t *testing.T) {
+	for _, stopStage := range preRuntimeStageOrder {
+		t.Run(stopStage, func(t *testing.T) {
+			calls := []string{}
+			orchestration := successfulPreRuntimeOrchestration(&calls)
+			switch stopStage {
+			case "provider-prerequisites":
+				orchestration.RunProviderPrerequisites = func(context.Context) (execution.StagedOperationReceipt, error) {
+					calls = append(calls, stopStage)
+					return execution.StagedOperationReceipt{}, errors.New("private failure")
+				}
+			case "cluster-lifecycle":
+				orchestration.RunClusterLifecycle = func(context.Context, execution.StagedOperationReceipt) (execution.StagedOperationReceipt, error) {
+					calls = append(calls, stopStage)
+					return execution.StagedOperationReceipt{}, errors.New("private failure")
+				}
+			case "lifecycle-observation":
+				orchestration.RunLifecycleObservation = func(context.Context, execution.StagedOperationReceipt) (execution.ObservationStageRunReceipt, error) {
+					calls = append(calls, stopStage)
+					return execution.ObservationStageRunReceipt{}, errors.New("private failure")
+				}
+			case "enablement":
+				orchestration.RunEnablement = func(context.Context, execution.ObservationStageRunReceipt) (execution.StagedOperationReceipt, error) {
+					calls = append(calls, stopStage)
+					return execution.StagedOperationReceipt{}, errors.New("private failure")
+				}
+			case "network-observation":
+				orchestration.RunNetworkObservation = func(context.Context, execution.StagedOperationReceipt) (execution.ObservationStageRunReceipt, error) {
+					calls = append(calls, stopStage)
+					return execution.ObservationStageRunReceipt{}, errors.New("private failure")
+				}
+			case "runtime-binding":
+				orchestration.RunRuntimeBinding = func(context.Context, execution.ObservationStageRunReceipt) (execution.BindingStageRunReceipt, error) {
+					calls = append(calls, stopStage)
+					return execution.BindingStageRunReceipt{}, errors.New("private failure")
+				}
+			case "target-access":
+				orchestration.RunTargetAccess = func(context.Context, execution.BindingStageRunReceipt) (execution.StagedOperationReceipt, error) {
+					calls = append(calls, stopStage)
+					return execution.StagedOperationReceipt{}, errors.New("private failure")
+				}
+			}
+			receipt, err := orchestration.Run(context.Background())
+			if err == nil || receipt.State != "STOPPED" || receipt.StoppedAt != stopStage {
+				t.Fatalf("orchestration did not stop at %s: %#v %v", stopStage, receipt, err)
+			}
+			stopIndex := stageIndex(preRuntimeStageOrder, stopStage)
+			if len(calls) != stopIndex+1 || !reflect.DeepEqual(calls, preRuntimeStageOrder[:stopIndex+1]) {
+				t.Fatalf("stages were retried or invoked after stop: %v", calls)
+			}
+		})
+	}
+}
+
+func TestPreRuntimeOrchestrationRejectsMalformedAndForeignReceipts(t *testing.T) {
+	for name, mutate := range map[string]func(*execution.ObservationStageRunReceipt){
+		"wrong format": func(receipt *execution.ObservationStageRunReceipt) { receipt.Format = execution.StagedReceiptFormat },
+		"wrong stage":  func(receipt *execution.ObservationStageRunReceipt) { receipt.StageID = "enablement" },
+		"foreign plan": func(receipt *execution.ObservationStageRunReceipt) { receipt.PlanDigest = runnerStageSHA("f") },
+		"failed state": func(receipt *execution.ObservationStageRunReceipt) { receipt.State = "COMPLETED_FAILED" },
+		"bad digest":   func(receipt *execution.ObservationStageRunReceipt) { receipt.StageReceiptDigest = "bad" },
+	} {
+		t.Run(name, func(t *testing.T) {
+			orchestration := successfulPreRuntimeOrchestration(nil)
+			orchestration.RunNetworkObservation = func(context.Context, execution.StagedOperationReceipt) (execution.ObservationStageRunReceipt, error) {
+				receipt := preRuntimeObservationReceipt("network-observation", "5")
+				mutate(&receipt)
+				return receipt, nil
+			}
+			receipt, err := orchestration.Run(context.Background())
+			if err == nil || receipt.State != "STOPPED" || receipt.StoppedAt != "network-observation" || len(receipt.Checkpoints) != 4 {
+				t.Fatalf("malformed receipt was accepted: %#v %v", receipt, err)
+			}
+		})
+	}
+}
+
+func TestPreRuntimeOrchestrationRequiresCompleteLiveContext(t *testing.T) {
+	if receipt, err := (PreRuntimeOrchestration{}).Run(context.Background()); err == nil || receipt.State != "STOPPED" {
+		t.Fatalf("incomplete orchestration was accepted: %#v %v", receipt, err)
+	}
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+	calls := []string{}
+	orchestration := successfulPreRuntimeOrchestration(&calls)
+	if receipt, err := orchestration.Run(cancelled); err == nil || receipt.StoppedAt != "provider-prerequisites" || len(calls) != 0 {
+		t.Fatalf("cancelled orchestration invoked a stage: %#v calls=%v err=%v", receipt, calls, err)
+	}
+
+	runtimeContext, stop := context.WithCancel(context.Background())
+	orchestration = successfulPreRuntimeOrchestration(nil)
+	lifecycleCalls := 0
+	orchestration.RunProviderPrerequisites = func(context.Context) (execution.StagedOperationReceipt, error) {
+		stop()
+		return preRuntimeStagedReceipt("provider-prerequisites", "1"), nil
+	}
+	orchestration.RunClusterLifecycle = func(context.Context, execution.StagedOperationReceipt) (execution.StagedOperationReceipt, error) {
+		lifecycleCalls++
+		return preRuntimeStagedReceipt("cluster-lifecycle", "2"), nil
+	}
+	if receipt, err := orchestration.Run(runtimeContext); err == nil || receipt.StoppedAt != "cluster-lifecycle" || len(receipt.Checkpoints) != 1 || lifecycleCalls != 0 {
+		t.Fatalf("cancelled prefix invoked a later stage: %#v lifecycleCalls=%d err=%v", receipt, lifecycleCalls, err)
+	}
+}
+
+func successfulPreRuntimeOrchestration(calls *[]string) PreRuntimeOrchestration {
+	record := func(stage string) {
+		if calls != nil {
+			*calls = append(*calls, stage)
+		}
+	}
+	return PreRuntimeOrchestration{
+		RunProviderPrerequisites: func(context.Context) (execution.StagedOperationReceipt, error) {
+			record("provider-prerequisites")
+			return preRuntimeStagedReceipt("provider-prerequisites", "1"), nil
+		},
+		RunClusterLifecycle: func(context.Context, execution.StagedOperationReceipt) (execution.StagedOperationReceipt, error) {
+			record("cluster-lifecycle")
+			return preRuntimeStagedReceipt("cluster-lifecycle", "2"), nil
+		},
+		RunLifecycleObservation: func(context.Context, execution.StagedOperationReceipt) (execution.ObservationStageRunReceipt, error) {
+			record("lifecycle-observation")
+			return preRuntimeObservationReceipt("lifecycle-observation", "3"), nil
+		},
+		RunEnablement: func(context.Context, execution.ObservationStageRunReceipt) (execution.StagedOperationReceipt, error) {
+			record("enablement")
+			return preRuntimeStagedReceipt("enablement", "4"), nil
+		},
+		RunNetworkObservation: func(context.Context, execution.StagedOperationReceipt) (execution.ObservationStageRunReceipt, error) {
+			record("network-observation")
+			return preRuntimeObservationReceipt("network-observation", "5"), nil
+		},
+		RunRuntimeBinding: func(context.Context, execution.ObservationStageRunReceipt) (execution.BindingStageRunReceipt, error) {
+			record("runtime-binding")
+			return preRuntimeBindingReceipt("6"), nil
+		},
+		RunTargetAccess: func(context.Context, execution.BindingStageRunReceipt) (execution.StagedOperationReceipt, error) {
+			record("target-access")
+			return preRuntimeStagedReceipt("target-access", "7"), nil
+		},
+	}
+}
+
+func preRuntimeStagedReceipt(stageID, digestValue string) execution.StagedOperationReceipt {
+	return execution.StagedOperationReceipt{
+		Format: execution.StagedReceiptFormat, State: "COMPLETED_SUCCEEDED", PlanDigest: runnerStageSHA("a"),
+		StageID: stageID, StageReceiptDigest: runnerStageSHA(digestValue),
+	}
+}
+
+func preRuntimeObservationReceipt(stageID, digestValue string) execution.ObservationStageRunReceipt {
+	return execution.ObservationStageRunReceipt{
+		Format: execution.ObservationStageReceiptFormat, State: "COMPLETED_SUCCEEDED", PlanDigest: runnerStageSHA("a"),
+		StageID: stageID, StageReceiptDigest: runnerStageSHA(digestValue),
+	}
+}
+
+func preRuntimeBindingReceipt(digestValue string) execution.BindingStageRunReceipt {
+	return execution.BindingStageRunReceipt{
+		Format: execution.BindingStageReceiptFormat, State: "COMPLETED_SUCCEEDED", PlanDigest: runnerStageSHA("a"),
+		StageID: "runtime-binding", StageReceiptDigest: runnerStageSHA(digestValue),
+	}
+}
+
+func stageIndex(stages []string, target string) int {
+	for index, stage := range stages {
+		if stage == target {
+			return index
+		}
+	}
+	return -1
+}


### PR DESCRIPTION
## Summary

- compose the existing typed Stage 1-7 operations in their exact bounded order
- pass only each direct predecessor receipt and enforce one Plan identity
- stop on stage error, malformed receipt, foreign Plan, or context cancellation without retry, rollback, or cleanup
- update the MVP boundary to distinguish the pre-runtime prefix from the activated post-runtime suffix

## Verification

- `go test ./... -count=1` in `golang:1.21.13`
- `go vet ./...` in `golang:1.21.13`
- `go test -race ./internal/runner -run TestPreRuntimeOrchestration -count=1`
- `git diff --check`

## Boundaries

- no infrastructure mutation
- no new renderer or Kubernetes writer
- no retry, rollback, cleanup, or controller ownership
- Stage 1-7 and Stage 8-12 are not yet joined into one CreateCluster activation surface