### PR TITLE
feat(runner): compose concrete full run

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -6,7 +6,7 @@ Contract planning and now models the complete twelve-stage bounded execution
 path, including separately authorized mutations, a durable ledger, bounded
 observation and evaluation components and offline Kubernetes workload
 packaging. The stages are now composed into a typed in-process Stage 1-7 prefix,
-a Stage 8-12 suffix and a receipt-bound, single-use full-run library seam. The
+a Stage 8-12 suffix and a receipt-bound, single-use full-run execution seam. The
 Stage 1-7 prefix and Stage 8-12 suffix both have concrete single-use execution
 adapters; only the post-runtime suffix currently has a bounded ephemeral Job
 activation path.
@@ -2798,6 +2798,16 @@ only the twelve ordered stage identities. A second invocation is rejected.
 This is an in-process composition seam only: it adds no renderer, dynamic
 writer, retry, rollback, cleanup, CLI command or Job mutation surface.
 
+The concrete full-run execution adapter now opens Stage 1-7 first and defers
+opening Stage 8-12 until all seven receipts are successful and durable. It
+loads the private prefix from the completed adapter, checks every private
+digest against the redaction-safe checkpoints and injects only that exact
+prefix into a fresh PostRuntimeExecution. A suffix carrying historical
+receipts or either recovery mode is rejected before the prefix opens. The
+existing full-run binding then independently compares the PostRuntimeExecution
+continuation identity before Stage 8 can run. The adapter is single-use and
+still has no manifest, CLI or Job activation surface.
+
 The accompanying receipt bridge can reload only the independently
 digest-bound, already durable public receipt selected by the current cursor.
 It writes canonical receipt bytes create-only as `0600` below an existing
@@ -2974,8 +2984,9 @@ covered by unit, negative, local TLS integration and race tests. Stage 1-7 and
 Stage 8-12 each have an exact, fail-closed in-process orchestration order and a
 concrete single-use execution adapter. The Stage 1-7 adapter dynamically binds
 its four mutation grants and persists all seven ledger-backed receipts before
-exposing its exact prefix. The full-run seam binds that prefix through the
-exact Plan and seven predecessor receipt digests. The Stage 8-12 suffix
+exposing its exact prefix. The concrete full-run execution injects that prefix
+into a fresh Stage 8-12 adapter, and the full-run seam independently binds it
+through the exact Plan and seven predecessor receipt digests. The Stage 8-12 suffix
 additionally has a local
 prepare/execute command, a bounded ephemeral Job, a deterministic private
 activation package, an exact installation plan and a single-use CLI launcher.
@@ -3000,8 +3011,8 @@ durable receipts. This is not yet the OK-147 Definition of Done:
   [ADR-030 amendment proposal](ok147-adr-030-amendment-proposal.md) are defined
   and remain to be reviewed with the live evidence.
 
-The remaining implementation work is to compose the concrete Stage 1-7 and
-Stage 8-12 adapters behind one shared local/Job activation surface; it is not a
+The remaining implementation work is a private full-run manifest plus the
+shared local/Job activation surface for this concrete composition; it is not a
 new controller or reconciliation mechanism. After that, live closure must
 publish the current image, construct fresh short-lived private inputs, run the
 exact bounded activation on `ok-mgmt`, preserve a stopped partial state without

