### PR TITLE
feat(runner): evaluate observability guarantees

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -2919,6 +2919,18 @@ execution-time parameter. A canonical profile digest makes any future change
 to this list explicit. This checkpoint defines identities only and still
 performs no Secret read, service-proxy request or cluster mutation.
 
+The five semantic checks now have one production evaluator over typed backend
+observations. Every observation must repeat the exact run ID, target Cluster
+UID, synthetic-fixture digest and check-profile digest before its result can
+count. Metrics require both target discovery and the exact synthetic sample;
+dashboards require reachability, the fixed provisioned dashboard and the
+synthetic sample through the named datasource; logs require the exact marker;
+alerts require both firing and delivery; autonomy requires all local services
+ready and zero cross-cluster dependencies. A wrong identity or tampered
+fixture is an error, while a correctly correlated unmet guarantee is `false`.
+The evaluator never repairs an observed mechanism. The Kubernetes backend that
+collects these typed observations remains the next adapter checkpoint.
+
 The post-runtime authorization resolver closes the next authority boundary.
 After a predecessor receipt is durable, it derives one canonical,
 redaction-safe request from the verified cursor, including the exact Plan,

--- a/internal/runner/observability_checks.go
+++ b/internal/runner/observability_checks.go
@@ -1,0 +1,153 @@
+package runner
+
+import (
+	"context"
+	"errors"
+)
+
+// ObservabilityCapabilityObservationIdentity prevents a backend observation
+// from being reused for another run, target, fixture or check profile.
+type ObservabilityCapabilityObservationIdentity struct {
+	RunID            string
+	TargetClusterUID string
+	FixtureDigest    string
+	ProfileDigest    string
+}
+
+type ObservabilityMetricsObservation struct {
+	Identity         ObservabilityCapabilityObservationIdentity
+	MetricName       string
+	TargetDiscovered bool
+	MetricPresent    bool
+}
+
+type ObservabilityDashboardObservation struct {
+	Identity             ObservabilityCapabilityObservationIdentity
+	DashboardUID         string
+	DatasourceName       string
+	GrafanaReachable     bool
+	DashboardProvisioned bool
+	MetricPresent        bool
+}
+
+type ObservabilityLogObservation struct {
+	Identity         ObservabilityCapabilityObservationIdentity
+	LogMarker        string
+	BackendReachable bool
+	MarkerPresent    bool
+}
+
+type ObservabilityAlertObservation struct {
+	Identity  ObservabilityCapabilityObservationIdentity
+	AlertName string
+	Firing    bool
+	Delivered bool
+}
+
+type ObservabilityAutonomyObservation struct {
+	Identity                    ObservabilityCapabilityObservationIdentity
+	ClusterLocalServicesReady   bool
+	ExternalClusterDependencies int
+}
+
+// ObservabilityCapabilityBackend is a typed observation source. It receives
+// no caller-selected Service name, URL, query, command or credential. The
+// Kubernetes implementation is responsible for using only the closed profile.
+type ObservabilityCapabilityBackend interface {
+	ObserveMetrics(context.Context, ObservabilityCapabilityRun, ObservabilitySyntheticFixture, ObservabilityCapabilityCheckProfile) (ObservabilityMetricsObservation, error)
+	ObserveDashboards(context.Context, ObservabilityCapabilityRun, ObservabilitySyntheticFixture, ObservabilityCapabilityCheckProfile) (ObservabilityDashboardObservation, error)
+	ObserveLogs(context.Context, ObservabilityCapabilityRun, ObservabilitySyntheticFixture, ObservabilityCapabilityCheckProfile) (ObservabilityLogObservation, error)
+	ObserveAlertDelivery(context.Context, ObservabilityCapabilityRun, ObservabilitySyntheticFixture, ObservabilityCapabilityCheckProfile) (ObservabilityAlertObservation, error)
+	ObserveAutonomy(context.Context, ObservabilityCapabilityRun, ObservabilitySyntheticFixture, ObservabilityCapabilityCheckProfile) (ObservabilityAutonomyObservation, error)
+}
+
+// StandardObservabilityCapabilityChecks applies the five accepted contract
+// assertions to identity-bound backend observations. It observes only; repair
+// and reconciliation remain owned by the platform mechanisms.
+type StandardObservabilityCapabilityChecks struct {
+	backend ObservabilityCapabilityBackend
+	profile ObservabilityCapabilityCheckProfile
+}
+
+func NewStandardObservabilityCapabilityChecks(backend ObservabilityCapabilityBackend, profile ObservabilityCapabilityCheckProfile) (*StandardObservabilityCapabilityChecks, error) {
+	standard, err := StandardObservabilityCapabilityCheckProfile("ok-observability")
+	if err != nil || backend == nil || profile.Digest() == "" || profile.Digest() != standard.Digest() {
+		return nil, errors.New("standard observability capability checks binding is invalid")
+	}
+	return &StandardObservabilityCapabilityChecks{backend: backend, profile: profile}, nil
+}
+
+func (checks *StandardObservabilityCapabilityChecks) Metrics(ctx context.Context, run ObservabilityCapabilityRun, fixture ObservabilitySyntheticFixture) (bool, error) {
+	if err := checks.validate(run, fixture); err != nil {
+		return false, err
+	}
+	observed, err := checks.backend.ObserveMetrics(ctx, run, cloneSyntheticFixture(fixture), checks.profile)
+	if err != nil || !checks.matches(observed.Identity, run, fixture) {
+		return false, errors.New("metrics capability observation is invalid")
+	}
+	return observed.MetricName == fixture.MetricName && observed.TargetDiscovered && observed.MetricPresent, nil
+}
+
+func (checks *StandardObservabilityCapabilityChecks) Dashboards(ctx context.Context, run ObservabilityCapabilityRun, fixture ObservabilitySyntheticFixture) (bool, error) {
+	if err := checks.validate(run, fixture); err != nil {
+		return false, err
+	}
+	observed, err := checks.backend.ObserveDashboards(ctx, run, cloneSyntheticFixture(fixture), checks.profile)
+	if err != nil || !checks.matches(observed.Identity, run, fixture) {
+		return false, errors.New("dashboard capability observation is invalid")
+	}
+	return observed.DashboardUID == checks.profile.dashboardUID && observed.DatasourceName == checks.profile.prometheusDatasource &&
+		observed.GrafanaReachable && observed.DashboardProvisioned && observed.MetricPresent, nil
+}
+
+func (checks *StandardObservabilityCapabilityChecks) Logs(ctx context.Context, run ObservabilityCapabilityRun, fixture ObservabilitySyntheticFixture) (bool, error) {
+	if err := checks.validate(run, fixture); err != nil {
+		return false, err
+	}
+	observed, err := checks.backend.ObserveLogs(ctx, run, cloneSyntheticFixture(fixture), checks.profile)
+	if err != nil || !checks.matches(observed.Identity, run, fixture) {
+		return false, errors.New("log capability observation is invalid")
+	}
+	return observed.LogMarker == fixture.LogMarker && observed.BackendReachable && observed.MarkerPresent, nil
+}
+
+func (checks *StandardObservabilityCapabilityChecks) AlertDelivery(ctx context.Context, run ObservabilityCapabilityRun, fixture ObservabilitySyntheticFixture) (bool, error) {
+	if err := checks.validate(run, fixture); err != nil {
+		return false, err
+	}
+	observed, err := checks.backend.ObserveAlertDelivery(ctx, run, cloneSyntheticFixture(fixture), checks.profile)
+	if err != nil || !checks.matches(observed.Identity, run, fixture) {
+		return false, errors.New("alert capability observation is invalid")
+	}
+	return observed.AlertName == checks.profile.alertName && observed.Firing && observed.Delivered, nil
+}
+
+func (checks *StandardObservabilityCapabilityChecks) Autonomy(ctx context.Context, run ObservabilityCapabilityRun, fixture ObservabilitySyntheticFixture) (bool, error) {
+	if err := checks.validate(run, fixture); err != nil {
+		return false, err
+	}
+	observed, err := checks.backend.ObserveAutonomy(ctx, run, cloneSyntheticFixture(fixture), checks.profile)
+	if err != nil || !checks.matches(observed.Identity, run, fixture) || observed.ExternalClusterDependencies < 0 {
+		return false, errors.New("autonomy capability observation is invalid")
+	}
+	return observed.ClusterLocalServicesReady && observed.ExternalClusterDependencies == 0, nil
+}
+
+func (checks *StandardObservabilityCapabilityChecks) validate(run ObservabilityCapabilityRun, fixture ObservabilitySyntheticFixture) error {
+	if checks == nil || checks.backend == nil || checks.profile.Digest() == "" || validateObservabilityCapabilityRun(run) != nil ||
+		fixture.RunID != run.RunID || fixture.Namespace != run.Namespace || fixture.Format != ObservabilitySyntheticFixtureFormat {
+		return errors.New("observability capability check input is invalid")
+	}
+	digestValue, err := ObservabilitySyntheticFixtureDigest(fixture)
+	if err != nil || digestValue != fixture.FixtureDigest {
+		return errors.New("observability capability fixture identity is invalid")
+	}
+	return nil
+}
+
+func (checks *StandardObservabilityCapabilityChecks) matches(identity ObservabilityCapabilityObservationIdentity, run ObservabilityCapabilityRun, fixture ObservabilitySyntheticFixture) bool {
+	return identity.RunID == run.RunID && identity.TargetClusterUID == run.TargetClusterUID &&
+		identity.FixtureDigest == fixture.FixtureDigest && identity.ProfileDigest == checks.profile.Digest()
+}
+
+var _ ObservabilityCapabilityChecks = (*StandardObservabilityCapabilityChecks)(nil)

