### PR TITLE
feat(runner): verify independent observability evidence

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -2963,8 +2963,20 @@ source; autonomy likewise comes from a separate source that must report both
 local readiness and the number of external-cluster dependencies. Neither claim
 is inferred from ordinary reachability. The resulting typed observations feed
 the five-check evaluator without adding repair, retry authority or lifecycle
-ownership. Concrete delivery/autonomy evidence sources and the full-run factory
-wiring remain separate follow-ups.
+ownership.
+
+The two independent claims now have a concrete signed-file consumer. One
+strict JSON envelope carries receiver delivery and autonomy observations bound
+to the exact run ID, target Cluster UID, synthetic-fixture digest and closed
+check-profile digest. The canonical payload digest is signed by a separately
+pinned Ed25519 authority, and the verifier accepts only canonical UTC
+timestamps inside a maximum 30-minute observation window. It reloads the
+private `0600` evidence file for each claim, rejects symlinks, unknown JSON,
+tampering, stale evidence, foreign identities and key substitution, and never
+treats a file path or digest alone as authority. A correlated `false` remains
+a capability result; malformed or unauthoritative evidence is an error.
+Producing that signed delivery/autonomy evidence through bounded live probes
+and wiring the source into the full-run factory remain separate follow-ups.
 
 The post-runtime authorization resolver closes the next authority boundary.
 After a predecessor receipt is durable, it derives one canonical,

