### PR TITLE
feat(runner): add shared full-run activation

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -2878,6 +2878,15 @@ then reused unchanged by aggregate evaluation. A failed capability is cached
 as failure and is never retried by this seam. The direct
 `OpenFullRunExecutionManifest` entry point remains inert until `Run`.
 
+The shared full-run activation boundary now wraps that exact operation for
+both a local adapter and a future ephemeral Job adapter. Opening produces one
+redaction-safe `PREPARED` receipt and performs no stage action. `Run` consumes
+the activation before delegating exactly once to the concrete Stage 1-12
+executor, preserves a stopped orchestration receipt unchanged and exposes no
+retry, rollback or cleanup method. The Platform capability factory remains an
+explicit process-local dependency; this boundary does not invent a production
+observability transport or widen the private execution manifest.
+
 The post-runtime authorization resolver closes the next authority boundary.
 After a predecessor receipt is durable, it derives one canonical,
 redaction-safe request from the verified cursor, including the exact Plan,
@@ -3050,7 +3059,9 @@ receipt, and persists all seven ledger-backed receipts before exposing its
 exact prefix. The concrete full-run execution injects that prefix into a fresh
 Stage 8-12 adapter, and the full-run seam independently binds it through the
 exact Plan, private runtime handoff paths and seven predecessor receipt
-digests. The Stage 8-12 suffix additionally has a local
+digests. A shared single-use activation type now provides the common inert-open
+and exact-run entry for future local and Job adapters without selecting a
+concrete capability transport. The Stage 8-12 suffix additionally has a local
 prepare/execute command, a bounded ephemeral Job, a deterministic private
 activation package, an exact installation plan and a single-use CLI launcher.
 Successful Stage-8 and Stage-9 crash boundaries can be reactivated through the
@@ -3058,8 +3069,9 @@ same manifest, authority, package, Job and CLI chain without rewriting their
 durable receipts. This is not yet the OK-147 Definition of Done:
 
 - the legacy `ok cluster create` command remains dry-run-only;
-- the joined concrete Stage 1-7 and Stage 8-12 adapters have no shared
-  local/Job CreateCluster activation surface yet;
+- the joined concrete Stage 1-7 and Stage 8-12 adapters have a shared
+  activation boundary, but no concrete local command or ephemeral Job adapter
+  selects its production capability transport yet;
 - the standalone Stage-12 launcher has not yet been executed as part of the
   complete predecessor-bound stage chain;
 - the current staged-library source is published as the immutable multi-platform

