### PR TITLE
feat(runner): wait for evidence identity handoff

### DIFF
--- a/cmd/ok/observability_evidence.go
+++ b/cmd/ok/observability_evidence.go
@@ -15,14 +15,20 @@ const observabilityEvidenceProductionOverhead = 10 * time.Second
 
 type observabilityEvidenceProductionConfig struct {
 	OutputPath, PrivateKeyPath                     string
-	IdentityPath, ExpectedIdentityDigest           string
+	IdentityPath, IdentityReceiptPath              string
+	ExpectedManifestDigest                         string
 	CollectorEndpoint, CollectorToken, CollectorCA string
 	CollectorCADigest                              string
+	IdentityPollInterval, IdentityWaitTimeout      time.Duration
 	ValidFor, Timeout                              time.Duration
 }
 
 var produceIndependentObservabilityEvidence = func(ctx context.Context, config observabilityEvidenceProductionConfig) (runner.ObservabilityIndependentEvidenceReceipt, error) {
-	identity, err := runner.LoadObservabilityIndependentEvidenceIdentity(config.IdentityPath, config.ExpectedIdentityDigest)
+	identity, err := runner.WaitForObservabilityIndependentEvidenceIdentity(ctx, runner.ObservabilityIndependentEvidenceIdentityWaitConfig{
+		IdentityPath: config.IdentityPath, ReceiptPath: config.IdentityReceiptPath,
+		ExpectedManifestDigest: config.ExpectedManifestDigest, PollInterval: config.IdentityPollInterval,
+		Timeout: config.IdentityWaitTimeout, Wait: runner.WaitWithTimer,
+	})
 	if err != nil {
 		return runner.ObservabilityIndependentEvidenceReceipt{}, errors.New("load runtime-bound observability evidence identity")
 	}
@@ -87,7 +93,10 @@ func runClusterStageEvidenceObservabilityProduce(ctx context.Context, arguments 
 	outputPath := flags.String("output", "", "absent private 0600 evidence destination")
 	privateKeyPath := flags.String("private-key", "", "private Ed25519 evidence-authority key")
 	identityPath := flags.String("identity-file", "", "private runtime-bound evidence identity")
-	expectedIdentityDigest := flags.String("expected-identity-digest", "", "exact private evidence identity digest")
+	identityReceiptPath := flags.String("identity-receipt-file", "", "redaction-safe runtime-bound evidence identity receipt")
+	expectedManifestDigest := flags.String("expected-manifest-digest", "", "exact full-run manifest digest")
+	identityPollInterval := flags.Duration("identity-poll-interval", 0, "private identity receipt polling interval")
+	identityWaitTimeout := flags.Duration("identity-wait-timeout", 0, "bounded private identity receipt wait")
 	collectorEndpoint := flags.String("collector-endpoint", "", "exact HTTPS independent-evidence authority endpoint")
 	collectorToken := flags.String("collector-token-file", "", "bounded evidence-authority bearer token file")
 	collectorCA := flags.String("collector-ca-file", "", "bounded evidence-authority CA file")
@@ -104,7 +113,9 @@ func runClusterStageEvidenceObservabilityProduce(ctx context.Context, arguments 
 	if !*produce {
 		return errors.New("independent Observability evidence production requires explicit --produce")
 	}
-	if *outputPath == "" || *privateKeyPath == "" || *identityPath == "" || !sha256DigestPattern.MatchString(*expectedIdentityDigest) ||
+	if *outputPath == "" || *privateKeyPath == "" || *identityPath == "" || *identityReceiptPath == "" ||
+		!sha256DigestPattern.MatchString(*expectedManifestDigest) || *identityPollInterval < time.Millisecond || *identityPollInterval > 30*time.Second ||
+		*identityWaitTimeout < time.Second || *identityWaitTimeout > fullRunExecutionTimeout ||
 		*collectorEndpoint == "" || *collectorToken == "" || *collectorCA == "" ||
 		!sha256DigestPattern.MatchString(*collectorCADigest) || *validFor < time.Minute || *validFor > 30*time.Minute ||
 		*timeout < time.Second || *timeout > 30*time.Minute {
@@ -112,11 +123,12 @@ func runClusterStageEvidenceObservabilityProduce(ctx context.Context, arguments 
 	}
 	config := observabilityEvidenceProductionConfig{
 		OutputPath: *outputPath, PrivateKeyPath: *privateKeyPath,
-		IdentityPath: *identityPath, ExpectedIdentityDigest: *expectedIdentityDigest,
+		IdentityPath: *identityPath, IdentityReceiptPath: *identityReceiptPath, ExpectedManifestDigest: *expectedManifestDigest,
+		IdentityPollInterval: *identityPollInterval, IdentityWaitTimeout: *identityWaitTimeout,
 		CollectorEndpoint: *collectorEndpoint, CollectorToken: *collectorToken, CollectorCA: *collectorCA,
 		CollectorCADigest: *collectorCADigest, ValidFor: *validFor, Timeout: *timeout,
 	}
-	bounded, cancel := context.WithTimeout(ctx, *timeout+observabilityEvidenceProductionOverhead)
+	bounded, cancel := context.WithTimeout(ctx, *identityWaitTimeout+*timeout+observabilityEvidenceProductionOverhead)
 	defer cancel()
 	receipt, produceErr := produceIndependentObservabilityEvidence(bounded, config)
 	if receipt.Format != "" {

--- a/cmd/ok/observability_evidence_test.go
+++ b/cmd/ok/observability_evidence_test.go
@@ -19,11 +19,12 @@ func TestObservabilityEvidenceProduceRunsOneBoundedIndependentCollection(t *test
 	produceIndependentObservabilityEvidence = func(ctx context.Context, config observabilityEvidenceProductionConfig) (runner.ObservabilityIndependentEvidenceReceipt, error) {
 		calls++
 		deadline, ok := ctx.Deadline()
-		if !ok || time.Until(deadline) <= 0 || time.Until(deadline) > config.Timeout+observabilityEvidenceProductionOverhead {
+		if !ok || time.Until(deadline) <= 0 || time.Until(deadline) > config.IdentityWaitTimeout+config.Timeout+observabilityEvidenceProductionOverhead {
 			t.Fatalf("evidence production was not bounded: deadline=%v config=%#v", deadline, config)
 		}
 		if config.OutputPath != "/private/evidence.json" || config.PrivateKeyPath != "/private/evidence.key" ||
-			config.IdentityPath != "/private/evidence-identity.json" || config.ExpectedIdentityDigest != testSHA("2") ||
+			config.IdentityPath != "/private/evidence-identity.json" || config.IdentityReceiptPath != "/private/evidence-identity-receipt.json" ||
+			config.ExpectedManifestDigest != testSHA("2") || config.IdentityPollInterval != time.Second || config.IdentityWaitTimeout != 30*time.Minute ||
 			config.CollectorEndpoint != "https://192.0.2.50:8443" || config.CollectorToken != "/private/collector-token" ||
 			config.CollectorCA != "/private/collector-ca" || config.CollectorCADigest != testSHA("3") ||
 			config.ValidFor != 10*time.Minute || config.Timeout != 2*time.Minute {
@@ -61,7 +62,9 @@ func TestObservabilityEvidenceProduceFailsClosedBeforeCollector(t *testing.T) {
 	valid := observabilityEvidenceProduceArguments()
 	for name, arguments := range map[string][]string{
 		"missing produce":     removeArgument(valid, "--produce"),
-		"bad identity digest": replaceArgument(valid, "--expected-identity-digest", "sha256:bad"),
+		"bad manifest digest": replaceArgument(valid, "--expected-manifest-digest", "sha256:bad"),
+		"short identity wait": replaceArgument(valid, "--identity-wait-timeout", "500ms"),
+		"slow identity poll":  replaceArgument(valid, "--identity-poll-interval", "31s"),
 		"bad CA digest":       replaceArgument(valid, "--collector-ca-digest", "sha256:bad"),
 		"short validity":      replaceArgument(valid, "--valid-for", "30s"),
 		"long collection":     replaceArgument(valid, "--timeout", "31m"),
@@ -98,7 +101,8 @@ func observabilityEvidenceProduceArguments() []string {
 	return []string{
 		"cluster", "stage", "evidence", "observability", "produce",
 		"--output", "/private/evidence.json", "--private-key", "/private/evidence.key",
-		"--identity-file", "/private/evidence-identity.json", "--expected-identity-digest", testSHA("2"),
+		"--identity-file", "/private/evidence-identity.json", "--identity-receipt-file", "/private/evidence-identity-receipt.json",
+		"--expected-manifest-digest", testSHA("2"), "--identity-poll-interval", "1s", "--identity-wait-timeout", "30m",
 		"--collector-endpoint", "https://192.0.2.50:8443", "--collector-token-file", "/private/collector-token",
 		"--collector-ca-file", "/private/collector-ca", "--collector-ca-digest", testSHA("3"),
 		"--valid-for", "10m", "--timeout", "2m", "--produce",

--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -3078,7 +3078,9 @@ ok cluster stage evidence observability produce \
   --output /private/observability-evidence.json \
   --private-key /private/observability-evidence.key \
   --identity-file /private/observability-evidence-identity.json \
-  --expected-identity-digest sha256:<exact derived identity> \
+  --identity-receipt-file /private/observability-evidence-identity-receipt.json \
+  --expected-manifest-digest sha256:<verified manifest identity> \
+  --identity-poll-interval 1s --identity-wait-timeout 30m \
   --collector-endpoint https://<authority> \
   --collector-token-file /private/collector-token \
   --collector-ca-file /private/collector-ca.crt \
@@ -3086,7 +3088,11 @@ ok cluster stage evidence observability produce \
   --valid-for 10m --timeout 2m --produce
 ```
 
-The command verifies the private canonical identity before opening the collector,
+The command may therefore start before the full runner. It waits boundedly for
+the redaction-safe receipt, obtains the dynamic identity digest from that
+receipt, correlates receipt and private identity back to the expected manifest,
+and only then opens the collector. An existing invalid receipt is terminal and
+is never polled past or retried. The command verifies the private canonical identity before opening the collector,
 uses the fixed HTTPS request path and standard profile, performs one bounded
 collection and delegates one create-only signed write to the existing
 single-use producer. It emits only the redaction-safe production receipt and

--- a/internal/runner/observability_evidence_identity.go
+++ b/internal/runner/observability_evidence_identity.go
@@ -2,10 +2,13 @@ package runner
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"os"
+	"path/filepath"
 	"sync"
+	"time"
 
 	"github.com/openkubes/ok-cluster/internal/contract"
 	"github.com/openkubes/ok-cluster/internal/digest"
@@ -49,6 +52,15 @@ type ObservabilityIndependentEvidenceIdentityMaterialConfig struct {
 	ReceiptPrefixPath           string
 	ExpectedReceiptPrefixDigest string
 	OutputPath                  string
+}
+
+type ObservabilityIndependentEvidenceIdentityWaitConfig struct {
+	IdentityPath           string
+	ReceiptPath            string
+	ExpectedManifestDigest string
+	PollInterval           time.Duration
+	Timeout                time.Duration
+	Wait                   ObservationWaiter
 }
 
 type fullRunObservabilityEvidenceIdentityBinder struct {
@@ -215,22 +227,110 @@ func deriveObservabilityIndependentEvidenceIdentity(manifest VerifiedFullRunExec
 // LoadObservabilityIndependentEvidenceIdentity reads one private identity and
 // returns only the typed producer input after canonical digest verification.
 func LoadObservabilityIndependentEvidenceIdentity(path, expectedDigest string) (ObservabilityCapabilityObservationIdentity, error) {
+	material, _, err := loadObservabilityIndependentEvidenceIdentityMaterial(path, expectedDigest)
+	if err != nil {
+		return ObservabilityCapabilityObservationIdentity{}, err
+	}
+	return observabilityObservationIdentity(material)
+}
+
+// WaitForObservabilityIndependentEvidenceIdentity lets a separately operated
+// authority start before the full runner. It waits only for the redaction-safe
+// receipt, then verifies the private identity through that receipt. Once a
+// receipt exists, any invalidity is terminal rather than retryable.
+func WaitForObservabilityIndependentEvidenceIdentity(ctx context.Context, config ObservabilityIndependentEvidenceIdentityWaitConfig) (ObservabilityCapabilityObservationIdentity, error) {
+	if config.Wait == nil || !stageReceiptPrefixDigestPattern.MatchString(config.ExpectedManifestDigest) ||
+		config.PollInterval < time.Millisecond || config.PollInterval > 30*time.Second ||
+		config.Timeout < time.Second || config.Timeout > 3*time.Hour || config.IdentityPath == config.ReceiptPath ||
+		validateObservabilityIdentityWaitPath(config.IdentityPath) != nil || validateObservabilityIdentityWaitPath(config.ReceiptPath) != nil {
+		return ObservabilityCapabilityObservationIdentity{}, errors.New("observability evidence identity wait binding is invalid")
+	}
+	bounded, cancel := context.WithTimeout(ctx, config.Timeout)
+	defer cancel()
+	for {
+		_, err := os.Lstat(config.ReceiptPath)
+		if err == nil {
+			return LoadObservabilityIndependentEvidenceIdentityFromReceipt(config.IdentityPath, config.ReceiptPath, config.ExpectedManifestDigest)
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			return ObservabilityCapabilityObservationIdentity{}, errors.New("inspect observability evidence identity receipt")
+		}
+		if err := config.Wait(bounded, config.PollInterval); err != nil {
+			return ObservabilityCapabilityObservationIdentity{}, errors.New("wait for observability evidence identity receipt")
+		}
+	}
+}
+
+func validateObservabilityIdentityWaitPath(path string) error {
+	if path == "" || !filepath.IsAbs(path) || filepath.Clean(path) != path || filepath.Base(path) == "." || filepath.Base(path) == string(filepath.Separator) {
+		return errors.New("observability evidence identity wait path is invalid")
+	}
+	parent, err := os.Lstat(filepath.Dir(path))
+	if err != nil || !parent.IsDir() || parent.Mode()&os.ModeSymlink != 0 || parent.Mode().Perm()&0o077 != 0 {
+		return errors.New("observability evidence identity wait directory is not private")
+	}
+	info, err := os.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil || !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 || info.Mode().Perm()&0o077 != 0 {
+		return errors.New("observability evidence identity wait file is unsafe")
+	}
+	return nil
+}
+
+// LoadObservabilityIndependentEvidenceIdentityFromReceipt verifies the
+// dynamic identity digest and source bindings without accepting them as CLI
+// values. Both files are local private handoff artifacts.
+func LoadObservabilityIndependentEvidenceIdentityFromReceipt(identityPath, receiptPath, expectedManifestDigest string) (ObservabilityCapabilityObservationIdentity, error) {
+	if !stageReceiptPrefixDigestPattern.MatchString(expectedManifestDigest) ||
+		validateObservabilityEvidenceFile(receiptPath, maximumObservabilityEvidenceIdentityBytes, true) != nil {
+		return ObservabilityCapabilityObservationIdentity{}, errors.New("observability evidence identity receipt is invalid")
+	}
+	receiptRaw, err := readBoundedRegular(receiptPath, maximumObservabilityEvidenceIdentityBytes)
+	if err != nil {
+		return ObservabilityCapabilityObservationIdentity{}, errors.New("read observability evidence identity receipt")
+	}
+	var receipt ObservabilityIndependentEvidenceIdentityReceipt
+	if err := jsonstrict.Decode(receiptRaw, &receipt); err != nil {
+		return ObservabilityCapabilityObservationIdentity{}, errors.New("decode strict observability evidence identity receipt")
+	}
+	canonicalReceipt, err := canonicalObservabilityIndependentEvidenceIdentityReceipt(receipt)
+	if err != nil || !bytes.Equal(canonicalReceipt, receiptRaw) || receipt.Format != ObservabilityIndependentEvidenceIdentityReceiptFormat ||
+		receipt.State != "WRITTEN_VERIFIED" || receipt.ManifestDigest != expectedManifestDigest || receipt.PersistentMutationAllowed ||
+		receipt.FileMode != "0600" || receipt.FileSize <= 0 || !stageReceiptPrefixDigestPattern.MatchString(receipt.RuntimeBindingDigest) ||
+		!stageReceiptPrefixDigestPattern.MatchString(receipt.TargetClusterUIDDigest) || !stageReceiptPrefixDigestPattern.MatchString(receipt.IdentityDigest) {
+		return ObservabilityCapabilityObservationIdentity{}, errors.New("observability evidence identity receipt is not canonical and bound")
+	}
+	material, raw, err := loadObservabilityIndependentEvidenceIdentityMaterial(identityPath, receipt.IdentityDigest)
+	if err != nil || len(raw) != receipt.FileSize || material.ManifestDigest != receipt.ManifestDigest ||
+		material.RuntimeBindingDigest != receipt.RuntimeBindingDigest || digest.SHA256([]byte(material.TargetClusterUID)) != receipt.TargetClusterUIDDigest {
+		return ObservabilityCapabilityObservationIdentity{}, errors.New("observability evidence identity differs from receipt")
+	}
+	return observabilityObservationIdentity(material)
+}
+
+func loadObservabilityIndependentEvidenceIdentityMaterial(path, expectedDigest string) (ObservabilityIndependentEvidenceIdentityMaterial, []byte, error) {
 	if !stageReceiptPrefixDigestPattern.MatchString(expectedDigest) || validateObservabilityEvidenceFile(path, maximumObservabilityEvidenceIdentityBytes, true) != nil {
-		return ObservabilityCapabilityObservationIdentity{}, errors.New("observability evidence identity file is invalid")
+		return ObservabilityIndependentEvidenceIdentityMaterial{}, nil, errors.New("observability evidence identity file is invalid")
 	}
 	raw, err := readBoundedRegular(path, maximumObservabilityEvidenceIdentityBytes)
 	if err != nil || digest.SHA256(raw) != expectedDigest {
-		return ObservabilityCapabilityObservationIdentity{}, errors.New("observability evidence identity digest differs")
+		return ObservabilityIndependentEvidenceIdentityMaterial{}, nil, errors.New("observability evidence identity digest differs")
 	}
 	var material ObservabilityIndependentEvidenceIdentityMaterial
 	if err := jsonstrict.Decode(raw, &material); err != nil {
-		return ObservabilityCapabilityObservationIdentity{}, errors.New("decode strict observability evidence identity")
+		return ObservabilityIndependentEvidenceIdentityMaterial{}, nil, errors.New("decode strict observability evidence identity")
 	}
 	canonical, err := canonicalObservabilityIndependentEvidenceIdentity(material)
 	if err != nil || !bytes.Equal(canonical, raw) || material.Format != ObservabilityIndependentEvidenceIdentityFormat || material.State != "RUNTIME_BOUND" ||
 		!stageReceiptPrefixDigestPattern.MatchString(material.ManifestDigest) || !stageReceiptPrefixDigestPattern.MatchString(material.RuntimeBindingDigest) {
-		return ObservabilityCapabilityObservationIdentity{}, errors.New("observability evidence identity is not canonical and bound")
+		return ObservabilityIndependentEvidenceIdentityMaterial{}, nil, errors.New("observability evidence identity is not canonical and bound")
 	}
+	return material, raw, nil
+}
+
+func observabilityObservationIdentity(material ObservabilityIndependentEvidenceIdentityMaterial) (ObservabilityCapabilityObservationIdentity, error) {
 	identity := ObservabilityCapabilityObservationIdentity{
 		RunID: material.RunID, TargetClusterUID: material.TargetClusterUID,
 		FixtureDigest: material.FixtureDigest, ProfileDigest: material.ProfileDigest,

--- a/internal/runner/observability_evidence_identity_test.go
+++ b/internal/runner/observability_evidence_identity_test.go
@@ -1,10 +1,12 @@
 package runner
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/openkubes/ok-cluster/internal/digest"
 )
@@ -78,6 +80,85 @@ func TestLoadObservabilityIndependentEvidenceIdentityIsPrivateCanonicalAndDigest
 	}
 	if _, err := LoadObservabilityIndependentEvidenceIdentity(link, digest.SHA256(raw)); err == nil {
 		t.Fatal("symlink identity was accepted")
+	}
+}
+
+func TestObservabilityIndependentEvidenceIdentityReceiptBindsDynamicIdentity(t *testing.T) {
+	root := t.TempDir()
+	if err := os.Chmod(root, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	identityPath := filepath.Join(root, "identity.json")
+	receiptPath := filepath.Join(root, "identity-receipt.json")
+	material := evidenceIdentityMaterial()
+	receipt, err := persistObservabilityIndependentEvidenceIdentity(material, identityPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receiptRaw, err := canonicalObservabilityIndependentEvidenceIdentityReceipt(receipt)
+	if err != nil || os.WriteFile(receiptPath, receiptRaw, 0o600) != nil {
+		t.Fatal("write identity receipt fixture")
+	}
+	identity, err := LoadObservabilityIndependentEvidenceIdentityFromReceipt(identityPath, receiptPath, material.ManifestDigest)
+	if err != nil || identity.RunID != material.RunID || identity.TargetClusterUID != material.TargetClusterUID {
+		t.Fatalf("receipt did not bind private identity: identity=%#v err=%v", identity, err)
+	}
+	if _, err := LoadObservabilityIndependentEvidenceIdentityFromReceipt(identityPath, receiptPath, evidenceIdentitySHA("9")); err == nil {
+		t.Fatal("foreign manifest identity was accepted")
+	}
+}
+
+func TestWaitForObservabilityIndependentEvidenceIdentityIsBoundedAndFailClosed(t *testing.T) {
+	root := t.TempDir()
+	if err := os.Chmod(root, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	identityPath := filepath.Join(root, "identity.json")
+	receiptPath := filepath.Join(root, "identity-receipt.json")
+	material := evidenceIdentityMaterial()
+	waits := 0
+	waiter := func(_ context.Context, duration time.Duration) error {
+		waits++
+		if duration != time.Millisecond || waits != 1 {
+			t.Fatalf("unexpected identity wait: duration=%s waits=%d", duration, waits)
+		}
+		receipt, err := persistObservabilityIndependentEvidenceIdentity(material, identityPath)
+		if err != nil {
+			return err
+		}
+		raw, err := canonicalObservabilityIndependentEvidenceIdentityReceipt(receipt)
+		if err != nil {
+			return err
+		}
+		return os.WriteFile(receiptPath, raw, 0o600)
+	}
+	identity, err := WaitForObservabilityIndependentEvidenceIdentity(context.Background(), ObservabilityIndependentEvidenceIdentityWaitConfig{
+		IdentityPath: identityPath, ReceiptPath: receiptPath, ExpectedManifestDigest: material.ManifestDigest,
+		PollInterval: time.Millisecond, Timeout: time.Second, Wait: waiter,
+	})
+	if err != nil || waits != 1 || identity.FixtureDigest != material.FixtureDigest {
+		t.Fatalf("bounded identity wait failed: identity=%#v waits=%d err=%v", identity, waits, err)
+	}
+	if err := os.WriteFile(receiptPath, []byte("tampered"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := WaitForObservabilityIndependentEvidenceIdentity(context.Background(), ObservabilityIndependentEvidenceIdentityWaitConfig{
+		IdentityPath: identityPath, ReceiptPath: receiptPath, ExpectedManifestDigest: material.ManifestDigest,
+		PollInterval: time.Millisecond, Timeout: time.Second, Wait: func(context.Context, time.Duration) error {
+			t.Fatal("invalid existing receipt was retried")
+			return nil
+		},
+	}); err == nil {
+		t.Fatal("invalid existing receipt was accepted")
+	}
+}
+
+func evidenceIdentityMaterial() ObservabilityIndependentEvidenceIdentityMaterial {
+	return ObservabilityIndependentEvidenceIdentityMaterial{
+		Format: ObservabilityIndependentEvidenceIdentityFormat, State: "RUNTIME_BOUND",
+		ManifestDigest: evidenceIdentitySHA("1"), RuntimeBindingDigest: evidenceIdentitySHA("2"),
+		RunID: "ok147-0123456789abcdef01234567", TargetClusterUID: "cluster-uid-runtime-a",
+		FixtureDigest: evidenceIdentitySHA("3"), ProfileDigest: evidenceIdentitySHA("4"),
 	}
 }
 


### PR DESCRIPTION
## Outcome

Allows the separately operated Observability evidence authority to start before the concrete full run without manually copying runtime identities.

- boundedly waits for the redaction-safe full-run identity receipt
- obtains the dynamic private identity digest from that receipt
- correlates receipt and private identity to the expected manifest, runtime binding and target UID digest
- treats any existing invalid receipt as terminal instead of polling or retrying past it
- replaces the producer's manually supplied identity digest with receipt + expected manifest binding
- performs no Kubernetes request or infrastructure mutation while waiting

## Verification

- `go test -race ./internal/runner ./cmd/ok` (Linux container)
- `go test ./...` (Linux container)
- `go vet ./...` (Linux container)
- `git diff --check`
