### PR TITLE
feat(runner): bind private full-run manifest (OK-147)

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -12,8 +12,10 @@ adapters; only the post-runtime suffix currently has a bounded ephemeral Job
 activation path.
 That Job path is fully exercised offline and against fake APIs, but has not yet
 been run on the DEV management plane. The full-run library is not yet exposed
-as one local or Job-based CreateCluster activation. It is still an MVP rather
-than a general lifecycle runner or controller.
+as one local or Job-based CreateCluster activation. A strict private full-run
+manifest now verifies the complete fresh-run input boundary offline, but does
+not yet open that execution. It is still an MVP rather than a general lifecycle
+runner or controller.
 
 ```text
 versioned contract + test schema
@@ -2829,6 +2831,27 @@ exposes the defensive private prefix required by the full-run seam. This adds
 no renderer, policy authority, retry, rollback, cleanup, CLI command or Job
 mutation surface.
 
+The private full-run execution manifest closes the fresh-run input contract
+without inventing runtime truth. It binds one empty Stage-1 Plan cursor, the
+verified Contract projection, all R/E/P profiles and renderer artifacts, one
+coherent ledger and the three isolated authority planes, bounded observation
+settings, private future handoff destinations and the eleven private
+create-only stage-receipt destinations across the twelve-stage chain.
+Loading is offline and grants no mutation.
+
+The manifest deliberately cannot carry a selected target identity. After
+Stage 2 succeeds, the concrete execution adapter reloads the exact lifecycle
+receipt and injects its CAPI-UID digest into the Stage 8-12 registration and
+Application expectations. Workload endpoint, CA and token material are also
+future lifecycle-derived files, Stage-8 authorization remains predecessor-
+bound, and capability evidence is produced in memory at observation time.
+Pre-existing handoff or receipt files, mismatched authorities or ledgers,
+foreign profile/artifact digests, duplicate destinations and a non-empty
+resume cursor stop verification. The redaction-safe manifest receipt contains
+only semantic identities and execution modes. This checkpoint defines the
+private contract; the following activation checkpoint converts the verified
+document into the existing concrete adapters.
+
 The post-runtime authorization resolver closes the next authority boundary.
 After a predecessor receipt is durable, it derives one canonical,
 redaction-safe request from the verified cursor, including the exact Plan,
@@ -3024,9 +3047,9 @@ durable receipts. This is not yet the OK-147 Definition of Done:
   [ADR-030 amendment proposal](ok147-adr-030-amendment-proposal.md) are defined
   and remain to be reviewed with the live evidence.
 
-The remaining implementation work is a private full-run manifest plus the
-shared local/Job activation surface for this concrete composition; it is not a
-new controller or reconciliation mechanism. After that, live closure must
+The remaining implementation work is the manifest-to-executor activation and
+the shared local/Job activation surface for this concrete composition; it is
+not a new controller or reconciliation mechanism. After that, live closure must
 publish the current image, construct fresh short-lived private inputs, run the
 exact bounded activation on `ok-mgmt`, preserve a stopped partial state without
 automatic retry, and separately repeat disposable-cluster and

--- a/internal/runner/full_run_execution.go
+++ b/internal/runner/full_run_execution.go
@@ -20,6 +20,7 @@ type FullRunExecutionConfig struct {
 type fullRunPreRuntimeExecution interface {
 	Run(context.Context) (PreRuntimeExecutionReceipt, error)
 	ReceiptPrefix() ([]StageReceiptSource, error)
+	RuntimeTargetIdentity() (string, error)
 }
 
 type fullRunExecutionFactories struct {
@@ -58,6 +59,10 @@ func openFullRunExecution(config FullRunExecutionConfig, factories fullRunExecut
 		config.PostRuntime.RuntimeBinding.ReceiptPath != config.PreRuntime.RuntimeBindingReceiptPath {
 		return nil, errors.New("full-run runtime binding handoff differs")
 	}
+	if config.PostRuntime.TargetRegistration.Expected.TargetIdentityDigest != "" ||
+		config.PostRuntime.PlatformApplications.Expected.TargetIdentityDigest != "" {
+		return nil, errors.New("full-run target identity must originate at lifecycle execution")
+	}
 	if len(config.PostRuntime.TargetCredential.Receipts) != 0 || config.PostRuntime.TargetCredentialRecovery != nil ||
 		config.PostRuntime.TargetRegistrationRecovery != nil {
 		return nil, errors.New("full-run execution requires a fresh unbound post-runtime suffix")
@@ -81,8 +86,14 @@ func openFullRunExecution(config FullRunExecutionConfig, factories fullRunExecut
 					return nil, errors.New("full-run private receipt prefix differs from completed execution")
 				}
 			}
+			targetIdentity, targetErr := preRuntime.RuntimeTargetIdentity()
+			if targetErr != nil || !stageReceiptPrefixDigestPattern.MatchString(targetIdentity) {
+				return nil, errors.New("full-run lifecycle target identity is unavailable")
+			}
 			bound := clonePostRuntimeExecutionConfigForFullRun(postRuntime)
 			bound.TargetCredential.Receipts = append([]StageReceiptSource(nil), privatePrefix...)
+			bound.TargetRegistration.Expected.TargetIdentityDigest = targetIdentity
+			bound.PlatformApplications.Expected.TargetIdentityDigest = targetIdentity
 			continuation, openErr := factories.postRuntime(bound)
 			if openErr != nil || continuation == nil {
 				return nil, errors.New("open full-run post-runtime execution")

--- a/internal/runner/full_run_execution_manifest.go
+++ b/internal/runner/full_run_execution_manifest.go
@@ -1,0 +1,535 @@
+package runner
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"net/url"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/contract"
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/jsonstrict"
+	"github.com/openkubes/ok-cluster/internal/observation"
+	"github.com/openkubes/ok-cluster/internal/projection"
+	"github.com/openkubes/ok-cluster/internal/stageplan"
+	"github.com/openkubes/ok-cluster/internal/submission"
+)
+
+const (
+	FullRunExecutionManifestFormat        = "ok147-full-run-execution-manifest/v1"
+	FullRunExecutionManifestReceiptFormat = "ok147-full-run-execution-manifest-receipt/v1"
+	maximumFullRunExecutionManifestBytes  = 1024 * 1024
+)
+
+type fullRunPlanDocument struct {
+	Path     string                          `json:"path"`
+	Expected postRuntimePlanExpectedDocument `json:"expected"`
+}
+
+type fullRunProjectionDocument struct {
+	ManifestPath string `json:"manifestPath"`
+	Root         string `json:"root"`
+}
+
+type fullRunSubmissionRuntimeDocument struct {
+	Ledger    postRuntimeLedgerDocument    `json:"ledger"`
+	Authority postRuntimeAuthorityDocument `json:"authority"`
+}
+
+type fullRunLifecycleObservationDocument struct {
+	Ledger       postRuntimeLedgerDocument    `json:"ledger"`
+	Management   postRuntimeAuthorityDocument `json:"management"`
+	PollInterval string                       `json:"pollInterval"`
+	PollTimeout  string                       `json:"pollTimeout"`
+}
+
+type fullRunEnablementDocument struct {
+	ArtifactPath   string                           `json:"artifactPath"`
+	ExpectedObject projection.ResourceIdentity      `json:"expectedObject"`
+	Runtime        fullRunSubmissionRuntimeDocument `json:"runtime"`
+}
+
+type fullRunWorkloadRuntimeDocument struct {
+	BindingPath string `json:"bindingPath"`
+	TokenFile   string `json:"tokenFile"`
+	CAFile      string `json:"caFile"`
+}
+
+type fullRunNetworkObservationDocument struct {
+	Ledger       postRuntimeLedgerDocument      `json:"ledger"`
+	Management   postRuntimeAuthorityDocument   `json:"management"`
+	Workload     fullRunWorkloadRuntimeDocument `json:"workload"`
+	PollInterval string                         `json:"pollInterval"`
+	PollTimeout  string                         `json:"pollTimeout"`
+}
+
+type fullRunRuntimeBindingDocument struct {
+	Ledger       postRuntimeLedgerDocument      `json:"ledger"`
+	Workload     fullRunWorkloadRuntimeDocument `json:"workload"`
+	MaterialPath string                         `json:"materialPath"`
+	ReceiptPath  string                         `json:"receiptPath"`
+}
+
+type fullRunTargetAccessDocument struct {
+	ArtifactPath    string                         `json:"artifactPath"`
+	ExpectedObjects []projection.ResourceIdentity  `json:"expectedObjects"`
+	Ledger          postRuntimeLedgerDocument      `json:"ledger"`
+	Workload        fullRunWorkloadRuntimeDocument `json:"workload"`
+}
+
+type fullRunTargetCredentialDocument struct {
+	PolicyPath string                         `json:"policyPath"`
+	Ledger     postRuntimeLedgerDocument      `json:"ledger"`
+	Workload   fullRunWorkloadRuntimeDocument `json:"workload"`
+}
+
+type fullRunTargetRegistrationDocument struct {
+	ArtifactPath     string                       `json:"artifactPath"`
+	ArgoNamespace    string                       `json:"argoNamespace"`
+	ProjectName      string                       `json:"projectName"`
+	RegistrationName string                       `json:"registrationName"`
+	TargetName       string                       `json:"targetName"`
+	SourceRepository string                       `json:"sourceRepository"`
+	TargetNamespaces []string                     `json:"targetNamespaces"`
+	Ledger           postRuntimeLedgerDocument    `json:"ledger"`
+	GitOps           postRuntimeAuthorityDocument `json:"gitOps"`
+}
+
+type fullRunPlatformApplicationsDocument struct {
+	ArtifactPath     string                       `json:"artifactPath"`
+	ArgoNamespace    string                       `json:"argoNamespace"`
+	ProjectName      string                       `json:"projectName"`
+	RegistrationName string                       `json:"registrationName"`
+	SourceRepository string                       `json:"sourceRepository"`
+	Ledger           postRuntimeLedgerDocument    `json:"ledger"`
+	GitOps           postRuntimeAuthorityDocument `json:"gitOps"`
+}
+
+type fullRunCapabilityDocument struct {
+	Namespace      string `json:"namespace"`
+	Timeout        string `json:"timeout"`
+	CleanupTimeout string `json:"cleanupTimeout"`
+}
+
+type fullRunPlatformObservationDocument struct {
+	Ledger       postRuntimeLedgerDocument    `json:"ledger"`
+	Argo         postRuntimeAuthorityDocument `json:"argo"`
+	Capability   fullRunCapabilityDocument    `json:"capability"`
+	PollInterval string                       `json:"pollInterval"`
+	PollTimeout  string                       `json:"pollTimeout"`
+}
+
+type fullRunAggregateEvidenceDocument struct {
+	Ledger            postRuntimeLedgerDocument    `json:"ledger"`
+	Management        postRuntimeAuthorityDocument `json:"management"`
+	Argo              postRuntimeAuthorityDocument `json:"argo"`
+	WorkloadTokenFile string                       `json:"workloadTokenFile"`
+	WorkloadCAFile    string                       `json:"workloadCAFile"`
+}
+
+type fullRunExecutionManifestDocument struct {
+	Format                string                              `json:"format"`
+	Plan                  fullRunPlanDocument                 `json:"plan"`
+	Projection            fullRunProjectionDocument           `json:"projection"`
+	Authorization         postRuntimeAuthorizationDocument    `json:"authorization"`
+	Profiles              postRuntimeProfilesDocument         `json:"profiles"`
+	ProviderPrerequisites fullRunSubmissionRuntimeDocument    `json:"providerPrerequisites"`
+	ClusterLifecycle      fullRunSubmissionRuntimeDocument    `json:"clusterLifecycle"`
+	LifecycleObservation  fullRunLifecycleObservationDocument `json:"lifecycleObservation"`
+	Enablement            fullRunEnablementDocument           `json:"enablement"`
+	NetworkObservation    fullRunNetworkObservationDocument   `json:"networkObservation"`
+	RuntimeBinding        fullRunRuntimeBindingDocument       `json:"runtimeBinding"`
+	TargetAccess          fullRunTargetAccessDocument         `json:"targetAccess"`
+	TargetCredential      fullRunTargetCredentialDocument     `json:"targetCredential"`
+	TargetRegistration    fullRunTargetRegistrationDocument   `json:"targetRegistration"`
+	PlatformApplications  fullRunPlatformApplicationsDocument `json:"platformApplications"`
+	PlatformObservation   fullRunPlatformObservationDocument  `json:"platformObservation"`
+	AggregateEvidence     fullRunAggregateEvidenceDocument    `json:"aggregateEvidence"`
+	ReceiptDirectory      string                              `json:"receiptDirectory"`
+}
+
+type FullRunExecutionManifestReceipt struct {
+	Format                    string `json:"format"`
+	State                     string `json:"state"`
+	ManifestDigest            string `json:"manifestDigest"`
+	PlanDigest                string `json:"planDigest"`
+	ProjectionManifestDigest  string `json:"projectionManifestDigest"`
+	ProjectionAuthorityDigest string `json:"projectionAuthorityDigest"`
+	NetworkProfileDigest      string `json:"networkProfileDigest"`
+	PlatformProfileDigest     string `json:"platformProfileDigest"`
+	AggregateProfileDigest    string `json:"aggregateProfileDigest"`
+	RuntimeIdentityMode       string `json:"runtimeIdentityMode"`
+	AuthorizationMode         string `json:"authorizationMode"`
+	CapabilityMode            string `json:"capabilityMode"`
+	MutationAllowed           bool   `json:"mutationAllowed"`
+}
+
+type VerifiedFullRunExecutionManifest struct {
+	document fullRunExecutionManifestDocument
+	receipt  FullRunExecutionManifestReceipt
+	verified bool
+}
+
+// Receipt returns the already verified, redaction-safe manifest identity. The
+// private activation document and its credential paths remain inaccessible.
+func (manifest VerifiedFullRunExecutionManifest) Receipt() (FullRunExecutionManifestReceipt, error) {
+	if !manifest.verified || manifest.receipt.State != "VERIFIED" {
+		return FullRunExecutionManifestReceipt{}, errors.New("full-run execution manifest is not verified")
+	}
+	return manifest.receipt, nil
+}
+
+// LoadFullRunExecutionManifest verifies the complete private first-run
+// contract without opening a credential, resolving a grant, contacting an API
+// or creating a file. Lifecycle-derived runtime identity and capability proof
+// deliberately remain later in-memory handoffs.
+func LoadFullRunExecutionManifest(path string) (VerifiedFullRunExecutionManifest, FullRunExecutionManifestReceipt, error) {
+	receipt := FullRunExecutionManifestReceipt{
+		Format: FullRunExecutionManifestReceiptFormat, State: "STOPPED", MutationAllowed: false,
+	}
+	document, manifestDigest, err := loadFullRunExecutionManifest(path)
+	if err != nil {
+		return VerifiedFullRunExecutionManifest{}, receipt, err
+	}
+	receipt.ManifestDigest = manifestDigest
+	expected := stageplan.Expected{
+		ContractIdentity: document.Plan.Expected.ContractIdentity,
+		IntentRevision:   document.Plan.Expected.IntentRevision, EnablementRevision: document.Plan.Expected.EnablementRevision,
+		PlatformRevision: document.Plan.Expected.PlatformRevision, ExecutionFixture: document.Plan.Expected.ExecutionFixture,
+		InfrastructureAuthority: document.Plan.Expected.InfrastructureAuthority,
+		ManagementAuthority:     document.Plan.Expected.ManagementAuthority, GitOpsAuthority: document.Plan.Expected.GitOpsAuthority,
+	}
+	plan, err := stageplan.Load(document.Plan.Path, expected)
+	if err != nil {
+		return VerifiedFullRunExecutionManifest{}, receipt, errors.New("load full-run staged plan")
+	}
+	decision, err := InspectStageResume(StageResumeConfig{PlanPath: document.Plan.Path, PlanExpected: expected, Receipts: []StageReceiptSource{}})
+	if err != nil || decision.State != "NEXT" || decision.StageID != "provider-prerequisites" {
+		return VerifiedFullRunExecutionManifest{}, receipt, errors.New("full-run manifest requires the exact empty Stage-1 cursor")
+	}
+	receipt.PlanDigest = plan.PlanDigest
+
+	projected, err := projection.Verify(document.Projection.ManifestPath, document.Projection.Root, plan.IntentRevision, plan.ContractIdentity)
+	if err != nil {
+		return VerifiedFullRunExecutionManifest{}, receipt, errors.New("verify full-run Contract projection")
+	}
+	for stageID, artifactName := range map[string]string{
+		"provider-prerequisites": "ok-infra-prerequisites.yaml", "cluster-lifecycle": "ok-mgmt-lifecycle.yaml",
+	} {
+		artifactDigest, artifactErr := verifiedProjectionArtifact(projected, artifactName)
+		if artifactErr != nil || plan.RequireInput(stageID, "projection."+stageID, artifactDigest) != nil {
+			return VerifiedFullRunExecutionManifest{}, receipt, errors.New("full-run projection differs from staged plan")
+		}
+	}
+	receipt.ProjectionManifestDigest, receipt.ProjectionAuthorityDigest = projected.ManifestDigest, projected.AuthorityMapDigest
+
+	network, err := LoadNetworkProfileFile(NetworkProfileFileConfig{
+		Path: document.Profiles.Network.Path, ExpectedProfileDigest: document.Profiles.Network.Digest,
+		ExpectedIntentRevision: plan.IntentRevision, ExpectedEnablementRevision: plan.EnablementRevision,
+	})
+	if err != nil {
+		return VerifiedFullRunExecutionManifest{}, receipt, errors.New("load full-run Network profile")
+	}
+	platform, err := LoadPlatformProfileFile(PlatformProfileFileConfig{
+		Path: document.Profiles.Platform.Path, ExpectedProfileDigest: document.Profiles.Platform.Digest,
+		ExpectedIntentRevision: plan.IntentRevision, ExpectedPlatformRevision: plan.PlatformRevision,
+		ExpectedExecutionFixture: plan.ExecutionFixture,
+	})
+	if err != nil {
+		return VerifiedFullRunExecutionManifest{}, receipt, errors.New("load full-run Platform profile")
+	}
+	aggregate, err := LoadAggregateEvidenceProfileFile(AggregateEvidenceProfileFileConfig{
+		Path: document.Profiles.Aggregate.Path, ExpectedProfileDigest: document.Profiles.Aggregate.Digest,
+		ExpectedIntentRevision: plan.IntentRevision, ExpectedEnablementRevision: plan.EnablementRevision,
+		ExpectedPlatformRevision: plan.PlatformRevision, ExpectedExecutionFixture: plan.ExecutionFixture,
+	})
+	if err != nil {
+		return VerifiedFullRunExecutionManifest{}, receipt, errors.New("load full-run aggregate profile")
+	}
+	receipt.NetworkProfileDigest, receipt.PlatformProfileDigest, receipt.AggregateProfileDigest = network.Digest, platform.Digest, aggregate.Digest
+	for stageID, input := range map[string]struct{ name, digest string }{
+		"network-observation":  {"stage.network-observation", network.Digest},
+		"platform-observation": {"stage.platform-observation", platform.Digest},
+		"aggregate-evidence":   {"stage.aggregate-evidence", aggregate.Digest},
+	} {
+		if err := plan.RequireInput(stageID, input.name, input.digest); err != nil {
+			return VerifiedFullRunExecutionManifest{}, receipt, errors.New("full-run profile differs from staged input")
+		}
+	}
+	if err := verifyFullRunStaticArtifacts(document, plan, platform.Profile); err != nil {
+		return VerifiedFullRunExecutionManifest{}, receipt, err
+	}
+	if err := validateFullRunRuntimeBoundary(document, plan); err != nil {
+		return VerifiedFullRunExecutionManifest{}, receipt, err
+	}
+	receipt.State = "VERIFIED"
+	receipt.RuntimeIdentityMode = "lifecycle-derived-private/v1"
+	receipt.AuthorizationMode = "predecessor-bound-tls/v1"
+	receipt.CapabilityMode = "runtime-bound-in-memory/v1"
+	verified := VerifiedFullRunExecutionManifest{document: document, receipt: receipt, verified: true}
+	return verified, receipt, nil
+}
+
+func loadFullRunExecutionManifest(path string) (fullRunExecutionManifestDocument, string, error) {
+	if !validFullRunAbsolutePath(path) {
+		return fullRunExecutionManifestDocument{}, "", errors.New("full-run execution manifest path is invalid")
+	}
+	info, err := os.Lstat(path)
+	if err != nil || !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 || info.Mode().Perm()&0o077 != 0 ||
+		info.Size() <= 0 || info.Size() > maximumFullRunExecutionManifestBytes {
+		return fullRunExecutionManifestDocument{}, "", errors.New("full-run execution manifest metadata is invalid")
+	}
+	raw, err := readBoundedRegular(path, maximumFullRunExecutionManifestBytes)
+	if err != nil {
+		return fullRunExecutionManifestDocument{}, "", errors.New("read bounded full-run execution manifest")
+	}
+	var document fullRunExecutionManifestDocument
+	if err := jsonstrict.Decode(raw, &document); err != nil {
+		return fullRunExecutionManifestDocument{}, "", errors.New("decode strict full-run execution manifest")
+	}
+	if document.Format != FullRunExecutionManifestFormat {
+		return fullRunExecutionManifestDocument{}, "", errors.New("full-run execution manifest format is not supported")
+	}
+	encoded, err := json.Marshal(document)
+	if err != nil {
+		return fullRunExecutionManifestDocument{}, "", errors.New("encode full-run execution manifest")
+	}
+	decoder := json.NewDecoder(bytes.NewReader(encoded))
+	decoder.UseNumber()
+	var value any
+	if err := decoder.Decode(&value); err != nil {
+		return fullRunExecutionManifestDocument{}, "", errors.New("decode full-run execution manifest identity")
+	}
+	canonical, err := contract.JCS(value)
+	if err != nil {
+		return fullRunExecutionManifestDocument{}, "", errors.New("canonicalize full-run execution manifest")
+	}
+	return document, digest.SHA256(canonical), nil
+}
+
+func verifyFullRunStaticArtifacts(document fullRunExecutionManifestDocument, plan stageplan.Binding, platformProfile observation.PlatformProfile) error {
+	enablementStage, _, err := plan.Stage("enablement")
+	if err != nil || len(enablementStage.Inputs) != 1 || enablementStage.Inputs[0].Name != "stage.enablement" {
+		return errors.New("full-run enablement input is invalid")
+	}
+	if _, err := submission.LoadEnablement(document.Enablement.ArtifactPath, submission.EnablementExpected{
+		ArtifactDigest: enablementStage.Inputs[0].Digest, ContractIdentity: plan.ContractIdentity,
+		IntentRevision: plan.IntentRevision, EnablementRevision: plan.EnablementRevision, ExecutionFixture: plan.ExecutionFixture,
+		ManagementAuthority: plan.Authorities.Management, ObjectIdentity: document.Enablement.ExpectedObject,
+	}); err != nil {
+		return errors.New("verify full-run enablement artifact")
+	}
+	targetIdentity := digest.SHA256([]byte("ok147-full-run-lifecycle-derived-target"))
+	targetAccessStage, _, err := plan.Stage("target-access")
+	if err != nil || len(targetAccessStage.Inputs) != 1 || targetAccessStage.Inputs[0].Name != "stage.target-access" {
+		return errors.New("full-run target-access input is invalid")
+	}
+	access, err := submission.LoadTargetAccess(document.TargetAccess.ArtifactPath, submission.TargetAccessExpected{
+		ArtifactDigest: targetAccessStage.Inputs[0].Digest, ContractIdentity: plan.ContractIdentity,
+		IntentRevision: plan.IntentRevision, PlatformRevision: plan.PlatformRevision, ExecutionFixture: plan.ExecutionFixture,
+		TargetIdentityDigest: targetIdentity, WorkloadAuthority: targetIdentity,
+		Objects: append([]projection.ResourceIdentity(nil), document.TargetAccess.ExpectedObjects...),
+	})
+	if err != nil || len(access.Workload.Objects) != 8 || access.Workload.Objects[1].Identity.Kind != "ServiceAccount" {
+		return errors.New("verify full-run target-access artifact")
+	}
+	targetCredentialStage, _, err := plan.Stage("target-credential")
+	if err != nil || len(targetCredentialStage.Inputs) != 1 || targetCredentialStage.Inputs[0].Name != "stage.target-credential" {
+		return errors.New("full-run target-credential input is invalid")
+	}
+	policyRaw, err := readBoundedRegular(document.TargetCredential.PolicyPath, maximumTargetCredentialPolicyBytes)
+	if err != nil || digest.SHA256(policyRaw) != targetCredentialStage.Inputs[0].Digest {
+		return errors.New("verify full-run target-credential policy identity")
+	}
+	var policy targetCredentialPolicyDocument
+	if err := jsonstrict.Decode(policyRaw, &policy); err != nil ||
+		validateTargetCredentialPolicy(policy, targetIdentity, access.Workload.Objects[1].Identity) != nil {
+		return errors.New("verify full-run target-credential policy")
+	}
+	targetRegistrationStage, _, err := plan.Stage("target-registration")
+	if err != nil || len(targetRegistrationStage.Inputs) != 1 || targetRegistrationStage.Inputs[0].Name != "stage.target-registration" {
+		return errors.New("full-run target-registration input is invalid")
+	}
+	registrationExpected := submission.TargetRegistrationExpected{
+		ArtifactDigest: targetRegistrationStage.Inputs[0].Digest, ContractIdentity: plan.ContractIdentity,
+		IntentRevision: plan.IntentRevision, PlatformRevision: plan.PlatformRevision, ExecutionFixture: plan.ExecutionFixture,
+		TargetIdentityDigest: targetIdentity, ArgoAuthority: plan.Authorities.GitOps,
+		ArgoNamespace: document.TargetRegistration.ArgoNamespace, ProjectName: document.TargetRegistration.ProjectName,
+		RegistrationName: document.TargetRegistration.RegistrationName, TargetName: document.TargetRegistration.TargetName,
+		SourceRepository: document.TargetRegistration.SourceRepository,
+		TargetNamespaces: append([]string(nil), document.TargetRegistration.TargetNamespaces...),
+	}
+	if _, err := submission.LoadTargetRegistration(document.TargetRegistration.ArtifactPath, registrationExpected); err != nil {
+		return errors.New("verify full-run target-registration template")
+	}
+	applicationsStage, _, err := plan.Stage("platform-applications")
+	if err != nil || len(applicationsStage.Inputs) != 1 || applicationsStage.Inputs[0].Name != "stage.platform-applications" {
+		return errors.New("full-run platform-applications input is invalid")
+	}
+	applicationsExpected := submission.PlatformApplicationsExpected{
+		ArtifactDigest: applicationsStage.Inputs[0].Digest, ContractIdentity: plan.ContractIdentity,
+		IntentRevision: plan.IntentRevision, PlatformRevision: plan.PlatformRevision, ExecutionFixture: plan.ExecutionFixture,
+		TargetIdentityDigest: targetIdentity, ArgoAuthority: plan.Authorities.GitOps,
+		ArgoNamespace: document.PlatformApplications.ArgoNamespace, ProjectName: document.PlatformApplications.ProjectName,
+		RegistrationName: document.PlatformApplications.RegistrationName,
+		SourceRepository: document.PlatformApplications.SourceRepository, Profile: platformProfile,
+	}
+	if _, err := submission.LoadPlatformApplications(document.PlatformApplications.ArtifactPath, applicationsExpected); err != nil {
+		return errors.New("verify full-run platform Applications template")
+	}
+	return nil
+}
+
+func validateFullRunRuntimeBoundary(document fullRunExecutionManifestDocument, plan stageplan.Binding) error {
+	paths := []string{
+		document.Plan.Path, document.Projection.ManifestPath, document.Projection.Root,
+		document.Authorization.TokenFile, document.Authorization.CAFile, document.Authorization.PublicKeyPath, document.Authorization.OutputDirectory,
+		document.Profiles.Network.Path, document.Profiles.Platform.Path, document.Profiles.Aggregate.Path,
+		document.Enablement.ArtifactPath, document.TargetAccess.ArtifactPath, document.TargetCredential.PolicyPath,
+		document.TargetRegistration.ArtifactPath, document.PlatformApplications.ArtifactPath, document.ReceiptDirectory,
+	}
+	for _, path := range paths {
+		if !validFullRunAbsolutePath(path) {
+			return errors.New("full-run manifest contains an invalid absolute path")
+		}
+	}
+	if !validFullRunAuthorization(document.Authorization) {
+		return errors.New("full-run authorization binding is invalid")
+	}
+	if !validFullRunLedger(document.ProviderPrerequisites.Ledger) {
+		return errors.New("full-run ledger binding is invalid")
+	}
+	workload := document.NetworkObservation.Workload
+	if workload != document.RuntimeBinding.Workload || workload != document.TargetAccess.Workload || workload != document.TargetCredential.Workload ||
+		workload.TokenFile != document.AggregateEvidence.WorkloadTokenFile || workload.CAFile != document.AggregateEvidence.WorkloadCAFile {
+		return errors.New("full-run workload runtime binding differs between stages")
+	}
+	runtimeOutputs := []string{workload.BindingPath, workload.TokenFile, workload.CAFile, document.RuntimeBinding.MaterialPath, document.RuntimeBinding.ReceiptPath}
+	seenOutputs := make(map[string]struct{}, len(runtimeOutputs)+len(preRuntimeStageOrder)+4)
+	for _, path := range runtimeOutputs {
+		if !validFullRunAbsolutePath(path) {
+			return errors.New("full-run runtime output path is invalid")
+		}
+		if _, exists := seenOutputs[path]; exists {
+			return errors.New("full-run private runtime outputs must be distinct")
+		}
+		seenOutputs[path] = struct{}{}
+		if err := validateRuntimeBindingOutputPath(path); err != nil {
+			return errors.New("full-run private runtime destination is invalid")
+		}
+	}
+	for _, stageID := range preRuntimeStageOrder {
+		path := filepath.Join(document.ReceiptDirectory, preRuntimeReceiptFiles[stageID])
+		if _, exists := seenOutputs[path]; exists || validateRuntimeBindingOutputPath(path) != nil {
+			return errors.New("full-run pre-runtime receipt destination is invalid")
+		}
+		seenOutputs[path] = struct{}{}
+	}
+	for _, stageID := range postRuntimeStageOrder[:4] {
+		path := filepath.Join(document.ReceiptDirectory, postRuntimeReceiptFiles[stageID])
+		if _, exists := seenOutputs[path]; exists || validateRuntimeBindingOutputPath(path) != nil {
+			return errors.New("full-run post-runtime receipt destination is invalid")
+		}
+		seenOutputs[path] = struct{}{}
+	}
+	if document.ProviderPrerequisites.Authority.AuthorityIdentity != plan.Authorities.Infrastructure ||
+		document.ClusterLifecycle.Authority.AuthorityIdentity != plan.Authorities.Management ||
+		document.Enablement.Runtime.Authority.AuthorityIdentity != plan.Authorities.Management {
+		return errors.New("full-run submission authority differs from staged plan")
+	}
+	if !validFullRunAuthority(document.ProviderPrerequisites.Authority) ||
+		!validFullRunAuthority(document.ClusterLifecycle.Authority) ||
+		!validFullRunAuthority(document.TargetRegistration.GitOps) ||
+		document.ProviderPrerequisites.Authority.Endpoint == document.ClusterLifecycle.Authority.Endpoint ||
+		document.ProviderPrerequisites.Authority.Endpoint == document.TargetRegistration.GitOps.Endpoint ||
+		document.ClusterLifecycle.Authority.Endpoint == document.TargetRegistration.GitOps.Endpoint ||
+		document.ProviderPrerequisites.Authority.TokenFile == document.ClusterLifecycle.Authority.TokenFile ||
+		document.ProviderPrerequisites.Authority.TokenFile == document.TargetRegistration.GitOps.TokenFile ||
+		document.ClusterLifecycle.Authority.TokenFile == document.TargetRegistration.GitOps.TokenFile {
+		return errors.New("full-run authority isolation is invalid")
+	}
+	ledger := document.ProviderPrerequisites.Ledger
+	ledgers := []postRuntimeLedgerDocument{
+		document.ClusterLifecycle.Ledger, document.LifecycleObservation.Ledger, document.Enablement.Runtime.Ledger,
+		document.NetworkObservation.Ledger, document.RuntimeBinding.Ledger, document.TargetAccess.Ledger,
+		document.TargetCredential.Ledger, document.TargetRegistration.Ledger, document.PlatformApplications.Ledger,
+		document.PlatformObservation.Ledger, document.AggregateEvidence.Ledger,
+	}
+	for _, candidate := range ledgers {
+		if candidate != ledger {
+			return errors.New("full-run ledger binding differs between stages")
+		}
+	}
+	management := document.LifecycleObservation.Management
+	if management != document.NetworkObservation.Management || management != document.AggregateEvidence.Management ||
+		management.AuthorityIdentity != plan.Authorities.Management {
+		return errors.New("full-run management observer binding differs between stages")
+	}
+	gitOps := document.TargetRegistration.GitOps
+	if gitOps != document.PlatformApplications.GitOps || gitOps != document.PlatformObservation.Argo ||
+		gitOps != document.AggregateEvidence.Argo || gitOps.AuthorityIdentity != plan.Authorities.GitOps {
+		return errors.New("full-run GitOps binding differs between stages")
+	}
+	for _, pair := range [][2]string{
+		{document.LifecycleObservation.PollInterval, document.LifecycleObservation.PollTimeout},
+		{document.NetworkObservation.PollInterval, document.NetworkObservation.PollTimeout},
+		{document.PlatformObservation.PollInterval, document.PlatformObservation.PollTimeout},
+	} {
+		if _, _, err := parsePostRuntimePolling(pair[0], pair[1]); err != nil {
+			return errors.New("full-run polling bounds are invalid")
+		}
+	}
+	capabilityTimeout, capabilityErr := time.ParseDuration(document.PlatformObservation.Capability.Timeout)
+	cleanupTimeout, cleanupErr := time.ParseDuration(document.PlatformObservation.Capability.CleanupTimeout)
+	if capabilityErr != nil || cleanupErr != nil || capabilityTimeout < time.Minute || capabilityTimeout > 30*time.Minute ||
+		cleanupTimeout < 10*time.Second || cleanupTimeout > 2*time.Minute ||
+		document.PlatformObservation.Capability.Namespace != "ok-observability" {
+		return errors.New("full-run capability execution bounds are invalid")
+	}
+	if document.TargetRegistration.TargetName != plan.ContractIdentity.Name ||
+		document.TargetRegistration.ArgoNamespace != document.PlatformApplications.ArgoNamespace ||
+		document.TargetRegistration.ProjectName != document.PlatformApplications.ProjectName ||
+		document.TargetRegistration.TargetName != document.PlatformApplications.RegistrationName ||
+		document.TargetRegistration.SourceRepository != document.PlatformApplications.SourceRepository {
+		return errors.New("full-run GitOps projection identity differs between stages")
+	}
+	return nil
+}
+
+func validFullRunAbsolutePath(path string) bool {
+	return path != "" && filepath.IsAbs(path) && filepath.Clean(path) == path
+}
+
+func validFullRunLedger(document postRuntimeLedgerDocument) bool {
+	return validFullRunKubernetesEndpoint(document.Endpoint) && document.Namespace == submissionStageInputNamespace &&
+		validFullRunAbsolutePath(document.TokenFile) && validFullRunAbsolutePath(document.CAFile) && document.TokenFile != document.CAFile
+}
+
+func validFullRunAuthority(document postRuntimeAuthorityDocument) bool {
+	return validFullRunKubernetesEndpoint(document.Endpoint) && document.AuthorityIdentity != "" &&
+		validFullRunAbsolutePath(document.TokenFile) && validFullRunAbsolutePath(document.CAFile) &&
+		document.TokenFile != document.CAFile && stageReceiptPrefixDigestPattern.MatchString(document.CABundleDigest)
+}
+
+func validFullRunAuthorization(document postRuntimeAuthorizationDocument) bool {
+	endpoint, err := url.Parse(document.Endpoint)
+	if err != nil || endpoint.Scheme != "https" || endpoint.Host == "" || endpoint.Port() == "" || endpoint.User != nil ||
+		endpoint.RawQuery != "" || endpoint.Fragment != "" || endpoint.Path != "/v1/stage-authorizations" {
+		return false
+	}
+	if !validFullRunAbsolutePath(document.TokenFile) || !validFullRunAbsolutePath(document.CAFile) ||
+		!validFullRunAbsolutePath(document.PublicKeyPath) || !validFullRunAbsolutePath(document.OutputDirectory) {
+		return false
+	}
+	info, err := os.Lstat(document.OutputDirectory)
+	return err == nil && info.IsDir() && info.Mode()&os.ModeSymlink == 0 && info.Mode().Perm()&0o077 == 0
+}
+
+func validFullRunKubernetesEndpoint(raw string) bool {
+	endpoint, err := url.Parse(raw)
+	return err == nil && endpoint.Scheme == "https" && endpoint.Host != "" && endpoint.Port() != "" && endpoint.User == nil &&
+		endpoint.RawQuery == "" && endpoint.Fragment == "" && (endpoint.Path == "" || endpoint.Path == "/")
+}

--- a/internal/runner/full_run_execution_manifest_test.go
+++ b/internal/runner/full_run_execution_manifest_test.go
@@ -1,0 +1,318 @@
+package runner
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/projection"
+	"github.com/openkubes/ok-cluster/internal/stageplan"
+)
+
+func TestLoadFullRunExecutionManifestBindsFreshPrivateContract(t *testing.T) {
+	manifest, cleanup := fullRunExecutionManifestFixture(t)
+	defer cleanup()
+
+	verified, receipt, err := LoadFullRunExecutionManifest(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	retained, err := verified.Receipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if receipt != retained || receipt.Format != FullRunExecutionManifestReceiptFormat || receipt.State != "VERIFIED" ||
+		receipt.ManifestDigest == "" || receipt.PlanDigest == "" || receipt.ProjectionManifestDigest == "" ||
+		receipt.ProjectionAuthorityDigest == "" || receipt.NetworkProfileDigest == "" || receipt.PlatformProfileDigest == "" ||
+		receipt.AggregateProfileDigest == "" || receipt.RuntimeIdentityMode != "lifecycle-derived-private/v1" ||
+		receipt.AuthorizationMode != "predecessor-bound-tls/v1" || receipt.CapabilityMode != "runtime-bound-in-memory/v1" ||
+		receipt.MutationAllowed {
+		t.Fatalf("unexpected full-run manifest receipt: %#v", receipt)
+	}
+	public, err := json.Marshal(receipt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range []string{"/private/", "token", "endpoint", "kubeconfig", "certificate", "targetidentitydigest"} {
+		if strings.Contains(strings.ToLower(string(public)), forbidden) {
+			t.Fatalf("public full-run manifest receipt disclosed %q", forbidden)
+		}
+	}
+}
+
+func TestFullRunExecutionManifestFailsClosed(t *testing.T) {
+	manifest, cleanup := fullRunExecutionManifestFixture(t)
+	defer cleanup()
+	raw, err := os.ReadFile(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root := filepath.Dir(manifest)
+	tests := map[string]func(map[string]any){
+		"unknown field": func(value map[string]any) { value["targetIdentityDigest"] = runnerStageSHA("f") },
+		"wrong profile": func(value map[string]any) {
+			value["profiles"].(map[string]any)["platform"].(map[string]any)["digest"] = runnerStageSHA("f")
+		},
+		"different workload handoff": func(value map[string]any) {
+			value["networkObservation"].(map[string]any)["workload"].(map[string]any)["tokenFile"] = filepath.Join(root, "other-workload-token")
+		},
+		"different ledger": func(value map[string]any) {
+			value["targetAccess"].(map[string]any)["ledger"].(map[string]any)["namespace"] = "other-ledger"
+		},
+		"relative ledger credential": func(value map[string]any) {
+			value["providerPrerequisites"].(map[string]any)["ledger"].(map[string]any)["tokenFile"] = "ledger-token"
+		},
+		"shared authority credential": func(value map[string]any) {
+			managementToken := value["clusterLifecycle"].(map[string]any)["authority"].(map[string]any)["tokenFile"]
+			value["providerPrerequisites"].(map[string]any)["authority"].(map[string]any)["tokenFile"] = managementToken
+		},
+		"unbounded authorization endpoint": func(value map[string]any) {
+			value["authorization"].(map[string]any)["endpoint"] = "https://authority.example.invalid/other"
+		},
+		"wrong capability namespace": func(value map[string]any) {
+			value["platformObservation"].(map[string]any)["capability"].(map[string]any)["namespace"] = "default"
+		},
+		"relative runtime output": func(value map[string]any) {
+			value["runtimeBinding"].(map[string]any)["materialPath"] = "runtime-binding.json"
+		},
+		"duplicate runtime output": func(value map[string]any) {
+			binding := value["networkObservation"].(map[string]any)["workload"].(map[string]any)["bindingPath"]
+			value["runtimeBinding"].(map[string]any)["materialPath"] = binding
+		},
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			var value map[string]any
+			if err := json.Unmarshal(raw, &value); err != nil {
+				t.Fatal(err)
+			}
+			mutate(value)
+			path := writeBundleFile(t, root, "unsafe-"+strings.ReplaceAll(name, " ", "-")+".json", mustJSON(t, value))
+			if _, _, err := LoadFullRunExecutionManifest(path); err == nil {
+				t.Fatal("unsafe full-run execution manifest was accepted")
+			}
+		})
+	}
+
+	existingOutput := filepath.Join(root, "future", "runtime-binding.json")
+	if err := os.WriteFile(existingOutput, []byte("occupied"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := LoadFullRunExecutionManifest(manifest); err == nil {
+		t.Fatal("full-run manifest accepted an occupied future output")
+	}
+}
+
+func TestFullRunExecutionManifestRejectsBroadModeAndRelativePath(t *testing.T) {
+	manifest, cleanup := fullRunExecutionManifestFixture(t)
+	defer cleanup()
+	if err := os.Chmod(manifest, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := LoadFullRunExecutionManifest(manifest); err == nil {
+		t.Fatal("broad full-run manifest was accepted")
+	}
+	if _, _, err := LoadFullRunExecutionManifest("full-run.json"); err == nil {
+		t.Fatal("relative full-run manifest was accepted")
+	}
+}
+
+func TestFullRunExecutionManifestRejectsTargetIdentityInRendererArtifacts(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		stageIndex int
+		field      func(*fullRunExecutionManifestDocument) *string
+	}{
+		{name: "target registration", stageIndex: 8, field: func(document *fullRunExecutionManifestDocument) *string {
+			return &document.TargetRegistration.ArtifactPath
+		}},
+		{name: "platform applications", stageIndex: 9, field: func(document *fullRunExecutionManifestDocument) *string {
+			return &document.PlatformApplications.ArtifactPath
+		}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			manifest, cleanup := fullRunExecutionManifestFixture(t)
+			defer cleanup()
+			document, _, err := loadFullRunExecutionManifest(manifest)
+			if err != nil {
+				t.Fatal(err)
+			}
+			artifactPath := *test.field(&document)
+			artifact, err := os.ReadFile(artifactPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			concrete := []byte(strings.ReplaceAll(string(artifact), "RUNTIME-TARGET-IDENTITY-DIGEST-REQUIRED", runnerStageSHA("9")))
+			unsafeArtifactPath := writeBundleFile(t, filepath.Dir(manifest), "unsafe-"+strings.ReplaceAll(test.name, " ", "-")+".yaml", concrete)
+			*test.field(&document) = unsafeArtifactPath
+
+			planRaw, err := os.ReadFile(document.Plan.Path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var plan map[string]any
+			if err := json.Unmarshal(planRaw, &plan); err != nil {
+				t.Fatal(err)
+			}
+			inputs := plan["stages"].([]any)[test.stageIndex].(map[string]any)["inputs"].([]any)
+			inputs[0].(map[string]any)["digest"] = digest.SHA256(concrete)
+			document.Plan.Path = writeBundleFile(t, filepath.Dir(manifest), "unsafe-"+strings.ReplaceAll(test.name, " ", "-")+"-plan.json", mustJSON(t, plan))
+			unsafeManifest := writeBundleFile(t, filepath.Dir(manifest), "unsafe-"+strings.ReplaceAll(test.name, " ", "-")+"-manifest.json", mustJSON(t, document))
+			if _, _, err := LoadFullRunExecutionManifest(unsafeManifest); err == nil {
+				t.Fatal("renderer artifact carrying a caller-selected target identity was accepted")
+			}
+		})
+	}
+}
+
+func TestFullRunExecutionManifestDigestIsFormattingIndependent(t *testing.T) {
+	manifest, cleanup := fullRunExecutionManifestFixture(t)
+	defer cleanup()
+	raw, err := os.ReadFile(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var value any
+	if err := json.Unmarshal(raw, &value); err != nil {
+		t.Fatal(err)
+	}
+	pretty, err := json.MarshalIndent(value, "", "    ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	prettyPath := writeBundleFile(t, filepath.Dir(manifest), "full-run-pretty.json", pretty)
+	_, first, err := loadFullRunExecutionManifest(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, second, err := loadFullRunExecutionManifest(prettyPath)
+	if err != nil || first != second {
+		t.Fatalf("semantic full-run manifest identity changed with formatting: %q %q %v", first, second, err)
+	}
+}
+
+func fullRunExecutionManifestFixture(t *testing.T) (string, func()) {
+	t.Helper()
+	postManifest, _, cleanup := postRuntimeManifestFixture(t)
+	post, _, err := loadPostRuntimeExecutionManifest(postManifest)
+	if err != nil {
+		cleanup()
+		t.Fatal(err)
+	}
+	root := filepath.Dir(postManifest)
+	expected := post.Plan.Expected
+
+	infra := []byte("apiVersion: v1\nkind: Namespace\nmetadata:\n  name: disposable-ok147\n  annotations:\n    openkubes.io/contract-name: disposable-ok147\n    openkubes.io/contract-namespace: disposable-ok147\n    openkubes.io/intent-revision: " + expected.IntentRevision + "\n")
+	management := []byte("apiVersion: cluster.x-k8s.io/v1beta2\nkind: Cluster\nmetadata:\n  name: disposable-ok147\n  namespace: disposable-ok147\n  annotations:\n    openkubes.io/contract-name: disposable-ok147\n    openkubes.io/contract-namespace: disposable-ok147\n    openkubes.io/intent-revision: " + expected.IntentRevision + "\nspec:\n  clusterNetwork:\n    services:\n      cidrBlocks: [10.100.0.0/20]\n")
+	authority := mustJSON(t, map[string]any{
+		"format": "ok141-contract-to-capi-projection/v2", "contractIdentity": expected.ContractIdentity, "intentRevision": expected.IntentRevision,
+		"infrastructurePlane": map[string]any{"identity": "ok-infra", "role": "provider-runtime-and-golden-image-prerequisites", "resources": []map[string]any{{"apiVersion": "v1", "kind": "Namespace", "name": "disposable-ok147"}}},
+		"managementPlane":     map[string]any{"identity": "ok-mgmt", "role": "single-lifecycle-writer", "resources": []map[string]any{{"apiVersion": "cluster.x-k8s.io/v1beta2", "kind": "Cluster", "namespace": "disposable-ok147", "name": "disposable-ok147"}}},
+		"providerAccess":      map[string]any{}, "excludedRendererArtifacts": []any{},
+	})
+	writeBundleFile(t, root, "authority-map.json", authority)
+	writeBundleFile(t, root, "ok-infra-prerequisites.yaml", infra)
+	writeBundleFile(t, root, "ok-mgmt-lifecycle.yaml", management)
+	projectionManifest := mustJSON(t, map[string]any{
+		"format": "ok141-contract-to-capi-projection/v2", "R": expected.IntentRevision, "authorizationState": "NO-GO",
+		"artifacts":      map[string]any{"authority-map.json": digest.SHA256(authority), "ok-infra-prerequisites.yaml": digest.SHA256(infra), "ok-mgmt-lifecycle.yaml": digest.SHA256(management)},
+		"objectSets":     map[string]any{"okInfraPrerequisites": map[string]any{"count": 1, "digest": runnerStageSHA("1")}, "okMgmtLifecycle": map[string]any{"count": 1, "digest": runnerStageSHA("2")}},
+		"providerAccess": map[string]any{}, "source": map[string]any{},
+	})
+	projectionManifestPath := writeBundleFile(t, root, "full-projection-manifest.json", projectionManifest)
+
+	enablement := runnerEnablementYAML(stagePlanExpected(expected))
+	enablementPath := writeBundleFile(t, root, "enablement.yaml", enablement)
+	planRaw, err := os.ReadFile(post.Plan.Path)
+	if err != nil {
+		cleanup()
+		t.Fatal(err)
+	}
+	var plan map[string]any
+	if err := json.Unmarshal(planRaw, &plan); err != nil {
+		cleanup()
+		t.Fatal(err)
+	}
+	stages := plan["stages"].([]any)
+	stages[0].(map[string]any)["inputs"] = []any{map[string]any{"name": "projection.provider-prerequisites", "digest": digest.SHA256(infra)}}
+	stages[1].(map[string]any)["inputs"] = []any{map[string]any{"name": "projection.cluster-lifecycle", "digest": digest.SHA256(management)}}
+	stages[3].(map[string]any)["inputs"] = []any{map[string]any{"name": "stage.enablement", "digest": digest.SHA256(enablement)}}
+	planPath := writeBundleFile(t, root, "full-staged-plan.json", mustJSON(t, plan))
+
+	privateRoot := filepath.Join(root, "future")
+	if err := os.Mkdir(privateRoot, 0o700); err != nil {
+		cleanup()
+		t.Fatal(err)
+	}
+	receiptDirectory := filepath.Join(root, "full-receipts")
+	if err := os.Mkdir(receiptDirectory, 0o700); err != nil {
+		cleanup()
+		t.Fatal(err)
+	}
+	workload := fullRunWorkloadRuntimeDocument{
+		BindingPath: filepath.Join(privateRoot, "workload-authority.json"),
+		TokenFile:   filepath.Join(privateRoot, "workload-token"),
+		CAFile:      filepath.Join(privateRoot, "workload-ca.crt"),
+	}
+	ledger := post.TargetCredential.Ledger
+	managementAuthority := post.AggregateEvidence.Management
+	infrastructureAuthority := managementAuthority
+	infrastructureAuthority.AuthorityIdentity = expected.InfrastructureAuthority
+	infrastructureAuthority.Endpoint = "https://192.0.2.13:6443"
+	infrastructureAuthority.TokenFile = "/private/tmp/infra-token"
+	infrastructureAuthority.CAFile = "/private/tmp/infra-ca"
+	infrastructureAuthority.CABundleDigest = runnerStageSHA("5")
+	providerRuntime := fullRunSubmissionRuntimeDocument{Ledger: ledger, Authority: infrastructureAuthority}
+	managementRuntime := fullRunSubmissionRuntimeDocument{Ledger: ledger, Authority: managementAuthority}
+	document := fullRunExecutionManifestDocument{
+		Format:                FullRunExecutionManifestFormat,
+		Plan:                  fullRunPlanDocument{Path: planPath, Expected: expected},
+		Projection:            fullRunProjectionDocument{ManifestPath: projectionManifestPath, Root: root},
+		Authorization:         post.Authorization,
+		Profiles:              post.Profiles,
+		ProviderPrerequisites: providerRuntime,
+		ClusterLifecycle:      managementRuntime,
+		LifecycleObservation:  fullRunLifecycleObservationDocument{Ledger: ledger, Management: managementAuthority, PollInterval: "1s", PollTimeout: "1m"},
+		Enablement: fullRunEnablementDocument{
+			ArtifactPath:   enablementPath,
+			ExpectedObject: projection.ResourceIdentity{APIVersion: "addons.cluster.x-k8s.io/v1alpha1", Kind: "HelmChartProxy", Namespace: "disposable-ok147", Name: "disposable-ok147-cilium"},
+			Runtime:        managementRuntime,
+		},
+		NetworkObservation: fullRunNetworkObservationDocument{Ledger: ledger, Management: managementAuthority, Workload: workload, PollInterval: "1s", PollTimeout: "1m"},
+		RuntimeBinding:     fullRunRuntimeBindingDocument{Ledger: ledger, Workload: workload, MaterialPath: filepath.Join(privateRoot, "runtime-binding.json"), ReceiptPath: filepath.Join(privateRoot, "runtime-binding-receipt.json")},
+		TargetAccess:       fullRunTargetAccessDocument{ArtifactPath: post.TargetCredential.TargetAccessArtifactPath, ExpectedObjects: append([]projection.ResourceIdentity(nil), post.TargetCredential.TargetAccessExpectedObjects...), Ledger: ledger, Workload: workload},
+		TargetCredential:   fullRunTargetCredentialDocument{PolicyPath: post.TargetCredential.PolicyPath, Ledger: ledger, Workload: workload},
+		TargetRegistration: fullRunTargetRegistrationDocument{
+			ArtifactPath: post.TargetRegistration.ArtifactPath, ArgoNamespace: post.TargetRegistration.ArgoNamespace,
+			ProjectName: post.TargetRegistration.ProjectName, RegistrationName: post.TargetRegistration.RegistrationName,
+			TargetName: post.TargetRegistration.TargetName, SourceRepository: post.TargetRegistration.SourceRepository,
+			TargetNamespaces: append([]string(nil), post.TargetRegistration.TargetNamespaces...), Ledger: ledger, GitOps: post.TargetRegistration.GitOps,
+		},
+		PlatformApplications: fullRunPlatformApplicationsDocument{
+			ArtifactPath: post.PlatformApplications.ArtifactPath, ArgoNamespace: post.PlatformApplications.ArgoNamespace,
+			ProjectName: post.PlatformApplications.ProjectName, RegistrationName: post.PlatformApplications.RegistrationName,
+			SourceRepository: post.PlatformApplications.SourceRepository, Ledger: ledger, GitOps: post.PlatformApplications.GitOps,
+		},
+		PlatformObservation: fullRunPlatformObservationDocument{
+			Ledger: ledger, Argo: post.PlatformObservation.Argo,
+			Capability:   fullRunCapabilityDocument{Namespace: "ok-observability", Timeout: "10m", CleanupTimeout: "1m"},
+			PollInterval: "1s", PollTimeout: "1m",
+		},
+		AggregateEvidence: fullRunAggregateEvidenceDocument{Ledger: ledger, Management: managementAuthority, Argo: post.AggregateEvidence.Argo, WorkloadTokenFile: workload.TokenFile, WorkloadCAFile: workload.CAFile},
+		ReceiptDirectory:  receiptDirectory,
+	}
+	return writeBundleFile(t, root, "full-run-manifest.json", mustJSON(t, document)), cleanup
+}
+
+func stagePlanExpected(document postRuntimePlanExpectedDocument) stageplan.Expected {
+	return stageplan.Expected{
+		ContractIdentity: document.ContractIdentity,
+		IntentRevision:   document.IntentRevision, EnablementRevision: document.EnablementRevision,
+		PlatformRevision: document.PlatformRevision, ExecutionFixture: document.ExecutionFixture,
+		InfrastructureAuthority: document.InfrastructureAuthority, ManagementAuthority: document.ManagementAuthority,
+		GitOpsAuthority: document.GitOpsAuthority,
+	}
+}

--- a/internal/runner/full_run_execution_test.go
+++ b/internal/runner/full_run_execution_test.go
@@ -14,6 +14,12 @@ type fakeConcretePreRuntimeExecution struct {
 	prefixErr   error
 	runs        int
 	prefixCalls int
+	target      string
+	targetErr   error
+}
+
+func (execution *fakeConcretePreRuntimeExecution) RuntimeTargetIdentity() (string, error) {
+	return execution.target, execution.targetErr
 }
 
 func (execution *fakeConcretePreRuntimeExecution) Run(context.Context) (PreRuntimeExecutionReceipt, error) {
@@ -39,6 +45,10 @@ func TestFullRunExecutionComposesConcreteAdaptersWithExactPrivatePrefix(t *testi
 			postCalls++
 			if preRuntime.runs != 1 || preRuntime.prefixCalls != 1 || !reflect.DeepEqual(bound.TargetCredential.Receipts, preRuntime.prefix) {
 				t.Fatalf("post-runtime suffix did not receive the completed private prefix: %#v", bound.TargetCredential.Receipts)
+			}
+			if bound.TargetRegistration.Expected.TargetIdentityDigest == "" ||
+				bound.PlatformApplications.Expected.TargetIdentityDigest != bound.TargetRegistration.Expected.TargetIdentityDigest {
+				t.Fatalf("post-runtime suffix did not receive one lifecycle-derived target identity: %#v", bound)
 			}
 			return postRuntime, nil
 		},
@@ -145,6 +155,28 @@ func TestFullRunExecutionRejectsPrivatePrefixDifferentFromPublicCheckpoints(t *t
 	}
 }
 
+func TestFullRunExecutionDoesNotOpenSuffixWithoutLifecycleTargetIdentity(t *testing.T) {
+	preRuntime := successfulFakeConcretePreRuntimeExecution(t)
+	preRuntime.target = ""
+	preRuntime.targetErr = errors.New("missing lifecycle identity")
+	postCalls := 0
+	execution, err := openFullRunExecution(testFullRunExecutionConfig(), fullRunExecutionFactories{
+		preRuntime: func(PreRuntimeExecutionConfig) (fullRunPreRuntimeExecution, error) { return preRuntime, nil },
+		postRuntime: func(PostRuntimeExecutionConfig) (PostRuntimeContinuation, error) {
+			postCalls++
+			return successfulFakePostRuntimeContinuation(), nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := execution.Run(context.Background())
+	if err == nil || receipt.State != "STOPPED" || receipt.StoppedAt != "target-credential" ||
+		len(receipt.Checkpoints) != 7 || postCalls != 0 {
+		t.Fatalf("missing lifecycle identity opened suffix: %#v post=%d err=%v", receipt, postCalls, err)
+	}
+}
+
 func TestOpenFullRunExecutionRejectsHistoricalSuffixState(t *testing.T) {
 	for name, mutate := range map[string]func(*FullRunExecutionConfig){
 		"prebound receipts": func(config *FullRunExecutionConfig) {
@@ -164,6 +196,12 @@ func TestOpenFullRunExecutionRejectsHistoricalSuffixState(t *testing.T) {
 		},
 		"foreign runtime receipt": func(config *FullRunExecutionConfig) {
 			config.PostRuntime.RuntimeBinding.ReceiptPath = "/private/foreign-runtime-receipt.json"
+		},
+		"prefilled registration target": func(config *FullRunExecutionConfig) {
+			config.PostRuntime.TargetRegistration.Expected.TargetIdentityDigest = runnerStageSHA("1")
+		},
+		"prefilled applications target": func(config *FullRunExecutionConfig) {
+			config.PostRuntime.PlatformApplications.Expected.TargetIdentityDigest = runnerStageSHA("1")
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -200,7 +238,7 @@ func successfulFakeConcretePreRuntimeExecution(t *testing.T) *fakeConcretePreRun
 	for index, checkpoint := range receipt.Checkpoints {
 		prefix[index] = StageReceiptSource{Path: "/private/" + checkpoint.StageID + ".json", Digest: checkpoint.StageReceiptDigest}
 	}
-	return &fakeConcretePreRuntimeExecution{receipt: receipt, prefix: prefix}
+	return &fakeConcretePreRuntimeExecution{receipt: receipt, prefix: prefix, target: runnerStageSHA("7")}
 }
 
 func testFullRunExecutionConfig() FullRunExecutionConfig {

--- a/internal/runner/pre_runtime_execution.go
+++ b/internal/runner/pre_runtime_execution.go
@@ -320,6 +320,28 @@ func (executor *PreRuntimeExecution) ReceiptPrefix() ([]StageReceiptSource, erro
 	return append([]StageReceiptSource(nil), executor.prefix...), nil
 }
 
+// RuntimeTargetIdentity reloads the completed private prefix and returns only
+// the lifecycle-derived CAPI Cluster UID digest. Raw target identity remains
+// private and no file path is exposed.
+func (executor *PreRuntimeExecution) RuntimeTargetIdentity() (string, error) {
+	prefix, err := executor.ReceiptPrefix()
+	if err != nil {
+		return "", err
+	}
+	plan, _, verifiedPrefix, err := loadStageResumeWithPrefix(StageResumeConfig{
+		PlanPath: executor.config.PlanPath, PlanExpected: executor.config.PlanExpected, Receipts: prefix,
+	})
+	if err != nil || len(verifiedPrefix) != len(preRuntimeStageOrder) {
+		return "", errors.New("verify completed pre-runtime target identity")
+	}
+	lifecycle, err := verifiedPrefix[1].Receipt()
+	if err != nil || lifecycle.StageID != "cluster-lifecycle" || lifecycle.State != "SUCCEEDED" ||
+		lifecycle.PlanDigest != plan.PlanDigest || !stageReceiptPrefixDigestPattern.MatchString(lifecycle.TargetClusterUIDDigest) {
+		return "", errors.New("completed pre-runtime target identity is unavailable")
+	}
+	return lifecycle.TargetClusterUIDDigest, nil
+}
+
 func (executor *PreRuntimeExecution) resume(receipts []StageReceiptSource) StageResumeConfig {
 	prefix := make([]StageReceiptSource, len(receipts))
 	copy(prefix, receipts)

--- a/internal/runner/pre_runtime_execution_test.go
+++ b/internal/runner/pre_runtime_execution_test.go
@@ -65,6 +65,10 @@ func TestPreRuntimeExecutionComposesExactPrefixWithDynamicAuthorization(t *testi
 	if err != nil || len(prefix) != 7 {
 		t.Fatalf("completed private prefix is unavailable: %#v %v", prefix, err)
 	}
+	targetIdentity, err := executor.RuntimeTargetIdentity()
+	if err != nil || targetIdentity != digest.SHA256([]byte("11111111-1111-4111-8111-111111111111")) {
+		t.Fatalf("completed runtime target identity differs: %q %v", targetIdentity, err)
+	}
 	prefix[0].Digest = runnerStageSHA("f")
 	again, err := executor.ReceiptPrefix()
 	if err != nil || again[0].Digest == prefix[0].Digest {


### PR DESCRIPTION
## Summary

- add a strict private manifest for a fresh twelve-stage full run
- derive target identity only from the verified lifecycle receipt before opening the post-runtime suffix
- bind exact projection, R/E/P profiles, artifacts, ledger, isolated authority planes, future runtime handoffs, and private receipt destinations
- fail closed on caller-selected target identity, mismatched bindings, occupied outputs, unsafe paths, or broad manifest permissions
- document that this checkpoint verifies the activation contract but does not yet activate a local or Job-based CreateCluster run

## Verification

- `go test ./...`
- `go vet ./...`
- targeted `go test -race ./internal/runner` for full-run manifest/execution and pre-runtime execution

## Boundary

No cluster contact, infrastructure mutation, retry, rollback, cleanup, or new reconciliation ownership is introduced.