### PR TITLE
feat(runner): execute packaged evidence authority

### DIFF
--- a/cmd/ok/observability_evidence.go
+++ b/cmd/ok/observability_evidence.go
@@ -23,6 +23,16 @@ type observabilityEvidenceProductionConfig struct {
 	ValidFor, Timeout                              time.Duration
 }
 
+type observabilityEvidenceAuthorityRunner interface {
+	Run(context.Context) (runner.ObservabilityIndependentEvidenceReceipt, error)
+}
+
+var openObservabilityEvidenceAuthorityActivation = func(path string) (observabilityEvidenceAuthorityRunner, error) {
+	return runner.OpenObservabilityEvidenceAuthorityActivation(path, runner.ObservabilityEvidenceAuthorityActivationRuntime{
+		Clock: time.Now, Wait: runner.WaitWithTimer,
+	})
+}
+
 var produceIndependentObservabilityEvidence = func(ctx context.Context, config observabilityEvidenceProductionConfig) (runner.ObservabilityIndependentEvidenceReceipt, error) {
 	identity, err := runner.WaitForObservabilityIndependentEvidenceIdentity(ctx, runner.ObservabilityIndependentEvidenceIdentityWaitConfig{
 		IdentityPath: config.IdentityPath, ReceiptPath: config.IdentityReceiptPath,
@@ -103,6 +113,7 @@ func runClusterStageEvidenceObservabilityProduce(ctx context.Context, arguments 
 	collectorCADigest := flags.String("collector-ca-digest", "", "expected evidence-authority CA digest")
 	validFor := flags.Duration("valid-for", 0, "signed evidence validity, from 1m through 30m")
 	timeout := flags.Duration("timeout", 0, "single collection timeout, from 1s through 30m")
+	activationPath := flags.String("activation", "", "canonical private evidence-authority activation")
 	produce := flags.Bool("produce", false, "perform one independent collection and create-only signed evidence write")
 	if err := flags.Parse(arguments); err != nil {
 		return err
@@ -112,6 +123,27 @@ func runClusterStageEvidenceObservabilityProduce(ctx context.Context, arguments 
 	}
 	if !*produce {
 		return errors.New("independent Observability evidence production requires explicit --produce")
+	}
+	if *activationPath != "" {
+		if *outputPath != "" || *privateKeyPath != "" || *identityPath != "" || *identityReceiptPath != "" || *expectedManifestDigest != "" ||
+			*identityPollInterval != 0 || *identityWaitTimeout != 0 || *collectorEndpoint != "" || *collectorToken != "" || *collectorCA != "" ||
+			*collectorCADigest != "" || *validFor != 0 || *timeout != 0 {
+			return errors.New("evidence-authority activation cannot be combined with individual production flags")
+		}
+		execution, err := openObservabilityEvidenceAuthorityActivation(*activationPath)
+		if err != nil {
+			return err
+		}
+		receipt, runErr := execution.Run(ctx)
+		if receipt.Format != "" {
+			encoder := json.NewEncoder(stdout)
+			encoder.SetEscapeHTML(false)
+			encoder.SetIndent("", "  ")
+			if err := encoder.Encode(receipt); err != nil {
+				return err
+			}
+		}
+		return runErr
 	}
 	if *outputPath == "" || *privateKeyPath == "" || *identityPath == "" || *identityReceiptPath == "" ||
 		!sha256DigestPattern.MatchString(*expectedManifestDigest) || *identityPollInterval < time.Millisecond || *identityPollInterval > 30*time.Second ||

--- a/cmd/ok/observability_evidence_test.go
+++ b/cmd/ok/observability_evidence_test.go
@@ -12,6 +12,47 @@ import (
 	"github.com/openkubes/ok-cluster/internal/runner"
 )
 
+type fakeObservabilityEvidenceAuthorityRunner struct {
+	receipt runner.ObservabilityIndependentEvidenceReceipt
+	err     error
+	calls   *int
+}
+
+func (fake fakeObservabilityEvidenceAuthorityRunner) Run(context.Context) (runner.ObservabilityIndependentEvidenceReceipt, error) {
+	*fake.calls++
+	return fake.receipt, fake.err
+}
+
+func TestObservabilityEvidenceProduceUsesCanonicalAuthorityActivation(t *testing.T) {
+	previous := openObservabilityEvidenceAuthorityActivation
+	defer func() { openObservabilityEvidenceAuthorityActivation = previous }()
+	calls := 0
+	openObservabilityEvidenceAuthorityActivation = func(path string) (observabilityEvidenceAuthorityRunner, error) {
+		if path != "/private/evidence-authority/activation.json" {
+			t.Fatalf("unexpected evidence authority activation path: %q", path)
+		}
+		return fakeObservabilityEvidenceAuthorityRunner{calls: &calls, receipt: runner.ObservabilityIndependentEvidenceReceipt{
+			Format: runner.ObservabilityIndependentEvidenceReceiptFormat, State: "WRITTEN_VERIFIED",
+			EvidenceDigest: testSHA("4"), KeyID: testSHA("5"),
+		}}, nil
+	}
+	var stdout bytes.Buffer
+	arguments := []string{
+		"cluster", "stage", "evidence", "observability", "produce",
+		"--activation", "/private/evidence-authority/activation.json", "--produce",
+	}
+	if err := run(arguments, &stdout, &bytes.Buffer{}); err != nil {
+		t.Fatal(err)
+	}
+	var receipt runner.ObservabilityIndependentEvidenceReceipt
+	if err := json.Unmarshal(stdout.Bytes(), &receipt); err != nil || receipt.State != "WRITTEN_VERIFIED" || calls != 1 {
+		t.Fatalf("authority activation receipt differs: %#v calls=%d err=%v", receipt, calls, err)
+	}
+	if err := run(append(arguments, "--timeout", "1m"), &bytes.Buffer{}, &bytes.Buffer{}); err == nil || calls != 1 {
+		t.Fatal("mixed activation and individual flags reached evidence authority")
+	}
+}
+
 func TestObservabilityEvidenceProduceRunsOneBoundedIndependentCollection(t *testing.T) {
 	previous := produceIndependentObservabilityEvidence
 	defer func() { produceIndependentObservabilityEvidence = previous }()

--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -3119,6 +3119,22 @@ key or collector token, while the issuer receives no Kubernetes lifecycle or
 GitOps credential. Package construction remains offline, creates no Kubernetes
 object and grants no launch, retry, repair or reconciliation authority.
 
+The packaged activation is also executable through the same producer entry
+point without repeating its secret-bearing fields as Pod arguments:
+
+```text
+ok cluster stage evidence observability produce \
+  --activation /var/run/openkubes/evidence-authority/activation.json \
+  --produce
+```
+
+Opening this activation re-verifies its canonical bytes, TLS CA, short-lived
+collector credential and signing key locally. The resulting process is
+single-use: it waits boundedly for the runtime identity handoff, performs one
+collector request and writes one signed evidence file create-only. Individual
+producer flags cannot be combined with the packaged activation, and a stopped
+attempt exposes no automatic retry.
+
 The post-runtime authorization resolver closes the next authority boundary.
 After a predecessor receipt is durable, it derives one canonical,
 redaction-safe request from the verified cursor, including the exact Plan,

--- a/internal/runner/observability_evidence_authority_activation.go
+++ b/internal/runner/observability_evidence_authority_activation.go
@@ -1,0 +1,106 @@
+package runner
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/jsonstrict"
+)
+
+const observabilityEvidenceAuthorityExecutionOverhead = 10 * time.Second
+
+type ObservabilityEvidenceAuthorityActivationRuntime struct {
+	Clock func() time.Time
+	Wait  ObservationWaiter
+}
+
+// ObservabilityEvidenceAuthorityExecution is a single-use, separately
+// credentialed producer process. Opening it reads and verifies only local
+// private files. Run is the sole collector contact and evidence-write boundary.
+type ObservabilityEvidenceAuthorityExecution struct {
+	activation ObservabilityEvidenceAuthorityActivation
+	producer   *ObservabilityIndependentEvidenceProducer
+	wait       ObservationWaiter
+
+	mu   sync.Mutex
+	used bool
+}
+
+// OpenObservabilityEvidenceAuthorityActivation verifies the canonical
+// activation, pinned TLS collector and private signing key without contacting
+// an API or creating a file.
+func OpenObservabilityEvidenceAuthorityActivation(path string, runtime ObservabilityEvidenceAuthorityActivationRuntime) (*ObservabilityEvidenceAuthorityExecution, error) {
+	if runtime.Clock == nil || runtime.Wait == nil || validateObservabilityEvidenceFile(path, maximumObservabilityEvidenceAuthorityBytes, true) != nil {
+		return nil, errors.New("observability evidence authority activation runtime is invalid")
+	}
+	raw, err := readBoundedRegular(path, maximumObservabilityEvidenceAuthorityBytes)
+	if err != nil {
+		return nil, errors.New("read observability evidence authority activation")
+	}
+	var activation ObservabilityEvidenceAuthorityActivation
+	if err := jsonstrict.Decode(raw, &activation); err != nil {
+		return nil, errors.New("decode strict observability evidence authority activation")
+	}
+	canonical, err := canonicalObservabilityEvidenceAuthorityActivation(activation)
+	if err != nil || !bytes.Equal(canonical, raw) {
+		return nil, errors.New("observability evidence authority activation is not canonical")
+	}
+	pollInterval, _ := time.ParseDuration(activation.IdentityPollInterval)
+	waitTimeout, _ := time.ParseDuration(activation.IdentityWaitTimeout)
+	validFor, _ := time.ParseDuration(activation.EvidenceValidity)
+	collectionTimeout, _ := time.ParseDuration(activation.CollectionTimeout)
+	profile, err := StandardObservabilityCapabilityCheckProfile("ok-observability")
+	if err != nil {
+		return nil, errors.New("open standard observability evidence authority profile")
+	}
+	collector, err := OpenHTTPObservabilityIndependentEvidenceCollector(HTTPObservabilityIndependentEvidenceCollectorConfig{
+		Endpoint: activation.CollectorEndpoint, TokenFile: activation.CollectorTokenPath,
+		CAFile: activation.CollectorCAPath, CABundleDigest: activation.CollectorCADigest,
+	})
+	if err != nil {
+		return nil, errors.New("open observability evidence authority collector")
+	}
+	producer, err := OpenObservabilityIndependentEvidenceProducer(ObservabilityIndependentEvidenceProducerConfig{
+		OutputPath: activation.EvidenceOutputPath, PrivateKeyPath: activation.PrivateKeyPath,
+		Profile: profile, ValidFor: validFor, Timeout: collectionTimeout, Clock: runtime.Clock, Collector: collector,
+	})
+	if err != nil {
+		return nil, errors.New("open observability evidence authority producer")
+	}
+	activation.IdentityPollInterval = pollInterval.String()
+	activation.IdentityWaitTimeout = waitTimeout.String()
+	activation.EvidenceValidity = validFor.String()
+	activation.CollectionTimeout = collectionTimeout.String()
+	return &ObservabilityEvidenceAuthorityExecution{activation: activation, producer: producer, wait: runtime.Wait}, nil
+}
+
+func (execution *ObservabilityEvidenceAuthorityExecution) Run(ctx context.Context) (ObservabilityIndependentEvidenceReceipt, error) {
+	receipt := ObservabilityIndependentEvidenceReceipt{Format: ObservabilityIndependentEvidenceReceiptFormat, State: "STOPPED_ZERO_WRITE"}
+	if execution == nil || execution.producer == nil || execution.wait == nil {
+		return receipt, errors.New("observability evidence authority execution is unavailable")
+	}
+	execution.mu.Lock()
+	if execution.used {
+		execution.mu.Unlock()
+		return receipt, errors.New("observability evidence authority execution is single-use")
+	}
+	execution.used = true
+	execution.mu.Unlock()
+	pollInterval, _ := time.ParseDuration(execution.activation.IdentityPollInterval)
+	waitTimeout, _ := time.ParseDuration(execution.activation.IdentityWaitTimeout)
+	collectionTimeout, _ := time.ParseDuration(execution.activation.CollectionTimeout)
+	bounded, cancel := context.WithTimeout(ctx, waitTimeout+collectionTimeout+observabilityEvidenceAuthorityExecutionOverhead)
+	defer cancel()
+	identity, err := WaitForObservabilityIndependentEvidenceIdentity(bounded, ObservabilityIndependentEvidenceIdentityWaitConfig{
+		IdentityPath: execution.activation.IdentityPath, ReceiptPath: execution.activation.IdentityReceiptPath,
+		ExpectedManifestDigest: execution.activation.ExpectedManifestDigest,
+		PollInterval:           pollInterval, Timeout: waitTimeout, Wait: execution.wait,
+	})
+	if err != nil {
+		return receipt, errors.New("load runtime-bound observability evidence identity")
+	}
+	return execution.producer.Produce(bounded, identity)
+}

--- a/internal/runner/observability_evidence_authority_activation_test.go
+++ b/internal/runner/observability_evidence_authority_activation_test.go
@@ -1,0 +1,130 @@
+package runner
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestObservabilityEvidenceAuthorityActivationRunsOneBoundedProduction(t *testing.T) {
+	config, cleanup := observabilityEvidenceAuthorityPackageFixture(t)
+	defer cleanup()
+	runtimeRoot := t.TempDir()
+	authorityRoot := filepath.Join(runtimeRoot, "authority")
+	handoffRoot := filepath.Join(runtimeRoot, "handoff")
+	for _, directory := range []string{runtimeRoot, authorityRoot, handoffRoot} {
+		if err := os.Chmod(directory, 0o700); err != nil && !errors.Is(err, os.ErrNotExist) {
+			t.Fatal(err)
+		}
+		if directory != runtimeRoot {
+			if err := os.Mkdir(directory, 0o700); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	config.RuntimeAuthorityRoot, config.RuntimeHandoffRoot = authorityRoot, handoffRoot
+	config.IdentityPollInterval, config.IdentityWaitTimeout = time.Millisecond, time.Second
+	packaged, err := BuildObservabilityEvidenceAuthorityPackage(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	packageReceipt, _ := packaged.Receipt()
+	raw, _ := packaged.PrivateBytes()
+	var secret postRuntimeActivationSecret
+	if err := json.Unmarshal(raw, &secret); err != nil {
+		t.Fatal(err)
+	}
+	for key, encoded := range secret.BinaryData {
+		content, err := base64.StdEncoding.DecodeString(encoded)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(authorityRoot, key), content, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	profile, err := StandardObservabilityCapabilityCheckProfile("ok-observability")
+	if err != nil {
+		t.Fatal(err)
+	}
+	material := ObservabilityIndependentEvidenceIdentityMaterial{
+		Format: ObservabilityIndependentEvidenceIdentityFormat, State: "RUNTIME_BOUND",
+		ManifestDigest: packageReceipt.ManifestDigest, RuntimeBindingDigest: evidenceIdentitySHA("2"),
+		RunID: "ok147-0123456789abcdef01234567", TargetClusterUID: "cluster-uid-runtime-a",
+		FixtureDigest: evidenceIdentitySHA("3"), ProfileDigest: profile.Digest(),
+	}
+	identityPath := filepath.Join(handoffRoot, "observability-evidence-identity.json")
+	identityReceiptPath := filepath.Join(handoffRoot, "observability-evidence-identity-receipt.json")
+	identityReceipt, err := persistObservabilityIndependentEvidenceIdentity(material, identityPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	identityReceiptRaw, err := canonicalObservabilityIndependentEvidenceIdentityReceipt(identityReceipt)
+	if err != nil || os.WriteFile(identityReceiptPath, identityReceiptRaw, 0o600) != nil {
+		t.Fatal("write evidence identity receipt")
+	}
+	clock := func() time.Time { return time.Date(2026, 8, 21, 16, 0, 0, 0, time.UTC) }
+	execution, err := OpenObservabilityEvidenceAuthorityActivation(
+		filepath.Join(authorityRoot, observabilityEvidenceAuthorityActivationKey),
+		ObservabilityEvidenceAuthorityActivationRuntime{Clock: clock, Wait: WaitWithTimer},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := execution.Run(context.Background())
+	if err != nil || receipt.State != "WRITTEN_VERIFIED" || receipt.KeyID != packageReceipt.EvidenceKeyID {
+		t.Fatalf("evidence authority activation did not complete: receipt=%#v err=%v", receipt, err)
+	}
+	evidencePath := filepath.Join(handoffRoot, "observability-evidence.json")
+	info, statErr := os.Lstat(evidencePath)
+	if statErr != nil || info.Mode().Perm() != 0o600 || info.Size() <= 0 {
+		t.Fatalf("evidence authority output is not private: info=%#v err=%v", info, statErr)
+	}
+	if second, err := execution.Run(context.Background()); err == nil || second.State != "STOPPED_ZERO_WRITE" {
+		t.Fatalf("evidence authority execution was reusable: receipt=%#v err=%v", second, err)
+	}
+}
+
+func TestOpenObservabilityEvidenceAuthorityActivationFailsClosed(t *testing.T) {
+	config, cleanup := observabilityEvidenceAuthorityPackageFixture(t)
+	defer cleanup()
+	runtimeRoot := t.TempDir()
+	authorityRoot, handoffRoot := filepath.Join(runtimeRoot, "authority"), filepath.Join(runtimeRoot, "handoff")
+	if err := os.Chmod(runtimeRoot, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	for _, directory := range []string{authorityRoot, handoffRoot} {
+		if err := os.Mkdir(directory, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	config.RuntimeAuthorityRoot, config.RuntimeHandoffRoot = authorityRoot, handoffRoot
+	packaged, err := BuildObservabilityEvidenceAuthorityPackage(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, _ := packaged.PrivateBytes()
+	var secret postRuntimeActivationSecret
+	if err := json.Unmarshal(raw, &secret); err != nil {
+		t.Fatal(err)
+	}
+	for key, encoded := range secret.BinaryData {
+		content, _ := base64.StdEncoding.DecodeString(encoded)
+		if err := os.WriteFile(filepath.Join(authorityRoot, key), content, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	activationPath := filepath.Join(authorityRoot, observabilityEvidenceAuthorityActivationKey)
+	clock := func() time.Time { return time.Date(2026, 8, 21, 16, 0, 0, 0, time.UTC) }
+	if err := os.WriteFile(activationPath, []byte("tampered"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := OpenObservabilityEvidenceAuthorityActivation(activationPath, ObservabilityEvidenceAuthorityActivationRuntime{Clock: clock, Wait: WaitWithTimer}); err == nil {
+		t.Fatal("tampered evidence authority activation was accepted")
+	}
+}

--- a/internal/runner/observability_evidence_authority_package.go
+++ b/internal/runner/observability_evidence_authority_package.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -39,6 +40,8 @@ type ObservabilityEvidenceAuthorityPackageConfig struct {
 	CollectorTokenPath   string
 	CollectorCAPath      string
 	CollectorCADigest    string
+	RuntimeAuthorityRoot string
+	RuntimeHandoffRoot   string
 	IdentityPollInterval time.Duration
 	IdentityWaitTimeout  time.Duration
 	EvidenceValidFor     time.Duration
@@ -95,6 +98,10 @@ func BuildObservabilityEvidenceAuthorityPackage(config ObservabilityEvidenceAuth
 		!strings.HasPrefix(config.ActivationSecret, "ok147-") {
 		return VerifiedObservabilityEvidenceAuthorityPackage{}, errors.New("observability evidence authority Secret name is invalid")
 	}
+	if !absoluteCleanDirectory(config.RuntimeAuthorityRoot) || !absoluteCleanDirectory(config.RuntimeHandoffRoot) ||
+		directoriesOverlap(config.RuntimeAuthorityRoot, config.RuntimeHandoffRoot) {
+		return VerifiedObservabilityEvidenceAuthorityPackage{}, errors.New("observability evidence authority runtime roots are invalid")
+	}
 	if config.IdentityPollInterval < time.Millisecond || config.IdentityPollInterval > 30*time.Second ||
 		config.IdentityWaitTimeout < time.Second || config.IdentityWaitTimeout > 3*time.Hour ||
 		config.EvidenceValidFor < minimumObservabilityIndependentEvidenceValidity || config.EvidenceValidFor > maximumObservabilityIndependentEvidenceWindow ||
@@ -129,13 +136,13 @@ func BuildObservabilityEvidenceAuthorityPackage(config ObservabilityEvidenceAuth
 	activation := ObservabilityEvidenceAuthorityActivation{
 		Format: ObservabilityEvidenceAuthorityActivationFormat, State: "BOUND",
 		ExpectedManifestDigest: manifestReceipt.ManifestDigest,
-		IdentityPath:           observabilityEvidenceAuthorityHandoffRoot + "/observability-evidence-identity.json",
-		IdentityReceiptPath:    observabilityEvidenceAuthorityHandoffRoot + "/observability-evidence-identity-receipt.json",
-		EvidenceOutputPath:     observabilityEvidenceAuthorityHandoffRoot + "/observability-evidence.json",
-		PrivateKeyPath:         observabilityEvidenceAuthorityRoot + "/" + observabilityEvidenceAuthorityPrivateKeyKey,
+		IdentityPath:           config.RuntimeHandoffRoot + "/observability-evidence-identity.json",
+		IdentityReceiptPath:    config.RuntimeHandoffRoot + "/observability-evidence-identity-receipt.json",
+		EvidenceOutputPath:     config.RuntimeHandoffRoot + "/observability-evidence.json",
+		PrivateKeyPath:         config.RuntimeAuthorityRoot + "/" + observabilityEvidenceAuthorityPrivateKeyKey,
 		CollectorEndpoint:      config.CollectorEndpoint,
-		CollectorTokenPath:     observabilityEvidenceAuthorityRoot + "/" + observabilityEvidenceAuthorityCollectorToken,
-		CollectorCAPath:        observabilityEvidenceAuthorityRoot + "/" + observabilityEvidenceAuthorityCollectorCA,
+		CollectorTokenPath:     config.RuntimeAuthorityRoot + "/" + observabilityEvidenceAuthorityCollectorToken,
+		CollectorCAPath:        config.RuntimeAuthorityRoot + "/" + observabilityEvidenceAuthorityCollectorCA,
 		CollectorCADigest:      config.CollectorCADigest,
 		IdentityPollInterval:   config.IdentityPollInterval.String(), IdentityWaitTimeout: config.IdentityWaitTimeout.String(),
 		EvidenceValidity: config.EvidenceValidFor.String(), CollectionTimeout: config.CollectionTimeout.String(),
@@ -263,15 +270,18 @@ func loadObservabilityEvidenceAuthorityPrivateKey(path string) ([]byte, string, 
 }
 
 func canonicalObservabilityEvidenceAuthorityActivation(activation ObservabilityEvidenceAuthorityActivation) ([]byte, error) {
+	handoffRoot := filepath.Dir(activation.IdentityPath)
+	authorityRoot := filepath.Dir(activation.PrivateKeyPath)
 	if activation.Format != ObservabilityEvidenceAuthorityActivationFormat || activation.State != "BOUND" ||
 		!stageReceiptPrefixDigestPattern.MatchString(activation.ExpectedManifestDigest) ||
 		!stageReceiptPrefixDigestPattern.MatchString(activation.CollectorCADigest) ||
-		activation.IdentityPath != observabilityEvidenceAuthorityHandoffRoot+"/observability-evidence-identity.json" ||
-		activation.IdentityReceiptPath != observabilityEvidenceAuthorityHandoffRoot+"/observability-evidence-identity-receipt.json" ||
-		activation.EvidenceOutputPath != observabilityEvidenceAuthorityHandoffRoot+"/observability-evidence.json" ||
-		activation.PrivateKeyPath != observabilityEvidenceAuthorityRoot+"/"+observabilityEvidenceAuthorityPrivateKeyKey ||
-		activation.CollectorTokenPath != observabilityEvidenceAuthorityRoot+"/"+observabilityEvidenceAuthorityCollectorToken ||
-		activation.CollectorCAPath != observabilityEvidenceAuthorityRoot+"/"+observabilityEvidenceAuthorityCollectorCA ||
+		!absoluteCleanDirectory(handoffRoot) || !absoluteCleanDirectory(authorityRoot) || directoriesOverlap(handoffRoot, authorityRoot) ||
+		activation.IdentityPath != handoffRoot+"/observability-evidence-identity.json" ||
+		activation.IdentityReceiptPath != handoffRoot+"/observability-evidence-identity-receipt.json" ||
+		activation.EvidenceOutputPath != handoffRoot+"/observability-evidence.json" ||
+		activation.PrivateKeyPath != authorityRoot+"/"+observabilityEvidenceAuthorityPrivateKeyKey ||
+		activation.CollectorTokenPath != authorityRoot+"/"+observabilityEvidenceAuthorityCollectorToken ||
+		activation.CollectorCAPath != authorityRoot+"/"+observabilityEvidenceAuthorityCollectorCA ||
 		activation.CollectorEndpoint == "" {
 		return nil, errors.New("observability evidence authority activation identity is invalid")
 	}

--- a/internal/runner/observability_evidence_authority_package_test.go
+++ b/internal/runner/observability_evidence_authority_package_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"encoding/pem"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -169,7 +170,30 @@ func observabilityEvidenceAuthorityPackageFixture(t *testing.T) (ObservabilityEv
 	if err := os.WriteFile(tokenPath, []byte("independent-evidence-token"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	server := httptest.NewTLSServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	server := httptest.NewTLSServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		raw, err := io.ReadAll(request.Body)
+		if err != nil {
+			response.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		var collection ObservabilityIndependentEvidenceCollectionRequest
+		if err := json.Unmarshal(raw, &collection); err != nil {
+			response.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		_, requestDigest, err := canonicalObservabilityIndependentEvidenceCollectionRequest(collection)
+		if err != nil {
+			response.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		response.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(response).Encode(ObservabilityIndependentEvidenceCollectionResponse{
+			Format: ObservabilityIndependentEvidenceCollectionResponseFormat, RequestDigest: requestDigest,
+			ReceiverDeliveryObserved: true, ReceiverIdentityDigest: digest.SHA256([]byte("receiver")),
+			ClusterLocalServicesReady: true, ExternalClusterDependencies: 0,
+			AutonomyProfileDigest: digest.SHA256([]byte("autonomy")),
+		})
+	}))
 	ca := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: server.Certificate().Raw})
 	if err := os.WriteFile(caPath, ca, 0o600); err != nil {
 		server.Close()
@@ -179,6 +203,7 @@ func observabilityEvidenceAuthorityPackageFixture(t *testing.T) (ObservabilityEv
 			ManifestPath: manifestPath, ActivationSecret: "ok147-observability-evidence-authority-01",
 			PrivateKeyPath: privateKeyPath, CollectorEndpoint: server.URL,
 			CollectorTokenPath: tokenPath, CollectorCAPath: caPath, CollectorCADigest: digest.SHA256(ca),
+			RuntimeAuthorityRoot: observabilityEvidenceAuthorityRoot, RuntimeHandoffRoot: observabilityEvidenceAuthorityHandoffRoot,
 			IdentityPollInterval: time.Second, IdentityWaitTimeout: 30 * time.Minute,
 			EvidenceValidFor: 10 * time.Minute, CollectionTimeout: 2 * time.Minute,
 		}, func() {


### PR DESCRIPTION
## Summary

- execute the canonical private evidence-authority activation as one bounded single-use process
- re-verify activation bytes, Ed25519 identity, TLS collector binding and all time limits before collection
- add an exclusive `--activation ... --produce` CLI path without repeating secret-bearing flags
- retain the shared private handoff model required by the future two-container full-run Job

## Verification

- `go test ./...` (Linux container)
- `go test -race ./internal/runner ./cmd/ok` (Linux container)
- `go vet ./...` (Linux container)
- `git diff --check`

## Boundary

Offline/local code checkpoint only. No Kubernetes installation, launch, infrastructure mutation, retry or reconciliation authority is added.