### PR TITLE
feat(runner): activate verified full-run manifest

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -2833,6 +2833,18 @@ exposes the defensive private prefix required by the full-run seam. This adds
 no renderer, policy authority, retry, rollback, cleanup, CLI command or Job
 mutation surface.
 
+The same adapter now defers its workload-authority binding until the exact
+four-receipt prefix through Enablement is durable. A caller may bind only three
+future private destinations while opening the execution; it cannot preselect
+the workload-authority binding digest. One injected resolver must return those
+exact destinations plus the lifecycle-derived binding digest before Stage 5
+opens.
+That one result is reused unchanged by Network observation, runtime binding,
+target access and the Stage-8 credential suffix. A missing resolver result,
+changed path or prebound identity stops before Network observation and exposes
+no completed workload handoff. The resolver seam performs no implicit retry or
+fallback and is not itself an authority materializer.
+
 The private full-run execution manifest closes the fresh-run input contract
 without inventing runtime truth. It binds one empty Stage-1 Plan cursor, the
 verified Contract projection, all R/E/P profiles and renderer artifacts, one
@@ -2844,15 +2856,27 @@ Loading is offline and grants no mutation.
 The manifest deliberately cannot carry a selected target identity. After
 Stage 2 succeeds, the concrete execution adapter reloads the exact lifecycle
 receipt and injects its CAPI-UID digest into the Stage 8-12 registration and
-Application expectations. Workload endpoint, CA and token material are also
-future lifecycle-derived files, Stage-8 authorization remains predecessor-
-bound, and capability evidence is produced in memory at observation time.
+Application expectations. Workload endpoint, CA and the client-certificate
+kubeconfig are also future lifecycle-derived files, Stage-8 authorization
+remains predecessor-bound, and capability evidence is produced in memory at
+observation time.
 Pre-existing handoff or receipt files, mismatched authorities or ledgers,
 foreign profile/artifact digests, duplicate destinations and a non-empty
 resume cursor stop verification. The redaction-safe manifest receipt contains
-only semantic identities and execution modes. This checkpoint defines the
-private contract; the following activation checkpoint converts the verified
-document into the existing concrete adapters.
+only semantic identities and execution modes.
+
+The local manifest-to-executor activation now converts that verified document
+into the existing concrete Stage 1-12 adapters. It binds the lifecycle-owned
+client-certificate kubeconfig materializer to the exact three future private
+destinations, opens the predecessor-bound authorization resolver and maps all
+profiles, artifacts, authorities, polling limits and receipt destinations
+without an API request. The process-local Platform capability factory receives
+only namespace, timeout, R, P, fixture, contract and executable identities; it
+receives no credential, endpoint, target UID, command or arbitrary payload.
+Its lazy result executes at most once after the Application gate opens and is
+then reused unchanged by aggregate evaluation. A failed capability is cached
+as failure and is never retried by this seam. The direct
+`OpenFullRunExecutionManifest` entry point remains inert until `Run`.
 
 The post-runtime authorization resolver closes the next authority boundary.
 After a predecessor receipt is durable, it derives one canonical,
@@ -3050,9 +3074,17 @@ durable receipts. This is not yet the OK-147 Definition of Done:
   [ADR-030 amendment proposal](ok147-adr-030-amendment-proposal.md) are defined
   and remain to be reviewed with the live evidence.
 
-The remaining implementation work is the manifest-to-executor activation and
-the shared local/Job activation surface for this concrete composition; it is
-not a new controller or reconciliation mechanism. After that, live closure must
+The concrete lifecycle-authority materializer now reads exactly the runtime
+CAPI Cluster and its CAPI-owned `<name>-kubeconfig` Secret after Stage 4. It
+verifies the lifecycle UID correlation, endpoint, CA and client-certificate
+kubeconfig, then writes the kubeconfig, CA and semantic binding create-only as
+private `0600` files with the binding last. It has no list, watch, discovery,
+Kubernetes mutation, retry or cleanup surface. The verified full-run manifest
+now opens that materializer, all concrete Stage 1-12 adapters and the shared
+single-execution Platform capability session without contacting a cluster.
+The remaining implementation work is the shared local/Job activation surface
+for this concrete composition; this is not a new controller or reconciliation
+mechanism. After that, live closure must
 publish the current image, construct fresh short-lived private inputs, run the
 exact bounded activation on `ok-mgmt`, preserve a stopped partial state without
 automatic retry, and separately repeat disposable-cluster and

