### PR TITLE
feat(runner): bind full-run installation package

### DIFF
--- a/internal/runner/full_run_activation_package.go
+++ b/internal/runner/full_run_activation_package.go
@@ -1,0 +1,185 @@
+package runner
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"strings"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+const (
+	FullRunExecutionActivationPackageFormat = "ok147-full-run-execution-activation-package/v1"
+	maximumFullRunExecutionPackageBytes     = 2 * 1024 * 1024
+)
+
+type FullRunExecutionActivationPackageConfig struct {
+	ManifestPath                 string
+	IndependentEvidencePublicKey string
+	ActivationSecret             string
+	EvidenceAuthority            ObservabilityEvidenceAuthorityPackageConfig
+	JobTemplate                  []byte
+	JobTemplateDigest            string
+	Job                          FullRunExecutionJobValues
+}
+
+type FullRunExecutionActivationPackageReceipt struct {
+	Format                        string   `json:"format"`
+	State                         string   `json:"state"`
+	PackageDigest                 string   `json:"packageDigest"`
+	ActivationSecret              string   `json:"activationSecret"`
+	ActivationSecretObjectDigest  string   `json:"activationSecretObjectDigest"`
+	EvidenceAuthoritySecret       string   `json:"evidenceAuthoritySecret"`
+	EvidenceAuthorityObjectDigest string   `json:"evidenceAuthorityObjectDigest"`
+	JobEnvelopeDigest             string   `json:"jobEnvelopeDigest"`
+	JobTemplateDigest             string   `json:"jobTemplateDigest"`
+	BundleDigest                  string   `json:"bundleDigest"`
+	SourceManifestDigest          string   `json:"sourceManifestDigest"`
+	ManifestDigest                string   `json:"manifestDigest"`
+	PlanDigest                    string   `json:"planDigest"`
+	EvidenceActivationDigest      string   `json:"evidenceActivationDigest"`
+	EvidenceKeyID                 string   `json:"evidenceKeyId"`
+	CollectorAuthorityDigest      string   `json:"collectorAuthorityDigest"`
+	CollectorCADigest             string   `json:"collectorCaDigest"`
+	PrivateFileCount              int      `json:"privateFileCount"`
+	ObjectKinds                   []string `json:"objectKinds"`
+	MutationAllowed               bool     `json:"mutationAllowed"`
+}
+
+type VerifiedFullRunExecutionActivationPackage struct {
+	raw      []byte
+	receipt  FullRunExecutionActivationPackageReceipt
+	verified bool
+}
+
+// BuildFullRunExecutionActivationPackage binds the executor Secret, the
+// separately credentialed Evidence Authority Secret and their shared Job
+// envelope into one locally verified installation unit.
+func BuildFullRunExecutionActivationPackage(config FullRunExecutionActivationPackageConfig) (VerifiedFullRunExecutionActivationPackage, error) {
+	if !stageReceiptPrefixDigestPattern.MatchString(config.JobTemplateDigest) || digest.SHA256(config.JobTemplate) != config.JobTemplateDigest {
+		return VerifiedFullRunExecutionActivationPackage{}, errors.New("full-run activation Job template differs from expected identity")
+	}
+	if !submissionStageInputNamePattern.MatchString(config.ActivationSecret) || len(config.ActivationSecret) > 63 ||
+		!strings.HasPrefix(config.ActivationSecret, "ok147-") || config.ActivationSecret == config.EvidenceAuthority.ActivationSecret {
+		return VerifiedFullRunExecutionActivationPackage{}, errors.New("full-run activation Secret identity is invalid")
+	}
+	bundle, err := BuildFullRunExecutionBundle(FullRunExecutionBundleConfig{
+		ManifestPath: config.ManifestPath, IndependentEvidencePublicKey: config.IndependentEvidencePublicKey,
+	})
+	if err != nil {
+		return VerifiedFullRunExecutionActivationPackage{}, err
+	}
+	bundleReceipt, err := bundle.Receipt()
+	if err != nil {
+		return VerifiedFullRunExecutionActivationPackage{}, err
+	}
+	config.EvidenceAuthority.ManifestPath = config.ManifestPath
+	evidence, err := BuildObservabilityEvidenceAuthorityPackage(config.EvidenceAuthority)
+	if err != nil {
+		return VerifiedFullRunExecutionActivationPackage{}, err
+	}
+	evidenceReceipt, err := evidence.Receipt()
+	if err != nil || evidenceReceipt.ManifestDigest != bundleReceipt.SourceManifestDigest || evidenceReceipt.EvidenceKeyID != bundleReceipt.EvidenceKeyID {
+		return VerifiedFullRunExecutionActivationPackage{}, errors.New("full-run Evidence Authority differs from executor identity")
+	}
+	evidenceRaw, err := evidence.PrivateBytes()
+	if err != nil {
+		return VerifiedFullRunExecutionActivationPackage{}, err
+	}
+	binaryData := map[string]string{fullRunExecutionBundleIndexName: base64.StdEncoding.EncodeToString(bundle.indexRaw)}
+	for path, raw := range bundle.files {
+		binaryData[strings.ReplaceAll(path, "/", ".")] = base64.StdEncoding.EncodeToString(raw)
+	}
+	secret := postRuntimeActivationSecret{
+		APIVersion: "v1", Kind: "Secret", Immutable: true, Type: "Opaque", BinaryData: binaryData,
+		Metadata: postRuntimeActivationSecretMetadata{
+			Name: config.ActivationSecret, Namespace: submissionStageInputNamespace,
+			Labels:      map[string]string{"app.kubernetes.io/name": "ok-cluster-contract-executor", "openkubes.io/stage-id": "full-run"},
+			Annotations: map[string]string{"openkubes.io/bundle-digest": bundleReceipt.BundleDigest, "openkubes.io/manifest-digest": bundleReceipt.ManifestDigest},
+		},
+	}
+	secretRaw, err := json.Marshal(secret)
+	if err != nil || len(secretRaw) > maximumPostRuntimeExecutionSecretBytes {
+		return VerifiedFullRunExecutionActivationPackage{}, errors.New("full-run activation Secret exceeds bounded object size")
+	}
+	document, _, err := loadFullRunExecutionManifest(config.ManifestPath)
+	if err != nil {
+		return VerifiedFullRunExecutionActivationPackage{}, errors.New("reload full-run source manifest")
+	}
+	values := config.Job
+	values.ActivationSecret, values.EvidenceAuthoritySecret = config.ActivationSecret, config.EvidenceAuthority.ActivationSecret
+	values.BundleDigest, values.ManifestDigest = bundleReceipt.BundleDigest, bundleReceipt.ManifestDigest
+	values.EvidenceActivationDigest, values.EvidenceKeyID = evidenceReceipt.ActivationDigest, evidenceReceipt.EvidenceKeyID
+	values.CollectorCADigest = evidenceReceipt.CollectorCADigest
+	values.InfrastructureAPIURL = document.ProviderPrerequisites.Authority.Endpoint
+	values.ManagementAPIURL = document.ClusterLifecycle.Authority.Endpoint
+	values.ArgoAPIURL = document.TargetRegistration.GitOps.Endpoint
+	values.AuthorizationAPIURL = document.Authorization.Endpoint
+	values.CollectorAPIURL = config.EvidenceAuthority.CollectorEndpoint
+	jobRaw, err := RenderFullRunExecutionJobTemplate(config.JobTemplate, values)
+	if err != nil {
+		return VerifiedFullRunExecutionActivationPackage{}, err
+	}
+	packageRaw := bytes.Join([][]byte{secretRaw, evidenceRaw, jobRaw}, []byte("\n---\n"))
+	if len(packageRaw) > maximumFullRunExecutionPackageBytes {
+		return VerifiedFullRunExecutionActivationPackage{}, errors.New("full-run activation package exceeds size limit")
+	}
+	receipt := FullRunExecutionActivationPackageReceipt{
+		Format: FullRunExecutionActivationPackageFormat, State: "VERIFIED", PackageDigest: digest.SHA256(packageRaw),
+		ActivationSecret: config.ActivationSecret, ActivationSecretObjectDigest: digest.SHA256(secretRaw),
+		EvidenceAuthoritySecret: config.EvidenceAuthority.ActivationSecret, EvidenceAuthorityObjectDigest: digest.SHA256(evidenceRaw),
+		JobEnvelopeDigest: digest.SHA256(jobRaw), JobTemplateDigest: config.JobTemplateDigest,
+		BundleDigest: bundleReceipt.BundleDigest, SourceManifestDigest: bundleReceipt.SourceManifestDigest,
+		ManifestDigest: bundleReceipt.ManifestDigest, PlanDigest: bundleReceipt.PlanDigest,
+		EvidenceActivationDigest: evidenceReceipt.ActivationDigest, EvidenceKeyID: evidenceReceipt.EvidenceKeyID,
+		CollectorAuthorityDigest: evidenceReceipt.CollectorAuthorityDigest, CollectorCADigest: evidenceReceipt.CollectorCADigest,
+		PrivateFileCount: len(bundle.files) + evidenceReceipt.PrivateFileCount,
+		ObjectKinds:      []string{"Secret", "Secret", "NetworkPolicy", "Job"}, MutationAllowed: false,
+	}
+	return VerifiedFullRunExecutionActivationPackage{raw: packageRaw, receipt: receipt, verified: true}, nil
+}
+
+func (packaged VerifiedFullRunExecutionActivationPackage) PrivateBytes() ([]byte, error) {
+	if err := verifyFullRunExecutionActivationPackage(packaged); err != nil {
+		return nil, errors.New("full-run activation package was not produced by verification")
+	}
+	return append([]byte(nil), packaged.raw...), nil
+}
+
+func (packaged VerifiedFullRunExecutionActivationPackage) Receipt() (FullRunExecutionActivationPackageReceipt, error) {
+	if err := verifyFullRunExecutionActivationPackage(packaged); err != nil {
+		return FullRunExecutionActivationPackageReceipt{}, errors.New("full-run activation package was not produced by verification")
+	}
+	receipt := packaged.receipt
+	receipt.ObjectKinds = append([]string(nil), packaged.receipt.ObjectKinds...)
+	return receipt, nil
+}
+
+func verifyFullRunExecutionActivationPackage(packaged VerifiedFullRunExecutionActivationPackage) error {
+	receipt := packaged.receipt
+	if !packaged.verified || receipt.Format != FullRunExecutionActivationPackageFormat || receipt.State != "VERIFIED" || receipt.MutationAllowed ||
+		len(packaged.raw) == 0 || digest.SHA256(packaged.raw) != receipt.PackageDigest || receipt.ActivationSecret == receipt.EvidenceAuthoritySecret ||
+		receipt.PrivateFileCount != len(fullRunExecutionBundleFiles)+len(observabilityEvidenceAuthorityProjectedFiles) ||
+		len(receipt.ObjectKinds) != 4 || receipt.ObjectKinds[0] != "Secret" || receipt.ObjectKinds[1] != "Secret" ||
+		receipt.ObjectKinds[2] != "NetworkPolicy" || receipt.ObjectKinds[3] != "Job" {
+		return errors.New("full-run activation package identity is incomplete")
+	}
+	for _, identity := range []string{
+		receipt.PackageDigest, receipt.ActivationSecretObjectDigest, receipt.EvidenceAuthorityObjectDigest,
+		receipt.JobEnvelopeDigest, receipt.JobTemplateDigest, receipt.BundleDigest, receipt.SourceManifestDigest,
+		receipt.ManifestDigest, receipt.PlanDigest, receipt.EvidenceActivationDigest, receipt.EvidenceKeyID,
+		receipt.CollectorAuthorityDigest, receipt.CollectorCADigest,
+	} {
+		if !stageReceiptPrefixDigestPattern.MatchString(identity) {
+			return errors.New("full-run activation package digest identity is incomplete")
+		}
+	}
+	parts := bytes.SplitN(packaged.raw, []byte("\n---\n"), 3)
+	if len(parts) != 3 || digest.SHA256(parts[0]) != receipt.ActivationSecretObjectDigest ||
+		digest.SHA256(parts[1]) != receipt.EvidenceAuthorityObjectDigest || digest.SHA256(parts[2]) != receipt.JobEnvelopeDigest {
+		return errors.New("full-run activation package components changed")
+	}
+	return nil
+}

