### PR TITLE
feat(runner): resolve Stage 8 authorization after prefix

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -2805,7 +2805,9 @@ opening Stage 8-12 until all seven receipts are successful and durable. It
 loads the private prefix from the completed adapter, checks every private
 digest against the redaction-safe checkpoints and injects only that exact
 prefix into a fresh PostRuntimeExecution. A suffix carrying historical
-receipts or either recovery mode is rejected before the prefix opens. The
+receipts, a prebound Stage-8 grant or either recovery mode is rejected before
+the prefix opens. Stage-8 authorization is instead resolved through the same
+external authority boundary after the completed seven-receipt prefix. The
 existing full-run binding then independently compares the PostRuntimeExecution
 continuation identity before Stage 8 can run. The adapter is single-use and
 still has no manifest, CLI or Job activation surface.
@@ -2878,10 +2880,11 @@ cannot confuse a normal stage grant with either recovery decision.
 
 The concrete post-runtime execution adapter now composes those boundaries into
 one single-use Stage 8-12 library path. It normally starts from the exact
-seven-receipt cursor, reuses one verified runtime binding, executes the
-memory-only credential handoff, resolves Stage 9 and Stage 10 authorization
-only after the current predecessor receipt is durable, and opens the existing
-registration, Application, observation and aggregate operations. An explicit
+seven-receipt cursor, reuses one verified runtime binding, resolves the fresh
+Stage 8 grant only after that exact prefix is durable, executes the memory-only
+credential handoff, then resolves Stage 9 and Stage 10 authorization only
+after each current direct predecessor receipt is durable. The three resolved
+authorization receipts are ordered with those stages. An explicit
 recovery configuration may instead supply the exact successful Stage-8 receipt
 and the separate recovery authority described above; after the new grant is
 durably consumed, execution continues at Stage 9 using that unchanged receipt

