### PR TITLE
feat(runner): parse observability evidence

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -2943,6 +2943,17 @@ performs no request. There is no list, watch, discovery, arbitrary URL or
 command surface. Parsing these bounded responses into the typed observations
 is the remaining backend step.
 
+The bounded service responses now feed strict, side-effect-free parsers for
+Prometheus samples, the unique named Grafana datasource, the exact provisioned
+dashboard ConfigMap/UID, OpenSearch hit counts and active Alertmanager alerts.
+Malformed, oversized, trailing, ambiguous or foreign evidence errors; a valid
+response that simply lacks the required result evaluates to `false`. Alert
+parsing establishes only `firing` and deliberately cannot manufacture the
+separate `delivered` claim. Likewise, cluster-local service responses alone do
+not prove autonomy under loss of external connectivity. Wiring the parsed
+results together with explicit delivery and autonomy evidence remains the next
+backend-composition boundary.
+
 The post-runtime authorization resolver closes the next authority boundary.
 After a predecessor receipt is durable, it derives one canonical,
 redaction-safe request from the verified cursor, including the exact Plan,

--- a/internal/runner/observability_response.go
+++ b/internal/runner/observability_response.go
@@ -1,0 +1,144 @@
+package runner
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"strconv"
+)
+
+func decodeObservabilityResponse(raw []byte, target any) error {
+	if len(raw) == 0 || len(raw) > maximumObservabilityBackendResponseBytes {
+		return errors.New("observability response size is invalid")
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	if err := decoder.Decode(target); err != nil {
+		return errors.New("observability response JSON is invalid")
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		return errors.New("observability response has trailing content")
+	}
+	return nil
+}
+
+func parsePrometheusMetricPresent(raw []byte, metricName string) (bool, error) {
+	var response struct {
+		Status string `json:"status"`
+		Data   struct {
+			Result []struct {
+				Metric map[string]string `json:"metric"`
+				Value  []json.RawMessage `json:"value"`
+			} `json:"result"`
+		} `json:"data"`
+	}
+	if err := decodeObservabilityResponse(raw, &response); err != nil || response.Status != "success" {
+		return false, errors.New("Prometheus capability response is invalid")
+	}
+	for _, result := range response.Data.Result {
+		if result.Metric["__name__"] == metricName && len(result.Value) == 2 {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func parseGrafanaPrometheusDatasource(raw []byte, expectedName string) (string, bool, error) {
+	var response []struct {
+		Name string `json:"name"`
+		Type string `json:"type"`
+		UID  string `json:"uid"`
+	}
+	if err := decodeObservabilityResponse(raw, &response); err != nil {
+		return "", false, errors.New("Grafana datasource response is invalid")
+	}
+	uid := ""
+	for _, datasource := range response {
+		if datasource.Name != expectedName || datasource.Type != "prometheus" {
+			continue
+		}
+		if !grafanaDatasourceUIDPattern.MatchString(datasource.UID) || uid != "" {
+			return "", false, errors.New("Grafana Prometheus datasource identity is ambiguous")
+		}
+		uid = datasource.UID
+	}
+	return uid, uid != "", nil
+}
+
+func parseDashboardProvisioned(raw []byte, namespace, configMapName, dashboardUID string) (bool, error) {
+	var response struct {
+		APIVersion string `json:"apiVersion"`
+		Kind       string `json:"kind"`
+		Metadata   struct {
+			Name      string            `json:"name"`
+			Namespace string            `json:"namespace"`
+			Labels    map[string]string `json:"labels"`
+		} `json:"metadata"`
+		Data map[string]string `json:"data"`
+	}
+	if err := decodeObservabilityResponse(raw, &response); err != nil || response.APIVersion != "v1" || response.Kind != "ConfigMap" ||
+		response.Metadata.Namespace != namespace || response.Metadata.Name != configMapName || response.Metadata.Labels["grafana_dashboard"] != "1" || len(response.Data) != 1 {
+		return false, errors.New("dashboard capability ConfigMap response is invalid")
+	}
+	dashboardRaw, ok := response.Data["platform-overview.json"]
+	if !ok {
+		return false, nil
+	}
+	var dashboard struct {
+		UID string `json:"uid"`
+	}
+	if err := decodeObservabilityResponse([]byte(dashboardRaw), &dashboard); err != nil {
+		return false, errors.New("provisioned dashboard JSON is invalid")
+	}
+	return dashboard.UID == dashboardUID, nil
+}
+
+func parseOpenSearchMarkerPresent(raw []byte) (bool, error) {
+	var response struct {
+		Hits struct {
+			Total json.RawMessage `json:"total"`
+		} `json:"hits"`
+	}
+	if err := decodeObservabilityResponse(raw, &response); err != nil || len(response.Hits.Total) == 0 {
+		return false, errors.New("OpenSearch capability response is invalid")
+	}
+	var object struct {
+		Value json.Number `json:"value"`
+	}
+	if err := decodeObservabilityResponse(response.Hits.Total, &object); err == nil && object.Value != "" {
+		value, parseErr := strconv.ParseInt(string(object.Value), 10, 64)
+		if parseErr != nil || value < 0 {
+			return false, errors.New("OpenSearch hit count is invalid")
+		}
+		return value > 0, nil
+	}
+	var number json.Number
+	if err := decodeObservabilityResponse(response.Hits.Total, &number); err != nil {
+		return false, errors.New("OpenSearch hit count is invalid")
+	}
+	value, err := strconv.ParseInt(string(number), 10, 64)
+	if err != nil || value < 0 {
+		return false, errors.New("OpenSearch hit count is invalid")
+	}
+	return value > 0, nil
+}
+
+func parseAlertmanagerFiring(raw []byte, alertName string) (bool, error) {
+	var response []struct {
+		Labels map[string]string `json:"labels"`
+		Status struct {
+			State string `json:"state"`
+		} `json:"status"`
+	}
+	if err := decodeObservabilityResponse(raw, &response); err != nil {
+		return false, errors.New("Alertmanager capability response is invalid")
+	}
+	for _, alert := range response {
+		if alert.Labels["alertname"] == alertName && alert.Status.State == "active" {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/internal/runner/observability_response_test.go
+++ b/internal/runner/observability_response_test.go
@@ -1,0 +1,67 @@
+package runner
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestObservabilityResponseParsersAcceptExactPositiveEvidence(t *testing.T) {
+	metric := "ok_observability_contract_metric_test"
+	if present, err := parsePrometheusMetricPresent([]byte(`{"status":"success","data":{"result":[{"metric":{"__name__":"`+metric+`"},"value":[1,"1"]}]}}`), metric); err != nil || !present {
+		t.Fatalf("exact Prometheus evidence failed: present=%v err=%v", present, err)
+	}
+	uid, present, err := parseGrafanaPrometheusDatasource([]byte(`[{"name":"Prometheus","type":"prometheus","uid":"prometheus-uid"}]`), "Prometheus")
+	if err != nil || !present || uid != "prometheus-uid" {
+		t.Fatalf("exact Grafana datasource failed: uid=%q present=%v err=%v", uid, present, err)
+	}
+	dashboard := `{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"ok-observability-dashboard-platform-overview","namespace":"ok-observability","labels":{"grafana_dashboard":"1"}},"data":{"platform-overview.json":"{\"uid\":\"ok-obs-platform-overview\"}"}}`
+	if present, err := parseDashboardProvisioned([]byte(dashboard), "ok-observability", "ok-observability-dashboard-platform-overview", "ok-obs-platform-overview"); err != nil || !present {
+		t.Fatalf("exact dashboard evidence failed: present=%v err=%v", present, err)
+	}
+	for _, raw := range []string{`{"hits":{"total":{"value":1,"relation":"eq"}}}`, `{"hits":{"total":1}}`} {
+		if present, err := parseOpenSearchMarkerPresent([]byte(raw)); err != nil || !present {
+			t.Fatalf("exact OpenSearch evidence failed: present=%v err=%v", present, err)
+		}
+	}
+	if firing, err := parseAlertmanagerFiring([]byte(`[{"labels":{"alertname":"OKObservabilitySyntheticAlert"},"status":{"state":"active"}}]`), "OKObservabilitySyntheticAlert"); err != nil || !firing {
+		t.Fatalf("exact Alertmanager evidence failed: firing=%v err=%v", firing, err)
+	}
+}
+
+func TestObservabilityResponseParsersReturnFalseForCorrelatedAbsence(t *testing.T) {
+	metric := "ok_observability_contract_metric_test"
+	if present, err := parsePrometheusMetricPresent([]byte(`{"status":"success","data":{"result":[]}}`), metric); err != nil || present {
+		t.Fatalf("empty Prometheus result did not return false: present=%v err=%v", present, err)
+	}
+	if _, present, err := parseGrafanaPrometheusDatasource([]byte(`[{"name":"Other","type":"prometheus","uid":"other"}]`), "Prometheus"); err != nil || present {
+		t.Fatalf("missing Grafana datasource did not return false: present=%v err=%v", present, err)
+	}
+	dashboard := `{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"ok-observability-dashboard-platform-overview","namespace":"ok-observability","labels":{"grafana_dashboard":"1"}},"data":{"platform-overview.json":"{\"uid\":\"other\"}"}}`
+	if present, err := parseDashboardProvisioned([]byte(dashboard), "ok-observability", "ok-observability-dashboard-platform-overview", "ok-obs-platform-overview"); err != nil || present {
+		t.Fatalf("wrong dashboard UID did not return false: present=%v err=%v", present, err)
+	}
+	if present, err := parseOpenSearchMarkerPresent([]byte(`{"hits":{"total":{"value":0}}}`)); err != nil || present {
+		t.Fatalf("zero OpenSearch hits did not return false: present=%v err=%v", present, err)
+	}
+	if firing, err := parseAlertmanagerFiring([]byte(`[{"labels":{"alertname":"Other"},"status":{"state":"active"}}]`), "OKObservabilitySyntheticAlert"); err != nil || firing {
+		t.Fatalf("missing alert did not return false: firing=%v err=%v", firing, err)
+	}
+}
+
+func TestObservabilityResponseParsersFailClosedOnMalformedOrAmbiguousEvidence(t *testing.T) {
+	if _, err := parsePrometheusMetricPresent([]byte(`{"status":"success","data":{"result":[]}} {}`), "metric"); err == nil {
+		t.Fatal("trailing Prometheus response was accepted")
+	}
+	if _, _, err := parseGrafanaPrometheusDatasource([]byte(`[{"name":"Prometheus","type":"prometheus","uid":"one"},{"name":"Prometheus","type":"prometheus","uid":"two"}]`), "Prometheus"); err == nil {
+		t.Fatal("ambiguous Grafana datasource was accepted")
+	}
+	if _, err := parseDashboardProvisioned([]byte(`{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"foreign","namespace":"ok-observability","labels":{"grafana_dashboard":"1"}},"data":{}}`), "ok-observability", "ok-observability-dashboard-platform-overview", "ok-obs-platform-overview"); err == nil {
+		t.Fatal("foreign dashboard ConfigMap was accepted")
+	}
+	if _, err := parseOpenSearchMarkerPresent([]byte(`{"hits":{"total":{"value":-1}}}`)); err == nil {
+		t.Fatal("negative OpenSearch hit count was accepted")
+	}
+	if _, err := parseAlertmanagerFiring([]byte(strings.Repeat("x", maximumObservabilityBackendResponseBytes+1)), "alert"); err == nil {
+		t.Fatal("oversized Alertmanager response was accepted")
+	}
+}


### PR DESCRIPTION
## Summary

- strictly parse bounded Prometheus, Grafana, dashboard ConfigMap, OpenSearch, and Alertmanager responses
- distinguish valid correlated absence (`false`) from malformed, oversized, trailing, ambiguous, or foreign evidence (error)
- establish only alert firing from Alertmanager; do not synthesize delivery evidence
- keep autonomy proof separate from ordinary local-service reachability

## Validation

- positive, absence, ambiguity, trailing-content, foreign-identity, and size-bound tests
- full unprivileged Linux `go test ./...`
- `go vet ./...`
- `git diff --check`

Pure parsing and documentation only; no Kubernetes contact or mutation.