--- a/internal/runner/observability_checks_test.go
+++ b/internal/runner/observability_checks_test.go
@@ -1,0 +1,128 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+type recordingObservabilityCapabilityBackend struct {
+	identity ObservabilityCapabilityObservationIdentity
+	fixture  ObservabilitySyntheticFixture
+	profile  ObservabilityCapabilityCheckProfile
+	fail     string
+}
+
+func (backend *recordingObservabilityCapabilityBackend) capture(run ObservabilityCapabilityRun, fixture ObservabilitySyntheticFixture, profile ObservabilityCapabilityCheckProfile, name string) error {
+	backend.identity = ObservabilityCapabilityObservationIdentity{RunID: run.RunID, TargetClusterUID: run.TargetClusterUID, FixtureDigest: fixture.FixtureDigest, ProfileDigest: profile.Digest()}
+	backend.fixture, backend.profile = fixture, profile
+	if backend.fail == name {
+		return errors.New("backend failure")
+	}
+	return nil
+}
+
+func (backend *recordingObservabilityCapabilityBackend) ObserveMetrics(_ context.Context, run ObservabilityCapabilityRun, fixture ObservabilitySyntheticFixture, profile ObservabilityCapabilityCheckProfile) (ObservabilityMetricsObservation, error) {
+	err := backend.capture(run, fixture, profile, "metrics")
+	return ObservabilityMetricsObservation{Identity: backend.identity, MetricName: fixture.MetricName, TargetDiscovered: true, MetricPresent: true}, err
+}
+
+func (backend *recordingObservabilityCapabilityBackend) ObserveDashboards(_ context.Context, run ObservabilityCapabilityRun, fixture ObservabilitySyntheticFixture, profile ObservabilityCapabilityCheckProfile) (ObservabilityDashboardObservation, error) {
+	err := backend.capture(run, fixture, profile, "dashboards")
+	return ObservabilityDashboardObservation{Identity: backend.identity, DashboardUID: profile.dashboardUID, DatasourceName: profile.prometheusDatasource, GrafanaReachable: true, DashboardProvisioned: true, MetricPresent: true}, err
+}
+
+func (backend *recordingObservabilityCapabilityBackend) ObserveLogs(_ context.Context, run ObservabilityCapabilityRun, fixture ObservabilitySyntheticFixture, profile ObservabilityCapabilityCheckProfile) (ObservabilityLogObservation, error) {
+	err := backend.capture(run, fixture, profile, "logs")
+	return ObservabilityLogObservation{Identity: backend.identity, LogMarker: fixture.LogMarker, BackendReachable: true, MarkerPresent: true}, err
+}
+
+func (backend *recordingObservabilityCapabilityBackend) ObserveAlertDelivery(_ context.Context, run ObservabilityCapabilityRun, fixture ObservabilitySyntheticFixture, profile ObservabilityCapabilityCheckProfile) (ObservabilityAlertObservation, error) {
+	err := backend.capture(run, fixture, profile, "alert")
+	return ObservabilityAlertObservation{Identity: backend.identity, AlertName: profile.alertName, Firing: true, Delivered: true}, err
+}
+
+func (backend *recordingObservabilityCapabilityBackend) ObserveAutonomy(_ context.Context, run ObservabilityCapabilityRun, fixture ObservabilitySyntheticFixture, profile ObservabilityCapabilityCheckProfile) (ObservabilityAutonomyObservation, error) {
+	err := backend.capture(run, fixture, profile, "autonomy")
+	return ObservabilityAutonomyObservation{Identity: backend.identity, ClusterLocalServicesReady: true}, err
+}
+
+func TestStandardObservabilityCapabilityChecksAcceptExactFiveGuarantees(t *testing.T) {
+	run, _ := observabilityCapabilityRun(observabilityProbeRequest(), "ok-observability")
+	fixture, err := BuildObservabilitySyntheticFixture(run, capabilityFixtureConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+	profile, _ := StandardObservabilityCapabilityCheckProfile("ok-observability")
+	backend := &recordingObservabilityCapabilityBackend{}
+	checks, err := NewStandardObservabilityCapabilityChecks(backend, profile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	operations := []func(context.Context, ObservabilityCapabilityRun, ObservabilitySyntheticFixture) (bool, error){checks.Metrics, checks.Dashboards, checks.Logs, checks.AlertDelivery, checks.Autonomy}
+	for index, operation := range operations {
+		passed, err := operation(context.Background(), run, fixture)
+		if err != nil || !passed {
+			t.Fatalf("exact capability guarantee %d failed: passed=%v err=%v", index, passed, err)
+		}
+		if backend.profile.Digest() != profile.Digest() || backend.fixture.FixtureDigest != fixture.FixtureDigest {
+			t.Fatal("backend did not receive the exact profile and fixture")
+		}
+	}
+}
+
+func TestStandardObservabilityCapabilityChecksFailClosed(t *testing.T) {
+	run, _ := observabilityCapabilityRun(observabilityProbeRequest(), "ok-observability")
+	fixture, _ := BuildObservabilitySyntheticFixture(run, capabilityFixtureConfig())
+	profile, _ := StandardObservabilityCapabilityCheckProfile("ok-observability")
+
+	t.Run("alert firing without delivery is false", func(t *testing.T) {
+		backend := &recordingObservabilityCapabilityBackend{}
+		checks, _ := NewStandardObservabilityCapabilityChecks(backend, profile)
+		backend.fail = ""
+		observed, _ := backend.ObserveAlertDelivery(context.Background(), run, fixture, profile)
+		observed.Delivered = false
+		backendWithObservation := &fixedAlertBackend{recordingObservabilityCapabilityBackend: backend, observed: observed}
+		checks, _ = NewStandardObservabilityCapabilityChecks(backendWithObservation, profile)
+		passed, err := checks.AlertDelivery(context.Background(), run, fixture)
+		if err != nil || passed {
+			t.Fatalf("firing-only alert became delivery proof: passed=%v err=%v", passed, err)
+		}
+	})
+
+	t.Run("foreign identity errors", func(t *testing.T) {
+		backend := &recordingObservabilityCapabilityBackend{}
+		checks, _ := NewStandardObservabilityCapabilityChecks(&foreignMetricsBackend{recordingObservabilityCapabilityBackend: backend}, profile)
+		if _, err := checks.Metrics(context.Background(), run, fixture); err == nil {
+			t.Fatal("foreign capability observation was accepted")
+		}
+	})
+
+	t.Run("tampered fixture errors before backend", func(t *testing.T) {
+		backend := &recordingObservabilityCapabilityBackend{}
+		checks, _ := NewStandardObservabilityCapabilityChecks(backend, profile)
+		fixture.MetricName += "_tampered"
+		if _, err := checks.Metrics(context.Background(), run, fixture); err == nil || backend.identity.RunID != "" {
+			t.Fatal("tampered fixture reached the capability backend")
+		}
+	})
+}
+
+type fixedAlertBackend struct {
+	*recordingObservabilityCapabilityBackend
+	observed ObservabilityAlertObservation
+}
+
+func (backend *fixedAlertBackend) ObserveAlertDelivery(context.Context, ObservabilityCapabilityRun, ObservabilitySyntheticFixture, ObservabilityCapabilityCheckProfile) (ObservabilityAlertObservation, error) {
+	return backend.observed, nil
+}
+
+type foreignMetricsBackend struct {
+	*recordingObservabilityCapabilityBackend
+}
+
+func (backend *foreignMetricsBackend) ObserveMetrics(ctx context.Context, run ObservabilityCapabilityRun, fixture ObservabilitySyntheticFixture, profile ObservabilityCapabilityCheckProfile) (ObservabilityMetricsObservation, error) {
+	observed, err := backend.recordingObservabilityCapabilityBackend.ObserveMetrics(ctx, run, fixture, profile)
+	observed.Identity.TargetClusterUID = "foreign-cluster-uid"
+	return observed, err
+}


### PR DESCRIPTION
## Summary

- add one production evaluator for the five accepted observability guarantees
- correlate every backend observation to the exact run, target Cluster UID, fixture digest, and check-profile digest
- fail closed on foreign or tampered evidence
- require target discovery plus metric presence, fixed dashboard/datasource evidence, exact log marker, alert firing plus delivery, and zero cross-cluster dependencies
- retain observation-only ownership; the evaluator never repairs platform mechanisms

## Validation

- targeted evaluator tests
- targeted race tests
- full unprivileged Linux `go test ./...`
- `go vet ./...`
- `git diff --check`

No Kubernetes contact or infrastructure mutation.