--- a/internal/runner/full_run_execution.go
+++ b/internal/runner/full_run_execution.go
@@ -1,0 +1,135 @@
+package runner
+
+import (
+	"context"
+	"errors"
+
+	"github.com/openkubes/ok-cluster/internal/observation"
+	"github.com/openkubes/ok-cluster/internal/projection"
+)
+
+// FullRunExecutionConfig binds the two existing concrete execution adapters.
+// PostRuntime must not carry a historical receipt prefix or recovery mode: the
+// exact seven private sources are supplied only by the completed PreRuntime
+// execution in this same single-use run.
+type FullRunExecutionConfig struct {
+	PreRuntime  PreRuntimeExecutionConfig
+	PostRuntime PostRuntimeExecutionConfig
+}
+
+type fullRunPreRuntimeExecution interface {
+	Run(context.Context) (PreRuntimeExecutionReceipt, error)
+	ReceiptPrefix() ([]StageReceiptSource, error)
+}
+
+type fullRunExecutionFactories struct {
+	preRuntime  func(PreRuntimeExecutionConfig) (fullRunPreRuntimeExecution, error)
+	postRuntime func(PostRuntimeExecutionConfig) (PostRuntimeContinuation, error)
+}
+
+type concretePreRuntimeContinuation struct {
+	executor fullRunPreRuntimeExecution
+}
+
+// FullRunExecution is the concrete, single-use in-process composition of the
+// Stage 1-7 and Stage 8-12 adapters. It adds no CLI, Job, retry, rollback or
+// cleanup surface.
+type FullRunExecution struct {
+	orchestration *FullRunOrchestration
+}
+
+// OpenFullRunExecution performs bounded local opening of the Stage 1-7
+// adapter. The Stage 8-12 adapter is deliberately opened only after all seven
+// predecessor receipts have completed and become durable.
+func OpenFullRunExecution(config FullRunExecutionConfig) (*FullRunExecution, error) {
+	return openFullRunExecution(config, defaultFullRunExecutionFactories())
+}
+
+func openFullRunExecution(config FullRunExecutionConfig, factories fullRunExecutionFactories) (*FullRunExecution, error) {
+	if factories.preRuntime == nil || factories.postRuntime == nil {
+		return nil, errors.New("full-run execution factories are incomplete")
+	}
+	if config.PreRuntime.PlanPath == "" || config.PostRuntime.TargetCredential.PlanPath != config.PreRuntime.PlanPath ||
+		config.PostRuntime.TargetCredential.PlanExpected != config.PreRuntime.PlanExpected {
+		return nil, errors.New("full-run execution plan binding differs")
+	}
+	if len(config.PostRuntime.TargetCredential.Receipts) != 0 || config.PostRuntime.TargetCredentialRecovery != nil ||
+		config.PostRuntime.TargetRegistrationRecovery != nil {
+		return nil, errors.New("full-run execution requires a fresh unbound post-runtime suffix")
+	}
+
+	preRuntime, err := factories.preRuntime(config.PreRuntime)
+	if err != nil || preRuntime == nil {
+		return nil, errors.New("open full-run pre-runtime execution")
+	}
+	postRuntime := clonePostRuntimeExecutionConfigForFullRun(config.PostRuntime)
+	prefix := &concretePreRuntimeContinuation{executor: preRuntime}
+	orchestration := &FullRunOrchestration{
+		PreRuntime: prefix,
+		BindPostRuntime: func(completed PreRuntimeOrchestrationReceipt) (PostRuntimeContinuation, error) {
+			privatePrefix, prefixErr := preRuntime.ReceiptPrefix()
+			if prefixErr != nil || len(privatePrefix) != len(completed.Checkpoints) || len(privatePrefix) != len(preRuntimeStageOrder) {
+				return nil, errors.New("load full-run private receipt prefix")
+			}
+			for index := range privatePrefix {
+				if privatePrefix[index].Digest != completed.Checkpoints[index].StageReceiptDigest {
+					return nil, errors.New("full-run private receipt prefix differs from completed execution")
+				}
+			}
+			bound := clonePostRuntimeExecutionConfigForFullRun(postRuntime)
+			bound.TargetCredential.Receipts = append([]StageReceiptSource(nil), privatePrefix...)
+			continuation, openErr := factories.postRuntime(bound)
+			if openErr != nil || continuation == nil {
+				return nil, errors.New("open full-run post-runtime execution")
+			}
+			return continuation, nil
+		},
+	}
+	return &FullRunExecution{orchestration: orchestration}, nil
+}
+
+func (execution *FullRunExecution) Run(ctx context.Context) (FullRunOrchestrationReceipt, error) {
+	if execution == nil || execution.orchestration == nil {
+		receipt := FullRunOrchestrationReceipt{
+			Format: FullRunOrchestrationReceiptFormat, State: "RUNNING", Checkpoints: []FullRunStageCheckpoint{},
+		}
+		return stopFullRunOrchestration(receipt, fullRunOrchestrationInitialStoppedStage)
+	}
+	return execution.orchestration.Run(ctx)
+}
+
+func (continuation *concretePreRuntimeContinuation) Run(ctx context.Context) (PreRuntimeOrchestrationReceipt, error) {
+	if continuation == nil || continuation.executor == nil {
+		return PreRuntimeOrchestrationReceipt{}, errors.New("concrete pre-runtime execution is unavailable")
+	}
+	receipt, err := continuation.executor.Run(ctx)
+	converted := PreRuntimeOrchestrationReceipt{
+		Format: receipt.Format, State: receipt.State, PlanDigest: receipt.PlanDigest, StoppedAt: receipt.StoppedAt,
+		Checkpoints: append([]PreRuntimeStageCheckpoint(nil), receipt.Checkpoints...),
+	}
+	if receipt.Format == PreRuntimeExecutionReceiptFormat {
+		converted.Format = PreRuntimeOrchestrationReceiptFormat
+	}
+	return converted, err
+}
+
+func defaultFullRunExecutionFactories() fullRunExecutionFactories {
+	return fullRunExecutionFactories{
+		preRuntime: func(config PreRuntimeExecutionConfig) (fullRunPreRuntimeExecution, error) {
+			return OpenPreRuntimeExecution(config)
+		},
+		postRuntime: func(config PostRuntimeExecutionConfig) (PostRuntimeContinuation, error) {
+			return OpenPostRuntimeExecution(config)
+		},
+	}
+}
+
+func clonePostRuntimeExecutionConfigForFullRun(config PostRuntimeExecutionConfig) PostRuntimeExecutionConfig {
+	config.TargetCredential.Receipts = append([]StageReceiptSource(nil), config.TargetCredential.Receipts...)
+	config.TargetCredential.TargetAccessExpectedObjects = append([]projection.ResourceIdentity(nil), config.TargetCredential.TargetAccessExpectedObjects...)
+	config.TargetRegistration.Expected.TargetNamespaces = append([]string(nil), config.TargetRegistration.Expected.TargetNamespaces...)
+	config.PlatformApplications.Expected.Profile.RequiredApplications = append([]observation.PlatformApplicationExpectation(nil), config.PlatformApplications.Expected.Profile.RequiredApplications...)
+	config.PlatformObservation.Profile.RequiredApplications = append([]observation.PlatformApplicationExpectation(nil), config.PlatformObservation.Profile.RequiredApplications...)
+	config.AggregateEvidence.Profile.Required = append([]string(nil), config.AggregateEvidence.Profile.Required...)
+	return config
+}

