### PR TITLE
feat(runner): compose observability backend

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -2954,6 +2954,18 @@ not prove autonomy under loss of external connectivity. Wiring the parsed
 results together with explicit delivery and autonomy evidence remains the next
 backend-composition boundary.
 
+The concrete backend now performs that composition. It pushes the generated
+metric pair exactly once, polls only valid correlated absence for Prometheus,
+Grafana, OpenSearch and Alertmanager, and stops on malformed or operational
+errors. Every call requires a caller deadline. Alert delivery is queried only
+after the exact alert is firing, through a separate identity-bound evidence
+source; autonomy likewise comes from a separate source that must report both
+local readiness and the number of external-cluster dependencies. Neither claim
+is inferred from ordinary reachability. The resulting typed observations feed
+the five-check evaluator without adding repair, retry authority or lifecycle
+ownership. Concrete delivery/autonomy evidence sources and the full-run factory
+wiring remain separate follow-ups.
+
 The post-runtime authorization resolver closes the next authority boundary.
 After a predecessor receipt is durable, it derives one canonical,
 redaction-safe request from the verified cursor, including the exact Plan,

--- a/internal/runner/observability_backend.go
+++ b/internal/runner/observability_backend.go
@@ -1,0 +1,210 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"time"
+)
+
+type observabilityBackendAPI interface {
+	credentials(context.Context, ObservabilityCapabilityRun) (observabilityBackendCredentials, error)
+	dashboard(context.Context, ObservabilityCapabilityRun) (observabilityBackendResponse, error)
+	pushMetrics(context.Context, ObservabilityCapabilityRun, ObservabilitySyntheticFixture) (observabilityBackendResponse, error)
+	prometheusQuery(context.Context, ObservabilityCapabilityRun, ObservabilitySyntheticFixture) (observabilityBackendResponse, error)
+	grafanaDatasources(context.Context, ObservabilityCapabilityRun, observabilityBackendCredentials) (observabilityBackendResponse, error)
+	grafanaQuery(context.Context, ObservabilityCapabilityRun, ObservabilitySyntheticFixture, string, observabilityBackendCredentials) (observabilityBackendResponse, error)
+	searchLogs(context.Context, ObservabilityCapabilityRun, ObservabilitySyntheticFixture, observabilityBackendCredentials) (observabilityBackendResponse, error)
+	alerts(context.Context, ObservabilityCapabilityRun) (observabilityBackendResponse, error)
+}
+
+// ObservabilityAlertDeliveryEvidenceSource proves receiver delivery separately
+// from Alertmanager firing. It receives only the immutable observation
+// identity and fixed alert name.
+type ObservabilityAlertDeliveryEvidenceSource interface {
+	Delivery(context.Context, ObservabilityCapabilityObservationIdentity, string) (bool, error)
+}
+
+// ObservabilityAutonomyEvidenceSource supplies the independent evidence needed
+// to claim that the stack remains functional without another cluster.
+type ObservabilityAutonomyEvidenceSource interface {
+	Autonomy(context.Context, ObservabilityCapabilityObservationIdentity) (clusterLocalServicesReady bool, externalClusterDependencies int, err error)
+}
+
+// KubernetesObservabilityCapabilityBackend composes the closed Kubernetes API
+// client, strict response parsers and the two claims that require independent
+// evidence. It polls only a valid correlated absence and performs no repair.
+type KubernetesObservabilityCapabilityBackend struct {
+	api          observabilityBackendAPI
+	delivery     ObservabilityAlertDeliveryEvidenceSource
+	autonomy     ObservabilityAutonomyEvidenceSource
+	profile      ObservabilityCapabilityCheckProfile
+	pollInterval time.Duration
+}
+
+func newKubernetesObservabilityCapabilityBackend(api observabilityBackendAPI, delivery ObservabilityAlertDeliveryEvidenceSource, autonomy ObservabilityAutonomyEvidenceSource, profile ObservabilityCapabilityCheckProfile, pollInterval time.Duration) (*KubernetesObservabilityCapabilityBackend, error) {
+	standard, err := StandardObservabilityCapabilityCheckProfile("ok-observability")
+	if err != nil || api == nil || delivery == nil || autonomy == nil || profile.Digest() == "" || profile.Digest() != standard.Digest() || pollInterval < time.Millisecond || pollInterval > 30*time.Second {
+		return nil, errors.New("Kubernetes observability capability backend binding is invalid")
+	}
+	return &KubernetesObservabilityCapabilityBackend{api: api, delivery: delivery, autonomy: autonomy, profile: profile, pollInterval: pollInterval}, nil
+}
+
+func (backend *KubernetesObservabilityCapabilityBackend) ObserveMetrics(ctx context.Context, run ObservabilityCapabilityRun, fixture ObservabilitySyntheticFixture, profile ObservabilityCapabilityCheckProfile) (ObservabilityMetricsObservation, error) {
+	identity, err := backend.identity(ctx, run, fixture, profile)
+	if err != nil {
+		return ObservabilityMetricsObservation{}, err
+	}
+	response, err := backend.api.pushMetrics(ctx, run, fixture)
+	if err != nil || response.status != http.StatusOK && response.status != http.StatusAccepted {
+		return ObservabilityMetricsObservation{}, errors.New("push exact observability metrics")
+	}
+	present, err := backend.poll(ctx, func() (bool, error) {
+		response, err := backend.api.prometheusQuery(ctx, run, fixture)
+		if err != nil || response.status != http.StatusOK {
+			return false, errors.New("query exact Prometheus metric")
+		}
+		return parsePrometheusMetricPresent(response.raw, fixture.MetricName)
+	})
+	if err != nil {
+		return ObservabilityMetricsObservation{}, err
+	}
+	return ObservabilityMetricsObservation{Identity: identity, MetricName: fixture.MetricName, TargetDiscovered: present, MetricPresent: present}, nil
+}
+
+func (backend *KubernetesObservabilityCapabilityBackend) ObserveDashboards(ctx context.Context, run ObservabilityCapabilityRun, fixture ObservabilitySyntheticFixture, profile ObservabilityCapabilityCheckProfile) (ObservabilityDashboardObservation, error) {
+	identity, err := backend.identity(ctx, run, fixture, profile)
+	if err != nil {
+		return ObservabilityDashboardObservation{}, err
+	}
+	dashboardResponse, err := backend.api.dashboard(ctx, run)
+	if err != nil || dashboardResponse.status != http.StatusOK {
+		return ObservabilityDashboardObservation{}, errors.New("read exact platform dashboard")
+	}
+	provisioned, err := parseDashboardProvisioned(dashboardResponse.raw, profile.namespace, profile.dashboardConfigMap, profile.dashboardUID)
+	if err != nil {
+		return ObservabilityDashboardObservation{}, err
+	}
+	credentials, err := backend.api.credentials(ctx, run)
+	if err != nil {
+		return ObservabilityDashboardObservation{}, err
+	}
+	datasourceResponse, err := backend.api.grafanaDatasources(ctx, run, credentials)
+	if err != nil || datasourceResponse.status != http.StatusOK {
+		return ObservabilityDashboardObservation{}, errors.New("read exact Grafana datasource")
+	}
+	datasourceUID, datasourcePresent, err := parseGrafanaPrometheusDatasource(datasourceResponse.raw, profile.prometheusDatasource)
+	if err != nil {
+		return ObservabilityDashboardObservation{}, err
+	}
+	metricPresent := false
+	if datasourcePresent {
+		metricPresent, err = backend.poll(ctx, func() (bool, error) {
+			response, err := backend.api.grafanaQuery(ctx, run, fixture, datasourceUID, credentials)
+			if err != nil || response.status != http.StatusOK {
+				return false, errors.New("query exact Grafana datasource metric")
+			}
+			return parsePrometheusMetricPresent(response.raw, fixture.MetricName)
+		})
+		if err != nil {
+			return ObservabilityDashboardObservation{}, err
+		}
+	}
+	return ObservabilityDashboardObservation{
+		Identity: identity, DashboardUID: profile.dashboardUID, DatasourceName: profile.prometheusDatasource,
+		GrafanaReachable: true, DashboardProvisioned: provisioned, MetricPresent: metricPresent,
+	}, nil
+}
+
+func (backend *KubernetesObservabilityCapabilityBackend) ObserveLogs(ctx context.Context, run ObservabilityCapabilityRun, fixture ObservabilitySyntheticFixture, profile ObservabilityCapabilityCheckProfile) (ObservabilityLogObservation, error) {
+	identity, err := backend.identity(ctx, run, fixture, profile)
+	if err != nil {
+		return ObservabilityLogObservation{}, err
+	}
+	credentials, err := backend.api.credentials(ctx, run)
+	if err != nil {
+		return ObservabilityLogObservation{}, err
+	}
+	present, err := backend.poll(ctx, func() (bool, error) {
+		response, err := backend.api.searchLogs(ctx, run, fixture, credentials)
+		if err != nil || response.status != http.StatusOK {
+			return false, errors.New("search exact OpenSearch log marker")
+		}
+		return parseOpenSearchMarkerPresent(response.raw)
+	})
+	if err != nil {
+		return ObservabilityLogObservation{}, err
+	}
+	return ObservabilityLogObservation{Identity: identity, LogMarker: fixture.LogMarker, BackendReachable: true, MarkerPresent: present}, nil
+}
+
+func (backend *KubernetesObservabilityCapabilityBackend) ObserveAlertDelivery(ctx context.Context, run ObservabilityCapabilityRun, fixture ObservabilitySyntheticFixture, profile ObservabilityCapabilityCheckProfile) (ObservabilityAlertObservation, error) {
+	identity, err := backend.identity(ctx, run, fixture, profile)
+	if err != nil {
+		return ObservabilityAlertObservation{}, err
+	}
+	firing, err := backend.poll(ctx, func() (bool, error) {
+		response, err := backend.api.alerts(ctx, run)
+		if err != nil || response.status != http.StatusOK {
+			return false, errors.New("read exact Alertmanager alert")
+		}
+		return parseAlertmanagerFiring(response.raw, profile.alertName)
+	})
+	if err != nil {
+		return ObservabilityAlertObservation{}, err
+	}
+	delivered := false
+	if firing {
+		delivered, err = backend.delivery.Delivery(ctx, identity, profile.alertName)
+		if err != nil {
+			return ObservabilityAlertObservation{}, errors.New("read independent alert-delivery evidence")
+		}
+	}
+	return ObservabilityAlertObservation{Identity: identity, AlertName: profile.alertName, Firing: firing, Delivered: delivered}, nil
+}
+
+func (backend *KubernetesObservabilityCapabilityBackend) ObserveAutonomy(ctx context.Context, run ObservabilityCapabilityRun, fixture ObservabilitySyntheticFixture, profile ObservabilityCapabilityCheckProfile) (ObservabilityAutonomyObservation, error) {
+	identity, err := backend.identity(ctx, run, fixture, profile)
+	if err != nil {
+		return ObservabilityAutonomyObservation{}, err
+	}
+	ready, dependencies, err := backend.autonomy.Autonomy(ctx, identity)
+	if err != nil || dependencies < 0 {
+		return ObservabilityAutonomyObservation{}, errors.New("read independent autonomy evidence")
+	}
+	return ObservabilityAutonomyObservation{Identity: identity, ClusterLocalServicesReady: ready, ExternalClusterDependencies: dependencies}, nil
+}
+
+func (backend *KubernetesObservabilityCapabilityBackend) identity(ctx context.Context, run ObservabilityCapabilityRun, fixture ObservabilitySyntheticFixture, profile ObservabilityCapabilityCheckProfile) (ObservabilityCapabilityObservationIdentity, error) {
+	if backend == nil || backend.api == nil || backend.delivery == nil || backend.autonomy == nil {
+		return ObservabilityCapabilityObservationIdentity{}, errors.New("observability capability backend is required")
+	}
+	if _, ok := ctx.Deadline(); !ok || ctx.Err() != nil || profile.Digest() != backend.profile.Digest() || validateObservabilityCapabilityRun(run) != nil || fixture.RunID != run.RunID || fixture.Namespace != run.Namespace {
+		return ObservabilityCapabilityObservationIdentity{}, errors.New("observability capability backend input is invalid")
+	}
+	digestValue, err := ObservabilitySyntheticFixtureDigest(fixture)
+	if err != nil || digestValue != fixture.FixtureDigest {
+		return ObservabilityCapabilityObservationIdentity{}, errors.New("observability capability backend fixture identity is invalid")
+	}
+	return ObservabilityCapabilityObservationIdentity{RunID: run.RunID, TargetClusterUID: run.TargetClusterUID, FixtureDigest: fixture.FixtureDigest, ProfileDigest: profile.Digest()}, nil
+}
+
+func (backend *KubernetesObservabilityCapabilityBackend) poll(ctx context.Context, observe func() (bool, error)) (bool, error) {
+	for {
+		present, err := observe()
+		if err != nil || present {
+			return present, err
+		}
+		timer := time.NewTimer(backend.pollInterval)
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				<-timer.C
+			}
+			return false, nil
+		case <-timer.C:
+		}
+	}
+}
+
+var _ ObservabilityCapabilityBackend = (*KubernetesObservabilityCapabilityBackend)(nil)

