### PR TITLE
feat(runner): isolate full-run job authorities

### DIFF
--- a/deploy/contract-executor-full-run-job.yaml.tpl
+++ b/deploy/contract-executor-full-run-job.yaml.tpl
@@ -1,0 +1,230 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: "${OK147_RUN_ID}"
+  namespace: openkubes-execution-system
+spec:
+  podSelector:
+    matchLabels:
+      openkubes.io/execution-id: "${OK147_RUN_ID}"
+  policyTypes: ["Ingress", "Egress"]
+  ingress: []
+  egress:
+    - to: [{ipBlock: {cidr: "${OK147_INFRASTRUCTURE_API_CIDR}"}}]
+      ports: [{protocol: TCP, port: ${OK147_INFRASTRUCTURE_API_PORT}}]
+    - to: [{ipBlock: {cidr: "${OK147_MANAGEMENT_API_CIDR}"}}]
+      ports: [{protocol: TCP, port: ${OK147_MANAGEMENT_API_PORT}}]
+    - to: [{ipBlock: {cidr: "${OK147_WORKLOAD_API_CIDR}"}}]
+      ports: [{protocol: TCP, port: ${OK147_WORKLOAD_API_PORT}}]
+    - to: [{ipBlock: {cidr: "${OK147_ARGO_API_CIDR}"}}]
+      ports: [{protocol: TCP, port: ${OK147_ARGO_API_PORT}}]
+    - to: [{ipBlock: {cidr: "${OK147_AUTHORIZATION_API_CIDR}"}}]
+      ports: [{protocol: TCP, port: ${OK147_AUTHORIZATION_API_PORT}}]
+    - to: [{ipBlock: {cidr: "${OK147_COLLECTOR_API_CIDR}"}}]
+      ports: [{protocol: TCP, port: ${OK147_COLLECTOR_API_PORT}}]
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "${OK147_RUN_ID}"
+  namespace: openkubes-execution-system
+  annotations:
+    openkubes.io/bundle-digest: "${OK147_BUNDLE_DIGEST}"
+    openkubes.io/manifest-digest: "${OK147_MANIFEST_DIGEST}"
+    openkubes.io/evidence-activation-digest: "${OK147_EVIDENCE_ACTIVATION_DIGEST}"
+    openkubes.io/evidence-key-id: "${OK147_EVIDENCE_KEY_ID}"
+  labels:
+    app.kubernetes.io/name: ok-cluster-contract-executor
+    openkubes.io/execution-id: "${OK147_RUN_ID}"
+    openkubes.io/stage-id: full-run
+spec:
+  backoffLimit: 0
+  completions: 1
+  parallelism: 1
+  activeDeadlineSeconds: 11100
+  ttlSecondsAfterFinished: 3600
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ok-cluster-contract-executor
+        openkubes.io/execution-id: "${OK147_RUN_ID}"
+    spec:
+      serviceAccountName: ok147-contract-executor-runtime
+      automountServiceAccountToken: false
+      enableServiceLinks: false
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile: {type: RuntimeDefault}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - {key: node-role.kubernetes.io/control-plane, operator: DoesNotExist}
+      initContainers:
+        - name: materialize-full-run
+          image: "${OK147_IMAGE_DIGEST}"
+          imagePullPolicy: IfNotPresent
+          command: ["/ok"]
+          args:
+            - cluster
+            - stage
+            - run
+            - full
+            - materialize
+            - --source
+            - /var/run/openkubes/source
+            - --destination
+            - /var/run/openkubes/workspace
+            - --handoff
+            - /var/run/openkubes/handoff
+            - --expected-bundle-digest
+            - "${OK147_BUNDLE_DIGEST}"
+            - --materialize
+          resources:
+            requests: {cpu: 25m, memory: 32Mi, ephemeral-storage: 16Mi}
+            limits: {cpu: 100m, memory: 64Mi, ephemeral-storage: 32Mi}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities: {drop: ["ALL"]}
+          volumeMounts:
+            - {name: activation-source, mountPath: /var/run/openkubes/source, readOnly: true}
+            - {name: executor-private, mountPath: /var/run/openkubes}
+            - {name: evidence-handoff, mountPath: /var/run/openkubes/handoff}
+        - name: materialize-evidence-authority
+          image: "${OK147_IMAGE_DIGEST}"
+          imagePullPolicy: IfNotPresent
+          command: ["/ok"]
+          args:
+            - cluster
+            - stage
+            - evidence
+            - observability
+            - authority
+            - materialize
+            - --source
+            - /var/run/openkubes/evidence-source
+            - --destination
+            - /var/run/openkubes/evidence-authority
+            - --expected-activation-digest
+            - "${OK147_EVIDENCE_ACTIVATION_DIGEST}"
+            - --expected-evidence-key-id
+            - "${OK147_EVIDENCE_KEY_ID}"
+            - --expected-collector-ca-digest
+            - "${OK147_COLLECTOR_CA_DIGEST}"
+            - --materialize
+          resources:
+            requests: {cpu: 25m, memory: 32Mi, ephemeral-storage: 16Mi}
+            limits: {cpu: 100m, memory: 64Mi, ephemeral-storage: 32Mi}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities: {drop: ["ALL"]}
+          volumeMounts:
+            - {name: evidence-source, mountPath: /var/run/openkubes/evidence-source, readOnly: true}
+            - {name: authority-private, mountPath: /var/run/openkubes}
+      containers:
+        - name: executor
+          image: "${OK147_IMAGE_DIGEST}"
+          imagePullPolicy: IfNotPresent
+          command: ["/ok"]
+          args:
+            - cluster
+            - stage
+            - run
+            - full
+            - execute
+            - --manifest
+            - /var/run/openkubes/workspace/activation/full-run-manifest.json
+            - --expected-manifest-digest
+            - "${OK147_MANIFEST_DIGEST}"
+            - --independent-evidence-public-key
+            - /var/run/openkubes/workspace/input/independent-evidence.pub
+            - --execute
+          resources:
+            requests: {cpu: 50m, memory: 96Mi, ephemeral-storage: 32Mi}
+            limits: {cpu: 500m, memory: 256Mi, ephemeral-storage: 64Mi}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities: {drop: ["ALL"]}
+          volumeMounts:
+            - {name: executor-private, mountPath: /var/run/openkubes/workspace, subPath: workspace}
+            - {name: evidence-handoff, mountPath: /var/run/openkubes/handoff}
+        - name: evidence-authority
+          image: "${OK147_IMAGE_DIGEST}"
+          imagePullPolicy: IfNotPresent
+          command: ["/ok"]
+          args:
+            - cluster
+            - stage
+            - evidence
+            - observability
+            - produce
+            - --activation
+            - /var/run/openkubes/evidence-authority/activation.json
+            - --produce
+          resources:
+            requests: {cpu: 25m, memory: 48Mi, ephemeral-storage: 16Mi}
+            limits: {cpu: 250m, memory: 128Mi, ephemeral-storage: 32Mi}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities: {drop: ["ALL"]}
+          volumeMounts:
+            - {name: authority-private, mountPath: /var/run/openkubes/evidence-authority, subPath: evidence-authority}
+            - {name: evidence-handoff, mountPath: /var/run/openkubes/handoff}
+      volumes:
+        - name: activation-source
+          secret:
+            secretName: "${OK147_ACTIVATION_SECRET}"
+            defaultMode: 0440
+            items:
+              - {key: bundle-index.json, path: bundle-index.json}
+              - {key: activation.full-run-manifest.json, path: activation/full-run-manifest.json}
+              - {key: credentials.authorization-ca.crt, path: credentials/authorization-ca.crt}
+              - {key: credentials.authorization-token, path: credentials/authorization-token}
+              - {key: credentials.gitops-ca.crt, path: credentials/gitops-ca.crt}
+              - {key: credentials.gitops-token, path: credentials/gitops-token}
+              - {key: credentials.infrastructure-ca.crt, path: credentials/infrastructure-ca.crt}
+              - {key: credentials.infrastructure-token, path: credentials/infrastructure-token}
+              - {key: credentials.ledger-ca.crt, path: credentials/ledger-ca.crt}
+              - {key: credentials.ledger-token, path: credentials/ledger-token}
+              - {key: credentials.management-ca.crt, path: credentials/management-ca.crt}
+              - {key: credentials.management-token, path: credentials/management-token}
+              - {key: input.aggregate-profile.json, path: input/aggregate-profile.json}
+              - {key: input.authorization-authority.pub, path: input/authorization-authority.pub}
+              - {key: input.enablement.yaml, path: input/enablement.yaml}
+              - {key: input.independent-evidence.pub, path: input/independent-evidence.pub}
+              - {key: input.network-profile.json, path: input/network-profile.json}
+              - {key: input.platform-applications.yaml, path: input/platform-applications.yaml}
+              - {key: input.platform-profile.json, path: input/platform-profile.json}
+              - {key: input.projection.authority-map.json, path: input/projection/authority-map.json}
+              - {key: input.projection.ok-infra-prerequisites.yaml, path: input/projection/ok-infra-prerequisites.yaml}
+              - {key: input.projection.ok-mgmt-lifecycle.yaml, path: input/projection/ok-mgmt-lifecycle.yaml}
+              - {key: input.projection-manifest.json, path: input/projection-manifest.json}
+              - {key: input.staged-plan.json, path: input/staged-plan.json}
+              - {key: input.target-access.yaml, path: input/target-access.yaml}
+              - {key: input.target-credential-policy.json, path: input/target-credential-policy.json}
+              - {key: input.target-registration.yaml, path: input/target-registration.yaml}
+        - name: evidence-source
+          secret:
+            secretName: "${OK147_EVIDENCE_AUTHORITY_SECRET}"
+            defaultMode: 0440
+            items:
+              - {key: activation.json, path: activation.json}
+              - {key: evidence-authority.key, path: evidence-authority.key}
+              - {key: collector-token, path: collector-token}
+              - {key: collector-ca.crt, path: collector-ca.crt}
+        - name: executor-private
+          emptyDir: {medium: Memory, sizeLimit: 8Mi}
+        - name: authority-private
+          emptyDir: {medium: Memory, sizeLimit: 1Mi}
+        - name: evidence-handoff
+          emptyDir: {medium: Memory, sizeLimit: 1Mi}