--- a/internal/runner/full_run_activation.go
+++ b/internal/runner/full_run_activation.go
@@ -1,0 +1,108 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"sync"
+)
+
+const FullRunExecutionActivationReceiptFormat = "ok147-full-run-execution-activation-receipt/v1"
+
+// FullRunExecutionActivationReceipt is the common redaction-safe result used
+// by local and future Job activation adapters. It contains no credentials,
+// endpoints, runtime target identity or private paths.
+type FullRunExecutionActivationReceipt struct {
+	Format    string                          `json:"format"`
+	State     string                          `json:"state"`
+	Manifest  FullRunExecutionManifestReceipt `json:"manifest"`
+	Execution *FullRunOrchestrationReceipt    `json:"execution,omitempty"`
+}
+
+type fullRunManifestExecution interface {
+	Run(context.Context) (FullRunOrchestrationReceipt, error)
+}
+
+type fullRunExecutionActivationFactories struct {
+	open func(string, FullRunExecutionManifestRuntime) (fullRunManifestExecution, FullRunExecutionManifestReceipt, error)
+}
+
+// FullRunExecutionActivation is the single shared manifest-to-run boundary
+// for a local adapter and an ephemeral Job adapter. Open remains inert; Run is
+// single-use and delegates exactly once to the already bounded Stage 1-12
+// executor. It adds no retry, rollback or cleanup surface.
+type FullRunExecutionActivation struct {
+	execution fullRunManifestExecution
+	manifest  FullRunExecutionManifestReceipt
+
+	mu   sync.Mutex
+	used bool
+}
+
+// OpenFullRunExecutionActivation verifies and opens one private full-run
+// manifest without contacting an authority or executing a stage.
+func OpenFullRunExecutionActivation(path string, runtime FullRunExecutionManifestRuntime) (*FullRunExecutionActivation, FullRunExecutionActivationReceipt, error) {
+	return openFullRunExecutionActivation(path, runtime, defaultFullRunExecutionActivationFactories())
+}
+
+func openFullRunExecutionActivation(path string, runtime FullRunExecutionManifestRuntime, factories fullRunExecutionActivationFactories) (*FullRunExecutionActivation, FullRunExecutionActivationReceipt, error) {
+	receipt := FullRunExecutionActivationReceipt{
+		Format: FullRunExecutionActivationReceiptFormat,
+		State:  "STOPPED",
+	}
+	if factories.open == nil {
+		return nil, receipt, errors.New("full-run activation factory is incomplete")
+	}
+	execution, manifest, err := factories.open(path, runtime)
+	receipt.Manifest = manifest
+	if err != nil || execution == nil || manifest.Format != FullRunExecutionManifestReceiptFormat || manifest.State != "VERIFIED" || manifest.MutationAllowed {
+		return nil, receipt, errors.New("open verified full-run activation")
+	}
+	receipt.State = "PREPARED"
+	return &FullRunExecutionActivation{execution: execution, manifest: manifest}, receipt, nil
+}
+
+// Run consumes the prepared activation before invoking the concrete executor.
+// A stopped concrete receipt is preserved exactly for durable evidence.
+func (activation *FullRunExecutionActivation) Run(ctx context.Context) (FullRunExecutionActivationReceipt, error) {
+	receipt := FullRunExecutionActivationReceipt{
+		Format: FullRunExecutionActivationReceiptFormat,
+		State:  "STOPPED",
+	}
+	if activation == nil {
+		return receipt, errors.New("full-run activation is unavailable")
+	}
+	activation.mu.Lock()
+	if activation.used || activation.execution == nil {
+		activation.mu.Unlock()
+		return receipt, errors.New("full-run activation is already consumed")
+	}
+	activation.used = true
+	receipt.Manifest = activation.manifest
+	execution := activation.execution
+	activation.mu.Unlock()
+	if err := ctx.Err(); err != nil {
+		return receipt, errors.New("full-run activation context is unavailable")
+	}
+	executed, err := execution.Run(ctx)
+	receipt.Execution = &executed
+	if err != nil {
+		if executed.State == "STOPPED" {
+			receipt.State = "STOPPED"
+		}
+		return receipt, err
+	}
+	if executed.Format != FullRunOrchestrationReceiptFormat || executed.State != "SUCCEEDED" || executed.StoppedAt != "" {
+		receipt.State = "STOPPED"
+		return receipt, errors.New("full-run execution returned an invalid success receipt")
+	}
+	receipt.State = "SUCCEEDED"
+	return receipt, nil
+}
+
+func defaultFullRunExecutionActivationFactories() fullRunExecutionActivationFactories {
+	return fullRunExecutionActivationFactories{
+		open: func(path string, runtime FullRunExecutionManifestRuntime) (fullRunManifestExecution, FullRunExecutionManifestReceipt, error) {
+			return OpenFullRunExecutionManifest(path, runtime)
+		},
+	}
+}

