### PR TITLE
feat(runner): execute pre-runtime stage chain

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -6,8 +6,10 @@ Contract planning and now models the complete twelve-stage bounded execution
 path, including separately authorized mutations, a durable ledger, bounded
 observation and evaluation components and offline Kubernetes workload
 packaging. The stages are now composed into a typed in-process Stage 1-7 prefix,
-a Stage 8-12 suffix and a receipt-bound, single-use full-run library seam. Only
-the post-runtime suffix currently has a bounded ephemeral Job activation path.
+a Stage 8-12 suffix and a receipt-bound, single-use full-run library seam. The
+Stage 1-7 prefix and Stage 8-12 suffix both have concrete single-use execution
+adapters; only the post-runtime suffix currently has a bounded ephemeral Job
+activation path.
 That Job path is fully exercised offline and against fake APIs, but has not yet
 been run on the DEV management plane. The full-run library is not yet exposed
 as one local or Job-based CreateCluster activation. It is still an MVP rather
@@ -2803,6 +2805,20 @@ private directory, re-verifies the stored digest and returns the exact
 `StageReceiptSource` for the next bundle. Private credentials, endpoints and
 runtime identity never enter this bridge.
 
+The concrete pre-runtime execution adapter now wires that bridge to the
+existing typed Stage 1-7 bundles. It resolves authorization dynamically only
+for provider prerequisites, Cluster lifecycle, Enablement and target access,
+and only after the exact direct predecessor receipt is durable. Observation
+and runtime-binding stages never receive a mutation grant. After every
+successful stage, the adapter reloads the authoritative ledger receipt and
+persists canonical bytes create-only as a private `0600` receipt source before
+the next stage can open. If this bridge fails after the operation succeeded,
+the successful stage checkpoint is preserved and the single-use adapter stops
+without replaying that stage. Only a fully successful seven-stage execution
+exposes the defensive private prefix required by the full-run seam. This adds
+no renderer, policy authority, retry, rollback, cleanup, CLI command or Job
+mutation surface.
+
 The post-runtime authorization resolver closes the next authority boundary.
 After a predecessor receipt is durable, it derives one canonical,
 redaction-safe request from the verified cursor, including the exact Plan,
@@ -2955,9 +2971,12 @@ activation implementation; it does not itself prove a live DEV Job run.
 
 The twelve-stage Go library and its durable replay semantics are complete and
 covered by unit, negative, local TLS integration and race tests. Stage 1-7 and
-Stage 8-12 each have an exact, fail-closed in-process orchestration order, and
-the single-use full-run seam binds them through the exact Plan and seven
-predecessor receipt digests. The Stage 8-12 suffix additionally has a local
+Stage 8-12 each have an exact, fail-closed in-process orchestration order and a
+concrete single-use execution adapter. The Stage 1-7 adapter dynamically binds
+its four mutation grants and persists all seven ledger-backed receipts before
+exposing its exact prefix. The full-run seam binds that prefix through the
+exact Plan and seven predecessor receipt digests. The Stage 8-12 suffix
+additionally has a local
 prepare/execute command, a bounded ephemeral Job, a deterministic private
 activation package, an exact installation plan and a single-use CLI launcher.
 Successful Stage-8 and Stage-9 crash boundaries can be reactivated through the
@@ -2965,8 +2984,8 @@ same manifest, authority, package, Job and CLI chain without rewriting their
 durable receipts. This is not yet the OK-147 Definition of Done:
 
 - the legacy `ok cluster create` command remains dry-run-only;
-- the joined full-run library has no shared local/Job CreateCluster activation
-  surface yet;
+- the joined concrete Stage 1-7 and Stage 8-12 adapters have no shared
+  local/Job CreateCluster activation surface yet;
 - the standalone Stage-12 launcher has not yet been executed as part of the
   complete predecessor-bound stage chain;
 - the current staged-library source is published as the immutable multi-platform
@@ -2981,13 +3000,13 @@ durable receipts. This is not yet the OK-147 Definition of Done:
   [ADR-030 amendment proposal](ok147-adr-030-amendment-proposal.md) are defined
   and remain to be reviewed with the live evidence.
 
-The remaining implementation work is the shared local/Job activation surface
-for the now receipt-bound full-run library; it is not a new controller or
-reconciliation mechanism. After that, live closure must publish the current
-image, construct fresh short-lived private inputs, run the exact bounded
-activation on `ok-mgmt`, preserve a stopped partial state without automatic
-retry, and separately repeat disposable-cluster and executor-termination
-conformance.
+The remaining implementation work is to compose the concrete Stage 1-7 and
+Stage 8-12 adapters behind one shared local/Job activation surface; it is not a
+new controller or reconciliation mechanism. After that, live closure must
+publish the current image, construct fresh short-lived private inputs, run the
+exact bounded activation on `ok-mgmt`, preserve a stopped partial state without
+automatic retry, and separately repeat disposable-cluster and
+executor-termination conformance.
 
 These remaining items may compose the verified packages, but must not add a
 second Contract-to-CAPI compiler, persistent aggregate-status controller,

