### PR TITLE
feat(runner): add observability backend client

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -2931,6 +2931,18 @@ fixture is an error, while a correctly correlated unmet guarantee is `false`.
 The evaluator never repairs an observed mechanism. The Kubernetes backend that
 collects these typed observations remains the next adapter checkpoint.
 
+That backend now has an mTLS-only, redirect-denying Kubernetes client with a
+closed request surface. It can read exactly the standard profile's credential
+Secret and dashboard ConfigMap, push the two generated metrics through the
+fixture Service, and query only the fixed Prometheus, Grafana, OpenSearch and
+Alertmanager Service proxies. The runtime Cluster UID and complete fixture
+digest are checked before every fixture-derived request. Basic-auth values are
+decoded only from the exact three-key Secret and are never placed in returned
+errors. Response sizes and JSON media types are bounded, and opening the client
+performs no request. There is no list, watch, discovery, arbitrary URL or
+command surface. Parsing these bounded responses into the typed observations
+is the remaining backend step.
+
 The post-runtime authorization resolver closes the next authority boundary.
 After a predecessor receipt is durable, it derives one canonical,
 redaction-safe request from the verified cursor, including the exact Plan,

--- a/internal/runner/observability_backend_client.go
+++ b/internal/runner/observability_backend_client.go
@@ -1,0 +1,238 @@
+package runner
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+	"time"
+)
+
+const maximumObservabilityBackendResponseBytes = 4 * 1024 * 1024
+
+var grafanaDatasourceUIDPattern = regexp.MustCompile(`^[A-Za-z0-9_-]{1,128}$`)
+
+type KubernetesObservabilityBackendClientConfig struct {
+	Endpoint          string
+	ClientCertificate bool
+	AuthorityIdentity string
+	Client            *http.Client
+	Profile           ObservabilityCapabilityCheckProfile
+}
+
+type kubernetesObservabilityBackendClient struct {
+	endpoint          *url.URL
+	authorityIdentity string
+	client            *http.Client
+	profile           ObservabilityCapabilityCheckProfile
+}
+
+type observabilityBackendCredentials struct {
+	grafanaUser        string
+	grafanaPassword    string
+	opensearchPassword string
+}
+
+type observabilityBackendResponse struct {
+	status int
+	raw    []byte
+}
+
+// newKubernetesObservabilityBackendClient opens an mTLS-only client for the
+// fixed standard profile. mTLS leaves the HTTP Authorization header available
+// for the profile's upstream Basic-Auth services without weakening Kubernetes
+// API authentication. Opening performs no request.
+func newKubernetesObservabilityBackendClient(config KubernetesObservabilityBackendClientConfig) (*kubernetesObservabilityBackendClient, error) {
+	standard, err := StandardObservabilityCapabilityCheckProfile("ok-observability")
+	if err != nil || config.Client == nil || !config.ClientCertificate || !runtimeInputUIDPattern.MatchString(config.AuthorityIdentity) ||
+		config.Profile.Digest() == "" || config.Profile.Digest() != standard.Digest() {
+		return nil, errors.New("Kubernetes observability backend binding is invalid")
+	}
+	endpoint, err := url.Parse(config.Endpoint)
+	if err != nil || endpoint.Host == "" || endpoint.User != nil || endpoint.RawQuery != "" || endpoint.Fragment != "" || endpoint.Path != "" && endpoint.Path != "/" {
+		return nil, errors.New("Kubernetes observability backend endpoint is invalid")
+	}
+	host := endpoint.Hostname()
+	if endpoint.Scheme != "https" && !(endpoint.Scheme == "http" && (host == "127.0.0.1" || host == "::1" || host == "localhost")) {
+		return nil, errors.New("Kubernetes observability backend endpoint must use HTTPS")
+	}
+	client := *config.Client
+	client.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+	if client.Timeout == 0 {
+		client.Timeout = 15 * time.Second
+	}
+	endpoint.Path, endpoint.RawPath = "", ""
+	return &kubernetesObservabilityBackendClient{endpoint: endpoint, authorityIdentity: config.AuthorityIdentity, client: &client, profile: config.Profile}, nil
+}
+
+func (client *kubernetesObservabilityBackendClient) credentials(ctx context.Context, run ObservabilityCapabilityRun) (observabilityBackendCredentials, error) {
+	if err := client.validateRun(run); err != nil {
+		return observabilityBackendCredentials{}, err
+	}
+	path := "/api/v1/namespaces/" + client.profile.namespace + "/secrets/" + client.profile.credentialsSecret
+	response, err := client.request(ctx, http.MethodGet, path, nil, nil, "", "", true)
+	if err != nil || response.status != http.StatusOK {
+		return observabilityBackendCredentials{}, errors.New("read exact observability credential Secret")
+	}
+	var secret struct {
+		APIVersion string            `json:"apiVersion"`
+		Kind       string            `json:"kind"`
+		Data       map[string]string `json:"data"`
+		Metadata   struct {
+			Name      string `json:"name"`
+			Namespace string `json:"namespace"`
+		} `json:"metadata"`
+	}
+	if err := json.Unmarshal(response.raw, &secret); err != nil || secret.APIVersion != "v1" || secret.Kind != "Secret" ||
+		secret.Metadata.Name != client.profile.credentialsSecret || secret.Metadata.Namespace != client.profile.namespace || len(secret.Data) != 3 {
+		return observabilityBackendCredentials{}, errors.New("observability credential Secret identity is invalid")
+	}
+	decode := func(key string) (string, error) {
+		encoded, ok := secret.Data[key]
+		if !ok || encoded == "" {
+			return "", errors.New("missing credential key")
+		}
+		raw, err := base64.StdEncoding.Strict().DecodeString(encoded)
+		if err != nil || len(raw) == 0 || len(raw) > maximumTokenBytes || bytes.IndexByte(raw, 0) >= 0 {
+			return "", errors.New("invalid credential value")
+		}
+		return string(raw), nil
+	}
+	user, userErr := decode(client.profile.grafanaUserKey)
+	grafanaPassword, grafanaErr := decode(client.profile.grafanaPasswordKey)
+	opensearchPassword, opensearchErr := decode(client.profile.opensearchPasswordKey)
+	if userErr != nil || grafanaErr != nil || opensearchErr != nil {
+		return observabilityBackendCredentials{}, errors.New("observability credential Secret data is invalid")
+	}
+	return observabilityBackendCredentials{grafanaUser: user, grafanaPassword: grafanaPassword, opensearchPassword: opensearchPassword}, nil
+}
+
+func (client *kubernetesObservabilityBackendClient) dashboard(ctx context.Context, run ObservabilityCapabilityRun) (observabilityBackendResponse, error) {
+	if err := client.validateRun(run); err != nil {
+		return observabilityBackendResponse{}, err
+	}
+	path := "/api/v1/namespaces/" + client.profile.namespace + "/configmaps/" + client.profile.dashboardConfigMap
+	return client.request(ctx, http.MethodGet, path, nil, nil, "", "", true)
+}
+
+func (client *kubernetesObservabilityBackendClient) pushMetrics(ctx context.Context, run ObservabilityCapabilityRun, fixture ObservabilitySyntheticFixture) (observabilityBackendResponse, error) {
+	if err := client.validateFixture(run, fixture); err != nil {
+		return observabilityBackendResponse{}, err
+	}
+	body := []byte(fmt.Sprintf("%s 1\n%s 1\n", fixture.MetricName, fixture.AlertTriggerMetric))
+	path := client.serviceProxyPath(observabilityServiceBinding{Name: fixture.MetricsWorkload, Port: 9091, Scheme: "http"}, "metrics/job/"+fixture.MetricsWorkload)
+	return client.request(ctx, http.MethodPost, path, nil, body, "", "", false)
+}
+
+func (client *kubernetesObservabilityBackendClient) prometheusQuery(ctx context.Context, run ObservabilityCapabilityRun, fixture ObservabilitySyntheticFixture) (observabilityBackendResponse, error) {
+	if err := client.validateFixture(run, fixture); err != nil {
+		return observabilityBackendResponse{}, err
+	}
+	query := url.Values{"query": []string{fixture.MetricName}}
+	return client.request(ctx, http.MethodGet, client.serviceProxyPath(client.profile.prometheus, "api/v1/query"), query, nil, "", "", true)
+}
+
+func (client *kubernetesObservabilityBackendClient) grafanaDatasources(ctx context.Context, run ObservabilityCapabilityRun, credentials observabilityBackendCredentials) (observabilityBackendResponse, error) {
+	if err := client.validateRun(run); err != nil || credentials.grafanaUser == "" || credentials.grafanaPassword == "" {
+		return observabilityBackendResponse{}, errors.New("Grafana capability request binding is invalid")
+	}
+	return client.request(ctx, http.MethodGet, client.serviceProxyPath(client.profile.grafana, "api/datasources"), nil, nil, credentials.grafanaUser, credentials.grafanaPassword, true)
+}
+
+func (client *kubernetesObservabilityBackendClient) grafanaQuery(ctx context.Context, run ObservabilityCapabilityRun, fixture ObservabilitySyntheticFixture, datasourceUID string, credentials observabilityBackendCredentials) (observabilityBackendResponse, error) {
+	if err := client.validateFixture(run, fixture); err != nil || !grafanaDatasourceUIDPattern.MatchString(datasourceUID) || credentials.grafanaUser == "" || credentials.grafanaPassword == "" {
+		return observabilityBackendResponse{}, errors.New("Grafana datasource capability request binding is invalid")
+	}
+	query := url.Values{"query": []string{fixture.MetricName}}
+	path := client.serviceProxyPath(client.profile.grafana, "api/datasources/proxy/uid/"+datasourceUID+"/api/v1/query")
+	return client.request(ctx, http.MethodGet, path, query, nil, credentials.grafanaUser, credentials.grafanaPassword, true)
+}
+
+func (client *kubernetesObservabilityBackendClient) searchLogs(ctx context.Context, run ObservabilityCapabilityRun, fixture ObservabilitySyntheticFixture, credentials observabilityBackendCredentials) (observabilityBackendResponse, error) {
+	if err := client.validateFixture(run, fixture); err != nil || credentials.opensearchPassword == "" {
+		return observabilityBackendResponse{}, errors.New("OpenSearch capability request binding is invalid")
+	}
+	body, _ := json.Marshal(map[string]any{"query": map[string]any{"match_phrase": map[string]any{"log": fixture.LogMarker}}})
+	path := client.serviceProxyPath(client.profile.opensearch, client.profile.logIndexPattern+"/_search")
+	return client.request(ctx, http.MethodPost, path, nil, body, "admin", credentials.opensearchPassword, true)
+}
+
+func (client *kubernetesObservabilityBackendClient) alerts(ctx context.Context, run ObservabilityCapabilityRun) (observabilityBackendResponse, error) {
+	if err := client.validateRun(run); err != nil {
+		return observabilityBackendResponse{}, err
+	}
+	return client.request(ctx, http.MethodGet, client.serviceProxyPath(client.profile.alertmanager, "api/v2/alerts"), nil, nil, "", "", true)
+}
+
+func (client *kubernetesObservabilityBackendClient) validateRun(run ObservabilityCapabilityRun) error {
+	if client == nil || client.client == nil || validateObservabilityCapabilityRun(run) != nil || run.TargetClusterUID != client.authorityIdentity || run.Namespace != client.profile.namespace {
+		return errors.New("observability backend run differs from bound authority")
+	}
+	return nil
+}
+
+func (client *kubernetesObservabilityBackendClient) validateFixture(run ObservabilityCapabilityRun, fixture ObservabilitySyntheticFixture) error {
+	if err := client.validateRun(run); err != nil || fixture.RunID != run.RunID || fixture.Namespace != run.Namespace {
+		return errors.New("observability backend fixture differs from run")
+	}
+	digestValue, err := ObservabilitySyntheticFixtureDigest(fixture)
+	if err != nil || digestValue != fixture.FixtureDigest {
+		return errors.New("observability backend fixture identity is invalid")
+	}
+	return nil
+}
+
+func (client *kubernetesObservabilityBackendClient) serviceProxyPath(service observabilityServiceBinding, suffix string) string {
+	return "/api/v1/namespaces/" + client.profile.namespace + "/services/" + service.Scheme + ":" + service.Name + ":" + fmt.Sprint(service.Port) + "/proxy/" + suffix
+}
+
+func (client *kubernetesObservabilityBackendClient) request(ctx context.Context, method, path string, query url.Values, body []byte, basicUser, basicPassword string, requireJSON bool) (observabilityBackendResponse, error) {
+	endpoint := *client.endpoint
+	endpoint.Path = path
+	if query != nil {
+		endpoint.RawQuery = query.Encode()
+	}
+	request, err := http.NewRequestWithContext(ctx, method, endpoint.String(), bytes.NewReader(body))
+	if err != nil {
+		return observabilityBackendResponse{}, errors.New("construct bounded observability backend request")
+	}
+	request.Header.Set("Accept", "application/json")
+	if basicUser != "" || basicPassword != "" {
+		request.SetBasicAuth(basicUser, basicPassword)
+	}
+	if body != nil {
+		if requireJSON {
+			request.Header.Set("Content-Type", "application/json")
+		} else {
+			request.Header.Set("Content-Type", "text/plain; version=0.0.4")
+		}
+	}
+	response, err := client.client.Do(request)
+	if err != nil {
+		return observabilityBackendResponse{}, errors.New("bounded observability backend request failed")
+	}
+	defer response.Body.Close()
+	raw, readErr := io.ReadAll(io.LimitReader(response.Body, maximumObservabilityBackendResponseBytes+1))
+	if readErr != nil || len(raw) > maximumObservabilityBackendResponseBytes {
+		return observabilityBackendResponse{}, errors.New("bounded observability backend response exceeds accepted size")
+	}
+	if requireJSON && len(raw) > 0 {
+		mediaType, _, mediaErr := mime.ParseMediaType(response.Header.Get("Content-Type"))
+		if mediaErr != nil || mediaType != "application/json" {
+			return observabilityBackendResponse{}, errors.New("bounded observability backend response is not JSON")
+		}
+	}
+	return observabilityBackendResponse{status: response.StatusCode, raw: raw}, nil
+}
+
+func validObservabilityCredential(value string) bool {
+	return value != "" && strings.IndexByte(value, 0) < 0
+}

