### PR TITLE
feat(runner): compose observability capability factory

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -2991,6 +2991,20 @@ into the lifecycle runner and cannot repair an observed platform. Concrete
 bounded collection of receiver delivery and external-dependency autonomy is
 still required before the issuer can produce live evidence.
 
+The production capability factory now composes the complete typed adapter
+lazily. Its inert open binds the immutable images, standard check profile,
+signed independent-evidence source, polling limit and workload-authority
+resolver without reading a workload credential or contacting Kubernetes. Only
+after the runtime observation policy supplies the CAPI Cluster UID does the
+single-use resolver open the lifecycle-derived client-certificate authority,
+verify its CA digest, and compose the exact fixture client, four service-proxy
+readers, strict parsers, signed evidence consumer, semantic checks and bounded
+probe. Token-mode workload authority, a foreign Platform profile, changed
+revision or second resolution fails before an API request. The factory adds no
+new action surface and still performs no delivery/autonomy collection itself.
+Binding this factory and its private paths through the execution manifest is
+the remaining full-run activation step.
+
 The post-runtime authorization resolver closes the next authority boundary.
 After a predecessor receipt is durable, it derives one canonical,
 redaction-safe request from the verified cursor, including the exact Plan,

--- a/internal/runner/observability_capability_factory.go
+++ b/internal/runner/observability_capability_factory.go
@@ -1,0 +1,151 @@
+package runner
+
+import (
+	"context"
+	"crypto/ed25519"
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/observation"
+)
+
+type KubernetesObservabilityPlatformCapabilityFactoryConfig struct {
+	WorkloadAuthority   WorkloadAuthorityResolver
+	IndependentEvidence *SignedObservabilityEvidenceFileSource
+	Fixture             ObservabilitySyntheticFixtureConfig
+	Profile             ObservabilityCapabilityCheckProfile
+	PollInterval        time.Duration
+	Clock               func() time.Time
+}
+
+// KubernetesObservabilityPlatformCapabilityFactory is the concrete production
+// composition for the already-closed observability adapter. Opening it reads
+// no workload credential and contacts no API. Runtime authority is resolved
+// only after CAPI has supplied the exact target Cluster UID.
+type KubernetesObservabilityPlatformCapabilityFactory struct {
+	config KubernetesObservabilityPlatformCapabilityFactoryConfig
+}
+
+func NewKubernetesObservabilityPlatformCapabilityFactory(config KubernetesObservabilityPlatformCapabilityFactoryConfig) (*KubernetesObservabilityPlatformCapabilityFactory, error) {
+	standard, err := StandardObservabilityCapabilityCheckProfile("ok-observability")
+	if err != nil || config.WorkloadAuthority == nil || config.IndependentEvidence == nil || config.Clock == nil ||
+		config.IndependentEvidence.clock == nil || len(config.IndependentEvidence.publicKey) != ed25519.PublicKeySize ||
+		config.Profile.Digest() == "" || config.Profile.Digest() != standard.Digest() ||
+		!capabilityImageDigestPattern.MatchString(config.Fixture.PushgatewayImage) || !capabilityImageDigestPattern.MatchString(config.Fixture.LogEmitterImage) ||
+		config.PollInterval < time.Millisecond || config.PollInterval > 30*time.Second {
+		return nil, errors.New("Kubernetes observability capability factory binding is invalid")
+	}
+	return &KubernetesObservabilityPlatformCapabilityFactory{config: config}, nil
+}
+
+func (factory *KubernetesObservabilityPlatformCapabilityFactory) OpenFullRunPlatformCapability(binding FullRunPlatformCapabilityBinding) (PlatformCapabilityResolver, error) {
+	if factory == nil || factory.config.WorkloadAuthority == nil || factory.config.IndependentEvidence == nil || factory.config.Clock == nil ||
+		binding.Namespace != factory.config.Profile.namespace || binding.Timeout < time.Minute || binding.Timeout > 30*time.Minute ||
+		binding.CleanupTimeout < 10*time.Second || binding.CleanupTimeout > 2*time.Minute {
+		return nil, errors.New("full-run observability capability binding is invalid")
+	}
+	for _, value := range []string{binding.IntentRevision, binding.PlatformRevision, binding.ExecutionFixture, binding.ContractDigest, binding.ExecutableDigest} {
+		if !platformInputDigestPattern.MatchString(value) {
+			return nil, errors.New("full-run observability capability revision is invalid")
+		}
+	}
+	return &kubernetesObservabilityPlatformCapabilityResolver{factory: factory, binding: binding}, nil
+}
+
+type kubernetesObservabilityPlatformCapabilityResolver struct {
+	factory *KubernetesObservabilityPlatformCapabilityFactory
+	binding FullRunPlatformCapabilityBinding
+
+	mu   sync.Mutex
+	used bool
+}
+
+func (resolver *kubernetesObservabilityPlatformCapabilityResolver) ResolvePlatformCapability(ctx context.Context, policy observation.Policy, profile observation.PlatformProfile) (observation.PlatformCapabilitySource, error) {
+	if resolver == nil || resolver.factory == nil || resolver.factory.config.WorkloadAuthority == nil || resolver.factory.config.IndependentEvidence == nil || resolver.factory.config.Clock == nil {
+		return nil, errors.New("Kubernetes observability capability resolver is required")
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, errors.New("Kubernetes observability capability resolution cancelled")
+	}
+	if _, err := observation.PolicyDigest(policy); err != nil {
+		return nil, errors.New("runtime-bound observability policy is invalid")
+	}
+	if _, err := observation.PlatformProfileDigest(profile); err != nil || policy.TargetClusterUID == "" ||
+		policy.IntentRevision != resolver.binding.IntentRevision || policy.PlatformRevision != resolver.binding.PlatformRevision ||
+		profile.IntentRevision != resolver.binding.IntentRevision || profile.PlatformRevision != resolver.binding.PlatformRevision ||
+		profile.ExecutionFixture != resolver.binding.ExecutionFixture || profile.CapabilityContractDigest != resolver.binding.ContractDigest ||
+		profile.CapabilityExecutableDigest != resolver.binding.ExecutableDigest {
+		return nil, errors.New("runtime-bound observability profile differs from full-run binding")
+	}
+	resolver.mu.Lock()
+	if resolver.used {
+		resolver.mu.Unlock()
+		return nil, errors.New("Kubernetes observability capability resolver is single-use")
+	}
+	resolver.used = true
+	resolver.mu.Unlock()
+
+	request := PlatformCapabilityProbeRequest{
+		Format: PlatformCapabilityProbeRequestFormat, TargetClusterUID: policy.TargetClusterUID,
+		IntentRevision: resolver.binding.IntentRevision, PlatformRevision: resolver.binding.PlatformRevision,
+		ExecutionFixture: resolver.binding.ExecutionFixture, ContractDigest: resolver.binding.ContractDigest,
+		ExecutableDigest: resolver.binding.ExecutableDigest,
+	}
+	run, err := observabilityCapabilityRun(request, resolver.binding.Namespace)
+	if err != nil {
+		return nil, errors.New("construct runtime-bound observability run")
+	}
+	workload, err := resolver.factory.config.WorkloadAuthority.ResolveWorkloadAuthority(ctx, policy)
+	if err != nil || workload.AuthorityIdentity != policy.TargetClusterUID || workload.CABundleDigest == "" {
+		return nil, errors.New("resolve runtime-bound observability workload authority")
+	}
+	transport, err := openBoundedKubernetesAuthorityTransport(workload)
+	if err != nil || digest.SHA256(transport.caData) != workload.CABundleDigest || !transport.clientCertificate || transport.bearerToken != "" {
+		return nil, errors.New("open runtime-bound observability workload authority")
+	}
+	fixtureClient, err := NewKubernetesCapabilityFixtureClient(KubernetesCapabilityFixtureClientConfig{
+		Endpoint: workload.Endpoint, ClientCertificate: true, AuthorityIdentity: workload.AuthorityIdentity, Client: transport.client,
+	}, run, resolver.factory.config.Fixture)
+	if err != nil {
+		return nil, errors.New("open runtime-bound observability fixture client")
+	}
+	backendClient, err := newKubernetesObservabilityBackendClient(KubernetesObservabilityBackendClientConfig{
+		Endpoint: workload.Endpoint, ClientCertificate: true, AuthorityIdentity: workload.AuthorityIdentity,
+		Client: transport.client, Profile: resolver.factory.config.Profile,
+	})
+	if err != nil {
+		return nil, errors.New("open runtime-bound observability backend client")
+	}
+	backend, err := newKubernetesObservabilityCapabilityBackend(
+		backendClient, resolver.factory.config.IndependentEvidence, resolver.factory.config.IndependentEvidence,
+		resolver.factory.config.Profile, resolver.factory.config.PollInterval,
+	)
+	if err != nil {
+		return nil, errors.New("open runtime-bound observability backend")
+	}
+	checks, err := NewStandardObservabilityCapabilityChecks(backend, resolver.factory.config.Profile)
+	if err != nil {
+		return nil, errors.New("open runtime-bound observability checks")
+	}
+	capabilityTransport, err := newKubernetesObservabilityTransport(fixtureClient, run, checks)
+	if err != nil {
+		return nil, errors.New("open runtime-bound observability transport")
+	}
+	probe, err := NewObservabilityCapabilityProbe(capabilityTransport, ObservabilityCapabilityProbeConfig{
+		Namespace: resolver.binding.Namespace, ExpectedContractDigest: resolver.binding.ContractDigest,
+		ExpectedExecutableDigest: resolver.binding.ExecutableDigest, Timeout: resolver.binding.Timeout, CleanupTimeout: resolver.binding.CleanupTimeout,
+	})
+	if err != nil {
+		return nil, errors.New("open runtime-bound observability probe")
+	}
+	firstRun, err := NewFirstRunPlatformCapabilityResolver(probe, resolver.factory.config.Clock)
+	if err != nil {
+		return nil, errors.New("open first-run observability capability")
+	}
+	return firstRun.ResolvePlatformCapability(ctx, policy, profile)
+}
+
+var _ FullRunPlatformCapabilityFactory = (*KubernetesObservabilityPlatformCapabilityFactory)(nil)
+var _ PlatformCapabilityResolver = (*kubernetesObservabilityPlatformCapabilityResolver)(nil)

