### PR TITLE
feat(runner): bind lifecycle capability authority

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -3002,8 +3002,14 @@ readers, strict parsers, signed evidence consumer, semantic checks and bounded
 probe. Token-mode workload authority, a foreign Platform profile, changed
 revision or second resolution fails before an API request. The factory adds no
 new action surface and still performs no delivery/autonomy collection itself.
-Binding this factory and its private paths through the execution manifest is
-the remaining full-run activation step.
+The full-run manifest now binds the factory's immutable Pushgateway and
+log-emitter image digests, signed-evidence path and public-key identity, and
+backend polling interval alongside the existing timeouts and semantic
+revisions. The concrete factory rejects any process-local configuration that
+differs from those values. Invalid or mutable images, an unbounded interval,
+foreign key identity, relative evidence path or collision with a private
+runtime output fails manifest verification. Selecting this factory from the
+local/Job execute entry point remains the activation step.
 
 The issuer can now obtain its typed input through one exact external-authority
 request. The TLS-only collector pins a CA digest and private bearer token,

--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -2908,6 +2908,15 @@ closes the credential-mode mismatch between the full-run lifecycle authority
 and the existing fixed synthetic fixture client; the five concrete
 observability checks remain the next separate adapter boundary.
 
+The full-run executor now also exposes a single-assignment in-process bridge
+from that lifecycle handoff to the concrete capability factory. The bridge is
+unresolvable before Stage 5, accepts exactly one already validated
+`WorkloadAuthorityFileResolverConfig` after the complete Stage 1-7 prefix and
+is bound before the Stage 8-12 suffix opens. A missing, invalid or second
+binding stops before Stage 8. No endpoint, credential path or target UID is
+added to the manifest or public activation receipt, and opening the bridge
+does not read a private file or contact an API.
+
 The first part of that adapter boundary is now a closed, deterministic
 `ok-observability-standard` check profile. It freezes the four Service names,
 ports and schemes; the credential Secret and exact key names; the platform