--- a/internal/runner/observability_independent_evidence.go
+++ b/internal/runner/observability_independent_evidence.go
@@ -1,0 +1,171 @@
+package runner
+
+import (
+	"context"
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/jsonstrict"
+)
+
+const (
+	ObservabilityIndependentEvidenceFormat        = "ok147-observability-independent-evidence/v1"
+	maximumObservabilityEvidencePublicKeyBytes    = 4 * 1024
+	maximumObservabilityIndependentEvidenceBytes  = 64 * 1024
+	maximumObservabilityIndependentEvidenceWindow = 30 * time.Minute
+)
+
+type ObservabilityIndependentEvidencePayload struct {
+	Format                      string `json:"format"`
+	State                       string `json:"state"`
+	RunID                       string `json:"runId"`
+	TargetClusterUID            string `json:"targetClusterUid"`
+	FixtureDigest               string `json:"fixtureDigest"`
+	ProfileDigest               string `json:"profileDigest"`
+	AlertName                   string `json:"alertName"`
+	ReceiverDeliveryObserved    bool   `json:"receiverDeliveryObserved"`
+	ReceiverIdentityDigest      string `json:"receiverIdentityDigest"`
+	ClusterLocalServicesReady   bool   `json:"clusterLocalServicesReady"`
+	ExternalClusterDependencies int    `json:"externalClusterDependencies"`
+	AutonomyProfileDigest       string `json:"autonomyProfileDigest"`
+	ObservedAt                  string `json:"observedAt"`
+	ExpiresAt                   string `json:"expiresAt"`
+}
+
+type ObservabilityIndependentEvidenceSignature struct {
+	Algorithm string `json:"algorithm"`
+	KeyID     string `json:"keyId"`
+	Value     string `json:"value"`
+}
+
+type ObservabilityIndependentEvidenceEnvelope struct {
+	Payload        ObservabilityIndependentEvidencePayload   `json:"payload"`
+	EvidenceDigest string                                    `json:"evidenceDigest"`
+	Signature      ObservabilityIndependentEvidenceSignature `json:"signature"`
+}
+
+type SignedObservabilityEvidenceFileConfig struct {
+	Path          string
+	PublicKeyPath string
+	Clock         func() time.Time
+}
+
+// SignedObservabilityEvidenceFileSource verifies one fresh, independently
+// signed envelope on every claim. It never trusts file placement or a digest
+// alone as evidence authority.
+type SignedObservabilityEvidenceFileSource struct {
+	path      string
+	publicKey ed25519.PublicKey
+	keyID     string
+	clock     func() time.Time
+}
+
+func OpenSignedObservabilityEvidenceFileSource(config SignedObservabilityEvidenceFileConfig) (*SignedObservabilityEvidenceFileSource, error) {
+	if config.Path == "" || config.PublicKeyPath == "" || config.Path == config.PublicKeyPath || config.Clock == nil {
+		return nil, errors.New("signed observability evidence source binding is invalid")
+	}
+	if err := validateObservabilityEvidenceFile(config.PublicKeyPath, maximumObservabilityEvidencePublicKeyBytes, false); err != nil {
+		return nil, errors.New("signed observability evidence public key is invalid")
+	}
+	publicRaw, err := readBoundedRegular(config.PublicKeyPath, maximumObservabilityEvidencePublicKeyBytes)
+	if err != nil {
+		return nil, errors.New("read signed observability evidence public key")
+	}
+	encoded := strings.TrimSuffix(string(publicRaw), "\n")
+	if encoded == "" || strings.ContainsAny(encoded, " \t\r\n") {
+		return nil, errors.New("signed observability evidence public key encoding is invalid")
+	}
+	publicBytes, err := base64.StdEncoding.Strict().DecodeString(encoded)
+	if err != nil || len(publicBytes) != ed25519.PublicKeySize {
+		return nil, errors.New("signed observability evidence public key encoding is invalid")
+	}
+	publicKey := append(ed25519.PublicKey(nil), publicBytes...)
+	return &SignedObservabilityEvidenceFileSource{path: config.Path, publicKey: publicKey, keyID: digest.SHA256(publicKey), clock: config.Clock}, nil
+}
+
+func (source *SignedObservabilityEvidenceFileSource) Delivery(ctx context.Context, identity ObservabilityCapabilityObservationIdentity, alertName string) (bool, error) {
+	if err := ctx.Err(); err != nil {
+		return false, errors.New("signed alert-delivery evidence context is done")
+	}
+	payload, err := source.load(identity)
+	if err != nil || alertName == "" || payload.AlertName != alertName {
+		return false, errors.New("signed alert-delivery evidence differs from the capability claim")
+	}
+	return payload.ReceiverDeliveryObserved, nil
+}
+
+func (source *SignedObservabilityEvidenceFileSource) Autonomy(ctx context.Context, identity ObservabilityCapabilityObservationIdentity) (bool, int, error) {
+	if err := ctx.Err(); err != nil {
+		return false, 0, errors.New("signed autonomy evidence context is done")
+	}
+	payload, err := source.load(identity)
+	if err != nil {
+		return false, 0, errors.New("signed autonomy evidence differs from the capability claim")
+	}
+	return payload.ClusterLocalServicesReady, payload.ExternalClusterDependencies, nil
+}
+
+func (source *SignedObservabilityEvidenceFileSource) load(identity ObservabilityCapabilityObservationIdentity) (ObservabilityIndependentEvidencePayload, error) {
+	if source == nil || source.clock == nil || len(source.publicKey) != ed25519.PublicKeySize || !validObservabilityObservationIdentity(identity) {
+		return ObservabilityIndependentEvidencePayload{}, errors.New("observability independent evidence claim identity is invalid")
+	}
+	if err := validateObservabilityEvidenceFile(source.path, maximumObservabilityIndependentEvidenceBytes, true); err != nil {
+		return ObservabilityIndependentEvidencePayload{}, errors.New("observability independent evidence file is invalid")
+	}
+	raw, err := readBoundedRegular(source.path, maximumObservabilityIndependentEvidenceBytes)
+	if err != nil {
+		return ObservabilityIndependentEvidencePayload{}, errors.New("read observability independent evidence")
+	}
+	var envelope ObservabilityIndependentEvidenceEnvelope
+	if err := jsonstrict.Decode(raw, &envelope); err != nil {
+		return ObservabilityIndependentEvidencePayload{}, errors.New("observability independent evidence envelope is invalid")
+	}
+	payloadRaw, err := json.Marshal(envelope.Payload)
+	if err != nil || envelope.EvidenceDigest != digest.SHA256(payloadRaw) {
+		return ObservabilityIndependentEvidencePayload{}, errors.New("observability independent evidence digest is invalid")
+	}
+	signatureBytes, err := base64.StdEncoding.Strict().DecodeString(envelope.Signature.Value)
+	if err != nil || envelope.Signature.Algorithm != "Ed25519" || envelope.Signature.KeyID != source.keyID || !ed25519.Verify(source.publicKey, payloadRaw, signatureBytes) {
+		return ObservabilityIndependentEvidencePayload{}, errors.New("observability independent evidence signature is invalid")
+	}
+	payload := envelope.Payload
+	observedAt, observedErr := time.Parse(time.RFC3339, payload.ObservedAt)
+	expiresAt, expiresErr := time.Parse(time.RFC3339, payload.ExpiresAt)
+	now := source.clock().UTC()
+	if observedErr != nil || expiresErr != nil || payload.ObservedAt != observedAt.UTC().Format(time.RFC3339) || payload.ExpiresAt != expiresAt.UTC().Format(time.RFC3339) ||
+		!expiresAt.After(observedAt) || expiresAt.Sub(observedAt) > maximumObservabilityIndependentEvidenceWindow || now.Before(observedAt) || !now.Before(expiresAt) {
+		return ObservabilityIndependentEvidencePayload{}, errors.New("observability independent evidence time binding is invalid")
+	}
+	if payload.Format != ObservabilityIndependentEvidenceFormat || payload.State != "OBSERVED" || payload.RunID != identity.RunID ||
+		payload.TargetClusterUID != identity.TargetClusterUID || payload.FixtureDigest != identity.FixtureDigest || payload.ProfileDigest != identity.ProfileDigest ||
+		payload.AlertName == "" || !platformInputDigestPattern.MatchString(payload.ReceiverIdentityDigest) || !platformInputDigestPattern.MatchString(payload.AutonomyProfileDigest) ||
+		payload.ExternalClusterDependencies < 0 {
+		return ObservabilityIndependentEvidencePayload{}, errors.New("observability independent evidence payload is invalid")
+	}
+	return payload, nil
+}
+
+func validateObservabilityEvidenceFile(path string, maximum int64, private bool) error {
+	info, err := os.Lstat(path)
+	if err != nil || info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() || info.Size() <= 0 || info.Size() > maximum {
+		return errors.New("evidence file metadata is invalid")
+	}
+	if private && info.Mode().Perm()&0o077 != 0 {
+		return errors.New("evidence file permissions are not private")
+	}
+	return nil
+}
+
+func validObservabilityObservationIdentity(identity ObservabilityCapabilityObservationIdentity) bool {
+	return capabilityNamespacePattern.MatchString(identity.RunID) && strings.HasPrefix(identity.RunID, "ok147-") && len(identity.RunID) == 30 &&
+		runtimeInputUIDPattern.MatchString(identity.TargetClusterUID) && platformInputDigestPattern.MatchString(identity.FixtureDigest) && platformInputDigestPattern.MatchString(identity.ProfileDigest)
+}
+
+var _ ObservabilityAlertDeliveryEvidenceSource = (*SignedObservabilityEvidenceFileSource)(nil)
+var _ ObservabilityAutonomyEvidenceSource = (*SignedObservabilityEvidenceFileSource)(nil)