--- a/internal/runner/full_run_orchestrator.go
+++ b/internal/runner/full_run_orchestrator.go
@@ -129,7 +129,7 @@ func appendFullRunPrefix(receipt *FullRunOrchestrationReceipt, prefix PreRuntime
 		return errors.New("successful full-run prefix is incomplete")
 	}
 	if prefix.State == "STOPPED" {
-		if len(prefix.Checkpoints) >= len(preRuntimeStageOrder) || prefix.StoppedAt != preRuntimeStageOrder[len(prefix.Checkpoints)] {
+		if !validStoppedStage(preRuntimeStageOrder, len(prefix.Checkpoints), prefix.StoppedAt) {
 			return errors.New("stopped full-run prefix is inconsistent")
 		}
 	}
@@ -154,7 +154,7 @@ func appendFullRunSuffix(receipt *FullRunOrchestrationReceipt, suffix PostRuntim
 		return errors.New("successful full-run suffix is incomplete")
 	}
 	if suffix.State == "STOPPED" {
-		if len(suffix.Checkpoints) >= len(postRuntimeStageOrder) || suffix.StoppedAt != postRuntimeStageOrder[len(suffix.Checkpoints)] {
+		if !validStoppedStage(postRuntimeStageOrder, len(suffix.Checkpoints), suffix.StoppedAt) {
 			return errors.New("stopped full-run suffix is inconsistent")
 		}
 	}
@@ -220,6 +220,13 @@ func nextFullRunStage(checkpoints []FullRunStageCheckpoint) string {
 		return postRuntimeStageOrder[index]
 	}
 	return postRuntimeStageOrder[len(postRuntimeStageOrder)-1]
+}
+
+func validStoppedStage(order []string, completed int, stoppedAt string) bool {
+	if completed < len(order) && stoppedAt == order[completed] {
+		return true
+	}
+	return completed > 0 && completed <= len(order) && stoppedAt == order[completed-1]
 }
 
 func stopFullRunOrchestration(receipt FullRunOrchestrationReceipt, stageID string) (FullRunOrchestrationReceipt, error) {

--- a/internal/runner/full_run_orchestrator_test.go
+++ b/internal/runner/full_run_orchestrator_test.go
@@ -117,6 +117,31 @@ func TestFullRunOrchestrationStopsBeforeContinuationWhenPrefixStops(t *testing.T
 	}
 }
 
+func TestFullRunOrchestrationPreservesCompletedPrefixCheckpointWhenBridgeStops(t *testing.T) {
+	prefix := successfulPreRuntimeOrchestration(nil)
+	runProvider := prefix.RunProviderPrerequisites
+	prefix.RunProviderPrerequisites = func(ctx context.Context) (execution.StagedOperationReceipt, error) {
+		receipt, err := runProvider(ctx)
+		if err != nil {
+			return receipt, err
+		}
+		return receipt, errors.New("private receipt bridge failure")
+	}
+	bindCalls := 0
+	orchestration := &FullRunOrchestration{
+		PreRuntime: prefix,
+		BindPostRuntime: func(PreRuntimeOrchestrationReceipt) (PostRuntimeContinuation, error) {
+			bindCalls++
+			return successfulFakePostRuntimeContinuation(), nil
+		},
+	}
+	receipt, err := orchestration.Run(context.Background())
+	if err == nil || receipt.State != "STOPPED" || receipt.StoppedAt != "provider-prerequisites" ||
+		len(receipt.Checkpoints) != 1 || bindCalls != 0 {
+		t.Fatalf("completed prefix checkpoint was not preserved: %#v bindCalls=%d err=%v", receipt, bindCalls, err)
+	}
+}
+
 func TestFullRunOrchestrationRejectsForeignContinuationBeforeRun(t *testing.T) {
 	for name, mutate := range map[string]func(*PostRuntimeContinuationBinding){
 		"foreign plan": func(binding *PostRuntimeContinuationBinding) { binding.PlanDigest = runnerStageSHA("f") },
@@ -159,6 +184,25 @@ func TestFullRunOrchestrationPreservesBoundedSuffixStop(t *testing.T) {
 	receipt, err := orchestration.Run(context.Background())
 	if err == nil || receipt.State != "STOPPED" || receipt.StoppedAt != "platform-applications" || len(receipt.Checkpoints) != 9 || continuation.calls.Load() != 1 {
 		t.Fatalf("suffix stop was not preserved: %#v calls=%d err=%v", receipt, continuation.calls.Load(), err)
+	}
+}
+
+func TestFullRunOrchestrationPreservesCompletedSuffixCheckpointWhenBridgeStops(t *testing.T) {
+	continuation := successfulFakePostRuntimeContinuation()
+	continuation.receipt.State = "STOPPED"
+	continuation.receipt.StoppedAt = "target-credential"
+	continuation.receipt.Checkpoints = continuation.receipt.Checkpoints[:1]
+	continuation.err = errors.New("private receipt bridge failure")
+	orchestration := &FullRunOrchestration{
+		PreRuntime: successfulPreRuntimeOrchestration(nil),
+		BindPostRuntime: func(PreRuntimeOrchestrationReceipt) (PostRuntimeContinuation, error) {
+			return continuation, nil
+		},
+	}
+	receipt, err := orchestration.Run(context.Background())
+	if err == nil || receipt.State != "STOPPED" || receipt.StoppedAt != "target-credential" ||
+		len(receipt.Checkpoints) != 8 || continuation.calls.Load() != 1 {
+		t.Fatalf("completed suffix checkpoint was not preserved: %#v calls=%d err=%v", receipt, continuation.calls.Load(), err)
 	}
 }
 

--- a/internal/runner/post_runtime_execution_test.go
+++ b/internal/runner/post_runtime_execution_test.go
@@ -419,7 +419,7 @@ func writeResolvedStageGrant(t *testing.T, root string, request StageAuthorizati
 		PlanDigest: request.PlanDigest, ContractIdentity: request.ContractIdentity, ContractRevision: request.ContractRevision,
 		EnablementRevision: request.EnablementRevision, PlatformRevision: request.PlatformRevision, ExecutionFixture: request.ExecutionFixture,
 		StageID: request.StageID, StageOrder: request.StageOrder, StageDigest: request.StageDigest,
-		Operation: request.Operation, Authority: request.Authority, MaxUses: request.MaxUses,
+		Operation: request.Operation, Authority: request.Authority, Predecessors: []authorization.StagePredecessor{}, MaxUses: request.MaxUses,
 		NotBefore: "2026-08-18T07:59:00Z", NotAfter: "2026-08-18T08:20:00Z",
 	}
 	for _, predecessor := range request.Predecessors {

--- a/internal/runner/pre_runtime_execution.go
+++ b/internal/runner/pre_runtime_execution.go
@@ -1,0 +1,413 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"sync"
+
+	"github.com/openkubes/ok-cluster/internal/execution"
+	"github.com/openkubes/ok-cluster/internal/ledger"
+	"github.com/openkubes/ok-cluster/internal/projection"
+	"github.com/openkubes/ok-cluster/internal/stageplan"
+)
+
+const PreRuntimeExecutionReceiptFormat = "ok147-pre-runtime-execution-receipt/v1"
+
+var preRuntimeReceiptFiles = map[string]string{
+	"provider-prerequisites": "01-provider-prerequisites.json",
+	"cluster-lifecycle":      "02-cluster-lifecycle.json",
+	"lifecycle-observation":  "03-lifecycle-observation.json",
+	"enablement":             "04-enablement.json",
+	"network-observation":    "05-network-observation.json",
+	"runtime-binding":        "06-runtime-binding.json",
+	"target-access":          "07-target-access.json",
+}
+
+type PreRuntimeEnablementExecutionConfig struct {
+	ArtifactPath   string
+	ExpectedObject projection.ResourceIdentity
+	Runtime        SubmissionStageRuntimeConfig
+}
+
+type PreRuntimeTargetAccessExecutionConfig struct {
+	ArtifactPath    string
+	ExpectedObjects []projection.ResourceIdentity
+	Runtime         TargetAccessStageRuntimeConfig
+}
+
+// PreRuntimeExecutionConfig binds all immutable artifacts and private runtime
+// capabilities for Stage 1-7. Mutating grants are resolved only after the
+// exact direct predecessor receipt is durable.
+type PreRuntimeExecutionConfig struct {
+	PlanPath               string
+	PlanExpected           stageplan.Expected
+	ProjectionManifestPath string
+	ProjectionRoot         string
+	Authorization          StageAuthorizationResolver
+	ProviderPrerequisites  SubmissionStageRuntimeConfig
+	ClusterLifecycle       SubmissionStageRuntimeConfig
+	LifecycleObservation   LifecycleObservationStageRuntimeConfig
+	Enablement             PreRuntimeEnablementExecutionConfig
+	NetworkObservation     NetworkObservationStageRuntimeConfig
+	RuntimeBinding         RuntimeBindingStageRuntimeConfig
+	TargetAccess           PreRuntimeTargetAccessExecutionConfig
+	ReceiptDirectory       string
+}
+
+type PreRuntimeExecutionReceipt struct {
+	Format                 string                              `json:"format"`
+	State                  string                              `json:"state"`
+	PlanDigest             string                              `json:"planDigest,omitempty"`
+	StoppedAt              string                              `json:"stoppedAt,omitempty"`
+	Checkpoints            []PreRuntimeStageCheckpoint         `json:"checkpoints"`
+	ResolvedAuthorizations []ResolvedStageAuthorizationReceipt `json:"resolvedAuthorizations"`
+}
+
+type preRuntimeStagedInvocation struct {
+	run   func(context.Context) (execution.StagedOperationReceipt, error)
+	store *ledger.Ledger
+}
+
+type preRuntimeObservationInvocation struct {
+	run   func(context.Context) (execution.ObservationStageRunReceipt, error)
+	store *ledger.Ledger
+}
+
+type preRuntimeBindingInvocation struct {
+	run   func(context.Context) (execution.BindingStageRunReceipt, error)
+	store *ledger.Ledger
+}
+
+type preRuntimeExecutionFactories struct {
+	submission func(StageResumeConfig, string, StageAuthorizationSource, PreRuntimeExecutionConfig) (preRuntimeStagedInvocation, error)
+	lifecycle  func(StageResumeConfig, PreRuntimeExecutionConfig) (preRuntimeObservationInvocation, error)
+	enablement func(StageResumeConfig, StageAuthorizationSource, PreRuntimeExecutionConfig) (preRuntimeStagedInvocation, error)
+	network    func(StageResumeConfig, PreRuntimeExecutionConfig) (preRuntimeObservationInvocation, error)
+	binding    func(StageResumeConfig, PreRuntimeExecutionConfig) (preRuntimeBindingInvocation, error)
+	target     func(StageResumeConfig, StageAuthorizationSource, PreRuntimeExecutionConfig) (preRuntimeStagedInvocation, error)
+	persist    func(context.Context, StageResumeConfig, *ledger.Ledger, StageRunReceiptReference, string) (StageReceiptSource, error)
+}
+
+type PreRuntimeExecution struct {
+	config    PreRuntimeExecutionConfig
+	initial   StageResumeConfig
+	factories preRuntimeExecutionFactories
+
+	mu        sync.Mutex
+	used      bool
+	completed bool
+	prefix    []StageReceiptSource
+}
+
+// OpenPreRuntimeExecution verifies the empty Stage-1 cursor and every future
+// receipt destination. It does not resolve a grant, read a credential, contact
+// Kubernetes or create a file.
+func OpenPreRuntimeExecution(config PreRuntimeExecutionConfig) (*PreRuntimeExecution, error) {
+	return openPreRuntimeExecution(config, defaultPreRuntimeExecutionFactories())
+}
+
+func openPreRuntimeExecution(config PreRuntimeExecutionConfig, factories preRuntimeExecutionFactories) (*PreRuntimeExecution, error) {
+	if config.Authorization == nil || config.ReceiptDirectory == "" || config.PlanPath == "" ||
+		factories.submission == nil || factories.lifecycle == nil || factories.enablement == nil ||
+		factories.network == nil || factories.binding == nil || factories.target == nil || factories.persist == nil {
+		return nil, errors.New("pre-runtime execution configuration is incomplete")
+	}
+	initial := StageResumeConfig{PlanPath: config.PlanPath, PlanExpected: config.PlanExpected, Receipts: []StageReceiptSource{}}
+	decision, err := InspectStageResume(initial)
+	if err != nil || decision.State != "NEXT" || decision.StageID != "provider-prerequisites" {
+		return nil, errors.New("pre-runtime execution requires the exact Stage-1 cursor")
+	}
+	for _, stageID := range preRuntimeStageOrder {
+		name, ok := preRuntimeReceiptFiles[stageID]
+		if !ok || validateRuntimeBindingOutputPath(filepath.Join(config.ReceiptDirectory, name)) != nil {
+			return nil, errors.New("pre-runtime receipt destination is invalid")
+		}
+	}
+	config.TargetAccess.ExpectedObjects = append([]projection.ResourceIdentity(nil), config.TargetAccess.ExpectedObjects...)
+	return &PreRuntimeExecution{config: config, initial: initial, factories: factories}, nil
+}
+
+// Run executes exactly one Stage 1-7 prefix. Every successful stage receipt
+// is reloaded from its authoritative ledger and persisted create-only as a
+// private 0600 source before a later stage can be opened.
+func (executor *PreRuntimeExecution) Run(ctx context.Context) (PreRuntimeExecutionReceipt, error) {
+	if executor == nil {
+		return stoppedPreRuntimeExecutionReceipt("provider-prerequisites", nil, nil), errors.New("pre-runtime execution is required")
+	}
+	executor.mu.Lock()
+	if executor.used {
+		executor.mu.Unlock()
+		return stoppedPreRuntimeExecutionReceipt("provider-prerequisites", nil, nil), errors.New("pre-runtime execution is single-use")
+	}
+	executor.used = true
+	executor.mu.Unlock()
+
+	receipts := []StageReceiptSource{}
+	authorizations := []ResolvedStageAuthorizationReceipt{}
+	orchestration := PreRuntimeOrchestration{}
+
+	resolve := func(ctx context.Context) (StageAuthorizationSource, error) {
+		resolved, err := ResolveStageAuthorization(ctx, executor.resume(receipts), executor.config.Authorization)
+		if err != nil {
+			return StageAuthorizationSource{}, err
+		}
+		source, err := resolved.Source()
+		if err != nil {
+			return StageAuthorizationSource{}, err
+		}
+		public, err := resolved.Receipt()
+		if err != nil {
+			return StageAuthorizationSource{}, err
+		}
+		authorizations = append(authorizations, public)
+		return source, nil
+	}
+	persist := func(ctx context.Context, store *ledger.Ledger, reference StageRunReceiptReference) error {
+		name, ok := preRuntimeReceiptFiles[reference.StageID]
+		if !ok {
+			return errors.New("pre-runtime receipt stage is not persistable")
+		}
+		source, err := executor.factories.persist(ctx, executor.resume(receipts), store, reference, filepath.Join(executor.config.ReceiptDirectory, name))
+		if err != nil {
+			return err
+		}
+		receipts = append(receipts, source)
+		return nil
+	}
+
+	orchestration.RunProviderPrerequisites = func(ctx context.Context) (execution.StagedOperationReceipt, error) {
+		source, err := resolve(ctx)
+		if err != nil {
+			return execution.StagedOperationReceipt{}, err
+		}
+		invocation, err := executor.factories.submission(executor.resume(receipts), "provider-prerequisites", source, executor.config)
+		if err != nil || invocation.run == nil || invocation.store == nil {
+			return execution.StagedOperationReceipt{}, errors.New("open provider-prerequisites stage")
+		}
+		run, err := invocation.run(ctx)
+		if err != nil {
+			return run, err
+		}
+		return run, persist(ctx, invocation.store, StagedOperationReceiptReference(run))
+	}
+	orchestration.RunClusterLifecycle = func(ctx context.Context, _ execution.StagedOperationReceipt) (execution.StagedOperationReceipt, error) {
+		source, err := resolve(ctx)
+		if err != nil {
+			return execution.StagedOperationReceipt{}, err
+		}
+		invocation, err := executor.factories.submission(executor.resume(receipts), "cluster-lifecycle", source, executor.config)
+		if err != nil || invocation.run == nil || invocation.store == nil {
+			return execution.StagedOperationReceipt{}, errors.New("open cluster-lifecycle stage")
+		}
+		run, err := invocation.run(ctx)
+		if err != nil {
+			return run, err
+		}
+		return run, persist(ctx, invocation.store, StagedOperationReceiptReference(run))
+	}
+	orchestration.RunLifecycleObservation = func(ctx context.Context, _ execution.StagedOperationReceipt) (execution.ObservationStageRunReceipt, error) {
+		invocation, err := executor.factories.lifecycle(executor.resume(receipts), executor.config)
+		if err != nil || invocation.run == nil || invocation.store == nil {
+			return execution.ObservationStageRunReceipt{}, errors.New("open lifecycle-observation stage")
+		}
+		run, err := invocation.run(ctx)
+		if err != nil {
+			return run, err
+		}
+		return run, persist(ctx, invocation.store, ObservationStageReceiptReference(run))
+	}
+	orchestration.RunEnablement = func(ctx context.Context, _ execution.ObservationStageRunReceipt) (execution.StagedOperationReceipt, error) {
+		source, err := resolve(ctx)
+		if err != nil {
+			return execution.StagedOperationReceipt{}, err
+		}
+		invocation, err := executor.factories.enablement(executor.resume(receipts), source, executor.config)
+		if err != nil || invocation.run == nil || invocation.store == nil {
+			return execution.StagedOperationReceipt{}, errors.New("open enablement stage")
+		}
+		run, err := invocation.run(ctx)
+		if err != nil {
+			return run, err
+		}
+		return run, persist(ctx, invocation.store, StagedOperationReceiptReference(run))
+	}
+	orchestration.RunNetworkObservation = func(ctx context.Context, _ execution.StagedOperationReceipt) (execution.ObservationStageRunReceipt, error) {
+		invocation, err := executor.factories.network(executor.resume(receipts), executor.config)
+		if err != nil || invocation.run == nil || invocation.store == nil {
+			return execution.ObservationStageRunReceipt{}, errors.New("open network-observation stage")
+		}
+		run, err := invocation.run(ctx)
+		if err != nil {
+			return run, err
+		}
+		return run, persist(ctx, invocation.store, ObservationStageReceiptReference(run))
+	}
+	orchestration.RunRuntimeBinding = func(ctx context.Context, _ execution.ObservationStageRunReceipt) (execution.BindingStageRunReceipt, error) {
+		invocation, err := executor.factories.binding(executor.resume(receipts), executor.config)
+		if err != nil || invocation.run == nil || invocation.store == nil {
+			return execution.BindingStageRunReceipt{}, errors.New("open runtime-binding stage")
+		}
+		run, err := invocation.run(ctx)
+		if err != nil {
+			return run, err
+		}
+		return run, persist(ctx, invocation.store, BindingStageReceiptReference(run))
+	}
+	orchestration.RunTargetAccess = func(ctx context.Context, _ execution.BindingStageRunReceipt) (execution.StagedOperationReceipt, error) {
+		source, err := resolve(ctx)
+		if err != nil {
+			return execution.StagedOperationReceipt{}, err
+		}
+		invocation, err := executor.factories.target(executor.resume(receipts), source, executor.config)
+		if err != nil || invocation.run == nil || invocation.store == nil {
+			return execution.StagedOperationReceipt{}, errors.New("open target-access stage")
+		}
+		run, err := invocation.run(ctx)
+		if err != nil {
+			return run, err
+		}
+		return run, persist(ctx, invocation.store, StagedOperationReceiptReference(run))
+	}
+
+	orchestrationReceipt, runErr := orchestration.Run(ctx)
+	result := PreRuntimeExecutionReceipt{
+		Format: PreRuntimeExecutionReceiptFormat, State: orchestrationReceipt.State,
+		PlanDigest: orchestrationReceipt.PlanDigest, StoppedAt: orchestrationReceipt.StoppedAt,
+		Checkpoints:            append([]PreRuntimeStageCheckpoint(nil), orchestrationReceipt.Checkpoints...),
+		ResolvedAuthorizations: append([]ResolvedStageAuthorizationReceipt(nil), authorizations...),
+	}
+	if runErr == nil && result.State == "SUCCEEDED" && len(receipts) == len(preRuntimeStageOrder) {
+		executor.mu.Lock()
+		executor.prefix = append([]StageReceiptSource(nil), receipts...)
+		executor.completed = true
+		executor.mu.Unlock()
+	}
+	return result, runErr
+}
+
+// ReceiptPrefix returns the exact private receipt sources only after all seven
+// stages completed. It is intended for the receipt-bound full-run adapter and
+// must never be serialized into public evidence.
+func (executor *PreRuntimeExecution) ReceiptPrefix() ([]StageReceiptSource, error) {
+	if executor == nil {
+		return nil, errors.New("pre-runtime execution is required")
+	}
+	executor.mu.Lock()
+	defer executor.mu.Unlock()
+	if !executor.completed || len(executor.prefix) != len(preRuntimeStageOrder) {
+		return nil, errors.New("pre-runtime receipt prefix is unavailable")
+	}
+	return append([]StageReceiptSource(nil), executor.prefix...), nil
+}
+
+func (executor *PreRuntimeExecution) resume(receipts []StageReceiptSource) StageResumeConfig {
+	prefix := make([]StageReceiptSource, len(receipts))
+	copy(prefix, receipts)
+	return StageResumeConfig{
+		PlanPath: executor.initial.PlanPath, PlanExpected: executor.initial.PlanExpected,
+		Receipts: prefix,
+	}
+}
+
+func defaultPreRuntimeExecutionFactories() preRuntimeExecutionFactories {
+	return preRuntimeExecutionFactories{
+		submission: func(resume StageResumeConfig, stageID string, grant StageAuthorizationSource, config PreRuntimeExecutionConfig) (preRuntimeStagedInvocation, error) {
+			bundle, err := LoadSubmissionStageBundle(SubmissionStageBundleConfig{
+				ExpectedStageID: stageID, PlanPath: resume.PlanPath, PlanExpected: resume.PlanExpected, Receipts: resume.Receipts,
+				GrantPath: grant.GrantPath, GrantPublicKeyPath: grant.PublicKeyPath, EvaluationTime: grant.EvaluationTime,
+				ProjectionManifestPath: config.ProjectionManifestPath, ProjectionRoot: config.ProjectionRoot,
+			})
+			if err != nil {
+				return preRuntimeStagedInvocation{}, err
+			}
+			runtime := config.ProviderPrerequisites
+			if stageID == "cluster-lifecycle" {
+				runtime = config.ClusterLifecycle
+			}
+			opened, err := bundle.Open(runtime)
+			if err != nil {
+				return preRuntimeStagedInvocation{}, err
+			}
+			return preRuntimeStagedInvocation{run: opened.Run, store: opened.operation.Ledger}, nil
+		},
+		lifecycle: func(resume StageResumeConfig, config PreRuntimeExecutionConfig) (preRuntimeObservationInvocation, error) {
+			bundle, err := LoadLifecycleObservationStageBundle(resume)
+			if err != nil {
+				return preRuntimeObservationInvocation{}, err
+			}
+			opened, err := bundle.Open(config.LifecycleObservation)
+			if err != nil {
+				return preRuntimeObservationInvocation{}, err
+			}
+			return preRuntimeObservationInvocation{run: opened.Run, store: opened.operation.Ledger}, nil
+		},
+		enablement: func(resume StageResumeConfig, grant StageAuthorizationSource, config PreRuntimeExecutionConfig) (preRuntimeStagedInvocation, error) {
+			bundle, err := LoadEnablementStageBundle(EnablementStageBundleConfig{
+				PlanPath: resume.PlanPath, PlanExpected: resume.PlanExpected, Receipts: resume.Receipts,
+				GrantPath: grant.GrantPath, GrantPublicKeyPath: grant.PublicKeyPath, EvaluationTime: grant.EvaluationTime,
+				ArtifactPath: config.Enablement.ArtifactPath, ExpectedObject: config.Enablement.ExpectedObject,
+			})
+			if err != nil {
+				return preRuntimeStagedInvocation{}, err
+			}
+			opened, err := bundle.Open(config.Enablement.Runtime)
+			if err != nil {
+				return preRuntimeStagedInvocation{}, err
+			}
+			return preRuntimeStagedInvocation{run: opened.Run, store: opened.operation.Ledger}, nil
+		},
+		network: func(resume StageResumeConfig, config PreRuntimeExecutionConfig) (preRuntimeObservationInvocation, error) {
+			bundle, err := LoadNetworkObservationStageBundle(resume)
+			if err != nil {
+				return preRuntimeObservationInvocation{}, err
+			}
+			opened, err := bundle.Open(config.NetworkObservation)
+			if err != nil {
+				return preRuntimeObservationInvocation{}, err
+			}
+			return preRuntimeObservationInvocation{run: opened.Run, store: opened.operation.Ledger}, nil
+		},
+		binding: func(resume StageResumeConfig, config PreRuntimeExecutionConfig) (preRuntimeBindingInvocation, error) {
+			bundle, err := LoadRuntimeBindingStageBundle(resume)
+			if err != nil {
+				return preRuntimeBindingInvocation{}, err
+			}
+			opened, err := bundle.Open(config.RuntimeBinding)
+			if err != nil {
+				return preRuntimeBindingInvocation{}, err
+			}
+			return preRuntimeBindingInvocation{run: opened.Run, store: opened.operation.Ledger}, nil
+		},
+		target: func(resume StageResumeConfig, grant StageAuthorizationSource, config PreRuntimeExecutionConfig) (preRuntimeStagedInvocation, error) {
+			bundle, err := LoadTargetAccessStageBundle(TargetAccessStageBundleConfig{
+				PlanPath: resume.PlanPath, PlanExpected: resume.PlanExpected, Receipts: resume.Receipts,
+				GrantPath: grant.GrantPath, GrantPublicKeyPath: grant.PublicKeyPath, EvaluationTime: grant.EvaluationTime,
+				ArtifactPath: config.TargetAccess.ArtifactPath, ExpectedObjects: config.TargetAccess.ExpectedObjects,
+			})
+			if err != nil {
+				return preRuntimeStagedInvocation{}, err
+			}
+			opened, err := bundle.Open(config.TargetAccess.Runtime)
+			if err != nil {
+				return preRuntimeStagedInvocation{}, err
+			}
+			return preRuntimeStagedInvocation{run: opened.Run, store: opened.operation.Ledger}, nil
+		},
+		persist: func(ctx context.Context, resume StageResumeConfig, store *ledger.Ledger, reference StageRunReceiptReference, path string) (StageReceiptSource, error) {
+			material, err := LoadStageReceiptMaterial(ctx, StageReceiptBridgeConfig{Bundle: resume, Ledger: store, Run: reference})
+			if err != nil {
+				return StageReceiptSource{}, err
+			}
+			return material.Persist(path)
+		},
+	}
+}
+
+func stoppedPreRuntimeExecutionReceipt(stageID string, checkpoints []PreRuntimeStageCheckpoint, authorizations []ResolvedStageAuthorizationReceipt) PreRuntimeExecutionReceipt {
+	return PreRuntimeExecutionReceipt{
+		Format: PreRuntimeExecutionReceiptFormat, State: "STOPPED", StoppedAt: stageID,
+		Checkpoints:            append([]PreRuntimeStageCheckpoint(nil), checkpoints...),
+		ResolvedAuthorizations: append([]ResolvedStageAuthorizationReceipt(nil), authorizations...),
+	}
+}

--- a/internal/runner/pre_runtime_execution_test.go
+++ b/internal/runner/pre_runtime_execution_test.go
@@ -1,0 +1,263 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/execution"
+	"github.com/openkubes/ok-cluster/internal/ledger"
+	"github.com/openkubes/ok-cluster/internal/stagereceipt"
+)
+
+func TestPreRuntimeExecutionComposesExactPrefixWithDynamicAuthorization(t *testing.T) {
+	config, factories, calls, requests := preRuntimeExecutionFixture(t)
+	executor, err := openPreRuntimeExecution(config, factories)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := executor.Run(context.Background())
+	if err != nil {
+		t.Fatalf("%v requests=%#v calls=%v", err, *requests, *calls)
+	}
+	if receipt.Format != PreRuntimeExecutionReceiptFormat || receipt.State != "SUCCEEDED" || receipt.StoppedAt != "" ||
+		len(receipt.Checkpoints) != 7 || len(receipt.ResolvedAuthorizations) != 4 {
+		t.Fatalf("unexpected pre-runtime execution receipt: %#v", receipt)
+	}
+	if !reflect.DeepEqual(*calls, preRuntimeStageOrder) {
+		t.Fatalf("pre-runtime execution order differs: %v", *calls)
+	}
+	wantAuthorized := []string{"provider-prerequisites", "cluster-lifecycle", "enablement", "target-access"}
+	if len(*requests) != len(wantAuthorized) {
+		t.Fatalf("authorization count differs: %#v", *requests)
+	}
+	for index, stageID := range wantAuthorized {
+		if (*requests)[index].StageID != stageID || len((*requests)[index].Predecessors) != minInt(index, 1) {
+			t.Fatalf("authorization %d differs: %#v", index, (*requests)[index])
+		}
+	}
+	for _, stageID := range preRuntimeStageOrder {
+		path := filepath.Join(config.ReceiptDirectory, preRuntimeReceiptFiles[stageID])
+		info, statErr := os.Lstat(path)
+		if statErr != nil || !info.Mode().IsRegular() || info.Mode().Perm() != 0o600 {
+			t.Fatalf("receipt %s was not persisted privately: %#v %v", stageID, info, statErr)
+		}
+	}
+	prefix, err := executor.ReceiptPrefix()
+	if err != nil || len(prefix) != 7 {
+		t.Fatalf("completed private prefix is unavailable: %#v %v", prefix, err)
+	}
+	prefix[0].Digest = runnerStageSHA("f")
+	again, err := executor.ReceiptPrefix()
+	if err != nil || again[0].Digest == prefix[0].Digest {
+		t.Fatal("private receipt prefix was not defensively copied")
+	}
+	if second, err := executor.Run(context.Background()); err == nil || second.State != "STOPPED" || len(*calls) != 7 {
+		t.Fatalf("single-use executor ran twice: %#v calls=%v err=%v", second, *calls, err)
+	}
+	public := mustJSON(t, receipt)
+	for _, forbidden := range []string{config.ReceiptDirectory, "token", "endpoint", "kubeconfig"} {
+		if strings.Contains(string(public), forbidden) {
+			t.Fatalf("public pre-runtime receipt exposed %q", forbidden)
+		}
+	}
+}
+
+func TestPreRuntimeExecutionStopsAfterDurableReceiptWhenNextGrantIsUnavailable(t *testing.T) {
+	config, factories, calls, requests := preRuntimeExecutionFixture(t)
+	resolved := config.Authorization
+	config.Authorization = StageAuthorizationResolverFunc(func(ctx context.Context, request StageAuthorizationRequest) (StageAuthorizationSource, error) {
+		if request.StageID == "cluster-lifecycle" {
+			*requests = append(*requests, cloneStageAuthorizationRequest(request))
+			return StageAuthorizationSource{}, errors.New("private authority failure")
+		}
+		return resolved.ResolveStageAuthorization(ctx, request)
+	})
+	executor, err := openPreRuntimeExecution(config, factories)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := executor.Run(context.Background())
+	if err == nil || receipt.State != "STOPPED" || receipt.StoppedAt != "cluster-lifecycle" || len(receipt.Checkpoints) != 1 || len(*calls) != 1 {
+		t.Fatalf("authority stop did not preserve exact prefix: %#v calls=%v err=%v", receipt, *calls, err)
+	}
+	if _, err := os.Lstat(filepath.Join(config.ReceiptDirectory, preRuntimeReceiptFiles["provider-prerequisites"])); err != nil {
+		t.Fatal("successful provider receipt was not retained")
+	}
+	if _, err := executor.ReceiptPrefix(); err == nil {
+		t.Fatal("partial prefix was exposed as complete")
+	}
+}
+
+func TestPreRuntimeExecutionStopsWithoutReplayWhenReceiptPersistenceFails(t *testing.T) {
+	config, factories, calls, _ := preRuntimeExecutionFixture(t)
+	persistCalls := 0
+	factories.persist = func(context.Context, StageResumeConfig, *ledger.Ledger, StageRunReceiptReference, string) (StageReceiptSource, error) {
+		persistCalls++
+		return StageReceiptSource{}, errors.New("private persistence failure")
+	}
+	executor, err := openPreRuntimeExecution(config, factories)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := executor.Run(context.Background())
+	if err == nil || receipt.State != "STOPPED" || receipt.StoppedAt != "provider-prerequisites" || len(receipt.Checkpoints) != 1 ||
+		!reflect.DeepEqual(*calls, []string{"provider-prerequisites"}) || persistCalls != 1 {
+		t.Fatalf("persistence stop replayed or lost durable stage identity: %#v calls=%v persist=%d err=%v", receipt, *calls, persistCalls, err)
+	}
+	if _, err := executor.ReceiptPrefix(); err == nil {
+		t.Fatal("unpersisted prefix was exposed")
+	}
+}
+
+func TestOpenPreRuntimeExecutionRejectsUnsafeReceiptDestination(t *testing.T) {
+	config, factories, calls, _ := preRuntimeExecutionFixture(t)
+	if err := os.Chmod(config.ReceiptDirectory, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := openPreRuntimeExecution(config, factories); err == nil || len(*calls) != 0 {
+		t.Fatalf("unsafe receipt directory was accepted: calls=%v err=%v", *calls, err)
+	}
+}
+
+func TestBindingStageReceiptReferenceRetainsExactPublicIdentity(t *testing.T) {
+	receipt := execution.BindingStageRunReceipt{
+		Format: execution.BindingStageReceiptFormat, State: "COMPLETED_SUCCEEDED", PlanDigest: runnerStageSHA("a"),
+		StageID: "runtime-binding", StageReceiptDigest: runnerStageSHA("6"),
+	}
+	reference := BindingStageReceiptReference(receipt)
+	if reference.Format != receipt.Format || reference.State != receipt.State || reference.PlanDigest != receipt.PlanDigest ||
+		reference.StageID != receipt.StageID || reference.StageReceiptDigest != receipt.StageReceiptDigest {
+		t.Fatalf("binding receipt reference differs: %#v", reference)
+	}
+}
+
+func preRuntimeExecutionFixture(t *testing.T) (PreRuntimeExecutionConfig, preRuntimeExecutionFactories, *[]string, *[]StageAuthorizationRequest) {
+	t.Helper()
+	base := submissionBundleFixture(t, false, "")
+	receiptDirectory := t.TempDir()
+	if err := os.Chmod(receiptDirectory, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	grantDirectory := t.TempDir()
+	if err := os.Chmod(grantDirectory, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	calls := []string{}
+	requests := []StageAuthorizationRequest{}
+	resolver := StageAuthorizationResolverFunc(func(_ context.Context, request StageAuthorizationRequest) (StageAuthorizationSource, error) {
+		requests = append(requests, cloneStageAuthorizationRequest(request))
+		return writeResolvedStageGrant(t, grantDirectory, request)
+	})
+	config := PreRuntimeExecutionConfig{
+		PlanPath: base.config.PlanPath, PlanExpected: base.config.PlanExpected,
+		ProjectionManifestPath: base.config.ProjectionManifestPath, ProjectionRoot: base.config.ProjectionRoot,
+		Authorization: resolver, ReceiptDirectory: receiptDirectory,
+	}
+	store := &ledger.Ledger{}
+	verified := map[string]stagereceipt.Verified{}
+	makeReceipt := func(resume StageResumeConfig, stageID string) (stagereceipt.Verified, string) {
+		plan, cursor, _, err := loadStageResumeWithPrefix(resume)
+		if err != nil {
+			t.Fatal(err)
+		}
+		predecessors, err := cursor.Predecessors()
+		if err != nil {
+			t.Fatal(err)
+		}
+		mutation, outcome := "NOT_APPLICABLE", ""
+		if stageID == "provider-prerequisites" || stageID == "cluster-lifecycle" || stageID == "enablement" || stageID == "target-access" {
+			mutation, outcome = "ATTEMPTED", digest.SHA256([]byte("operation-"+stageID))
+		}
+		at := time.Date(2026, 8, 18, 8, len(resume.Receipts), 0, 0, time.UTC)
+		var stageReceipt stagereceipt.Verified
+		if stageID == "cluster-lifecycle" {
+			stageReceipt, err = stagereceipt.NewWithTargetClusterUIDDigest(plan, stageID, predecessors, "SUCCEEDED", mutation, outcome, digest.SHA256([]byte("evidence-"+stageID)), runnerStageSHA("7"), at)
+		} else {
+			stageReceipt, err = stagereceipt.New(plan, stageID, predecessors, "SUCCEEDED", mutation, outcome, digest.SHA256([]byte("evidence-"+stageID)), at)
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		receiptDigest, err := stageReceipt.Digest()
+		if err != nil {
+			t.Fatal(err)
+		}
+		verified[receiptDigest] = stageReceipt
+		return stageReceipt, receiptDigest
+	}
+	staged := func(resume StageResumeConfig, stageID string) preRuntimeStagedInvocation {
+		return preRuntimeStagedInvocation{store: store, run: func(context.Context) (execution.StagedOperationReceipt, error) {
+			calls = append(calls, stageID)
+			_, receiptDigest := makeReceipt(resume, stageID)
+			return execution.StagedOperationReceipt{Format: execution.StagedReceiptFormat, State: "COMPLETED_SUCCEEDED", PlanDigest: base.plan.PlanDigest, StageID: stageID, StageReceiptDigest: receiptDigest}, nil
+		}}
+	}
+	observation := func(resume StageResumeConfig, stageID string) preRuntimeObservationInvocation {
+		return preRuntimeObservationInvocation{store: store, run: func(context.Context) (execution.ObservationStageRunReceipt, error) {
+			calls = append(calls, stageID)
+			_, receiptDigest := makeReceipt(resume, stageID)
+			return execution.ObservationStageRunReceipt{Format: execution.ObservationStageReceiptFormat, State: "COMPLETED_SUCCEEDED", PlanDigest: base.plan.PlanDigest, StageID: stageID, StageReceiptDigest: receiptDigest}, nil
+		}}
+	}
+	factories := preRuntimeExecutionFactories{
+		submission: func(resume StageResumeConfig, stageID string, _ StageAuthorizationSource, _ PreRuntimeExecutionConfig) (preRuntimeStagedInvocation, error) {
+			return staged(resume, stageID), nil
+		},
+		lifecycle: func(resume StageResumeConfig, _ PreRuntimeExecutionConfig) (preRuntimeObservationInvocation, error) {
+			return observation(resume, "lifecycle-observation"), nil
+		},
+		enablement: func(resume StageResumeConfig, _ StageAuthorizationSource, _ PreRuntimeExecutionConfig) (preRuntimeStagedInvocation, error) {
+			return staged(resume, "enablement"), nil
+		},
+		network: func(resume StageResumeConfig, _ PreRuntimeExecutionConfig) (preRuntimeObservationInvocation, error) {
+			return observation(resume, "network-observation"), nil
+		},
+		binding: func(resume StageResumeConfig, _ PreRuntimeExecutionConfig) (preRuntimeBindingInvocation, error) {
+			return preRuntimeBindingInvocation{store: store, run: func(context.Context) (execution.BindingStageRunReceipt, error) {
+				calls = append(calls, "runtime-binding")
+				_, receiptDigest := makeReceipt(resume, "runtime-binding")
+				return execution.BindingStageRunReceipt{Format: execution.BindingStageReceiptFormat, State: "COMPLETED_SUCCEEDED", PlanDigest: base.plan.PlanDigest, StageID: "runtime-binding", StageReceiptDigest: receiptDigest}, nil
+			}}, nil
+		},
+		target: func(resume StageResumeConfig, _ StageAuthorizationSource, _ PreRuntimeExecutionConfig) (preRuntimeStagedInvocation, error) {
+			return staged(resume, "target-access"), nil
+		},
+		persist: func(_ context.Context, _ StageResumeConfig, _ *ledger.Ledger, reference StageRunReceiptReference, path string) (StageReceiptSource, error) {
+			stageReceipt, ok := verified[reference.StageReceiptDigest]
+			if !ok {
+				return StageReceiptSource{}, errors.New("test receipt is unavailable")
+			}
+			raw, err := stageReceipt.Bytes()
+			if err != nil {
+				return StageReceiptSource{}, err
+			}
+			file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+			if err != nil {
+				return StageReceiptSource{}, err
+			}
+			if _, err = file.Write(raw); err != nil {
+				file.Close()
+				return StageReceiptSource{}, err
+			}
+			if err = file.Close(); err != nil {
+				return StageReceiptSource{}, err
+			}
+			return StageReceiptSource{Path: path, Digest: reference.StageReceiptDigest}, nil
+		},
+	}
+	return config, factories, &calls, &requests
+}
+
+func minInt(first, second int) int {
+	if first < second {
+		return first
+	}
+	return second
+}

--- a/internal/runner/stage_receipt_bridge.go
+++ b/internal/runner/stage_receipt_bridge.go
@@ -45,6 +45,13 @@ func ObservationStageReceiptReference(receipt execution.ObservationStageRunRecei
 	}
 }
 
+func BindingStageReceiptReference(receipt execution.BindingStageRunReceipt) StageRunReceiptReference {
+	return StageRunReceiptReference{
+		Format: receipt.Format, State: receipt.State, PlanDigest: receipt.PlanDigest,
+		StageID: receipt.StageID, StageReceiptDigest: receipt.StageReceiptDigest,
+	}
+}
+
 // LoadStageReceiptMaterial reads exactly one independently digest-bound,
 // already durable redaction-safe stage receipt. It never reconstructs private
 // credential material and performs no source-authority request.


### PR DESCRIPTION
## Summary

- compose the existing typed Stage 1-7 bundles behind one single-use PreRuntimeExecution adapter
- resolve mutation authorization only after the exact direct predecessor receipt is durable
- bridge every successful ledger receipt into a create-only private 0600 source and preserve completed checkpoints on bridge failure without replay
- expose the exact seven-receipt prefix required by the full-run seam
- document the narrowed remaining shared local/Job activation boundary

## Validation

- go test ./... -count=1
- go vet ./...
- go test -race ./internal/runner -run TestPreRuntimeExecution -count=1
- git diff --check

## Boundary

This checkpoint adds no CLI or Job mutation surface, renderer, policy authority, retry, rollback, cleanup, controller, or infrastructure mutation.