### PR TITLE
fix(runner): close private runtime binding handoff

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -2977,17 +2977,30 @@ opening the installer credential. It then invokes the single-use three-create
 launcher in a bounded context. This completes the offline and fake-API
 activation implementation; it does not itself prove a live DEV Job run.
 
+The concrete Stage 6 to Stage 8 private handoff is now closed as well. Stage 6
+creates the canonical runtime material first, then the Stage 1-7 adapter reads
+the material receipt directly from that exact opened binding operation,
+re-verifies it against the canonical private bytes and current Plan, and writes
+the receipt create-only as a distinct `0600` file. Only after both private
+files exist does the adapter persist the public Stage-6 ledger receipt and
+open Stage 7. The full-run composition requires the Stage 8-12 material and
+receipt paths to equal those exact Stage 1-7 destinations. A missing,
+pre-existing, non-canonical, changed or foreign handoff stops at Stage 6; it
+cannot open target access or the post-runtime suffix. Neither private file is
+part of public evidence.
+
 ## Current OK-147 implementation boundary
 
 The twelve-stage Go library and its durable replay semantics are complete and
 covered by unit, negative, local TLS integration and race tests. Stage 1-7 and
 Stage 8-12 each have an exact, fail-closed in-process orchestration order and a
 concrete single-use execution adapter. The Stage 1-7 adapter dynamically binds
-its four mutation grants and persists all seven ledger-backed receipts before
-exposing its exact prefix. The concrete full-run execution injects that prefix
-into a fresh Stage 8-12 adapter, and the full-run seam independently binds it
-through the exact Plan and seven predecessor receipt digests. The Stage 8-12 suffix
-additionally has a local
+its four mutation grants, persists the private runtime material and matching
+receipt, and persists all seven ledger-backed receipts before exposing its
+exact prefix. The concrete full-run execution injects that prefix into a fresh
+Stage 8-12 adapter, and the full-run seam independently binds it through the
+exact Plan, private runtime handoff paths and seven predecessor receipt
+digests. The Stage 8-12 suffix additionally has a local
 prepare/execute command, a bounded ephemeral Job, a deterministic private
 activation package, an exact installation plan and a single-use CLI launcher.
 Successful Stage-8 and Stage-9 crash boundaries can be reactivated through the

