### PR TITLE
feat(runner): issue independent observability evidence

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -2978,6 +2978,19 @@ a capability result; malformed or unauthoritative evidence is an error.
 Producing that signed delivery/autonomy evidence through bounded live probes
 and wiring the source into the full-run factory remain separate follow-ups.
 
+A separate single-use producer now closes the cryptographic issuance half of
+that boundary. It accepts only one typed collector result, the exact standard
+profile and an already correlated observation identity; then it canonicalizes,
+signs and writes one private envelope with `O_EXCL`, `0600`, `fsync` and byte
+pullback verification. Its private Ed25519 key must itself be a private regular
+file, while the runner-side consumer receives only the corresponding pinned
+public key. Pre-existing output, an invalid collector result or any write
+uncertainty consumes the producer and exposes no overwrite or retry path. This
+issuer is intended to run under a separate evidence authority; it is not wired
+into the lifecycle runner and cannot repair an observed platform. Concrete
+bounded collection of receiver delivery and external-dependency autonomy is
+still required before the issuer can produce live evidence.
+
 The post-runtime authorization resolver closes the next authority boundary.
 After a predecessor receipt is durable, it derives one canonical,
 redaction-safe request from the verified cursor, including the exact Plan,

--- a/internal/runner/observability_independent_evidence.go
+++ b/internal/runner/observability_independent_evidence.go
@@ -1,6 +1,7 @@
 package runner
 
 import (
+	"bytes"
 	"context"
 	"crypto/ed25519"
 	"encoding/base64"
@@ -10,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/openkubes/ok-cluster/internal/contract"
 	"github.com/openkubes/ok-cluster/internal/digest"
 	"github.com/openkubes/ok-cluster/internal/jsonstrict"
 )