--- a/internal/runner/full_run_execution.go
+++ b/internal/runner/full_run_execution.go
@@ -67,6 +67,10 @@ func openFullRunExecution(config FullRunExecutionConfig, factories fullRunExecut
 		config.PostRuntime.TargetRegistrationRecovery != nil {
 		return nil, errors.New("full-run execution requires a fresh unbound post-runtime suffix")
 	}
+	if config.PostRuntime.TargetCredential.GrantPath != "" || config.PostRuntime.TargetCredential.GrantPublicKeyPath != "" ||
+		!config.PostRuntime.TargetCredential.EvaluationTime.IsZero() {
+		return nil, errors.New("full-run Stage-8 authorization must be resolved after the completed prefix")
+	}
 
 	preRuntime, err := factories.preRuntime(config.PreRuntime)
 	if err != nil || preRuntime == nil {

--- a/internal/runner/full_run_execution_test.go
+++ b/internal/runner/full_run_execution_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"reflect"
 	"testing"
+	"time"
 )
 
 type fakeConcretePreRuntimeExecution struct {
@@ -187,6 +188,11 @@ func TestOpenFullRunExecutionRejectsHistoricalSuffixState(t *testing.T) {
 		},
 		"registration recovery": func(config *FullRunExecutionConfig) {
 			config.PostRuntime.TargetRegistrationRecovery = &PostRuntimeTargetRegistrationRecoveryConfig{}
+		},
+		"prebound Stage-8 authorization": func(config *FullRunExecutionConfig) {
+			config.PostRuntime.TargetCredential.GrantPath = "/private/stage8-grant.json"
+			config.PostRuntime.TargetCredential.GrantPublicKeyPath = "/private/stage8-authority.pub"
+			config.PostRuntime.TargetCredential.EvaluationTime = time.Date(2026, 8, 21, 8, 0, 0, 0, time.UTC)
 		},
 		"foreign plan": func(config *FullRunExecutionConfig) {
 			config.PostRuntime.TargetCredential.PlanPath = "/private/foreign-plan.json"

--- a/internal/runner/post_runtime_execution.go
+++ b/internal/runner/post_runtime_execution.go
@@ -63,9 +63,10 @@ type PostRuntimeTargetRegistrationRecoveryConfig struct {
 }
 
 // PostRuntimeExecutionConfig supplies immutable artifacts and private runtime
-// bindings for exactly Stage 8-12. The Stage-8 grant is already part of its
-// verified bundle; later mutating grants are resolved only after their direct
-// predecessor receipt is durable.
+// bindings for exactly Stage 8-12. A fresh execution may leave the Stage-8
+// grant fields empty so authorization is resolved only after the exact seven
+// predecessor receipts are durable. Recovery still requires the historical,
+// prebound Stage-8 bundle it is proving and continuing.
 type PostRuntimeExecutionConfig struct {
 	TargetCredential           TargetCredentialStageBundleConfig
 	TargetCredentialRun        TargetCredentialStageRuntimeConfig
@@ -127,6 +128,7 @@ type PostRuntimeExecution struct {
 	continuation         PostRuntimeContinuationBinding
 	runtime              VerifiedRuntimeBindingMaterial
 	credential           postRuntimeCredentialInvocation
+	dynamicCredential    bool
 	recoveryBundle       *VerifiedTargetCredentialStageBundle
 	recovery             *PostRuntimeTargetCredentialRecoveryConfig
 	registrationRecovery *PostRuntimeTargetRegistrationRecoveryConfig
@@ -183,12 +185,21 @@ func openPostRuntimeExecution(config PostRuntimeExecutionConfig, factories postR
 	}
 	var credential postRuntimeCredentialInvocation
 	var recoveryBundle *VerifiedTargetCredentialStageBundle
+	dynamicCredential, err := targetCredentialAuthorizationIsDynamic(config.TargetCredential)
+	if err != nil {
+		return nil, err
+	}
 	if config.TargetCredentialRecovery == nil {
-		credential, err = factories.credential(config.TargetCredential, config.TargetCredentialRun)
-		if err != nil || credential.run == nil || credential.ledger == nil {
-			return nil, errors.New("open post-runtime target credential stage")
+		if !dynamicCredential {
+			credential, err = factories.credential(config.TargetCredential, config.TargetCredentialRun)
+			if err != nil || credential.run == nil || credential.ledger == nil {
+				return nil, errors.New("open post-runtime target credential stage")
+			}
 		}
 	} else {
+		if dynamicCredential {
+			return nil, errors.New("post-runtime target-credential recovery requires a prebound Stage-8 authorization")
+		}
 		retainedRecovery := *config.TargetCredentialRecovery
 		config.TargetCredentialRecovery = &retainedRecovery
 		if config.TargetCredentialRecovery.Authorization == nil {
@@ -233,7 +244,8 @@ func openPostRuntimeExecution(config PostRuntimeExecutionConfig, factories postR
 	config.AggregateEvidence.Runtime.RuntimeReceiptPath = config.RuntimeBinding.ReceiptPath
 	return &PostRuntimeExecution{
 		config: config, initial: initial, continuation: continuation, runtime: runtime, credential: credential,
-		recoveryBundle: recoveryBundle, recovery: config.TargetCredentialRecovery, factories: factories,
+		dynamicCredential: dynamicCredential,
+		recoveryBundle:    recoveryBundle, recovery: config.TargetCredentialRecovery, factories: factories,
 		registrationRecovery: registrationRecovery,
 	}, nil
 }
@@ -300,13 +312,38 @@ func (executor *PostRuntimeExecution) Run(ctx context.Context) (PostRuntimeExecu
 			receipts = append(receipts, executor.recovery.StageReceipt)
 			return runReceipt, handoff, nil
 		}
-		runReceipt, handoff, err := executor.credential.run(ctx)
+		credential := executor.credential
+		var resolved *ResolvedStageAuthorization
+		if executor.dynamicCredential {
+			resolvedAuthorization, err := ResolveStageAuthorization(ctx, executor.resume(receipts), executor.config.Authorization)
+			if err != nil {
+				return execution.StagedOperationReceipt{}, nil, err
+			}
+			source, err := resolvedAuthorization.Source()
+			if err != nil {
+				return execution.StagedOperationReceipt{}, nil, err
+			}
+			bundle := executor.config.TargetCredential
+			bundle.GrantPath = source.GrantPath
+			bundle.GrantPublicKeyPath = source.PublicKeyPath
+			bundle.EvaluationTime = source.EvaluationTime
+			credential, err = executor.factories.credential(bundle, executor.config.TargetCredentialRun)
+			if err != nil || credential.run == nil || credential.ledger == nil {
+				return execution.StagedOperationReceipt{}, nil, errors.New("open post-runtime target credential stage")
+			}
+			resolved = &resolvedAuthorization
+		}
+		runReceipt, handoff, err := credential.run(ctx)
 		if err != nil {
 			return runReceipt, handoff, err
 		}
-		source, err := executor.bridgeStagedReceipt(ctx, receipts, executor.credential.ledger, runReceipt)
+		source, err := executor.bridgeStagedReceipt(ctx, receipts, credential.ledger, runReceipt)
 		if err != nil {
 			return runReceipt, handoff, err
+		}
+		if resolved != nil {
+			receipt, _ := resolved.Receipt()
+			authorizations = append(authorizations, receipt)
 		}
 		receipts = append(receipts, source)
 		return runReceipt, handoff, nil
@@ -425,6 +462,18 @@ func (executor *PostRuntimeExecution) Run(ctx context.Context) (PostRuntimeExecu
 		TargetRegistrationRecovery:                registrationRecoveryReceipt,
 	}
 	return result, err
+}
+
+func targetCredentialAuthorizationIsDynamic(config TargetCredentialStageBundleConfig) (bool, error) {
+	pathsAbsent := config.GrantPath == "" && config.GrantPublicKeyPath == ""
+	pathsPresent := config.GrantPath != "" && config.GrantPublicKeyPath != ""
+	if pathsAbsent && config.EvaluationTime.IsZero() {
+		return true, nil
+	}
+	if pathsPresent && !config.EvaluationTime.IsZero() {
+		return false, nil
+	}
+	return false, errors.New("post-runtime Stage-8 authorization must be either fully dynamic or fully prebound")
 }
 
 func (executor *PostRuntimeExecution) resume(receipts []StageReceiptSource) StageResumeConfig {

--- a/internal/runner/post_runtime_execution_test.go
+++ b/internal/runner/post_runtime_execution_test.go
@@ -24,6 +24,9 @@ import (
 
 func TestPostRuntimeExecutionComposesExactSuffixWithDynamicAuthorization(t *testing.T) {
 	config, factories, calls, requests := postRuntimeExecutionFixture(t)
+	config.TargetCredential.GrantPath = ""
+	config.TargetCredential.GrantPublicKeyPath = ""
+	config.TargetCredential.EvaluationTime = time.Time{}
 	executor, err := openPostRuntimeExecution(config, factories)
 	if err != nil {
 		t.Fatal(err)
@@ -33,15 +36,16 @@ func TestPostRuntimeExecutionComposesExactSuffixWithDynamicAuthorization(t *test
 		t.Fatal(err)
 	}
 	if receipt.Format != PostRuntimeExecutionReceiptFormat || receipt.State != "SUCCEEDED" || receipt.StoppedAt != "" ||
-		len(receipt.Checkpoints) != 5 || len(receipt.ResolvedAuthorizations) != 2 {
+		len(receipt.Checkpoints) != 5 || len(receipt.ResolvedAuthorizations) != 3 {
 		t.Fatalf("unexpected post-runtime execution receipt: %#v", receipt)
 	}
 	if !reflect.DeepEqual(*calls, postRuntimeStageOrder) {
 		t.Fatalf("post-runtime execution order differs: %v", *calls)
 	}
-	if len(*requests) != 2 || (*requests)[0].StageID != "target-registration" || (*requests)[1].StageID != "platform-applications" ||
-		(*requests)[0].Predecessors[0].StageID != "target-credential" || (*requests)[1].Predecessors[0].StageID != "target-registration" ||
-		(*requests)[0].RequestDigest == (*requests)[1].RequestDigest {
+	if len(*requests) != 3 || (*requests)[0].StageID != "target-credential" || (*requests)[1].StageID != "target-registration" ||
+		(*requests)[2].StageID != "platform-applications" || (*requests)[0].Predecessors[0].StageID != "target-access" ||
+		(*requests)[1].Predecessors[0].StageID != "target-credential" || (*requests)[2].Predecessors[0].StageID != "target-registration" ||
+		(*requests)[0].RequestDigest == (*requests)[1].RequestDigest || (*requests)[1].RequestDigest == (*requests)[2].RequestDigest {
 		t.Fatalf("unexpected dynamic authorization sequence: %#v", *requests)
 	}
 	for index, stageID := range postRuntimeStageOrder[:4] {
@@ -62,6 +66,55 @@ func TestPostRuntimeExecutionComposesExactSuffixWithDynamicAuthorization(t *test
 		if strings.Contains(string(public), forbidden) {
 			t.Fatalf("public execution receipt exposed %q", forbidden)
 		}
+	}
+}
+
+func TestPostRuntimeExecutionStopsBeforeStageEightWhenDynamicGrantIsUnavailable(t *testing.T) {
+	config, factories, calls, _ := postRuntimeExecutionFixture(t)
+	config.TargetCredential.GrantPath = ""
+	config.TargetCredential.GrantPublicKeyPath = ""
+	config.TargetCredential.EvaluationTime = time.Time{}
+	resolverCalls := 0
+	config.Authorization = StageAuthorizationResolverFunc(func(context.Context, StageAuthorizationRequest) (StageAuthorizationSource, error) {
+		resolverCalls++
+		return StageAuthorizationSource{}, errors.New("authority unavailable with private details")
+	})
+	executor, err := openPostRuntimeExecution(config, factories)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := executor.Run(context.Background())
+	if err == nil || receipt.State != "STOPPED" || receipt.StoppedAt != "target-credential" || len(receipt.Checkpoints) != 0 ||
+		len(receipt.ResolvedAuthorizations) != 0 || resolverCalls != 1 || len(*calls) != 0 {
+		t.Fatalf("unavailable Stage-8 authority was not fail-closed: %#v resolver=%d calls=%v err=%v", receipt, resolverCalls, *calls, err)
+	}
+	for _, stageID := range postRuntimeStageOrder[:4] {
+		if _, statErr := os.Lstat(filepath.Join(config.ReceiptDirectory, postRuntimeReceiptFiles[stageID])); !errors.Is(statErr, os.ErrNotExist) {
+			t.Fatalf("receipt %s exists after Stage-8 authorization stop: %v", stageID, statErr)
+		}
+	}
+}
+
+func TestPostRuntimeExecutionRejectsPartialStageEightAuthorization(t *testing.T) {
+	for name, mutate := range map[string]func(*TargetCredentialStageBundleConfig){
+		"grant only": func(config *TargetCredentialStageBundleConfig) {
+			config.GrantPublicKeyPath = ""
+		},
+		"evaluation only": func(config *TargetCredentialStageBundleConfig) {
+			config.GrantPath = ""
+			config.GrantPublicKeyPath = ""
+		},
+		"paths without evaluation": func(config *TargetCredentialStageBundleConfig) {
+			config.EvaluationTime = time.Time{}
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			config, factories, calls, requests := postRuntimeExecutionFixture(t)
+			mutate(&config.TargetCredential)
+			if _, err := openPostRuntimeExecution(config, factories); err == nil || len(*calls) != 0 || len(*requests) != 0 {
+				t.Fatalf("partial Stage-8 authorization was accepted: calls=%v requests=%v err=%v", *calls, *requests, err)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Outcome

Closes the first full-run activation gap by resolving the fresh Stage-8 target-credential grant only after the exact seven-receipt prefix is durable.

## Scope

- support fully dynamic or fully prebound Stage-8 authorization, rejecting partial bindings
- resolve, verify and receipt the dynamic Stage-8 grant before opening target credential execution
- require fresh full runs to use the dynamic path
- preserve existing prebound crash-recovery semantics
- document the receipt-bound Stage 8/9/10 authority chain

## Safety

- no infrastructure or cluster contact
- no retry, rollback, cleanup or new ownership
- authority failures stop before Stage 8 and write no later receipt

## Verification

- go test ./...
- go vet ./...
- go test -race ./internal/runner