--- a/internal/runner/observability_independent_evidence_test.go
+++ b/internal/runner/observability_independent_evidence_test.go
@@ -1,0 +1,238 @@
+package runner
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+func TestSignedObservabilityEvidenceFileSourceAcceptsExactFreshEnvelope(t *testing.T) {
+	material := newSignedObservabilityEvidenceMaterial(t)
+	source, err := OpenSignedObservabilityEvidenceFileSource(SignedObservabilityEvidenceFileConfig{
+		Path: material.evidencePath, PublicKeyPath: material.publicKeyPath,
+		Clock: func() time.Time { return material.observedAt.Add(time.Minute) },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	delivered, err := source.Delivery(context.Background(), material.identity, material.alertName)
+	if err != nil || !delivered {
+		t.Fatalf("exact delivery evidence failed: delivered=%v err=%v", delivered, err)
+	}
+	ready, dependencies, err := source.Autonomy(context.Background(), material.identity)
+	if err != nil || !ready || dependencies != 0 {
+		t.Fatalf("exact autonomy evidence failed: ready=%v dependencies=%d err=%v", ready, dependencies, err)
+	}
+
+	// The authority is bound when the source opens. Replacing the path later
+	// cannot silently rotate the key for an already-open capability session.
+	replacement, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(material.publicKeyPath, []byte(base64.StdEncoding.EncodeToString(replacement)+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if delivered, err = source.Delivery(context.Background(), material.identity, material.alertName); err != nil || !delivered {
+		t.Fatalf("opened authority changed with its path: delivered=%v err=%v", delivered, err)
+	}
+}
+
+func TestSignedObservabilityEvidenceFileSourcePreservesCorrelatedFalse(t *testing.T) {
+	material := newSignedObservabilityEvidenceMaterialWithPayload(t, func(payload *ObservabilityIndependentEvidencePayload) {
+		payload.ReceiverDeliveryObserved = false
+		payload.ClusterLocalServicesReady = false
+		payload.ExternalClusterDependencies = 1
+	})
+	source := openSignedObservabilityEvidenceSource(t, material, material.observedAt.Add(time.Minute))
+	delivered, err := source.Delivery(context.Background(), material.identity, material.alertName)
+	if err != nil || delivered {
+		t.Fatalf("correlated delivery absence was not preserved: delivered=%v err=%v", delivered, err)
+	}
+	ready, dependencies, err := source.Autonomy(context.Background(), material.identity)
+	if err != nil || ready || dependencies != 1 {
+		t.Fatalf("correlated autonomy failure was not preserved: ready=%v dependencies=%d err=%v", ready, dependencies, err)
+	}
+}
+
+func TestSignedObservabilityEvidenceFileSourceFailsClosed(t *testing.T) {
+	t.Run("foreign identity", func(t *testing.T) {
+		material := newSignedObservabilityEvidenceMaterial(t)
+		source := openSignedObservabilityEvidenceSource(t, material, material.observedAt.Add(time.Minute))
+		foreign := material.identity
+		foreign.TargetClusterUID = "cluster-uid-foreign-ok147"
+		if _, err := source.Delivery(context.Background(), foreign, material.alertName); err == nil {
+			t.Fatal("foreign target identity was accepted")
+		}
+	})
+
+	t.Run("wrong alert", func(t *testing.T) {
+		material := newSignedObservabilityEvidenceMaterial(t)
+		source := openSignedObservabilityEvidenceSource(t, material, material.observedAt.Add(time.Minute))
+		if _, err := source.Delivery(context.Background(), material.identity, "ForeignAlert"); err == nil {
+			t.Fatal("foreign alert identity was accepted")
+		}
+	})
+
+	t.Run("expired", func(t *testing.T) {
+		material := newSignedObservabilityEvidenceMaterial(t)
+		source := openSignedObservabilityEvidenceSource(t, material, material.observedAt.Add(10*time.Minute))
+		if _, _, err := source.Autonomy(context.Background(), material.identity); err == nil {
+			t.Fatal("expired evidence was accepted")
+		}
+	})
+
+	t.Run("tampered payload", func(t *testing.T) {
+		material := newSignedObservabilityEvidenceMaterial(t)
+		raw, err := os.ReadFile(material.evidencePath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var envelope ObservabilityIndependentEvidenceEnvelope
+		if err := json.Unmarshal(raw, &envelope); err != nil {
+			t.Fatal(err)
+		}
+		envelope.Payload.ReceiverDeliveryObserved = false
+		writePrivateJSON(t, material.evidencePath, envelope)
+		source := openSignedObservabilityEvidenceSource(t, material, material.observedAt.Add(time.Minute))
+		if _, err := source.Delivery(context.Background(), material.identity, material.alertName); err == nil {
+			t.Fatal("tampered payload was accepted")
+		}
+	})
+
+	t.Run("non-private evidence file", func(t *testing.T) {
+		material := newSignedObservabilityEvidenceMaterial(t)
+		if err := os.Chmod(material.evidencePath, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		source := openSignedObservabilityEvidenceSource(t, material, material.observedAt.Add(time.Minute))
+		if _, err := source.Delivery(context.Background(), material.identity, material.alertName); err == nil {
+			t.Fatal("non-private evidence file was accepted")
+		}
+	})
+
+	t.Run("canceled context", func(t *testing.T) {
+		material := newSignedObservabilityEvidenceMaterial(t)
+		source := openSignedObservabilityEvidenceSource(t, material, material.observedAt.Add(time.Minute))
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		if _, _, err := source.Autonomy(ctx, material.identity); err == nil {
+			t.Fatal("canceled evidence claim was accepted")
+		}
+	})
+}
+
+func TestSignedObservabilityEvidenceFileSourceRejectsNonCanonicalAuthority(t *testing.T) {
+	material := newSignedObservabilityEvidenceMaterial(t)
+	raw, err := os.ReadFile(material.publicKeyPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(material.publicKeyPath, append([]byte(" "), raw...), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := OpenSignedObservabilityEvidenceFileSource(SignedObservabilityEvidenceFileConfig{
+		Path: material.evidencePath, PublicKeyPath: material.publicKeyPath, Clock: time.Now,
+	}); err == nil {
+		t.Fatal("non-canonical public-key encoding was accepted")
+	}
+}
+
+type signedObservabilityEvidenceMaterial struct {
+	evidencePath  string
+	publicKeyPath string
+	identity      ObservabilityCapabilityObservationIdentity
+	alertName     string
+	observedAt    time.Time
+}
+
+func newSignedObservabilityEvidenceMaterial(t *testing.T) signedObservabilityEvidenceMaterial {
+	t.Helper()
+	return newSignedObservabilityEvidenceMaterialWithPayload(t, nil)
+}
+
+func newSignedObservabilityEvidenceMaterialWithPayload(t *testing.T, mutate func(*ObservabilityIndependentEvidencePayload)) signedObservabilityEvidenceMaterial {
+	t.Helper()
+	run, err := observabilityCapabilityRun(observabilityProbeRequest(), "ok-observability")
+	if err != nil {
+		t.Fatal(err)
+	}
+	fixture, err := BuildObservabilitySyntheticFixture(run, capabilityFixtureConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+	profile, err := StandardObservabilityCapabilityCheckProfile("ok-observability")
+	if err != nil {
+		t.Fatal(err)
+	}
+	identity := ObservabilityCapabilityObservationIdentity{
+		RunID: run.RunID, TargetClusterUID: run.TargetClusterUID,
+		FixtureDigest: fixture.FixtureDigest, ProfileDigest: profile.Digest(),
+	}
+	observedAt := time.Date(2026, 8, 21, 8, 0, 0, 0, time.UTC)
+	payload := ObservabilityIndependentEvidencePayload{
+		Format: ObservabilityIndependentEvidenceFormat, State: "OBSERVED", RunID: identity.RunID,
+		TargetClusterUID: identity.TargetClusterUID, FixtureDigest: identity.FixtureDigest, ProfileDigest: identity.ProfileDigest,
+		AlertName: profile.alertName, ReceiverDeliveryObserved: true, ReceiverIdentityDigest: digest.SHA256([]byte("receiver-identity")),
+		ClusterLocalServicesReady: true, ExternalClusterDependencies: 0, AutonomyProfileDigest: digest.SHA256([]byte("autonomy-profile")),
+		ObservedAt: observedAt.Format(time.RFC3339), ExpiresAt: observedAt.Add(10 * time.Minute).Format(time.RFC3339),
+	}
+	if mutate != nil {
+		mutate(&payload)
+	}
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	payloadRaw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	envelope := ObservabilityIndependentEvidenceEnvelope{
+		Payload: payload, EvidenceDigest: digest.SHA256(payloadRaw),
+		Signature: ObservabilityIndependentEvidenceSignature{
+			Algorithm: "Ed25519", KeyID: digest.SHA256(publicKey), Value: base64.StdEncoding.EncodeToString(ed25519.Sign(privateKey, payloadRaw)),
+		},
+	}
+	root := t.TempDir()
+	evidencePath := filepath.Join(root, "independent-evidence.json")
+	writePrivateJSON(t, evidencePath, envelope)
+	publicKeyPath := filepath.Join(root, "authority.pub")
+	if err := os.WriteFile(publicKeyPath, []byte(base64.StdEncoding.EncodeToString(publicKey)+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return signedObservabilityEvidenceMaterial{
+		evidencePath: evidencePath, publicKeyPath: publicKeyPath, identity: identity,
+		alertName: profile.alertName, observedAt: observedAt,
+	}
+}
+
+func openSignedObservabilityEvidenceSource(t *testing.T, material signedObservabilityEvidenceMaterial, now time.Time) *SignedObservabilityEvidenceFileSource {
+	t.Helper()
+	source, err := OpenSignedObservabilityEvidenceFileSource(SignedObservabilityEvidenceFileConfig{
+		Path: material.evidencePath, PublicKeyPath: material.publicKeyPath, Clock: func() time.Time { return now },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return source
+}
+
+func writePrivateJSON(t *testing.T, path string, value any) {
+	t.Helper()
+	raw, err := json.Marshal(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
## Outcome

Adds a concrete fail-closed consumer for the two observability claims that cannot be inferred from ordinary service reachability: alert receiver delivery and cluster autonomy.

## Boundary

- Ed25519-signed strict JSON envelope
- exact run ID, target Cluster UID, fixture digest, profile digest, and alert identity
- canonical payload digest and pinned public-key identity
- maximum 30-minute UTC observation window
- private regular evidence file; symlinks and permissive modes rejected
- correlated false remains false; malformed, stale, foreign, or tampered evidence errors
- no repair, reconciliation, Kubernetes mutation, or live probe producer added

## Verification

- targeted unit and negative tests
- targeted race test
- `go test ./...`
- `go vet ./...`
- `git diff --check`
