### PR TITLE
feat(runner): package independent evidence authority

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -3100,6 +3100,25 @@ has no Kubernetes credential, arbitrary probe, overwrite or retry surface.
 Operating the external collector and securely injecting its short-lived token
 and Ed25519 private key remain separate evidence-authority responsibilities.
 
+The evidence-authority inputs now also have a deterministic private activation
+package. Its offline builder verifies the exact full-run manifest, proves that
+the private Ed25519 key matches the public key ID pinned by that manifest,
+opens the fixed TLS collector binding without making a request, and binds the
+CA digest plus collection, validity and identity-wait bounds. It emits exactly
+one immutable opaque Secret object containing a canonical activation document,
+the private signing key, collector token and collector CA. Its public receipt
+contains only object, activation, manifest, key, collector-authority and CA
+digests; it contains no endpoint, credential or private path.
+
+The activation document fixes three paths in a private shared in-Pod handoff:
+the runtime-derived identity, its redaction-safe receipt and the signed evidence
+output. The remaining authority files live under a separate evidence-authority
+mount. This permits a future two-container full-run Pod in which the executor
+and issuer share only the handoff `emptyDir`: the executor receives no signing
+key or collector token, while the issuer receives no Kubernetes lifecycle or
+GitOps credential. Package construction remains offline, creates no Kubernetes
+object and grants no launch, retry, repair or reconciliation authority.
+
 The post-runtime authorization resolver closes the next authority boundary.
 After a predecessor receipt is durable, it derives one canonical,
 redaction-safe request from the verified cursor, including the exact Plan,

