### PR TITLE
feat(runner): publish full-run evidence handoff

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -3059,6 +3059,17 @@ Cluster UID, and writes one canonical private `0600` identity with `O_EXCL`,
 `fsync` and pullback verification. Its public receipt contains only source and
 identity digests, the target-UID digest and file metadata.
 
+The concrete full-run manifest now binds distinct destinations for that
+private identity and its redaction-safe receipt. Once the exact Stage 1-7
+prefix has succeeded, the in-process composition replays only the Stage 1-6
+prefix, verifies the runtime-binding material and persists both files before
+opening Stage 8. A missing, foreign or already occupied destination stops the
+run before the post-runtime suffix. Stage 7 is deliberately excluded from the
+identity derivation: target-access mutation is not a source of runtime target
+authority. The handoff does not contact the collector, sign evidence or wait
+for an external process; bounded evidence-authority coordination remains the
+next packaging step.
+
 The issuer consumes that private identity through an explicit one-shot CLI
 boundary:
 

--- a/internal/runner/full_run_execution.go
+++ b/internal/runner/full_run_execution.go
@@ -16,6 +16,14 @@ type FullRunExecutionConfig struct {
 	PreRuntime              PreRuntimeExecutionConfig
 	PostRuntime             PostRuntimeExecutionConfig
 	WorkloadAuthorityBinder FullRunWorkloadAuthorityBinder
+	EvidenceIdentityBinder  FullRunEvidenceIdentityBinder
+}
+
+// FullRunEvidenceIdentityBinder publishes only the private, derived
+// independent-evidence identity after the exact Stage 1-6 prefix is durable.
+// It must not contact an API or produce capability evidence itself.
+type FullRunEvidenceIdentityBinder interface {
+	BindFullRunEvidenceIdentity([]StageReceiptSource) error
 }
 
 type fullRunPreRuntimeExecution interface {
@@ -103,6 +111,11 @@ func openFullRunExecution(config FullRunExecutionConfig, factories fullRunExecut
 			if config.WorkloadAuthorityBinder != nil {
 				if bindErr := config.WorkloadAuthorityBinder.BindFullRunWorkloadAuthority(workloadAuthority); bindErr != nil {
 					return nil, errors.New("bind full-run capability workload authority")
+				}
+			}
+			if config.EvidenceIdentityBinder != nil {
+				if bindErr := config.EvidenceIdentityBinder.BindFullRunEvidenceIdentity(append([]StageReceiptSource(nil), privatePrefix[:6]...)); bindErr != nil {
+					return nil, errors.New("bind full-run independent evidence identity")
 				}
 			}
 			bound := clonePostRuntimeExecutionConfigForFullRun(postRuntime)

--- a/internal/runner/full_run_execution_manifest.go
+++ b/internal/runner/full_run_execution_manifest.go
@@ -111,14 +111,16 @@ type fullRunPlatformApplicationsDocument struct {
 }
 
 type fullRunCapabilityDocument struct {
-	Namespace                string `json:"namespace"`
-	Timeout                  string `json:"timeout"`
-	CleanupTimeout           string `json:"cleanupTimeout"`
-	PollInterval             string `json:"pollInterval"`
-	PushgatewayImage         string `json:"pushgatewayImage"`
-	LogEmitterImage          string `json:"logEmitterImage"`
-	IndependentEvidencePath  string `json:"independentEvidencePath"`
-	IndependentEvidenceKeyID string `json:"independentEvidenceKeyId"`
+	Namespace                              string `json:"namespace"`
+	Timeout                                string `json:"timeout"`
+	CleanupTimeout                         string `json:"cleanupTimeout"`
+	PollInterval                           string `json:"pollInterval"`
+	PushgatewayImage                       string `json:"pushgatewayImage"`
+	LogEmitterImage                        string `json:"logEmitterImage"`
+	IndependentEvidenceIdentityPath        string `json:"independentEvidenceIdentityPath"`
+	IndependentEvidenceIdentityReceiptPath string `json:"independentEvidenceIdentityReceiptPath"`
+	IndependentEvidencePath                string `json:"independentEvidencePath"`
+	IndependentEvidenceKeyID               string `json:"independentEvidenceKeyId"`
 }
 
 type fullRunPlatformObservationDocument struct {
@@ -328,6 +330,11 @@ func (manifest VerifiedFullRunExecutionManifest) ExecutionConfig(runtime FullRun
 		SourceRepository: document.PlatformApplications.SourceRepository, Profile: clonePlatformProfile(manifest.platform),
 	}
 	config := FullRunExecutionConfig{
+		EvidenceIdentityBinder: newFullRunObservabilityEvidenceIdentityBinder(
+			manifest,
+			document.PlatformObservation.Capability.IndependentEvidenceIdentityPath,
+			document.PlatformObservation.Capability.IndependentEvidenceIdentityReceiptPath,
+		),
 		PreRuntime: PreRuntimeExecutionConfig{
 			PlanPath: document.Plan.Path, PlanExpected: expected,
 			ProjectionManifestPath: document.Projection.ManifestPath, ProjectionRoot: document.Projection.Root,
@@ -685,7 +692,12 @@ func validateFullRunRuntimeBoundary(document fullRunExecutionManifestDocument, p
 		return errors.New("full-run workload runtime binding differs between stages")
 	}
 	workloadCredentialPath := workload.KubeconfigFile
-	runtimeOutputs := []string{workload.BindingPath, workloadCredentialPath, workload.CAFile, document.RuntimeBinding.MaterialPath, document.RuntimeBinding.ReceiptPath}
+	runtimeOutputs := []string{
+		workload.BindingPath, workloadCredentialPath, workload.CAFile,
+		document.RuntimeBinding.MaterialPath, document.RuntimeBinding.ReceiptPath,
+		document.PlatformObservation.Capability.IndependentEvidenceIdentityPath,
+		document.PlatformObservation.Capability.IndependentEvidenceIdentityReceiptPath,
+	}
 	seenOutputs := make(map[string]struct{}, len(runtimeOutputs)+len(preRuntimeStageOrder)+4)
 	for _, path := range runtimeOutputs {
 		if !validFullRunAbsolutePath(path) {

--- a/internal/runner/full_run_execution_manifest_test.go
+++ b/internal/runner/full_run_execution_manifest_test.go
@@ -73,6 +73,7 @@ func TestVerifiedFullRunExecutionManifestBuildsConcreteConfiguration(t *testing.
 	}
 	if config.PreRuntime.NetworkObservation.Workload.KubeconfigFile == "" || config.PreRuntime.NetworkObservation.Workload.TokenFile != "" ||
 		config.PostRuntime.TargetCredentialRun.Workload != config.PreRuntime.NetworkObservation.Workload ||
+		config.EvidenceIdentityBinder == nil ||
 		config.PostRuntime.PlatformObservation.Capability == nil || config.PostRuntime.AggregateEvidence.Capability == nil ||
 		config.PostRuntime.TargetRegistration.Expected.TargetIdentityDigest != "" ||
 		!config.PostRuntime.TargetRegistration.Runtime.MaterializationTime.IsZero() {
@@ -158,6 +159,10 @@ func TestFullRunExecutionManifestFailsClosed(t *testing.T) {
 		"evidence path collides with runtime output": func(value map[string]any) {
 			binding := value["networkObservation"].(map[string]any)["workload"].(map[string]any)["bindingPath"]
 			value["platformObservation"].(map[string]any)["capability"].(map[string]any)["independentEvidencePath"] = binding
+		},
+		"identity receipt collides with identity": func(value map[string]any) {
+			capability := value["platformObservation"].(map[string]any)["capability"].(map[string]any)
+			capability["independentEvidenceIdentityReceiptPath"] = capability["independentEvidenceIdentityPath"]
 		},
 		"relative runtime output": func(value map[string]any) {
 			value["runtimeBinding"].(map[string]any)["materialPath"] = "runtime-binding.json"
@@ -391,7 +396,9 @@ func fullRunExecutionManifestFixture(t *testing.T) (string, func()) {
 			Capability: fullRunCapabilityDocument{
 				Namespace: "ok-observability", Timeout: "10m", CleanupTimeout: "1m", PollInterval: "1s",
 				PushgatewayImage: capabilityFixtureConfig().PushgatewayImage, LogEmitterImage: capabilityFixtureConfig().LogEmitterImage,
-				IndependentEvidencePath: filepath.Join(privateRoot, "observability-independent-evidence.json"), IndependentEvidenceKeyID: digestOf("d"),
+				IndependentEvidenceIdentityPath:        filepath.Join(privateRoot, "observability-independent-evidence-identity.json"),
+				IndependentEvidenceIdentityReceiptPath: filepath.Join(privateRoot, "observability-independent-evidence-identity-receipt.json"),
+				IndependentEvidencePath:                filepath.Join(privateRoot, "observability-independent-evidence.json"), IndependentEvidenceKeyID: digestOf("d"),
 			},
 			PollInterval: "1s", PollTimeout: "1m",
 		},

--- a/internal/runner/full_run_execution_test.go
+++ b/internal/runner/full_run_execution_test.go
@@ -129,10 +129,70 @@ func TestFullRunExecutionStopsBeforeSuffixWhenCapabilityAuthorityBindingFails(t 
 	}
 }
 
+func TestFullRunExecutionBindsEvidenceIdentityFromExactSixStagePrefix(t *testing.T) {
+	preRuntime := successfulFakeConcretePreRuntimeExecution(t)
+	binder := &recordingFullRunEvidenceIdentityBinder{}
+	config := testFullRunExecutionConfig()
+	config.EvidenceIdentityBinder = binder
+	postCalls := 0
+	execution, err := openFullRunExecution(config, fullRunExecutionFactories{
+		preRuntime: func(PreRuntimeExecutionConfig) (fullRunPreRuntimeExecution, error) { return preRuntime, nil },
+		postRuntime: func(PostRuntimeExecutionConfig) (PostRuntimeContinuation, error) {
+			postCalls++
+			if binder.calls != 1 || !reflect.DeepEqual(binder.prefix, preRuntime.prefix[:6]) {
+				t.Fatalf("suffix opened before exact evidence identity binding: %#v", binder)
+			}
+			return successfulFakePostRuntimeContinuation(), nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := execution.Run(context.Background())
+	if err != nil || receipt.State != "SUCCEEDED" || binder.calls != 1 || postCalls != 1 {
+		t.Fatalf("full run did not bind evidence identity once: receipt=%#v binder=%#v post=%d err=%v", receipt, binder, postCalls, err)
+	}
+}
+
+func TestFullRunExecutionStopsBeforeSuffixWhenEvidenceIdentityBindingFails(t *testing.T) {
+	preRuntime := successfulFakeConcretePreRuntimeExecution(t)
+	binder := &recordingFullRunEvidenceIdentityBinder{err: errors.New("identity rejected")}
+	config := testFullRunExecutionConfig()
+	config.EvidenceIdentityBinder = binder
+	postCalls := 0
+	execution, err := openFullRunExecution(config, fullRunExecutionFactories{
+		preRuntime: func(PreRuntimeExecutionConfig) (fullRunPreRuntimeExecution, error) { return preRuntime, nil },
+		postRuntime: func(PostRuntimeExecutionConfig) (PostRuntimeContinuation, error) {
+			postCalls++
+			return successfulFakePostRuntimeContinuation(), nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := execution.Run(context.Background())
+	if err == nil || receipt.State != "STOPPED" || receipt.StoppedAt != "target-credential" ||
+		len(receipt.Checkpoints) != 7 || binder.calls != 1 || postCalls != 0 {
+		t.Fatalf("failed evidence identity binding opened suffix: receipt=%#v binder=%#v post=%d err=%v", receipt, binder, postCalls, err)
+	}
+}
+
 type recordingFullRunWorkloadAuthorityBinder struct {
 	bound WorkloadAuthorityFileResolverConfig
 	calls int
 	err   error
+}
+
+type recordingFullRunEvidenceIdentityBinder struct {
+	prefix []StageReceiptSource
+	calls  int
+	err    error
+}
+
+func (binder *recordingFullRunEvidenceIdentityBinder) BindFullRunEvidenceIdentity(prefix []StageReceiptSource) error {
+	binder.calls++
+	binder.prefix = append([]StageReceiptSource(nil), prefix...)
+	return binder.err
 }
 
 func (binder *recordingFullRunWorkloadAuthorityBinder) BindFullRunWorkloadAuthority(config WorkloadAuthorityFileResolverConfig) error {

--- a/internal/runner/observability_evidence_identity.go
+++ b/internal/runner/observability_evidence_identity.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"os"
+	"sync"
 
 	"github.com/openkubes/ok-cluster/internal/contract"
 	"github.com/openkubes/ok-cluster/internal/digest"
@@ -50,6 +51,62 @@ type ObservabilityIndependentEvidenceIdentityMaterialConfig struct {
 	OutputPath                  string
 }
 
+type fullRunObservabilityEvidenceIdentityBinder struct {
+	manifest     VerifiedFullRunExecutionManifest
+	identityPath string
+	receiptPath  string
+
+	mu   sync.Mutex
+	used bool
+}
+
+func newFullRunObservabilityEvidenceIdentityBinder(manifest VerifiedFullRunExecutionManifest, identityPath, receiptPath string) FullRunEvidenceIdentityBinder {
+	return &fullRunObservabilityEvidenceIdentityBinder{manifest: manifest, identityPath: identityPath, receiptPath: receiptPath}
+}
+
+// BindFullRunEvidenceIdentity is invoked by the concrete full-run exactly
+// after Stage 1-7 succeeds. It deliberately replays only Stage 1-6 because
+// runtime binding, not target-access mutation, is the identity authority.
+func (binder *fullRunObservabilityEvidenceIdentityBinder) BindFullRunEvidenceIdentity(prefix []StageReceiptSource) error {
+	if binder == nil || !binder.manifest.verified || len(prefix) != 6 || binder.identityPath == "" || binder.receiptPath == "" || binder.identityPath == binder.receiptPath {
+		return errors.New("full-run observability evidence identity binder is invalid")
+	}
+	binder.mu.Lock()
+	if binder.used {
+		binder.mu.Unlock()
+		return errors.New("full-run observability evidence identity binder is single-use")
+	}
+	binder.used = true
+	binder.mu.Unlock()
+	document := binder.manifest.document
+	runtime, err := LoadRuntimeBindingMaterialFiles(RuntimeBindingMaterialFileConfig{
+		Bundle: StageResumeConfig{
+			PlanPath: document.Plan.Path, PlanExpected: fullRunPlanExpected(document.Plan.Expected),
+			Receipts: append([]StageReceiptSource(nil), prefix...),
+		},
+		MaterialPath: document.RuntimeBinding.MaterialPath, ReceiptPath: document.RuntimeBinding.ReceiptPath,
+	})
+	if err != nil {
+		return errors.New("load full-run runtime binding for evidence identity")
+	}
+	material, err := deriveObservabilityIndependentEvidenceIdentity(binder.manifest, runtime)
+	if err != nil {
+		return err
+	}
+	receipt, err := persistObservabilityIndependentEvidenceIdentity(material, binder.identityPath)
+	if err != nil || receipt.State != "WRITTEN_VERIFIED" {
+		return errors.New("persist full-run observability evidence identity")
+	}
+	receiptRaw, err := canonicalObservabilityIndependentEvidenceIdentityReceipt(receipt)
+	if err != nil {
+		return errors.New("canonicalize full-run observability evidence identity receipt")
+	}
+	if err := writeExclusivePrivateMaterial(binder.receiptPath, receiptRaw); err != nil {
+		return errors.New("persist full-run observability evidence identity receipt")
+	}
+	return nil
+}
+
 // MaterializeObservabilityIndependentEvidenceIdentity derives the evidence
 // authority identity from the verified full-run contract and the durable
 // lifecycle-produced runtime binding. It performs local reads and one
@@ -86,15 +143,26 @@ func MaterializeObservabilityIndependentEvidenceIdentity(config ObservabilityInd
 	if err != nil {
 		return receipt, err
 	}
+	return persistObservabilityIndependentEvidenceIdentity(material, config.OutputPath)
+}
+
+func persistObservabilityIndependentEvidenceIdentity(material ObservabilityIndependentEvidenceIdentityMaterial, outputPath string) (ObservabilityIndependentEvidenceIdentityReceipt, error) {
+	receipt := ObservabilityIndependentEvidenceIdentityReceipt{
+		Format: ObservabilityIndependentEvidenceIdentityReceiptFormat, State: "STOPPED_ZERO_WRITE",
+		PersistentMutationAllowed: false,
+	}
+	if err := validateRuntimeBindingOutputPath(outputPath); err != nil {
+		return receipt, errors.New("observability evidence identity destination is invalid")
+	}
 	raw, err := canonicalObservabilityIndependentEvidenceIdentity(material)
 	if err != nil || len(raw) == 0 || len(raw) > maximumObservabilityEvidenceIdentityBytes {
 		return receipt, errors.New("canonicalize observability evidence identity")
 	}
 	receipt.State = "STOPPED_PARTIAL_OR_UNKNOWN"
-	if err := writeExclusivePrivateMaterial(config.OutputPath, raw); err != nil {
+	if err := writeExclusivePrivateMaterial(outputPath, raw); err != nil {
 		return receipt, errors.New("materialize private observability evidence identity")
 	}
-	info, err := os.Lstat(config.OutputPath)
+	info, err := os.Lstat(outputPath)
 	if err != nil || !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 || info.Mode().Perm() != 0o600 || info.Size() != int64(len(raw)) {
 		return receipt, errors.New("observability evidence identity metadata differs after write")
 	}
@@ -186,3 +254,19 @@ func canonicalObservabilityIndependentEvidenceIdentity(material ObservabilityInd
 	}
 	return contract.JCS(value)
 }
+
+func canonicalObservabilityIndependentEvidenceIdentityReceipt(receipt ObservabilityIndependentEvidenceIdentityReceipt) ([]byte, error) {
+	raw, err := json.Marshal(receipt)
+	if err != nil {
+		return nil, err
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	var value any
+	if err := decoder.Decode(&value); err != nil {
+		return nil, err
+	}
+	return contract.JCS(value)
+}
+
+var _ FullRunEvidenceIdentityBinder = (*fullRunObservabilityEvidenceIdentityBinder)(nil)


### PR DESCRIPTION
## Outcome

Makes the independent Observability evidence identity an automatic, fail-closed part of the concrete full run.

- binds distinct private identity and redaction-safe receipt destinations in the verified full-run manifest
- after successful Stage 1-7, replays only the authoritative Stage 1-6 prefix and derives the identity from runtime binding
- persists identity and receipt create-only before Stage 8 can open
- stops before the post-runtime suffix if derivation or either write is uncertain
- adds no collector call, signature issuance, retry, cleanup or Kubernetes mutation surface

## Verification

- `go test -race ./internal/runner ./cmd/ok` (Linux container)
- `go test ./...` (Linux container)
- `go vet ./...` (Linux container)
- `git diff --check`