--- a/internal/runner/full_run_execution.go
+++ b/internal/runner/full_run_execution.go
@@ -13,8 +13,9 @@ import (
 // exact seven private sources are supplied only by the completed PreRuntime
 // execution in this same single-use run.
 type FullRunExecutionConfig struct {
-	PreRuntime  PreRuntimeExecutionConfig
-	PostRuntime PostRuntimeExecutionConfig
+	PreRuntime              PreRuntimeExecutionConfig
+	PostRuntime             PostRuntimeExecutionConfig
+	WorkloadAuthorityBinder FullRunWorkloadAuthorityBinder
 }
 
 type fullRunPreRuntimeExecution interface {
@@ -98,6 +99,11 @@ func openFullRunExecution(config FullRunExecutionConfig, factories fullRunExecut
 			workloadAuthority, workloadErr := preRuntime.RuntimeWorkloadAuthority()
 			if workloadErr != nil {
 				return nil, errors.New("full-run lifecycle workload authority is unavailable")
+			}
+			if config.WorkloadAuthorityBinder != nil {
+				if bindErr := config.WorkloadAuthorityBinder.BindFullRunWorkloadAuthority(workloadAuthority); bindErr != nil {
+					return nil, errors.New("bind full-run capability workload authority")
+				}
 			}
 			bound := clonePostRuntimeExecutionConfigForFullRun(postRuntime)
 			bound.TargetCredential.Receipts = append([]StageReceiptSource(nil), privatePrefix...)

--- a/internal/runner/full_run_execution_manifest.go
+++ b/internal/runner/full_run_execution_manifest.go
@@ -111,9 +111,14 @@ type fullRunPlatformApplicationsDocument struct {
 }
 
 type fullRunCapabilityDocument struct {
-	Namespace      string `json:"namespace"`
-	Timeout        string `json:"timeout"`
-	CleanupTimeout string `json:"cleanupTimeout"`
+	Namespace                string `json:"namespace"`
+	Timeout                  string `json:"timeout"`
+	CleanupTimeout           string `json:"cleanupTimeout"`
+	PollInterval             string `json:"pollInterval"`
+	PushgatewayImage         string `json:"pushgatewayImage"`
+	LogEmitterImage          string `json:"logEmitterImage"`
+	IndependentEvidencePath  string `json:"independentEvidencePath"`
+	IndependentEvidenceKeyID string `json:"independentEvidenceKeyId"`
 }
 
 type fullRunPlatformObservationDocument struct {
@@ -184,14 +189,19 @@ type VerifiedFullRunExecutionManifest struct {
 // first-run capability boundary. The factory receives no credential, endpoint,
 // target UID, command or arbitrary payload.
 type FullRunPlatformCapabilityBinding struct {
-	Namespace        string
-	Timeout          time.Duration
-	CleanupTimeout   time.Duration
-	IntentRevision   string
-	PlatformRevision string
-	ExecutionFixture string
-	ContractDigest   string
-	ExecutableDigest string
+	Namespace                string
+	Timeout                  time.Duration
+	CleanupTimeout           time.Duration
+	PollInterval             time.Duration
+	PushgatewayImage         string
+	LogEmitterImage          string
+	IndependentEvidencePath  string
+	IndependentEvidenceKeyID string
+	IntentRevision           string
+	PlatformRevision         string
+	ExecutionFixture         string
+	ContractDigest           string
+	ExecutableDigest         string
 }
 
 // FullRunPlatformCapabilityFactory supplies the process-local fixed checks and
@@ -278,9 +288,17 @@ func (manifest VerifiedFullRunExecutionManifest) ExecutionConfig(runtime FullRun
 	if err != nil {
 		return FullRunExecutionConfig{}, errors.New("parse full-run capability cleanup timeout")
 	}
+	capabilityPollInterval, err := time.ParseDuration(document.PlatformObservation.Capability.PollInterval)
+	if err != nil {
+		return FullRunExecutionConfig{}, errors.New("parse full-run capability polling")
+	}
 	capabilityResolver, err := runtime.PlatformCapability.OpenFullRunPlatformCapability(FullRunPlatformCapabilityBinding{
 		Namespace: document.PlatformObservation.Capability.Namespace, Timeout: capabilityTimeout, CleanupTimeout: cleanupTimeout,
-		IntentRevision: plan.IntentRevision, PlatformRevision: plan.PlatformRevision, ExecutionFixture: plan.ExecutionFixture,
+		PollInterval: capabilityPollInterval, PushgatewayImage: document.PlatformObservation.Capability.PushgatewayImage,
+		LogEmitterImage:          document.PlatformObservation.Capability.LogEmitterImage,
+		IndependentEvidencePath:  document.PlatformObservation.Capability.IndependentEvidencePath,
+		IndependentEvidenceKeyID: document.PlatformObservation.Capability.IndependentEvidenceKeyID,
+		IntentRevision:           plan.IntentRevision, PlatformRevision: plan.PlatformRevision, ExecutionFixture: plan.ExecutionFixture,
 		ContractDigest: manifest.platform.CapabilityContractDigest, ExecutableDigest: manifest.platform.CapabilityExecutableDigest,
 	})
 	if err != nil || capabilityResolver == nil {
@@ -744,10 +762,19 @@ func validateFullRunRuntimeBoundary(document fullRunExecutionManifestDocument, p
 	}
 	capabilityTimeout, capabilityErr := time.ParseDuration(document.PlatformObservation.Capability.Timeout)
 	cleanupTimeout, cleanupErr := time.ParseDuration(document.PlatformObservation.Capability.CleanupTimeout)
+	capabilityPollInterval, capabilityPollErr := time.ParseDuration(document.PlatformObservation.Capability.PollInterval)
 	if capabilityErr != nil || cleanupErr != nil || capabilityTimeout < time.Minute || capabilityTimeout > 30*time.Minute ||
 		cleanupTimeout < 10*time.Second || cleanupTimeout > 2*time.Minute ||
-		document.PlatformObservation.Capability.Namespace != "ok-observability" {
+		capabilityPollErr != nil || capabilityPollInterval < time.Millisecond || capabilityPollInterval > 30*time.Second ||
+		document.PlatformObservation.Capability.Namespace != "ok-observability" ||
+		!capabilityImageDigestPattern.MatchString(document.PlatformObservation.Capability.PushgatewayImage) ||
+		!capabilityImageDigestPattern.MatchString(document.PlatformObservation.Capability.LogEmitterImage) ||
+		!validFullRunAbsolutePath(document.PlatformObservation.Capability.IndependentEvidencePath) ||
+		!platformInputDigestPattern.MatchString(document.PlatformObservation.Capability.IndependentEvidenceKeyID) {
 		return errors.New("full-run capability execution bounds are invalid")
+	}
+	if _, exists := seenOutputs[document.PlatformObservation.Capability.IndependentEvidencePath]; exists {
+		return errors.New("full-run capability evidence path collides with a private runtime output")
 	}
 	if document.TargetRegistration.TargetName != plan.ContractIdentity.Name ||
 		document.TargetRegistration.ArgoNamespace != document.PlatformApplications.ArgoNamespace ||

--- a/internal/runner/full_run_execution_manifest_test.go
+++ b/internal/runner/full_run_execution_manifest_test.go
@@ -85,7 +85,9 @@ func TestVerifiedFullRunExecutionManifestBuildsConcreteConfiguration(t *testing.
 		t.Fatal("opening the full-run manifest executed the Platform capability probe")
 	}
 	if capabilityBinding.Namespace != "ok-observability" || capabilityBinding.Timeout != 10*time.Minute ||
-		capabilityBinding.CleanupTimeout != time.Minute || capabilityBinding.IntentRevision == "" ||
+		capabilityBinding.CleanupTimeout != time.Minute || capabilityBinding.PollInterval != time.Second ||
+		capabilityBinding.PushgatewayImage == "" || capabilityBinding.LogEmitterImage == "" ||
+		capabilityBinding.IndependentEvidencePath == "" || capabilityBinding.IndependentEvidenceKeyID == "" || capabilityBinding.IntentRevision == "" ||
 		capabilityBinding.PlatformRevision == "" || capabilityBinding.ExecutionFixture == "" ||
 		capabilityBinding.ContractDigest == "" || capabilityBinding.ExecutableDigest == "" {
 		t.Fatalf("capability factory did not receive the exact manifest binding: %#v", capabilityBinding)
@@ -143,6 +145,19 @@ func TestFullRunExecutionManifestFailsClosed(t *testing.T) {
 		},
 		"wrong capability namespace": func(value map[string]any) {
 			value["platformObservation"].(map[string]any)["capability"].(map[string]any)["namespace"] = "default"
+		},
+		"mutable capability image": func(value map[string]any) {
+			value["platformObservation"].(map[string]any)["capability"].(map[string]any)["pushgatewayImage"] = "registry.k8s.io/pushgateway:latest"
+		},
+		"foreign evidence key": func(value map[string]any) {
+			value["platformObservation"].(map[string]any)["capability"].(map[string]any)["independentEvidenceKeyId"] = "mutable"
+		},
+		"unbounded capability polling": func(value map[string]any) {
+			value["platformObservation"].(map[string]any)["capability"].(map[string]any)["pollInterval"] = "1m"
+		},
+		"evidence path collides with runtime output": func(value map[string]any) {
+			binding := value["networkObservation"].(map[string]any)["workload"].(map[string]any)["bindingPath"]
+			value["platformObservation"].(map[string]any)["capability"].(map[string]any)["independentEvidencePath"] = binding
 		},
 		"relative runtime output": func(value map[string]any) {
 			value["runtimeBinding"].(map[string]any)["materialPath"] = "runtime-binding.json"
@@ -373,7 +388,11 @@ func fullRunExecutionManifestFixture(t *testing.T) (string, func()) {
 		},
 		PlatformObservation: fullRunPlatformObservationDocument{
 			Ledger: ledger, Argo: post.PlatformObservation.Argo,
-			Capability:   fullRunCapabilityDocument{Namespace: "ok-observability", Timeout: "10m", CleanupTimeout: "1m"},
+			Capability: fullRunCapabilityDocument{
+				Namespace: "ok-observability", Timeout: "10m", CleanupTimeout: "1m", PollInterval: "1s",
+				PushgatewayImage: capabilityFixtureConfig().PushgatewayImage, LogEmitterImage: capabilityFixtureConfig().LogEmitterImage,
+				IndependentEvidencePath: filepath.Join(privateRoot, "observability-independent-evidence.json"), IndependentEvidenceKeyID: digestOf("d"),
+			},
 			PollInterval: "1s", PollTimeout: "1m",
 		},
 		AggregateEvidence: fullRunAggregateEvidenceDocument{Ledger: ledger, Management: managementAuthority, Argo: post.AggregateEvidence.Argo, WorkloadKubeconfigFile: workload.KubeconfigFile, WorkloadCAFile: workload.CAFile},

--- a/internal/runner/full_run_execution_test.go
+++ b/internal/runner/full_run_execution_test.go
@@ -82,6 +82,65 @@ func TestFullRunExecutionComposesConcreteAdaptersWithExactPrivatePrefix(t *testi
 	}
 }
 
+func TestFullRunExecutionBindsCapabilityAuthorityBeforeOpeningSuffix(t *testing.T) {
+	preRuntime := successfulFakeConcretePreRuntimeExecution(t)
+	binder := &recordingFullRunWorkloadAuthorityBinder{}
+	config := testFullRunExecutionConfig()
+	config.WorkloadAuthorityBinder = binder
+	postCalls := 0
+	execution, err := openFullRunExecution(config, fullRunExecutionFactories{
+		preRuntime: func(PreRuntimeExecutionConfig) (fullRunPreRuntimeExecution, error) { return preRuntime, nil },
+		postRuntime: func(PostRuntimeExecutionConfig) (PostRuntimeContinuation, error) {
+			postCalls++
+			if binder.calls != 1 || binder.bound != preRuntime.workload {
+				t.Fatalf("suffix opened before exact capability authority binding: %#v", binder)
+			}
+			return successfulFakePostRuntimeContinuation(), nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := execution.Run(context.Background())
+	if err != nil || receipt.State != "SUCCEEDED" || binder.calls != 1 || postCalls != 1 {
+		t.Fatalf("full run did not bind capability authority once: receipt=%#v binder=%#v post=%d err=%v", receipt, binder, postCalls, err)
+	}
+}
+
+func TestFullRunExecutionStopsBeforeSuffixWhenCapabilityAuthorityBindingFails(t *testing.T) {
+	preRuntime := successfulFakeConcretePreRuntimeExecution(t)
+	binder := &recordingFullRunWorkloadAuthorityBinder{err: errors.New("binding rejected")}
+	config := testFullRunExecutionConfig()
+	config.WorkloadAuthorityBinder = binder
+	postCalls := 0
+	execution, err := openFullRunExecution(config, fullRunExecutionFactories{
+		preRuntime: func(PreRuntimeExecutionConfig) (fullRunPreRuntimeExecution, error) { return preRuntime, nil },
+		postRuntime: func(PostRuntimeExecutionConfig) (PostRuntimeContinuation, error) {
+			postCalls++
+			return successfulFakePostRuntimeContinuation(), nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := execution.Run(context.Background())
+	if err == nil || receipt.State != "STOPPED" || receipt.StoppedAt != "target-credential" || len(receipt.Checkpoints) != 7 || binder.calls != 1 || postCalls != 0 {
+		t.Fatalf("failed capability binding opened suffix: receipt=%#v binder=%#v post=%d err=%v", receipt, binder, postCalls, err)
+	}
+}
+
+type recordingFullRunWorkloadAuthorityBinder struct {
+	bound WorkloadAuthorityFileResolverConfig
+	calls int
+	err   error
+}
+
+func (binder *recordingFullRunWorkloadAuthorityBinder) BindFullRunWorkloadAuthority(config WorkloadAuthorityFileResolverConfig) error {
+	binder.calls++
+	binder.bound = config
+	return binder.err
+}
+
 func TestFullRunExecutionRunsRealPreRuntimeAdapterBeforeOpeningSuffix(t *testing.T) {
 	preConfig, preFactories, calls, _ := preRuntimeExecutionFixture(t)
 	config := FullRunExecutionConfig{PreRuntime: preConfig}

--- a/internal/runner/full_run_workload_authority.go
+++ b/internal/runner/full_run_workload_authority.go
@@ -1,0 +1,61 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	"github.com/openkubes/ok-cluster/internal/observation"
+)
+
+// FullRunWorkloadAuthorityBinder accepts the exact lifecycle-derived private
+// authority once the Stage 1-7 prefix has completed. It is an in-process
+// handoff only; the binding is never added to a public receipt.
+type FullRunWorkloadAuthorityBinder interface {
+	BindFullRunWorkloadAuthority(WorkloadAuthorityFileResolverConfig) error
+}
+
+// DeferredFullRunWorkloadAuthorityResolver bridges the lifecycle-owned
+// authority materializer to the concrete Platform capability factory. It is
+// inert until the completed prefix binds one already validated file resolver.
+type DeferredFullRunWorkloadAuthorityResolver struct {
+	mu       sync.Mutex
+	resolver *WorkloadAuthorityFileResolver
+}
+
+func NewDeferredFullRunWorkloadAuthorityResolver() *DeferredFullRunWorkloadAuthorityResolver {
+	return &DeferredFullRunWorkloadAuthorityResolver{}
+}
+
+func (resolver *DeferredFullRunWorkloadAuthorityResolver) BindFullRunWorkloadAuthority(config WorkloadAuthorityFileResolverConfig) error {
+	if resolver == nil {
+		return errors.New("deferred full-run workload authority resolver is required")
+	}
+	bound, err := OpenWorkloadAuthorityFileResolver(config)
+	if err != nil {
+		return errors.New("bind lifecycle-derived full-run workload authority")
+	}
+	resolver.mu.Lock()
+	defer resolver.mu.Unlock()
+	if resolver.resolver != nil {
+		return errors.New("full-run workload authority is already bound")
+	}
+	resolver.resolver = bound
+	return nil
+}
+
+func (resolver *DeferredFullRunWorkloadAuthorityResolver) ResolveWorkloadAuthority(ctx context.Context, policy observation.Policy) (KubernetesAuthorityConfig, error) {
+	if resolver == nil {
+		return KubernetesAuthorityConfig{}, errors.New("deferred full-run workload authority resolver is required")
+	}
+	resolver.mu.Lock()
+	bound := resolver.resolver
+	resolver.mu.Unlock()
+	if bound == nil {
+		return KubernetesAuthorityConfig{}, errors.New("full-run workload authority is not bound")
+	}
+	return bound.ResolveWorkloadAuthority(ctx, policy)
+}
+
+var _ FullRunWorkloadAuthorityBinder = (*DeferredFullRunWorkloadAuthorityResolver)(nil)
+var _ WorkloadAuthorityResolver = (*DeferredFullRunWorkloadAuthorityResolver)(nil)

--- a/internal/runner/full_run_workload_authority_test.go
+++ b/internal/runner/full_run_workload_authority_test.go
@@ -1,0 +1,68 @@
+package runner
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDeferredFullRunWorkloadAuthorityBindsLifecycleResultOnce(t *testing.T) {
+	root := t.TempDir()
+	policy, binding, ca := runtimeWorkloadBindingFixture(t)
+	bindingPath := filepath.Join(root, "binding.json")
+	kubeconfigPath := filepath.Join(root, "workload.kubeconfig")
+	caPath := filepath.Join(root, "ca.crt")
+	writePlatformJSON(t, bindingPath, binding)
+	if err := os.WriteFile(kubeconfigPath, []byte("lifecycle-derived-kubeconfig"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(caPath, ca, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	bindingDigest, err := WorkloadAuthorityBindingDigest(binding)
+	if err != nil {
+		t.Fatal(err)
+	}
+	config := WorkloadAuthorityFileResolverConfig{
+		Path: bindingPath, ExpectedBindingDigest: bindingDigest, KubeconfigFile: kubeconfigPath, CAFile: caPath,
+	}
+
+	resolver := NewDeferredFullRunWorkloadAuthorityResolver()
+	if _, err := resolver.ResolveWorkloadAuthority(context.Background(), policy); err == nil {
+		t.Fatal("unbound full-run workload authority resolved")
+	}
+	if err := resolver.BindFullRunWorkloadAuthority(config); err != nil {
+		t.Fatal(err)
+	}
+	authority, err := resolver.ResolveWorkloadAuthority(context.Background(), policy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if authority.Endpoint != binding.Endpoint || authority.AuthorityIdentity != binding.TargetClusterUID || authority.KubeconfigFile != kubeconfigPath || authority.TokenFile != "" || authority.CABundleDigest != binding.CABundleDigest {
+		t.Fatalf("deferred full-run authority differs from lifecycle binding: %#v", authority)
+	}
+	if err := resolver.BindFullRunWorkloadAuthority(config); err == nil {
+		t.Fatal("deferred full-run workload authority rebound")
+	}
+	foreign := policy
+	foreign.TargetClusterUID = "foreign-cluster-uid"
+	if _, err := resolver.ResolveWorkloadAuthority(context.Background(), foreign); err == nil || strings.Contains(err.Error(), binding.Endpoint) || strings.Contains(err.Error(), root) {
+		t.Fatalf("foreign runtime target was accepted or private data disclosed: %v", err)
+	}
+}
+
+func TestDeferredFullRunWorkloadAuthorityRejectsInvalidBindingWithoutReading(t *testing.T) {
+	resolver := NewDeferredFullRunWorkloadAuthorityResolver()
+	missing := filepath.Join(t.TempDir(), "not-created")
+	config := WorkloadAuthorityFileResolverConfig{
+		Path: missing, ExpectedBindingDigest: digestOf("a"), KubeconfigFile: missing + "-kubeconfig", CAFile: missing + "-ca",
+	}
+	if err := resolver.BindFullRunWorkloadAuthority(config); err != nil {
+		t.Fatalf("binding performed an eager private file read: %v", err)
+	}
+	if err := NewDeferredFullRunWorkloadAuthorityResolver().BindFullRunWorkloadAuthority(WorkloadAuthorityFileResolverConfig{}); err == nil {
+		t.Fatal("invalid lifecycle authority binding was accepted")
+	}
+}

--- a/internal/runner/observability_capability_factory.go
+++ b/internal/runner/observability_capability_factory.go
@@ -43,7 +43,10 @@ func NewKubernetesObservabilityPlatformCapabilityFactory(config KubernetesObserv
 func (factory *KubernetesObservabilityPlatformCapabilityFactory) OpenFullRunPlatformCapability(binding FullRunPlatformCapabilityBinding) (PlatformCapabilityResolver, error) {
 	if factory == nil || factory.config.WorkloadAuthority == nil || factory.config.IndependentEvidence == nil || factory.config.Clock == nil ||
 		binding.Namespace != factory.config.Profile.namespace || binding.Timeout < time.Minute || binding.Timeout > 30*time.Minute ||
-		binding.CleanupTimeout < 10*time.Second || binding.CleanupTimeout > 2*time.Minute {
+		binding.CleanupTimeout < 10*time.Second || binding.CleanupTimeout > 2*time.Minute ||
+		binding.PollInterval != factory.config.PollInterval || binding.PushgatewayImage != factory.config.Fixture.PushgatewayImage ||
+		binding.LogEmitterImage != factory.config.Fixture.LogEmitterImage || binding.IndependentEvidencePath != factory.config.IndependentEvidence.path ||
+		binding.IndependentEvidenceKeyID != factory.config.IndependentEvidence.keyID {
 		return nil, errors.New("full-run observability capability binding is invalid")
 	}
 	for _, value := range []string{binding.IntentRevision, binding.PlatformRevision, binding.ExecutionFixture, binding.ContractDigest, binding.ExecutableDigest} {

--- a/internal/runner/observability_capability_factory_test.go
+++ b/internal/runner/observability_capability_factory_test.go
@@ -63,6 +63,8 @@ func TestKubernetesObservabilityPlatformCapabilityFactoryResolvesLazily(t *testi
 	platformProfile := runnerPlatformProfile()
 	binding := FullRunPlatformCapabilityBinding{
 		Namespace: "ok-observability", Timeout: time.Minute, CleanupTimeout: 10 * time.Second,
+		PollInterval: time.Millisecond, PushgatewayImage: capabilityFixtureConfig().PushgatewayImage,
+		LogEmitterImage: capabilityFixtureConfig().LogEmitterImage, IndependentEvidencePath: evidenceSource.path, IndependentEvidenceKeyID: evidenceSource.keyID,
 		IntentRevision: platformProfile.IntentRevision, PlatformRevision: platformProfile.PlatformRevision,
 		ExecutionFixture: platformProfile.ExecutionFixture, ContractDigest: platformProfile.CapabilityContractDigest,
 		ExecutableDigest: platformProfile.CapabilityExecutableDigest,
@@ -151,6 +153,8 @@ func TestKubernetesObservabilityPlatformCapabilityFactoryRejectsForeignProfileBe
 	platformProfile := runnerPlatformProfile()
 	resolver, err := factory.OpenFullRunPlatformCapability(FullRunPlatformCapabilityBinding{
 		Namespace: "ok-observability", Timeout: time.Minute, CleanupTimeout: 10 * time.Second,
+		PollInterval: time.Millisecond, PushgatewayImage: capabilityFixtureConfig().PushgatewayImage,
+		LogEmitterImage: capabilityFixtureConfig().LogEmitterImage, IndependentEvidencePath: evidenceSource.path, IndependentEvidenceKeyID: evidenceSource.keyID,
 		IntentRevision: platformProfile.IntentRevision, PlatformRevision: platformProfile.PlatformRevision,
 		ExecutionFixture: platformProfile.ExecutionFixture, ContractDigest: platformProfile.CapabilityContractDigest,
 		ExecutableDigest: platformProfile.CapabilityExecutableDigest,


### PR DESCRIPTION
## Summary

- add a single-assignment in-process workload-authority bridge for the concrete Platform capability
- bind the exact lifecycle-derived authority after the Stage 1–7 prefix and before opening Stage 8
- fail closed on missing, invalid, foreign, or repeated authority binding without exposing private runtime data

## Validation

- unprivileged Linux `go test ./internal/runner`
- unprivileged Linux race tests for `./internal/runner`
- unprivileged Linux `go test ./...`
- unprivileged Linux `go vet ./...`
- `git diff --check`

No infrastructure mutation is part of this change.