--- a/internal/runner/full_run_execution_test.go
+++ b/internal/runner/full_run_execution_test.go
@@ -1,0 +1,204 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+)
+
+type fakeConcretePreRuntimeExecution struct {
+	receipt     PreRuntimeExecutionReceipt
+	prefix      []StageReceiptSource
+	runErr      error
+	prefixErr   error
+	runs        int
+	prefixCalls int
+}
+
+func (execution *fakeConcretePreRuntimeExecution) Run(context.Context) (PreRuntimeExecutionReceipt, error) {
+	execution.runs++
+	return execution.receipt, execution.runErr
+}
+
+func (execution *fakeConcretePreRuntimeExecution) ReceiptPrefix() ([]StageReceiptSource, error) {
+	execution.prefixCalls++
+	return append([]StageReceiptSource(nil), execution.prefix...), execution.prefixErr
+}
+
+func TestFullRunExecutionComposesConcreteAdaptersWithExactPrivatePrefix(t *testing.T) {
+	preRuntime := successfulFakeConcretePreRuntimeExecution(t)
+	postRuntime := successfulFakePostRuntimeContinuation()
+	postCalls := 0
+	config := testFullRunExecutionConfig()
+	execution, err := openFullRunExecution(config, fullRunExecutionFactories{
+		preRuntime: func(PreRuntimeExecutionConfig) (fullRunPreRuntimeExecution, error) {
+			return preRuntime, nil
+		},
+		postRuntime: func(bound PostRuntimeExecutionConfig) (PostRuntimeContinuation, error) {
+			postCalls++
+			if preRuntime.runs != 1 || preRuntime.prefixCalls != 1 || !reflect.DeepEqual(bound.TargetCredential.Receipts, preRuntime.prefix) {
+				t.Fatalf("post-runtime suffix did not receive the completed private prefix: %#v", bound.TargetCredential.Receipts)
+			}
+			return postRuntime, nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := execution.Run(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if receipt.Format != FullRunOrchestrationReceiptFormat || receipt.State != "SUCCEEDED" || len(receipt.Checkpoints) != 12 ||
+		preRuntime.runs != 1 || preRuntime.prefixCalls != 1 || postCalls != 1 || postRuntime.calls.Load() != 1 {
+		t.Fatalf("unexpected concrete full-run result: %#v pre=%d prefix=%d post=%d suffix=%d", receipt, preRuntime.runs, preRuntime.prefixCalls, postCalls, postRuntime.calls.Load())
+	}
+	if second, secondErr := execution.Run(context.Background()); secondErr == nil || second.State != "STOPPED" ||
+		preRuntime.runs != 1 || postCalls != 1 || postRuntime.calls.Load() != 1 {
+		t.Fatalf("concrete full-run execution was replayed: %#v err=%v", second, secondErr)
+	}
+}
+
+func TestFullRunExecutionRunsRealPreRuntimeAdapterBeforeOpeningSuffix(t *testing.T) {
+	preConfig, preFactories, calls, _ := preRuntimeExecutionFixture(t)
+	config := FullRunExecutionConfig{PreRuntime: preConfig}
+	config.PostRuntime.TargetCredential.PlanPath = preConfig.PlanPath
+	config.PostRuntime.TargetCredential.PlanExpected = preConfig.PlanExpected
+	postCalls := 0
+	execution, err := openFullRunExecution(config, fullRunExecutionFactories{
+		preRuntime: func(config PreRuntimeExecutionConfig) (fullRunPreRuntimeExecution, error) {
+			return openPreRuntimeExecution(config, preFactories)
+		},
+		postRuntime: func(bound PostRuntimeExecutionConfig) (PostRuntimeContinuation, error) {
+			postCalls++
+			plan, _, prefix, loadErr := loadStageResumeWithPrefix(StageResumeConfig{
+				PlanPath: bound.TargetCredential.PlanPath, PlanExpected: bound.TargetCredential.PlanExpected,
+				Receipts: bound.TargetCredential.Receipts,
+			})
+			if loadErr != nil {
+				t.Fatal(loadErr)
+			}
+			binding, bindErr := newPostRuntimeContinuationBinding(plan.PlanDigest, prefix)
+			if bindErr != nil {
+				t.Fatal(bindErr)
+			}
+			continuation := successfulFakePostRuntimeContinuation()
+			continuation.binding = binding
+			continuation.receipt.PlanDigest = binding.PlanDigest
+			return continuation, nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := execution.Run(context.Background())
+	if err != nil || receipt.State != "SUCCEEDED" || len(receipt.Checkpoints) != 12 ||
+		!reflect.DeepEqual(*calls, preRuntimeStageOrder) || postCalls != 1 {
+		t.Fatalf("real pre-runtime adapter did not compose: %#v calls=%v post=%d err=%v", receipt, *calls, postCalls, err)
+	}
+}
+
+func TestFullRunExecutionDoesNotOpenSuffixAfterStoppedPrefix(t *testing.T) {
+	preRuntime := successfulFakeConcretePreRuntimeExecution(t)
+	preRuntime.receipt.State = "STOPPED"
+	preRuntime.receipt.StoppedAt = "enablement"
+	preRuntime.receipt.Checkpoints = preRuntime.receipt.Checkpoints[:3]
+	preRuntime.runErr = errors.New("private prefix failure")
+	postCalls := 0
+	execution, err := openFullRunExecution(testFullRunExecutionConfig(), fullRunExecutionFactories{
+		preRuntime: func(PreRuntimeExecutionConfig) (fullRunPreRuntimeExecution, error) { return preRuntime, nil },
+		postRuntime: func(PostRuntimeExecutionConfig) (PostRuntimeContinuation, error) {
+			postCalls++
+			return successfulFakePostRuntimeContinuation(), nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := execution.Run(context.Background())
+	if err == nil || receipt.State != "STOPPED" || receipt.StoppedAt != "enablement" || len(receipt.Checkpoints) != 3 ||
+		preRuntime.prefixCalls != 0 || postCalls != 0 {
+		t.Fatalf("stopped concrete prefix opened the suffix: %#v prefix=%d post=%d err=%v", receipt, preRuntime.prefixCalls, postCalls, err)
+	}
+}
+
+func TestFullRunExecutionRejectsPrivatePrefixDifferentFromPublicCheckpoints(t *testing.T) {
+	preRuntime := successfulFakeConcretePreRuntimeExecution(t)
+	preRuntime.prefix[6].Digest = runnerStageSHA("f")
+	postCalls := 0
+	execution, err := openFullRunExecution(testFullRunExecutionConfig(), fullRunExecutionFactories{
+		preRuntime: func(PreRuntimeExecutionConfig) (fullRunPreRuntimeExecution, error) { return preRuntime, nil },
+		postRuntime: func(PostRuntimeExecutionConfig) (PostRuntimeContinuation, error) {
+			postCalls++
+			return successfulFakePostRuntimeContinuation(), nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := execution.Run(context.Background())
+	if err == nil || receipt.State != "STOPPED" || receipt.StoppedAt != "target-credential" || len(receipt.Checkpoints) != 7 || postCalls != 0 {
+		t.Fatalf("foreign private prefix opened the suffix: %#v post=%d err=%v", receipt, postCalls, err)
+	}
+}
+
+func TestOpenFullRunExecutionRejectsHistoricalSuffixState(t *testing.T) {
+	for name, mutate := range map[string]func(*FullRunExecutionConfig){
+		"prebound receipts": func(config *FullRunExecutionConfig) {
+			config.PostRuntime.TargetCredential.Receipts = []StageReceiptSource{{Path: "/private/receipt.json", Digest: runnerStageSHA("1")}}
+		},
+		"credential recovery": func(config *FullRunExecutionConfig) {
+			config.PostRuntime.TargetCredentialRecovery = &PostRuntimeTargetCredentialRecoveryConfig{}
+		},
+		"registration recovery": func(config *FullRunExecutionConfig) {
+			config.PostRuntime.TargetRegistrationRecovery = &PostRuntimeTargetRegistrationRecoveryConfig{}
+		},
+		"foreign plan": func(config *FullRunExecutionConfig) {
+			config.PostRuntime.TargetCredential.PlanPath = "/private/foreign-plan.json"
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			config := testFullRunExecutionConfig()
+			mutate(&config)
+			preCalls := 0
+			if _, err := openFullRunExecution(config, fullRunExecutionFactories{
+				preRuntime: func(PreRuntimeExecutionConfig) (fullRunPreRuntimeExecution, error) {
+					preCalls++
+					return successfulFakeConcretePreRuntimeExecution(t), nil
+				},
+				postRuntime: func(PostRuntimeExecutionConfig) (PostRuntimeContinuation, error) {
+					return successfulFakePostRuntimeContinuation(), nil
+				},
+			}); err == nil || preCalls != 0 {
+				t.Fatalf("unsafe full-run suffix was accepted: preCalls=%d err=%v", preCalls, err)
+			}
+		})
+	}
+}
+
+func successfulFakeConcretePreRuntimeExecution(t *testing.T) *fakeConcretePreRuntimeExecution {
+	t.Helper()
+	orchestrationReceipt, err := successfulPreRuntimeOrchestration(nil).Run(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt := PreRuntimeExecutionReceipt{
+		Format: PreRuntimeExecutionReceiptFormat, State: orchestrationReceipt.State, PlanDigest: orchestrationReceipt.PlanDigest,
+		StoppedAt: orchestrationReceipt.StoppedAt, Checkpoints: append([]PreRuntimeStageCheckpoint(nil), orchestrationReceipt.Checkpoints...),
+		ResolvedAuthorizations: []ResolvedStageAuthorizationReceipt{},
+	}
+	prefix := make([]StageReceiptSource, len(receipt.Checkpoints))
+	for index, checkpoint := range receipt.Checkpoints {
+		prefix[index] = StageReceiptSource{Path: "/private/" + checkpoint.StageID + ".json", Digest: checkpoint.StageReceiptDigest}
+	}
+	return &fakeConcretePreRuntimeExecution{receipt: receipt, prefix: prefix}
+}
+
+func testFullRunExecutionConfig() FullRunExecutionConfig {
+	config := FullRunExecutionConfig{}
+	config.PreRuntime.PlanPath = "/private/ok147-plan.json"
+	config.PostRuntime.TargetCredential.PlanPath = config.PreRuntime.PlanPath
+	config.PostRuntime.TargetCredential.PlanExpected = config.PreRuntime.PlanExpected
+	return config
+}

--- a/internal/runner/full_run_orchestrator.go
+++ b/internal/runner/full_run_orchestrator.go
@@ -48,12 +48,18 @@ type PostRuntimeContinuation interface {
 	Run(context.Context) (PostRuntimeExecutionReceipt, error)
 }
 
+// PreRuntimeContinuation is the redaction-safe prefix seam. Both the typed
+// orchestration and the concrete Stage 1-7 execution adapter can satisfy it.
+type PreRuntimeContinuation interface {
+	Run(context.Context) (PreRuntimeOrchestrationReceipt, error)
+}
+
 // FullRunOrchestration composes the exact Stage 1-7 prefix with one
 // receipt-bound Stage 8-12 continuation. BindPostRuntime may open private
 // runtime material but must not execute a stage; the returned binding is
 // independently checked before Run.
 type FullRunOrchestration struct {
-	PreRuntime      PreRuntimeOrchestration
+	PreRuntime      PreRuntimeContinuation
 	BindPostRuntime func(PreRuntimeOrchestrationReceipt) (PostRuntimeContinuation, error)
 
 	mu   sync.Mutex
@@ -78,7 +84,7 @@ func (orchestration *FullRunOrchestration) Run(ctx context.Context) (FullRunOrch
 	}
 	orchestration.used = true
 	orchestration.mu.Unlock()
-	if orchestration.BindPostRuntime == nil {
+	if orchestration.PreRuntime == nil || orchestration.BindPostRuntime == nil {
 		return stopFullRunOrchestration(receipt, fullRunOrchestrationInitialStoppedStage)
 	}
 	if err := ctx.Err(); err != nil {


### PR DESCRIPTION
## Summary

- compose the concrete Stage 1-7 and Stage 8-12 adapters behind one single-use in-process full-run execution
- defer opening the suffix until the seven predecessor receipts are successful and durable
- require exact equality between private receipt sources and redaction-safe prefix checkpoints
- reject prebound historical receipt prefixes and recovery modes before Stage 1 opens
- document the remaining private manifest and shared local/Job activation boundary

## Validation

- go test ./... -count=1
- go vet ./...
- go test -race ./internal/runner -run TestFullRunExecution|TestFullRunOrchestration -count=1
- git diff --check

## Boundary

This checkpoint adds no manifest, CLI or Job mutation surface, renderer, retry, rollback, cleanup, controller, credential persistence or infrastructure mutation.