--- a/internal/runner/full_run_execution.go
+++ b/internal/runner/full_run_execution.go
@@ -53,6 +53,11 @@ func openFullRunExecution(config FullRunExecutionConfig, factories fullRunExecut
 		config.PostRuntime.TargetCredential.PlanExpected != config.PreRuntime.PlanExpected {
 		return nil, errors.New("full-run execution plan binding differs")
 	}
+	if config.PreRuntime.RuntimeBinding.OutputPath == "" || config.PreRuntime.RuntimeBindingReceiptPath == "" ||
+		config.PostRuntime.RuntimeBinding.MaterialPath != config.PreRuntime.RuntimeBinding.OutputPath ||
+		config.PostRuntime.RuntimeBinding.ReceiptPath != config.PreRuntime.RuntimeBindingReceiptPath {
+		return nil, errors.New("full-run runtime binding handoff differs")
+	}
 	if len(config.PostRuntime.TargetCredential.Receipts) != 0 || config.PostRuntime.TargetCredentialRecovery != nil ||
 		config.PostRuntime.TargetRegistrationRecovery != nil {
 		return nil, errors.New("full-run execution requires a fresh unbound post-runtime suffix")

--- a/internal/runner/full_run_execution_test.go
+++ b/internal/runner/full_run_execution_test.go
@@ -65,6 +65,8 @@ func TestFullRunExecutionRunsRealPreRuntimeAdapterBeforeOpeningSuffix(t *testing
 	config := FullRunExecutionConfig{PreRuntime: preConfig}
 	config.PostRuntime.TargetCredential.PlanPath = preConfig.PlanPath
 	config.PostRuntime.TargetCredential.PlanExpected = preConfig.PlanExpected
+	config.PostRuntime.RuntimeBinding.MaterialPath = preConfig.RuntimeBinding.OutputPath
+	config.PostRuntime.RuntimeBinding.ReceiptPath = preConfig.RuntimeBindingReceiptPath
 	postCalls := 0
 	execution, err := openFullRunExecution(config, fullRunExecutionFactories{
 		preRuntime: func(config PreRuntimeExecutionConfig) (fullRunPreRuntimeExecution, error) {
@@ -157,6 +159,12 @@ func TestOpenFullRunExecutionRejectsHistoricalSuffixState(t *testing.T) {
 		"foreign plan": func(config *FullRunExecutionConfig) {
 			config.PostRuntime.TargetCredential.PlanPath = "/private/foreign-plan.json"
 		},
+		"foreign runtime material": func(config *FullRunExecutionConfig) {
+			config.PostRuntime.RuntimeBinding.MaterialPath = "/private/foreign-runtime.json"
+		},
+		"foreign runtime receipt": func(config *FullRunExecutionConfig) {
+			config.PostRuntime.RuntimeBinding.ReceiptPath = "/private/foreign-runtime-receipt.json"
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			config := testFullRunExecutionConfig()
@@ -198,7 +206,11 @@ func successfulFakeConcretePreRuntimeExecution(t *testing.T) *fakeConcretePreRun
 func testFullRunExecutionConfig() FullRunExecutionConfig {
 	config := FullRunExecutionConfig{}
 	config.PreRuntime.PlanPath = "/private/ok147-plan.json"
+	config.PreRuntime.RuntimeBinding.OutputPath = "/private/runtime-binding.json"
+	config.PreRuntime.RuntimeBindingReceiptPath = "/private/runtime-binding-receipt.json"
 	config.PostRuntime.TargetCredential.PlanPath = config.PreRuntime.PlanPath
 	config.PostRuntime.TargetCredential.PlanExpected = config.PreRuntime.PlanExpected
+	config.PostRuntime.RuntimeBinding.MaterialPath = config.PreRuntime.RuntimeBinding.OutputPath
+	config.PostRuntime.RuntimeBinding.ReceiptPath = config.PreRuntime.RuntimeBindingReceiptPath
 	return config
 }

--- a/internal/runner/pre_runtime_execution.go
+++ b/internal/runner/pre_runtime_execution.go
@@ -40,19 +40,20 @@ type PreRuntimeTargetAccessExecutionConfig struct {
 // capabilities for Stage 1-7. Mutating grants are resolved only after the
 // exact direct predecessor receipt is durable.
 type PreRuntimeExecutionConfig struct {
-	PlanPath               string
-	PlanExpected           stageplan.Expected
-	ProjectionManifestPath string
-	ProjectionRoot         string
-	Authorization          StageAuthorizationResolver
-	ProviderPrerequisites  SubmissionStageRuntimeConfig
-	ClusterLifecycle       SubmissionStageRuntimeConfig
-	LifecycleObservation   LifecycleObservationStageRuntimeConfig
-	Enablement             PreRuntimeEnablementExecutionConfig
-	NetworkObservation     NetworkObservationStageRuntimeConfig
-	RuntimeBinding         RuntimeBindingStageRuntimeConfig
-	TargetAccess           PreRuntimeTargetAccessExecutionConfig
-	ReceiptDirectory       string
+	PlanPath                  string
+	PlanExpected              stageplan.Expected
+	ProjectionManifestPath    string
+	ProjectionRoot            string
+	Authorization             StageAuthorizationResolver
+	ProviderPrerequisites     SubmissionStageRuntimeConfig
+	ClusterLifecycle          SubmissionStageRuntimeConfig
+	LifecycleObservation      LifecycleObservationStageRuntimeConfig
+	Enablement                PreRuntimeEnablementExecutionConfig
+	NetworkObservation        NetworkObservationStageRuntimeConfig
+	RuntimeBinding            RuntimeBindingStageRuntimeConfig
+	RuntimeBindingReceiptPath string
+	TargetAccess              PreRuntimeTargetAccessExecutionConfig
+	ReceiptDirectory          string
 }
 
 type PreRuntimeExecutionReceipt struct {
@@ -75,8 +76,9 @@ type preRuntimeObservationInvocation struct {
 }
 
 type preRuntimeBindingInvocation struct {
-	run   func(context.Context) (execution.BindingStageRunReceipt, error)
-	store *ledger.Ledger
+	run             func(context.Context) (execution.BindingStageRunReceipt, error)
+	materialReceipt func() (RuntimeBindingMaterialReceipt, error)
+	store           *ledger.Ledger
 }
 
 type preRuntimeExecutionFactories struct {
@@ -123,6 +125,11 @@ func openPreRuntimeExecution(config PreRuntimeExecutionConfig, factories preRunt
 		if !ok || validateRuntimeBindingOutputPath(filepath.Join(config.ReceiptDirectory, name)) != nil {
 			return nil, errors.New("pre-runtime receipt destination is invalid")
 		}
+	}
+	if config.RuntimeBinding.OutputPath == config.RuntimeBindingReceiptPath ||
+		validateRuntimeBindingOutputPath(config.RuntimeBinding.OutputPath) != nil ||
+		validateRuntimeBindingOutputPath(config.RuntimeBindingReceiptPath) != nil {
+		return nil, errors.New("pre-runtime binding handoff destination is invalid")
 	}
 	config.TargetAccess.ExpectedObjects = append([]projection.ResourceIdentity(nil), config.TargetAccess.ExpectedObjects...)
 	return &PreRuntimeExecution{config: config, initial: initial, factories: factories}, nil
@@ -245,12 +252,24 @@ func (executor *PreRuntimeExecution) Run(ctx context.Context) (PreRuntimeExecuti
 	}
 	orchestration.RunRuntimeBinding = func(ctx context.Context, _ execution.ObservationStageRunReceipt) (execution.BindingStageRunReceipt, error) {
 		invocation, err := executor.factories.binding(executor.resume(receipts), executor.config)
-		if err != nil || invocation.run == nil || invocation.store == nil {
+		if err != nil || invocation.run == nil || invocation.materialReceipt == nil || invocation.store == nil {
 			return execution.BindingStageRunReceipt{}, errors.New("open runtime-binding stage")
 		}
 		run, err := invocation.run(ctx)
 		if err != nil {
 			return run, err
+		}
+		materialReceipt, err := invocation.materialReceipt()
+		if err != nil {
+			return run, errors.New("read runtime-binding material receipt")
+		}
+		if err := persistRuntimeBindingMaterialReceipt(
+			materialReceipt,
+			executor.config.RuntimeBinding.OutputPath,
+			executor.config.RuntimeBindingReceiptPath,
+			run.PlanDigest,
+		); err != nil {
+			return run, errors.New("persist runtime-binding material receipt")
 		}
 		return run, persist(ctx, invocation.store, BindingStageReceiptReference(run))
 	}
@@ -377,7 +396,16 @@ func defaultPreRuntimeExecutionFactories() preRuntimeExecutionFactories {
 			if err != nil {
 				return preRuntimeBindingInvocation{}, err
 			}
-			return preRuntimeBindingInvocation{run: opened.Run, store: opened.operation.Ledger}, nil
+			return preRuntimeBindingInvocation{
+				run: opened.Run, materialReceipt: func() (RuntimeBindingMaterialReceipt, error) {
+					evidence, evidenceErr := opened.EvidenceReceipt()
+					if evidenceErr != nil || evidence.State != "SUCCEEDED" || evidence.Material == nil {
+						return RuntimeBindingMaterialReceipt{}, errors.New("runtime-binding material evidence is unavailable")
+					}
+					return *evidence.Material, nil
+				},
+				store: opened.operation.Ledger,
+			}, nil
 		},
 		target: func(resume StageResumeConfig, grant StageAuthorizationSource, config PreRuntimeExecutionConfig) (preRuntimeStagedInvocation, error) {
 			bundle, err := LoadTargetAccessStageBundle(TargetAccessStageBundleConfig{

--- a/internal/runner/pre_runtime_execution_test.go
+++ b/internal/runner/pre_runtime_execution_test.go
@@ -49,6 +49,18 @@ func TestPreRuntimeExecutionComposesExactPrefixWithDynamicAuthorization(t *testi
 			t.Fatalf("receipt %s was not persisted privately: %#v %v", stageID, info, statErr)
 		}
 	}
+	for _, path := range []string{config.RuntimeBinding.OutputPath, config.RuntimeBindingReceiptPath} {
+		info, statErr := os.Lstat(path)
+		if statErr != nil || !info.Mode().IsRegular() || info.Mode().Perm() != 0o600 {
+			t.Fatalf("runtime binding handoff was not persisted privately: %s %#v %v", path, info, statErr)
+		}
+	}
+	if _, err := LoadRuntimeBindingMaterialFiles(RuntimeBindingMaterialFileConfig{
+		Bundle:       StageResumeConfig{PlanPath: config.PlanPath, PlanExpected: config.PlanExpected, Receipts: mustReceiptPrefix(t, executor)},
+		MaterialPath: config.RuntimeBinding.OutputPath, ReceiptPath: config.RuntimeBindingReceiptPath,
+	}); err != nil {
+		t.Fatalf("completed runtime binding handoff is not replayable: %v", err)
+	}
 	prefix, err := executor.ReceiptPrefix()
 	if err != nil || len(prefix) != 7 {
 		t.Fatalf("completed private prefix is unavailable: %#v %v", prefix, err)
@@ -62,7 +74,10 @@ func TestPreRuntimeExecutionComposesExactPrefixWithDynamicAuthorization(t *testi
 		t.Fatalf("single-use executor ran twice: %#v calls=%v err=%v", second, *calls, err)
 	}
 	public := mustJSON(t, receipt)
-	for _, forbidden := range []string{config.ReceiptDirectory, "token", "endpoint", "kubeconfig"} {
+	for _, forbidden := range []string{
+		config.ReceiptDirectory, config.RuntimeBinding.OutputPath, config.RuntimeBindingReceiptPath,
+		"token", "endpoint", "kubeconfig",
+	} {
 		if strings.Contains(string(public), forbidden) {
 			t.Fatalf("public pre-runtime receipt exposed %q", forbidden)
 		}
@@ -116,6 +131,39 @@ func TestPreRuntimeExecutionStopsWithoutReplayWhenReceiptPersistenceFails(t *tes
 	}
 }
 
+func TestPreRuntimeExecutionStopsAfterStageSixWhenMaterialReceiptDiffers(t *testing.T) {
+	config, factories, calls, _ := preRuntimeExecutionFixture(t)
+	original := factories.binding
+	factories.binding = func(resume StageResumeConfig, config PreRuntimeExecutionConfig) (preRuntimeBindingInvocation, error) {
+		invocation, err := original(resume, config)
+		if err != nil {
+			return preRuntimeBindingInvocation{}, err
+		}
+		valid := invocation.materialReceipt
+		invocation.materialReceipt = func() (RuntimeBindingMaterialReceipt, error) {
+			receipt, receiptErr := valid()
+			receipt.PrivateMaterialDigest = runnerStageSHA("f")
+			return receipt, receiptErr
+		}
+		return invocation, nil
+	}
+	executor, err := openPreRuntimeExecution(config, factories)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := executor.Run(context.Background())
+	if err == nil || receipt.State != "STOPPED" || receipt.StoppedAt != "runtime-binding" || len(receipt.Checkpoints) != 6 ||
+		!reflect.DeepEqual(*calls, preRuntimeStageOrder[:6]) {
+		t.Fatalf("material-receipt mismatch crossed Stage 6: %#v calls=%v err=%v", receipt, *calls, err)
+	}
+	if _, statErr := os.Lstat(config.RuntimeBindingReceiptPath); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("invalid material receipt was persisted: %v", statErr)
+	}
+	if _, statErr := os.Lstat(filepath.Join(config.ReceiptDirectory, preRuntimeReceiptFiles["runtime-binding"])); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("public Stage-6 receipt crossed failed private handoff: %v", statErr)
+	}
+}
+
 func TestOpenPreRuntimeExecutionRejectsUnsafeReceiptDestination(t *testing.T) {
 	config, factories, calls, _ := preRuntimeExecutionFixture(t)
 	if err := os.Chmod(config.ReceiptDirectory, 0o755); err != nil {
@@ -160,6 +208,12 @@ func preRuntimeExecutionFixture(t *testing.T) (PreRuntimeExecutionConfig, preRun
 		ProjectionManifestPath: base.config.ProjectionManifestPath, ProjectionRoot: base.config.ProjectionRoot,
 		Authorization: resolver, ReceiptDirectory: receiptDirectory,
 	}
+	runtimeDirectory := t.TempDir()
+	if err := os.Chmod(runtimeDirectory, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	config.RuntimeBinding.OutputPath = filepath.Join(runtimeDirectory, "runtime-binding.json")
+	config.RuntimeBindingReceiptPath = filepath.Join(runtimeDirectory, "runtime-binding-receipt.json")
 	store := &ledger.Ledger{}
 	verified := map[string]stagereceipt.Verified{}
 	makeReceipt := func(resume StageResumeConfig, stageID string) (stagereceipt.Verified, string) {
@@ -178,7 +232,7 @@ func preRuntimeExecutionFixture(t *testing.T) (PreRuntimeExecutionConfig, preRun
 		at := time.Date(2026, 8, 18, 8, len(resume.Receipts), 0, 0, time.UTC)
 		var stageReceipt stagereceipt.Verified
 		if stageID == "cluster-lifecycle" {
-			stageReceipt, err = stagereceipt.NewWithTargetClusterUIDDigest(plan, stageID, predecessors, "SUCCEEDED", mutation, outcome, digest.SHA256([]byte("evidence-"+stageID)), runnerStageSHA("7"), at)
+			stageReceipt, err = stagereceipt.NewWithTargetClusterUIDDigest(plan, stageID, predecessors, "SUCCEEDED", mutation, outcome, digest.SHA256([]byte("evidence-"+stageID)), digest.SHA256([]byte("11111111-1111-4111-8111-111111111111")), at)
 		} else {
 			stageReceipt, err = stagereceipt.New(plan, stageID, predecessors, "SUCCEEDED", mutation, outcome, digest.SHA256([]byte("evidence-"+stageID)), at)
 		}
@@ -219,11 +273,53 @@ func preRuntimeExecutionFixture(t *testing.T) (PreRuntimeExecutionConfig, preRun
 		network: func(resume StageResumeConfig, _ PreRuntimeExecutionConfig) (preRuntimeObservationInvocation, error) {
 			return observation(resume, "network-observation"), nil
 		},
-		binding: func(resume StageResumeConfig, _ PreRuntimeExecutionConfig) (preRuntimeBindingInvocation, error) {
+		binding: func(resume StageResumeConfig, config PreRuntimeExecutionConfig) (preRuntimeBindingInvocation, error) {
+			var materialReceipt RuntimeBindingMaterialReceipt
 			return preRuntimeBindingInvocation{store: store, run: func(context.Context) (execution.BindingStageRunReceipt, error) {
 				calls = append(calls, "runtime-binding")
+				plan, _, prefix, err := loadStageResumeWithPrefix(resume)
+				if err != nil {
+					return execution.BindingStageRunReceipt{}, err
+				}
+				lifecycle, err := prefix[1].Receipt()
+				if err != nil {
+					return execution.BindingStageRunReceipt{}, err
+				}
+				network, err := prefix[4].Receipt()
+				if err != nil {
+					return execution.BindingStageRunReceipt{}, err
+				}
+				material := RuntimeBindingMaterial{
+					Format: RuntimeBindingMaterialFormat, State: "CURRENT_RUNTIME_BOUND", PlanDigest: plan.PlanDigest,
+					IntentRevision: plan.IntentRevision, EnablementRevision: plan.EnablementRevision,
+					PlatformRevision: plan.PlatformRevision, ExecutionFixture: plan.ExecutionFixture,
+					Target: RuntimeBindingTarget{
+						Name: plan.ContractIdentity.Name, CAPIClusterUID: "11111111-1111-4111-8111-111111111111",
+						TargetIdentityScheme: "capi-cluster-uid", WorkloadAPIEndpoint: "https://runtime.invalid:6443",
+						WorkloadAPICAData: "Y2E=", WorkloadAPICADigest: runnerStageSHA("a"),
+						KubeSystemUID: "22222222-2222-4222-8222-222222222222",
+					},
+					Storage:  RuntimeBindingStorage{Name: "local-path", UID: "33333333-3333-4333-8333-333333333333", Provisioner: "rancher.io/local-path"},
+					Evidence: RuntimeBindingEvidence{LifecycleEvidenceDigest: lifecycle.EvidenceDigest, NetworkEvidenceDigest: network.EvidenceDigest},
+				}
+				raw, err := canonicalRuntimeBinding(material)
+				if err != nil {
+					return execution.BindingStageRunReceipt{}, err
+				}
+				if err := os.WriteFile(config.RuntimeBinding.OutputPath, raw, 0o600); err != nil {
+					return execution.BindingStageRunReceipt{}, err
+				}
+				materialReceipt = RuntimeBindingMaterialReceipt{
+					Format: RuntimeBindingMaterialFormat, State: "VERIFIED", StageID: "runtime-binding", PlanDigest: plan.PlanDigest,
+					IntentRevision: plan.IntentRevision, TargetClusterUIDDigest: digest.SHA256([]byte(material.Target.CAPIClusterUID)),
+					WorkloadAPICADigest: material.Target.WorkloadAPICADigest, KubeSystemUIDDigest: digest.SHA256([]byte(material.Target.KubeSystemUID)),
+					LocalPathStorageUIDDigest: digest.SHA256([]byte(material.Storage.UID)), LifecycleEvidenceDigest: lifecycle.EvidenceDigest,
+					NetworkEvidenceDigest: network.EvidenceDigest, PrivateMaterialDigest: digest.SHA256(raw), PersistentMutationAllowed: false,
+				}
 				_, receiptDigest := makeReceipt(resume, "runtime-binding")
 				return execution.BindingStageRunReceipt{Format: execution.BindingStageReceiptFormat, State: "COMPLETED_SUCCEEDED", PlanDigest: base.plan.PlanDigest, StageID: "runtime-binding", StageReceiptDigest: receiptDigest}, nil
+			}, materialReceipt: func() (RuntimeBindingMaterialReceipt, error) {
+				return materialReceipt, nil
 			}}, nil
 		},
 		target: func(resume StageResumeConfig, _ StageAuthorizationSource, _ PreRuntimeExecutionConfig) (preRuntimeStagedInvocation, error) {
@@ -253,6 +349,15 @@ func preRuntimeExecutionFixture(t *testing.T) (PreRuntimeExecutionConfig, preRun
 		},
 	}
 	return config, factories, &calls, &requests
+}
+
+func mustReceiptPrefix(t *testing.T, executor *PreRuntimeExecution) []StageReceiptSource {
+	t.Helper()
+	prefix, err := executor.ReceiptPrefix()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return prefix
 }
 
 func minInt(first, second int) int {

--- a/internal/runner/runtime_binding_material_receipt_writer.go
+++ b/internal/runner/runtime_binding_material_receipt_writer.go
@@ -1,0 +1,68 @@
+package runner
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"os"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/jsonstrict"
+)
+
+// persistRuntimeBindingMaterialReceipt closes the private Stage-6 handoff.
+// It verifies the already create-only material against the stage-produced
+// receipt, then writes that receipt create-only as a separate 0600 file.
+func persistRuntimeBindingMaterialReceipt(receipt RuntimeBindingMaterialReceipt, materialPath, receiptPath, planDigest string) error {
+	if materialPath == receiptPath || validateRuntimeBindingOutputPath(receiptPath) != nil ||
+		receipt.PlanDigest != planDigest || !stageReceiptPrefixDigestPattern.MatchString(planDigest) {
+		return errors.New("runtime binding material receipt destination or plan is invalid")
+	}
+	materialRaw, err := readBoundedRegular(materialPath, maximumRuntimeBindingMaterialFileBytes)
+	if err != nil {
+		return errors.New("read runtime binding material for receipt persistence")
+	}
+	var material RuntimeBindingMaterial
+	if err := jsonstrict.Decode(materialRaw, &material); err != nil {
+		return errors.New("decode runtime binding material for receipt persistence")
+	}
+	canonical, err := canonicalRuntimeBinding(material)
+	if err != nil || !bytes.Equal(canonical, materialRaw) {
+		return errors.New("runtime binding material is not canonical for receipt persistence")
+	}
+	verified := VerifiedRuntimeBindingMaterial{
+		material: material, raw: append([]byte(nil), materialRaw...), receipt: receipt, verified: true,
+	}
+	if err := verifyRuntimeBindingMaterial(verified); err != nil {
+		return errors.New("runtime binding material receipt differs from private material")
+	}
+	receiptRaw, err := json.Marshal(receipt)
+	if err != nil || len(receiptRaw) == 0 || len(receiptRaw) > maximumRuntimeBindingMaterialFileBytes {
+		return errors.New("encode runtime binding material receipt")
+	}
+	receiptDigest := digest.SHA256(receiptRaw)
+	file, err := os.OpenFile(receiptPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return errors.New("create exclusive runtime binding material receipt")
+	}
+	if _, err := file.Write(receiptRaw); err != nil {
+		file.Close()
+		return errors.New("write runtime binding material receipt")
+	}
+	if err := file.Sync(); err != nil {
+		file.Close()
+		return errors.New("sync runtime binding material receipt")
+	}
+	if err := file.Close(); err != nil {
+		return errors.New("close runtime binding material receipt")
+	}
+	info, err := os.Lstat(receiptPath)
+	if err != nil || !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 || info.Mode().Perm() != 0o600 || info.Size() != int64(len(receiptRaw)) {
+		return errors.New("runtime binding material receipt metadata differs after write")
+	}
+	stored, err := readBoundedRegular(receiptPath, int64(len(receiptRaw)))
+	if err != nil || !bytes.Equal(stored, receiptRaw) || digest.SHA256(stored) != receiptDigest {
+		return errors.New("runtime binding material receipt differs after write")
+	}
+	return nil
+}

--- a/internal/runner/runtime_binding_material_receipt_writer_test.go
+++ b/internal/runner/runtime_binding_material_receipt_writer_test.go
@@ -1,0 +1,126 @@
+package runner
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/jsonstrict"
+)
+
+func TestPersistRuntimeBindingMaterialReceiptWritesVerifiedPrivateHandoff(t *testing.T) {
+	materialPath, receiptPath, receipt := runtimeBindingMaterialReceiptWriterFixture(t)
+	if err := persistRuntimeBindingMaterialReceipt(receipt, materialPath, receiptPath, receipt.PlanDigest); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Lstat(receiptPath)
+	if err != nil || !info.Mode().IsRegular() || info.Mode().Perm() != 0o600 {
+		t.Fatalf("private material receipt metadata differs: %#v %v", info, err)
+	}
+	raw, err := readBoundedRegular(receiptPath, maximumRuntimeBindingMaterialFileBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var stored RuntimeBindingMaterialReceipt
+	if err := jsonstrict.Decode(raw, &stored); err != nil || stored != receipt {
+		t.Fatalf("stored material receipt differs: %#v %v", stored, err)
+	}
+	if err := persistRuntimeBindingMaterialReceipt(receipt, materialPath, receiptPath, receipt.PlanDigest); err == nil {
+		t.Fatal("existing material receipt was overwritten")
+	}
+}
+
+func TestPersistRuntimeBindingMaterialReceiptRejectsUnsafeOrDifferentInputs(t *testing.T) {
+	for name, mutate := range map[string]func(string, string, *RuntimeBindingMaterialReceipt){
+		"different material digest": func(_, _ string, receipt *RuntimeBindingMaterialReceipt) {
+			receipt.PrivateMaterialDigest = runnerStageSHA("f")
+		},
+		"different plan": func(_, _ string, receipt *RuntimeBindingMaterialReceipt) {
+			receipt.PlanDigest = runnerStageSHA("e")
+		},
+		"existing destination": func(_, receiptPath string, _ *RuntimeBindingMaterialReceipt) {
+			if err := os.WriteFile(receiptPath, []byte("existing"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+		},
+		"symlink destination": func(_, receiptPath string, _ *RuntimeBindingMaterialReceipt) {
+			target := filepath.Join(filepath.Dir(receiptPath), "target")
+			if err := os.WriteFile(target, []byte("target"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Symlink(target, receiptPath); err != nil {
+				t.Fatal(err)
+			}
+		},
+		"noncanonical material": func(materialPath, _ string, _ *RuntimeBindingMaterialReceipt) {
+			raw, err := os.ReadFile(materialPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(materialPath, append(raw, '\n'), 0o600); err != nil {
+				t.Fatal(err)
+			}
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			materialPath, receiptPath, receipt := runtimeBindingMaterialReceiptWriterFixture(t)
+			planDigest := receipt.PlanDigest
+			mutate(materialPath, receiptPath, &receipt)
+			if err := persistRuntimeBindingMaterialReceipt(receipt, materialPath, receiptPath, planDigest); err == nil {
+				t.Fatal("unsafe or different runtime binding receipt input was accepted")
+			}
+		})
+	}
+}
+
+func runtimeBindingMaterialReceiptWriterFixture(t *testing.T) (string, string, RuntimeBindingMaterialReceipt) {
+	t.Helper()
+	directory := t.TempDir()
+	if err := os.Chmod(directory, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	materialPath := filepath.Join(directory, "runtime-binding.json")
+	receiptPath := filepath.Join(directory, "runtime-binding-receipt.json")
+	material := RuntimeBindingMaterial{
+		Format: RuntimeBindingMaterialFormat, State: "CURRENT_RUNTIME_BOUND", PlanDigest: runnerStageSHA("1"),
+		IntentRevision: runnerStageSHA("2"), EnablementRevision: runnerStageSHA("3"),
+		PlatformRevision: runnerStageSHA("4"), ExecutionFixture: runnerStageSHA("5"),
+		Target: RuntimeBindingTarget{
+			Name: "disposable-ok147", CAPIClusterUID: "11111111-1111-4111-8111-111111111111",
+			TargetIdentityScheme: "capi-cluster-uid", WorkloadAPIEndpoint: "https://runtime.invalid:6443",
+			WorkloadAPICAData: "Y2E=", WorkloadAPICADigest: runnerStageSHA("6"),
+			KubeSystemUID: "22222222-2222-4222-8222-222222222222",
+		},
+		Storage:  RuntimeBindingStorage{Name: "local-path", UID: "33333333-3333-4333-8333-333333333333", Provisioner: "rancher.io/local-path"},
+		Evidence: RuntimeBindingEvidence{LifecycleEvidenceDigest: runnerStageSHA("7"), NetworkEvidenceDigest: runnerStageSHA("8")},
+	}
+	raw, err := canonicalRuntimeBinding(material)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(materialPath, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	receipt := RuntimeBindingMaterialReceipt{
+		Format: RuntimeBindingMaterialFormat, State: "VERIFIED", StageID: "runtime-binding",
+		PlanDigest: material.PlanDigest, IntentRevision: material.IntentRevision,
+		TargetClusterUIDDigest: digest.SHA256([]byte(material.Target.CAPIClusterUID)), WorkloadAPICADigest: material.Target.WorkloadAPICADigest,
+		KubeSystemUIDDigest: digest.SHA256([]byte(material.Target.KubeSystemUID)), LocalPathStorageUIDDigest: digest.SHA256([]byte(material.Storage.UID)),
+		LifecycleEvidenceDigest: material.Evidence.LifecycleEvidenceDigest, NetworkEvidenceDigest: material.Evidence.NetworkEvidenceDigest,
+		PrivateMaterialDigest: digest.SHA256(raw), PersistentMutationAllowed: false,
+	}
+	return materialPath, receiptPath, receipt
+}
+
+func TestPersistRuntimeBindingMaterialReceiptLeavesAbsentDestinationOnVerificationFailure(t *testing.T) {
+	materialPath, receiptPath, receipt := runtimeBindingMaterialReceiptWriterFixture(t)
+	receipt.KubeSystemUIDDigest = runnerStageSHA("f")
+	if err := persistRuntimeBindingMaterialReceipt(receipt, materialPath, receiptPath, receipt.PlanDigest); err == nil {
+		t.Fatal("different runtime identity was accepted")
+	}
+	if _, err := os.Lstat(receiptPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("verification failure wrote a receipt: %v", err)
+	}
+}


### PR DESCRIPTION
## Outcome

Closes the concrete private Stage 6 to Stage 8 handoff required before a shared full-run manifest can be built.

## Changes

- persist the Stage 6 runtime material receipt create-only as a separate private 0600 file
- verify the receipt against canonical runtime material and the current Plan before Stage 7 opens
- require the post-runtime material and receipt paths to equal the pre-runtime destinations
- fail closed on changed, foreign, existing, symlinked or non-canonical handoff inputs
- document the resulting execution boundary

## Verification

- go test ./...
- go vet ./...
- targeted Go race tests for the pre-runtime, full-run and material-receipt paths

## Boundaries

- no infrastructure contact or mutation
- no CLI or Job activation surface added
- private runtime material remains excluded from public evidence
- the private full-run manifest remains the next checkpoint