--- a/internal/runner/observability_evidence_authority_package.go
+++ b/internal/runner/observability_evidence_authority_package.go
@@ -1,0 +1,299 @@
+package runner
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/contract"
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/jsonstrict"
+)
+
+const (
+	ObservabilityEvidenceAuthorityActivationFormat = "ok147-observability-evidence-authority-activation/v1"
+	ObservabilityEvidenceAuthorityPackageFormat    = "ok147-observability-evidence-authority-package/v1"
+	maximumObservabilityEvidenceAuthorityBytes     = 950 * 1024
+
+	observabilityEvidenceAuthorityRoot           = "/var/run/openkubes/evidence-authority"
+	observabilityEvidenceAuthorityHandoffRoot    = "/var/run/openkubes/handoff"
+	observabilityEvidenceAuthorityActivationKey  = "activation.json"
+	observabilityEvidenceAuthorityPrivateKeyKey  = "evidence-authority.key"
+	observabilityEvidenceAuthorityCollectorToken = "collector-token"
+	observabilityEvidenceAuthorityCollectorCA    = "collector-ca.crt"
+)
+
+// ObservabilityEvidenceAuthorityPackageConfig binds the secret-bearing half
+// of the independent evidence producer. Package construction is local-only;
+// the resulting Secret is intended for a container that does not receive any
+// lifecycle or Kubernetes credential.
+type ObservabilityEvidenceAuthorityPackageConfig struct {
+	ManifestPath         string
+	ActivationSecret     string
+	PrivateKeyPath       string
+	CollectorEndpoint    string
+	CollectorTokenPath   string
+	CollectorCAPath      string
+	CollectorCADigest    string
+	IdentityPollInterval time.Duration
+	IdentityWaitTimeout  time.Duration
+	EvidenceValidFor     time.Duration
+	CollectionTimeout    time.Duration
+}
+
+type ObservabilityEvidenceAuthorityActivation struct {
+	Format                 string `json:"format"`
+	State                  string `json:"state"`
+	ExpectedManifestDigest string `json:"expectedManifestDigest"`
+	IdentityPath           string `json:"identityPath"`
+	IdentityReceiptPath    string `json:"identityReceiptPath"`
+	EvidenceOutputPath     string `json:"evidenceOutputPath"`
+	PrivateKeyPath         string `json:"privateKeyPath"`
+	CollectorEndpoint      string `json:"collectorEndpoint"`
+	CollectorTokenPath     string `json:"collectorTokenPath"`
+	CollectorCAPath        string `json:"collectorCaPath"`
+	CollectorCADigest      string `json:"collectorCaDigest"`
+	IdentityPollInterval   string `json:"identityPollInterval"`
+	IdentityWaitTimeout    string `json:"identityWaitTimeout"`
+	EvidenceValidity       string `json:"evidenceValidity"`
+	CollectionTimeout      string `json:"collectionTimeout"`
+}
+
+type ObservabilityEvidenceAuthorityPackageReceipt struct {
+	Format                   string   `json:"format"`
+	State                    string   `json:"state"`
+	PackageDigest            string   `json:"packageDigest"`
+	ActivationSecret         string   `json:"activationSecret"`
+	SecretObjectDigest       string   `json:"secretObjectDigest"`
+	ActivationDigest         string   `json:"activationDigest"`
+	ManifestDigest           string   `json:"manifestDigest"`
+	EvidenceKeyID            string   `json:"evidenceKeyId"`
+	CollectorAuthorityDigest string   `json:"collectorAuthorityDigest"`
+	CollectorCADigest        string   `json:"collectorCaDigest"`
+	PrivateFileCount         int      `json:"privateFileCount"`
+	ObjectKinds              []string `json:"objectKinds"`
+	MutationAllowed          bool     `json:"mutationAllowed"`
+}
+
+type VerifiedObservabilityEvidenceAuthorityPackage struct {
+	raw      []byte
+	receipt  ObservabilityEvidenceAuthorityPackageReceipt
+	verified bool
+}
+
+// BuildObservabilityEvidenceAuthorityPackage creates one immutable private
+// Secret object. It verifies the key pair, collector TLS material, exact
+// full-run identity and all bounds without contacting either Kubernetes or the
+// collector. The dynamic Cluster UID remains absent and arrives later through
+// the shared private handoff.
+func BuildObservabilityEvidenceAuthorityPackage(config ObservabilityEvidenceAuthorityPackageConfig) (VerifiedObservabilityEvidenceAuthorityPackage, error) {
+	if !submissionStageInputNamePattern.MatchString(config.ActivationSecret) || len(config.ActivationSecret) > 63 ||
+		!strings.HasPrefix(config.ActivationSecret, "ok147-") {
+		return VerifiedObservabilityEvidenceAuthorityPackage{}, errors.New("observability evidence authority Secret name is invalid")
+	}
+	if config.IdentityPollInterval < time.Millisecond || config.IdentityPollInterval > 30*time.Second ||
+		config.IdentityWaitTimeout < time.Second || config.IdentityWaitTimeout > 3*time.Hour ||
+		config.EvidenceValidFor < minimumObservabilityIndependentEvidenceValidity || config.EvidenceValidFor > maximumObservabilityIndependentEvidenceWindow ||
+		config.CollectionTimeout < time.Second || config.CollectionTimeout > maximumObservabilityIndependentEvidenceWindow {
+		return VerifiedObservabilityEvidenceAuthorityPackage{}, errors.New("observability evidence authority time bounds are invalid")
+	}
+	manifest, manifestReceipt, err := LoadFullRunExecutionManifest(config.ManifestPath)
+	if err != nil || !manifest.verified || manifestReceipt.State != "VERIFIED" || manifestReceipt.MutationAllowed {
+		return VerifiedObservabilityEvidenceAuthorityPackage{}, errors.New("verify observability evidence authority full-run manifest")
+	}
+	privateKeyRaw, keyID, err := loadObservabilityEvidenceAuthorityPrivateKey(config.PrivateKeyPath)
+	if err != nil || keyID != manifest.document.PlatformObservation.Capability.IndependentEvidenceKeyID {
+		return VerifiedObservabilityEvidenceAuthorityPackage{}, errors.New("observability evidence authority key differs from full-run manifest")
+	}
+	if err := validateObservabilityEvidenceFile(config.CollectorTokenPath, maximumTokenBytes, true); err != nil {
+		return VerifiedObservabilityEvidenceAuthorityPackage{}, errors.New("observability evidence authority collector credential is invalid")
+	}
+	tokenRaw, err := readBoundedRegular(config.CollectorTokenPath, maximumTokenBytes)
+	if err != nil {
+		return VerifiedObservabilityEvidenceAuthorityPackage{}, errors.New("read observability evidence authority collector credential")
+	}
+	caRaw, err := readBoundedRegular(config.CollectorCAPath, maximumCABytes)
+	if err != nil || digest.SHA256(caRaw) != config.CollectorCADigest {
+		return VerifiedObservabilityEvidenceAuthorityPackage{}, errors.New("observability evidence authority collector CA differs")
+	}
+	if _, err := OpenHTTPObservabilityIndependentEvidenceCollector(HTTPObservabilityIndependentEvidenceCollectorConfig{
+		Endpoint: config.CollectorEndpoint, TokenFile: config.CollectorTokenPath,
+		CAFile: config.CollectorCAPath, CABundleDigest: config.CollectorCADigest,
+	}); err != nil {
+		return VerifiedObservabilityEvidenceAuthorityPackage{}, errors.New("verify observability evidence authority collector binding")
+	}
+	activation := ObservabilityEvidenceAuthorityActivation{
+		Format: ObservabilityEvidenceAuthorityActivationFormat, State: "BOUND",
+		ExpectedManifestDigest: manifestReceipt.ManifestDigest,
+		IdentityPath:           observabilityEvidenceAuthorityHandoffRoot + "/observability-evidence-identity.json",
+		IdentityReceiptPath:    observabilityEvidenceAuthorityHandoffRoot + "/observability-evidence-identity-receipt.json",
+		EvidenceOutputPath:     observabilityEvidenceAuthorityHandoffRoot + "/observability-evidence.json",
+		PrivateKeyPath:         observabilityEvidenceAuthorityRoot + "/" + observabilityEvidenceAuthorityPrivateKeyKey,
+		CollectorEndpoint:      config.CollectorEndpoint,
+		CollectorTokenPath:     observabilityEvidenceAuthorityRoot + "/" + observabilityEvidenceAuthorityCollectorToken,
+		CollectorCAPath:        observabilityEvidenceAuthorityRoot + "/" + observabilityEvidenceAuthorityCollectorCA,
+		CollectorCADigest:      config.CollectorCADigest,
+		IdentityPollInterval:   config.IdentityPollInterval.String(), IdentityWaitTimeout: config.IdentityWaitTimeout.String(),
+		EvidenceValidity: config.EvidenceValidFor.String(), CollectionTimeout: config.CollectionTimeout.String(),
+	}
+	activationRaw, err := canonicalObservabilityEvidenceAuthorityActivation(activation)
+	if err != nil {
+		return VerifiedObservabilityEvidenceAuthorityPackage{}, err
+	}
+	binaryData := map[string]string{
+		observabilityEvidenceAuthorityActivationKey:  base64.StdEncoding.EncodeToString(activationRaw),
+		observabilityEvidenceAuthorityPrivateKeyKey:  base64.StdEncoding.EncodeToString(privateKeyRaw),
+		observabilityEvidenceAuthorityCollectorToken: base64.StdEncoding.EncodeToString(tokenRaw),
+		observabilityEvidenceAuthorityCollectorCA:    base64.StdEncoding.EncodeToString(caRaw),
+	}
+	secret := postRuntimeActivationSecret{
+		APIVersion: "v1", Kind: "Secret", Immutable: true, Type: "Opaque", BinaryData: binaryData,
+		Metadata: postRuntimeActivationSecretMetadata{
+			Name: config.ActivationSecret, Namespace: submissionStageInputNamespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/name": "ok-cluster-evidence-authority", "openkubes.io/stage-id": "independent-evidence",
+			},
+			Annotations: map[string]string{
+				"openkubes.io/manifest-digest":   manifestReceipt.ManifestDigest,
+				"openkubes.io/activation-digest": digest.SHA256(activationRaw),
+			},
+		},
+	}
+	raw, err := json.Marshal(secret)
+	if err != nil || len(raw) == 0 || len(raw) > maximumObservabilityEvidenceAuthorityBytes {
+		return VerifiedObservabilityEvidenceAuthorityPackage{}, errors.New("observability evidence authority Secret exceeds bounded object size")
+	}
+	receipt := ObservabilityEvidenceAuthorityPackageReceipt{
+		Format: ObservabilityEvidenceAuthorityPackageFormat, State: "VERIFIED",
+		PackageDigest: digest.SHA256(raw), ActivationSecret: config.ActivationSecret,
+		SecretObjectDigest: digest.SHA256(raw), ActivationDigest: digest.SHA256(activationRaw),
+		ManifestDigest: manifestReceipt.ManifestDigest, EvidenceKeyID: keyID,
+		CollectorAuthorityDigest: digest.SHA256([]byte(config.CollectorEndpoint)), CollectorCADigest: config.CollectorCADigest,
+		PrivateFileCount: 4, ObjectKinds: []string{"Secret"}, MutationAllowed: false,
+	}
+	return VerifiedObservabilityEvidenceAuthorityPackage{raw: raw, receipt: receipt, verified: true}, nil
+}
+
+func (packaged VerifiedObservabilityEvidenceAuthorityPackage) PrivateBytes() ([]byte, error) {
+	if err := verifyObservabilityEvidenceAuthorityPackage(packaged); err != nil {
+		return nil, errors.New("observability evidence authority package was not produced by verification")
+	}
+	return append([]byte(nil), packaged.raw...), nil
+}
+
+func (packaged VerifiedObservabilityEvidenceAuthorityPackage) Receipt() (ObservabilityEvidenceAuthorityPackageReceipt, error) {
+	if err := verifyObservabilityEvidenceAuthorityPackage(packaged); err != nil {
+		return ObservabilityEvidenceAuthorityPackageReceipt{}, errors.New("observability evidence authority package was not produced by verification")
+	}
+	receipt := packaged.receipt
+	receipt.ObjectKinds = append([]string(nil), packaged.receipt.ObjectKinds...)
+	return receipt, nil
+}
+
+func verifyObservabilityEvidenceAuthorityPackage(packaged VerifiedObservabilityEvidenceAuthorityPackage) error {
+	receipt := packaged.receipt
+	if !packaged.verified || receipt.Format != ObservabilityEvidenceAuthorityPackageFormat || receipt.State != "VERIFIED" ||
+		receipt.MutationAllowed || len(packaged.raw) == 0 || digest.SHA256(packaged.raw) != receipt.PackageDigest ||
+		receipt.SecretObjectDigest != receipt.PackageDigest || !stageReceiptPrefixDigestPattern.MatchString(receipt.ActivationDigest) ||
+		!stageReceiptPrefixDigestPattern.MatchString(receipt.ManifestDigest) || !stageReceiptPrefixDigestPattern.MatchString(receipt.EvidenceKeyID) ||
+		!stageReceiptPrefixDigestPattern.MatchString(receipt.CollectorAuthorityDigest) || !stageReceiptPrefixDigestPattern.MatchString(receipt.CollectorCADigest) ||
+		receipt.PrivateFileCount != 4 || len(receipt.ObjectKinds) != 1 || receipt.ObjectKinds[0] != "Secret" {
+		return errors.New("observability evidence authority package identity is incomplete")
+	}
+	var secret postRuntimeActivationSecret
+	if err := json.Unmarshal(packaged.raw, &secret); err != nil || secret.Kind != "Secret" || !secret.Immutable || secret.Type != "Opaque" ||
+		secret.Metadata.Name != receipt.ActivationSecret || secret.Metadata.Namespace != submissionStageInputNamespace ||
+		secret.Metadata.Labels["app.kubernetes.io/name"] != "ok-cluster-evidence-authority" ||
+		secret.Metadata.Labels["openkubes.io/stage-id"] != "independent-evidence" ||
+		secret.Metadata.Annotations["openkubes.io/manifest-digest"] != receipt.ManifestDigest ||
+		secret.Metadata.Annotations["openkubes.io/activation-digest"] != receipt.ActivationDigest ||
+		len(secret.BinaryData) != receipt.PrivateFileCount {
+		return errors.New("observability evidence authority Secret identity differs")
+	}
+	activationRaw, err := base64.StdEncoding.DecodeString(secret.BinaryData[observabilityEvidenceAuthorityActivationKey])
+	if err != nil || digest.SHA256(activationRaw) != receipt.ActivationDigest {
+		return errors.New("observability evidence authority activation identity differs")
+	}
+	var activation ObservabilityEvidenceAuthorityActivation
+	if err := jsonstrict.Decode(activationRaw, &activation); err != nil {
+		return errors.New("decode strict observability evidence authority activation")
+	}
+	canonical, err := canonicalObservabilityEvidenceAuthorityActivation(activation)
+	if err != nil || !bytes.Equal(canonical, activationRaw) || activation.ExpectedManifestDigest != receipt.ManifestDigest ||
+		activation.CollectorCADigest != receipt.CollectorCADigest || digest.SHA256([]byte(activation.CollectorEndpoint)) != receipt.CollectorAuthorityDigest {
+		return errors.New("observability evidence authority activation differs from receipt")
+	}
+	privateKeyRaw, err := base64.StdEncoding.DecodeString(secret.BinaryData[observabilityEvidenceAuthorityPrivateKeyKey])
+	if err != nil {
+		return errors.New("decode observability evidence authority private key")
+	}
+	encoded := strings.TrimSuffix(string(privateKeyRaw), "\n")
+	privateKey, err := base64.StdEncoding.Strict().DecodeString(encoded)
+	if err != nil || len(privateKey) != ed25519.PrivateKeySize ||
+		digest.SHA256(ed25519.PrivateKey(privateKey).Public().(ed25519.PublicKey)) != receipt.EvidenceKeyID {
+		return errors.New("observability evidence authority key identity differs")
+	}
+	tokenRaw, tokenErr := base64.StdEncoding.DecodeString(secret.BinaryData[observabilityEvidenceAuthorityCollectorToken])
+	caRaw, caErr := base64.StdEncoding.DecodeString(secret.BinaryData[observabilityEvidenceAuthorityCollectorCA])
+	if tokenErr != nil || len(tokenRaw) == 0 || caErr != nil || digest.SHA256(caRaw) != receipt.CollectorCADigest {
+		return errors.New("observability evidence authority collector material differs")
+	}
+	return nil
+}
+
+func loadObservabilityEvidenceAuthorityPrivateKey(path string) ([]byte, string, error) {
+	if err := validateObservabilityEvidenceFile(path, maximumObservabilityEvidencePrivateKeyBytes, true); err != nil {
+		return nil, "", err
+	}
+	raw, err := readBoundedRegular(path, maximumObservabilityEvidencePrivateKeyBytes)
+	if err != nil {
+		return nil, "", err
+	}
+	encoded := strings.TrimSuffix(string(raw), "\n")
+	privateRaw, err := base64.StdEncoding.Strict().DecodeString(encoded)
+	if err != nil || len(privateRaw) != ed25519.PrivateKeySize || base64.StdEncoding.EncodeToString(privateRaw) != encoded {
+		return nil, "", errors.New("observability evidence authority private key encoding is invalid")
+	}
+	privateKey := append(ed25519.PrivateKey(nil), privateRaw...)
+	return raw, digest.SHA256(privateKey.Public().(ed25519.PublicKey)), nil
+}
+
+func canonicalObservabilityEvidenceAuthorityActivation(activation ObservabilityEvidenceAuthorityActivation) ([]byte, error) {
+	if activation.Format != ObservabilityEvidenceAuthorityActivationFormat || activation.State != "BOUND" ||
+		!stageReceiptPrefixDigestPattern.MatchString(activation.ExpectedManifestDigest) ||
+		!stageReceiptPrefixDigestPattern.MatchString(activation.CollectorCADigest) ||
+		activation.IdentityPath != observabilityEvidenceAuthorityHandoffRoot+"/observability-evidence-identity.json" ||
+		activation.IdentityReceiptPath != observabilityEvidenceAuthorityHandoffRoot+"/observability-evidence-identity-receipt.json" ||
+		activation.EvidenceOutputPath != observabilityEvidenceAuthorityHandoffRoot+"/observability-evidence.json" ||
+		activation.PrivateKeyPath != observabilityEvidenceAuthorityRoot+"/"+observabilityEvidenceAuthorityPrivateKeyKey ||
+		activation.CollectorTokenPath != observabilityEvidenceAuthorityRoot+"/"+observabilityEvidenceAuthorityCollectorToken ||
+		activation.CollectorCAPath != observabilityEvidenceAuthorityRoot+"/"+observabilityEvidenceAuthorityCollectorCA ||
+		activation.CollectorEndpoint == "" {
+		return nil, errors.New("observability evidence authority activation identity is invalid")
+	}
+	pollInterval, pollErr := time.ParseDuration(activation.IdentityPollInterval)
+	waitTimeout, waitErr := time.ParseDuration(activation.IdentityWaitTimeout)
+	validFor, validErr := time.ParseDuration(activation.EvidenceValidity)
+	collectionTimeout, collectionErr := time.ParseDuration(activation.CollectionTimeout)
+	if pollErr != nil || pollInterval < time.Millisecond || pollInterval > 30*time.Second ||
+		waitErr != nil || waitTimeout < time.Second || waitTimeout > 3*time.Hour ||
+		validErr != nil || validFor < minimumObservabilityIndependentEvidenceValidity || validFor > maximumObservabilityIndependentEvidenceWindow ||
+		collectionErr != nil || collectionTimeout < time.Second || collectionTimeout > maximumObservabilityIndependentEvidenceWindow {
+		return nil, errors.New("observability evidence authority activation bounds are invalid")
+	}
+	raw, err := json.Marshal(activation)
+	if err != nil {
+		return nil, err
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	var value any
+	if err := decoder.Decode(&value); err != nil {
+		return nil, err
+	}
+	return contract.JCS(value)
+}

--- a/internal/runner/observability_evidence_authority_package_test.go
+++ b/internal/runner/observability_evidence_authority_package_test.go
@@ -1,0 +1,188 @@
+package runner
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+func TestBuildObservabilityEvidenceAuthorityPackageBindsPrivateAuthority(t *testing.T) {
+	config, cleanup := observabilityEvidenceAuthorityPackageFixture(t)
+	defer cleanup()
+	packaged, err := BuildObservabilityEvidenceAuthorityPackage(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := packaged.Receipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if receipt.Format != ObservabilityEvidenceAuthorityPackageFormat || receipt.State != "VERIFIED" ||
+		receipt.ActivationSecret != config.ActivationSecret || receipt.PrivateFileCount != 4 ||
+		len(receipt.ObjectKinds) != 1 || receipt.ObjectKinds[0] != "Secret" || receipt.MutationAllowed {
+		t.Fatalf("unexpected evidence authority package receipt: %#v", receipt)
+	}
+	public, err := json.Marshal(receipt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range []string{"independent-evidence-token", config.CollectorEndpoint, config.PrivateKeyPath, "BEGIN CERTIFICATE"} {
+		if strings.Contains(string(public), forbidden) {
+			t.Fatalf("evidence authority receipt disclosed %q: %s", forbidden, public)
+		}
+	}
+	raw, err := packaged.PrivateBytes()
+	if err != nil || digest.SHA256(raw) != receipt.PackageDigest {
+		t.Fatalf("private evidence authority package identity differs: %v", err)
+	}
+	var secret postRuntimeActivationSecret
+	if err := json.Unmarshal(raw, &secret); err != nil {
+		t.Fatal(err)
+	}
+	if secret.Kind != "Secret" || !secret.Immutable || secret.Metadata.Namespace != submissionStageInputNamespace ||
+		secret.Metadata.Name != config.ActivationSecret || len(secret.BinaryData) != 4 {
+		t.Fatalf("unexpected evidence authority Secret: %#v", secret)
+	}
+	activationRaw, err := base64.StdEncoding.DecodeString(secret.BinaryData[observabilityEvidenceAuthorityActivationKey])
+	if err != nil {
+		t.Fatal(err)
+	}
+	var activation ObservabilityEvidenceAuthorityActivation
+	if err := json.Unmarshal(activationRaw, &activation); err != nil {
+		t.Fatal(err)
+	}
+	if activation.Format != ObservabilityEvidenceAuthorityActivationFormat || activation.State != "BOUND" ||
+		activation.ExpectedManifestDigest != receipt.ManifestDigest ||
+		activation.IdentityPath != observabilityEvidenceAuthorityHandoffRoot+"/observability-evidence-identity.json" ||
+		activation.IdentityReceiptPath != observabilityEvidenceAuthorityHandoffRoot+"/observability-evidence-identity-receipt.json" ||
+		activation.EvidenceOutputPath != observabilityEvidenceAuthorityHandoffRoot+"/observability-evidence.json" ||
+		activation.PrivateKeyPath != observabilityEvidenceAuthorityRoot+"/"+observabilityEvidenceAuthorityPrivateKeyKey ||
+		activation.CollectorEndpoint != config.CollectorEndpoint || activation.IdentityWaitTimeout != "30m0s" {
+		t.Fatalf("evidence authority activation differs: %#v", activation)
+	}
+	privateKey, _ := base64.StdEncoding.DecodeString(secret.BinaryData[observabilityEvidenceAuthorityPrivateKeyKey])
+	token, _ := base64.StdEncoding.DecodeString(secret.BinaryData[observabilityEvidenceAuthorityCollectorToken])
+	ca, _ := base64.StdEncoding.DecodeString(secret.BinaryData[observabilityEvidenceAuthorityCollectorCA])
+	if len(privateKey) == 0 || string(token) != "independent-evidence-token" || digest.SHA256(ca) != receipt.CollectorCADigest {
+		t.Fatal("private evidence authority material differs from verified sources")
+	}
+}
+
+func TestBuildObservabilityEvidenceAuthorityPackageFailsClosed(t *testing.T) {
+	for name, mutate := range map[string]func(*testing.T, *ObservabilityEvidenceAuthorityPackageConfig){
+		"foreign Secret": func(_ *testing.T, config *ObservabilityEvidenceAuthorityPackageConfig) {
+			config.ActivationSecret = "foreign-secret"
+		},
+		"foreign key": func(t *testing.T, config *ObservabilityEvidenceAuthorityPackageConfig) {
+			_, privateKey, err := ed25519.GenerateKey(rand.Reader)
+			if err != nil {
+				t.Fatal(err)
+			}
+			path := filepath.Join(t.TempDir(), "foreign.key")
+			if err := os.WriteFile(path, []byte(base64.StdEncoding.EncodeToString(privateKey)+"\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			config.PrivateKeyPath = path
+		},
+		"exposed collector credential": func(t *testing.T, config *ObservabilityEvidenceAuthorityPackageConfig) {
+			if err := os.Chmod(config.CollectorTokenPath, 0o644); err != nil {
+				t.Fatal(err)
+			}
+		},
+		"foreign CA": func(_ *testing.T, config *ObservabilityEvidenceAuthorityPackageConfig) {
+			config.CollectorCADigest = bundleSHA("f")
+		},
+		"insecure endpoint": func(_ *testing.T, config *ObservabilityEvidenceAuthorityPackageConfig) {
+			config.CollectorEndpoint = "http://192.0.2.50:8443"
+		},
+		"unbounded wait": func(_ *testing.T, config *ObservabilityEvidenceAuthorityPackageConfig) {
+			config.IdentityWaitTimeout = 4 * time.Hour
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			config, cleanup := observabilityEvidenceAuthorityPackageFixture(t)
+			defer cleanup()
+			mutate(t, &config)
+			if _, err := BuildObservabilityEvidenceAuthorityPackage(config); err == nil {
+				t.Fatal("unsafe evidence authority package was accepted")
+			}
+		})
+	}
+}
+
+func TestObservabilityEvidenceAuthorityPackageRejectsTampering(t *testing.T) {
+	config, cleanup := observabilityEvidenceAuthorityPackageFixture(t)
+	defer cleanup()
+	packaged, err := BuildObservabilityEvidenceAuthorityPackage(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	packaged.raw[0] ^= 0xff
+	if _, err := packaged.PrivateBytes(); err == nil {
+		t.Fatal("tampered evidence authority package was accepted")
+	}
+	packaged, err = BuildObservabilityEvidenceAuthorityPackage(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	packaged.receipt.ObjectKinds[0] = "ConfigMap"
+	if _, err := packaged.Receipt(); err == nil {
+		t.Fatal("tampered evidence authority inventory was accepted")
+	}
+	packaged, err = BuildObservabilityEvidenceAuthorityPackage(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	packaged.receipt.CollectorCADigest = bundleSHA("a")
+	if _, err := packaged.Receipt(); err == nil {
+		t.Fatal("tampered evidence authority CA identity was accepted")
+	}
+}
+
+func observabilityEvidenceAuthorityPackageFixture(t *testing.T) (ObservabilityEvidenceAuthorityPackageConfig, func()) {
+	t.Helper()
+	manifestPath, manifestCleanup := fullRunExecutionManifestFixture(t)
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyID := digest.SHA256(publicKey)
+	bindFullRunEvidenceKeyID(t, manifestPath, keyID)
+	root := t.TempDir()
+	privateKeyPath := filepath.Join(root, "evidence-authority.key")
+	tokenPath := filepath.Join(root, "collector-token")
+	caPath := filepath.Join(root, "collector-ca.crt")
+	if err := os.WriteFile(privateKeyPath, []byte(base64.StdEncoding.EncodeToString(privateKey)+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(tokenPath, []byte("independent-evidence-token"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	server := httptest.NewTLSServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	ca := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: server.Certificate().Raw})
+	if err := os.WriteFile(caPath, ca, 0o600); err != nil {
+		server.Close()
+		t.Fatal(err)
+	}
+	return ObservabilityEvidenceAuthorityPackageConfig{
+			ManifestPath: manifestPath, ActivationSecret: "ok147-observability-evidence-authority-01",
+			PrivateKeyPath: privateKeyPath, CollectorEndpoint: server.URL,
+			CollectorTokenPath: tokenPath, CollectorCAPath: caPath, CollectorCADigest: digest.SHA256(ca),
+			IdentityPollInterval: time.Second, IdentityWaitTimeout: 30 * time.Minute,
+			EvidenceValidFor: 10 * time.Minute, CollectionTimeout: 2 * time.Minute,
+		}, func() {
+			server.Close()
+			manifestCleanup()
+		}
+}


### PR DESCRIPTION
## Summary

- bind the independent Observability evidence authority to the exact verified full-run manifest
- package the Ed25519 signing key, collector credential, pinned CA and bounded activation as one immutable private Secret
- expose only digest-based, redaction-safe package evidence
- define the future executor/authority shared-handoff boundary without adding a controller or infrastructure mutation

## Verification

- `go test ./...` (Linux container)
- `go test -race ./internal/runner ./cmd/ok` (Linux container)
- `go vet ./...` (Linux container)
- `git diff --check`

## Boundary

This checkpoint is offline only. It installs or launches nothing, contacts no cluster or collector, and grants no retry, repair, reconciliation or infrastructure authority.