### PR TITLE
OK-147: bind the complete runner stage chain

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -5,13 +5,13 @@ and in-cluster Job execution. The current boundary retains non-mutating
 Contract planning and now models the complete twelve-stage bounded execution
 path, including separately authorized mutations, a durable ledger, bounded
 observation and evaluation components and offline Kubernetes workload
-packaging. The stages are now composed into a typed in-process Stage 1-7 prefix
-and a separate local Stage 8-12 suffix. Only the post-runtime suffix currently
-has a bounded ephemeral Job activation path. That Job path is fully exercised
-offline and against fake APIs, but has not yet been run on the DEV management
-plane. The two orchestration segments are not yet joined into one CreateCluster
-activation. It is still an MVP rather than a general lifecycle runner or
-controller.
+packaging. The stages are now composed into a typed in-process Stage 1-7 prefix,
+a Stage 8-12 suffix and a receipt-bound, single-use full-run library seam. Only
+the post-runtime suffix currently has a bounded ephemeral Job activation path.
+That Job path is fully exercised offline and against fake APIs, but has not yet
+been run on the DEV management plane. The full-run library is not yet exposed
+as one local or Job-based CreateCluster activation. It is still an MVP rather
+than a general lifecycle runner or controller.
 
 ```text
 versioned contract + test schema
@@ -2773,6 +2773,29 @@ unconsumed credential. It deliberately exposes no retry, rollback or cleanup
 method. The later activation checkpoints provide its concrete CLI and Job
 adapters without changing this orchestrator's ownership.
 
+The full-run orchestrator joins those two segments without weakening the
+receipt boundary:
+
+```text
+Stage 1-7 completed receipt identities
+                  |
+                  v
+exact Plan + seven-digest continuation binding
+                  |
+             exact match only
+                  v
+concrete single-use PostRuntimeExecution (Stage 8-12)
+```
+
+The already-opened `PostRuntimeExecution` exposes the exact verified seven-
+receipt prefix it will consume. The full runner compares every stage ID, state
+and digest with the prefix it just completed before invoking Stage 8. A foreign
+Plan, changed/missing receipt, malformed suffix or cancelled context stops
+without running a later stage. The combined redaction-safe receipt contains
+only the twelve ordered stage identities. A second invocation is rejected.
+This is an in-process composition seam only: it adds no renderer, dynamic
+writer, retry, rollback, cleanup, CLI command or Job mutation surface.
+
 The accompanying receipt bridge can reload only the independently
 digest-bound, already durable public receipt selected by the current cursor.
 It writes canonical receipt bytes create-only as `0600` below an existing
@@ -2932,17 +2955,18 @@ activation implementation; it does not itself prove a live DEV Job run.
 
 The twelve-stage Go library and its durable replay semantics are complete and
 covered by unit, negative, local TLS integration and race tests. Stage 1-7 and
-Stage 8-12 now each have an exact, fail-closed in-process orchestration order.
-The Stage 8-12 suffix additionally has a local prepare/execute command, a
-bounded ephemeral Job, a deterministic private activation package, an exact
-installation plan and a single-use CLI launcher. Successful Stage-8 and
-Stage-9 crash boundaries can be reactivated through the same manifest,
-authority, package, Job and CLI chain without rewriting their durable receipts.
-This is not yet the OK-147 Definition of Done:
+Stage 8-12 each have an exact, fail-closed in-process orchestration order, and
+the single-use full-run seam binds them through the exact Plan and seven
+predecessor receipt digests. The Stage 8-12 suffix additionally has a local
+prepare/execute command, a bounded ephemeral Job, a deterministic private
+activation package, an exact installation plan and a single-use CLI launcher.
+Successful Stage-8 and Stage-9 crash boundaries can be reactivated through the
+same manifest, authority, package, Job and CLI chain without rewriting their
+durable receipts. This is not yet the OK-147 Definition of Done:
 
 - the legacy `ok cluster create` command remains dry-run-only;
-- the two orchestration segments are not yet joined into one typed
-  CreateCluster execution and activation surface;
+- the joined full-run library has no shared local/Job CreateCluster activation
+  surface yet;
 - the standalone Stage-12 launcher has not yet been executed as part of the
   complete predecessor-bound stage chain;
 - the current staged-library source is published as the immutable multi-platform
@@ -2957,13 +2981,13 @@ This is not yet the OK-147 Definition of Done:
   [ADR-030 amendment proposal](ok147-adr-030-amendment-proposal.md) are defined
   and remain to be reviewed with the live evidence.
 
-The remaining implementation work is the narrow receipt-bound seam between the
-two orchestrators and its shared local/Job activation surface; it is not a new
-controller or reconciliation mechanism. After that, live closure must publish
-the current image, construct fresh short-lived private inputs, run the exact
-bounded activation on `ok-mgmt`, preserve a stopped partial state without
-automatic retry, and separately repeat disposable-cluster and
-executor-termination conformance.
+The remaining implementation work is the shared local/Job activation surface
+for the now receipt-bound full-run library; it is not a new controller or
+reconciliation mechanism. After that, live closure must publish the current
+image, construct fresh short-lived private inputs, run the exact bounded
+activation on `ok-mgmt`, preserve a stopped partial state without automatic
+retry, and separately repeat disposable-cluster and executor-termination
+conformance.
 
 These remaining items may compose the verified packages, but must not add a
 second Contract-to-CAPI compiler, persistent aggregate-status controller,

--- a/internal/runner/full_run_orchestrator.go
+++ b/internal/runner/full_run_orchestrator.go
@@ -1,0 +1,240 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	"github.com/openkubes/ok-cluster/internal/stagereceipt"
+)
+
+const (
+	FullRunOrchestrationReceiptFormat       = "ok147-full-run-orchestration-receipt/v1"
+	PostRuntimeContinuationBindingFormat    = "ok147-post-runtime-continuation-binding/v1"
+	postRuntimeContinuationBindingState     = "VERIFIED"
+	fullRunOrchestrationInitialStoppedStage = "provider-prerequisites"
+)
+
+type FullRunStageCheckpoint struct {
+	StageID            string `json:"stageId"`
+	State              string `json:"state"`
+	StageReceiptDigest string `json:"stageReceiptDigest"`
+}
+
+// FullRunOrchestrationReceipt contains only redaction-safe stage identities.
+// It does not contain authorization material, credentials, endpoints, target
+// identities, raw objects or local paths.
+type FullRunOrchestrationReceipt struct {
+	Format      string                   `json:"format"`
+	State       string                   `json:"state"`
+	PlanDigest  string                   `json:"planDigest,omitempty"`
+	StoppedAt   string                   `json:"stoppedAt,omitempty"`
+	Checkpoints []FullRunStageCheckpoint `json:"checkpoints"`
+}
+
+// PostRuntimeContinuationBinding proves that one already-opened Stage 8-12
+// execution consumes the exact seven durable receipts produced by the prefix.
+type PostRuntimeContinuationBinding struct {
+	Format       string                      `json:"format"`
+	State        string                      `json:"state"`
+	PlanDigest   string                      `json:"planDigest"`
+	Predecessors []PreRuntimeStageCheckpoint `json:"predecessors"`
+}
+
+// PostRuntimeContinuation is the narrow seam to the existing concrete
+// PostRuntimeExecution. Binding is checked before Run can be invoked.
+type PostRuntimeContinuation interface {
+	ContinuationBinding() (PostRuntimeContinuationBinding, error)
+	Run(context.Context) (PostRuntimeExecutionReceipt, error)
+}
+
+// FullRunOrchestration composes the exact Stage 1-7 prefix with one
+// receipt-bound Stage 8-12 continuation. BindPostRuntime may open private
+// runtime material but must not execute a stage; the returned binding is
+// independently checked before Run.
+type FullRunOrchestration struct {
+	PreRuntime      PreRuntimeOrchestration
+	BindPostRuntime func(PreRuntimeOrchestrationReceipt) (PostRuntimeContinuation, error)
+
+	mu   sync.Mutex
+	used bool
+}
+
+// Run is single-use and fail-closed. It has no retry, rollback or cleanup
+// path, and never invokes the post-runtime continuation unless its exact seven
+// predecessor receipt identities equal the completed prefix.
+func (orchestration *FullRunOrchestration) Run(ctx context.Context) (FullRunOrchestrationReceipt, error) {
+	receipt := FullRunOrchestrationReceipt{
+		Format: FullRunOrchestrationReceiptFormat, State: "RUNNING",
+		Checkpoints: []FullRunStageCheckpoint{},
+	}
+	if orchestration == nil {
+		return stopFullRunOrchestration(receipt, fullRunOrchestrationInitialStoppedStage)
+	}
+	orchestration.mu.Lock()
+	if orchestration.used {
+		orchestration.mu.Unlock()
+		return stopFullRunOrchestration(receipt, fullRunOrchestrationInitialStoppedStage)
+	}
+	orchestration.used = true
+	orchestration.mu.Unlock()
+	if orchestration.BindPostRuntime == nil {
+		return stopFullRunOrchestration(receipt, fullRunOrchestrationInitialStoppedStage)
+	}
+	if err := ctx.Err(); err != nil {
+		return stopFullRunOrchestration(receipt, fullRunOrchestrationInitialStoppedStage)
+	}
+
+	prefix, prefixErr := orchestration.PreRuntime.Run(ctx)
+	if err := appendFullRunPrefix(&receipt, prefix); err != nil {
+		return stopFullRunOrchestration(receipt, nextFullRunStage(receipt.Checkpoints))
+	}
+	if prefixErr != nil || prefix.State != "SUCCEEDED" {
+		return stopFullRunOrchestration(receipt, prefix.StoppedAt)
+	}
+	if err := ctx.Err(); err != nil {
+		return stopFullRunOrchestration(receipt, postRuntimeStageOrder[0])
+	}
+
+	continuation, err := orchestration.BindPostRuntime(prefix)
+	if err != nil || continuation == nil {
+		return stopFullRunOrchestration(receipt, postRuntimeStageOrder[0])
+	}
+	binding, err := continuation.ContinuationBinding()
+	if err != nil || validatePostRuntimeContinuationBinding(prefix, binding) != nil {
+		return stopFullRunOrchestration(receipt, postRuntimeStageOrder[0])
+	}
+	if err := ctx.Err(); err != nil {
+		return stopFullRunOrchestration(receipt, postRuntimeStageOrder[0])
+	}
+
+	suffix, suffixErr := continuation.Run(ctx)
+	if err := appendFullRunSuffix(&receipt, suffix); err != nil {
+		return stopFullRunOrchestration(receipt, nextFullRunStage(receipt.Checkpoints))
+	}
+	if suffixErr != nil || suffix.State != "SUCCEEDED" {
+		return stopFullRunOrchestration(receipt, suffix.StoppedAt)
+	}
+	receipt.State = "SUCCEEDED"
+	return receipt, nil
+}
+
+func appendFullRunPrefix(receipt *FullRunOrchestrationReceipt, prefix PreRuntimeOrchestrationReceipt) error {
+	if receipt == nil || prefix.Format != PreRuntimeOrchestrationReceiptFormat ||
+		!oneOfString(prefix.State, "SUCCEEDED", "STOPPED") ||
+		!stageReceiptPrefixDigestPattern.MatchString(prefix.PlanDigest) || len(prefix.Checkpoints) > len(preRuntimeStageOrder) {
+		return errors.New("full-run pre-runtime receipt is invalid")
+	}
+	if prefix.State == "SUCCEEDED" && (len(prefix.Checkpoints) != len(preRuntimeStageOrder) || prefix.StoppedAt != "") {
+		return errors.New("successful full-run prefix is incomplete")
+	}
+	if prefix.State == "STOPPED" {
+		if len(prefix.Checkpoints) >= len(preRuntimeStageOrder) || prefix.StoppedAt != preRuntimeStageOrder[len(prefix.Checkpoints)] {
+			return errors.New("stopped full-run prefix is inconsistent")
+		}
+	}
+	receipt.PlanDigest = prefix.PlanDigest
+	for index, checkpoint := range prefix.Checkpoints {
+		if checkpoint.StageID != preRuntimeStageOrder[index] || checkpoint.State != "COMPLETED_SUCCEEDED" ||
+			!stageReceiptPrefixDigestPattern.MatchString(checkpoint.StageReceiptDigest) {
+			return errors.New("full-run pre-runtime checkpoint is invalid")
+		}
+		receipt.Checkpoints = append(receipt.Checkpoints, FullRunStageCheckpoint(checkpoint))
+	}
+	return nil
+}
+
+func appendFullRunSuffix(receipt *FullRunOrchestrationReceipt, suffix PostRuntimeExecutionReceipt) error {
+	if receipt == nil || suffix.Format != PostRuntimeExecutionReceiptFormat ||
+		!oneOfString(suffix.State, "SUCCEEDED", "STOPPED") || suffix.PlanDigest != receipt.PlanDigest ||
+		len(receipt.Checkpoints) != len(preRuntimeStageOrder) || len(suffix.Checkpoints) > len(postRuntimeStageOrder) {
+		return errors.New("full-run post-runtime receipt is invalid")
+	}
+	if suffix.State == "SUCCEEDED" && (len(suffix.Checkpoints) != len(postRuntimeStageOrder) || suffix.StoppedAt != "") {
+		return errors.New("successful full-run suffix is incomplete")
+	}
+	if suffix.State == "STOPPED" {
+		if len(suffix.Checkpoints) >= len(postRuntimeStageOrder) || suffix.StoppedAt != postRuntimeStageOrder[len(suffix.Checkpoints)] {
+			return errors.New("stopped full-run suffix is inconsistent")
+		}
+	}
+	for index, checkpoint := range suffix.Checkpoints {
+		if checkpoint.StageID != postRuntimeStageOrder[index] || checkpoint.State != "COMPLETED_SUCCEEDED" ||
+			!stageReceiptPrefixDigestPattern.MatchString(checkpoint.StageReceiptDigest) {
+			return errors.New("full-run post-runtime checkpoint is invalid")
+		}
+		receipt.Checkpoints = append(receipt.Checkpoints, FullRunStageCheckpoint(checkpoint))
+	}
+	return nil
+}
+
+func newPostRuntimeContinuationBinding(planDigest string, prefix []stagereceipt.Verified) (PostRuntimeContinuationBinding, error) {
+	binding := PostRuntimeContinuationBinding{
+		Format: PostRuntimeContinuationBindingFormat, State: postRuntimeContinuationBindingState,
+		PlanDigest: planDigest, Predecessors: []PreRuntimeStageCheckpoint{},
+	}
+	if !stageReceiptPrefixDigestPattern.MatchString(planDigest) || len(prefix) != len(preRuntimeStageOrder) {
+		return PostRuntimeContinuationBinding{}, errors.New("post-runtime continuation prefix is invalid")
+	}
+	for index, verified := range prefix {
+		stage, err := verified.Receipt()
+		if err != nil || stage.StageID != preRuntimeStageOrder[index] || stage.State != "SUCCEEDED" {
+			return PostRuntimeContinuationBinding{}, errors.New("post-runtime continuation stage is invalid")
+		}
+		digest, err := verified.Digest()
+		if err != nil || !stageReceiptPrefixDigestPattern.MatchString(digest) {
+			return PostRuntimeContinuationBinding{}, errors.New("post-runtime continuation digest is invalid")
+		}
+		binding.Predecessors = append(binding.Predecessors, PreRuntimeStageCheckpoint{
+			StageID: stage.StageID, State: "COMPLETED_SUCCEEDED", StageReceiptDigest: digest,
+		})
+	}
+	return binding, nil
+}
+
+func validatePostRuntimeContinuationBinding(prefix PreRuntimeOrchestrationReceipt, binding PostRuntimeContinuationBinding) error {
+	if binding.Format != PostRuntimeContinuationBindingFormat || binding.State != postRuntimeContinuationBindingState ||
+		binding.PlanDigest != prefix.PlanDigest || len(binding.Predecessors) != len(prefix.Checkpoints) {
+		return errors.New("post-runtime continuation binding differs from completed prefix")
+	}
+	for index := range prefix.Checkpoints {
+		if binding.Predecessors[index] != prefix.Checkpoints[index] {
+			return errors.New("post-runtime continuation predecessor differs from completed prefix")
+		}
+	}
+	return nil
+}
+
+func (binding PostRuntimeContinuationBinding) clone() PostRuntimeContinuationBinding {
+	binding.Predecessors = append([]PreRuntimeStageCheckpoint(nil), binding.Predecessors...)
+	return binding
+}
+
+func nextFullRunStage(checkpoints []FullRunStageCheckpoint) string {
+	index := len(checkpoints)
+	if index < len(preRuntimeStageOrder) {
+		return preRuntimeStageOrder[index]
+	}
+	index -= len(preRuntimeStageOrder)
+	if index < len(postRuntimeStageOrder) {
+		return postRuntimeStageOrder[index]
+	}
+	return postRuntimeStageOrder[len(postRuntimeStageOrder)-1]
+}
+
+func stopFullRunOrchestration(receipt FullRunOrchestrationReceipt, stageID string) (FullRunOrchestrationReceipt, error) {
+	if stageID == "" {
+		stageID = nextFullRunStage(receipt.Checkpoints)
+	}
+	receipt.State, receipt.StoppedAt = "STOPPED", stageID
+	return receipt, errors.New("full-run orchestration stopped at " + stageID)
+}
+
+func oneOfString(value string, options ...string) bool {
+	for _, option := range options {
+		if value == option {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/runner/full_run_orchestrator_test.go
+++ b/internal/runner/full_run_orchestrator_test.go
@@ -1,0 +1,235 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/openkubes/ok-cluster/internal/execution"
+)
+
+type fakePostRuntimeContinuation struct {
+	binding PostRuntimeContinuationBinding
+	receipt PostRuntimeExecutionReceipt
+	err     error
+	calls   atomic.Int32
+}
+
+func (continuation *fakePostRuntimeContinuation) ContinuationBinding() (PostRuntimeContinuationBinding, error) {
+	if continuation == nil {
+		return PostRuntimeContinuationBinding{}, errors.New("missing continuation")
+	}
+	return continuation.binding.clone(), nil
+}
+
+func (continuation *fakePostRuntimeContinuation) Run(context.Context) (PostRuntimeExecutionReceipt, error) {
+	continuation.calls.Add(1)
+	return continuation.receipt, continuation.err
+}
+
+func TestFullRunOrchestrationComposesExactTwelveStageChainOnce(t *testing.T) {
+	calls := []string{}
+	continuation := successfulFakePostRuntimeContinuation()
+	orchestration := &FullRunOrchestration{
+		PreRuntime: successfulPreRuntimeOrchestration(&calls),
+		BindPostRuntime: func(prefix PreRuntimeOrchestrationReceipt) (PostRuntimeContinuation, error) {
+			calls = append(calls, "bind-post-runtime")
+			if prefix.State != "SUCCEEDED" || len(prefix.Checkpoints) != 7 {
+				t.Fatal("post-runtime binder did not receive the completed prefix")
+			}
+			return continuation, nil
+		},
+	}
+	receipt, err := orchestration.Run(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantCalls := append(append([]string(nil), preRuntimeStageOrder...), "bind-post-runtime")
+	if !reflect.DeepEqual(calls, wantCalls) || continuation.calls.Load() != 1 {
+		t.Fatalf("unexpected full-run calls: prefix=%v suffix=%d", calls, continuation.calls.Load())
+	}
+	if receipt.Format != FullRunOrchestrationReceiptFormat || receipt.State != "SUCCEEDED" || receipt.PlanDigest != runnerStageSHA("a") || receipt.StoppedAt != "" || len(receipt.Checkpoints) != 12 {
+		t.Fatalf("unexpected full-run receipt: %#v", receipt)
+	}
+	wantOrder := append(append([]string(nil), preRuntimeStageOrder...), postRuntimeStageOrder...)
+	for index, checkpoint := range receipt.Checkpoints {
+		if checkpoint.StageID != wantOrder[index] || checkpoint.State != "COMPLETED_SUCCEEDED" {
+			t.Fatalf("unexpected checkpoint %d: %#v", index, checkpoint)
+		}
+	}
+	if second, err := orchestration.Run(context.Background()); err == nil || second.State != "STOPPED" || len(calls) != 8 || continuation.calls.Load() != 1 {
+		t.Fatalf("single-use full run executed twice: %#v calls=%v suffix=%d err=%v", second, calls, continuation.calls.Load(), err)
+	}
+}
+
+func TestFullRunOrchestrationAllowsExactlyOneConcurrentInvocation(t *testing.T) {
+	continuation := successfulFakePostRuntimeContinuation()
+	orchestration := &FullRunOrchestration{
+		PreRuntime: successfulPreRuntimeOrchestration(nil),
+		BindPostRuntime: func(PreRuntimeOrchestrationReceipt) (PostRuntimeContinuation, error) {
+			return continuation, nil
+		},
+	}
+	const attempts = 24
+	results := make(chan error, attempts)
+	var group sync.WaitGroup
+	for index := 0; index < attempts; index++ {
+		group.Add(1)
+		go func() {
+			defer group.Done()
+			_, err := orchestration.Run(context.Background())
+			results <- err
+		}()
+	}
+	group.Wait()
+	close(results)
+	succeeded := 0
+	for err := range results {
+		if err == nil {
+			succeeded++
+		}
+	}
+	if succeeded != 1 || continuation.calls.Load() != 1 {
+		t.Fatalf("full-run single use was not atomic: succeeded=%d continuationCalls=%d", succeeded, continuation.calls.Load())
+	}
+}
+
+func TestFullRunOrchestrationStopsBeforeContinuationWhenPrefixStops(t *testing.T) {
+	calls := []string{}
+	prefix := successfulPreRuntimeOrchestration(&calls)
+	prefix.RunEnablement = func(context.Context, execution.ObservationStageRunReceipt) (execution.StagedOperationReceipt, error) {
+		return execution.StagedOperationReceipt{}, errors.New("private failure")
+	}
+	bindCalls := 0
+	orchestration := &FullRunOrchestration{
+		PreRuntime: prefix,
+		BindPostRuntime: func(PreRuntimeOrchestrationReceipt) (PostRuntimeContinuation, error) {
+			bindCalls++
+			return successfulFakePostRuntimeContinuation(), nil
+		},
+	}
+	receipt, err := orchestration.Run(context.Background())
+	if err == nil || receipt.State != "STOPPED" || receipt.StoppedAt != "enablement" || len(receipt.Checkpoints) != 3 || bindCalls != 0 {
+		t.Fatalf("stopped prefix reached continuation: %#v bindCalls=%d err=%v", receipt, bindCalls, err)
+	}
+}
+
+func TestFullRunOrchestrationRejectsForeignContinuationBeforeRun(t *testing.T) {
+	for name, mutate := range map[string]func(*PostRuntimeContinuationBinding){
+		"foreign plan": func(binding *PostRuntimeContinuationBinding) { binding.PlanDigest = runnerStageSHA("f") },
+		"foreign receipt": func(binding *PostRuntimeContinuationBinding) {
+			binding.Predecessors[6].StageReceiptDigest = runnerStageSHA("f")
+		},
+		"missing receipt": func(binding *PostRuntimeContinuationBinding) {
+			binding.Predecessors = binding.Predecessors[:6]
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			continuation := successfulFakePostRuntimeContinuation()
+			mutate(&continuation.binding)
+			orchestration := &FullRunOrchestration{
+				PreRuntime: successfulPreRuntimeOrchestration(nil),
+				BindPostRuntime: func(PreRuntimeOrchestrationReceipt) (PostRuntimeContinuation, error) {
+					return continuation, nil
+				},
+			}
+			receipt, err := orchestration.Run(context.Background())
+			if err == nil || receipt.StoppedAt != "target-credential" || len(receipt.Checkpoints) != 7 || continuation.calls.Load() != 0 {
+				t.Fatalf("foreign continuation ran: %#v calls=%d err=%v", receipt, continuation.calls.Load(), err)
+			}
+		})
+	}
+}
+
+func TestFullRunOrchestrationPreservesBoundedSuffixStop(t *testing.T) {
+	continuation := successfulFakePostRuntimeContinuation()
+	continuation.receipt.State = "STOPPED"
+	continuation.receipt.StoppedAt = "platform-applications"
+	continuation.receipt.Checkpoints = continuation.receipt.Checkpoints[:2]
+	continuation.err = errors.New("private suffix failure")
+	orchestration := &FullRunOrchestration{
+		PreRuntime: successfulPreRuntimeOrchestration(nil),
+		BindPostRuntime: func(PreRuntimeOrchestrationReceipt) (PostRuntimeContinuation, error) {
+			return continuation, nil
+		},
+	}
+	receipt, err := orchestration.Run(context.Background())
+	if err == nil || receipt.State != "STOPPED" || receipt.StoppedAt != "platform-applications" || len(receipt.Checkpoints) != 9 || continuation.calls.Load() != 1 {
+		t.Fatalf("suffix stop was not preserved: %#v calls=%d err=%v", receipt, continuation.calls.Load(), err)
+	}
+}
+
+func TestFullRunOrchestrationRejectsMalformedSuffix(t *testing.T) {
+	continuation := successfulFakePostRuntimeContinuation()
+	continuation.receipt.Checkpoints[0].StageReceiptDigest = "bad"
+	orchestration := &FullRunOrchestration{
+		PreRuntime: successfulPreRuntimeOrchestration(nil),
+		BindPostRuntime: func(PreRuntimeOrchestrationReceipt) (PostRuntimeContinuation, error) {
+			return continuation, nil
+		},
+	}
+	receipt, err := orchestration.Run(context.Background())
+	if err == nil || receipt.State != "STOPPED" || receipt.StoppedAt != "target-credential" || len(receipt.Checkpoints) != 7 {
+		t.Fatalf("malformed suffix was accepted: %#v err=%v", receipt, err)
+	}
+}
+
+func TestPostRuntimeExecutionExposesExactVerifiedContinuationBinding(t *testing.T) {
+	config, factories, _, _ := postRuntimeExecutionFixture(t)
+	executor, err := openPostRuntimeExecution(config, factories)
+	if err != nil {
+		t.Fatal(err)
+	}
+	binding, err := executor.ContinuationBinding()
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan, _, prefix, err := loadStageResumeWithPrefix(StageResumeConfig{
+		PlanPath: config.TargetCredential.PlanPath, PlanExpected: config.TargetCredential.PlanExpected,
+		Receipts: config.TargetCredential.Receipts,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, err := newPostRuntimeContinuationBinding(plan.PlanDigest, prefix)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(binding, want) {
+		t.Fatalf("post-runtime binding differs: got=%#v want=%#v", binding, want)
+	}
+	binding.Predecessors[0].StageID = "changed"
+	again, err := executor.ContinuationBinding()
+	if err != nil || again.Predecessors[0].StageID != "provider-prerequisites" {
+		t.Fatalf("post-runtime binding was not defensively copied: %#v %v", again, err)
+	}
+}
+
+func successfulFakePostRuntimeContinuation() *fakePostRuntimeContinuation {
+	predecessors := make([]PreRuntimeStageCheckpoint, len(preRuntimeStageOrder))
+	for index, stageID := range preRuntimeStageOrder {
+		predecessors[index] = PreRuntimeStageCheckpoint{
+			StageID: stageID, State: "COMPLETED_SUCCEEDED", StageReceiptDigest: runnerStageSHA(string(rune('1' + index))),
+		}
+	}
+	checkpoints := make([]PostRuntimeStageCheckpoint, len(postRuntimeStageOrder))
+	digestValues := []string{"8", "9", "b", "c", "d"}
+	for index, stageID := range postRuntimeStageOrder {
+		checkpoints[index] = PostRuntimeStageCheckpoint{
+			StageID: stageID, State: "COMPLETED_SUCCEEDED", StageReceiptDigest: runnerStageSHA(digestValues[index]),
+		}
+	}
+	return &fakePostRuntimeContinuation{
+		binding: PostRuntimeContinuationBinding{
+			Format: PostRuntimeContinuationBindingFormat, State: postRuntimeContinuationBindingState,
+			PlanDigest: runnerStageSHA("a"), Predecessors: predecessors,
+		},
+		receipt: PostRuntimeExecutionReceipt{
+			Format: PostRuntimeExecutionReceiptFormat, State: "SUCCEEDED", PlanDigest: runnerStageSHA("a"),
+			Checkpoints: checkpoints, ResolvedAuthorizations: []ResolvedStageAuthorizationReceipt{},
+		},
+	}
+}

--- a/internal/runner/post_runtime_execution.go
+++ b/internal/runner/post_runtime_execution.go
@@ -124,6 +124,7 @@ type postRuntimeExecutionFactories struct {
 type PostRuntimeExecution struct {
 	config               PostRuntimeExecutionConfig
 	initial              StageResumeConfig
+	continuation         PostRuntimeContinuationBinding
 	runtime              VerifiedRuntimeBindingMaterial
 	credential           postRuntimeCredentialInvocation
 	recoveryBundle       *VerifiedTargetCredentialStageBundle
@@ -150,9 +151,17 @@ func openPostRuntimeExecution(config PostRuntimeExecutionConfig, factories postR
 		PlanPath: config.TargetCredential.PlanPath, PlanExpected: config.TargetCredential.PlanExpected,
 		Receipts: append([]StageReceiptSource(nil), config.TargetCredential.Receipts...),
 	}
-	decision, err := InspectStageResume(initial)
+	plan, cursor, prefix, err := loadStageResumeWithPrefix(initial)
+	if err != nil {
+		return nil, errors.New("verify post-runtime Stage-8 cursor")
+	}
+	decision, err := cursor.Decision()
 	if err != nil || decision.State != "NEXT" || decision.StageID != "target-credential" || len(initial.Receipts) != 7 {
 		return nil, errors.New("post-runtime execution requires the exact Stage-8 cursor")
+	}
+	continuation, err := newPostRuntimeContinuationBinding(plan.PlanDigest, prefix)
+	if err != nil {
+		return nil, errors.New("bind post-runtime continuation")
 	}
 	persistedStages := postRuntimeStageOrder[:4]
 	if config.TargetCredentialRecovery != nil {
@@ -223,10 +232,20 @@ func openPostRuntimeExecution(config PostRuntimeExecutionConfig, factories postR
 	config.AggregateEvidence.Runtime.RuntimeMaterialPath = config.RuntimeBinding.MaterialPath
 	config.AggregateEvidence.Runtime.RuntimeReceiptPath = config.RuntimeBinding.ReceiptPath
 	return &PostRuntimeExecution{
-		config: config, initial: initial, runtime: runtime, credential: credential,
+		config: config, initial: initial, continuation: continuation, runtime: runtime, credential: credential,
 		recoveryBundle: recoveryBundle, recovery: config.TargetCredentialRecovery, factories: factories,
 		registrationRecovery: registrationRecovery,
 	}, nil
+}
+
+// ContinuationBinding exposes only the exact seven redaction-safe predecessor
+// identities verified while opening this single-use execution.
+func (executor *PostRuntimeExecution) ContinuationBinding() (PostRuntimeContinuationBinding, error) {
+	if executor == nil || executor.continuation.Format != PostRuntimeContinuationBindingFormat ||
+		executor.continuation.State != postRuntimeContinuationBindingState || len(executor.continuation.Predecessors) != len(preRuntimeStageOrder) {
+		return PostRuntimeContinuationBinding{}, errors.New("post-runtime continuation is unavailable")
+	}
+	return executor.continuation.clone(), nil
 }
 
 // Run executes exactly one Stage 8-12 suffix. It persists only canonical


### PR DESCRIPTION
## Summary

- join the typed Stage 1-7 prefix to the concrete Stage 8-12 execution through an exact continuation binding
- require the same Plan and all seven ordered predecessor receipt digests before Stage 8 can run
- emit one redaction-safe twelve-stage summary and enforce atomic single use
- stop before later work on foreign, missing, malformed, cancelled, or terminal stage evidence
- update the MVP boundary to identify shared local/Job activation as the remaining implementation step

## Verification

- `go test ./... -count=1` in `golang:1.21.13`
- `go vet ./...` in `golang:1.21.13`
- `go test -race ./internal/runner -run TestFullRunOrchestration -count=1`
- concurrent invocation test proves exactly one full-run winner
- `git diff --check`

## Boundaries

- no infrastructure mutation
- no CLI or Job activation yet
- no renderer, dynamic writer, retry, rollback, cleanup, or controller ownership
- durable stage owners and R/E/P correlation remain unchanged