--- a/internal/runner/observability_backend_test.go
+++ b/internal/runner/observability_backend_test.go
@@ -1,0 +1,166 @@
+package runner
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+)
+
+type scriptedObservabilityBackendAPI struct {
+	metricQueries     int
+	grafanaQueries    int
+	logQueries        int
+	alertQueries      int
+	pushes            int
+	alertAlwaysAbsent bool
+}
+
+func (api *scriptedObservabilityBackendAPI) credentials(context.Context, ObservabilityCapabilityRun) (observabilityBackendCredentials, error) {
+	return observabilityBackendCredentials{grafanaUser: "admin", grafanaPassword: "grafana", opensearchPassword: "opensearch"}, nil
+}
+
+func (api *scriptedObservabilityBackendAPI) dashboard(context.Context, ObservabilityCapabilityRun) (observabilityBackendResponse, error) {
+	return observabilityBackendResponse{status: http.StatusOK, raw: []byte(`{"apiVersion":"v1","kind":"ConfigMap","metadata":{"name":"ok-observability-dashboard-platform-overview","namespace":"ok-observability","labels":{"grafana_dashboard":"1"}},"data":{"platform-overview.json":"{\"uid\":\"ok-obs-platform-overview\"}"}}`)}, nil
+}
+
+func (api *scriptedObservabilityBackendAPI) pushMetrics(context.Context, ObservabilityCapabilityRun, ObservabilitySyntheticFixture) (observabilityBackendResponse, error) {
+	api.pushes++
+	return observabilityBackendResponse{status: http.StatusOK}, nil
+}
+
+func (api *scriptedObservabilityBackendAPI) prometheusQuery(_ context.Context, _ ObservabilityCapabilityRun, fixture ObservabilitySyntheticFixture) (observabilityBackendResponse, error) {
+	api.metricQueries++
+	return prometheusBackendResponse(fixture.MetricName, api.metricQueries > 1), nil
+}
+
+func (api *scriptedObservabilityBackendAPI) grafanaDatasources(context.Context, ObservabilityCapabilityRun, observabilityBackendCredentials) (observabilityBackendResponse, error) {
+	return observabilityBackendResponse{status: http.StatusOK, raw: []byte(`[{"name":"Prometheus","type":"prometheus","uid":"prometheus-uid"}]`)}, nil
+}
+
+func (api *scriptedObservabilityBackendAPI) grafanaQuery(_ context.Context, _ ObservabilityCapabilityRun, fixture ObservabilitySyntheticFixture, _ string, _ observabilityBackendCredentials) (observabilityBackendResponse, error) {
+	api.grafanaQueries++
+	return prometheusBackendResponse(fixture.MetricName, api.grafanaQueries > 1), nil
+}
+
+func (api *scriptedObservabilityBackendAPI) searchLogs(context.Context, ObservabilityCapabilityRun, ObservabilitySyntheticFixture, observabilityBackendCredentials) (observabilityBackendResponse, error) {
+	api.logQueries++
+	count := 0
+	if api.logQueries > 1 {
+		count = 1
+	}
+	return observabilityBackendResponse{status: http.StatusOK, raw: []byte(fmt.Sprintf(`{"hits":{"total":{"value":%d}}}`, count))}, nil
+}
+
+func (api *scriptedObservabilityBackendAPI) alerts(context.Context, ObservabilityCapabilityRun) (observabilityBackendResponse, error) {
+	api.alertQueries++
+	if api.alertAlwaysAbsent || api.alertQueries == 1 {
+		return observabilityBackendResponse{status: http.StatusOK, raw: []byte(`[]`)}, nil
+	}
+	return observabilityBackendResponse{status: http.StatusOK, raw: []byte(`[{"labels":{"alertname":"OKObservabilitySyntheticAlert"},"status":{"state":"active"}}]`)}, nil
+}
+
+func prometheusBackendResponse(metric string, present bool) observabilityBackendResponse {
+	result := "[]"
+	if present {
+		result = `[{"metric":{"__name__":"` + metric + `"},"value":[1,"1"]}]`
+	}
+	return observabilityBackendResponse{status: http.StatusOK, raw: []byte(`{"status":"success","data":{"result":` + result + `}}`)}
+}
+
+type recordingDeliveryEvidenceSource struct {
+	identity  ObservabilityCapabilityObservationIdentity
+	alert     string
+	calls     int
+	delivered bool
+}
+
+func (source *recordingDeliveryEvidenceSource) Delivery(_ context.Context, identity ObservabilityCapabilityObservationIdentity, alert string) (bool, error) {
+	source.identity, source.alert = identity, alert
+	source.calls++
+	return source.delivered, nil
+}
+
+type recordingAutonomyEvidenceSource struct {
+	identity     ObservabilityCapabilityObservationIdentity
+	ready        bool
+	dependencies int
+}
+
+func (source *recordingAutonomyEvidenceSource) Autonomy(_ context.Context, identity ObservabilityCapabilityObservationIdentity) (bool, int, error) {
+	source.identity = identity
+	return source.ready, source.dependencies, nil
+}
+
+func TestKubernetesObservabilityCapabilityBackendComposesExactObservations(t *testing.T) {
+	run, _ := observabilityCapabilityRun(observabilityProbeRequest(), "ok-observability")
+	fixture, _ := BuildObservabilitySyntheticFixture(run, capabilityFixtureConfig())
+	profile, _ := StandardObservabilityCapabilityCheckProfile("ok-observability")
+	api := &scriptedObservabilityBackendAPI{}
+	delivery := &recordingDeliveryEvidenceSource{delivered: true}
+	autonomy := &recordingAutonomyEvidenceSource{ready: true}
+	backend, err := newKubernetesObservabilityCapabilityBackend(api, delivery, autonomy, profile, time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	metrics, err := backend.ObserveMetrics(ctx, run, fixture, profile)
+	if err != nil || !metrics.TargetDiscovered || !metrics.MetricPresent || api.pushes != 1 || api.metricQueries != 2 {
+		t.Fatalf("metrics observation differs: %#v pushes=%d queries=%d err=%v", metrics, api.pushes, api.metricQueries, err)
+	}
+	dashboards, err := backend.ObserveDashboards(ctx, run, fixture, profile)
+	if err != nil || !dashboards.GrafanaReachable || !dashboards.DashboardProvisioned || !dashboards.MetricPresent || api.grafanaQueries != 2 {
+		t.Fatalf("dashboard observation differs: %#v queries=%d err=%v", dashboards, api.grafanaQueries, err)
+	}
+	logs, err := backend.ObserveLogs(ctx, run, fixture, profile)
+	if err != nil || !logs.BackendReachable || !logs.MarkerPresent || api.logQueries != 2 {
+		t.Fatalf("log observation differs: %#v queries=%d err=%v", logs, api.logQueries, err)
+	}
+	alert, err := backend.ObserveAlertDelivery(ctx, run, fixture, profile)
+	if err != nil || !alert.Firing || !alert.Delivered || api.alertQueries != 2 || delivery.calls != 1 || delivery.alert != profile.alertName {
+		t.Fatalf("alert observation differs: %#v queries=%d delivery=%d err=%v", alert, api.alertQueries, delivery.calls, err)
+	}
+	autonomyResult, err := backend.ObserveAutonomy(ctx, run, fixture, profile)
+	if err != nil || !autonomyResult.ClusterLocalServicesReady || autonomyResult.ExternalClusterDependencies != 0 {
+		t.Fatalf("autonomy observation differs: %#v err=%v", autonomyResult, err)
+	}
+	expectedIdentity := ObservabilityCapabilityObservationIdentity{RunID: run.RunID, TargetClusterUID: run.TargetClusterUID, FixtureDigest: fixture.FixtureDigest, ProfileDigest: profile.Digest()}
+	if delivery.identity != expectedIdentity || autonomy.identity != expectedIdentity {
+		t.Fatal("independent evidence sources did not receive the exact observation identity")
+	}
+}
+
+func TestKubernetesObservabilityCapabilityBackendDoesNotInventDeliveryOrAutonomy(t *testing.T) {
+	run, _ := observabilityCapabilityRun(observabilityProbeRequest(), "ok-observability")
+	fixture, _ := BuildObservabilitySyntheticFixture(run, capabilityFixtureConfig())
+	profile, _ := StandardObservabilityCapabilityCheckProfile("ok-observability")
+	api := &scriptedObservabilityBackendAPI{alertAlwaysAbsent: true}
+	delivery := &recordingDeliveryEvidenceSource{delivered: true}
+	autonomy := &recordingAutonomyEvidenceSource{ready: true, dependencies: 1}
+	backend, _ := newKubernetesObservabilityCapabilityBackend(api, delivery, autonomy, profile, time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Millisecond)
+	defer cancel()
+	alert, err := backend.ObserveAlertDelivery(ctx, run, fixture, profile)
+	if err != nil || alert.Firing || alert.Delivered || delivery.calls != 0 {
+		t.Fatalf("non-firing alert invented delivery: %#v calls=%d err=%v", alert, delivery.calls, err)
+	}
+	autonomyCtx, autonomyCancel := context.WithTimeout(context.Background(), time.Second)
+	defer autonomyCancel()
+	autonomyResult, err := backend.ObserveAutonomy(autonomyCtx, run, fixture, profile)
+	if err != nil || autonomyResult.ExternalClusterDependencies != 1 {
+		t.Fatalf("external dependency was hidden: %#v err=%v", autonomyResult, err)
+	}
+}
+
+func TestKubernetesObservabilityCapabilityBackendRequiresBoundedContext(t *testing.T) {
+	run, _ := observabilityCapabilityRun(observabilityProbeRequest(), "ok-observability")
+	fixture, _ := BuildObservabilitySyntheticFixture(run, capabilityFixtureConfig())
+	profile, _ := StandardObservabilityCapabilityCheckProfile("ok-observability")
+	api := &scriptedObservabilityBackendAPI{}
+	backend, _ := newKubernetesObservabilityCapabilityBackend(api, &recordingDeliveryEvidenceSource{}, &recordingAutonomyEvidenceSource{}, profile, time.Millisecond)
+	if _, err := backend.ObserveMetrics(context.Background(), run, fixture, profile); err == nil || api.pushes != 0 {
+		t.Fatal("unbounded capability context reached the backend API")
+	}
+}


### PR DESCRIPTION
## Summary

- compose the closed Kubernetes client and strict response parsers into the production observability backend
- push the exact metric pair once and poll only valid correlated absence
- require a caller deadline for every check
- consult independent identity-bound evidence sources for alert delivery and autonomy
- never infer delivery from firing or autonomy from ordinary service reachability
- retain observation-only ownership with no repair or reconciliation behavior

## Validation

- positive bounded composition tests
- firing-without-delivery and external-dependency negative tests
- unbounded-context zero-call test
- targeted race tests
- full unprivileged Linux `go test ./...`
- `go vet ./...`
- `git diff --check`

No live Kubernetes contact or infrastructure mutation.