--- a/internal/runner/full_run_activation_materializer.go
+++ b/internal/runner/full_run_activation_materializer.go
@@ -58,8 +58,12 @@ func materializeFullRunExecutionBundle(config FullRunExecutionBundleMaterializat
 		return receipt, errors.New("full-run bundle destination must be absent")
 	}
 	handoffInfo, err := os.Lstat(config.HandoffDirectory)
-	if err != nil || !handoffInfo.IsDir() || handoffInfo.Mode()&os.ModeSymlink != 0 || handoffInfo.Mode().Perm()&0o077 != 0 {
+	if err != nil || !handoffInfo.IsDir() || handoffInfo.Mode()&os.ModeSymlink != 0 || handoffInfo.Mode().Perm()&0o007 != 0 {
 		return receipt, errors.New("full-run evidence handoff is not a private directory")
+	}
+	entries, err := os.ReadDir(config.HandoffDirectory)
+	if err != nil || len(entries) != 0 {
+		return receipt, errors.New("full-run evidence handoff must be empty before materialization")
 	}
 	indexRaw, err := readProjectedPostRuntimeBundleFile(config.SourceDirectory, fullRunExecutionBundleIndexName, 64*1024)
 	if err != nil {

--- a/internal/runner/full_run_job.go
+++ b/internal/runner/full_run_job.go
@@ -1,0 +1,110 @@
+package runner
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+type FullRunExecutionJobValues struct {
+	RunID                    string
+	ImageDigest              string
+	ActivationSecret         string
+	EvidenceAuthoritySecret  string
+	BundleDigest             string
+	ManifestDigest           string
+	EvidenceActivationDigest string
+	EvidenceKeyID            string
+	CollectorCADigest        string
+	InfrastructureAPIURL     string
+	InfrastructureAPICIDR    string
+	ManagementAPIURL         string
+	ManagementAPICIDR        string
+	WorkloadAPIURL           string
+	WorkloadAPICIDR          string
+	ArgoAPIURL               string
+	ArgoAPICIDR              string
+	AuthorizationAPIURL      string
+	AuthorizationAPICIDR     string
+	CollectorAPIURL          string
+	CollectorAPICIDR         string
+}
+
+// RenderFullRunExecutionJobTemplate binds one Stage 1-12 executor and one
+// independent evidence authority into a single Pod. They share only the
+// evidence handoff; neither container can mount the other's private material.
+func RenderFullRunExecutionJobTemplate(template []byte, values FullRunExecutionJobValues) ([]byte, error) {
+	if len(template) == 0 || len(template) > 1024*1024 {
+		return nil, errors.New("full-run Job template size is invalid")
+	}
+	dnsLabel := regexp.MustCompile(`^[a-z0-9](?:[-a-z0-9]*[a-z0-9])?$`)
+	for _, name := range []string{values.RunID, values.ActivationSecret, values.EvidenceAuthoritySecret} {
+		if !dnsLabel.MatchString(name) || len(name) > 63 || !strings.HasPrefix(name, "ok147-") {
+			return nil, errors.New("full-run Job object identity is invalid")
+		}
+	}
+	if values.ActivationSecret == values.EvidenceAuthoritySecret ||
+		!regexp.MustCompile(`^[a-z0-9][a-z0-9./:_-]*@sha256:[0-9a-f]{64}$`).MatchString(values.ImageDigest) {
+		return nil, errors.New("full-run Job private Secret or image identity is invalid")
+	}
+	for _, identity := range []string{
+		values.BundleDigest, values.ManifestDigest, values.EvidenceActivationDigest, values.EvidenceKeyID, values.CollectorCADigest,
+	} {
+		if !stageReceiptPrefixDigestPattern.MatchString(identity) {
+			return nil, errors.New("full-run Job digest identity is invalid")
+		}
+	}
+	endpoints := []struct {
+		name, rawURL, cidr string
+	}{
+		{"infrastructure", values.InfrastructureAPIURL, values.InfrastructureAPICIDR},
+		{"management", values.ManagementAPIURL, values.ManagementAPICIDR},
+		{"workload", values.WorkloadAPIURL, values.WorkloadAPICIDR},
+		{"Argo", values.ArgoAPIURL, values.ArgoAPICIDR},
+		{"collector", values.CollectorAPIURL, values.CollectorAPICIDR},
+	}
+	ports := make(map[string]string, len(endpoints)+1)
+	targets := make(map[string]struct{}, len(endpoints)+1)
+	for _, endpoint := range endpoints {
+		port, target, err := exactAPIEndpoint(endpoint.rawURL, endpoint.cidr)
+		if err != nil {
+			return nil, fmt.Errorf("full-run %s endpoint: %w", endpoint.name, err)
+		}
+		if _, exists := targets[target]; exists {
+			return nil, errors.New("full-run network authorities must be distinct")
+		}
+		targets[target], ports[endpoint.name] = struct{}{}, port
+	}
+	authorizationPort, authorizationTarget, err := exactPostRuntimeAuthorizationEndpoint(values.AuthorizationAPIURL, values.AuthorizationAPICIDR)
+	if err != nil {
+		return nil, err
+	}
+	if _, exists := targets[authorizationTarget]; exists {
+		return nil, errors.New("full-run authorization authority must be distinct")
+	}
+	replacements := map[string]string{
+		"${OK147_RUN_ID}": values.RunID, "${OK147_IMAGE_DIGEST}": values.ImageDigest,
+		"${OK147_ACTIVATION_SECRET}": values.ActivationSecret, "${OK147_EVIDENCE_AUTHORITY_SECRET}": values.EvidenceAuthoritySecret,
+		"${OK147_BUNDLE_DIGEST}": values.BundleDigest, "${OK147_MANIFEST_DIGEST}": values.ManifestDigest,
+		"${OK147_EVIDENCE_ACTIVATION_DIGEST}": values.EvidenceActivationDigest,
+		"${OK147_EVIDENCE_KEY_ID}":            values.EvidenceKeyID, "${OK147_COLLECTOR_CA_DIGEST}": values.CollectorCADigest,
+		"${OK147_INFRASTRUCTURE_API_CIDR}": values.InfrastructureAPICIDR, "${OK147_INFRASTRUCTURE_API_PORT}": ports["infrastructure"],
+		"${OK147_MANAGEMENT_API_CIDR}": values.ManagementAPICIDR, "${OK147_MANAGEMENT_API_PORT}": ports["management"],
+		"${OK147_WORKLOAD_API_CIDR}": values.WorkloadAPICIDR, "${OK147_WORKLOAD_API_PORT}": ports["workload"],
+		"${OK147_ARGO_API_CIDR}": values.ArgoAPICIDR, "${OK147_ARGO_API_PORT}": ports["Argo"],
+		"${OK147_AUTHORIZATION_API_CIDR}": values.AuthorizationAPICIDR, "${OK147_AUTHORIZATION_API_PORT}": authorizationPort,
+		"${OK147_COLLECTOR_API_CIDR}": values.CollectorAPICIDR, "${OK147_COLLECTOR_API_PORT}": ports["collector"],
+	}
+	result := string(template)
+	for placeholder, value := range replacements {
+		if !strings.Contains(result, placeholder) {
+			return nil, fmt.Errorf("full-run Job template lacks %s", placeholder)
+		}
+		result = strings.ReplaceAll(result, placeholder, value)
+	}
+	if strings.Contains(result, "${") {
+		return nil, errors.New("full-run Job template contains an unknown placeholder")
+	}
+	return []byte(result), nil
+}

--- a/internal/runner/full_run_job_test.go
+++ b/internal/runner/full_run_job_test.go
@@ -1,0 +1,179 @@
+package runner
+
+import (
+	"os"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+)
+
+func TestRenderFullRunExecutionJobTemplateIsolatesExecutorAndEvidenceAuthority(t *testing.T) {
+	values := validFullRunExecutionJobValues()
+	raw, err := RenderFullRunExecutionJobTemplate(fullRunExecutionJobTemplate(t), values)
+	if err != nil {
+		t.Fatal(err)
+	}
+	objects := decodeJobObjects(t, raw)
+	if len(objects) != 2 || objects["NetworkPolicy"] == nil || objects["Job"] == nil {
+		t.Fatalf("unexpected full-run object set: %#v", objects)
+	}
+	job := objects["Job"]
+	annotations := objectAt(t, objectAt(t, job, "metadata"), "annotations")
+	if annotations["openkubes.io/bundle-digest"] != values.BundleDigest ||
+		annotations["openkubes.io/manifest-digest"] != values.ManifestDigest ||
+		annotations["openkubes.io/evidence-activation-digest"] != values.EvidenceActivationDigest ||
+		annotations["openkubes.io/evidence-key-id"] != values.EvidenceKeyID {
+		t.Fatalf("full-run annotations differ: %#v", annotations)
+	}
+	spec := objectAt(t, job, "spec")
+	if spec["backoffLimit"] != 0 || spec["completions"] != 1 || spec["parallelism"] != 1 || spec["activeDeadlineSeconds"] != 11100 {
+		t.Fatalf("full-run retry or deadline differs: %#v", spec)
+	}
+	podSpec := objectAt(t, objectAt(t, spec, "template"), "spec")
+	if podSpec["automountServiceAccountToken"] != false || podSpec["restartPolicy"] != "Never" || podSpec["serviceAccountName"] != "ok147-contract-executor-runtime" {
+		t.Fatalf("unsafe full-run Pod identity: %#v", podSpec)
+	}
+	inits := arrayAt(t, podSpec, "initContainers")
+	if len(inits) != 2 {
+		t.Fatalf("unexpected initializer count: %#v", inits)
+	}
+	fullInit := inits[0].(map[string]any)
+	if got := stringArray(t, fullInit, "args"); !reflect.DeepEqual(got, []string{
+		"cluster", "stage", "run", "full", "materialize", "--source", "/var/run/openkubes/source",
+		"--destination", "/var/run/openkubes/workspace", "--handoff", "/var/run/openkubes/handoff",
+		"--expected-bundle-digest", values.BundleDigest, "--materialize",
+	}) {
+		t.Fatalf("unexpected full-run initializer: %v", got)
+	}
+	authorityInit := inits[1].(map[string]any)
+	if got := stringArray(t, authorityInit, "args"); !reflect.DeepEqual(got, []string{
+		"cluster", "stage", "evidence", "observability", "authority", "materialize",
+		"--source", "/var/run/openkubes/evidence-source", "--destination", "/var/run/openkubes/evidence-authority",
+		"--expected-activation-digest", values.EvidenceActivationDigest, "--expected-evidence-key-id", values.EvidenceKeyID,
+		"--expected-collector-ca-digest", values.CollectorCADigest, "--materialize",
+	}) {
+		t.Fatalf("unexpected authority initializer: %v", got)
+	}
+	containers := arrayAt(t, podSpec, "containers")
+	if len(containers) != 2 {
+		t.Fatalf("unexpected full-run container count: %#v", containers)
+	}
+	executor, authority := containers[0].(map[string]any), containers[1].(map[string]any)
+	if got := stringArray(t, executor, "args"); !reflect.DeepEqual(got, []string{
+		"cluster", "stage", "run", "full", "execute", "--manifest", "/var/run/openkubes/workspace/activation/full-run-manifest.json",
+		"--expected-manifest-digest", values.ManifestDigest, "--independent-evidence-public-key", "/var/run/openkubes/workspace/input/independent-evidence.pub", "--execute",
+	}) {
+		t.Fatalf("unexpected executor command: %v", got)
+	}
+	if got := stringArray(t, authority, "args"); !reflect.DeepEqual(got, []string{
+		"cluster", "stage", "evidence", "observability", "produce", "--activation", "/var/run/openkubes/evidence-authority/activation.json", "--produce",
+	}) {
+		t.Fatalf("unexpected evidence authority command: %v", got)
+	}
+	assertFullRunContainerMounts(t, executor, map[string]string{"executor-private": "workspace", "evidence-handoff": ""})
+	assertFullRunContainerMounts(t, authority, map[string]string{"authority-private": "evidence-authority", "evidence-handoff": ""})
+
+	volumes := arrayAt(t, podSpec, "volumes")
+	if len(volumes) != 5 {
+		t.Fatalf("unexpected full-run volume count: %#v", volumes)
+	}
+	activationSecret := objectAt(t, volumes[0].(map[string]any), "secret")
+	if activationSecret["secretName"] != values.ActivationSecret || activationSecret["defaultMode"] != 288 || len(arrayAt(t, activationSecret, "items")) != len(fullRunExecutionBundleFiles)+1 {
+		t.Fatalf("full-run activation projection differs: %#v", activationSecret)
+	}
+	paths := make([]string, 0, len(fullRunExecutionBundleFiles)+1)
+	for _, item := range arrayAt(t, activationSecret, "items") {
+		paths = append(paths, item.(map[string]any)["path"].(string))
+	}
+	want := append([]string{fullRunExecutionBundleIndexName}, fullRunExecutionBundleFiles...)
+	sort.Strings(paths)
+	sort.Strings(want)
+	if !reflect.DeepEqual(paths, want) {
+		t.Fatalf("full-run activation projection path set differs: %v", paths)
+	}
+	evidenceSecret := objectAt(t, volumes[1].(map[string]any), "secret")
+	if evidenceSecret["secretName"] != values.EvidenceAuthoritySecret || len(arrayAt(t, evidenceSecret, "items")) != 4 {
+		t.Fatalf("evidence authority projection differs: %#v", evidenceSecret)
+	}
+	if egress := arrayAt(t, objectAt(t, objects["NetworkPolicy"], "spec"), "egress"); len(egress) != 6 {
+		t.Fatalf("full-run egress is not exact: %#v", egress)
+	}
+	text := string(raw)
+	for _, forbidden := range []string{"latest", "system:masters", "privileged: true", "automountServiceAccountToken: true", "restartPolicy: Always"} {
+		if strings.Contains(text, forbidden) {
+			t.Fatalf("full-run Job contains forbidden value %q", forbidden)
+		}
+	}
+}
+
+func TestRenderFullRunExecutionJobTemplateFailsClosed(t *testing.T) {
+	valid := validFullRunExecutionJobValues()
+	for name, mutate := range map[string]func(*FullRunExecutionJobValues){
+		"mutable image":             func(values *FullRunExecutionJobValues) { values.ImageDigest = "ghcr.io/openkubes/ok-cluster:latest" },
+		"foreign run":               func(values *FullRunExecutionJobValues) { values.RunID = "foreign-run" },
+		"same Secrets":              func(values *FullRunExecutionJobValues) { values.EvidenceAuthoritySecret = values.ActivationSecret },
+		"bad bundle":                func(values *FullRunExecutionJobValues) { values.BundleDigest = "sha256:bad" },
+		"broad infrastructure CIDR": func(values *FullRunExecutionJobValues) { values.InfrastructureAPICIDR = "192.0.2.0/24" },
+		"shared authority": func(values *FullRunExecutionJobValues) {
+			values.CollectorAPIURL, values.CollectorAPICIDR = values.ArgoAPIURL, values.ArgoAPICIDR
+		},
+		"authorization without path": func(values *FullRunExecutionJobValues) { values.AuthorizationAPIURL = "https://192.0.2.50:8443" },
+	} {
+		t.Run(name, func(t *testing.T) {
+			candidate := valid
+			mutate(&candidate)
+			if _, err := RenderFullRunExecutionJobTemplate(fullRunExecutionJobTemplate(t), candidate); err == nil {
+				t.Fatal("unsafe full-run Job values were accepted")
+			}
+		})
+	}
+	template := append(fullRunExecutionJobTemplate(t), []byte("\n${UNKNOWN}")...)
+	if _, err := RenderFullRunExecutionJobTemplate(template, valid); err == nil {
+		t.Fatal("unknown full-run Job placeholder was accepted")
+	}
+}
+
+func assertFullRunContainerMounts(t *testing.T, container map[string]any, expected map[string]string) {
+	t.Helper()
+	mounts := arrayAt(t, container, "volumeMounts")
+	if len(mounts) != len(expected) {
+		t.Fatalf("container mount count differs: %#v", mounts)
+	}
+	for _, raw := range mounts {
+		mount := raw.(map[string]any)
+		name := mount["name"].(string)
+		wantSubPath, ok := expected[name]
+		if !ok {
+			t.Fatalf("container received foreign mount %q", name)
+		}
+		gotSubPath, _ := mount["subPath"].(string)
+		if gotSubPath != wantSubPath {
+			t.Fatalf("container mount %q subPath differs: %q", name, gotSubPath)
+		}
+	}
+}
+
+func validFullRunExecutionJobValues() FullRunExecutionJobValues {
+	return FullRunExecutionJobValues{
+		RunID: "ok147-full-run-01", ImageDigest: "ghcr.io/openkubes/ok-cluster@" + bundleSHA("a"),
+		ActivationSecret: "ok147-full-run-activation-01", EvidenceAuthoritySecret: "ok147-evidence-authority-01",
+		BundleDigest: bundleSHA("b"), ManifestDigest: bundleSHA("c"), EvidenceActivationDigest: bundleSHA("d"),
+		EvidenceKeyID: bundleSHA("e"), CollectorCADigest: bundleSHA("f"),
+		InfrastructureAPIURL: "https://192.0.2.10:6443", InfrastructureAPICIDR: "192.0.2.10/32",
+		ManagementAPIURL: "https://192.0.2.20:6443", ManagementAPICIDR: "192.0.2.20/32",
+		WorkloadAPIURL: "https://192.0.2.30:6443", WorkloadAPICIDR: "192.0.2.30/32",
+		ArgoAPIURL: "https://192.0.2.40:6443", ArgoAPICIDR: "192.0.2.40/32",
+		AuthorizationAPIURL: "https://192.0.2.50:8443/v1/stage-authorizations", AuthorizationAPICIDR: "192.0.2.50/32",
+		CollectorAPIURL: "https://192.0.2.60:8443", CollectorAPICIDR: "192.0.2.60/32",
+	}
+}
+
+func fullRunExecutionJobTemplate(t *testing.T) []byte {
+	t.Helper()
+	raw, err := os.ReadFile("../../deploy/contract-executor-full-run-job.yaml.tpl")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return raw
+}


### PR DESCRIPTION
## Summary

- add the bounded two-container Stage 1–12 Job envelope
- run the executor and independent Evidence Authority with disjoint private volumes
- share only a private evidence handoff between the two runtime containers
- materialize both immutable Secret projections through dedicated init containers
- bind six exact single-address egress destinations and disable retries/service-account token mounting

## Boundary

Template/rendering only. This checkpoint creates no Secret, Job, token or cluster mutation.

## Verification

- `go test ./...`
- `go test -race ./internal/runner ./cmd/ok`
- `go vet ./...`
- `git diff --check`
