### PR TITLE
feat(runner): collect independent observability evidence

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -3005,6 +3005,17 @@ new action surface and still performs no delivery/autonomy collection itself.
 Binding this factory and its private paths through the execution manifest is
 the remaining full-run activation step.
 
+The issuer can now obtain its typed input through one exact external-authority
+request. The TLS-only collector pins a CA digest and private bearer token,
+posts canonical JSON to the fixed
+`/v1/observability/independent-evidence` path, rejects redirects and requires a
+caller deadline. The response must be strict bounded JSON correlated to the
+request digest and may contain only the two booleans, dependency count and the
+receiver/autonomy identity digests. Foreign, malformed, oversized or
+non-JSON responses fail closed and there is no retry or arbitrary URL surface.
+The external service implementation remains a separate operational component;
+this client neither invents delivery evidence nor performs an outage test.
+
 The post-runtime authorization resolver closes the next authority boundary.
 After a predecessor receipt is durable, it derives one canonical,
 redaction-safe request from the verified cursor, including the exact Plan,

--- a/internal/runner/observability_independent_evidence_http_collector.go
+++ b/internal/runner/observability_independent_evidence_http_collector.go
@@ -1,0 +1,152 @@
+package runner
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"mime"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/openkubes/ok-cluster/internal/contract"
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/jsonstrict"
+)
+
+const (
+	ObservabilityIndependentEvidenceCollectionRequestFormat  = "ok147-observability-independent-evidence-collection-request/v1"
+	ObservabilityIndependentEvidenceCollectionResponseFormat = "ok147-observability-independent-evidence-collection-response/v1"
+	observabilityIndependentEvidenceCollectionPath           = "/v1/observability/independent-evidence"
+	maximumObservabilityIndependentEvidenceCollectionBytes   = 64 * 1024
+)
+
+type ObservabilityIndependentEvidenceCollectionRequest struct {
+	Format           string `json:"format"`
+	RunID            string `json:"runId"`
+	TargetClusterUID string `json:"targetClusterUid"`
+	FixtureDigest    string `json:"fixtureDigest"`
+	ProfileDigest    string `json:"profileDigest"`
+	AlertName        string `json:"alertName"`
+}
+
+type ObservabilityIndependentEvidenceCollectionResponse struct {
+	Format                      string `json:"format"`
+	RequestDigest               string `json:"requestDigest"`
+	ReceiverDeliveryObserved    bool   `json:"receiverDeliveryObserved"`
+	ReceiverIdentityDigest      string `json:"receiverIdentityDigest"`
+	ClusterLocalServicesReady   bool   `json:"clusterLocalServicesReady"`
+	ExternalClusterDependencies int    `json:"externalClusterDependencies"`
+	AutonomyProfileDigest       string `json:"autonomyProfileDigest"`
+}
+
+type HTTPObservabilityIndependentEvidenceCollectorConfig struct {
+	Endpoint       string
+	TokenFile      string
+	CAFile         string
+	CABundleDigest string
+}
+
+// HTTPObservabilityIndependentEvidenceCollector performs one exact request to
+// a separately operated evidence authority. It has no caller-selected path,
+// query, method, payload extension, retry or redirect surface.
+type HTTPObservabilityIndependentEvidenceCollector struct {
+	endpoint *url.URL
+	token    string
+	client   *http.Client
+}
+
+func OpenHTTPObservabilityIndependentEvidenceCollector(config HTTPObservabilityIndependentEvidenceCollectorConfig) (*HTTPObservabilityIndependentEvidenceCollector, error) {
+	endpoint, err := url.Parse(config.Endpoint)
+	if err != nil || endpoint.Scheme != "https" || endpoint.Host == "" || endpoint.User != nil || endpoint.Path != "" && endpoint.Path != "/" ||
+		endpoint.RawQuery != "" || endpoint.Fragment != "" || config.TokenFile == "" || config.CAFile == "" ||
+		!platformInputDigestPattern.MatchString(config.CABundleDigest) {
+		return nil, errors.New("observability independent evidence collector binding is invalid")
+	}
+	token, ca, client, err := openBoundedKubernetesMaterial(config.TokenFile, config.CAFile)
+	if err != nil || digest.SHA256(ca) != config.CABundleDigest {
+		return nil, errors.New("open observability independent evidence collector authority")
+	}
+	copyClient := *client
+	copyClient.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+	endpoint.Path, endpoint.RawPath = "", ""
+	return &HTTPObservabilityIndependentEvidenceCollector{endpoint: endpoint, token: token, client: &copyClient}, nil
+}
+
+func (collector *HTTPObservabilityIndependentEvidenceCollector) Collect(ctx context.Context, identity ObservabilityCapabilityObservationIdentity, alertName string) (ObservabilityIndependentEvidenceObservation, error) {
+	if collector == nil || collector.endpoint == nil || collector.client == nil || collector.token == "" || !validObservabilityObservationIdentity(identity) ||
+		alertName == "" || !runtimeInputUIDPattern.MatchString(alertName) {
+		return ObservabilityIndependentEvidenceObservation{}, errors.New("observability independent evidence collection input is invalid")
+	}
+	if _, ok := ctx.Deadline(); !ok || ctx.Err() != nil {
+		return ObservabilityIndependentEvidenceObservation{}, errors.New("observability independent evidence collection requires a live deadline")
+	}
+	requestDocument := ObservabilityIndependentEvidenceCollectionRequest{
+		Format: ObservabilityIndependentEvidenceCollectionRequestFormat, RunID: identity.RunID, TargetClusterUID: identity.TargetClusterUID,
+		FixtureDigest: identity.FixtureDigest, ProfileDigest: identity.ProfileDigest, AlertName: alertName,
+	}
+	requestRaw, requestDigest, err := canonicalObservabilityIndependentEvidenceCollectionRequest(requestDocument)
+	if err != nil {
+		return ObservabilityIndependentEvidenceObservation{}, errors.New("canonicalize observability independent evidence collection request")
+	}
+	endpoint := *collector.endpoint
+	endpoint.Path = observabilityIndependentEvidenceCollectionPath
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint.String(), bytes.NewReader(requestRaw))
+	if err != nil {
+		return ObservabilityIndependentEvidenceObservation{}, errors.New("construct observability independent evidence collection request")
+	}
+	request.Header.Set("Authorization", "Bearer "+collector.token)
+	request.Header.Set("Accept", "application/json")
+	request.Header.Set("Content-Type", "application/json")
+	response, err := collector.client.Do(request)
+	if err != nil {
+		return ObservabilityIndependentEvidenceObservation{}, errors.New("request independent observability evidence")
+	}
+	defer response.Body.Close()
+	mediaType, _, mediaErr := mime.ParseMediaType(response.Header.Get("Content-Type"))
+	if response.StatusCode != http.StatusOK || mediaErr != nil || mediaType != "application/json" {
+		return ObservabilityIndependentEvidenceObservation{}, errors.New("independent observability evidence response is invalid")
+	}
+	raw, err := io.ReadAll(io.LimitReader(response.Body, maximumObservabilityIndependentEvidenceCollectionBytes+1))
+	if err != nil || len(raw) == 0 || len(raw) > maximumObservabilityIndependentEvidenceCollectionBytes {
+		return ObservabilityIndependentEvidenceObservation{}, errors.New("independent observability evidence response exceeds accepted size")
+	}
+	var document ObservabilityIndependentEvidenceCollectionResponse
+	if err := jsonstrict.Decode(raw, &document); err != nil || document.Format != ObservabilityIndependentEvidenceCollectionResponseFormat ||
+		document.RequestDigest != requestDigest || !platformInputDigestPattern.MatchString(document.ReceiverIdentityDigest) ||
+		!platformInputDigestPattern.MatchString(document.AutonomyProfileDigest) || document.ExternalClusterDependencies < 0 {
+		return ObservabilityIndependentEvidenceObservation{}, errors.New("independent observability evidence response differs from request")
+	}
+	return ObservabilityIndependentEvidenceObservation{
+		ReceiverDeliveryObserved: document.ReceiverDeliveryObserved, ReceiverIdentityDigest: document.ReceiverIdentityDigest,
+		ClusterLocalServicesReady: document.ClusterLocalServicesReady, ExternalClusterDependencies: document.ExternalClusterDependencies,
+		AutonomyProfileDigest: document.AutonomyProfileDigest,
+	}, nil
+}
+
+func canonicalObservabilityIndependentEvidenceCollectionRequest(request ObservabilityIndependentEvidenceCollectionRequest) ([]byte, string, error) {
+	if request.Format != ObservabilityIndependentEvidenceCollectionRequestFormat || !validObservabilityObservationIdentity(ObservabilityCapabilityObservationIdentity{
+		RunID: request.RunID, TargetClusterUID: request.TargetClusterUID, FixtureDigest: request.FixtureDigest, ProfileDigest: request.ProfileDigest,
+	}) || request.AlertName == "" || !runtimeInputUIDPattern.MatchString(request.AlertName) || strings.ContainsAny(request.AlertName, "\r\n") {
+		return nil, "", errors.New("observability independent evidence collection request is invalid")
+	}
+	raw, err := json.Marshal(request)
+	if err != nil {
+		return nil, "", err
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	var value any
+	if err := decoder.Decode(&value); err != nil {
+		return nil, "", err
+	}
+	canonical, err := contract.JCS(value)
+	if err != nil {
+		return nil, "", err
+	}
+	return canonical, digest.SHA256(canonical), nil
+}
+
+var _ ObservabilityIndependentEvidenceCollector = (*HTTPObservabilityIndependentEvidenceCollector)(nil)

--- a/internal/runner/observability_independent_evidence_http_collector_test.go
+++ b/internal/runner/observability_independent_evidence_http_collector_test.go
@@ -1,0 +1,144 @@
+package runner
+
+import (
+	"context"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+func TestHTTPObservabilityIndependentEvidenceCollectorUsesExactRequest(t *testing.T) {
+	material := newSignedObservabilityEvidenceMaterial(t)
+	requests := 0
+	server := httptest.NewTLSServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		requests++
+		if request.Method != http.MethodPost || request.URL.Path != observabilityIndependentEvidenceCollectionPath || request.URL.RawQuery != "" ||
+			request.Header.Get("Authorization") != "Bearer independent-evidence-token" || request.Header.Get("Content-Type") != "application/json" {
+			response.WriteHeader(http.StatusForbidden)
+			return
+		}
+		raw, err := io.ReadAll(request.Body)
+		if err != nil {
+			response.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		var document ObservabilityIndependentEvidenceCollectionRequest
+		if err := json.Unmarshal(raw, &document); err != nil {
+			response.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		canonical, requestDigest, err := canonicalObservabilityIndependentEvidenceCollectionRequest(document)
+		if err != nil || string(canonical) != string(raw) {
+			response.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		response.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(response).Encode(ObservabilityIndependentEvidenceCollectionResponse{
+			Format: ObservabilityIndependentEvidenceCollectionResponseFormat, RequestDigest: requestDigest,
+			ReceiverDeliveryObserved: true, ReceiverIdentityDigest: digest.SHA256([]byte("receiver")),
+			ClusterLocalServicesReady: true, ExternalClusterDependencies: 0, AutonomyProfileDigest: digest.SHA256([]byte("autonomy")),
+		})
+	}))
+	defer server.Close()
+	collector := openHTTPIndependentEvidenceCollector(t, server)
+	if requests != 0 {
+		t.Fatal("collector open contacted evidence authority")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	observation, err := collector.Collect(ctx, material.identity, material.alertName)
+	if err != nil || !observation.ReceiverDeliveryObserved || !observation.ClusterLocalServicesReady || observation.ExternalClusterDependencies != 0 || requests != 1 {
+		t.Fatalf("exact evidence collection differs: %#v requests=%d err=%v", observation, requests, err)
+	}
+}
+
+func TestHTTPObservabilityIndependentEvidenceCollectorFailsClosed(t *testing.T) {
+	material := newSignedObservabilityEvidenceMaterial(t)
+
+	t.Run("unbounded context", func(t *testing.T) {
+		requests := 0
+		server := httptest.NewTLSServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) { requests++ }))
+		defer server.Close()
+		collector := openHTTPIndependentEvidenceCollector(t, server)
+		if _, err := collector.Collect(context.Background(), material.identity, material.alertName); err == nil || requests != 0 {
+			t.Fatal("unbounded collection reached evidence authority")
+		}
+	})
+
+	t.Run("foreign response", func(t *testing.T) {
+		server := httptest.NewTLSServer(http.HandlerFunc(func(response http.ResponseWriter, _ *http.Request) {
+			response.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(response).Encode(ObservabilityIndependentEvidenceCollectionResponse{
+				Format: ObservabilityIndependentEvidenceCollectionResponseFormat, RequestDigest: digest.SHA256([]byte("foreign")),
+				ReceiverIdentityDigest: digest.SHA256([]byte("receiver")), AutonomyProfileDigest: digest.SHA256([]byte("autonomy")),
+			})
+		}))
+		defer server.Close()
+		collector := openHTTPIndependentEvidenceCollector(t, server)
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		if _, err := collector.Collect(ctx, material.identity, material.alertName); err == nil {
+			t.Fatal("foreign request correlation was accepted")
+		}
+	})
+
+	t.Run("oversized response", func(t *testing.T) {
+		server := httptest.NewTLSServer(http.HandlerFunc(func(response http.ResponseWriter, _ *http.Request) {
+			response.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(response, strings.Repeat("x", maximumObservabilityIndependentEvidenceCollectionBytes+1))
+		}))
+		defer server.Close()
+		collector := openHTTPIndependentEvidenceCollector(t, server)
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		if _, err := collector.Collect(ctx, material.identity, material.alertName); err == nil {
+			t.Fatal("oversized evidence response was accepted")
+		}
+	})
+
+	t.Run("redirect", func(t *testing.T) {
+		requests := 0
+		server := httptest.NewTLSServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+			requests++
+			http.Redirect(response, request, "/foreign", http.StatusFound)
+		}))
+		defer server.Close()
+		collector := openHTTPIndependentEvidenceCollector(t, server)
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		if _, err := collector.Collect(ctx, material.identity, material.alertName); err == nil || requests != 1 {
+			t.Fatal("evidence authority redirect was followed")
+		}
+	})
+}
+
+func openHTTPIndependentEvidenceCollector(t *testing.T, server *httptest.Server) *HTTPObservabilityIndependentEvidenceCollector {
+	t.Helper()
+	root := t.TempDir()
+	tokenPath := filepath.Join(root, "token")
+	caPath := filepath.Join(root, "ca.crt")
+	ca := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: server.Certificate().Raw})
+	if err := os.WriteFile(tokenPath, []byte("independent-evidence-token"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(caPath, ca, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	collector, err := OpenHTTPObservabilityIndependentEvidenceCollector(HTTPObservabilityIndependentEvidenceCollectorConfig{
+		Endpoint: server.URL, TokenFile: tokenPath, CAFile: caPath, CABundleDigest: digest.SHA256(ca),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return collector
+}


### PR DESCRIPTION
## Outcome

Defines the exact TLS protocol through which a separately operated evidence authority supplies receiver-delivery and autonomy observations to the single-use signer.

## Boundary

- HTTPS only with pinned CA digest and private bearer token
- one canonical POST to a fixed path
- exact run/target/fixture/profile/alert request identity
- strict response correlation by request digest
- bounded 64-KiB JSON response
- redirects, arbitrary paths, unbounded contexts, malformed and foreign responses rejected
- no retry, repair, outage injection, or arbitrary command surface

## Verification

- exact-request TLS integration test
- unbounded-context, foreign-response, oversized-response, and redirect negatives
- targeted race test
- `go test ./...`
- `go vet ./...`
- `git diff --check`
