### PR TITLE
feat(runner): bind observability capability execution

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -3002,8 +3002,14 @@ readers, strict parsers, signed evidence consumer, semantic checks and bounded
 probe. Token-mode workload authority, a foreign Platform profile, changed
 revision or second resolution fails before an API request. The factory adds no
 new action surface and still performs no delivery/autonomy collection itself.
-Binding this factory and its private paths through the execution manifest is
-the remaining full-run activation step.
+The full-run manifest now binds the factory's immutable Pushgateway and
+log-emitter image digests, signed-evidence path and public-key identity, and
+backend polling interval alongside the existing timeouts and semantic
+revisions. The concrete factory rejects any process-local configuration that
+differs from those values. Invalid or mutable images, an unbounded interval,
+foreign key identity, relative evidence path or collision with a private
+runtime output fails manifest verification. Selecting this factory from the
+local/Job execute entry point remains the activation step.
 
 The issuer can now obtain its typed input through one exact external-authority
 request. The TLS-only collector pins a CA digest and private bearer token,

--- a/internal/runner/full_run_execution_manifest.go
+++ b/internal/runner/full_run_execution_manifest.go
@@ -111,9 +111,14 @@ type fullRunPlatformApplicationsDocument struct {
 }
 
 type fullRunCapabilityDocument struct {
-	Namespace      string `json:"namespace"`
-	Timeout        string `json:"timeout"`
-	CleanupTimeout string `json:"cleanupTimeout"`
+	Namespace                string `json:"namespace"`
+	Timeout                  string `json:"timeout"`
+	CleanupTimeout           string `json:"cleanupTimeout"`
+	PollInterval             string `json:"pollInterval"`
+	PushgatewayImage         string `json:"pushgatewayImage"`
+	LogEmitterImage          string `json:"logEmitterImage"`
+	IndependentEvidencePath  string `json:"independentEvidencePath"`
+	IndependentEvidenceKeyID string `json:"independentEvidenceKeyId"`
 }
 
 type fullRunPlatformObservationDocument struct {
@@ -184,14 +189,19 @@ type VerifiedFullRunExecutionManifest struct {
 // first-run capability boundary. The factory receives no credential, endpoint,
 // target UID, command or arbitrary payload.
 type FullRunPlatformCapabilityBinding struct {
-	Namespace        string
-	Timeout          time.Duration
-	CleanupTimeout   time.Duration
-	IntentRevision   string
-	PlatformRevision string
-	ExecutionFixture string
-	ContractDigest   string
-	ExecutableDigest string
+	Namespace                string
+	Timeout                  time.Duration
+	CleanupTimeout           time.Duration
+	PollInterval             time.Duration
+	PushgatewayImage         string
+	LogEmitterImage          string
+	IndependentEvidencePath  string
+	IndependentEvidenceKeyID string
+	IntentRevision           string
+	PlatformRevision         string
+	ExecutionFixture         string
+	ContractDigest           string
+	ExecutableDigest         string
 }
 
 // FullRunPlatformCapabilityFactory supplies the process-local fixed checks and
@@ -278,9 +288,17 @@ func (manifest VerifiedFullRunExecutionManifest) ExecutionConfig(runtime FullRun
 	if err != nil {
 		return FullRunExecutionConfig{}, errors.New("parse full-run capability cleanup timeout")
 	}
+	capabilityPollInterval, err := time.ParseDuration(document.PlatformObservation.Capability.PollInterval)
+	if err != nil {
+		return FullRunExecutionConfig{}, errors.New("parse full-run capability polling")
+	}
 	capabilityResolver, err := runtime.PlatformCapability.OpenFullRunPlatformCapability(FullRunPlatformCapabilityBinding{
 		Namespace: document.PlatformObservation.Capability.Namespace, Timeout: capabilityTimeout, CleanupTimeout: cleanupTimeout,
-		IntentRevision: plan.IntentRevision, PlatformRevision: plan.PlatformRevision, ExecutionFixture: plan.ExecutionFixture,
+		PollInterval: capabilityPollInterval, PushgatewayImage: document.PlatformObservation.Capability.PushgatewayImage,
+		LogEmitterImage:          document.PlatformObservation.Capability.LogEmitterImage,
+		IndependentEvidencePath:  document.PlatformObservation.Capability.IndependentEvidencePath,
+		IndependentEvidenceKeyID: document.PlatformObservation.Capability.IndependentEvidenceKeyID,
+		IntentRevision:           plan.IntentRevision, PlatformRevision: plan.PlatformRevision, ExecutionFixture: plan.ExecutionFixture,
 		ContractDigest: manifest.platform.CapabilityContractDigest, ExecutableDigest: manifest.platform.CapabilityExecutableDigest,
 	})
 	if err != nil || capabilityResolver == nil {
@@ -744,10 +762,19 @@ func validateFullRunRuntimeBoundary(document fullRunExecutionManifestDocument, p
 	}
 	capabilityTimeout, capabilityErr := time.ParseDuration(document.PlatformObservation.Capability.Timeout)
 	cleanupTimeout, cleanupErr := time.ParseDuration(document.PlatformObservation.Capability.CleanupTimeout)
+	capabilityPollInterval, capabilityPollErr := time.ParseDuration(document.PlatformObservation.Capability.PollInterval)
 	if capabilityErr != nil || cleanupErr != nil || capabilityTimeout < time.Minute || capabilityTimeout > 30*time.Minute ||
 		cleanupTimeout < 10*time.Second || cleanupTimeout > 2*time.Minute ||
-		document.PlatformObservation.Capability.Namespace != "ok-observability" {
+		capabilityPollErr != nil || capabilityPollInterval < time.Millisecond || capabilityPollInterval > 30*time.Second ||
+		document.PlatformObservation.Capability.Namespace != "ok-observability" ||
+		!capabilityImageDigestPattern.MatchString(document.PlatformObservation.Capability.PushgatewayImage) ||
+		!capabilityImageDigestPattern.MatchString(document.PlatformObservation.Capability.LogEmitterImage) ||
+		!validFullRunAbsolutePath(document.PlatformObservation.Capability.IndependentEvidencePath) ||
+		!platformInputDigestPattern.MatchString(document.PlatformObservation.Capability.IndependentEvidenceKeyID) {
 		return errors.New("full-run capability execution bounds are invalid")
+	}
+	if _, exists := seenOutputs[document.PlatformObservation.Capability.IndependentEvidencePath]; exists {
+		return errors.New("full-run capability evidence path collides with a private runtime output")
 	}
 	if document.TargetRegistration.TargetName != plan.ContractIdentity.Name ||
 		document.TargetRegistration.ArgoNamespace != document.PlatformApplications.ArgoNamespace ||

--- a/internal/runner/full_run_execution_manifest_test.go
+++ b/internal/runner/full_run_execution_manifest_test.go
@@ -85,7 +85,9 @@ func TestVerifiedFullRunExecutionManifestBuildsConcreteConfiguration(t *testing.
 		t.Fatal("opening the full-run manifest executed the Platform capability probe")
 	}
 	if capabilityBinding.Namespace != "ok-observability" || capabilityBinding.Timeout != 10*time.Minute ||
-		capabilityBinding.CleanupTimeout != time.Minute || capabilityBinding.IntentRevision == "" ||
+		capabilityBinding.CleanupTimeout != time.Minute || capabilityBinding.PollInterval != time.Second ||
+		capabilityBinding.PushgatewayImage == "" || capabilityBinding.LogEmitterImage == "" ||
+		capabilityBinding.IndependentEvidencePath == "" || capabilityBinding.IndependentEvidenceKeyID == "" || capabilityBinding.IntentRevision == "" ||
 		capabilityBinding.PlatformRevision == "" || capabilityBinding.ExecutionFixture == "" ||
 		capabilityBinding.ContractDigest == "" || capabilityBinding.ExecutableDigest == "" {
 		t.Fatalf("capability factory did not receive the exact manifest binding: %#v", capabilityBinding)
@@ -143,6 +145,19 @@ func TestFullRunExecutionManifestFailsClosed(t *testing.T) {
 		},
 		"wrong capability namespace": func(value map[string]any) {
 			value["platformObservation"].(map[string]any)["capability"].(map[string]any)["namespace"] = "default"
+		},
+		"mutable capability image": func(value map[string]any) {
+			value["platformObservation"].(map[string]any)["capability"].(map[string]any)["pushgatewayImage"] = "registry.k8s.io/pushgateway:latest"
+		},
+		"foreign evidence key": func(value map[string]any) {
+			value["platformObservation"].(map[string]any)["capability"].(map[string]any)["independentEvidenceKeyId"] = "mutable"
+		},
+		"unbounded capability polling": func(value map[string]any) {
+			value["platformObservation"].(map[string]any)["capability"].(map[string]any)["pollInterval"] = "1m"
+		},
+		"evidence path collides with runtime output": func(value map[string]any) {
+			binding := value["networkObservation"].(map[string]any)["workload"].(map[string]any)["bindingPath"]
+			value["platformObservation"].(map[string]any)["capability"].(map[string]any)["independentEvidencePath"] = binding
 		},
 		"relative runtime output": func(value map[string]any) {
 			value["runtimeBinding"].(map[string]any)["materialPath"] = "runtime-binding.json"
@@ -373,7 +388,11 @@ func fullRunExecutionManifestFixture(t *testing.T) (string, func()) {
 		},
 		PlatformObservation: fullRunPlatformObservationDocument{
 			Ledger: ledger, Argo: post.PlatformObservation.Argo,
-			Capability:   fullRunCapabilityDocument{Namespace: "ok-observability", Timeout: "10m", CleanupTimeout: "1m"},
+			Capability: fullRunCapabilityDocument{
+				Namespace: "ok-observability", Timeout: "10m", CleanupTimeout: "1m", PollInterval: "1s",
+				PushgatewayImage: capabilityFixtureConfig().PushgatewayImage, LogEmitterImage: capabilityFixtureConfig().LogEmitterImage,
+				IndependentEvidencePath: filepath.Join(privateRoot, "observability-independent-evidence.json"), IndependentEvidenceKeyID: digestOf("d"),
+			},
 			PollInterval: "1s", PollTimeout: "1m",
 		},
 		AggregateEvidence: fullRunAggregateEvidenceDocument{Ledger: ledger, Management: managementAuthority, Argo: post.AggregateEvidence.Argo, WorkloadKubeconfigFile: workload.KubeconfigFile, WorkloadCAFile: workload.CAFile},

--- a/internal/runner/observability_capability_factory.go
+++ b/internal/runner/observability_capability_factory.go
@@ -43,7 +43,10 @@ func NewKubernetesObservabilityPlatformCapabilityFactory(config KubernetesObserv
 func (factory *KubernetesObservabilityPlatformCapabilityFactory) OpenFullRunPlatformCapability(binding FullRunPlatformCapabilityBinding) (PlatformCapabilityResolver, error) {
 	if factory == nil || factory.config.WorkloadAuthority == nil || factory.config.IndependentEvidence == nil || factory.config.Clock == nil ||
 		binding.Namespace != factory.config.Profile.namespace || binding.Timeout < time.Minute || binding.Timeout > 30*time.Minute ||
-		binding.CleanupTimeout < 10*time.Second || binding.CleanupTimeout > 2*time.Minute {
+		binding.CleanupTimeout < 10*time.Second || binding.CleanupTimeout > 2*time.Minute ||
+		binding.PollInterval != factory.config.PollInterval || binding.PushgatewayImage != factory.config.Fixture.PushgatewayImage ||
+		binding.LogEmitterImage != factory.config.Fixture.LogEmitterImage || binding.IndependentEvidencePath != factory.config.IndependentEvidence.path ||
+		binding.IndependentEvidenceKeyID != factory.config.IndependentEvidence.keyID {
 		return nil, errors.New("full-run observability capability binding is invalid")
 	}
 	for _, value := range []string{binding.IntentRevision, binding.PlatformRevision, binding.ExecutionFixture, binding.ContractDigest, binding.ExecutableDigest} {

--- a/internal/runner/observability_capability_factory_test.go
+++ b/internal/runner/observability_capability_factory_test.go
@@ -63,6 +63,8 @@ func TestKubernetesObservabilityPlatformCapabilityFactoryResolvesLazily(t *testi
 	platformProfile := runnerPlatformProfile()
 	binding := FullRunPlatformCapabilityBinding{
 		Namespace: "ok-observability", Timeout: time.Minute, CleanupTimeout: 10 * time.Second,
+		PollInterval: time.Millisecond, PushgatewayImage: capabilityFixtureConfig().PushgatewayImage,
+		LogEmitterImage: capabilityFixtureConfig().LogEmitterImage, IndependentEvidencePath: evidenceSource.path, IndependentEvidenceKeyID: evidenceSource.keyID,
 		IntentRevision: platformProfile.IntentRevision, PlatformRevision: platformProfile.PlatformRevision,
 		ExecutionFixture: platformProfile.ExecutionFixture, ContractDigest: platformProfile.CapabilityContractDigest,
 		ExecutableDigest: platformProfile.CapabilityExecutableDigest,
@@ -151,6 +153,8 @@ func TestKubernetesObservabilityPlatformCapabilityFactoryRejectsForeignProfileBe
 	platformProfile := runnerPlatformProfile()
 	resolver, err := factory.OpenFullRunPlatformCapability(FullRunPlatformCapabilityBinding{
 		Namespace: "ok-observability", Timeout: time.Minute, CleanupTimeout: 10 * time.Second,
+		PollInterval: time.Millisecond, PushgatewayImage: capabilityFixtureConfig().PushgatewayImage,
+		LogEmitterImage: capabilityFixtureConfig().LogEmitterImage, IndependentEvidencePath: evidenceSource.path, IndependentEvidenceKeyID: evidenceSource.keyID,
 		IntentRevision: platformProfile.IntentRevision, PlatformRevision: platformProfile.PlatformRevision,
 		ExecutionFixture: platformProfile.ExecutionFixture, ContractDigest: platformProfile.CapabilityContractDigest,
 		ExecutableDigest: platformProfile.CapabilityExecutableDigest,


### PR DESCRIPTION
## Outcome

Binds the concrete observability capability implementation to the verified full-run manifest instead of leaving its runtime details process-local and implicit.

## Bound values

- immutable Pushgateway and log-emitter image digests
- signed independent-evidence path
- Ed25519 evidence-authority key identity
- backend polling interval
- existing namespace, timeout, cleanup timeout, R, P, fixture, contract, and executable identities

The concrete factory must match all manifest values. Mutable images, foreign key identity, relative evidence path, unbounded polling, or collision with private runtime outputs fails before execution.

## Verification

- positive concrete configuration test
- explicit negative manifest fixtures
- full `go test ./...`
- full `go vet ./...`
- `git diff --check`