--- a/internal/runner/full_run_activation_package_test.go
+++ b/internal/runner/full_run_activation_package_test.go
@@ -1,0 +1,147 @@
+package runner
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+func TestBuildFullRunExecutionActivationPackageBindsBothAuthoritiesAndJob(t *testing.T) {
+	config := fullRunExecutionActivationPackageFixture(t)
+	packaged, err := BuildFullRunExecutionActivationPackage(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := packaged.Receipt()
+	if err != nil || receipt.State != "VERIFIED" || receipt.MutationAllowed || receipt.PrivateFileCount != 30 ||
+		receipt.ActivationSecret != config.ActivationSecret || receipt.EvidenceAuthoritySecret != config.EvidenceAuthority.ActivationSecret ||
+		len(receipt.ObjectKinds) != 4 {
+		t.Fatalf("unexpected full-run package receipt: %#v err=%v", receipt, err)
+	}
+	raw, err := packaged.PrivateBytes()
+	if err != nil || digest.SHA256(raw) != receipt.PackageDigest {
+		t.Fatalf("private full-run package differs: %v", err)
+	}
+	parts := bytes.SplitN(raw, []byte("\n---\n"), 3)
+	if len(parts) != 3 {
+		t.Fatalf("unexpected package component count: %d", len(parts))
+	}
+	var activationSecret, evidenceSecret postRuntimeActivationSecret
+	if err := json.Unmarshal(parts[0], &activationSecret); err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(parts[1], &evidenceSecret); err != nil {
+		t.Fatal(err)
+	}
+	if !activationSecret.Immutable || len(activationSecret.BinaryData) != len(fullRunExecutionBundleFiles)+1 ||
+		!evidenceSecret.Immutable || len(evidenceSecret.BinaryData) != 4 ||
+		activationSecret.Metadata.Name == evidenceSecret.Metadata.Name {
+		t.Fatalf("private Secret boundary differs: activation=%#v evidence=%#v", activationSecret.Metadata, evidenceSecret.Metadata)
+	}
+	objects := decodeJobObjects(t, parts[2])
+	if objects["NetworkPolicy"] == nil || objects["Job"] == nil {
+		t.Fatalf("bounded Job envelope differs: %#v", objects)
+	}
+	public, err := json.Marshal(receipt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range []string{filepath.Dir(config.ManifestPath), config.EvidenceAuthority.CollectorEndpoint, "token", "kubeconfig", "private-key", "BEGIN CERTIFICATE"} {
+		if strings.Contains(strings.ToLower(string(public)), strings.ToLower(forbidden)) {
+			t.Fatalf("public full-run package receipt disclosed %q: %s", forbidden, public)
+		}
+	}
+}
+
+func TestBuildFullRunExecutionActivationPackageFailsClosed(t *testing.T) {
+	for name, mutate := range map[string]func(*FullRunExecutionActivationPackageConfig){
+		"wrong template": func(config *FullRunExecutionActivationPackageConfig) { config.JobTemplateDigest = bundleSHA("f") },
+		"same Secret": func(config *FullRunExecutionActivationPackageConfig) {
+			config.ActivationSecret = config.EvidenceAuthority.ActivationSecret
+		},
+		"mutable image": func(config *FullRunExecutionActivationPackageConfig) {
+			config.Job.ImageDigest = "ghcr.io/openkubes/ok-cluster:latest"
+		},
+		"broad workload CIDR": func(config *FullRunExecutionActivationPackageConfig) { config.Job.WorkloadAPICIDR = "192.0.2.0/24" },
+		"foreign evidence key": func(config *FullRunExecutionActivationPackageConfig) {
+			config.IndependentEvidencePublicKey = config.EvidenceAuthority.CollectorCAPath
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			config := fullRunExecutionActivationPackageFixture(t)
+			mutate(&config)
+			if packaged, err := BuildFullRunExecutionActivationPackage(config); err == nil || packaged.verified {
+				t.Fatalf("unsafe full-run activation package was accepted: %#v err=%v", packaged.receipt, err)
+			}
+		})
+	}
+}
+
+func TestFullRunExecutionActivationPackageRejectsTampering(t *testing.T) {
+	config := fullRunExecutionActivationPackageFixture(t)
+	packaged, err := BuildFullRunExecutionActivationPackage(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	packaged.raw[0] ^= 0xff
+	if _, err := packaged.PrivateBytes(); err == nil {
+		t.Fatal("tampered full-run package bytes were accepted")
+	}
+	packaged, err = BuildFullRunExecutionActivationPackage(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	packaged.receipt.ObjectKinds[1] = "ConfigMap"
+	if _, err := packaged.Receipt(); err == nil {
+		t.Fatal("tampered full-run package inventory was accepted")
+	}
+}
+
+func fullRunExecutionActivationPackageFixture(t *testing.T) FullRunExecutionActivationPackageConfig {
+	t.Helper()
+	evidenceConfig, cleanup := observabilityEvidenceAuthorityPackageFixture(t)
+	t.Cleanup(cleanup)
+	privateRaw, err := os.ReadFile(evidenceConfig.PrivateKeyPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	privateKey, err := base64.StdEncoding.Strict().DecodeString(strings.TrimSuffix(string(privateRaw), "\n"))
+	if err != nil || len(privateKey) != ed25519.PrivateKeySize {
+		t.Fatal("invalid fixture private key")
+	}
+	publicPath := filepath.Join(t.TempDir(), "evidence-authority.pub")
+	publicKey := ed25519.PrivateKey(privateKey).Public().(ed25519.PublicKey)
+	if err := os.WriteFile(publicPath, []byte(base64.StdEncoding.EncodeToString(publicKey)+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	template := fullRunExecutionJobTemplate(t)
+	return FullRunExecutionActivationPackageConfig{
+		ManifestPath: evidenceConfig.ManifestPath, IndependentEvidencePublicKey: publicPath,
+		ActivationSecret: "ok147-full-run-activation-01", EvidenceAuthority: evidenceConfig,
+		JobTemplate: template, JobTemplateDigest: digest.SHA256(template),
+		Job: FullRunExecutionJobValues{
+			RunID: "ok147-full-run-01", ImageDigest: "ghcr.io/openkubes/ok-cluster@" + bundleSHA("a"),
+			InfrastructureAPICIDR: "192.0.2.13/32", ManagementAPICIDR: "192.0.2.12/32",
+			WorkloadAPIURL: "https://192.0.2.30:6443", WorkloadAPICIDR: "192.0.2.30/32",
+			ArgoAPICIDR: "192.0.2.11/32", AuthorizationAPICIDR: "127.0.0.1/32",
+			CollectorAPICIDR: collectorFixtureCIDR(t, evidenceConfig.CollectorEndpoint),
+		},
+	}
+}
+
+func collectorFixtureCIDR(t *testing.T, endpoint string) string {
+	t.Helper()
+	// httptest.NewTLSServer always binds an IPv4 loopback endpoint in this
+	// fixture; the URL parser in the renderer verifies the exact match.
+	if !strings.HasPrefix(endpoint, "https://127.0.0.1:") {
+		t.Fatalf("unexpected fixture collector endpoint: %s", endpoint)
+	}
+	return "127.0.0.1/32"
+}


### PR DESCRIPTION
## Summary

- bind the full-run executor Secret, independent Evidence Authority Secret and two-container Job envelope into one verified package
- correlate manifest, plan, bundle, signing-key, collector CA and template identities
- preserve a redaction-safe public receipt while keeping all 30 private files in the private package only
- fail closed on component tampering, foreign keys, mutable images, broad CIDRs and Secret identity collisions

## Boundary

Package construction is local-only. No Kubernetes object, token, Job or infrastructure mutation is created.

## Verification

- `go test ./...`
- `go test -race ./internal/runner ./cmd/ok`
- `go vet ./...`
- `git diff --check`