--- a/internal/observation/network_kubernetes.go
+++ b/internal/observation/network_kubernetes.go
@@ -16,18 +16,20 @@ import (
 // configured TLS client to one Kubernetes API endpoint. The plane-specific
 // constructors derive their request allowlists internally.
 type KubernetesNetworkReaderConfig struct {
-	Endpoint    string
-	BearerToken string
-	Client      *http.Client
+	Endpoint          string
+	BearerToken       string
+	ClientCertificate bool
+	Client            *http.Client
 }
 
 // KubernetesNetworkReader implements NetworkRawGetter without exposing
 // discovery, arbitrary list paths, watch, mutation, retry, or redirects.
 type KubernetesNetworkReader struct {
-	endpoint *url.URL
-	token    string
-	client   *http.Client
-	allowed  map[string]struct{}
+	endpoint          *url.URL
+	token             string
+	clientCertificate bool
+	client            *http.Client
+	allowed           map[string]struct{}
 }
 
 func NewKubernetesManagementNetworkReader(config KubernetesNetworkReaderConfig, namespace, name, hcpName string) (*KubernetesNetworkReader, error) {
@@ -54,8 +56,9 @@ func newKubernetesNetworkReader(config KubernetesNetworkReaderConfig, allowed []
 	if endpoint.Scheme != "https" && !(endpoint.Scheme == "http" && (host == "127.0.0.1" || host == "::1" || host == "localhost")) {
 		return nil, errors.New("network reader Kubernetes endpoint must use HTTPS")
 	}
-	if config.BearerToken == "" || strings.TrimSpace(config.BearerToken) != config.BearerToken || strings.ContainsAny(config.BearerToken, "\r\n") {
-		return nil, errors.New("network reader Kubernetes bearer token is invalid")
+	tokenMode := config.BearerToken != ""
+	if tokenMode == config.ClientCertificate || strings.TrimSpace(config.BearerToken) != config.BearerToken || strings.ContainsAny(config.BearerToken, "\r\n") {
+		return nil, errors.New("network reader Kubernetes transport credential is invalid")
 	}
 	if config.Client == nil {
 		return nil, errors.New("network reader requires an explicitly configured HTTP client")
@@ -73,7 +76,10 @@ func newKubernetesNetworkReader(config KubernetesNetworkReaderConfig, allowed []
 		client.Timeout = 15 * time.Second
 	}
 	endpoint.Path, endpoint.RawPath = "", ""
-	return &KubernetesNetworkReader{endpoint: endpoint, token: config.BearerToken, client: &client, allowed: paths}, nil
+	return &KubernetesNetworkReader{
+		endpoint: endpoint, token: config.BearerToken, clientCertificate: config.ClientCertificate,
+		client: &client, allowed: paths,
+	}, nil
 }
 
 func (reader *KubernetesNetworkReader) Get(ctx context.Context, path string) ([]byte, error) {
@@ -91,7 +97,9 @@ func (reader *KubernetesNetworkReader) Get(ctx context.Context, path string) ([]
 		return nil, errors.New("construct bounded network source request")
 	}
 	request.Header.Set("Accept", "application/json")
-	request.Header.Set("Authorization", "Bearer "+reader.token)
+	if !reader.clientCertificate {
+		request.Header.Set("Authorization", "Bearer "+reader.token)
+	}
 	response, err := reader.client.Do(request)
 	if err != nil {
 		return nil, errors.New("bounded network source request failed")

--- a/internal/runner/aggregate_evidence_files.go
+++ b/internal/runner/aggregate_evidence_files.go
@@ -18,6 +18,7 @@ type AggregateEvidenceStageFileRuntimeConfig struct {
 	Argo                     KubernetesAuthorityConfig
 	ExpectedWorkloadEndpoint string
 	WorkloadTokenFile        string
+	WorkloadKubeconfigFile   string
 	WorkloadCAFile           string
 	RuntimeMaterialPath      string
 	RuntimeReceiptPath       string
@@ -39,7 +40,7 @@ func LoadAggregateEvidenceStageFileRuntime(config AggregateEvidenceStageFileRunt
 	if config.ExpectedWorkloadEndpoint == "" || runtime.material.Target.WorkloadAPIEndpoint != config.ExpectedWorkloadEndpoint {
 		return AggregateEvidenceStageRuntimeConfig{}, errors.New("aggregate workload endpoint differs from runtime binding")
 	}
-	if config.WorkloadTokenFile == "" || config.WorkloadCAFile == "" {
+	if config.WorkloadCAFile == "" || (config.WorkloadTokenFile != "") == (config.WorkloadKubeconfigFile != "") {
 		return AggregateEvidenceStageRuntimeConfig{}, errors.New("aggregate workload credential files are required")
 	}
 	capability, err := OpenPlatformCapabilityFileResolver(PlatformCapabilityFileResolverConfig{
@@ -55,7 +56,8 @@ func LoadAggregateEvidenceStageFileRuntime(config AggregateEvidenceStageFileRunt
 	config.Argo.CABundleDigest = digest.SHA256(argoCA)
 	workload := &runtimeBindingWorkloadAuthorityResolver{
 		targetUID: runtime.material.Target.CAPIClusterUID, endpoint: runtime.material.Target.WorkloadAPIEndpoint,
-		caDigest: runtime.material.Target.WorkloadAPICADigest, tokenFile: config.WorkloadTokenFile, caFile: config.WorkloadCAFile,
+		caDigest: runtime.material.Target.WorkloadAPICADigest, tokenFile: config.WorkloadTokenFile,
+		kubeconfigFile: config.WorkloadKubeconfigFile, caFile: config.WorkloadCAFile,
 	}
 	return AggregateEvidenceStageRuntimeConfig{
 		Ledger: config.Ledger,
@@ -72,7 +74,7 @@ func LoadAggregateEvidenceStageFileRuntime(config AggregateEvidenceStageFileRunt
 }
 
 type runtimeBindingWorkloadAuthorityResolver struct {
-	targetUID, endpoint, caDigest, tokenFile, caFile string
+	targetUID, endpoint, caDigest, tokenFile, kubeconfigFile, caFile string
 }
 
 func (resolver *runtimeBindingWorkloadAuthorityResolver) ResolveWorkloadAuthority(ctx context.Context, policy observation.Policy) (KubernetesAuthorityConfig, error) {
@@ -87,7 +89,8 @@ func (resolver *runtimeBindingWorkloadAuthorityResolver) ResolveWorkloadAuthorit
 	}
 	return KubernetesAuthorityConfig{
 		Endpoint: resolver.endpoint, AuthorityIdentity: resolver.targetUID,
-		TokenFile: resolver.tokenFile, CAFile: resolver.caFile, CABundleDigest: resolver.caDigest,
+		TokenFile: resolver.tokenFile, KubeconfigFile: resolver.kubeconfigFile,
+		CAFile: resolver.caFile, CABundleDigest: resolver.caDigest,
 	}, nil
 }
 

--- a/internal/runner/cilium_websocket.go
+++ b/internal/runner/cilium_websocket.go
@@ -30,25 +30,39 @@ type websocketExecutorFactory func(*rest.Config, string, string) (remotecommand.
 // command over Kubernetes RemoteCommand v5 WebSockets. It performs exact Pod
 // UID checks immediately before and after exec to reject name-reuse races.
 type KubernetesCiliumWebSocketExecutor struct {
-	endpoint       *url.URL
-	token          string
-	caData         []byte
-	identityClient *http.Client
-	timeout        time.Duration
-	factory        websocketExecutorFactory
+	endpoint          *url.URL
+	token             string
+	clientCertificate bool
+	caData            []byte
+	certificateData   []byte
+	keyData           []byte
+	identityClient    *http.Client
+	timeout           time.Duration
+	factory           websocketExecutorFactory
 }
 
 func newKubernetesCiliumWebSocketExecutor(endpoint, token string, caData []byte, client *http.Client) (*KubernetesCiliumWebSocketExecutor, error) {
+	return newKubernetesCiliumWebSocketExecutorWithTransport(endpoint, boundedKubernetesTransport{
+		bearerToken: token, caData: caData, credentialIdentity: token, client: client,
+	})
+}
+
+func newKubernetesCiliumWebSocketExecutorWithTransport(endpoint string, transport boundedKubernetesTransport) (*KubernetesCiliumWebSocketExecutor, error) {
 	parsed, err := url.Parse(endpoint)
 	if err != nil || parsed.Scheme != "https" || parsed.Host == "" || parsed.User != nil || parsed.Path != "" && parsed.Path != "/" || parsed.RawQuery != "" || parsed.Fragment != "" {
 		return nil, errors.New("Cilium WebSocket executor Kubernetes endpoint is invalid")
 	}
-	if token == "" || strings.TrimSpace(token) != token || strings.ContainsAny(token, "\r\n") || len(caData) == 0 || client == nil {
+	tokenMode := transport.bearerToken != ""
+	if tokenMode == transport.clientCertificate || strings.TrimSpace(transport.bearerToken) != transport.bearerToken ||
+		strings.ContainsAny(transport.bearerToken, "\r\n") || len(transport.caData) == 0 || transport.client == nil ||
+		transport.clientCertificate && (len(transport.certificateData) == 0 || len(transport.keyData) == 0) {
 		return nil, errors.New("Cilium WebSocket executor credential material is invalid")
 	}
 	parsed.Path, parsed.RawPath = "", ""
 	return &KubernetesCiliumWebSocketExecutor{
-		endpoint: parsed, token: token, caData: append([]byte(nil), caData...), identityClient: client,
+		endpoint: parsed, token: transport.bearerToken, clientCertificate: transport.clientCertificate,
+		caData: append([]byte(nil), transport.caData...), certificateData: append([]byte(nil), transport.certificateData...),
+		keyData: append([]byte(nil), transport.keyData...), identityClient: transport.client,
 		timeout: defaultCiliumExecTimeout, factory: remotecommand.NewWebSocketExecutor,
 	}, nil
 }
@@ -83,6 +97,10 @@ func (executor *KubernetesCiliumWebSocketExecutor) Exec(ctx context.Context, req
 		BearerToken: executor.token, Timeout: executor.timeout, DisableCompression: true,
 		Proxy: func(*http.Request) (*url.URL, error) { return nil, nil },
 	}
+	if executor.clientCertificate {
+		restConfig.TLSClientConfig.CertData = append([]byte(nil), executor.certificateData...)
+		restConfig.TLSClientConfig.KeyData = append([]byte(nil), executor.keyData...)
+	}
 	stream, err := executor.factory(restConfig, http.MethodGet, execURL.String())
 	if err != nil {
 		return nil, errors.New("construct fixed Cilium WebSocket stream")
@@ -114,7 +132,9 @@ func (executor *KubernetesCiliumWebSocketExecutor) verifyPodUID(ctx context.Cont
 		return errors.New("construct exact Cilium Pod identity request")
 	}
 	request.Header.Set("Accept", "application/json")
-	request.Header.Set("Authorization", "Bearer "+executor.token)
+	if !executor.clientCertificate {
+		request.Header.Set("Authorization", "Bearer "+executor.token)
+	}
 	response, err := executor.identityClient.Do(request)
 	if err != nil {
 		return errors.New("exact Cilium Pod identity request failed")

--- a/internal/runner/first_run_capability_runtime.go
+++ b/internal/runner/first_run_capability_runtime.go
@@ -1,0 +1,153 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/observation"
+)
+
+// sharedPlatformCapabilityResolver turns one single-use first-run probe into
+// one immutable in-memory assertion shared by Stage 11 and Stage 12. It never
+// retries the underlying probe: success and failure are both cached.
+type sharedPlatformCapabilityResolver struct {
+	resolver PlatformCapabilityResolver
+
+	mu            sync.Mutex
+	policyDigest  string
+	profileDigest string
+	source        *sharedPlatformCapabilitySource
+}
+
+type sharedPlatformCapabilitySource struct {
+	source observation.PlatformCapabilitySource
+
+	once  sync.Once
+	state observation.PlatformCapabilityState
+	err   error
+}
+
+func newSharedPlatformCapabilityResolver(resolver PlatformCapabilityResolver) (*sharedPlatformCapabilityResolver, error) {
+	if resolver == nil {
+		return nil, errors.New("first-run Platform capability resolver is required")
+	}
+	return &sharedPlatformCapabilityResolver{resolver: resolver}, nil
+}
+
+func (resolver *sharedPlatformCapabilityResolver) ResolvePlatformCapability(ctx context.Context, policy observation.Policy, profile observation.PlatformProfile) (observation.PlatformCapabilitySource, error) {
+	if resolver == nil || resolver.resolver == nil {
+		return nil, errors.New("shared Platform capability resolver is required")
+	}
+	policyDigest, err := observation.PolicyDigest(policy)
+	if err != nil {
+		return nil, errors.New("first-run Platform capability policy is invalid")
+	}
+	profileDigest, err := observation.PlatformProfileDigest(profile)
+	if err != nil {
+		return nil, errors.New("first-run Platform capability profile is invalid")
+	}
+
+	resolver.mu.Lock()
+	defer resolver.mu.Unlock()
+	if resolver.source != nil {
+		if resolver.policyDigest != policyDigest || resolver.profileDigest != profileDigest {
+			return nil, errors.New("first-run Platform capability identity changed after binding")
+		}
+		return resolver.source, nil
+	}
+	source, err := resolver.resolver.ResolvePlatformCapability(ctx, policy, clonePlatformProfile(profile))
+	if err != nil || source == nil {
+		return nil, errors.New("resolve first-run Platform capability")
+	}
+	shared := &sharedPlatformCapabilitySource{source: source}
+	resolver.policyDigest, resolver.profileDigest, resolver.source = policyDigest, profileDigest, shared
+	return shared, nil
+}
+
+func (source *sharedPlatformCapabilitySource) Capability(ctx context.Context) (observation.PlatformCapabilityState, error) {
+	if source == nil || source.source == nil {
+		return observation.PlatformCapabilityState{}, errors.New("shared Platform capability source is required")
+	}
+	source.once.Do(func() {
+		state, err := source.source.Capability(ctx)
+		if err != nil {
+			source.err = errors.New("bounded first-run Platform capability failed")
+			return
+		}
+		if err := observation.ValidatePlatformCapabilityState(state); err != nil {
+			source.err = errors.New("bounded first-run Platform capability result is invalid")
+			return
+		}
+		source.state = state
+	})
+	if source.err != nil {
+		return observation.PlatformCapabilityState{}, source.err
+	}
+	return source.state, nil
+}
+
+func loadFirstRunPlatformObservationRuntime(config PlatformObservationStageFileRuntimeConfig, capability PlatformCapabilityResolver) (PlatformObservationStageRuntimeConfig, error) {
+	runtime, err := LoadRuntimeBindingMaterialFiles(RuntimeBindingMaterialFileConfig{
+		Bundle: config.Bundle, MaterialPath: config.RuntimeMaterialPath, ReceiptPath: config.RuntimeReceiptPath,
+	})
+	if err != nil {
+		return PlatformObservationStageRuntimeConfig{}, errors.New("load first-run platform observation runtime binding")
+	}
+	policy := runtimeObservationPolicy(config.Bundle, runtime.material.Target.CAPIClusterUID, []string{"PlatformReady"})
+	source, err := capability.ResolvePlatformCapability(context.Background(), policy, clonePlatformProfile(config.Profile))
+	if err != nil || source == nil {
+		return PlatformObservationStageRuntimeConfig{}, errors.New("resolve first-run Platform capability source")
+	}
+	return PlatformObservationStageRuntimeConfig{
+		Ledger: config.Ledger, Argo: config.Argo, Runtime: runtime, Capability: source,
+		PollInterval: config.PollInterval, PollTimeout: config.PollTimeout, Clock: config.Clock, Wait: config.Wait,
+	}, nil
+}
+
+func loadFirstRunAggregateEvidenceRuntime(config AggregateEvidenceStageFileRuntimeConfig, capability PlatformCapabilityResolver) (AggregateEvidenceStageRuntimeConfig, error) {
+	runtime, err := LoadRuntimeBindingMaterialFiles(RuntimeBindingMaterialFileConfig{
+		Bundle: config.Bundle, MaterialPath: config.RuntimeMaterialPath, ReceiptPath: config.RuntimeReceiptPath,
+	})
+	if err != nil {
+		return AggregateEvidenceStageRuntimeConfig{}, errors.New("load first-run aggregate runtime binding")
+	}
+	if config.ExpectedWorkloadEndpoint == "" || runtime.material.Target.WorkloadAPIEndpoint != config.ExpectedWorkloadEndpoint ||
+		config.WorkloadCAFile == "" || (config.WorkloadTokenFile != "") == (config.WorkloadKubeconfigFile != "") {
+		return AggregateEvidenceStageRuntimeConfig{}, errors.New("first-run aggregate workload binding is invalid")
+	}
+	argoCA, err := readBoundedRegular(config.Argo.CAFile, maximumCABytes)
+	if err != nil {
+		return AggregateEvidenceStageRuntimeConfig{}, errors.New("read bounded first-run aggregate GitOps CA")
+	}
+	config.Argo.CABundleDigest = digest.SHA256(argoCA)
+	workload := &runtimeBindingWorkloadAuthorityResolver{
+		targetUID: runtime.material.Target.CAPIClusterUID, endpoint: runtime.material.Target.WorkloadAPIEndpoint,
+		caDigest: runtime.material.Target.WorkloadAPICADigest, tokenFile: config.WorkloadTokenFile,
+		kubeconfigFile: config.WorkloadKubeconfigFile, caFile: config.WorkloadCAFile,
+	}
+	return AggregateEvidenceStageRuntimeConfig{
+		Ledger: config.Ledger,
+		Observer: KubernetesAggregateObserverConfig{
+			Management: config.Management, ExpectedManagementAuthority: config.Bundle.PlanExpected.ManagementAuthority,
+			Argo: config.Argo, ExpectedArgoAuthority: config.Bundle.PlanExpected.GitOpsAuthority,
+			Namespace: config.Bundle.PlanExpected.ContractIdentity.Namespace, Name: config.Bundle.PlanExpected.ContractIdentity.Name,
+			HCPName:        config.Bundle.PlanExpected.ContractIdentity.Name + "-cilium",
+			NetworkProfile: config.NetworkProfile, PlatformProfile: config.PlatformProfile,
+			WorkloadAuthority: workload, PlatformCapability: capability, Clock: config.Clock,
+		},
+		Runtime: runtime,
+	}, nil
+}
+
+func runtimeObservationPolicy(bundle StageResumeConfig, targetUID string, required []string) observation.Policy {
+	return observation.Policy{
+		Format: observation.PolicyFormat, IntentRevision: bundle.PlanExpected.IntentRevision,
+		EnablementRevision: bundle.PlanExpected.EnablementRevision, PlatformRevision: bundle.PlanExpected.PlatformRevision,
+		TargetClusterUID: targetUID, Required: append([]string(nil), required...),
+	}
+}
+
+var _ PlatformCapabilityResolver = (*sharedPlatformCapabilityResolver)(nil)
+var _ observation.PlatformCapabilitySource = (*sharedPlatformCapabilitySource)(nil)

--- a/internal/runner/first_run_capability_runtime_test.go
+++ b/internal/runner/first_run_capability_runtime_test.go
@@ -1,0 +1,75 @@
+package runner
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/observation"
+)
+
+func TestSharedPlatformCapabilityResolverExecutesOnceAcrossStageElevenAndTwelve(t *testing.T) {
+	profile := runnerPlatformProfile()
+	policy := observation.Policy{
+		Format: observation.PolicyFormat, IntentRevision: profile.IntentRevision,
+		EnablementRevision: digestOf("e"), PlatformRevision: profile.PlatformRevision,
+		TargetClusterUID: "cluster-uid-disposable-ok147", Required: []string{"PlatformReady"},
+	}
+	probe := &recordingPlatformCapabilityProbe{result: PlatformCapabilityProbeResult{Passed: true}}
+	firstRun, err := NewFirstRunPlatformCapabilityResolver(probe, func() time.Time {
+		return time.Date(2026, 8, 21, 9, 0, 0, 0, time.UTC)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	shared, err := newSharedPlatformCapabilityResolver(firstRun)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stageEleven, err := shared.ResolvePlatformCapability(context.Background(), policy, profile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	first, err := stageEleven.Capability(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	stageTwelve, err := shared.ResolvePlatformCapability(context.Background(), policy, profile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := stageTwelve.Capability(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first != second || probe.calls != 1 {
+		t.Fatalf("first-run capability was not reused exactly: first=%#v second=%#v calls=%d", first, second, probe.calls)
+	}
+	foreign := policy
+	foreign.TargetClusterUID = "cluster-uid-foreign"
+	if _, err := shared.ResolvePlatformCapability(context.Background(), foreign, profile); err == nil || probe.calls != 1 {
+		t.Fatalf("shared capability accepted foreign target: err=%v calls=%d", err, probe.calls)
+	}
+}
+
+func TestSharedPlatformCapabilityResolverCachesFailureWithoutRetry(t *testing.T) {
+	profile := runnerPlatformProfile()
+	policy := observation.Policy{
+		Format: observation.PolicyFormat, IntentRevision: profile.IntentRevision,
+		EnablementRevision: digestOf("e"), PlatformRevision: profile.PlatformRevision,
+		TargetClusterUID: "cluster-uid-disposable-ok147", Required: []string{"PlatformReady"},
+	}
+	probe := &recordingPlatformCapabilityProbe{err: context.DeadlineExceeded}
+	firstRun, _ := NewFirstRunPlatformCapabilityResolver(probe, time.Now)
+	shared, _ := newSharedPlatformCapabilityResolver(firstRun)
+	source, err := shared.ResolvePlatformCapability(context.Background(), policy, profile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := source.Capability(context.Background()); err == nil {
+		t.Fatal("failed first-run capability was accepted")
+	}
+	if _, err := source.Capability(context.Background()); err == nil || probe.calls != 1 {
+		t.Fatalf("failed first-run capability was retried: err=%v calls=%d", err, probe.calls)
+	}
+}

--- a/internal/runner/full_run_execution.go
+++ b/internal/runner/full_run_execution.go
@@ -21,6 +21,7 @@ type fullRunPreRuntimeExecution interface {
 	Run(context.Context) (PreRuntimeExecutionReceipt, error)
 	ReceiptPrefix() ([]StageReceiptSource, error)
 	RuntimeTargetIdentity() (string, error)
+	RuntimeWorkloadAuthority() (WorkloadAuthorityFileResolverConfig, error)
 }
 
 type fullRunExecutionFactories struct {
@@ -94,10 +95,21 @@ func openFullRunExecution(config FullRunExecutionConfig, factories fullRunExecut
 			if targetErr != nil || !stageReceiptPrefixDigestPattern.MatchString(targetIdentity) {
 				return nil, errors.New("full-run lifecycle target identity is unavailable")
 			}
+			workloadAuthority, workloadErr := preRuntime.RuntimeWorkloadAuthority()
+			if workloadErr != nil {
+				return nil, errors.New("full-run lifecycle workload authority is unavailable")
+			}
 			bound := clonePostRuntimeExecutionConfigForFullRun(postRuntime)
 			bound.TargetCredential.Receipts = append([]StageReceiptSource(nil), privatePrefix...)
+			bound.TargetCredentialRun.Workload = workloadAuthority
+			bound.AggregateEvidence.Runtime.WorkloadTokenFile = workloadAuthority.TokenFile
+			bound.AggregateEvidence.Runtime.WorkloadKubeconfigFile = workloadAuthority.KubeconfigFile
+			bound.AggregateEvidence.Runtime.WorkloadCAFile = workloadAuthority.CAFile
 			bound.TargetRegistration.Expected.TargetIdentityDigest = targetIdentity
 			bound.PlatformApplications.Expected.TargetIdentityDigest = targetIdentity
+			if bound.TargetRegistration.Runtime.Clock != nil {
+				bound.TargetRegistration.Runtime.MaterializationTime = bound.TargetRegistration.Runtime.Clock().UTC()
+			}
 			continuation, openErr := factories.postRuntime(bound)
 			if openErr != nil || continuation == nil {
 				return nil, errors.New("open full-run post-runtime execution")

--- a/internal/runner/full_run_execution_manifest.go
+++ b/internal/runner/full_run_execution_manifest.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -53,9 +54,10 @@ type fullRunEnablementDocument struct {
 }
 
 type fullRunWorkloadRuntimeDocument struct {
-	BindingPath string `json:"bindingPath"`
-	TokenFile   string `json:"tokenFile"`
-	CAFile      string `json:"caFile"`
+	BindingPath    string `json:"bindingPath"`
+	TokenFile      string `json:"tokenFile,omitempty"`
+	KubeconfigFile string `json:"kubeconfigFile,omitempty"`
+	CAFile         string `json:"caFile"`
 }
 
 type fullRunNetworkObservationDocument struct {
@@ -123,11 +125,12 @@ type fullRunPlatformObservationDocument struct {
 }
 
 type fullRunAggregateEvidenceDocument struct {
-	Ledger            postRuntimeLedgerDocument    `json:"ledger"`
-	Management        postRuntimeAuthorityDocument `json:"management"`
-	Argo              postRuntimeAuthorityDocument `json:"argo"`
-	WorkloadTokenFile string                       `json:"workloadTokenFile"`
-	WorkloadCAFile    string                       `json:"workloadCAFile"`
+	Ledger                 postRuntimeLedgerDocument    `json:"ledger"`
+	Management             postRuntimeAuthorityDocument `json:"management"`
+	Argo                   postRuntimeAuthorityDocument `json:"argo"`
+	WorkloadTokenFile      string                       `json:"workloadTokenFile"`
+	WorkloadKubeconfigFile string                       `json:"workloadKubeconfigFile,omitempty"`
+	WorkloadCAFile         string                       `json:"workloadCAFile"`
 }
 
 type fullRunExecutionManifestDocument struct {
@@ -168,9 +171,49 @@ type FullRunExecutionManifestReceipt struct {
 }
 
 type VerifiedFullRunExecutionManifest struct {
-	document fullRunExecutionManifestDocument
-	receipt  FullRunExecutionManifestReceipt
-	verified bool
+	document  fullRunExecutionManifestDocument
+	receipt   FullRunExecutionManifestReceipt
+	plan      stageplan.Binding
+	network   observation.NetworkProfile
+	platform  observation.PlatformProfile
+	aggregate AggregateEvidenceProfile
+	verified  bool
+}
+
+// FullRunPlatformCapabilityBinding is the complete serializable part of the
+// first-run capability boundary. The factory receives no credential, endpoint,
+// target UID, command or arbitrary payload.
+type FullRunPlatformCapabilityBinding struct {
+	Namespace        string
+	Timeout          time.Duration
+	CleanupTimeout   time.Duration
+	IntentRevision   string
+	PlatformRevision string
+	ExecutionFixture string
+	ContractDigest   string
+	ExecutableDigest string
+}
+
+// FullRunPlatformCapabilityFactory supplies the process-local fixed checks and
+// transport adapter. It must return a lazy resolver; opening the factory must
+// not execute the capability.
+type FullRunPlatformCapabilityFactory interface {
+	OpenFullRunPlatformCapability(FullRunPlatformCapabilityBinding) (PlatformCapabilityResolver, error)
+}
+
+type FullRunPlatformCapabilityFactoryFunc func(FullRunPlatformCapabilityBinding) (PlatformCapabilityResolver, error)
+
+func (factory FullRunPlatformCapabilityFactoryFunc) OpenFullRunPlatformCapability(binding FullRunPlatformCapabilityBinding) (PlatformCapabilityResolver, error) {
+	return factory(binding)
+}
+
+// FullRunExecutionManifestRuntime supplies the process-local dependencies
+// that cannot be serialized in the private manifest. Capability construction
+// is typed and runtime-bound; Clock and Wait make bounded polling testable.
+type FullRunExecutionManifestRuntime struct {
+	PlatformCapability FullRunPlatformCapabilityFactory
+	Clock              func() time.Time
+	Wait               ObservationWaiter
 }
 
 // Receipt returns the already verified, redaction-safe manifest identity. The
@@ -180,6 +223,190 @@ func (manifest VerifiedFullRunExecutionManifest) Receipt() (FullRunExecutionMani
 		return FullRunExecutionManifestReceipt{}, errors.New("full-run execution manifest is not verified")
 	}
 	return manifest.receipt, nil
+}
+
+// ExecutionConfig converts one already verified private manifest into the
+// concrete Stage 1-12 configuration. It performs bounded local credential
+// reads while opening the authorization and lifecycle-authority adapters, but
+// performs no API request, grant resolution, capability action or mutation.
+func (manifest VerifiedFullRunExecutionManifest) ExecutionConfig(runtime FullRunExecutionManifestRuntime) (FullRunExecutionConfig, error) {
+	if !manifest.verified || manifest.receipt.State != "VERIFIED" || runtime.PlatformCapability == nil || runtime.Clock == nil || runtime.Wait == nil {
+		return FullRunExecutionConfig{}, errors.New("verified full-run manifest runtime is incomplete")
+	}
+	document, plan := manifest.document, manifest.plan
+	expected := fullRunPlanExpected(document.Plan.Expected)
+	if plan.PlanDigest != manifest.receipt.PlanDigest || plan.IntentRevision != expected.IntentRevision ||
+		plan.EnablementRevision != expected.EnablementRevision || plan.PlatformRevision != expected.PlatformRevision ||
+		plan.ExecutionFixture != expected.ExecutionFixture {
+		return FullRunExecutionConfig{}, errors.New("verified full-run manifest plan changed after loading")
+	}
+	lifecycleInterval, lifecycleTimeout, err := parsePostRuntimePolling(document.LifecycleObservation.PollInterval, document.LifecycleObservation.PollTimeout)
+	if err != nil {
+		return FullRunExecutionConfig{}, errors.New("parse full-run lifecycle polling")
+	}
+	networkInterval, networkTimeout, err := parsePostRuntimePolling(document.NetworkObservation.PollInterval, document.NetworkObservation.PollTimeout)
+	if err != nil {
+		return FullRunExecutionConfig{}, errors.New("parse full-run network polling")
+	}
+	platformInterval, platformTimeout, err := parsePostRuntimePolling(document.PlatformObservation.PollInterval, document.PlatformObservation.PollTimeout)
+	if err != nil {
+		return FullRunExecutionConfig{}, errors.New("parse full-run platform polling")
+	}
+	authorization, err := OpenStageAuthorizationHTTPResolver(StageAuthorizationHTTPResolverConfig{
+		Endpoint: document.Authorization.Endpoint, TokenFile: document.Authorization.TokenFile, CAFile: document.Authorization.CAFile,
+		PublicKeyPath: document.Authorization.PublicKeyPath, OutputDirectory: document.Authorization.OutputDirectory, Clock: runtime.Clock,
+	})
+	if err != nil {
+		return FullRunExecutionConfig{}, errors.New("open full-run authorization resolver")
+	}
+	workload := document.NetworkObservation.Workload
+	if workload.KubeconfigFile == "" || workload.TokenFile != "" {
+		return FullRunExecutionConfig{}, errors.New("full-run lifecycle workload authority requires a client-certificate kubeconfig destination")
+	}
+	materializer, err := OpenKubernetesLifecycleWorkloadAuthorityMaterializer(KubernetesLifecycleWorkloadAuthorityMaterializerConfig{
+		Management: authorityConfig(document.LifecycleObservation.Management), ExpectedManagementAuthority: plan.Authorities.Management,
+		BindingPath: workload.BindingPath, KubeconfigFile: workload.KubeconfigFile, CAFile: workload.CAFile,
+	})
+	if err != nil {
+		return FullRunExecutionConfig{}, fmt.Errorf("open full-run lifecycle workload authority materializer: %w", err)
+	}
+	capabilityTimeout, err := time.ParseDuration(document.PlatformObservation.Capability.Timeout)
+	if err != nil {
+		return FullRunExecutionConfig{}, errors.New("parse full-run capability timeout")
+	}
+	cleanupTimeout, err := time.ParseDuration(document.PlatformObservation.Capability.CleanupTimeout)
+	if err != nil {
+		return FullRunExecutionConfig{}, errors.New("parse full-run capability cleanup timeout")
+	}
+	capabilityResolver, err := runtime.PlatformCapability.OpenFullRunPlatformCapability(FullRunPlatformCapabilityBinding{
+		Namespace: document.PlatformObservation.Capability.Namespace, Timeout: capabilityTimeout, CleanupTimeout: cleanupTimeout,
+		IntentRevision: plan.IntentRevision, PlatformRevision: plan.PlatformRevision, ExecutionFixture: plan.ExecutionFixture,
+		ContractDigest: manifest.platform.CapabilityContractDigest, ExecutableDigest: manifest.platform.CapabilityExecutableDigest,
+	})
+	if err != nil || capabilityResolver == nil {
+		return FullRunExecutionConfig{}, errors.New("open bound full-run Platform capability")
+	}
+	capability, err := newSharedPlatformCapabilityResolver(capabilityResolver)
+	if err != nil {
+		return FullRunExecutionConfig{}, err
+	}
+	ledger := ledgerConfig(document.ProviderPrerequisites.Ledger)
+	workloadFiles := WorkloadAuthorityFileResolverConfig{
+		Path: workload.BindingPath, KubeconfigFile: workload.KubeconfigFile, CAFile: workload.CAFile,
+	}
+	registrationExpected := submission.TargetRegistrationExpected{
+		ArtifactDigest: fullRunStageInputDigest(plan, "target-registration"), ContractIdentity: plan.ContractIdentity,
+		IntentRevision: plan.IntentRevision, PlatformRevision: plan.PlatformRevision, ExecutionFixture: plan.ExecutionFixture,
+		ArgoAuthority: plan.Authorities.GitOps, ArgoNamespace: document.TargetRegistration.ArgoNamespace,
+		ProjectName: document.TargetRegistration.ProjectName, RegistrationName: document.TargetRegistration.RegistrationName,
+		TargetName: document.TargetRegistration.TargetName, SourceRepository: document.TargetRegistration.SourceRepository,
+		TargetNamespaces: append([]string(nil), document.TargetRegistration.TargetNamespaces...),
+	}
+	applicationsExpected := submission.PlatformApplicationsExpected{
+		ArtifactDigest: fullRunStageInputDigest(plan, "platform-applications"), ContractIdentity: plan.ContractIdentity,
+		IntentRevision: plan.IntentRevision, PlatformRevision: plan.PlatformRevision, ExecutionFixture: plan.ExecutionFixture,
+		ArgoAuthority: plan.Authorities.GitOps, ArgoNamespace: document.PlatformApplications.ArgoNamespace,
+		ProjectName: document.PlatformApplications.ProjectName, RegistrationName: document.PlatformApplications.RegistrationName,
+		SourceRepository: document.PlatformApplications.SourceRepository, Profile: clonePlatformProfile(manifest.platform),
+	}
+	config := FullRunExecutionConfig{
+		PreRuntime: PreRuntimeExecutionConfig{
+			PlanPath: document.Plan.Path, PlanExpected: expected,
+			ProjectionManifestPath: document.Projection.ManifestPath, ProjectionRoot: document.Projection.Root,
+			Authorization:         authorization,
+			ProviderPrerequisites: SubmissionStageRuntimeConfig{Ledger: ledger, Authority: authorityConfig(document.ProviderPrerequisites.Authority), Clock: runtime.Clock},
+			ClusterLifecycle:      SubmissionStageRuntimeConfig{Ledger: ledger, Authority: authorityConfig(document.ClusterLifecycle.Authority), Clock: runtime.Clock},
+			LifecycleObservation: LifecycleObservationStageRuntimeConfig{
+				Ledger: ledger, Management: authorityConfig(document.LifecycleObservation.Management),
+				PollInterval: lifecycleInterval, PollTimeout: lifecycleTimeout, Clock: runtime.Clock, Wait: runtime.Wait,
+			},
+			Enablement: PreRuntimeEnablementExecutionConfig{
+				ArtifactPath: document.Enablement.ArtifactPath, ExpectedObject: document.Enablement.ExpectedObject,
+				Runtime: SubmissionStageRuntimeConfig{Ledger: ledger, Authority: authorityConfig(document.Enablement.Runtime.Authority), Clock: runtime.Clock},
+			},
+			WorkloadAuthority: materializer,
+			NetworkObservation: NetworkObservationStageRuntimeConfig{
+				Ledger: ledger, Management: authorityConfig(document.NetworkObservation.Management), Workload: workloadFiles,
+				NetworkProfilePath: document.Profiles.Network.Path, ExpectedNetworkProfileDigest: manifest.receipt.NetworkProfileDigest,
+				PollInterval: networkInterval, PollTimeout: networkTimeout, Clock: runtime.Clock, Wait: runtime.Wait,
+			},
+			RuntimeBinding: RuntimeBindingStageRuntimeConfig{
+				Ledger: ledger, Workload: workloadFiles, OutputPath: document.RuntimeBinding.MaterialPath, Clock: runtime.Clock,
+			},
+			RuntimeBindingReceiptPath: document.RuntimeBinding.ReceiptPath,
+			TargetAccess: PreRuntimeTargetAccessExecutionConfig{
+				ArtifactPath: document.TargetAccess.ArtifactPath, ExpectedObjects: append([]projection.ResourceIdentity(nil), document.TargetAccess.ExpectedObjects...),
+				Runtime: TargetAccessStageRuntimeConfig{Ledger: ledger, Workload: workloadFiles, Clock: runtime.Clock},
+			},
+			ReceiptDirectory: document.ReceiptDirectory,
+		},
+		PostRuntime: PostRuntimeExecutionConfig{
+			TargetCredential: TargetCredentialStageBundleConfig{
+				PlanPath: document.Plan.Path, PlanExpected: expected, Receipts: []StageReceiptSource{}, PolicyPath: document.TargetCredential.PolicyPath,
+				TargetAccessArtifactPath:    document.TargetAccess.ArtifactPath,
+				TargetAccessExpectedObjects: append([]projection.ResourceIdentity(nil), document.TargetAccess.ExpectedObjects...),
+			},
+			TargetCredentialRun: TargetCredentialStageRuntimeConfig{Ledger: ledger, Workload: workloadFiles, Clock: runtime.Clock},
+			Authorization:       authorization,
+			TargetRegistration: PostRuntimeTargetRegistrationConfig{
+				ArtifactPath: document.TargetRegistration.ArtifactPath, Expected: registrationExpected,
+				Runtime: TargetRegistrationStageHandoffRuntimeConfig{Ledger: ledger, GitOps: authorityConfig(document.TargetRegistration.GitOps), Clock: runtime.Clock},
+			},
+			PlatformApplications: PostRuntimePlatformApplicationsConfig{
+				ArtifactPath: document.PlatformApplications.ArtifactPath, Expected: applicationsExpected,
+				Runtime: PlatformApplicationsStageRuntimeConfig{Ledger: ledger, GitOps: authorityConfig(document.PlatformApplications.GitOps), Clock: runtime.Clock},
+			},
+			PlatformObservation: PostRuntimePlatformObservationConfig{
+				Profile: clonePlatformProfile(manifest.platform), Capability: capability,
+				Runtime: PlatformObservationStageFileRuntimeConfig{
+					Ledger: ledger, Argo: authorityConfig(document.PlatformObservation.Argo),
+					RuntimeMaterialPath: document.RuntimeBinding.MaterialPath, RuntimeReceiptPath: document.RuntimeBinding.ReceiptPath,
+					PollInterval: platformInterval, PollTimeout: platformTimeout, Clock: runtime.Clock, Wait: runtime.Wait,
+				},
+			},
+			AggregateEvidence: PostRuntimeAggregateEvidenceConfig{
+				Profile: cloneAggregateEvidenceProfile(manifest.aggregate), Capability: capability,
+				Runtime: AggregateEvidenceStageFileRuntimeConfig{
+					NetworkProfile: cloneNetworkProfile(manifest.network), PlatformProfile: clonePlatformProfile(manifest.platform),
+					Ledger: ledger, Management: authorityConfig(document.AggregateEvidence.Management), Argo: authorityConfig(document.AggregateEvidence.Argo),
+					WorkloadKubeconfigFile: workload.KubeconfigFile, WorkloadCAFile: workload.CAFile,
+					RuntimeMaterialPath: document.RuntimeBinding.MaterialPath, RuntimeReceiptPath: document.RuntimeBinding.ReceiptPath, Clock: runtime.Clock,
+				},
+			},
+			RuntimeBinding: RuntimeBindingMaterialFileConfig{
+				Bundle:       StageResumeConfig{PlanPath: document.Plan.Path, PlanExpected: expected},
+				MaterialPath: document.RuntimeBinding.MaterialPath, ReceiptPath: document.RuntimeBinding.ReceiptPath,
+			},
+			ReceiptDirectory: document.ReceiptDirectory,
+		},
+	}
+	return config, nil
+}
+
+// Open composes the concrete single-use Stage 1-12 executor from this
+// verified manifest. It remains a local open boundary; Run is the only method
+// that may contact authorities or mutate authorized resources.
+func (manifest VerifiedFullRunExecutionManifest) Open(runtime FullRunExecutionManifestRuntime) (*FullRunExecution, error) {
+	config, err := manifest.ExecutionConfig(runtime)
+	if err != nil {
+		return nil, err
+	}
+	return OpenFullRunExecution(config)
+}
+
+// OpenFullRunExecutionManifest is the direct private manifest-to-executor
+// activation seam. It performs only the same bounded local opening as Load,
+// ExecutionConfig and Open; the returned executor remains inert until Run.
+func OpenFullRunExecutionManifest(path string, runtime FullRunExecutionManifestRuntime) (*FullRunExecution, FullRunExecutionManifestReceipt, error) {
+	manifest, receipt, err := LoadFullRunExecutionManifest(path)
+	if err != nil {
+		return nil, receipt, err
+	}
+	execution, err := manifest.Open(runtime)
+	if err != nil {
+		return nil, receipt, err
+	}
+	return execution, receipt, nil
 }
 
 // LoadFullRunExecutionManifest verifies the complete private first-run
@@ -269,8 +496,38 @@ func LoadFullRunExecutionManifest(path string) (VerifiedFullRunExecutionManifest
 	receipt.RuntimeIdentityMode = "lifecycle-derived-private/v1"
 	receipt.AuthorizationMode = "predecessor-bound-tls/v1"
 	receipt.CapabilityMode = "runtime-bound-in-memory/v1"
-	verified := VerifiedFullRunExecutionManifest{document: document, receipt: receipt, verified: true}
+	verified := VerifiedFullRunExecutionManifest{
+		document: document, receipt: receipt, plan: plan,
+		network: cloneNetworkProfile(network.Profile), platform: clonePlatformProfile(platform.Profile),
+		aggregate: cloneAggregateEvidenceProfile(aggregate.Profile), verified: true,
+	}
 	return verified, receipt, nil
+}
+
+func fullRunPlanExpected(document postRuntimePlanExpectedDocument) stageplan.Expected {
+	return stageplan.Expected{
+		ContractIdentity: document.ContractIdentity, IntentRevision: document.IntentRevision,
+		EnablementRevision: document.EnablementRevision, PlatformRevision: document.PlatformRevision,
+		ExecutionFixture: document.ExecutionFixture, InfrastructureAuthority: document.InfrastructureAuthority,
+		ManagementAuthority: document.ManagementAuthority, GitOpsAuthority: document.GitOpsAuthority,
+	}
+}
+
+func fullRunStageInputDigest(plan stageplan.Binding, stageID string) string {
+	stage, _, err := plan.Stage(stageID)
+	if err != nil || len(stage.Inputs) != 1 {
+		return ""
+	}
+	return stage.Inputs[0].Digest
+}
+
+func cloneNetworkProfile(profile observation.NetworkProfile) observation.NetworkProfile {
+	return profile
+}
+
+func cloneAggregateEvidenceProfile(profile AggregateEvidenceProfile) AggregateEvidenceProfile {
+	profile.Required = append([]string(nil), profile.Required...)
+	return profile
 }
 
 func loadFullRunExecutionManifest(path string) (fullRunExecutionManifestDocument, string, error) {
@@ -404,10 +661,13 @@ func validateFullRunRuntimeBoundary(document fullRunExecutionManifestDocument, p
 	}
 	workload := document.NetworkObservation.Workload
 	if workload != document.RuntimeBinding.Workload || workload != document.TargetAccess.Workload || workload != document.TargetCredential.Workload ||
-		workload.TokenFile != document.AggregateEvidence.WorkloadTokenFile || workload.CAFile != document.AggregateEvidence.WorkloadCAFile {
+		workload.TokenFile != document.AggregateEvidence.WorkloadTokenFile ||
+		workload.KubeconfigFile != document.AggregateEvidence.WorkloadKubeconfigFile ||
+		workload.CAFile != document.AggregateEvidence.WorkloadCAFile || workload.TokenFile != "" || workload.KubeconfigFile == "" {
 		return errors.New("full-run workload runtime binding differs between stages")
 	}
-	runtimeOutputs := []string{workload.BindingPath, workload.TokenFile, workload.CAFile, document.RuntimeBinding.MaterialPath, document.RuntimeBinding.ReceiptPath}
+	workloadCredentialPath := workload.KubeconfigFile
+	runtimeOutputs := []string{workload.BindingPath, workloadCredentialPath, workload.CAFile, document.RuntimeBinding.MaterialPath, document.RuntimeBinding.ReceiptPath}
 	seenOutputs := make(map[string]struct{}, len(runtimeOutputs)+len(preRuntimeStageOrder)+4)
 	for _, path := range runtimeOutputs {
 		if !validFullRunAbsolutePath(path) {

--- a/internal/runner/full_run_execution_manifest_test.go
+++ b/internal/runner/full_run_execution_manifest_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/openkubes/ok-cluster/internal/digest"
 	"github.com/openkubes/ok-cluster/internal/projection"
@@ -40,6 +41,74 @@ func TestLoadFullRunExecutionManifestBindsFreshPrivateContract(t *testing.T) {
 		if strings.Contains(strings.ToLower(string(public)), forbidden) {
 			t.Fatalf("public full-run manifest receipt disclosed %q", forbidden)
 		}
+	}
+}
+
+func TestVerifiedFullRunExecutionManifestBuildsConcreteConfiguration(t *testing.T) {
+	manifestPath, cleanup := fullRunExecutionManifestFixture(t)
+	defer cleanup()
+	manifest, _, err := LoadFullRunExecutionManifest(manifestPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	clock := func() time.Time { return time.Date(2026, 8, 21, 9, 0, 0, 0, time.UTC) }
+	probe := &recordingPlatformCapabilityProbe{result: PlatformCapabilityProbeResult{Passed: true}}
+	capability, err := NewFirstRunPlatformCapabilityResolver(probe, clock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var capabilityBinding FullRunPlatformCapabilityBinding
+	config, err := manifest.ExecutionConfig(FullRunExecutionManifestRuntime{
+		PlatformCapability: FullRunPlatformCapabilityFactoryFunc(func(binding FullRunPlatformCapabilityBinding) (PlatformCapabilityResolver, error) {
+			capabilityBinding = binding
+			return capability, nil
+		}),
+		Clock: clock, Wait: WaitWithTimer,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := config.PreRuntime.WorkloadAuthority.(*KubernetesLifecycleWorkloadAuthorityMaterializer); !ok {
+		t.Fatalf("manifest did not select lifecycle workload materialization: %T", config.PreRuntime.WorkloadAuthority)
+	}
+	if config.PreRuntime.NetworkObservation.Workload.KubeconfigFile == "" || config.PreRuntime.NetworkObservation.Workload.TokenFile != "" ||
+		config.PostRuntime.TargetCredentialRun.Workload != config.PreRuntime.NetworkObservation.Workload ||
+		config.PostRuntime.PlatformObservation.Capability == nil || config.PostRuntime.AggregateEvidence.Capability == nil ||
+		config.PostRuntime.TargetRegistration.Expected.TargetIdentityDigest != "" ||
+		!config.PostRuntime.TargetRegistration.Runtime.MaterializationTime.IsZero() {
+		t.Fatalf("concrete full-run configuration widened a dynamic boundary: %#v", config)
+	}
+	if _, err := OpenFullRunExecution(config); err != nil {
+		t.Fatalf("verified manifest did not open concrete full-run execution: %v", err)
+	}
+	if probe.calls != 0 {
+		t.Fatal("opening the full-run manifest executed the Platform capability probe")
+	}
+	if capabilityBinding.Namespace != "ok-observability" || capabilityBinding.Timeout != 10*time.Minute ||
+		capabilityBinding.CleanupTimeout != time.Minute || capabilityBinding.IntentRevision == "" ||
+		capabilityBinding.PlatformRevision == "" || capabilityBinding.ExecutionFixture == "" ||
+		capabilityBinding.ContractDigest == "" || capabilityBinding.ExecutableDigest == "" {
+		t.Fatalf("capability factory did not receive the exact manifest binding: %#v", capabilityBinding)
+	}
+}
+
+func TestOpenFullRunExecutionManifestStopsBeforeAnyRuntimeAction(t *testing.T) {
+	manifestPath, cleanup := fullRunExecutionManifestFixture(t)
+	defer cleanup()
+	clock := func() time.Time { return time.Date(2026, 8, 21, 9, 0, 0, 0, time.UTC) }
+	probe := &recordingPlatformCapabilityProbe{result: PlatformCapabilityProbeResult{Passed: true}}
+	capability, _ := NewFirstRunPlatformCapabilityResolver(probe, clock)
+	execution, receipt, err := OpenFullRunExecutionManifest(manifestPath, FullRunExecutionManifestRuntime{
+		PlatformCapability: FullRunPlatformCapabilityFactoryFunc(func(FullRunPlatformCapabilityBinding) (PlatformCapabilityResolver, error) {
+			return capability, nil
+		}),
+		Clock: clock, Wait: WaitWithTimer,
+	})
+	if err != nil || execution == nil || receipt.State != "VERIFIED" {
+		t.Fatalf("direct full-run manifest activation failed: receipt=%#v execution=%#v err=%v", receipt, execution, err)
+	}
+	if probe.calls != 0 {
+		t.Fatal("direct full-run activation executed a runtime capability")
 	}
 }
 
@@ -253,18 +322,24 @@ func fullRunExecutionManifestFixture(t *testing.T) (string, func()) {
 		t.Fatal(err)
 	}
 	workload := fullRunWorkloadRuntimeDocument{
-		BindingPath: filepath.Join(privateRoot, "workload-authority.json"),
-		TokenFile:   filepath.Join(privateRoot, "workload-token"),
-		CAFile:      filepath.Join(privateRoot, "workload-ca.crt"),
+		BindingPath:    filepath.Join(privateRoot, "workload-authority.json"),
+		KubeconfigFile: filepath.Join(privateRoot, "workload-kubeconfig.yaml"),
+		CAFile:         filepath.Join(privateRoot, "workload-ca.crt"),
 	}
 	ledger := post.TargetCredential.Ledger
 	managementAuthority := post.AggregateEvidence.Management
+	managementAuthority.TokenFile = writeBundleFile(t, root, "full-management-token", []byte("full-management-token"))
+	managementAuthority.CAFile = ledger.CAFile
+	managementCA, err := os.ReadFile(ledger.CAFile)
+	if err != nil {
+		cleanup()
+		t.Fatal(err)
+	}
+	managementAuthority.CABundleDigest = digest.SHA256(managementCA)
 	infrastructureAuthority := managementAuthority
 	infrastructureAuthority.AuthorityIdentity = expected.InfrastructureAuthority
 	infrastructureAuthority.Endpoint = "https://192.0.2.13:6443"
-	infrastructureAuthority.TokenFile = "/private/tmp/infra-token"
-	infrastructureAuthority.CAFile = "/private/tmp/infra-ca"
-	infrastructureAuthority.CABundleDigest = runnerStageSHA("5")
+	infrastructureAuthority.TokenFile = writeBundleFile(t, root, "full-infrastructure-token", []byte("full-infrastructure-token"))
 	providerRuntime := fullRunSubmissionRuntimeDocument{Ledger: ledger, Authority: infrastructureAuthority}
 	managementRuntime := fullRunSubmissionRuntimeDocument{Ledger: ledger, Authority: managementAuthority}
 	document := fullRunExecutionManifestDocument{
@@ -301,7 +376,7 @@ func fullRunExecutionManifestFixture(t *testing.T) (string, func()) {
 			Capability:   fullRunCapabilityDocument{Namespace: "ok-observability", Timeout: "10m", CleanupTimeout: "1m"},
 			PollInterval: "1s", PollTimeout: "1m",
 		},
-		AggregateEvidence: fullRunAggregateEvidenceDocument{Ledger: ledger, Management: managementAuthority, Argo: post.AggregateEvidence.Argo, WorkloadTokenFile: workload.TokenFile, WorkloadCAFile: workload.CAFile},
+		AggregateEvidence: fullRunAggregateEvidenceDocument{Ledger: ledger, Management: managementAuthority, Argo: post.AggregateEvidence.Argo, WorkloadKubeconfigFile: workload.KubeconfigFile, WorkloadCAFile: workload.CAFile},
 		ReceiptDirectory:  receiptDirectory,
 	}
 	return writeBundleFile(t, root, "full-run-manifest.json", mustJSON(t, document)), cleanup

--- a/internal/runner/full_run_execution_test.go
+++ b/internal/runner/full_run_execution_test.go
@@ -17,10 +17,16 @@ type fakeConcretePreRuntimeExecution struct {
 	prefixCalls int
 	target      string
 	targetErr   error
+	workload    WorkloadAuthorityFileResolverConfig
+	workloadErr error
 }
 
 func (execution *fakeConcretePreRuntimeExecution) RuntimeTargetIdentity() (string, error) {
 	return execution.target, execution.targetErr
+}
+
+func (execution *fakeConcretePreRuntimeExecution) RuntimeWorkloadAuthority() (WorkloadAuthorityFileResolverConfig, error) {
+	return execution.workload, execution.workloadErr
 }
 
 func (execution *fakeConcretePreRuntimeExecution) Run(context.Context) (PreRuntimeExecutionReceipt, error) {
@@ -50,6 +56,11 @@ func TestFullRunExecutionComposesConcreteAdaptersWithExactPrivatePrefix(t *testi
 			if bound.TargetRegistration.Expected.TargetIdentityDigest == "" ||
 				bound.PlatformApplications.Expected.TargetIdentityDigest != bound.TargetRegistration.Expected.TargetIdentityDigest {
 				t.Fatalf("post-runtime suffix did not receive one lifecycle-derived target identity: %#v", bound)
+			}
+			if bound.TargetCredentialRun.Workload != preRuntime.workload ||
+				bound.AggregateEvidence.Runtime.WorkloadTokenFile != preRuntime.workload.TokenFile ||
+				bound.AggregateEvidence.Runtime.WorkloadCAFile != preRuntime.workload.CAFile {
+				t.Fatalf("post-runtime suffix did not receive one lifecycle-derived workload authority: %#v", bound)
 			}
 			return postRuntime, nil
 		},
@@ -178,6 +189,28 @@ func TestFullRunExecutionDoesNotOpenSuffixWithoutLifecycleTargetIdentity(t *test
 	}
 }
 
+func TestFullRunExecutionDoesNotOpenSuffixWithoutLifecycleWorkloadAuthority(t *testing.T) {
+	preRuntime := successfulFakeConcretePreRuntimeExecution(t)
+	preRuntime.workload = WorkloadAuthorityFileResolverConfig{}
+	preRuntime.workloadErr = errors.New("missing lifecycle workload authority")
+	postCalls := 0
+	execution, err := openFullRunExecution(testFullRunExecutionConfig(), fullRunExecutionFactories{
+		preRuntime: func(PreRuntimeExecutionConfig) (fullRunPreRuntimeExecution, error) { return preRuntime, nil },
+		postRuntime: func(PostRuntimeExecutionConfig) (PostRuntimeContinuation, error) {
+			postCalls++
+			return successfulFakePostRuntimeContinuation(), nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := execution.Run(context.Background())
+	if err == nil || receipt.State != "STOPPED" || receipt.StoppedAt != "target-credential" ||
+		len(receipt.Checkpoints) != 7 || postCalls != 0 {
+		t.Fatalf("missing workload authority opened suffix: %#v post=%d err=%v", receipt, postCalls, err)
+	}
+}
+
 func TestOpenFullRunExecutionRejectsHistoricalSuffixState(t *testing.T) {
 	for name, mutate := range map[string]func(*FullRunExecutionConfig){
 		"prebound receipts": func(config *FullRunExecutionConfig) {
@@ -244,7 +277,13 @@ func successfulFakeConcretePreRuntimeExecution(t *testing.T) *fakeConcretePreRun
 	for index, checkpoint := range receipt.Checkpoints {
 		prefix[index] = StageReceiptSource{Path: "/private/" + checkpoint.StageID + ".json", Digest: checkpoint.StageReceiptDigest}
 	}
-	return &fakeConcretePreRuntimeExecution{receipt: receipt, prefix: prefix, target: runnerStageSHA("7")}
+	return &fakeConcretePreRuntimeExecution{
+		receipt: receipt, prefix: prefix, target: runnerStageSHA("7"),
+		workload: WorkloadAuthorityFileResolverConfig{
+			Path: "/private/workload-authority.json", ExpectedBindingDigest: runnerStageSHA("8"),
+			TokenFile: "/private/workload-token", CAFile: "/private/workload-ca.crt",
+		},
+	}
 }
 
 func testFullRunExecutionConfig() FullRunExecutionConfig {

--- a/internal/runner/kubernetes.go
+++ b/internal/runner/kubernetes.go
@@ -3,10 +3,11 @@
 package runner
 
 import (
+	"bytes"
 	"context"
-	"crypto/subtle"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"io"
@@ -20,6 +21,7 @@ import (
 	"github.com/openkubes/ok-cluster/internal/ledger"
 	"github.com/openkubes/ok-cluster/internal/observation"
 	"github.com/openkubes/ok-cluster/internal/submission"
+	"gopkg.in/yaml.v3"
 )
 
 const (
@@ -43,8 +45,19 @@ type KubernetesAuthorityConfig struct {
 	Endpoint          string
 	AuthorityIdentity string
 	TokenFile         string
+	KubeconfigFile    string
 	CAFile            string
 	CABundleDigest    string
+}
+
+type boundedKubernetesTransport struct {
+	bearerToken        string
+	clientCertificate  bool
+	caData             []byte
+	certificateData    []byte
+	keyData            []byte
+	credentialIdentity string
+	client             *http.Client
 }
 
 // KubernetesNetworkObserverConfig binds distinct management and workload
@@ -127,24 +140,164 @@ func OpenKubernetesSubmissionClient(config KubernetesAuthorityConfig) (*submissi
 	return client, err
 }
 
-// openKubernetesSubmissionClient also returns the bounded token so operation
-// composition can prove that the two write authorities do not share one
-// credential. The token never leaves this package or enters an error/receipt.
+// openKubernetesSubmissionClient also returns a private credential identity so
+// operation composition can prove that two write authorities do not share one
+// credential. It never enters an error or receipt.
 func openKubernetesSubmissionClient(config KubernetesAuthorityConfig) (*submission.KubernetesClient, string, error) {
-	if config.Endpoint == "" || config.AuthorityIdentity == "" || config.TokenFile == "" || config.CAFile == "" {
-		return nil, "", errors.New("Kubernetes authority endpoint, identity, token file, and CA file are required")
+	if config.Endpoint == "" || config.AuthorityIdentity == "" || config.CAFile == "" {
+		return nil, "", errors.New("Kubernetes authority endpoint, identity, credential, and CA file are required")
 	}
-	token, client, err := openBoundedKubernetesHTTP(config.TokenFile, config.CAFile)
+	transport, err := openBoundedKubernetesAuthorityTransport(config)
 	if err != nil {
 		return nil, "", err
 	}
 	submitter, err := submission.NewKubernetesClient(submission.KubernetesClientConfig{
-		Endpoint: config.Endpoint, AuthorityIdentity: config.AuthorityIdentity, BearerToken: token, Client: client,
+		Endpoint: config.Endpoint, AuthorityIdentity: config.AuthorityIdentity, BearerToken: transport.bearerToken,
+		ClientCertificate: transport.clientCertificate, Client: transport.client,
 	})
 	if err != nil {
 		return nil, "", err
 	}
-	return submitter, token, nil
+	return submitter, transport.credentialIdentity, nil
+}
+
+func openBoundedKubernetesAuthorityTransport(config KubernetesAuthorityConfig) (boundedKubernetesTransport, error) {
+	tokenMode := config.TokenFile != ""
+	kubeconfigMode := config.KubeconfigFile != ""
+	if config.Endpoint == "" || config.CAFile == "" || tokenMode == kubeconfigMode {
+		return boundedKubernetesTransport{}, errors.New("Kubernetes authority requires exactly one transport credential")
+	}
+	if tokenMode {
+		token, ca, client, err := openBoundedKubernetesMaterial(config.TokenFile, config.CAFile)
+		if err != nil {
+			return boundedKubernetesTransport{}, err
+		}
+		return boundedKubernetesTransport{
+			bearerToken: token, caData: ca, credentialIdentity: token, client: client,
+		}, nil
+	}
+	return openBoundedKubernetesKubeconfigTransport(config.KubeconfigFile, config.Endpoint, config.CAFile)
+}
+
+func openBoundedKubernetesKubeconfigTransport(kubeconfigFile, expectedEndpoint, caFile string) (boundedKubernetesTransport, error) {
+	raw, err := readBoundedRegular(kubeconfigFile, maximumCABytes)
+	if err != nil {
+		return boundedKubernetesTransport{}, errors.New("read temporary Kubernetes kubeconfig")
+	}
+	boundCA, err := readBoundedRegular(caFile, maximumCABytes)
+	if err != nil {
+		return boundedKubernetesTransport{}, errors.New("read runtime-bound Kubernetes API CA")
+	}
+	return parseBoundedKubernetesKubeconfig(raw, expectedEndpoint, boundCA)
+}
+
+func parseBoundedKubernetesKubeconfig(raw []byte, expectedEndpoint string, boundCA []byte) (boundedKubernetesTransport, error) {
+	type namedCluster struct {
+		Name    string `yaml:"name"`
+		Cluster struct {
+			Server                   string `yaml:"server"`
+			CertificateAuthorityData string `yaml:"certificate-authority-data"`
+		} `yaml:"cluster"`
+	}
+	type namedContext struct {
+		Name    string `yaml:"name"`
+		Context struct {
+			Cluster   string `yaml:"cluster"`
+			User      string `yaml:"user"`
+			Namespace string `yaml:"namespace,omitempty"`
+		} `yaml:"context"`
+	}
+	type namedUser struct {
+		Name string `yaml:"name"`
+		User struct {
+			ClientCertificateData string `yaml:"client-certificate-data"`
+			ClientKeyData         string `yaml:"client-key-data"`
+		} `yaml:"user"`
+	}
+	var document struct {
+		APIVersion     string         `yaml:"apiVersion"`
+		Kind           string         `yaml:"kind"`
+		CurrentContext string         `yaml:"current-context"`
+		Clusters       []namedCluster `yaml:"clusters"`
+		Contexts       []namedContext `yaml:"contexts"`
+		Preferences    map[string]any `yaml:"preferences,omitempty"`
+		Users          []namedUser    `yaml:"users"`
+	}
+	decoder := yaml.NewDecoder(bytes.NewReader(raw))
+	decoder.KnownFields(true)
+	if err := decoder.Decode(&document); err != nil {
+		return boundedKubernetesTransport{}, errors.New("temporary Kubernetes kubeconfig is invalid")
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		return boundedKubernetesTransport{}, errors.New("temporary Kubernetes kubeconfig has trailing content")
+	}
+	if document.APIVersion != "v1" || document.Kind != "Config" || document.CurrentContext == "" ||
+		len(document.Clusters) != 1 || len(document.Contexts) != 1 || len(document.Users) != 1 {
+		return boundedKubernetesTransport{}, errors.New("temporary Kubernetes kubeconfig shape is invalid")
+	}
+	cluster := document.Clusters[0]
+	contextEntry := document.Contexts[0]
+	user := document.Users[0]
+	if contextEntry.Name != document.CurrentContext || contextEntry.Context.Cluster != cluster.Name ||
+		contextEntry.Context.User != user.Name || cluster.Name == "" || user.Name == "" ||
+		cluster.Cluster.Server != expectedEndpoint || !validFullRunKubernetesEndpoint(expectedEndpoint) {
+		return boundedKubernetesTransport{}, errors.New("temporary Kubernetes kubeconfig differs from runtime authority")
+	}
+	decode := func(encoded string) ([]byte, error) {
+		if encoded == "" || strings.TrimSpace(encoded) != encoded || strings.ContainsAny(encoded, "\r\n") {
+			return nil, errors.New("empty or non-canonical base64")
+		}
+		return base64.StdEncoding.Strict().DecodeString(encoded)
+	}
+	caData, err := decode(cluster.Cluster.CertificateAuthorityData)
+	if err != nil {
+		return boundedKubernetesTransport{}, errors.New("temporary Kubernetes CA encoding is invalid")
+	}
+	certificateData, err := decode(user.User.ClientCertificateData)
+	if err != nil {
+		return boundedKubernetesTransport{}, errors.New("temporary Kubernetes certificate encoding is invalid")
+	}
+	keyData, err := decode(user.User.ClientKeyData)
+	if err != nil {
+		return boundedKubernetesTransport{}, errors.New("temporary Kubernetes key encoding is invalid")
+	}
+	if boundCA != nil && !bytes.Equal(caData, boundCA) {
+		return boundedKubernetesTransport{}, errors.New("temporary Kubernetes kubeconfig CA differs from runtime binding")
+	}
+	certificate, err := tls.X509KeyPair(certificateData, keyData)
+	if err != nil || len(certificate.Certificate) == 0 {
+		return boundedKubernetesTransport{}, errors.New("temporary Kubernetes client credential is invalid")
+	}
+	leaf, err := x509.ParseCertificate(certificate.Certificate[0])
+	if err != nil {
+		return boundedKubernetesTransport{}, errors.New("temporary Kubernetes client certificate is invalid")
+	}
+	certificate.Leaf = leaf
+	roots := x509.NewCertPool()
+	if !roots.AppendCertsFromPEM(caData) {
+		return boundedKubernetesTransport{}, errors.New("runtime-bound Kubernetes API CA contains no certificate")
+	}
+	intermediates := x509.NewCertPool()
+	for _, rawCertificate := range certificate.Certificate[1:] {
+		intermediate, err := x509.ParseCertificate(rawCertificate)
+		if err != nil {
+			return boundedKubernetesTransport{}, errors.New("temporary Kubernetes client certificate chain is invalid")
+		}
+		intermediates.AddCert(intermediate)
+	}
+	if _, err := leaf.Verify(x509.VerifyOptions{Roots: roots, Intermediates: intermediates, KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}}); err != nil {
+		return boundedKubernetesTransport{}, errors.New("temporary Kubernetes client certificate is not trusted by the runtime-bound CA")
+	}
+	client := &http.Client{Timeout: 15 * time.Second, Transport: &http.Transport{
+		Proxy: nil, DisableCompression: true, ForceAttemptHTTP2: true,
+		TLSClientConfig: &tls.Config{MinVersion: tls.VersionTLS12, RootCAs: roots, Certificates: []tls.Certificate{certificate}},
+	}}
+	identityMaterial := append(append([]byte(nil), certificateData...), keyData...)
+	return boundedKubernetesTransport{
+		clientCertificate: true, caData: append([]byte(nil), caData...), certificateData: certificateData,
+		keyData: keyData, credentialIdentity: digest.SHA256(identityMaterial), client: client,
+	}, nil
 }
 
 // OpenKubernetesCAPILifecycleObserver materializes a bounded management-plane
@@ -186,8 +339,8 @@ func OpenKubernetesNetworkSourceCollector(config KubernetesNetworkObserverConfig
 	return collector, err
 }
 
-// openKubernetesNetworkSourceCollector returns token values only to private
-// stage composition so it can prove that capabilities remain separate.
+// openKubernetesNetworkSourceCollector returns credential identities only to
+// private stage composition so it can prove that capabilities remain separate.
 func openKubernetesNetworkSourceCollector(config KubernetesNetworkObserverConfig) (*observation.NetworkSourceCollector, string, string, error) {
 	if config.ExpectedManagementAuthority == "" || config.Management.AuthorityIdentity != config.ExpectedManagementAuthority {
 		return nil, "", "", errors.New("network observer management authority differs from the verified management plane")
@@ -202,14 +355,14 @@ func openKubernetesNetworkSourceCollector(config KubernetesNetworkObserverConfig
 	if err != nil {
 		return nil, "", "", errors.New("open bounded management network credential")
 	}
-	workloadToken, workloadCA, workloadClient, err := openBoundedKubernetesMaterial(config.Workload.TokenFile, config.Workload.CAFile)
+	workloadTransport, err := openBoundedKubernetesAuthorityTransport(config.Workload)
 	if err != nil {
 		return nil, "", "", errors.New("open bounded workload network credential")
 	}
-	if !platformInputDigestPattern.MatchString(config.Workload.CABundleDigest) || digest.SHA256(workloadCA) != config.Workload.CABundleDigest {
+	if !platformInputDigestPattern.MatchString(config.Workload.CABundleDigest) || digest.SHA256(workloadTransport.caData) != config.Workload.CABundleDigest {
 		return nil, "", "", errors.New("workload network CA differs from the runtime-bound authority")
 	}
-	if len(managementToken) == len(workloadToken) && subtle.ConstantTimeCompare([]byte(managementToken), []byte(workloadToken)) == 1 {
+	if sameSecret(managementToken, workloadTransport.credentialIdentity) {
 		return nil, "", "", errors.New("network observer management and workload credentials must be distinct")
 	}
 	management, err := observation.NewKubernetesManagementNetworkReader(observation.KubernetesNetworkReaderConfig{
@@ -219,12 +372,13 @@ func openKubernetesNetworkSourceCollector(config KubernetesNetworkObserverConfig
 		return nil, "", "", err
 	}
 	workload, err := observation.NewKubernetesWorkloadNetworkReader(observation.KubernetesNetworkReaderConfig{
-		Endpoint: config.Workload.Endpoint, BearerToken: workloadToken, Client: workloadClient,
+		Endpoint: config.Workload.Endpoint, BearerToken: workloadTransport.bearerToken,
+		ClientCertificate: workloadTransport.clientCertificate, Client: workloadTransport.client,
 	})
 	if err != nil {
 		return nil, "", "", err
 	}
-	podExecutor, err := newKubernetesCiliumWebSocketExecutor(config.Workload.Endpoint, workloadToken, workloadCA, workloadClient)
+	podExecutor, err := newKubernetesCiliumWebSocketExecutorWithTransport(config.Workload.Endpoint, workloadTransport)
 	if err != nil {
 		return nil, "", "", err
 	}
@@ -239,7 +393,7 @@ func openKubernetesNetworkSourceCollector(config KubernetesNetworkObserverConfig
 	if err != nil {
 		return nil, "", "", err
 	}
-	return collector, managementToken, workloadToken, nil
+	return collector, managementToken, workloadTransport.credentialIdentity, nil
 }
 
 // OpenKubernetesPlatformSourceCollector materializes one TLS client restricted

--- a/internal/runner/kubernetes_test.go
+++ b/internal/runner/kubernetes_test.go
@@ -7,7 +7,9 @@ import (
 	"crypto/rand"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/base64"
 	"encoding/pem"
+	"fmt"
 	"math/big"
 	"os"
 	"path/filepath"
@@ -99,6 +101,47 @@ func TestOpenKubernetesSubmissionClientBindsOneAuthority(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestOpenKubernetesSubmissionClientAcceptsStrictClientCertificateKubeconfig(t *testing.T) {
+	root := t.TempDir()
+	ca, certificate, key := testClientCredential(t)
+	caPath := filepath.Join(root, "workload-ca.crt")
+	kubeconfigPath := filepath.Join(root, "workload.kubeconfig")
+	endpoint := "https://192.0.2.90:6443"
+	if err := os.WriteFile(caPath, ca, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(kubeconfigPath, testClientKubeconfig(endpoint, ca, certificate, key), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	config := KubernetesAuthorityConfig{
+		Endpoint: endpoint, AuthorityIdentity: "cluster-uid-disposable-ok147",
+		KubeconfigFile: kubeconfigPath, CAFile: caPath,
+	}
+	if _, identity, err := openKubernetesSubmissionClient(config); err != nil || !stageReceiptPrefixDigestPattern.MatchString(identity) {
+		t.Fatalf("strict client-certificate kubeconfig was not accepted: identity=%q err=%v", identity, err)
+	}
+
+	t.Run("token and kubeconfig fail closed", func(t *testing.T) {
+		candidate := config
+		candidate.TokenFile = kubeconfigPath
+		if _, err := OpenKubernetesSubmissionClient(candidate); err == nil || strings.Contains(err.Error(), root) {
+			t.Fatalf("ambiguous workload credential accepted or disclosed path: %v", err)
+		}
+	})
+
+	t.Run("different separately bound CA fails closed", func(t *testing.T) {
+		foreignCA := filepath.Join(root, "foreign-ca.crt")
+		if err := os.WriteFile(foreignCA, testCA(t), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		candidate := config
+		candidate.CAFile = foreignCA
+		if _, err := OpenKubernetesSubmissionClient(candidate); err == nil || strings.Contains(err.Error(), root) {
+			t.Fatalf("foreign workload CA accepted or disclosed path: %v", err)
+		}
+	})
 }
 
 func TestOpenKubernetesCAPILifecycleObserverBindsManagementAuthority(t *testing.T) {
@@ -245,4 +288,64 @@ func testCA(t *testing.T) []byte {
 		t.Fatal(err)
 	}
 	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: raw})
+}
+
+func testClientCredential(t *testing.T) ([]byte, []byte, []byte) {
+	t.Helper()
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	caTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(101), Subject: pkix.Name{CommonName: "ok147-workload-test-ca"},
+		NotBefore: time.Date(2026, 8, 20, 0, 0, 0, 0, time.UTC), NotAfter: time.Date(2026, 8, 30, 0, 0, 0, 0, time.UTC),
+		IsCA: true, KeyUsage: x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature, BasicConstraintsValid: true,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	clientKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	clientTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(102), Subject: pkix.Name{CommonName: "ok147-workload-client"},
+		NotBefore: time.Date(2026, 8, 20, 0, 0, 0, 0, time.UTC), NotAfter: time.Date(2026, 8, 30, 0, 0, 0, 0, time.UTC),
+		KeyUsage: x509.KeyUsageDigitalSignature, ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+	clientDER, err := x509.CreateCertificate(rand.Reader, clientTemplate, caTemplate, &clientKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyDER, err := x509.MarshalECPrivateKey(clientKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER}),
+		pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: clientDER}),
+		pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+}
+
+func testClientKubeconfig(endpoint string, ca, certificate, key []byte) []byte {
+	return []byte(fmt.Sprintf(`apiVersion: v1
+kind: Config
+clusters:
+- name: workload
+  cluster:
+    server: %s
+    certificate-authority-data: %s
+contexts:
+- name: workload
+  context:
+    cluster: workload
+    user: workload
+current-context: workload
+preferences: {}
+users:
+- name: workload
+  user:
+    client-certificate-data: %s
+    client-key-data: %s
+`, endpoint, base64.StdEncoding.EncodeToString(ca), base64.StdEncoding.EncodeToString(certificate), base64.StdEncoding.EncodeToString(key)))
 }

--- a/internal/runner/lifecycle_workload_authority_materializer.go
+++ b/internal/runner/lifecycle_workload_authority_materializer.go
@@ -1,0 +1,276 @@
+package runner
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"strconv"
+	"sync"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+const maximumLifecycleAuthorityResponseBytes = 4 * 1024 * 1024
+
+// KubernetesLifecycleWorkloadAuthorityMaterializerConfig binds the exact
+// management authority and the three private create-only destinations used to
+// hand the lifecycle-derived workload authority to Stage 5 and later stages.
+type KubernetesLifecycleWorkloadAuthorityMaterializerConfig struct {
+	Management                  KubernetesAuthorityConfig
+	ExpectedManagementAuthority string
+	BindingPath                 string
+	KubeconfigFile              string
+	CAFile                      string
+}
+
+// KubernetesLifecycleWorkloadAuthorityMaterializer reads exactly one CAPI
+// Cluster and its CAPI-owned kubeconfig Secret after the durable Stage-4
+// prefix exists. It performs no Kubernetes mutation and creates the semantic
+// binding last so partial local material cannot be mistaken for a complete
+// handoff.
+type KubernetesLifecycleWorkloadAuthorityMaterializer struct {
+	config KubernetesLifecycleWorkloadAuthorityMaterializerConfig
+
+	mu   sync.Mutex
+	used bool
+}
+
+func OpenKubernetesLifecycleWorkloadAuthorityMaterializer(config KubernetesLifecycleWorkloadAuthorityMaterializerConfig) (*KubernetesLifecycleWorkloadAuthorityMaterializer, error) {
+	if config.ExpectedManagementAuthority == "" || config.Management.AuthorityIdentity != config.ExpectedManagementAuthority ||
+		config.Management.TokenFile == "" || config.Management.KubeconfigFile != "" {
+		return nil, errors.New("lifecycle workload authority management binding is invalid")
+	}
+	if config.BindingPath == config.KubeconfigFile || config.BindingPath == config.CAFile || config.KubeconfigFile == config.CAFile {
+		return nil, errors.New("lifecycle workload authority destinations are not distinct")
+	}
+	for _, path := range []string{config.KubeconfigFile, config.CAFile, config.BindingPath} {
+		if validateRuntimeBindingOutputPath(path) != nil {
+			return nil, errors.New("lifecycle workload authority destination is invalid")
+		}
+	}
+	if _, _, err := openKubernetesSubmissionClient(config.Management); err != nil {
+		return nil, fmt.Errorf("open bounded lifecycle workload management authority: %w", err)
+	}
+	return &KubernetesLifecycleWorkloadAuthorityMaterializer{config: config}, nil
+}
+
+func (materializer *KubernetesLifecycleWorkloadAuthorityMaterializer) ResolvePreRuntimeWorkloadAuthority(ctx context.Context, resume StageResumeConfig) (WorkloadAuthorityFileResolverConfig, error) {
+	if materializer == nil {
+		return WorkloadAuthorityFileResolverConfig{}, errors.New("lifecycle workload authority materializer is required")
+	}
+	materializer.mu.Lock()
+	if materializer.used {
+		materializer.mu.Unlock()
+		return WorkloadAuthorityFileResolverConfig{}, errors.New("lifecycle workload authority materializer is single-use")
+	}
+	materializer.used = true
+	materializer.mu.Unlock()
+
+	plan, cursor, prefix, err := loadStageResumeWithPrefix(resume)
+	if err != nil || len(prefix) != 4 {
+		return WorkloadAuthorityFileResolverConfig{}, errors.New("verify exact Stage-5 workload authority cursor")
+	}
+	decision, err := cursor.Decision()
+	if err != nil || decision.State != "NEXT" || decision.StageID != "network-observation" || decision.Authority != "workload" {
+		return WorkloadAuthorityFileResolverConfig{}, errors.New("workload authority materialization requires the Stage-5 cursor")
+	}
+	lifecycle, err := prefix[1].Receipt()
+	if err != nil || lifecycle.StageID != "cluster-lifecycle" || lifecycle.State != "SUCCEEDED" ||
+		lifecycle.PlanDigest != plan.PlanDigest || !stageReceiptPrefixDigestPattern.MatchString(lifecycle.TargetClusterUIDDigest) {
+		return WorkloadAuthorityFileResolverConfig{}, errors.New("lifecycle receipt lacks target authority identity")
+	}
+
+	transport, err := openBoundedKubernetesAuthorityTransport(materializer.config.Management)
+	if err != nil || transport.clientCertificate {
+		return WorkloadAuthorityFileResolverConfig{}, errors.New("open lifecycle workload management transport")
+	}
+	namespace, name := plan.ContractIdentity.Namespace, plan.ContractIdentity.Name
+	clusterPath := "/apis/cluster.x-k8s.io/v1beta2/namespaces/" + namespace + "/clusters/" + name
+	clusterRaw, err := exactLifecycleAuthorityGET(ctx, materializer.config.Management.Endpoint, clusterPath, transport)
+	if err != nil {
+		return WorkloadAuthorityFileResolverConfig{}, errors.New("read lifecycle-derived CAPI Cluster")
+	}
+	cluster, err := decodeLifecycleAuthorityCluster(clusterRaw, namespace, name)
+	if err != nil || digest.SHA256([]byte(cluster.Metadata.UID)) != lifecycle.TargetClusterUIDDigest {
+		return WorkloadAuthorityFileResolverConfig{}, errors.New("CAPI Cluster differs from durable lifecycle identity")
+	}
+	endpoint := "https://" + net.JoinHostPort(cluster.Spec.ControlPlaneEndpoint.Host, strconv.Itoa(cluster.Spec.ControlPlaneEndpoint.Port))
+	if !validFullRunKubernetesEndpoint(endpoint) {
+		return WorkloadAuthorityFileResolverConfig{}, errors.New("CAPI Cluster workload endpoint is invalid")
+	}
+
+	secretPath := "/api/v1/namespaces/" + namespace + "/secrets/" + name + "-kubeconfig"
+	secretRaw, err := exactLifecycleAuthorityGET(ctx, materializer.config.Management.Endpoint, secretPath, transport)
+	if err != nil {
+		return WorkloadAuthorityFileResolverConfig{}, errors.New("read lifecycle-derived workload kubeconfig Secret")
+	}
+	kubeconfigRaw, err := decodeLifecycleAuthorityKubeconfigSecret(secretRaw, namespace, name+"-kubeconfig")
+	if err != nil {
+		return WorkloadAuthorityFileResolverConfig{}, err
+	}
+	parsed, err := parseBoundedKubernetesKubeconfig(kubeconfigRaw, endpoint, nil)
+	if err != nil {
+		return WorkloadAuthorityFileResolverConfig{}, errors.New("verify lifecycle-derived workload kubeconfig")
+	}
+
+	binding := WorkloadAuthorityBinding{
+		Format: WorkloadAuthorityBindingFormat, IntentRevision: plan.IntentRevision,
+		TargetClusterUID: cluster.Metadata.UID, TargetIdentityScheme: "capi-cluster-uid/v1",
+		Endpoint: endpoint, CABundleDigest: digest.SHA256(parsed.caData),
+	}
+	bindingRaw, err := canonicalWorkloadAuthorityBinding(binding)
+	if err != nil {
+		return WorkloadAuthorityFileResolverConfig{}, errors.New("canonicalize lifecycle workload authority binding")
+	}
+	bindingDigest := digest.SHA256(bindingRaw)
+
+	// Secret-derived material comes first; the semantic binding is the final
+	// completion marker. Any error preserves partial local state for diagnosis.
+	for _, output := range []struct {
+		path string
+		raw  []byte
+	}{
+		{materializer.config.KubeconfigFile, kubeconfigRaw},
+		{materializer.config.CAFile, parsed.caData},
+		{materializer.config.BindingPath, bindingRaw},
+	} {
+		if err := writeExclusivePrivateMaterial(output.path, output.raw); err != nil {
+			return WorkloadAuthorityFileResolverConfig{}, err
+		}
+	}
+	result := WorkloadAuthorityFileResolverConfig{
+		Path: materializer.config.BindingPath, ExpectedBindingDigest: bindingDigest,
+		KubeconfigFile: materializer.config.KubeconfigFile, CAFile: materializer.config.CAFile,
+	}
+	if _, authority, err := loadWorkloadAuthorityFiles(result); err != nil {
+		return WorkloadAuthorityFileResolverConfig{}, errors.New("reload lifecycle workload authority binding")
+	} else if _, err := openBoundedKubernetesAuthorityTransport(authority); err != nil {
+		return WorkloadAuthorityFileResolverConfig{}, errors.New("reopen lifecycle workload authority transport")
+	}
+	return result, nil
+}
+
+type lifecycleAuthorityCluster struct {
+	APIVersion string `json:"apiVersion"`
+	Kind       string `json:"kind"`
+	Metadata   struct {
+		Name            string `json:"name"`
+		Namespace       string `json:"namespace"`
+		UID             string `json:"uid"`
+		ResourceVersion string `json:"resourceVersion"`
+	} `json:"metadata"`
+	Spec struct {
+		ControlPlaneEndpoint struct {
+			Host string `json:"host"`
+			Port int    `json:"port"`
+		} `json:"controlPlaneEndpoint"`
+	} `json:"spec"`
+}
+
+func decodeLifecycleAuthorityCluster(raw []byte, namespace, name string) (lifecycleAuthorityCluster, error) {
+	var cluster lifecycleAuthorityCluster
+	if err := decodeOneJSONDocument(raw, &cluster); err != nil || cluster.APIVersion != "cluster.x-k8s.io/v1beta2" || cluster.Kind != "Cluster" ||
+		cluster.Metadata.Namespace != namespace || cluster.Metadata.Name != name || !runtimeInputUIDPattern.MatchString(cluster.Metadata.UID) ||
+		cluster.Metadata.ResourceVersion == "" || cluster.Spec.ControlPlaneEndpoint.Host == "" || cluster.Spec.ControlPlaneEndpoint.Port < 1 || cluster.Spec.ControlPlaneEndpoint.Port > 65535 {
+		return lifecycleAuthorityCluster{}, errors.New("lifecycle-derived CAPI Cluster is invalid")
+	}
+	return cluster, nil
+}
+
+func decodeLifecycleAuthorityKubeconfigSecret(raw []byte, namespace, name string) ([]byte, error) {
+	var secret struct {
+		APIVersion string `json:"apiVersion"`
+		Kind       string `json:"kind"`
+		Type       string `json:"type"`
+		Metadata   struct {
+			Name            string `json:"name"`
+			Namespace       string `json:"namespace"`
+			UID             string `json:"uid"`
+			ResourceVersion string `json:"resourceVersion"`
+		} `json:"metadata"`
+		Data map[string]string `json:"data"`
+	}
+	if err := decodeOneJSONDocument(raw, &secret); err != nil || secret.APIVersion != "v1" || secret.Kind != "Secret" ||
+		secret.Type != "cluster.x-k8s.io/secret" || secret.Metadata.Namespace != namespace || secret.Metadata.Name != name ||
+		!runtimeInputUIDPattern.MatchString(secret.Metadata.UID) || secret.Metadata.ResourceVersion == "" || len(secret.Data) != 1 {
+		return nil, errors.New("lifecycle-derived workload kubeconfig Secret is invalid")
+	}
+	encoded, ok := secret.Data["value"]
+	if !ok || encoded == "" {
+		return nil, errors.New("lifecycle-derived workload kubeconfig Secret lacks exact data.value")
+	}
+	rawKubeconfig, err := base64.StdEncoding.Strict().DecodeString(encoded)
+	if err != nil || len(rawKubeconfig) == 0 || len(rawKubeconfig) > maximumCABytes {
+		return nil, errors.New("lifecycle-derived workload kubeconfig value is invalid")
+	}
+	return rawKubeconfig, nil
+}
+
+func decodeOneJSONDocument(raw []byte, destination any) error {
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	if err := decoder.Decode(destination); err != nil {
+		return err
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		return errors.New("JSON response has trailing content")
+	}
+	return nil
+}
+
+func exactLifecycleAuthorityGET(ctx context.Context, endpoint, path string, transport boundedKubernetesTransport) ([]byte, error) {
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint+path, nil)
+	if err != nil {
+		return nil, errors.New("construct exact lifecycle authority request")
+	}
+	request.Header.Set("Accept", "application/json")
+	request.Header.Set("Authorization", "Bearer "+transport.bearerToken)
+	response, err := transport.client.Do(request)
+	if err != nil {
+		return nil, errors.New("exact lifecycle authority request failed")
+	}
+	defer response.Body.Close()
+	raw, err := io.ReadAll(io.LimitReader(response.Body, maximumLifecycleAuthorityResponseBytes+1))
+	if err != nil || len(raw) > maximumLifecycleAuthorityResponseBytes {
+		return nil, errors.New("exact lifecycle authority response exceeds accepted size")
+	}
+	if response.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("exact lifecycle authority request returned HTTP %d", response.StatusCode)
+	}
+	return raw, nil
+}
+
+func writeExclusivePrivateMaterial(path string, raw []byte) error {
+	if len(raw) == 0 || validateRuntimeBindingOutputPath(path) != nil {
+		return errors.New("private workload authority output is invalid")
+	}
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return errors.New("create exclusive private workload authority output")
+	}
+	if _, err := file.Write(raw); err != nil {
+		file.Close()
+		return errors.New("write private workload authority output")
+	}
+	if err := file.Sync(); err != nil {
+		file.Close()
+		return errors.New("sync private workload authority output")
+	}
+	if err := file.Close(); err != nil {
+		return errors.New("close private workload authority output")
+	}
+	stored, err := readBoundedRegular(path, int64(len(raw)))
+	if err != nil || !bytes.Equal(stored, raw) {
+		return errors.New("private workload authority output differs after write")
+	}
+	return nil
+}
+
+var _ PreRuntimeWorkloadAuthorityResolver = (*KubernetesLifecycleWorkloadAuthorityMaterializer)(nil)

--- a/internal/runner/lifecycle_workload_authority_materializer_test.go
+++ b/internal/runner/lifecycle_workload_authority_materializer_test.go
@@ -1,0 +1,131 @@
+package runner
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/openkubes/ok-cluster/internal/observation"
+)
+
+func TestKubernetesLifecycleWorkloadAuthorityMaterializerUsesExactStageFiveAuthority(t *testing.T) {
+	workloadCA, workloadCertificate, workloadKey := testClientCredential(t)
+	workloadEndpoint := "https://192.0.2.90:6443"
+	kubeconfig := testClientKubeconfig(workloadEndpoint, workloadCA, workloadCertificate, workloadKey)
+	wantPaths := []string{
+		"/apis/cluster.x-k8s.io/v1beta2/namespaces/disposable-ok147/clusters/disposable-ok147",
+		"/api/v1/namespaces/disposable-ok147/secrets/disposable-ok147-kubeconfig",
+	}
+	requests := []string{}
+	server := httptest.NewTLSServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		requests = append(requests, request.URL.Path)
+		if request.Method != http.MethodGet || request.URL.RawQuery != "" || request.Header.Get("Authorization") != "Bearer bounded-management-token" {
+			response.WriteHeader(http.StatusForbidden)
+			return
+		}
+		response.Header().Set("Content-Type", "application/json")
+		switch request.URL.Path {
+		case wantPaths[0]:
+			_ = json.NewEncoder(response).Encode(map[string]any{
+				"apiVersion": "cluster.x-k8s.io/v1beta2", "kind": "Cluster",
+				"metadata": map[string]any{
+					"name": "disposable-ok147", "namespace": "disposable-ok147",
+					"uid": "11111111-1111-4111-8111-111111111111", "resourceVersion": "42",
+				},
+				"spec": map[string]any{"controlPlaneEndpoint": map[string]any{"host": "192.0.2.90", "port": 6443}},
+			})
+		case wantPaths[1]:
+			_ = json.NewEncoder(response).Encode(map[string]any{
+				"apiVersion": "v1", "kind": "Secret", "type": "cluster.x-k8s.io/secret",
+				"metadata": map[string]any{
+					"name": "disposable-ok147-kubeconfig", "namespace": "disposable-ok147",
+					"uid": "22222222-2222-4222-8222-222222222222", "resourceVersion": "43",
+				},
+				"data": map[string]string{"value": base64.StdEncoding.EncodeToString(kubeconfig)},
+			})
+		default:
+			response.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	config, factories, _, _ := preRuntimeExecutionFixture(t)
+	privateRoot := t.TempDir()
+	if err := os.Chmod(privateRoot, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	managementCA := filepath.Join(privateRoot, "management-ca.crt")
+	managementToken := filepath.Join(privateRoot, "management-token")
+	if err := os.WriteFile(managementCA, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: server.Certificate().Raw}), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(managementToken, []byte("bounded-management-token"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	materializer, err := OpenKubernetesLifecycleWorkloadAuthorityMaterializer(KubernetesLifecycleWorkloadAuthorityMaterializerConfig{
+		Management: KubernetesAuthorityConfig{
+			Endpoint: server.URL, AuthorityIdentity: "ok-mgmt", TokenFile: managementToken, CAFile: managementCA,
+		},
+		ExpectedManagementAuthority: "ok-mgmt",
+		BindingPath:                 filepath.Join(privateRoot, "workload-authority.json"),
+		KubeconfigFile:              filepath.Join(privateRoot, "workload.kubeconfig"),
+		CAFile:                      filepath.Join(privateRoot, "workload-ca.crt"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	original := config.WorkloadAuthority
+	var materialized WorkloadAuthorityFileResolverConfig
+	var materializeErr error
+	config.WorkloadAuthority = PreRuntimeWorkloadAuthorityResolverFunc(func(ctx context.Context, resume StageResumeConfig) (WorkloadAuthorityFileResolverConfig, error) {
+		materialized, materializeErr = materializer.ResolvePreRuntimeWorkloadAuthority(ctx, resume)
+		if materializeErr != nil {
+			return WorkloadAuthorityFileResolverConfig{}, materializeErr
+		}
+		// The fake stage factories retain their original synthetic authority;
+		// this wrapper lets the concrete resolver execute at its real cursor.
+		return original.ResolvePreRuntimeWorkloadAuthority(ctx, resume)
+	})
+	executor, err := openPreRuntimeExecution(config, factories)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if receipt, err := executor.Run(context.Background()); err != nil || receipt.State != "SUCCEEDED" {
+		t.Fatalf("pre-runtime execution did not reach materializer: %#v err=%v materializer=%v requests=%v", receipt, err, materializeErr, requests)
+	}
+	if !reflect.DeepEqual(requests, wantPaths) {
+		t.Fatalf("materializer request surface differs: got=%v want=%v", requests, wantPaths)
+	}
+	for _, path := range []string{materialized.KubeconfigFile, materialized.CAFile, materialized.Path} {
+		info, err := os.Lstat(path)
+		if err != nil || !info.Mode().IsRegular() || info.Mode().Perm() != 0o600 {
+			t.Fatalf("private material is not a regular 0600 file: %s %#v %v", path, info, err)
+		}
+	}
+	resolver, err := OpenWorkloadAuthorityFileResolver(materialized)
+	if err != nil {
+		t.Fatal(err)
+	}
+	authority, err := resolver.ResolveWorkloadAuthority(context.Background(), networkPolicyForMaterializedAuthority(config, "11111111-1111-4111-8111-111111111111"))
+	if err != nil || authority.Endpoint != workloadEndpoint || authority.TokenFile != "" || authority.KubeconfigFile != materialized.KubeconfigFile {
+		t.Fatalf("materialized workload authority is not replayable: %#v err=%v", authority, err)
+	}
+	if _, err := materializer.ResolvePreRuntimeWorkloadAuthority(context.Background(), StageResumeConfig{}); err == nil {
+		t.Fatal("single-use materializer resolved twice")
+	}
+}
+
+func networkPolicyForMaterializedAuthority(config PreRuntimeExecutionConfig, targetUID string) observation.Policy {
+	return observation.Policy{
+		Format: observation.PolicyFormat, IntentRevision: config.PlanExpected.IntentRevision,
+		EnablementRevision: config.PlanExpected.EnablementRevision, PlatformRevision: config.PlanExpected.PlatformRevision,
+		TargetClusterUID: targetUID, Required: []string{"NetworkReady"},
+	}
+}

--- a/internal/runner/post_runtime_execution.go
+++ b/internal/runner/post_runtime_execution.go
@@ -36,13 +36,15 @@ type PostRuntimePlatformApplicationsConfig struct {
 }
 
 type PostRuntimePlatformObservationConfig struct {
-	Profile observation.PlatformProfile
-	Runtime PlatformObservationStageFileRuntimeConfig
+	Profile    observation.PlatformProfile
+	Runtime    PlatformObservationStageFileRuntimeConfig
+	Capability PlatformCapabilityResolver
 }
 
 type PostRuntimeAggregateEvidenceConfig struct {
-	Profile AggregateEvidenceProfile
-	Runtime AggregateEvidenceStageFileRuntimeConfig
+	Profile    AggregateEvidenceProfile
+	Runtime    AggregateEvidenceStageFileRuntimeConfig
+	Capability PlatformCapabilityResolver
 }
 
 // PostRuntimeTargetCredentialRecoveryConfig selects the explicit crash-only
@@ -568,7 +570,12 @@ func defaultPostRuntimeExecutionFactories() postRuntimeExecutionFactories {
 			}
 			runtimeConfig := config.Runtime
 			runtimeConfig.Bundle, runtimeConfig.Profile = resume, config.Profile
-			runtime, err := LoadPlatformObservationStageFileRuntime(runtimeConfig)
+			var runtime PlatformObservationStageRuntimeConfig
+			if config.Capability == nil {
+				runtime, err = LoadPlatformObservationStageFileRuntime(runtimeConfig)
+			} else {
+				runtime, err = loadFirstRunPlatformObservationRuntime(runtimeConfig, config.Capability)
+			}
 			if err != nil {
 				return postRuntimeObservationInvocation{}, err
 			}
@@ -592,7 +599,12 @@ func defaultPostRuntimeExecutionFactories() postRuntimeExecutionFactories {
 			runtimeConfig := config.Runtime
 			runtimeConfig.Bundle = resume
 			runtimeConfig.ExpectedWorkloadEndpoint = runtimeBinding.material.Target.WorkloadAPIEndpoint
-			runtime, err := LoadAggregateEvidenceStageFileRuntime(runtimeConfig)
+			var runtime AggregateEvidenceStageRuntimeConfig
+			if config.Capability == nil {
+				runtime, err = LoadAggregateEvidenceStageFileRuntime(runtimeConfig)
+			} else {
+				runtime, err = loadFirstRunAggregateEvidenceRuntime(runtimeConfig, config.Capability)
+			}
 			if err != nil {
 				return postRuntimeEvaluationInvocation{}, err
 			}

--- a/internal/runner/pre_runtime_execution.go
+++ b/internal/runner/pre_runtime_execution.go
@@ -36,6 +36,20 @@ type PreRuntimeTargetAccessExecutionConfig struct {
 	Runtime         TargetAccessStageRuntimeConfig
 }
 
+// PreRuntimeWorkloadAuthorityResolver materializes or resolves the one
+// lifecycle-derived workload authority only after the exact Stage-4 receipt
+// prefix is durable. The returned private paths must equal the future paths
+// bound while opening the execution; only the binding digest is dynamic.
+type PreRuntimeWorkloadAuthorityResolver interface {
+	ResolvePreRuntimeWorkloadAuthority(context.Context, StageResumeConfig) (WorkloadAuthorityFileResolverConfig, error)
+}
+
+type PreRuntimeWorkloadAuthorityResolverFunc func(context.Context, StageResumeConfig) (WorkloadAuthorityFileResolverConfig, error)
+
+func (resolver PreRuntimeWorkloadAuthorityResolverFunc) ResolvePreRuntimeWorkloadAuthority(ctx context.Context, resume StageResumeConfig) (WorkloadAuthorityFileResolverConfig, error) {
+	return resolver(ctx, resume)
+}
+
 // PreRuntimeExecutionConfig binds all immutable artifacts and private runtime
 // capabilities for Stage 1-7. Mutating grants are resolved only after the
 // exact direct predecessor receipt is durable.
@@ -49,6 +63,7 @@ type PreRuntimeExecutionConfig struct {
 	ClusterLifecycle          SubmissionStageRuntimeConfig
 	LifecycleObservation      LifecycleObservationStageRuntimeConfig
 	Enablement                PreRuntimeEnablementExecutionConfig
+	WorkloadAuthority         PreRuntimeWorkloadAuthorityResolver
 	NetworkObservation        NetworkObservationStageRuntimeConfig
 	RuntimeBinding            RuntimeBindingStageRuntimeConfig
 	RuntimeBindingReceiptPath string
@@ -100,6 +115,7 @@ type PreRuntimeExecution struct {
 	used      bool
 	completed bool
 	prefix    []StageReceiptSource
+	workload  WorkloadAuthorityFileResolverConfig
 }
 
 // OpenPreRuntimeExecution verifies the empty Stage-1 cursor and every future
@@ -110,7 +126,7 @@ func OpenPreRuntimeExecution(config PreRuntimeExecutionConfig) (*PreRuntimeExecu
 }
 
 func openPreRuntimeExecution(config PreRuntimeExecutionConfig, factories preRuntimeExecutionFactories) (*PreRuntimeExecution, error) {
-	if config.Authorization == nil || config.ReceiptDirectory == "" || config.PlanPath == "" ||
+	if config.Authorization == nil || config.WorkloadAuthority == nil || config.ReceiptDirectory == "" || config.PlanPath == "" ||
 		factories.submission == nil || factories.lifecycle == nil || factories.enablement == nil ||
 		factories.network == nil || factories.binding == nil || factories.target == nil || factories.persist == nil {
 		return nil, errors.New("pre-runtime execution configuration is incomplete")
@@ -130,6 +146,9 @@ func openPreRuntimeExecution(config PreRuntimeExecutionConfig, factories preRunt
 		validateRuntimeBindingOutputPath(config.RuntimeBinding.OutputPath) != nil ||
 		validateRuntimeBindingOutputPath(config.RuntimeBindingReceiptPath) != nil {
 		return nil, errors.New("pre-runtime binding handoff destination is invalid")
+	}
+	if err := validatePreRuntimeWorkloadAuthorityDestinations(config); err != nil {
+		return nil, err
 	}
 	config.TargetAccess.ExpectedObjects = append([]projection.ResourceIdentity(nil), config.TargetAccess.ExpectedObjects...)
 	return &PreRuntimeExecution{config: config, initial: initial, factories: factories}, nil
@@ -153,6 +172,8 @@ func (executor *PreRuntimeExecution) Run(ctx context.Context) (PreRuntimeExecuti
 	receipts := []StageReceiptSource{}
 	authorizations := []ResolvedStageAuthorizationReceipt{}
 	orchestration := PreRuntimeOrchestration{}
+	runtimeConfig := executor.config
+	var workloadAuthority WorkloadAuthorityFileResolverConfig
 
 	resolve := func(ctx context.Context) (StageAuthorizationSource, error) {
 		resolved, err := ResolveStageAuthorization(ctx, executor.resume(receipts), executor.config.Authorization)
@@ -240,7 +261,15 @@ func (executor *PreRuntimeExecution) Run(ctx context.Context) (PreRuntimeExecuti
 		return run, persist(ctx, invocation.store, StagedOperationReceiptReference(run))
 	}
 	orchestration.RunNetworkObservation = func(ctx context.Context, _ execution.StagedOperationReceipt) (execution.ObservationStageRunReceipt, error) {
-		invocation, err := executor.factories.network(executor.resume(receipts), executor.config)
+		resolved, err := executor.config.WorkloadAuthority.ResolvePreRuntimeWorkloadAuthority(ctx, executor.resume(receipts))
+		if err != nil {
+			return execution.ObservationStageRunReceipt{}, errors.New("resolve lifecycle-derived workload authority")
+		}
+		if err := bindPreRuntimeWorkloadAuthority(&runtimeConfig, resolved); err != nil {
+			return execution.ObservationStageRunReceipt{}, err
+		}
+		workloadAuthority = resolved
+		invocation, err := executor.factories.network(executor.resume(receipts), runtimeConfig)
 		if err != nil || invocation.run == nil || invocation.store == nil {
 			return execution.ObservationStageRunReceipt{}, errors.New("open network-observation stage")
 		}
@@ -251,7 +280,7 @@ func (executor *PreRuntimeExecution) Run(ctx context.Context) (PreRuntimeExecuti
 		return run, persist(ctx, invocation.store, ObservationStageReceiptReference(run))
 	}
 	orchestration.RunRuntimeBinding = func(ctx context.Context, _ execution.ObservationStageRunReceipt) (execution.BindingStageRunReceipt, error) {
-		invocation, err := executor.factories.binding(executor.resume(receipts), executor.config)
+		invocation, err := executor.factories.binding(executor.resume(receipts), runtimeConfig)
 		if err != nil || invocation.run == nil || invocation.materialReceipt == nil || invocation.store == nil {
 			return execution.BindingStageRunReceipt{}, errors.New("open runtime-binding stage")
 		}
@@ -278,7 +307,7 @@ func (executor *PreRuntimeExecution) Run(ctx context.Context) (PreRuntimeExecuti
 		if err != nil {
 			return execution.StagedOperationReceipt{}, err
 		}
-		invocation, err := executor.factories.target(executor.resume(receipts), source, executor.config)
+		invocation, err := executor.factories.target(executor.resume(receipts), source, runtimeConfig)
 		if err != nil || invocation.run == nil || invocation.store == nil {
 			return execution.StagedOperationReceipt{}, errors.New("open target-access stage")
 		}
@@ -299,10 +328,29 @@ func (executor *PreRuntimeExecution) Run(ctx context.Context) (PreRuntimeExecuti
 	if runErr == nil && result.State == "SUCCEEDED" && len(receipts) == len(preRuntimeStageOrder) {
 		executor.mu.Lock()
 		executor.prefix = append([]StageReceiptSource(nil), receipts...)
+		executor.workload = workloadAuthority
 		executor.completed = true
 		executor.mu.Unlock()
 	}
 	return result, runErr
+}
+
+// RuntimeWorkloadAuthority returns the exact lifecycle-derived private file
+// binding only after all seven stages completed. It is for in-process suffix
+// composition and must never be serialized into public evidence.
+func (executor *PreRuntimeExecution) RuntimeWorkloadAuthority() (WorkloadAuthorityFileResolverConfig, error) {
+	if executor == nil {
+		return WorkloadAuthorityFileResolverConfig{}, errors.New("pre-runtime execution is required")
+	}
+	executor.mu.Lock()
+	defer executor.mu.Unlock()
+	if !executor.completed {
+		return WorkloadAuthorityFileResolverConfig{}, errors.New("pre-runtime workload authority is unavailable")
+	}
+	if _, err := OpenWorkloadAuthorityFileResolver(executor.workload); err != nil {
+		return WorkloadAuthorityFileResolverConfig{}, errors.New("pre-runtime workload authority is invalid")
+	}
+	return executor.workload, nil
 }
 
 // ReceiptPrefix returns the exact private receipt sources only after all seven
@@ -349,6 +397,45 @@ func (executor *PreRuntimeExecution) resume(receipts []StageReceiptSource) Stage
 		PlanPath: executor.initial.PlanPath, PlanExpected: executor.initial.PlanExpected,
 		Receipts: prefix,
 	}
+}
+
+func validatePreRuntimeWorkloadAuthorityDestinations(config PreRuntimeExecutionConfig) error {
+	expected := config.NetworkObservation.Workload
+	if expected != config.RuntimeBinding.Workload || expected != config.TargetAccess.Runtime.Workload ||
+		expected.ExpectedBindingDigest != "" || expected.Path == "" || expected.CAFile == "" || !validWorkloadTransportCredential(expected) {
+		return errors.New("pre-runtime workload authority destinations are invalid")
+	}
+	credentialPath := expected.TokenFile
+	if credentialPath == "" {
+		credentialPath = expected.KubeconfigFile
+	}
+	if expected.Path == credentialPath || expected.Path == expected.CAFile || credentialPath == expected.CAFile {
+		return errors.New("pre-runtime workload authority destinations are invalid")
+	}
+	for _, path := range []string{expected.Path, credentialPath, expected.CAFile} {
+		if validateRuntimeBindingOutputPath(path) != nil {
+			return errors.New("pre-runtime workload authority destination is invalid")
+		}
+	}
+	return nil
+}
+
+func bindPreRuntimeWorkloadAuthority(config *PreRuntimeExecutionConfig, resolved WorkloadAuthorityFileResolverConfig) error {
+	if config == nil {
+		return errors.New("pre-runtime execution configuration is required")
+	}
+	expected := config.NetworkObservation.Workload
+	if resolved.Path != expected.Path || resolved.TokenFile != expected.TokenFile ||
+		resolved.KubeconfigFile != expected.KubeconfigFile || resolved.CAFile != expected.CAFile {
+		return errors.New("resolved workload authority differs from bound destinations")
+	}
+	if _, err := OpenWorkloadAuthorityFileResolver(resolved); err != nil {
+		return errors.New("resolved workload authority is invalid")
+	}
+	config.NetworkObservation.Workload = resolved
+	config.RuntimeBinding.Workload = resolved
+	config.TargetAccess.Runtime.Workload = resolved
+	return nil
 }
 
 func defaultPreRuntimeExecutionFactories() preRuntimeExecutionFactories {

--- a/internal/runner/pre_runtime_execution_test.go
+++ b/internal/runner/pre_runtime_execution_test.go
@@ -69,6 +69,12 @@ func TestPreRuntimeExecutionComposesExactPrefixWithDynamicAuthorization(t *testi
 	if err != nil || targetIdentity != digest.SHA256([]byte("11111111-1111-4111-8111-111111111111")) {
 		t.Fatalf("completed runtime target identity differs: %q %v", targetIdentity, err)
 	}
+	workloadAuthority, err := executor.RuntimeWorkloadAuthority()
+	if err != nil || workloadAuthority.Path != config.NetworkObservation.Workload.Path ||
+		workloadAuthority.TokenFile != config.NetworkObservation.Workload.TokenFile ||
+		workloadAuthority.CAFile != config.NetworkObservation.Workload.CAFile || workloadAuthority.ExpectedBindingDigest == "" {
+		t.Fatalf("completed workload authority differs: %#v %v", workloadAuthority, err)
+	}
 	prefix[0].Digest = runnerStageSHA("f")
 	again, err := executor.ReceiptPrefix()
 	if err != nil || again[0].Digest == prefix[0].Digest {
@@ -85,6 +91,45 @@ func TestPreRuntimeExecutionComposesExactPrefixWithDynamicAuthorization(t *testi
 		if strings.Contains(string(public), forbidden) {
 			t.Fatalf("public pre-runtime receipt exposed %q", forbidden)
 		}
+	}
+}
+
+func TestPreRuntimeExecutionStopsBeforeNetworkWhenWorkloadAuthorityIsUnavailable(t *testing.T) {
+	config, factories, calls, _ := preRuntimeExecutionFixture(t)
+	config.WorkloadAuthority = PreRuntimeWorkloadAuthorityResolverFunc(func(context.Context, StageResumeConfig) (WorkloadAuthorityFileResolverConfig, error) {
+		return WorkloadAuthorityFileResolverConfig{}, errors.New("private workload authority unavailable")
+	})
+	executor, err := openPreRuntimeExecution(config, factories)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := executor.Run(context.Background())
+	if err == nil || receipt.State != "STOPPED" || receipt.StoppedAt != "network-observation" || len(receipt.Checkpoints) != 4 ||
+		!reflect.DeepEqual(*calls, preRuntimeStageOrder[:4]) {
+		t.Fatalf("missing workload authority crossed Stage 5: %#v calls=%v err=%v", receipt, *calls, err)
+	}
+	if _, err := executor.RuntimeWorkloadAuthority(); err == nil {
+		t.Fatal("partial execution exposed workload authority")
+	}
+}
+
+func TestPreRuntimeExecutionRejectsWorkloadAuthorityOutsideBoundDestinations(t *testing.T) {
+	config, factories, calls, _ := preRuntimeExecutionFixture(t)
+	config.WorkloadAuthority = PreRuntimeWorkloadAuthorityResolverFunc(func(context.Context, StageResumeConfig) (WorkloadAuthorityFileResolverConfig, error) {
+		return WorkloadAuthorityFileResolverConfig{
+			Path:                  filepath.Join(filepath.Dir(config.NetworkObservation.Workload.Path), "foreign-binding.json"),
+			ExpectedBindingDigest: runnerStageSHA("c"), TokenFile: config.NetworkObservation.Workload.TokenFile,
+			CAFile: config.NetworkObservation.Workload.CAFile,
+		}, nil
+	})
+	executor, err := openPreRuntimeExecution(config, factories)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := executor.Run(context.Background())
+	if err == nil || receipt.State != "STOPPED" || receipt.StoppedAt != "network-observation" || len(receipt.Checkpoints) != 4 ||
+		!reflect.DeepEqual(*calls, preRuntimeStageOrder[:4]) {
+		t.Fatalf("foreign workload destination crossed Stage 5: %#v calls=%v err=%v", receipt, *calls, err)
 	}
 }
 
@@ -178,6 +223,18 @@ func TestOpenPreRuntimeExecutionRejectsUnsafeReceiptDestination(t *testing.T) {
 	}
 }
 
+func TestOpenPreRuntimeExecutionRejectsPreboundWorkloadIdentity(t *testing.T) {
+	config, factories, calls, _ := preRuntimeExecutionFixture(t)
+	prebound := config.NetworkObservation.Workload
+	prebound.ExpectedBindingDigest = runnerStageSHA("d")
+	config.NetworkObservation.Workload = prebound
+	config.RuntimeBinding.Workload = prebound
+	config.TargetAccess.Runtime.Workload = prebound
+	if _, err := openPreRuntimeExecution(config, factories); err == nil || len(*calls) != 0 {
+		t.Fatalf("caller-selected workload identity was accepted: calls=%v err=%v", *calls, err)
+	}
+}
+
 func TestBindingStageReceiptReferenceRetainsExactPublicIdentity(t *testing.T) {
 	receipt := execution.BindingStageRunReceipt{
 		Format: execution.BindingStageReceiptFormat, State: "COMPLETED_SUCCEEDED", PlanDigest: runnerStageSHA("a"),
@@ -218,6 +275,23 @@ func preRuntimeExecutionFixture(t *testing.T) (PreRuntimeExecutionConfig, preRun
 	}
 	config.RuntimeBinding.OutputPath = filepath.Join(runtimeDirectory, "runtime-binding.json")
 	config.RuntimeBindingReceiptPath = filepath.Join(runtimeDirectory, "runtime-binding-receipt.json")
+	workloadAuthority := WorkloadAuthorityFileResolverConfig{
+		Path:      filepath.Join(runtimeDirectory, "workload-authority.json"),
+		TokenFile: filepath.Join(runtimeDirectory, "workload-token"),
+		CAFile:    filepath.Join(runtimeDirectory, "workload-ca.crt"),
+	}
+	config.NetworkObservation.Workload = workloadAuthority
+	config.RuntimeBinding.Workload = workloadAuthority
+	config.TargetAccess.Runtime.Workload = workloadAuthority
+	resolvedWorkloadAuthority := workloadAuthority
+	resolvedWorkloadAuthority.ExpectedBindingDigest = runnerStageSHA("b")
+	config.WorkloadAuthority = PreRuntimeWorkloadAuthorityResolverFunc(func(_ context.Context, resume StageResumeConfig) (WorkloadAuthorityFileResolverConfig, error) {
+		decision, err := InspectStageResume(resume)
+		if err != nil || decision.State != "NEXT" || decision.StageID != "network-observation" || len(resume.Receipts) != 4 {
+			return WorkloadAuthorityFileResolverConfig{}, errors.New("workload authority resolved outside exact Stage-5 cursor")
+		}
+		return resolvedWorkloadAuthority, nil
+	})
 	store := &ledger.Ledger{}
 	verified := map[string]stagereceipt.Verified{}
 	makeReceipt := func(resume StageResumeConfig, stageID string) (stagereceipt.Verified, string) {
@@ -274,10 +348,16 @@ func preRuntimeExecutionFixture(t *testing.T) (PreRuntimeExecutionConfig, preRun
 		enablement: func(resume StageResumeConfig, _ StageAuthorizationSource, _ PreRuntimeExecutionConfig) (preRuntimeStagedInvocation, error) {
 			return staged(resume, "enablement"), nil
 		},
-		network: func(resume StageResumeConfig, _ PreRuntimeExecutionConfig) (preRuntimeObservationInvocation, error) {
+		network: func(resume StageResumeConfig, config PreRuntimeExecutionConfig) (preRuntimeObservationInvocation, error) {
+			if config.NetworkObservation.Workload != resolvedWorkloadAuthority {
+				return preRuntimeObservationInvocation{}, errors.New("network stage lacks resolved workload authority")
+			}
 			return observation(resume, "network-observation"), nil
 		},
 		binding: func(resume StageResumeConfig, config PreRuntimeExecutionConfig) (preRuntimeBindingInvocation, error) {
+			if config.RuntimeBinding.Workload != resolvedWorkloadAuthority {
+				return preRuntimeBindingInvocation{}, errors.New("runtime binding stage lacks resolved workload authority")
+			}
 			var materialReceipt RuntimeBindingMaterialReceipt
 			return preRuntimeBindingInvocation{store: store, run: func(context.Context) (execution.BindingStageRunReceipt, error) {
 				calls = append(calls, "runtime-binding")
@@ -326,7 +406,10 @@ func preRuntimeExecutionFixture(t *testing.T) (PreRuntimeExecutionConfig, preRun
 				return materialReceipt, nil
 			}}, nil
 		},
-		target: func(resume StageResumeConfig, _ StageAuthorizationSource, _ PreRuntimeExecutionConfig) (preRuntimeStagedInvocation, error) {
+		target: func(resume StageResumeConfig, _ StageAuthorizationSource, config PreRuntimeExecutionConfig) (preRuntimeStagedInvocation, error) {
+			if config.TargetAccess.Runtime.Workload != resolvedWorkloadAuthority {
+				return preRuntimeStagedInvocation{}, errors.New("target access stage lacks resolved workload authority")
+			}
 			return staged(resume, "target-access"), nil
 		},
 		persist: func(_ context.Context, _ StageResumeConfig, _ *ledger.Ledger, reference StageRunReceiptReference, path string) (StageReceiptSource, error) {

--- a/internal/runner/runtime_binding_source.go
+++ b/internal/runner/runtime_binding_source.go
@@ -22,9 +22,10 @@ const (
 )
 
 type KubernetesRuntimeBindingSource struct {
-	endpoint *url.URL
-	token    string
-	client   *http.Client
+	endpoint          *url.URL
+	token             string
+	clientCertificate bool
+	client            *http.Client
 }
 
 // OpenKubernetesRuntimeBindingSource opens one short-lived, read-only workload
@@ -35,9 +36,9 @@ func OpenKubernetesRuntimeBindingSource(authority KubernetesAuthorityConfig, bin
 	return source, err
 }
 
-// openKubernetesRuntimeBindingSource also returns the bounded token so stage
-// composition can prove that workload reads and ledger writes use distinct
-// credentials. The token never leaves this package or enters evidence.
+// openKubernetesRuntimeBindingSource also returns a private credential
+// identity so stage composition can prove that workload reads and ledger
+// writes use distinct credentials. It never enters evidence.
 func openKubernetesRuntimeBindingSource(authority KubernetesAuthorityConfig, binding WorkloadAuthorityBinding) (*KubernetesRuntimeBindingSource, string, error) {
 	if err := validateWorkloadAuthorityBinding(binding); err != nil {
 		return nil, "", errors.New("runtime binding workload authority is invalid")
@@ -45,21 +46,27 @@ func openKubernetesRuntimeBindingSource(authority KubernetesAuthorityConfig, bin
 	if authority.Endpoint != binding.Endpoint || authority.AuthorityIdentity != binding.TargetClusterUID || authority.CABundleDigest != binding.CABundleDigest {
 		return nil, "", errors.New("runtime binding source differs from workload authority")
 	}
-	token, ca, client, err := openBoundedKubernetesMaterial(authority.TokenFile, authority.CAFile)
+	transport, err := openBoundedKubernetesAuthorityTransport(authority)
 	if err != nil {
 		return nil, "", errors.New("open bounded runtime binding credential")
 	}
-	if digest.SHA256(ca) != binding.CABundleDigest {
+	if digest.SHA256(transport.caData) != binding.CABundleDigest {
 		return nil, "", errors.New("runtime binding source CA differs from workload authority")
 	}
-	source, err := newKubernetesRuntimeBindingSource(authority.Endpoint, token, client)
+	source, err := newKubernetesRuntimeBindingSourceWithTransport(authority.Endpoint, transport)
 	if err != nil {
 		return nil, "", err
 	}
-	return source, token, nil
+	return source, transport.credentialIdentity, nil
 }
 
 func newKubernetesRuntimeBindingSource(endpoint, token string, client *http.Client) (*KubernetesRuntimeBindingSource, error) {
+	return newKubernetesRuntimeBindingSourceWithTransport(endpoint, boundedKubernetesTransport{
+		bearerToken: token, credentialIdentity: token, client: client,
+	})
+}
+
+func newKubernetesRuntimeBindingSourceWithTransport(endpoint string, transport boundedKubernetesTransport) (*KubernetesRuntimeBindingSource, error) {
 	parsed, err := url.Parse(endpoint)
 	if err != nil || parsed.Host == "" || parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" || parsed.Path != "" && parsed.Path != "/" {
 		return nil, errors.New("runtime binding Kubernetes endpoint is invalid")
@@ -68,16 +75,20 @@ func newKubernetesRuntimeBindingSource(endpoint, token string, client *http.Clie
 	if parsed.Scheme != "https" && !(parsed.Scheme == "http" && (host == "127.0.0.1" || host == "::1" || host == "localhost")) {
 		return nil, errors.New("runtime binding Kubernetes endpoint must use HTTPS")
 	}
-	if token == "" || strings.TrimSpace(token) != token || strings.ContainsAny(token, "\r\n") || client == nil {
+	tokenMode := transport.bearerToken != ""
+	if tokenMode == transport.clientCertificate || strings.TrimSpace(transport.bearerToken) != transport.bearerToken ||
+		strings.ContainsAny(transport.bearerToken, "\r\n") || transport.client == nil {
 		return nil, errors.New("runtime binding credential or client is invalid")
 	}
-	bounded := *client
+	bounded := *transport.client
 	bounded.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
 	if bounded.Timeout == 0 {
 		bounded.Timeout = 15 * time.Second
 	}
 	parsed.Path, parsed.RawPath = "", ""
-	return &KubernetesRuntimeBindingSource{endpoint: parsed, token: token, client: &bounded}, nil
+	return &KubernetesRuntimeBindingSource{
+		endpoint: parsed, token: transport.bearerToken, clientCertificate: transport.clientCertificate, client: &bounded,
+	}, nil
 }
 
 // Observe performs exactly the namespace GET followed by the StorageClass GET.
@@ -118,7 +129,9 @@ func (source *KubernetesRuntimeBindingSource) get(ctx context.Context, path stri
 		return nil, errors.New("construct bounded runtime binding request")
 	}
 	request.Header.Set("Accept", "application/json")
-	request.Header.Set("Authorization", "Bearer "+source.token)
+	if !source.clientCertificate {
+		request.Header.Set("Authorization", "Bearer "+source.token)
+	}
 	response, err := source.client.Do(request)
 	if err != nil {
 		return nil, errors.New("bounded runtime binding request failed")

--- a/internal/runner/runtime_resolvers.go
+++ b/internal/runner/runtime_resolvers.go
@@ -34,13 +34,14 @@ type WorkloadAuthorityBinding struct {
 	CABundleDigest       string `json:"caBundleDigest"`
 }
 
-// WorkloadAuthorityFileResolverConfig binds the semantic record to separately
-// mounted short-lived credential material. Paths are execution inputs and are
-// deliberately excluded from the binding digest.
+// WorkloadAuthorityFileResolverConfig binds the semantic record to exactly one
+// separately mounted bearer token or client-certificate kubeconfig. Paths are
+// execution inputs and are deliberately excluded from the binding digest.
 type WorkloadAuthorityFileResolverConfig struct {
 	Path                  string
 	ExpectedBindingDigest string
 	TokenFile             string
+	KubeconfigFile        string
 	CAFile                string
 }
 
@@ -53,7 +54,7 @@ type WorkloadAuthorityFileResolver struct {
 // OpenWorkloadAuthorityFileResolver validates only the static configuration;
 // it performs no file read and no API request.
 func OpenWorkloadAuthorityFileResolver(config WorkloadAuthorityFileResolverConfig) (*WorkloadAuthorityFileResolver, error) {
-	if config.Path == "" || config.TokenFile == "" || config.CAFile == "" || !platformInputDigestPattern.MatchString(config.ExpectedBindingDigest) {
+	if config.Path == "" || config.CAFile == "" || !validWorkloadTransportCredential(config) || !platformInputDigestPattern.MatchString(config.ExpectedBindingDigest) {
 		return nil, errors.New("workload authority file resolver binding is invalid")
 	}
 	return &WorkloadAuthorityFileResolver{config: config}, nil
@@ -80,9 +81,9 @@ func (resolver *WorkloadAuthorityFileResolver) ResolveWorkloadAuthority(ctx cont
 }
 
 // loadWorkloadAuthorityFiles reads one strict private binding and its CA. It
-// does not read the bearer token or contact either API authority.
+// does not read the transport credential or contact either API authority.
 func loadWorkloadAuthorityFiles(config WorkloadAuthorityFileResolverConfig) (WorkloadAuthorityBinding, KubernetesAuthorityConfig, error) {
-	if config.Path == "" || config.TokenFile == "" || config.CAFile == "" || !platformInputDigestPattern.MatchString(config.ExpectedBindingDigest) {
+	if config.Path == "" || config.CAFile == "" || !validWorkloadTransportCredential(config) || !platformInputDigestPattern.MatchString(config.ExpectedBindingDigest) {
 		return WorkloadAuthorityBinding{}, KubernetesAuthorityConfig{}, errors.New("workload authority file resolver binding is invalid")
 	}
 	binding, err := loadWorkloadAuthorityBinding(config.Path, config.ExpectedBindingDigest)
@@ -98,8 +99,13 @@ func loadWorkloadAuthorityFiles(config WorkloadAuthorityFileResolverConfig) (Wor
 	}
 	return binding, KubernetesAuthorityConfig{
 		Endpoint: binding.Endpoint, AuthorityIdentity: binding.TargetClusterUID,
-		TokenFile: config.TokenFile, CAFile: config.CAFile, CABundleDigest: binding.CABundleDigest,
+		TokenFile: config.TokenFile, KubeconfigFile: config.KubeconfigFile,
+		CAFile: config.CAFile, CABundleDigest: binding.CABundleDigest,
 	}, nil
+}
+
+func validWorkloadTransportCredential(config WorkloadAuthorityFileResolverConfig) bool {
+	return (config.TokenFile != "") != (config.KubeconfigFile != "")
 }
 
 // loadWorkloadAuthorityBinding verifies only the strict private semantic
@@ -129,24 +135,28 @@ func loadWorkloadAuthorityBinding(path, expectedDigest string) (WorkloadAuthorit
 // WorkloadAuthorityBindingDigest identifies the canonical, secret-free
 // runtime correlation record.
 func WorkloadAuthorityBindingDigest(binding WorkloadAuthorityBinding) (string, error) {
-	if err := validateWorkloadAuthorityBinding(binding); err != nil {
+	canonical, err := canonicalWorkloadAuthorityBinding(binding)
+	if err != nil {
 		return "", err
+	}
+	return digest.SHA256(canonical), nil
+}
+
+func canonicalWorkloadAuthorityBinding(binding WorkloadAuthorityBinding) ([]byte, error) {
+	if err := validateWorkloadAuthorityBinding(binding); err != nil {
+		return nil, err
 	}
 	raw, err := json.Marshal(binding)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	decoder := json.NewDecoder(bytes.NewReader(raw))
 	decoder.UseNumber()
 	var value any
 	if err := decoder.Decode(&value); err != nil {
-		return "", err
+		return nil, err
 	}
-	canonical, err := contract.JCS(value)
-	if err != nil {
-		return "", err
-	}
-	return digest.SHA256(canonical), nil
+	return contract.JCS(value)
 }
 
 func validateWorkloadAuthorityBinding(binding WorkloadAuthorityBinding) error {

--- a/internal/runner/target_credential_issuer.go
+++ b/internal/runner/target_credential_issuer.go
@@ -32,12 +32,13 @@ type TargetCredentialIssuerConfig struct {
 }
 
 type targetCredentialIssuerClientConfig struct {
-	Endpoint       string
-	BearerToken    string
-	CABundle       []byte
-	TargetIdentity string
-	Client         *http.Client
-	Clock          func() time.Time
+	Endpoint          string
+	BearerToken       string
+	ClientCertificate bool
+	CABundle          []byte
+	TargetIdentity    string
+	Client            *http.Client
+	Clock             func() time.Time
 }
 
 type TargetCredentialIssueReceipt struct {
@@ -79,17 +80,18 @@ type targetCredentialPrivateBinding struct {
 }
 
 type KubernetesTargetCredentialIssuer struct {
-	mu             sync.Mutex
-	used           bool
-	endpoint       *url.URL
-	authorityToken string
-	caBundle       []byte
-	targetIdentity string
-	client         *http.Client
-	clock          func() time.Time
-	policy         targetCredentialPolicyDocument
-	bundleReceipt  TargetCredentialStageBundleReceipt
-	request        []byte
+	mu                sync.Mutex
+	used              bool
+	endpoint          *url.URL
+	authorityToken    string
+	clientCertificate bool
+	caBundle          []byte
+	targetIdentity    string
+	client            *http.Client
+	clock             func() time.Time
+	policy            targetCredentialPolicyDocument
+	bundleReceipt     TargetCredentialStageBundleReceipt
+	request           []byte
 }
 
 type targetCredentialTokenRequest struct {
@@ -135,16 +137,16 @@ func OpenTargetCredentialIssuer(bundle VerifiedTargetCredentialStageBundle, conf
 	if binding.IntentRevision != bundle.plan.IntentRevision || digest.SHA256([]byte(binding.TargetClusterUID)) != bundle.receipt.TargetIdentityDigest {
 		return nil, errors.New("target-credential workload authority differs from verified target")
 	}
-	token, ca, client, err := openBoundedKubernetesMaterial(authority.TokenFile, authority.CAFile)
+	transport, err := openBoundedKubernetesAuthorityTransport(authority)
 	if err != nil {
 		return nil, errors.New("open bounded target-credential authority")
 	}
-	if digest.SHA256(ca) != authority.CABundleDigest {
+	if digest.SHA256(transport.caData) != authority.CABundleDigest {
 		return nil, errors.New("target-credential CA differs from runtime binding")
 	}
 	return newKubernetesTargetCredentialIssuer(targetCredentialIssuerClientConfig{
-		Endpoint: authority.Endpoint, BearerToken: token, CABundle: ca,
-		TargetIdentity: bundle.receipt.TargetIdentityDigest, Client: client, Clock: config.Clock,
+		Endpoint: authority.Endpoint, BearerToken: transport.bearerToken, ClientCertificate: transport.clientCertificate,
+		CABundle: transport.caData, TargetIdentity: bundle.receipt.TargetIdentityDigest, Client: transport.client, Clock: config.Clock,
 	}, bundle)
 }
 
@@ -160,7 +162,8 @@ func newKubernetesTargetCredentialIssuer(config targetCredentialIssuerClientConf
 		return nil, errors.New("target-credential issuer endpoint must use HTTPS")
 	}
 	endpoint.Path, endpoint.RawPath = "", ""
-	if config.BearerToken == "" || strings.TrimSpace(config.BearerToken) != config.BearerToken || strings.ContainsAny(config.BearerToken, "\r\n") || len(config.CABundle) == 0 || config.TargetIdentity != bundle.receipt.TargetIdentityDigest || config.Client == nil || config.Clock == nil {
+	tokenMode := config.BearerToken != ""
+	if tokenMode == config.ClientCertificate || strings.TrimSpace(config.BearerToken) != config.BearerToken || strings.ContainsAny(config.BearerToken, "\r\n") || len(config.CABundle) == 0 || config.TargetIdentity != bundle.receipt.TargetIdentityDigest || config.Client == nil || config.Clock == nil {
 		return nil, errors.New("target-credential issuer authority is invalid")
 	}
 	request := targetCredentialTokenRequest{
@@ -177,7 +180,8 @@ func newKubernetesTargetCredentialIssuer(config targetCredentialIssuerClientConf
 		client.Timeout = 15 * time.Second
 	}
 	return &KubernetesTargetCredentialIssuer{
-		endpoint: endpoint, authorityToken: config.BearerToken, caBundle: append([]byte(nil), config.CABundle...),
+		endpoint: endpoint, authorityToken: config.BearerToken, clientCertificate: config.ClientCertificate,
+		caBundle:       append([]byte(nil), config.CABundle...),
 		targetIdentity: config.TargetIdentity, client: &client, clock: config.Clock,
 		policy: bundle.policy, bundleReceipt: bundle.receipt, request: requestRaw,
 	}, nil
@@ -207,7 +211,9 @@ func (issuer *KubernetesTargetCredentialIssuer) Issue(ctx context.Context) (Veri
 	}
 	request.Header.Set("Accept", "application/json")
 	request.Header.Set("Content-Type", "application/json")
-	request.Header.Set("Authorization", "Bearer "+issuer.authorityToken)
+	if !issuer.clientCertificate {
+		request.Header.Set("Authorization", "Bearer "+issuer.authorityToken)
+	}
 	response, err := issuer.client.Do(request)
 	if err != nil {
 		return VerifiedTargetCredentialMaterial{}, errors.New("target-credential request failed")

--- a/internal/submission/kubernetes.go
+++ b/internal/submission/kubernetes.go
@@ -25,16 +25,18 @@ const (
 type KubernetesClientConfig struct {
 	Endpoint          string
 	BearerToken       string
+	ClientCertificate bool
 	AuthorityIdentity string
 	Client            *http.Client
 }
 
 // KubernetesClient performs only exact GET and collection POST operations.
 type KubernetesClient struct {
-	endpoint  *url.URL
-	token     string
-	authority string
-	client    *http.Client
+	endpoint          *url.URL
+	token             string
+	clientCertificate bool
+	authority         string
+	client            *http.Client
 }
 
 // ObjectResult records only redacted, immutable submission identity.
@@ -88,8 +90,9 @@ func NewKubernetesClient(config KubernetesClientConfig) (*KubernetesClient, erro
 	if endpoint.Scheme != "https" && !(endpoint.Scheme == "http" && (host == "127.0.0.1" || host == "::1" || host == "localhost")) {
 		return nil, errors.New("submission Kubernetes endpoint must use HTTPS")
 	}
-	if config.BearerToken == "" || strings.TrimSpace(config.BearerToken) != config.BearerToken || strings.ContainsAny(config.BearerToken, "\r\n") {
-		return nil, errors.New("submission Kubernetes bearer token is invalid")
+	tokenMode := config.BearerToken != ""
+	if tokenMode == config.ClientCertificate || strings.TrimSpace(config.BearerToken) != config.BearerToken || strings.ContainsAny(config.BearerToken, "\r\n") {
+		return nil, errors.New("submission Kubernetes transport credential is invalid")
 	}
 	if (!validName(config.AuthorityIdentity, 63) || strings.Contains(config.AuthorityIdentity, ".")) && !immutableDigestPattern.MatchString(config.AuthorityIdentity) {
 		return nil, errors.New("submission authority identity is invalid")
@@ -103,7 +106,10 @@ func NewKubernetesClient(config KubernetesClientConfig) (*KubernetesClient, erro
 		client.Timeout = 15 * time.Second
 	}
 	endpoint.Path = ""
-	return &KubernetesClient{endpoint: endpoint, token: config.BearerToken, authority: config.AuthorityIdentity, client: &client}, nil
+	return &KubernetesClient{
+		endpoint: endpoint, token: config.BearerToken, clientCertificate: config.ClientCertificate,
+		authority: config.AuthorityIdentity, client: &client,
+	}, nil
 }
 
 // Submit verifies existing objects or creates missing objects in projection
@@ -191,7 +197,9 @@ func (client *KubernetesClient) request(ctx context.Context, method, path string
 		return nil, 0, errors.New("construct bounded Kubernetes request")
 	}
 	request.Header.Set("Accept", "application/json")
-	request.Header.Set("Authorization", "Bearer "+client.token)
+	if !client.clientCertificate {
+		request.Header.Set("Authorization", "Bearer "+client.token)
+	}
 	if body != nil {
 		request.Header.Set("Content-Type", "application/json")
 	}


### PR DESCRIPTION
## Outcome

Closes the local OK-147 full-run manifest-to-executor seam without cluster contact.

- derives the workload authority from the exact lifecycle Cluster and CAPI kubeconfig Secret after Stage 4
- supports strictly verified client-certificate kubeconfigs across the bounded workload clients
- maps the verified private full-run manifest into the concrete Stage 1-12 execution adapters
- executes first-run Platform capability at most once and reuses the same in-memory assertion for aggregate evidence
- leaves retry, rollback, cleanup, CLI/Job activation and infrastructure mutation outside this checkpoint

## Validation

- `go test ./...`
- `go vet ./...`
- targeted `go test -race` for lifecycle materialization, full-run activation and shared capability execution
- `git diff --check`

All validation ran locally in an isolated Go container. No Kubernetes API was contacted.