### PR TITLE
feat(runner): bind observability check profile

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -2908,6 +2908,17 @@ closes the credential-mode mismatch between the full-run lifecycle authority
 and the existing fixed synthetic fixture client; the five concrete
 observability checks remain the next separate adapter boundary.
 
+The first part of that adapter boundary is now a closed, deterministic
+`ok-observability-standard` check profile. It freezes the four Service names,
+ports and schemes; the credential Secret and exact key names; the platform
+dashboard ConfigMap and UID; the Prometheus datasource, synthetic alert and
+log-index identities; and the requirement that alert *delivery* is proven
+rather than treating alert firing as equivalent. Callers may select this
+profile only for `ok-observability`; none of these targets or assertions is an
+execution-time parameter. A canonical profile digest makes any future change
+to this list explicit. This checkpoint defines identities only and still
+performs no Secret read, service-proxy request or cluster mutation.
+
 The post-runtime authorization resolver closes the next authority boundary.
 After a predecessor receipt is durable, it derives one canonical,
 redaction-safe request from the verified cursor, including the exact Plan,

--- a/internal/runner/observability_check_profile.go
+++ b/internal/runner/observability_check_profile.go
@@ -1,0 +1,102 @@
+package runner
+
+import (
+	"encoding/json"
+	"errors"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+const ObservabilityCapabilityCheckProfileFormat = "ok147-observability-capability-check-profile/v1"
+
+type observabilityServiceBinding struct {
+	Name   string `json:"name"`
+	Port   int    `json:"port"`
+	Scheme string `json:"scheme"`
+}
+
+// ObservabilityCapabilityCheckProfile is the closed service and assertion
+// identity consumed by the production capability adapter. Its fields are
+// deliberately private: callers can select the accepted standard profile,
+// but cannot redirect checks to arbitrary Services, Secrets or assertions.
+type ObservabilityCapabilityCheckProfile struct {
+	format                  string
+	namespace               string
+	prometheus              observabilityServiceBinding
+	grafana                 observabilityServiceBinding
+	opensearch              observabilityServiceBinding
+	alertmanager            observabilityServiceBinding
+	credentialsSecret       string
+	grafanaUserKey          string
+	grafanaPasswordKey      string
+	opensearchPasswordKey   string
+	dashboardConfigMap      string
+	dashboardUID            string
+	prometheusDatasource    string
+	alertName               string
+	logIndexPattern         string
+	requireReceiverDelivery bool
+	profileDigest           string
+}
+
+type observabilityCapabilityCheckProfileDocument struct {
+	Format                  string                      `json:"format"`
+	Namespace               string                      `json:"namespace"`
+	Prometheus              observabilityServiceBinding `json:"prometheus"`
+	Grafana                 observabilityServiceBinding `json:"grafana"`
+	OpenSearch              observabilityServiceBinding `json:"openSearch"`
+	Alertmanager            observabilityServiceBinding `json:"alertmanager"`
+	CredentialsSecret       string                      `json:"credentialsSecret"`
+	GrafanaUserKey          string                      `json:"grafanaUserKey"`
+	GrafanaPasswordKey      string                      `json:"grafanaPasswordKey"`
+	OpenSearchPasswordKey   string                      `json:"openSearchPasswordKey"`
+	DashboardConfigMap      string                      `json:"dashboardConfigMap"`
+	DashboardUID            string                      `json:"dashboardUid"`
+	PrometheusDatasource    string                      `json:"prometheusDatasource"`
+	AlertName               string                      `json:"alertName"`
+	LogIndexPattern         string                      `json:"logIndexPattern"`
+	RequireReceiverDelivery bool                        `json:"requireReceiverDelivery"`
+}
+
+// StandardObservabilityCapabilityCheckProfile freezes the accepted
+// ok-observability-standard v1 identities. Alert delivery is strict: observing
+// a firing alert alone is not a successful delivery check.
+func StandardObservabilityCapabilityCheckProfile(namespace string) (ObservabilityCapabilityCheckProfile, error) {
+	if namespace != "ok-observability" {
+		return ObservabilityCapabilityCheckProfile{}, errors.New("observability capability check namespace is not the standard profile namespace")
+	}
+	profile := ObservabilityCapabilityCheckProfile{
+		format: ObservabilityCapabilityCheckProfileFormat, namespace: namespace,
+		prometheus:        observabilityServiceBinding{Name: "ok-observability-prometheus", Port: 9090, Scheme: "http"},
+		grafana:           observabilityServiceBinding{Name: "ok-observability-grafana", Port: 80, Scheme: "http"},
+		opensearch:        observabilityServiceBinding{Name: "opensearch-cluster-master", Port: 9200, Scheme: "https"},
+		alertmanager:      observabilityServiceBinding{Name: "ok-observability-alertmanager", Port: 9093, Scheme: "http"},
+		credentialsSecret: "ok-observability-credentials", grafanaUserKey: "grafana-admin-user",
+		grafanaPasswordKey: "grafana-admin-password", opensearchPasswordKey: "opensearch-admin-password",
+		dashboardConfigMap: "ok-observability-dashboard-platform-overview", dashboardUID: "ok-obs-platform-overview",
+		prometheusDatasource: "Prometheus", alertName: "OKObservabilitySyntheticAlert",
+		logIndexPattern: "ok-observability-logs*", requireReceiverDelivery: true,
+	}
+	raw, err := json.Marshal(profile.document())
+	if err != nil {
+		return ObservabilityCapabilityCheckProfile{}, errors.New("encode observability capability check profile")
+	}
+	profile.profileDigest = digest.SHA256(raw)
+	return profile, nil
+}
+
+func (profile ObservabilityCapabilityCheckProfile) Digest() string {
+	return profile.profileDigest
+}
+
+func (profile ObservabilityCapabilityCheckProfile) document() observabilityCapabilityCheckProfileDocument {
+	return observabilityCapabilityCheckProfileDocument{
+		Format: profile.format, Namespace: profile.namespace, Prometheus: profile.prometheus,
+		Grafana: profile.grafana, OpenSearch: profile.opensearch, Alertmanager: profile.alertmanager,
+		CredentialsSecret: profile.credentialsSecret, GrafanaUserKey: profile.grafanaUserKey,
+		GrafanaPasswordKey: profile.grafanaPasswordKey, OpenSearchPasswordKey: profile.opensearchPasswordKey,
+		DashboardConfigMap: profile.dashboardConfigMap, DashboardUID: profile.dashboardUID,
+		PrometheusDatasource: profile.prometheusDatasource, AlertName: profile.alertName,
+		LogIndexPattern: profile.logIndexPattern, RequireReceiverDelivery: profile.requireReceiverDelivery,
+	}
+}

--- a/internal/runner/observability_check_profile_test.go
+++ b/internal/runner/observability_check_profile_test.go
@@ -1,0 +1,47 @@
+package runner
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+func TestStandardObservabilityCapabilityCheckProfileFreezesExactContractIdentities(t *testing.T) {
+	profile, err := StandardObservabilityCapabilityCheckProfile("ok-observability")
+	if err != nil {
+		t.Fatal(err)
+	}
+	document := profile.document()
+	if document.Format != ObservabilityCapabilityCheckProfileFormat || document.Namespace != "ok-observability" ||
+		document.Prometheus != (observabilityServiceBinding{Name: "ok-observability-prometheus", Port: 9090, Scheme: "http"}) ||
+		document.Grafana != (observabilityServiceBinding{Name: "ok-observability-grafana", Port: 80, Scheme: "http"}) ||
+		document.OpenSearch != (observabilityServiceBinding{Name: "opensearch-cluster-master", Port: 9200, Scheme: "https"}) ||
+		document.Alertmanager != (observabilityServiceBinding{Name: "ok-observability-alertmanager", Port: 9093, Scheme: "http"}) ||
+		document.CredentialsSecret != "ok-observability-credentials" || document.GrafanaUserKey != "grafana-admin-user" ||
+		document.GrafanaPasswordKey != "grafana-admin-password" || document.OpenSearchPasswordKey != "opensearch-admin-password" ||
+		document.DashboardConfigMap != "ok-observability-dashboard-platform-overview" || document.DashboardUID != "ok-obs-platform-overview" ||
+		document.PrometheusDatasource != "Prometheus" || document.AlertName != "OKObservabilitySyntheticAlert" ||
+		document.LogIndexPattern != "ok-observability-logs*" || !document.RequireReceiverDelivery {
+		t.Fatalf("standard capability identities changed: %#v", document)
+	}
+	raw, err := json.Marshal(document)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if profile.Digest() != digest.SHA256(raw) || profile.Digest() == "" {
+		t.Fatalf("profile digest does not bind the canonical document: %s", profile.Digest())
+	}
+	second, err := StandardObservabilityCapabilityCheckProfile("ok-observability")
+	if err != nil || second.Digest() != profile.Digest() {
+		t.Fatal("standard capability profile is not reproducible")
+	}
+}
+
+func TestStandardObservabilityCapabilityCheckProfileRejectsRedirectedNamespace(t *testing.T) {
+	for _, namespace := range []string{"", "default", "ok-observability-other"} {
+		if _, err := StandardObservabilityCapabilityCheckProfile(namespace); err == nil {
+			t.Fatalf("redirected capability namespace %q was accepted", namespace)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- freeze the exact `ok-observability-standard` Service, credential, dashboard, datasource, alert, and log-index identities
- require actual alert-delivery evidence instead of equating alert firing with delivery
- expose only a deterministic profile digest; callers cannot redirect runtime checks to arbitrary targets

## Validation

- targeted profile tests
- full unprivileged Linux `go test ./...`
- `go vet ./...`
- `git diff --check`

This checkpoint defines immutable check identities only. It performs no Secret read, service-proxy request, or Kubernetes mutation.