--- a/internal/runner/full_run_activation_test.go
+++ b/internal/runner/full_run_activation_test.go
@@ -1,0 +1,203 @@
+package runner
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"reflect"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+func TestFullRunExecutionActivationIsInertThenRunsExactlyOnce(t *testing.T) {
+	execution := &recordingFullRunManifestExecution{
+		receipt: successfulFullRunActivationExecutionReceipt(),
+	}
+	factories := fullRunExecutionActivationFactories{
+		open: func(path string, _ FullRunExecutionManifestRuntime) (fullRunManifestExecution, FullRunExecutionManifestReceipt, error) {
+			if path != "/private/full-run.json" {
+				t.Fatalf("activation path differs: %q", path)
+			}
+			return execution, verifiedFullRunActivationManifestReceipt(), nil
+		},
+	}
+	activation, prepared, err := openFullRunExecutionActivation("/private/full-run.json", FullRunExecutionManifestRuntime{}, factories)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if prepared.Format != FullRunExecutionActivationReceiptFormat || prepared.State != "PREPARED" || prepared.Execution != nil || execution.calls.Load() != 0 {
+		t.Fatalf("opening activation was not inert: receipt=%#v calls=%d", prepared, execution.calls.Load())
+	}
+
+	receipt, err := activation.Run(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if receipt.State != "SUCCEEDED" || receipt.Execution == nil || receipt.Execution.State != "SUCCEEDED" || execution.calls.Load() != 1 {
+		t.Fatalf("full-run activation receipt differs: %#v calls=%d", receipt, execution.calls.Load())
+	}
+	if second, err := activation.Run(context.Background()); err == nil || second.State != "STOPPED" || execution.calls.Load() != 1 {
+		t.Fatalf("consumed activation ran again: receipt=%#v calls=%d err=%v", second, execution.calls.Load(), err)
+	}
+}
+
+func TestFullRunExecutionActivationPreservesStoppedExecution(t *testing.T) {
+	stopped := successfulFullRunActivationExecutionReceipt()
+	stopped.State = "STOPPED"
+	stopped.StoppedAt = "network-observation"
+	stopped.Checkpoints = stopped.Checkpoints[:4]
+	expectedErr := errors.New("bounded stage stopped")
+	execution := &recordingFullRunManifestExecution{receipt: stopped, err: expectedErr}
+	activation, _, err := openFullRunExecutionActivation("/private/full-run.json", FullRunExecutionManifestRuntime{}, fullRunExecutionActivationFactories{
+		open: func(string, FullRunExecutionManifestRuntime) (fullRunManifestExecution, FullRunExecutionManifestReceipt, error) {
+			return execution, verifiedFullRunActivationManifestReceipt(), nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := activation.Run(context.Background())
+	if !errors.Is(err, expectedErr) || receipt.State != "STOPPED" || receipt.Execution == nil || !reflect.DeepEqual(*receipt.Execution, stopped) {
+		t.Fatalf("stopped execution was not preserved: receipt=%#v err=%v", receipt, err)
+	}
+}
+
+func TestFullRunExecutionActivationAllowsOneConcurrentRun(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	execution := &recordingFullRunManifestExecution{
+		receipt: successfulFullRunActivationExecutionReceipt(), started: started, release: release,
+	}
+	activation := &FullRunExecutionActivation{execution: execution, manifest: verifiedFullRunActivationManifestReceipt()}
+	var group sync.WaitGroup
+	group.Add(2)
+	results := make(chan error, 2)
+	go func() {
+		defer group.Done()
+		_, err := activation.Run(context.Background())
+		results <- err
+	}()
+	<-started
+	go func() {
+		defer group.Done()
+		_, err := activation.Run(context.Background())
+		results <- err
+	}()
+	close(release)
+	group.Wait()
+	close(results)
+	succeeded, stopped := 0, 0
+	for err := range results {
+		if err == nil {
+			succeeded++
+		} else {
+			stopped++
+		}
+	}
+	if succeeded != 1 || stopped != 1 || execution.calls.Load() != 1 {
+		t.Fatalf("concurrent activation was not single-use: succeeded=%d stopped=%d calls=%d", succeeded, stopped, execution.calls.Load())
+	}
+}
+
+func TestFullRunExecutionActivationFailsClosedBeforeExecution(t *testing.T) {
+	tests := map[string]func() (*FullRunExecutionActivation, FullRunExecutionActivationReceipt, error){
+		"missing factory": func() (*FullRunExecutionActivation, FullRunExecutionActivationReceipt, error) {
+			return openFullRunExecutionActivation("/private/full-run.json", FullRunExecutionManifestRuntime{}, fullRunExecutionActivationFactories{})
+		},
+		"open error": func() (*FullRunExecutionActivation, FullRunExecutionActivationReceipt, error) {
+			return openFullRunExecutionActivation("/private/full-run.json", FullRunExecutionManifestRuntime{}, fullRunExecutionActivationFactories{
+				open: func(string, FullRunExecutionManifestRuntime) (fullRunManifestExecution, FullRunExecutionManifestReceipt, error) {
+					return nil, FullRunExecutionManifestReceipt{}, errors.New("private input rejected")
+				},
+			})
+		},
+		"unverified manifest": func() (*FullRunExecutionActivation, FullRunExecutionActivationReceipt, error) {
+			return openFullRunExecutionActivation("/private/full-run.json", FullRunExecutionManifestRuntime{}, fullRunExecutionActivationFactories{
+				open: func(string, FullRunExecutionManifestRuntime) (fullRunManifestExecution, FullRunExecutionManifestReceipt, error) {
+					receipt := verifiedFullRunActivationManifestReceipt()
+					receipt.State = "STOPPED"
+					return &recordingFullRunManifestExecution{}, receipt, nil
+				},
+			})
+		},
+	}
+	for name, run := range tests {
+		t.Run(name, func(t *testing.T) {
+			activation, receipt, err := run()
+			if err == nil || activation != nil || receipt.State != "STOPPED" || receipt.Execution != nil {
+				t.Fatalf("unsafe activation was accepted: activation=%#v receipt=%#v err=%v", activation, receipt, err)
+			}
+		})
+	}
+
+	execution := &recordingFullRunManifestExecution{receipt: successfulFullRunActivationExecutionReceipt()}
+	activation := &FullRunExecutionActivation{execution: execution, manifest: verifiedFullRunActivationManifestReceipt()}
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+	if receipt, err := activation.Run(cancelled); err == nil || receipt.State != "STOPPED" || execution.calls.Load() != 0 {
+		t.Fatalf("cancelled activation reached execution: receipt=%#v calls=%d err=%v", receipt, execution.calls.Load(), err)
+	}
+}
+
+func TestFullRunExecutionActivationReceiptIsRedactionSafe(t *testing.T) {
+	receipt := FullRunExecutionActivationReceipt{
+		Format:   FullRunExecutionActivationReceiptFormat,
+		State:    "PREPARED",
+		Manifest: verifiedFullRunActivationManifestReceipt(),
+	}
+	raw, err := json.Marshal(receipt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range []string{"/private/", "token", "endpoint", "kubeconfig", "certificate", "targetidentity"} {
+		if strings.Contains(strings.ToLower(string(raw)), forbidden) {
+			t.Fatalf("activation receipt disclosed %q: %s", forbidden, raw)
+		}
+	}
+}
+
+type recordingFullRunManifestExecution struct {
+	calls   atomic.Int32
+	receipt FullRunOrchestrationReceipt
+	err     error
+	started chan struct{}
+	release chan struct{}
+}
+
+func (execution *recordingFullRunManifestExecution) Run(context.Context) (FullRunOrchestrationReceipt, error) {
+	execution.calls.Add(1)
+	if execution.started != nil {
+		close(execution.started)
+	}
+	if execution.release != nil {
+		<-execution.release
+	}
+	return execution.receipt, execution.err
+}
+
+func verifiedFullRunActivationManifestReceipt() FullRunExecutionManifestReceipt {
+	return FullRunExecutionManifestReceipt{
+		Format: FullRunExecutionManifestReceiptFormat, State: "VERIFIED",
+		ManifestDigest: runnerStageSHA("a"), PlanDigest: runnerStageSHA("b"),
+		ProjectionManifestDigest: runnerStageSHA("c"), ProjectionAuthorityDigest: runnerStageSHA("d"),
+		NetworkProfileDigest: runnerStageSHA("e"), PlatformProfileDigest: runnerStageSHA("f"),
+		AggregateProfileDigest: runnerStageSHA("1"), RuntimeIdentityMode: "lifecycle-derived-private/v1",
+		AuthorizationMode: "predecessor-bound-tls/v1", CapabilityMode: "runtime-bound-in-memory/v1",
+	}
+}
+
+func successfulFullRunActivationExecutionReceipt() FullRunOrchestrationReceipt {
+	stages := append(append([]string(nil), preRuntimeStageOrder...), postRuntimeStageOrder...)
+	receipt := FullRunOrchestrationReceipt{
+		Format: FullRunOrchestrationReceiptFormat, State: "SUCCEEDED", PlanDigest: runnerStageSHA("b"),
+		Checkpoints: make([]FullRunStageCheckpoint, 0, len(stages)),
+	}
+	for index, stageID := range stages {
+		receipt.Checkpoints = append(receipt.Checkpoints, FullRunStageCheckpoint{
+			StageID: stageID, State: "COMPLETED_SUCCEEDED", StageReceiptDigest: runnerStageSHA(string(rune('a' + index%6))),
+		})
+	}
+	return receipt
+}


### PR DESCRIPTION
## Summary
- add one shared, inert-open Full-Run activation boundary for local and future Job adapters
- enforce exact single-use execution with fail-closed concurrency semantics
- preserve stopped Stage 1–12 receipts without adding retry, rollback, or cleanup authority
- document the remaining concrete capability-transport and adapter boundary

## Validation
- `go test ./...` in an unprivileged Linux container
- `go test -race ./internal/runner -run FullRunExecutionActivation -count=1`
- `go vet ./...`
- `git diff --check`

## Scope
No Kubernetes contact, infrastructure mutation, credential material, or production capability transport is introduced.