--- a/internal/runner/observability_backend_client_test.go
+++ b/internal/runner/observability_backend_client_test.go
@@ -1,0 +1,140 @@
+package runner
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+)
+
+type observabilityBackendRecordedRequest struct {
+	method        string
+	requestURI    string
+	authorization string
+	contentType   string
+}
+
+func TestKubernetesObservabilityBackendClientUsesOnlyBoundExactRequests(t *testing.T) {
+	run, _ := observabilityCapabilityRun(observabilityProbeRequest(), "ok-observability")
+	fixture, _ := BuildObservabilitySyntheticFixture(run, capabilityFixtureConfig())
+	profile, _ := StandardObservabilityCapabilityCheckProfile("ok-observability")
+	var requests []observabilityBackendRecordedRequest
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		requests = append(requests, observabilityBackendRecordedRequest{method: request.Method, requestURI: request.URL.RequestURI(), authorization: request.Header.Get("Authorization"), contentType: request.Header.Get("Content-Type")})
+		if request.URL.Path == "/api/v1/namespaces/ok-observability/secrets/ok-observability-credentials" {
+			writeObservabilityBackendJSON(writer, http.StatusOK, map[string]any{
+				"apiVersion": "v1", "kind": "Secret", "metadata": map[string]any{"name": "ok-observability-credentials", "namespace": "ok-observability"},
+				"data": map[string]any{
+					"grafana-admin-user":        base64.StdEncoding.EncodeToString([]byte("admin")),
+					"grafana-admin-password":    base64.StdEncoding.EncodeToString([]byte("grafana-password")),
+					"opensearch-admin-password": base64.StdEncoding.EncodeToString([]byte("opensearch-password")),
+				},
+			})
+			return
+		}
+		if request.Method == http.MethodPost && request.URL.Path == "/api/v1/namespaces/ok-observability/services/http:"+fixture.MetricsWorkload+":9091/proxy/metrics/job/"+fixture.MetricsWorkload {
+			writer.WriteHeader(http.StatusOK)
+			return
+		}
+		writeObservabilityBackendJSON(writer, http.StatusOK, map[string]any{"status": "ok"})
+	}))
+	defer server.Close()
+	client, err := newKubernetesObservabilityBackendClient(KubernetesObservabilityBackendClientConfig{
+		Endpoint: server.URL, ClientCertificate: true, AuthorityIdentity: run.TargetClusterUID, Client: server.Client(), Profile: profile,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	credentials, err := client.credentials(context.Background(), run)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !validObservabilityCredential(credentials.grafanaUser) || !validObservabilityCredential(credentials.grafanaPassword) || !validObservabilityCredential(credentials.opensearchPassword) {
+		t.Fatal("exact credential Secret did not produce the three private values")
+	}
+	operations := []func() error{
+		func() error { _, err := client.dashboard(context.Background(), run); return err },
+		func() error { _, err := client.pushMetrics(context.Background(), run, fixture); return err },
+		func() error { _, err := client.prometheusQuery(context.Background(), run, fixture); return err },
+		func() error { _, err := client.grafanaDatasources(context.Background(), run, credentials); return err },
+		func() error {
+			_, err := client.grafanaQuery(context.Background(), run, fixture, "prometheus-uid", credentials)
+			return err
+		},
+		func() error { _, err := client.searchLogs(context.Background(), run, fixture, credentials); return err },
+		func() error { _, err := client.alerts(context.Background(), run); return err },
+	}
+	for index, operation := range operations {
+		if err := operation(); err != nil {
+			t.Fatalf("bounded backend operation %d failed: %v", index, err)
+		}
+	}
+	expected := []observabilityBackendRecordedRequest{
+		{method: "GET", requestURI: "/api/v1/namespaces/ok-observability/secrets/ok-observability-credentials"},
+		{method: "GET", requestURI: "/api/v1/namespaces/ok-observability/configmaps/ok-observability-dashboard-platform-overview"},
+		{method: "POST", requestURI: "/api/v1/namespaces/ok-observability/services/http:" + fixture.MetricsWorkload + ":9091/proxy/metrics/job/" + fixture.MetricsWorkload, contentType: "text/plain; version=0.0.4"},
+		{method: "GET", requestURI: "/api/v1/namespaces/ok-observability/services/http:ok-observability-prometheus:9090/proxy/api/v1/query?query=" + fixture.MetricName},
+		{method: "GET", requestURI: "/api/v1/namespaces/ok-observability/services/http:ok-observability-grafana:80/proxy/api/datasources", authorization: "Basic YWRtaW46Z3JhZmFuYS1wYXNzd29yZA=="},
+		{method: "GET", requestURI: "/api/v1/namespaces/ok-observability/services/http:ok-observability-grafana:80/proxy/api/datasources/proxy/uid/prometheus-uid/api/v1/query?query=" + fixture.MetricName, authorization: "Basic YWRtaW46Z3JhZmFuYS1wYXNzd29yZA=="},
+		{method: "POST", requestURI: "/api/v1/namespaces/ok-observability/services/https:opensearch-cluster-master:9200/proxy/ok-observability-logs%2A/_search", authorization: "Basic YWRtaW46b3BlbnNlYXJjaC1wYXNzd29yZA==", contentType: "application/json"},
+		{method: "GET", requestURI: "/api/v1/namespaces/ok-observability/services/http:ok-observability-alertmanager:9093/proxy/api/v2/alerts"},
+	}
+	if !reflect.DeepEqual(requests, expected) {
+		t.Fatalf("backend request surface changed:\nobserved=%#v\nexpected=%#v", requests, expected)
+	}
+}
+
+func TestKubernetesObservabilityBackendClientRejectsUnsafeBindings(t *testing.T) {
+	run, _ := observabilityCapabilityRun(observabilityProbeRequest(), "ok-observability")
+	profile, _ := StandardObservabilityCapabilityCheckProfile("ok-observability")
+	base := KubernetesObservabilityBackendClientConfig{Endpoint: "http://127.0.0.1:12345", ClientCertificate: true, AuthorityIdentity: run.TargetClusterUID, Client: &http.Client{}, Profile: profile}
+	for name, mutate := range map[string]func(*KubernetesObservabilityBackendClientConfig){
+		"no mTLS identity":  func(config *KubernetesObservabilityBackendClientConfig) { config.ClientCertificate = false },
+		"foreign authority": func(config *KubernetesObservabilityBackendClientConfig) { config.AuthorityIdentity = "" },
+		"unbound profile": func(config *KubernetesObservabilityBackendClientConfig) {
+			config.Profile = ObservabilityCapabilityCheckProfile{}
+		},
+		"redirectable endpoint": func(config *KubernetesObservabilityBackendClientConfig) {
+			config.Endpoint = "https://user@example.test/path"
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			config := base
+			mutate(&config)
+			if _, err := newKubernetesObservabilityBackendClient(config); err == nil {
+				t.Fatal("unsafe observability backend binding was accepted")
+			}
+		})
+	}
+}
+
+func TestKubernetesObservabilityBackendClientRejectsCredentialAndFixtureDrift(t *testing.T) {
+	run, _ := observabilityCapabilityRun(observabilityProbeRequest(), "ok-observability")
+	profile, _ := StandardObservabilityCapabilityCheckProfile("ok-observability")
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		writeObservabilityBackendJSON(writer, http.StatusOK, map[string]any{
+			"apiVersion": "v1", "kind": "Secret", "metadata": map[string]any{"name": "ok-observability-credentials", "namespace": "ok-observability"},
+			"data": map[string]any{"grafana-admin-user": base64.StdEncoding.EncodeToString([]byte("admin"))},
+		})
+	}))
+	defer server.Close()
+	client, _ := newKubernetesObservabilityBackendClient(KubernetesObservabilityBackendClientConfig{Endpoint: server.URL, ClientCertificate: true, AuthorityIdentity: run.TargetClusterUID, Client: server.Client(), Profile: profile})
+	if _, err := client.credentials(context.Background(), run); err == nil {
+		t.Fatal("incomplete credential Secret was accepted")
+	}
+	fixture, _ := BuildObservabilitySyntheticFixture(run, capabilityFixtureConfig())
+	fixture.LogMarker += "_tampered"
+	if _, err := client.searchLogs(context.Background(), run, fixture, observabilityBackendCredentials{opensearchPassword: "password"}); err == nil {
+		t.Fatal("tampered synthetic fixture reached the service proxy")
+	}
+}
+
+func writeObservabilityBackendJSON(writer http.ResponseWriter, status int, value any) {
+	raw, _ := json.Marshal(value)
+	writer.Header().Set("Content-Type", "application/json")
+	writer.WriteHeader(status)
+	_, _ = writer.Write(raw)
+}


### PR DESCRIPTION
## Summary

- add an mTLS-only, redirect-denying Kubernetes client for the fixed observability profile
- bind every fixture-derived request to the runtime Cluster UID and complete fixture digest
- allow only the exact credential Secret, dashboard ConfigMap, synthetic Pushgateway, Prometheus, Grafana, OpenSearch, and Alertmanager request forms
- bound response sizes/media types and keep decoded credentials private
- expose no list, watch, discovery, arbitrary URL, or command surface

## Validation

- exact request-surface tests
- drift and unsafe-binding negative tests
- targeted race tests
- full unprivileged Linux `go test ./...`
- `go vet ./...`
- `git diff --check`

No live Kubernetes contact or infrastructure mutation.