@@ -126,7 +128,7 @@ func (source *SignedObservabilityEvidenceFileSource) load(identity Observability
 	if err := jsonstrict.Decode(raw, &envelope); err != nil {
 		return ObservabilityIndependentEvidencePayload{}, errors.New("observability independent evidence envelope is invalid")
 	}
-	payloadRaw, err := json.Marshal(envelope.Payload)
+	payloadRaw, err := canonicalObservabilityIndependentEvidencePayload(envelope.Payload)
 	if err != nil || envelope.EvidenceDigest != digest.SHA256(payloadRaw) {
 		return ObservabilityIndependentEvidencePayload{}, errors.New("observability independent evidence digest is invalid")
 	}
@@ -149,6 +151,20 @@ func (source *SignedObservabilityEvidenceFileSource) load(identity Observability
 		return ObservabilityIndependentEvidencePayload{}, errors.New("observability independent evidence payload is invalid")
 	}
 	return payload, nil
+}
+
+func canonicalObservabilityIndependentEvidencePayload(payload ObservabilityIndependentEvidencePayload) ([]byte, error) {
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	var value any
+	if err := decoder.Decode(&value); err != nil {
+		return nil, err
+	}
+	return contract.JCS(value)
 }
 
 func validateObservabilityEvidenceFile(path string, maximum int64, private bool) error {

--- a/internal/runner/observability_independent_evidence_producer.go
+++ b/internal/runner/observability_independent_evidence_producer.go
@@ -1,0 +1,188 @@
+package runner
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+const (
+	ObservabilityIndependentEvidenceReceiptFormat   = "ok147-observability-independent-evidence-receipt/v1"
+	maximumObservabilityEvidencePrivateKeyBytes     = 8 * 1024
+	minimumObservabilityIndependentEvidenceValidity = time.Minute
+)
+
+// ObservabilityIndependentEvidenceObservation is the closed result expected
+// from a separately operated delivery/autonomy collector. It has no endpoint,
+// credential, command, manifest or repair surface.
+type ObservabilityIndependentEvidenceObservation struct {
+	ReceiverDeliveryObserved    bool
+	ReceiverIdentityDigest      string
+	ClusterLocalServicesReady   bool
+	ExternalClusterDependencies int
+	AutonomyProfileDigest       string
+}
+
+type ObservabilityIndependentEvidenceCollector interface {
+	Collect(context.Context, ObservabilityCapabilityObservationIdentity, string) (ObservabilityIndependentEvidenceObservation, error)
+}
+
+type ObservabilityIndependentEvidenceProducerConfig struct {
+	OutputPath     string
+	PrivateKeyPath string
+	Profile        ObservabilityCapabilityCheckProfile
+	ValidFor       time.Duration
+	Timeout        time.Duration
+	Clock          func() time.Time
+	Collector      ObservabilityIndependentEvidenceCollector
+}
+
+type ObservabilityIndependentEvidenceReceipt struct {
+	Format         string `json:"format"`
+	State          string `json:"state"`
+	EvidenceDigest string `json:"evidenceDigest,omitempty"`
+	KeyID          string `json:"keyId,omitempty"`
+	ObservedAt     string `json:"observedAt,omitempty"`
+	ExpiresAt      string `json:"expiresAt,omitempty"`
+	FileMode       string `json:"fileMode,omitempty"`
+	FileSize       int    `json:"fileSize,omitempty"`
+}
+
+// ObservabilityIndependentEvidenceProducer signs exactly one collected
+// observation and persists it create-only. It is intended for a separately
+// authorized evidence process; the full runner only receives the public key.
+type ObservabilityIndependentEvidenceProducer struct {
+	outputPath string
+	privateKey ed25519.PrivateKey
+	keyID      string
+	profile    ObservabilityCapabilityCheckProfile
+	validFor   time.Duration
+	timeout    time.Duration
+	clock      func() time.Time
+	collector  ObservabilityIndependentEvidenceCollector
+
+	mu   sync.Mutex
+	used bool
+}
+
+func OpenObservabilityIndependentEvidenceProducer(config ObservabilityIndependentEvidenceProducerConfig) (*ObservabilityIndependentEvidenceProducer, error) {
+	standard, err := StandardObservabilityCapabilityCheckProfile("ok-observability")
+	if err != nil || config.OutputPath == "" || config.PrivateKeyPath == "" || config.OutputPath == config.PrivateKeyPath ||
+		config.Clock == nil || config.Collector == nil || config.Profile.Digest() == "" || config.Profile.Digest() != standard.Digest() ||
+		config.ValidFor < minimumObservabilityIndependentEvidenceValidity || config.ValidFor > maximumObservabilityIndependentEvidenceWindow ||
+		config.Timeout < time.Second || config.Timeout > maximumObservabilityIndependentEvidenceWindow {
+		return nil, errors.New("observability independent evidence producer binding is invalid")
+	}
+	if err := validateRuntimeBindingOutputPath(config.OutputPath); err != nil {
+		return nil, errors.New("observability independent evidence output is invalid")
+	}
+	if err := validateObservabilityEvidenceFile(config.PrivateKeyPath, maximumObservabilityEvidencePrivateKeyBytes, true); err != nil {
+		return nil, errors.New("observability independent evidence private key is invalid")
+	}
+	privateRaw, err := readBoundedRegular(config.PrivateKeyPath, maximumObservabilityEvidencePrivateKeyBytes)
+	if err != nil {
+		return nil, errors.New("read observability independent evidence private key")
+	}
+	encoded := string(privateRaw)
+	if len(encoded) > 0 && encoded[len(encoded)-1] == '\n' {
+		encoded = encoded[:len(encoded)-1]
+	}
+	privateBytes, err := base64.StdEncoding.Strict().DecodeString(encoded)
+	if err != nil || len(privateBytes) != ed25519.PrivateKeySize || base64.StdEncoding.EncodeToString(privateBytes) != encoded {
+		return nil, errors.New("observability independent evidence private key encoding is invalid")
+	}
+	privateKey := append(ed25519.PrivateKey(nil), privateBytes...)
+	publicKey := privateKey.Public().(ed25519.PublicKey)
+	return &ObservabilityIndependentEvidenceProducer{
+		outputPath: config.OutputPath, privateKey: privateKey, keyID: digest.SHA256(publicKey), profile: config.Profile,
+		validFor: config.ValidFor, timeout: config.Timeout, clock: config.Clock, collector: config.Collector,
+	}, nil
+}
+
+func (producer *ObservabilityIndependentEvidenceProducer) Produce(ctx context.Context, identity ObservabilityCapabilityObservationIdentity) (ObservabilityIndependentEvidenceReceipt, error) {
+	receipt := ObservabilityIndependentEvidenceReceipt{Format: ObservabilityIndependentEvidenceReceiptFormat, State: "PREWRITE"}
+	if producer == nil || producer.collector == nil || producer.clock == nil || len(producer.privateKey) != ed25519.PrivateKeySize ||
+		!validObservabilityObservationIdentity(identity) || identity.ProfileDigest != producer.profile.Digest() {
+		return receipt, errors.New("observability independent evidence production identity is invalid")
+	}
+	producer.mu.Lock()
+	if producer.used {
+		producer.mu.Unlock()
+		return receipt, errors.New("observability independent evidence producer is single-use")
+	}
+	producer.used = true
+	producer.mu.Unlock()
+	if err := validateRuntimeBindingOutputPath(producer.outputPath); err != nil {
+		return receipt, errors.New("observability independent evidence output changed before collection")
+	}
+	bounded, cancel := context.WithTimeout(ctx, producer.timeout)
+	defer cancel()
+	observation, err := producer.collector.Collect(bounded, identity, producer.profile.alertName)
+	if err != nil || bounded.Err() != nil {
+		return receipt, errors.New("collect independent observability evidence")
+	}
+	if !platformInputDigestPattern.MatchString(observation.ReceiverIdentityDigest) ||
+		!platformInputDigestPattern.MatchString(observation.AutonomyProfileDigest) || observation.ExternalClusterDependencies < 0 {
+		return receipt, errors.New("independent observability evidence observation is invalid")
+	}
+	observedAt := producer.clock().UTC().Truncate(time.Second)
+	payload := ObservabilityIndependentEvidencePayload{
+		Format: ObservabilityIndependentEvidenceFormat, State: "OBSERVED", RunID: identity.RunID,
+		TargetClusterUID: identity.TargetClusterUID, FixtureDigest: identity.FixtureDigest, ProfileDigest: identity.ProfileDigest,
+		AlertName: producer.profile.alertName, ReceiverDeliveryObserved: observation.ReceiverDeliveryObserved,
+		ReceiverIdentityDigest: observation.ReceiverIdentityDigest, ClusterLocalServicesReady: observation.ClusterLocalServicesReady,
+		ExternalClusterDependencies: observation.ExternalClusterDependencies, AutonomyProfileDigest: observation.AutonomyProfileDigest,
+		ObservedAt: observedAt.Format(time.RFC3339), ExpiresAt: observedAt.Add(producer.validFor).Format(time.RFC3339),
+	}
+	payloadRaw, err := canonicalObservabilityIndependentEvidencePayload(payload)
+	if err != nil {
+		return receipt, errors.New("canonicalize independent observability evidence")
+	}
+	envelope := ObservabilityIndependentEvidenceEnvelope{
+		Payload: payload, EvidenceDigest: digest.SHA256(payloadRaw),
+		Signature: ObservabilityIndependentEvidenceSignature{
+			Algorithm: "Ed25519", KeyID: producer.keyID,
+			Value: base64.StdEncoding.EncodeToString(ed25519.Sign(producer.privateKey, payloadRaw)),
+		},
+	}
+	raw, err := json.Marshal(envelope)
+	if err != nil || len(raw) == 0 || len(raw) > maximumObservabilityIndependentEvidenceBytes {
+		return receipt, errors.New("encode independent observability evidence envelope")
+	}
+	receipt.State = "STOPPED_PARTIAL_OR_UNKNOWN"
+	file, err := os.OpenFile(producer.outputPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		receipt.State = "STOPPED_ZERO_WRITE"
+		return receipt, errors.New("create exclusive independent observability evidence")
+	}
+	if _, err := file.Write(raw); err != nil {
+		file.Close()
+		return receipt, errors.New("write independent observability evidence")
+	}
+	if err := file.Sync(); err != nil {
+		file.Close()
+		return receipt, errors.New("sync independent observability evidence")
+	}
+	if err := file.Close(); err != nil {
+		return receipt, errors.New("close independent observability evidence")
+	}
+	info, err := os.Lstat(producer.outputPath)
+	if err != nil || !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 || info.Mode().Perm() != 0o600 || info.Size() != int64(len(raw)) {
+		return receipt, errors.New("independent observability evidence metadata differs after write")
+	}
+	stored, err := readBoundedRegular(producer.outputPath, maximumObservabilityIndependentEvidenceBytes)
+	if err != nil || !bytes.Equal(stored, raw) {
+		return receipt, errors.New("independent observability evidence differs after write")
+	}
+	receipt.State, receipt.EvidenceDigest, receipt.KeyID = "WRITTEN_VERIFIED", envelope.EvidenceDigest, producer.keyID
+	receipt.ObservedAt, receipt.ExpiresAt, receipt.FileMode, receipt.FileSize = payload.ObservedAt, payload.ExpiresAt, "0600", len(raw)
+	return receipt, nil
+}

--- a/internal/runner/observability_independent_evidence_producer_test.go
+++ b/internal/runner/observability_independent_evidence_producer_test.go
@@ -1,0 +1,238 @@
+package runner
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+type recordingIndependentEvidenceCollector struct {
+	identity    ObservabilityCapabilityObservationIdentity
+	alertName   string
+	observation ObservabilityIndependentEvidenceObservation
+	err         error
+	calls       int
+}
+
+func (collector *recordingIndependentEvidenceCollector) Collect(_ context.Context, identity ObservabilityCapabilityObservationIdentity, alertName string) (ObservabilityIndependentEvidenceObservation, error) {
+	collector.identity, collector.alertName = identity, alertName
+	collector.calls++
+	return collector.observation, collector.err
+}
+
+func TestObservabilityIndependentEvidenceProducerWritesVerifiableEnvelope(t *testing.T) {
+	material := newIndependentEvidenceProducerMaterial(t)
+	producer, err := OpenObservabilityIndependentEvidenceProducer(material.config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := producer.Produce(context.Background(), material.identity)
+	if err != nil || receipt.State != "WRITTEN_VERIFIED" || receipt.KeyID != digest.SHA256(material.publicKey) || receipt.FileMode != "0600" || receipt.FileSize == 0 {
+		t.Fatalf("independent evidence receipt differs: %#v err=%v", receipt, err)
+	}
+	if material.collector.calls != 1 || material.collector.identity != material.identity || material.collector.alertName != material.config.Profile.alertName {
+		t.Fatalf("collector binding differs: %#v", material.collector)
+	}
+	publicKeyPath := filepath.Join(material.root, "authority.pub")
+	if err := os.WriteFile(publicKeyPath, []byte(base64.StdEncoding.EncodeToString(material.publicKey)+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	source, err := OpenSignedObservabilityEvidenceFileSource(SignedObservabilityEvidenceFileConfig{
+		Path: material.config.OutputPath, PublicKeyPath: publicKeyPath,
+		Clock: func() time.Time { return material.now.Add(time.Minute) },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	delivered, err := source.Delivery(context.Background(), material.identity, material.config.Profile.alertName)
+	if err != nil || !delivered {
+		t.Fatalf("producer output failed delivery verification: delivered=%v err=%v", delivered, err)
+	}
+	ready, dependencies, err := source.Autonomy(context.Background(), material.identity)
+	if err != nil || !ready || dependencies != 0 {
+		t.Fatalf("producer output failed autonomy verification: ready=%v dependencies=%d err=%v", ready, dependencies, err)
+	}
+	if _, err := producer.Produce(context.Background(), material.identity); err == nil || material.collector.calls != 1 {
+		t.Fatal("single-use producer repeated collection")
+	}
+}
+
+func TestObservabilityIndependentEvidenceProducerPreservesCorrelatedFalse(t *testing.T) {
+	material := newIndependentEvidenceProducerMaterial(t)
+	material.collector.observation.ReceiverDeliveryObserved = false
+	material.collector.observation.ClusterLocalServicesReady = false
+	material.collector.observation.ExternalClusterDependencies = 2
+	producer, err := OpenObservabilityIndependentEvidenceProducer(material.config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if receipt, err := producer.Produce(context.Background(), material.identity); err != nil || receipt.State != "WRITTEN_VERIFIED" {
+		t.Fatalf("correlated false evidence was not written: %#v err=%v", receipt, err)
+	}
+	publicKeyPath := filepath.Join(material.root, "authority.pub")
+	if err := os.WriteFile(publicKeyPath, []byte(base64.StdEncoding.EncodeToString(material.publicKey)+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	source, err := OpenSignedObservabilityEvidenceFileSource(SignedObservabilityEvidenceFileConfig{
+		Path: material.config.OutputPath, PublicKeyPath: publicKeyPath, Clock: func() time.Time { return material.now.Add(time.Minute) },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if delivered, err := source.Delivery(context.Background(), material.identity, material.config.Profile.alertName); err != nil || delivered {
+		t.Fatalf("correlated false delivery changed: delivered=%v err=%v", delivered, err)
+	}
+	if ready, dependencies, err := source.Autonomy(context.Background(), material.identity); err != nil || ready || dependencies != 2 {
+		t.Fatalf("correlated false autonomy changed: ready=%v dependencies=%d err=%v", ready, dependencies, err)
+	}
+}
+
+func TestObservabilityIndependentEvidenceProducerFailsClosedBeforeWrite(t *testing.T) {
+	t.Run("output appeared after open", func(t *testing.T) {
+		material := newIndependentEvidenceProducerMaterial(t)
+		producer, err := OpenObservabilityIndependentEvidenceProducer(material.config)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(material.config.OutputPath, []byte("foreign"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		receipt, err := producer.Produce(context.Background(), material.identity)
+		if err == nil || receipt.State != "PREWRITE" || material.collector.calls != 0 {
+			t.Fatalf("pre-existing output reached collector: %#v calls=%d err=%v", receipt, material.collector.calls, err)
+		}
+	})
+
+	t.Run("collector failure", func(t *testing.T) {
+		material := newIndependentEvidenceProducerMaterial(t)
+		material.collector.err = errors.New("private collector detail")
+		producer, err := OpenObservabilityIndependentEvidenceProducer(material.config)
+		if err != nil {
+			t.Fatal(err)
+		}
+		receipt, err := producer.Produce(context.Background(), material.identity)
+		if err == nil || receipt.State != "PREWRITE" || !errors.Is(fileError(material.config.OutputPath), os.ErrNotExist) {
+			t.Fatalf("collector failure wrote evidence: %#v err=%v", receipt, err)
+		}
+	})
+
+	t.Run("invalid observation", func(t *testing.T) {
+		material := newIndependentEvidenceProducerMaterial(t)
+		material.collector.observation.AutonomyProfileDigest = "mutable"
+		producer, err := OpenObservabilityIndependentEvidenceProducer(material.config)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := producer.Produce(context.Background(), material.identity); err == nil {
+			t.Fatal("invalid collector observation was signed")
+		}
+		if _, err := os.Lstat(material.config.OutputPath); !errors.Is(err, os.ErrNotExist) {
+			t.Fatal("invalid collector observation created output")
+		}
+	})
+
+	t.Run("canceled collection", func(t *testing.T) {
+		material := newIndependentEvidenceProducerMaterial(t)
+		producer, err := OpenObservabilityIndependentEvidenceProducer(material.config)
+		if err != nil {
+			t.Fatal(err)
+		}
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		if _, err := producer.Produce(ctx, material.identity); err == nil {
+			t.Fatal("canceled collector result was signed")
+		}
+		if _, err := os.Lstat(material.config.OutputPath); !errors.Is(err, os.ErrNotExist) {
+			t.Fatal("canceled collection created output")
+		}
+	})
+
+	t.Run("foreign profile identity", func(t *testing.T) {
+		material := newIndependentEvidenceProducerMaterial(t)
+		producer, err := OpenObservabilityIndependentEvidenceProducer(material.config)
+		if err != nil {
+			t.Fatal(err)
+		}
+		foreign := material.identity
+		foreign.ProfileDigest = digest.SHA256([]byte("foreign-profile"))
+		if _, err := producer.Produce(context.Background(), foreign); err == nil || material.collector.calls != 0 {
+			t.Fatal("foreign profile identity reached collector")
+		}
+	})
+}
+
+func TestObservabilityIndependentEvidenceProducerRejectsExposedPrivateKey(t *testing.T) {
+	material := newIndependentEvidenceProducerMaterial(t)
+	if err := os.Chmod(material.config.PrivateKeyPath, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := OpenObservabilityIndependentEvidenceProducer(material.config); err == nil {
+		t.Fatal("exposed evidence private key was accepted")
+	}
+}
+
+type independentEvidenceProducerMaterial struct {
+	root      string
+	config    ObservabilityIndependentEvidenceProducerConfig
+	identity  ObservabilityCapabilityObservationIdentity
+	collector *recordingIndependentEvidenceCollector
+	publicKey ed25519.PublicKey
+	now       time.Time
+}
+
+func newIndependentEvidenceProducerMaterial(t *testing.T) independentEvidenceProducerMaterial {
+	t.Helper()
+	root := t.TempDir()
+	if err := os.Chmod(root, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	privateKeyPath := filepath.Join(root, "authority.key")
+	if err := os.WriteFile(privateKeyPath, []byte(base64.StdEncoding.EncodeToString(privateKey)+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	run, err := observabilityCapabilityRun(observabilityProbeRequest(), "ok-observability")
+	if err != nil {
+		t.Fatal(err)
+	}
+	fixture, err := BuildObservabilitySyntheticFixture(run, capabilityFixtureConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+	profile, err := StandardObservabilityCapabilityCheckProfile("ok-observability")
+	if err != nil {
+		t.Fatal(err)
+	}
+	identity := ObservabilityCapabilityObservationIdentity{
+		RunID: run.RunID, TargetClusterUID: run.TargetClusterUID,
+		FixtureDigest: fixture.FixtureDigest, ProfileDigest: profile.Digest(),
+	}
+	collector := &recordingIndependentEvidenceCollector{observation: ObservabilityIndependentEvidenceObservation{
+		ReceiverDeliveryObserved: true, ReceiverIdentityDigest: digest.SHA256([]byte("receiver")), ClusterLocalServicesReady: true,
+		ExternalClusterDependencies: 0, AutonomyProfileDigest: digest.SHA256([]byte("autonomy")),
+	}}
+	now := time.Date(2026, 8, 21, 9, 0, 0, 0, time.UTC)
+	return independentEvidenceProducerMaterial{
+		root: root, identity: identity, collector: collector, publicKey: publicKey, now: now,
+		config: ObservabilityIndependentEvidenceProducerConfig{
+			OutputPath: filepath.Join(root, "evidence.json"), PrivateKeyPath: privateKeyPath, Profile: profile,
+			ValidFor: 10 * time.Minute, Timeout: time.Minute, Clock: func() time.Time { return now }, Collector: collector,
+		},
+	}
+}
+
+func fileError(path string) error {
+	_, err := os.Lstat(path)
+	return err
+}

--- a/internal/runner/observability_independent_evidence_test.go
+++ b/internal/runner/observability_independent_evidence_test.go
@@ -192,7 +192,7 @@ func newSignedObservabilityEvidenceMaterialWithPayload(t *testing.T, mutate func
 	if err != nil {
 		t.Fatal(err)
 	}
-	payloadRaw, err := json.Marshal(payload)
+	payloadRaw, err := canonicalObservabilityIndependentEvidencePayload(payload)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Outcome

Adds the separately operated, single-use issuance half of the independent observability evidence boundary.

## Boundary

- closed typed collector result; no endpoint, credential, command, manifest, or repair surface
- exact standard profile and already-correlated run/target/fixture/profile identity
- canonical JCS payload
- private Ed25519 signing key and public key identity
- create-only `0600` output with fsync and byte pullback
- pre-existing output, invalid observation, cancellation, or write uncertainty fails closed
- no overwrite, retry, Kubernetes mutation, lifecycle ownership, or full-run wiring

## Verification

- positive, correlated-false, negative, and single-use tests
- race detector
- `go test ./...`
- `go vet ./...`
- `git diff --check`
