### PR TITLE
feat(runner): support lifecycle capability credentials

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -2900,6 +2900,14 @@ is deliberately no `full execute` command yet: registering one before the
 binary has a fixed production Observability capability adapter would create an
 incomplete mutation surface.
 
+The capability fixture transport now accepts either one bounded bearer token
+or the strict client-certificate kubeconfig produced by the lifecycle handoff,
+never both. The latter reuses the already verified endpoint and CA binding,
+adds no synthetic bearer header and performs no request while opening. This
+closes the credential-mode mismatch between the full-run lifecycle authority
+and the existing fixed synthetic fixture client; the five concrete
+observability checks remain the next separate adapter boundary.
+
 The post-runtime authorization resolver closes the next authority boundary.
 After a predecessor receipt is durable, it derives one canonical,
 redaction-safe request from the verified cursor, including the exact Plan,

--- a/internal/runner/kubernetes.go
+++ b/internal/runner/kubernetes.go
@@ -440,15 +440,16 @@ func OpenKubernetesObservabilityTransport(config KubernetesObservabilityTranspor
 	if config.Workload.AuthorityIdentity != config.Run.TargetClusterUID || !platformInputDigestPattern.MatchString(config.Workload.CABundleDigest) {
 		return nil, errors.New("observability transport workload authority differs from runtime target")
 	}
-	token, ca, client, err := openBoundedKubernetesMaterial(config.Workload.TokenFile, config.Workload.CAFile)
+	transport, err := openBoundedKubernetesAuthorityTransport(config.Workload)
 	if err != nil {
 		return nil, errors.New("open bounded observability transport credential")
 	}
-	if digest.SHA256(ca) != config.Workload.CABundleDigest {
+	if digest.SHA256(transport.caData) != config.Workload.CABundleDigest {
 		return nil, errors.New("observability transport CA differs from runtime-bound authority")
 	}
 	fixtureClient, err := NewKubernetesCapabilityFixtureClient(KubernetesCapabilityFixtureClientConfig{
-		Endpoint: config.Workload.Endpoint, BearerToken: token, AuthorityIdentity: config.Workload.AuthorityIdentity, Client: client,
+		Endpoint: config.Workload.Endpoint, BearerToken: transport.bearerToken, ClientCertificate: transport.clientCertificate,
+		AuthorityIdentity: config.Workload.AuthorityIdentity, Client: transport.client,
 	}, config.Run, config.Fixture)
 	if err != nil {
 		return nil, errors.New("open bounded observability fixture client")

--- a/internal/runner/observability_fixture_client.go
+++ b/internal/runner/observability_fixture_client.go
@@ -23,6 +23,7 @@ const (
 type KubernetesCapabilityFixtureClientConfig struct {
 	Endpoint          string
 	BearerToken       string
+	ClientCertificate bool
 	AuthorityIdentity string
 	Client            *http.Client
 }
@@ -45,10 +46,11 @@ type CapabilityFixtureReceipt struct {
 // KubernetesCapabilityFixtureClient freezes one generated fixture and one
 // workload authority. Create and cleanup accept no manifests, names or paths.
 type KubernetesCapabilityFixtureClient struct {
-	endpoint *url.URL
-	token    string
-	client   *http.Client
-	fixture  ObservabilitySyntheticFixture
+	endpoint          *url.URL
+	token             string
+	clientCertificate bool
+	client            *http.Client
+	fixture           ObservabilitySyntheticFixture
 }
 
 func NewKubernetesCapabilityFixtureClient(config KubernetesCapabilityFixtureClientConfig, run ObservabilityCapabilityRun, fixtureConfig ObservabilitySyntheticFixtureConfig) (*KubernetesCapabilityFixtureClient, error) {
@@ -63,7 +65,11 @@ func NewKubernetesCapabilityFixtureClient(config KubernetesCapabilityFixtureClie
 	if endpoint.Scheme != "https" && !(endpoint.Scheme == "http" && (host == "127.0.0.1" || host == "::1" || host == "localhost")) {
 		return nil, errors.New("capability fixture Kubernetes endpoint must use HTTPS")
 	}
-	if config.BearerToken == "" || strings.TrimSpace(config.BearerToken) != config.BearerToken || strings.ContainsAny(config.BearerToken, "\r\n") || config.Client == nil {
+	tokenMode := config.BearerToken != ""
+	if tokenMode == config.ClientCertificate || config.Client == nil {
+		return nil, errors.New("capability fixture Kubernetes credential or client is invalid")
+	}
+	if tokenMode && (strings.TrimSpace(config.BearerToken) != config.BearerToken || strings.ContainsAny(config.BearerToken, "\r\n")) {
 		return nil, errors.New("capability fixture Kubernetes credential or client is invalid")
 	}
 	fixture, err := BuildObservabilitySyntheticFixture(run, fixtureConfig)
@@ -76,7 +82,10 @@ func NewKubernetesCapabilityFixtureClient(config KubernetesCapabilityFixtureClie
 		client.Timeout = 15 * time.Second
 	}
 	endpoint.Path, endpoint.RawPath = "", ""
-	return &KubernetesCapabilityFixtureClient{endpoint: endpoint, token: config.BearerToken, client: &client, fixture: cloneSyntheticFixture(fixture)}, nil
+	return &KubernetesCapabilityFixtureClient{
+		endpoint: endpoint, token: config.BearerToken, clientCertificate: config.ClientCertificate,
+		client: &client, fixture: cloneSyntheticFixture(fixture),
+	}, nil
 }
 
 func (client *KubernetesCapabilityFixtureClient) FixtureDigest() string {
@@ -198,7 +207,9 @@ func (client *KubernetesCapabilityFixtureClient) request(ctx context.Context, me
 		return nil, 0, errors.New("construct bounded capability fixture request")
 	}
 	request.Header.Set("Accept", "application/json")
-	request.Header.Set("Authorization", "Bearer "+client.token)
+	if client.token != "" {
+		request.Header.Set("Authorization", "Bearer "+client.token)
+	}
 	if body != nil {
 		request.Header.Set("Content-Type", "application/json")
 	}

--- a/internal/runner/observability_fixture_client_test.go
+++ b/internal/runner/observability_fixture_client_test.go
@@ -105,6 +105,43 @@ func TestKubernetesCapabilityFixtureClientRejectsForeignAuthorityAndRedirect(t *
 	}
 }
 
+func TestKubernetesCapabilityFixtureClientAcceptsExplicitClientCertificateTransport(t *testing.T) {
+	run, _ := observabilityCapabilityRun(observabilityProbeRequest(), "ok-observability")
+	authorization := "unobserved"
+	client, err := NewKubernetesCapabilityFixtureClient(KubernetesCapabilityFixtureClientConfig{
+		Endpoint: "http://127.0.0.1:12345", ClientCertificate: true, AuthorityIdentity: run.TargetClusterUID,
+		Client: &http.Client{Transport: capabilityRoundTripFunc(func(request *http.Request) (*http.Response, error) {
+			authorization = request.Header.Get("Authorization")
+			return capabilityJSONResponse(http.StatusNotFound, nil, nil), nil
+		})},
+	}, run, capabilityFixtureConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.Create(context.Background()); err == nil {
+		t.Fatal("incomplete fixture preflight unexpectedly succeeded")
+	}
+	if authorization != "" || !client.clientCertificate || client.token != "" {
+		t.Fatalf("client-certificate fixture transport synthesized bearer authority: authorization=%q", authorization)
+	}
+
+	for name, mutate := range map[string]func(*KubernetesCapabilityFixtureClientConfig){
+		"ambiguous token and certificate": func(config *KubernetesCapabilityFixtureClientConfig) { config.BearerToken = "token" },
+		"missing transport identity":      func(config *KubernetesCapabilityFixtureClientConfig) { config.ClientCertificate = false },
+	} {
+		t.Run(name, func(t *testing.T) {
+			config := KubernetesCapabilityFixtureClientConfig{
+				Endpoint: "http://127.0.0.1:12345", ClientCertificate: true,
+				AuthorityIdentity: run.TargetClusterUID, Client: &http.Client{},
+			}
+			mutate(&config)
+			if _, err := NewKubernetesCapabilityFixtureClient(config, run, capabilityFixtureConfig()); err == nil {
+				t.Fatal("unsafe capability credential mode was accepted")
+			}
+		})
+	}
+}
+
 type capabilityRecordedRequest struct {
 	method string
 	path   string

--- a/internal/runner/observability_transport_test.go
+++ b/internal/runner/observability_transport_test.go
@@ -135,6 +135,34 @@ func TestOpenKubernetesObservabilityTransportBindsCredentialAndCA(t *testing.T) 
 	}
 }
 
+func TestOpenKubernetesObservabilityTransportAcceptsLifecycleClientCertificate(t *testing.T) {
+	root := t.TempDir()
+	ca, certificate, key := testClientCredential(t)
+	caPath := filepath.Join(root, "workload-ca.crt")
+	kubeconfigPath := filepath.Join(root, "workload.kubeconfig")
+	endpoint := "https://192.0.2.90:6443"
+	if err := os.WriteFile(caPath, ca, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(kubeconfigPath, testClientKubeconfig(endpoint, ca, certificate, key), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	run, _ := observabilityCapabilityRun(observabilityProbeRequest(), "ok-observability")
+	transport, err := OpenKubernetesObservabilityTransport(KubernetesObservabilityTransportConfig{
+		Workload: KubernetesAuthorityConfig{
+			Endpoint: endpoint, AuthorityIdentity: run.TargetClusterUID, KubeconfigFile: kubeconfigPath,
+			CAFile: caPath, CABundleDigest: digest.SHA256(ca),
+		},
+		Run: run, Fixture: capabilityFixtureConfig(), Checks: &recordingCapabilityChecks{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if transport.client == nil || !transport.client.clientCertificate || transport.client.token != "" {
+		t.Fatalf("lifecycle client-certificate authority was not retained: %#v", transport.client)
+	}
+}
+
 type recordingCapabilityChecks struct {
 	calls    []string
 	fixtures []ObservabilitySyntheticFixture


### PR DESCRIPTION
## Summary

- accept exactly one bounded bearer-token or lifecycle-derived client-certificate authority for the fixed capability fixture
- preserve the runtime-bound endpoint, CA digest, and target identity
- emit no synthetic bearer header in mTLS mode
- keep the five concrete observability checks as the next separate adapter boundary

## Validation

- `go test ./...` as an unprivileged Linux user
- targeted race tests for the capability fixture and transport
- `go vet ./...`
- `git diff --check`

Library, tests, and documentation only. No Kubernetes contact, infrastructure mutation, or credential material.