--- a/internal/runner/observability_capability_factory_test.go
+++ b/internal/runner/observability_capability_factory_test.go
@@ -1,0 +1,170 @@
+package runner
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/observation"
+)
+
+func TestKubernetesObservabilityPlatformCapabilityFactoryResolvesLazily(t *testing.T) {
+	root := t.TempDir()
+	requests := 0
+	server, ca, certificate, key := newObservabilityFactoryTLSServer(t, http.HandlerFunc(func(http.ResponseWriter, *http.Request) { requests++ }))
+	defer server.Close()
+	caPath := filepath.Join(root, "workload-ca.crt")
+	if err := os.WriteFile(caPath, ca, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	kubeconfigPath := filepath.Join(root, "workload.kubeconfig")
+	if err := os.WriteFile(kubeconfigPath, testClientKubeconfig(server.URL, ca, certificate, key), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	evidenceMaterial := newSignedObservabilityEvidenceMaterial(t)
+	evidenceSource := openSignedObservabilityEvidenceSource(t, evidenceMaterial, evidenceMaterial.observedAt.Add(time.Minute))
+	profile, _ := StandardObservabilityCapabilityCheckProfile("ok-observability")
+	workloadCalls := 0
+	boundAuthority := KubernetesAuthorityConfig{
+		Endpoint: server.URL, AuthorityIdentity: evidenceMaterial.identity.TargetClusterUID, KubeconfigFile: kubeconfigPath,
+		CAFile: caPath, CABundleDigest: digest.SHA256(ca),
+	}
+	openedTransport, err := openBoundedKubernetesAuthorityTransport(boundAuthority)
+	if err != nil || !openedTransport.clientCertificate || digest.SHA256(openedTransport.caData) != boundAuthority.CABundleDigest {
+		t.Fatalf("test workload authority is invalid: cert=%v ca=%v err=%v", openedTransport.clientCertificate, digest.SHA256(openedTransport.caData) == boundAuthority.CABundleDigest, err)
+	}
+	workload := WorkloadAuthorityResolverFunc(func(_ context.Context, policy observation.Policy) (KubernetesAuthorityConfig, error) {
+		workloadCalls++
+		bound := boundAuthority
+		bound.AuthorityIdentity = policy.TargetClusterUID
+		return bound, nil
+	})
+	factory, err := NewKubernetesObservabilityPlatformCapabilityFactory(KubernetesObservabilityPlatformCapabilityFactoryConfig{
+		WorkloadAuthority: workload, IndependentEvidence: evidenceSource, Fixture: capabilityFixtureConfig(), Profile: profile,
+		PollInterval: time.Millisecond, Clock: func() time.Time { return evidenceMaterial.observedAt.Add(time.Minute) },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	platformProfile := runnerPlatformProfile()
+	binding := FullRunPlatformCapabilityBinding{
+		Namespace: "ok-observability", Timeout: time.Minute, CleanupTimeout: 10 * time.Second,
+		IntentRevision: platformProfile.IntentRevision, PlatformRevision: platformProfile.PlatformRevision,
+		ExecutionFixture: platformProfile.ExecutionFixture, ContractDigest: platformProfile.CapabilityContractDigest,
+		ExecutableDigest: platformProfile.CapabilityExecutableDigest,
+	}
+	resolver, err := factory.OpenFullRunPlatformCapability(binding)
+	if err != nil || workloadCalls != 0 || requests != 0 {
+		t.Fatalf("factory open was not inert: workload=%d requests=%d err=%v", workloadCalls, requests, err)
+	}
+	policy := observation.Policy{
+		Format: observation.PolicyFormat, IntentRevision: platformProfile.IntentRevision, EnablementRevision: digestOf("e"),
+		PlatformRevision: platformProfile.PlatformRevision, TargetClusterUID: evidenceMaterial.identity.TargetClusterUID,
+		Required: []string{"PlatformReady"},
+	}
+	source, err := resolver.ResolvePlatformCapability(context.Background(), policy, platformProfile)
+	if err != nil || source == nil || workloadCalls != 1 || requests != 0 {
+		t.Fatalf("lazy capability resolution differs: source=%T workload=%d requests=%d err=%v", source, workloadCalls, requests, err)
+	}
+	if _, err := resolver.ResolvePlatformCapability(context.Background(), policy, platformProfile); err == nil || workloadCalls != 1 || requests != 0 {
+		t.Fatal("single-use capability resolver repeated authority resolution")
+	}
+}
+
+func newObservabilityFactoryTLSServer(t *testing.T, handler http.Handler) (*httptest.Server, []byte, []byte, []byte) {
+	t.Helper()
+	now := time.Now().UTC()
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	caTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(201), Subject: pkix.Name{CommonName: "ok147-observability-factory-ca"},
+		NotBefore: now.Add(-time.Hour), NotAfter: now.Add(24 * time.Hour), IsCA: true,
+		KeyUsage: x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature, BasicConstraintsValid: true,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sign := func(serial int64, commonName string, usages []x509.ExtKeyUsage, addresses []net.IP) ([]byte, []byte) {
+		key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		if err != nil {
+			t.Fatal(err)
+		}
+		template := &x509.Certificate{
+			SerialNumber: big.NewInt(serial), Subject: pkix.Name{CommonName: commonName}, NotBefore: now.Add(-time.Hour), NotAfter: now.Add(24 * time.Hour),
+			KeyUsage: x509.KeyUsageDigitalSignature, ExtKeyUsage: usages, IPAddresses: addresses,
+		}
+		certificateDER, err := x509.CreateCertificate(rand.Reader, template, caTemplate, &key.PublicKey, caKey)
+		if err != nil {
+			t.Fatal(err)
+		}
+		keyDER, err := x509.MarshalECPrivateKey(key)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certificateDER}), pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+	}
+	serverCertificate, serverKey := sign(202, "127.0.0.1", []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}, []net.IP{net.ParseIP("127.0.0.1")})
+	clientCertificate, clientKey := sign(203, "ok147-observability-client", []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}, nil)
+	tlsCertificate, err := tls.X509KeyPair(serverCertificate, serverKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	server := httptest.NewUnstartedServer(handler)
+	server.TLS = &tls.Config{MinVersion: tls.VersionTLS12, Certificates: []tls.Certificate{tlsCertificate}}
+	server.StartTLS()
+	return server, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER}), clientCertificate, clientKey
+}
+
+func TestKubernetesObservabilityPlatformCapabilityFactoryRejectsForeignProfileBeforeAuthority(t *testing.T) {
+	evidenceMaterial := newSignedObservabilityEvidenceMaterial(t)
+	evidenceSource := openSignedObservabilityEvidenceSource(t, evidenceMaterial, evidenceMaterial.observedAt.Add(time.Minute))
+	checkProfile, _ := StandardObservabilityCapabilityCheckProfile("ok-observability")
+	workloadCalls := 0
+	factory, err := NewKubernetesObservabilityPlatformCapabilityFactory(KubernetesObservabilityPlatformCapabilityFactoryConfig{
+		WorkloadAuthority: WorkloadAuthorityResolverFunc(func(context.Context, observation.Policy) (KubernetesAuthorityConfig, error) {
+			workloadCalls++
+			return KubernetesAuthorityConfig{}, nil
+		}),
+		IndependentEvidence: evidenceSource, Fixture: capabilityFixtureConfig(), Profile: checkProfile,
+		PollInterval: time.Millisecond, Clock: time.Now,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	platformProfile := runnerPlatformProfile()
+	resolver, err := factory.OpenFullRunPlatformCapability(FullRunPlatformCapabilityBinding{
+		Namespace: "ok-observability", Timeout: time.Minute, CleanupTimeout: 10 * time.Second,
+		IntentRevision: platformProfile.IntentRevision, PlatformRevision: platformProfile.PlatformRevision,
+		ExecutionFixture: platformProfile.ExecutionFixture, ContractDigest: platformProfile.CapabilityContractDigest,
+		ExecutableDigest: platformProfile.CapabilityExecutableDigest,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	policy := observation.Policy{
+		Format: observation.PolicyFormat, IntentRevision: platformProfile.IntentRevision, EnablementRevision: digestOf("e"),
+		PlatformRevision: platformProfile.PlatformRevision, TargetClusterUID: evidenceMaterial.identity.TargetClusterUID,
+		Required: []string{"PlatformReady"},
+	}
+	platformProfile.CapabilityExecutableDigest = digestOf("9")
+	if _, err := resolver.ResolvePlatformCapability(context.Background(), policy, platformProfile); err == nil || workloadCalls != 0 {
+		t.Fatal("foreign profile reached workload authority")
+	}
+}


### PR DESCRIPTION
## Outcome

Adds the concrete production factory that lazily composes the closed observability capability adapter after the runtime CAPI Cluster UID exists.

## Boundary

- inert factory open: no credential read and no API contact
- lifecycle-derived mTLS workload authority only; bearer-token mode rejected
- exact R/P/fixture/contract/executable binding
- immutable fixture images and standard check profile
- fixed fixture client, service-proxy backend, strict parsers, signed independent evidence, semantic evaluator, and bounded probe
- single-use resolution; foreign profiles and second resolution fail before API contact
- no new action, repair, retry, or lifecycle ownership surface

## Verification

- real mTLS authority construction test
- lazy/no-contact and foreign-profile tests
- targeted race test
- `go test ./...`
- `go vet ./...`
- `git diff --check`
