### PR TITLE
feat(runner): launch full-run activation package

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -3336,6 +3336,27 @@ single-address egress target is explicit. The output is create-only with mode
 does not open a Kubernetes credential, contact an API or grant installation
 authority.
 
+The corresponding bounded installer derives a credential-free plan from that
+same verified package. It requires four exact absence GETs before its first
+write and then permits only this order:
+
+```text
+GET executor Secret, Evidence Authority Secret, NetworkPolicy, Job
+        ↓ all four absent
+POST executor Secret
+POST Evidence Authority Secret
+POST NetworkPolicy
+POST Job
+```
+
+The package digest is checked before the management installer credential is
+opened. A pre-existing object stops with zero writes. Any failure or uncertain
+response after the first POST is retained as partial/unknown state; the
+single-use launcher exposes no retry, update, patch, apply, delete, rollback or
+cleanup path. Raw UIDs and resourceVersions are reduced to digests in its
+public receipt. Wiring this launcher to a separate prepare/execute CLI remains
+the next activation checkpoint.
+
 ## Current OK-147 implementation boundary
 
 The twelve-stage Go library and its durable replay semantics are complete and
@@ -3362,8 +3383,8 @@ durable receipts. This is not yet the OK-147 Definition of Done:
 - the joined concrete Stage 1-7 and Stage 8-12 adapters have a shared
   activation boundary plus concrete local prepare/execute commands; the
   ephemeral full-run Job and private activation package select that same
-  production capability transport, while their bounded installer launcher
-  remains to be implemented;
+  production capability transport and have a bounded installer library, while
+  the installer prepare/execute CLI remains to be implemented;
 - the standalone Stage-12 launcher has not yet been executed as part of the
   complete predecessor-bound stage chain;
 - the current staged-library source is published as the immutable multi-platform

--- a/internal/runner/full_run_activation_installation_plan.go
+++ b/internal/runner/full_run_activation_installation_plan.go
@@ -1,0 +1,199 @@
+package runner
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"gopkg.in/yaml.v3"
+)
+
+const FullRunExecutionActivationInstallationPlanFormat = "ok147-full-run-execution-activation-installation-plan/v1"
+
+// FullRunExecutionActivationInstallationPlan is the credential-free exact
+// absence/create sequence for the complete ephemeral Stage 1-12 execution.
+// It is evidence and grants no installation authority.
+type FullRunExecutionActivationInstallationPlan struct {
+	Format          string                      `json:"format"`
+	State           string                      `json:"state"`
+	RunID           string                      `json:"runId"`
+	PackageDigest   string                      `json:"packageDigest"`
+	PlanDigest      string                      `json:"planDigest"`
+	Authority       string                      `json:"authority"`
+	Creates         []SubmissionStageCreatePlan `json:"creates"`
+	MutationAllowed bool                        `json:"mutationAllowed"`
+}
+
+// PlanFullRunExecutionActivationInstallation derives the exact
+// executor-Secret -> evidence-Secret -> NetworkPolicy -> Job sequence without
+// opening a credential or contacting Kubernetes.
+func PlanFullRunExecutionActivationInstallation(packaged VerifiedFullRunExecutionActivationPackage) (FullRunExecutionActivationInstallationPlan, error) {
+	receipt, err := packaged.Receipt()
+	if err != nil {
+		return FullRunExecutionActivationInstallationPlan{}, err
+	}
+	expectedKinds := []string{"Secret", "Secret", "NetworkPolicy", "Job"}
+	if !equalStringList(receipt.ObjectKinds, expectedKinds) || packaged.managementAuthority == "" {
+		return FullRunExecutionActivationInstallationPlan{}, errors.New("full-run activation package inventory or authority is invalid")
+	}
+	objects, err := decodeFullRunActivationObjects(packaged.raw, len(expectedKinds))
+	if err != nil {
+		return FullRunExecutionActivationInstallationPlan{}, err
+	}
+
+	runID := ""
+	creates := make([]SubmissionStageCreatePlan, 0, len(objects))
+	for index, object := range objects {
+		apiVersion, _ := object["apiVersion"].(string)
+		kind, _ := object["kind"].(string)
+		if kind != expectedKinds[index] {
+			return FullRunExecutionActivationInstallationPlan{}, errors.New("full-run activation create order is invalid")
+		}
+		metadata, ok := object["metadata"].(map[string]any)
+		if !ok {
+			return FullRunExecutionActivationInstallationPlan{}, errors.New("full-run activation object metadata is invalid")
+		}
+		name, _ := metadata["name"].(string)
+		namespace, _ := metadata["namespace"].(string)
+		if !submissionStageInputNamePattern.MatchString(name) || len(name) > 63 || namespace != submissionStageInputNamespace || metadata["generateName"] != nil {
+			return FullRunExecutionActivationInstallationPlan{}, errors.New("full-run activation object identity is invalid")
+		}
+		collectionPath, objectPath, err := postRuntimeActivationCreatePaths(apiVersion, kind, namespace, name)
+		if err != nil {
+			return FullRunExecutionActivationInstallationPlan{}, err
+		}
+		canonical, err := json.Marshal(object)
+		if err != nil {
+			return FullRunExecutionActivationInstallationPlan{}, errors.New("encode full-run activation object")
+		}
+		creates = append(creates, SubmissionStageCreatePlan{
+			Order: index + 1, APIVersion: apiVersion, Kind: kind, Namespace: namespace, Name: name,
+			PreflightMethod: http.MethodGet, ObjectPath: objectPath, CreateMethod: http.MethodPost,
+			CollectionPath: collectionPath, ObjectDigest: digest.SHA256(canonical),
+		})
+		switch index {
+		case 0:
+			if !fullRunActivationSecretMatches(object, receipt.ActivationSecret, "full-run", receipt.BundleDigest, receipt.ManifestDigest, "", len(fullRunExecutionBundleFiles)+1) {
+				return FullRunExecutionActivationInstallationPlan{}, errors.New("full-run executor Secret semantics differ")
+			}
+		case 1:
+			if !fullRunActivationSecretMatches(object, receipt.EvidenceAuthoritySecret, "independent-evidence", "", receipt.SourceManifestDigest, receipt.EvidenceActivationDigest, 4) {
+				return FullRunExecutionActivationInstallationPlan{}, errors.New("full-run Evidence Authority Secret semantics differ")
+			}
+		case 2:
+			runID = name
+			spec, _ := object["spec"].(map[string]any)
+			selector, _ := spec["podSelector"].(map[string]any)
+			matchLabels, _ := selector["matchLabels"].(map[string]any)
+			if matchLabels["openkubes.io/execution-id"] != runID {
+				return FullRunExecutionActivationInstallationPlan{}, errors.New("full-run NetworkPolicy selector differs")
+			}
+		case 3:
+			spec, _ := object["spec"].(map[string]any)
+			template, _ := spec["template"].(map[string]any)
+			podSpec, _ := template["spec"].(map[string]any)
+			annotations, _ := metadata["annotations"].(map[string]any)
+			if name != runID || spec["backoffLimit"] != 0 || podSpec["serviceAccountName"] != "ok147-contract-executor-runtime" ||
+				podSpec["automountServiceAccountToken"] != false || annotations["openkubes.io/bundle-digest"] != receipt.BundleDigest ||
+				annotations["openkubes.io/manifest-digest"] != receipt.ManifestDigest ||
+				annotations["openkubes.io/evidence-activation-digest"] != receipt.EvidenceActivationDigest ||
+				annotations["openkubes.io/evidence-key-id"] != receipt.EvidenceKeyID ||
+				!fullRunJobMountsPrivateSecrets(podSpec, receipt.ActivationSecret, receipt.EvidenceAuthoritySecret) {
+				return FullRunExecutionActivationInstallationPlan{}, errors.New("full-run activation Job binding differs")
+			}
+		}
+	}
+	return FullRunExecutionActivationInstallationPlan{
+		Format: FullRunExecutionActivationInstallationPlanFormat, State: "VERIFIED", RunID: runID,
+		PackageDigest: receipt.PackageDigest, PlanDigest: receipt.PlanDigest,
+		Authority: packaged.managementAuthority, Creates: creates, MutationAllowed: false,
+	}, nil
+}
+
+func fullRunActivationSecretMatches(object map[string]any, name, stageID, bundleDigest, manifestDigest, activationDigest string, fileCount int) bool {
+	metadata, _ := object["metadata"].(map[string]any)
+	annotations, _ := metadata["annotations"].(map[string]any)
+	labels, _ := metadata["labels"].(map[string]any)
+	binaryData, _ := object["binaryData"].(map[string]any)
+	if metadata["name"] != name || object["immutable"] != true || object["type"] != "Opaque" ||
+		labels["openkubes.io/stage-id"] != stageID || annotations["openkubes.io/manifest-digest"] != manifestDigest || len(binaryData) != fileCount {
+		return false
+	}
+	if bundleDigest != "" && annotations["openkubes.io/bundle-digest"] != bundleDigest {
+		return false
+	}
+	return activationDigest == "" || annotations["openkubes.io/activation-digest"] == activationDigest
+}
+
+func fullRunJobMountsPrivateSecrets(podSpec map[string]any, executorSecret, evidenceSecret string) bool {
+	volumes, ok := podSpec["volumes"].([]any)
+	if !ok {
+		return false
+	}
+	wanted := map[string]struct {
+		secret string
+		items  int
+	}{
+		"activation-source": {secret: executorSecret, items: len(fullRunExecutionBundleFiles) + 1},
+		"evidence-source":   {secret: evidenceSecret, items: 4},
+	}
+	found := map[string]bool{}
+	for _, value := range volumes {
+		volume, _ := value.(map[string]any)
+		name, _ := volume["name"].(string)
+		expected, required := wanted[name]
+		if !required {
+			continue
+		}
+		secret, _ := volume["secret"].(map[string]any)
+		items, _ := secret["items"].([]any)
+		if secret["secretName"] != expected.secret || len(items) != expected.items || found[name] {
+			return false
+		}
+		found[name] = true
+	}
+	return found["activation-source"] && found["evidence-source"]
+}
+
+func decodeFullRunActivationObjects(raw []byte, expected int) ([]map[string]any, error) {
+	decoder := yaml.NewDecoder(bytes.NewReader(raw))
+	objects := make([]map[string]any, 0, expected)
+	for {
+		var object map[string]any
+		err := decoder.Decode(&object)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil || len(object) == 0 {
+			return nil, errors.New("decode full-run activation package")
+		}
+		objects = append(objects, object)
+	}
+	if len(objects) != expected {
+		return nil, errors.New("full-run activation package object count is invalid")
+	}
+	return objects, nil
+}
+
+func prepareFullRunExecutionActivationInstallation(packaged VerifiedFullRunExecutionActivationPackage) (FullRunExecutionActivationInstallationPlan, []submissionStageInstallObject, error) {
+	plan, err := PlanFullRunExecutionActivationInstallation(packaged)
+	if err != nil {
+		return FullRunExecutionActivationInstallationPlan{}, nil, err
+	}
+	values, err := decodeFullRunActivationObjects(packaged.raw, len(plan.Creates))
+	if err != nil {
+		return FullRunExecutionActivationInstallationPlan{}, nil, err
+	}
+	objects := make([]submissionStageInstallObject, 0, len(values))
+	for index, value := range values {
+		raw, err := json.Marshal(value)
+		if err != nil || digest.SHA256(raw) != plan.Creates[index].ObjectDigest {
+			return FullRunExecutionActivationInstallationPlan{}, nil, errors.New("full-run activation object differs from plan")
+		}
+		objects = append(objects, submissionStageInstallObject{plan: plan.Creates[index], raw: raw})
+	}
+	return plan, objects, nil
+}

--- a/internal/runner/full_run_activation_launcher.go
+++ b/internal/runner/full_run_activation_launcher.go
@@ -1,0 +1,215 @@
+package runner
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+const FullRunExecutionActivationLaunchReceiptFormat = "ok147-full-run-execution-activation-launch-receipt/v1"
+
+type FullRunExecutionActivationLauncherConfig struct {
+	Authority             KubernetesAuthorityConfig
+	ExpectedPackageDigest string
+}
+
+// FullRunExecutionActivationLaunchReceipt contains only redaction-safe
+// identities. Package bytes and installer credentials are never retained.
+type FullRunExecutionActivationLaunchReceipt struct {
+	Format        string                           `json:"format"`
+	RunID         string                           `json:"runId"`
+	PackageDigest string                           `json:"packageDigest"`
+	PlanDigest    string                           `json:"planDigest"`
+	Authority     string                           `json:"authority"`
+	State         string                           `json:"state"`
+	MutationState string                           `json:"mutationState"`
+	Results       []SubmissionStageInstalledObject `json:"results"`
+}
+
+// KubernetesFullRunExecutionActivationLauncher installs one verified private
+// full-run activation package. It is bounded, single-use and create-only.
+type KubernetesFullRunExecutionActivationLauncher struct {
+	mu       sync.Mutex
+	used     bool
+	endpoint *url.URL
+	token    string
+	client   *http.Client
+	plan     FullRunExecutionActivationInstallationPlan
+	objects  []submissionStageInstallObject
+}
+
+// OpenKubernetesFullRunExecutionActivationLauncher verifies the exact package
+// identity before opening the management credential and performs no API call.
+func OpenKubernetesFullRunExecutionActivationLauncher(config FullRunExecutionActivationLauncherConfig, packaged VerifiedFullRunExecutionActivationPackage) (*KubernetesFullRunExecutionActivationLauncher, error) {
+	receipt, err := packaged.Receipt()
+	if err != nil || config.ExpectedPackageDigest != receipt.PackageDigest {
+		return nil, errors.New("full-run activation package differs from expected identity")
+	}
+	if config.Authority.AuthorityIdentity == "" || config.Authority.AuthorityIdentity != packaged.managementAuthority ||
+		!stageReceiptPrefixDigestPattern.MatchString(config.Authority.CABundleDigest) {
+		return nil, errors.New("full-run activation authority differs from verified management authority")
+	}
+	endpoint, err := normalizeSubmissionStageLaunchEndpoint(config.Authority.Endpoint)
+	if err != nil {
+		return nil, errors.New("full-run activation endpoint is invalid")
+	}
+	token, ca, client, err := openBoundedKubernetesMaterial(config.Authority.TokenFile, config.Authority.CAFile)
+	if err != nil {
+		return nil, errors.New("open bounded full-run activation credential")
+	}
+	if digest.SHA256(ca) != config.Authority.CABundleDigest {
+		return nil, errors.New("full-run activation CA differs from bound identity")
+	}
+	return newKubernetesFullRunExecutionActivationLauncher(submissionStageInstallerClientConfig{
+		Endpoint: endpoint, BearerToken: token, AuthorityIdentity: config.Authority.AuthorityIdentity, Client: client,
+	}, packaged)
+}
+
+func newKubernetesFullRunExecutionActivationLauncher(config submissionStageInstallerClientConfig, packaged VerifiedFullRunExecutionActivationPackage) (*KubernetesFullRunExecutionActivationLauncher, error) {
+	plan, objects, err := prepareFullRunExecutionActivationInstallation(packaged)
+	if err != nil {
+		return nil, err
+	}
+	if config.AuthorityIdentity == "" || config.AuthorityIdentity != plan.Authority {
+		return nil, errors.New("full-run activation authority differs from verified management authority")
+	}
+	endpoint, err := url.Parse(config.Endpoint)
+	if err != nil || endpoint.Host == "" || endpoint.User != nil || endpoint.RawQuery != "" || endpoint.Fragment != "" ||
+		endpoint.Path != "" && endpoint.Path != "/" || endpoint.Port() == "" || net.ParseIP(endpoint.Hostname()) == nil {
+		return nil, errors.New("full-run activation Kubernetes endpoint is invalid")
+	}
+	if endpoint.Scheme != "https" && !(endpoint.Scheme == "http" && endpoint.Hostname() == "127.0.0.1") {
+		return nil, errors.New("full-run activation Kubernetes endpoint must use HTTPS")
+	}
+	if config.BearerToken == "" || strings.TrimSpace(config.BearerToken) != config.BearerToken ||
+		strings.ContainsAny(config.BearerToken, "\r\n") || config.Client == nil {
+		return nil, errors.New("full-run activation credential or client is invalid")
+	}
+	client := *config.Client
+	client.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+	if client.Timeout == 0 {
+		client.Timeout = 15 * time.Second
+	}
+	endpoint.Path, endpoint.RawPath = "", ""
+	return &KubernetesFullRunExecutionActivationLauncher{
+		endpoint: endpoint, token: config.BearerToken, client: &client, plan: plan, objects: objects,
+	}, nil
+}
+
+// Launch completes all four exact-name GETs before its first POST, then
+// creates executor Secret, Evidence Authority Secret, NetworkPolicy and Job in
+// that order. It exposes no retry, update, patch, apply, delete or cleanup.
+func (launcher *KubernetesFullRunExecutionActivationLauncher) Launch(ctx context.Context) (FullRunExecutionActivationLaunchReceipt, error) {
+	receipt := launcher.newReceipt()
+	if launcher == nil || launcher.client == nil {
+		return receipt, errors.New("full-run activation launcher is required")
+	}
+	launcher.mu.Lock()
+	if launcher.used {
+		launcher.mu.Unlock()
+		return stopFullRunExecutionActivation(receipt, "STOPPED_ZERO_WRITE", errors.New("full-run activation launcher is single-use"))
+	}
+	launcher.used = true
+	launcher.mu.Unlock()
+
+	for _, object := range launcher.objects {
+		_, status, err := launcher.request(ctx, http.MethodGet, object.plan.ObjectPath, nil)
+		if err != nil {
+			return stopFullRunExecutionActivation(receipt, "STOPPED_ZERO_WRITE", err)
+		}
+		switch status {
+		case http.StatusNotFound:
+		case http.StatusOK:
+			return stopFullRunExecutionActivation(receipt, "STOPPED_ZERO_WRITE", errors.New("full-run activation object already exists; zero-write preflight stopped"))
+		default:
+			return stopFullRunExecutionActivation(receipt, "STOPPED_ZERO_WRITE", fullRunActivationStatusError(http.MethodGet, status))
+		}
+	}
+
+	receipt.State = "ACTIVATING"
+	for _, object := range launcher.objects {
+		receipt.MutationState = "ATTEMPTED_UNKNOWN"
+		raw, status, err := launcher.request(ctx, http.MethodPost, object.plan.CollectionPath, object.raw)
+		if err != nil {
+			return stopFullRunExecutionActivation(receipt, "STOPPED_PARTIAL_OR_UNKNOWN", err)
+		}
+		if status != http.StatusCreated {
+			receipt.MutationState = "ATTEMPTED"
+			return stopFullRunExecutionActivation(receipt, "STOPPED_PARTIAL_OR_UNKNOWN", fullRunActivationStatusError(http.MethodPost, status))
+		}
+		uid, resourceVersion, err := verifySubmissionStageCreatedObject(raw, object)
+		if err != nil {
+			return stopFullRunExecutionActivation(receipt, "STOPPED_PARTIAL_OR_UNKNOWN", errors.New("created full-run activation object differs from verified package"))
+		}
+		receipt.MutationState = "ATTEMPTED"
+		receipt.Results = append(receipt.Results, SubmissionStageInstalledObject{
+			Order: object.plan.Order, APIVersion: object.plan.APIVersion, Kind: object.plan.Kind,
+			Namespace: object.plan.Namespace, Name: object.plan.Name, ObjectDigest: object.plan.ObjectDigest,
+			UIDDigest: digest.SHA256([]byte(uid)), ResourceVersionDigest: digest.SHA256([]byte(resourceVersion)), State: "CREATED",
+		})
+	}
+	receipt.State = "ACTIVATED"
+	return receipt, nil
+}
+
+func (launcher *KubernetesFullRunExecutionActivationLauncher) newReceipt() FullRunExecutionActivationLaunchReceipt {
+	receipt := FullRunExecutionActivationLaunchReceipt{
+		Format: FullRunExecutionActivationLaunchReceiptFormat, State: "PREFLIGHT", MutationState: "NOT_ATTEMPTED",
+		Results: []SubmissionStageInstalledObject{},
+	}
+	if launcher != nil {
+		receipt.RunID, receipt.PackageDigest, receipt.PlanDigest, receipt.Authority =
+			launcher.plan.RunID, launcher.plan.PackageDigest, launcher.plan.PlanDigest, launcher.plan.Authority
+	}
+	return receipt
+}
+
+func stopFullRunExecutionActivation(receipt FullRunExecutionActivationLaunchReceipt, state string, err error) (FullRunExecutionActivationLaunchReceipt, error) {
+	receipt.State = state
+	return receipt, err
+}
+
+func (launcher *KubernetesFullRunExecutionActivationLauncher) request(ctx context.Context, method, path string, body []byte) ([]byte, int, error) {
+	endpoint := *launcher.endpoint
+	endpoint.Path = path
+	request, err := http.NewRequestWithContext(ctx, method, endpoint.String(), bytes.NewReader(body))
+	if err != nil {
+		return nil, 0, errors.New("construct bounded full-run activation request")
+	}
+	request.Header.Set("Accept", "application/json")
+	request.Header.Set("Authorization", "Bearer "+launcher.token)
+	if body != nil {
+		request.Header.Set("Content-Type", "application/json")
+	}
+	response, err := launcher.client.Do(request)
+	if err != nil {
+		return nil, 0, fmt.Errorf("bounded full-run activation %s request failed", method)
+	}
+	defer response.Body.Close()
+	raw, readErr := io.ReadAll(io.LimitReader(response.Body, maximumStageInstallationResponseBytes+1))
+	if readErr != nil || len(raw) > maximumStageInstallationResponseBytes {
+		return nil, 0, errors.New("bounded full-run activation response exceeds accepted size")
+	}
+	if len(raw) > 0 {
+		mediaType, _, err := mime.ParseMediaType(response.Header.Get("Content-Type"))
+		if err != nil || mediaType != "application/json" {
+			return nil, 0, errors.New("bounded full-run activation response is not JSON")
+		}
+	}
+	return raw, response.StatusCode, nil
+}
+
+func fullRunActivationStatusError(method string, status int) error {
+	return fmt.Errorf("bounded full-run activation %s returned HTTP %d", method, status)
+}

--- a/internal/runner/full_run_activation_launcher_test.go
+++ b/internal/runner/full_run_activation_launcher_test.go
@@ -1,0 +1,171 @@
+package runner
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+func TestPlanFullRunExecutionActivationInstallationBindsExactOrder(t *testing.T) {
+	packaged := fullRunActivationLauncherPackage(t)
+	plan, err := PlanFullRunExecutionActivationInstallation(packaged)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plan.Format != FullRunExecutionActivationInstallationPlanFormat || plan.State != "VERIFIED" ||
+		plan.RunID != "ok147-full-run-01" || plan.Authority != "ok-mgmt" || plan.MutationAllowed || len(plan.Creates) != 4 {
+		t.Fatalf("unexpected full-run activation plan: %#v", plan)
+	}
+	for index, kind := range []string{"Secret", "Secret", "NetworkPolicy", "Job"} {
+		create := plan.Creates[index]
+		if create.Order != index+1 || create.Kind != kind || create.Namespace != submissionStageInputNamespace ||
+			create.PreflightMethod != http.MethodGet || create.CreateMethod != http.MethodPost || create.ObjectPath == "" ||
+			create.CollectionPath == "" || !stageReceiptPrefixDigestPattern.MatchString(create.ObjectDigest) {
+			t.Fatalf("create %d differs: %#v", index, create)
+		}
+	}
+	public, err := json.Marshal(plan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range []string{"bearer", "token", "certificate", "/private/"} {
+		if strings.Contains(strings.ToLower(string(public)), forbidden) {
+			t.Fatalf("installation plan exposed %q", forbidden)
+		}
+	}
+}
+
+func TestPlanFullRunExecutionActivationInstallationFailsClosed(t *testing.T) {
+	packaged := fullRunActivationLauncherPackage(t)
+	for name, mutate := range map[string]func(*VerifiedFullRunExecutionActivationPackage){
+		"raw":       func(value *VerifiedFullRunExecutionActivationPackage) { value.raw[0] ^= 0xff },
+		"authority": func(value *VerifiedFullRunExecutionActivationPackage) { value.managementAuthority = "ok-infra" },
+		"inventory": func(value *VerifiedFullRunExecutionActivationPackage) { value.receipt.ObjectKinds[1] = "ConfigMap" },
+	} {
+		t.Run(name, func(t *testing.T) {
+			candidate := packaged
+			candidate.raw = append([]byte(nil), packaged.raw...)
+			candidate.receipt.ObjectKinds = append([]string(nil), packaged.receipt.ObjectKinds...)
+			mutate(&candidate)
+			if _, err := PlanFullRunExecutionActivationInstallation(candidate); err == nil {
+				t.Fatal("changed full-run package produced an installation plan")
+			}
+		})
+	}
+}
+
+func TestFullRunExecutionActivationLauncherPreflightsThenCreates(t *testing.T) {
+	packaged := fullRunActivationLauncherPackage(t)
+	api := newSubmissionStageInstallerAPI(t)
+	launcher := newFullRunActivationLauncher(t, packaged, api.client())
+	receipt, err := launcher.Launch(context.Background())
+	if err != nil || receipt.State != "ACTIVATED" || receipt.MutationState != "ATTEMPTED" || len(receipt.Results) != 4 {
+		t.Fatalf("full-run activation failed: %#v %v", receipt, err)
+	}
+	plan, _ := PlanFullRunExecutionActivationInstallation(packaged)
+	if receipt.Format != FullRunExecutionActivationLaunchReceiptFormat || receipt.PackageDigest != plan.PackageDigest ||
+		receipt.PlanDigest != plan.PlanDigest || receipt.RunID != plan.RunID || receipt.Authority != "ok-mgmt" {
+		t.Fatalf("activation receipt identity differs: %#v", receipt)
+	}
+	if len(api.requests) != 8 {
+		t.Fatalf("requests=%d, want four GETs then four POSTs: %#v", len(api.requests), api.requests)
+	}
+	for index, create := range plan.Creates {
+		preflight, submission := api.requests[index], api.requests[index+4]
+		if preflight.method != http.MethodGet || preflight.path != create.ObjectPath || len(preflight.body) != 0 {
+			t.Fatalf("preflight %d differs: %#v", index, preflight)
+		}
+		if submission.method != http.MethodPost || submission.path != create.CollectionPath || digest.SHA256(submission.body) != create.ObjectDigest {
+			t.Fatalf("submission %d differs: %#v", index, submission)
+		}
+	}
+	public, err := json.Marshal(receipt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(public, []byte("short-lived-installer-token")) || bytes.Contains(public, []byte("created-stage-uid")) {
+		t.Fatal("activation receipt disclosed credential or raw runtime identity")
+	}
+}
+
+func TestFullRunExecutionActivationLauncherStopsZeroWriteOnExistingObject(t *testing.T) {
+	packaged := fullRunActivationLauncherPackage(t)
+	api := newSubmissionStageInstallerAPI(t)
+	plan, _ := PlanFullRunExecutionActivationInstallation(packaged)
+	api.objects[plan.Creates[3].ObjectPath] = map[string]any{"kind": "Job"}
+	launcher := newFullRunActivationLauncher(t, packaged, api.client())
+	receipt, err := launcher.Launch(context.Background())
+	if err == nil || receipt.State != "STOPPED_ZERO_WRITE" || receipt.MutationState != "NOT_ATTEMPTED" || api.posts != 0 || len(api.requests) != 4 {
+		t.Fatalf("existing activation object did not stop zero-write: %#v requests=%d posts=%d err=%v", receipt, len(api.requests), api.posts, err)
+	}
+}
+
+func TestFullRunExecutionActivationLauncherPreservesPartialAndCannotRetry(t *testing.T) {
+	packaged := fullRunActivationLauncherPackage(t)
+	api := newSubmissionStageInstallerAPI(t)
+	api.failPost = 3
+	launcher := newFullRunActivationLauncher(t, packaged, api.client())
+	receipt, err := launcher.Launch(context.Background())
+	if err == nil || receipt.State != "STOPPED_PARTIAL_OR_UNKNOWN" || receipt.MutationState != "ATTEMPTED" ||
+		len(receipt.Results) != 2 || receipt.Results[0].Kind != "Secret" || receipt.Results[1].Kind != "Secret" {
+		t.Fatalf("partial activation prefix differs: %#v %v", receipt, err)
+	}
+	requestCount := len(api.requests)
+	retry, retryErr := launcher.Launch(context.Background())
+	if retryErr == nil || retry.State != "STOPPED_ZERO_WRITE" || retry.MutationState != "NOT_ATTEMPTED" || len(api.requests) != requestCount {
+		t.Fatalf("single-use activation boundary failed: %#v requests=%d/%d err=%v", retry, len(api.requests), requestCount, retryErr)
+	}
+}
+
+func TestOpenFullRunExecutionActivationLauncherRequiresExactPackageBeforeCredential(t *testing.T) {
+	packaged := fullRunActivationLauncherPackage(t)
+	if _, err := OpenKubernetesFullRunExecutionActivationLauncher(FullRunExecutionActivationLauncherConfig{
+		Authority: KubernetesAuthorityConfig{
+			Endpoint: "https://192.0.2.10:6443", AuthorityIdentity: "ok-mgmt",
+			TokenFile: "/private/tmp/must-not-open-token", CAFile: "/private/tmp/must-not-open-ca", CABundleDigest: bundleSHA("a"),
+		},
+		ExpectedPackageDigest: bundleSHA("f"),
+	}, packaged); err == nil || !strings.Contains(err.Error(), "expected identity") {
+		t.Fatalf("foreign activation package identity reached credential opening: %v", err)
+	}
+}
+
+func TestFullRunExecutionActivationLauncherRejectsForeignAuthorityAndUnboundedEndpoint(t *testing.T) {
+	packaged := fullRunActivationLauncherPackage(t)
+	api := newSubmissionStageInstallerAPI(t)
+	for _, test := range []submissionStageInstallerClientConfig{
+		{Endpoint: "http://127.0.0.1:12345", BearerToken: "short-lived-installer-token", AuthorityIdentity: "ok-infra", Client: api.client()},
+		{Endpoint: "https://ok-mgmt.example:6443", BearerToken: "short-lived-installer-token", AuthorityIdentity: "ok-mgmt", Client: api.client()},
+		{Endpoint: "https://192.0.2.10:6443/path", BearerToken: "short-lived-installer-token", AuthorityIdentity: "ok-mgmt", Client: api.client()},
+	} {
+		if _, err := newKubernetesFullRunExecutionActivationLauncher(test, packaged); err == nil {
+			t.Fatalf("unsafe full-run launcher config accepted: %#v", test)
+		}
+	}
+}
+
+func fullRunActivationLauncherPackage(t *testing.T) VerifiedFullRunExecutionActivationPackage {
+	t.Helper()
+	config := fullRunExecutionActivationPackageFixture(t)
+	packaged, err := BuildFullRunExecutionActivationPackage(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return packaged
+}
+
+func newFullRunActivationLauncher(t *testing.T, packaged VerifiedFullRunExecutionActivationPackage, client *http.Client) *KubernetesFullRunExecutionActivationLauncher {
+	t.Helper()
+	launcher, err := newKubernetesFullRunExecutionActivationLauncher(submissionStageInstallerClientConfig{
+		Endpoint: "http://127.0.0.1:12345", BearerToken: "short-lived-installer-token", AuthorityIdentity: "ok-mgmt", Client: client,
+	}, packaged)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return launcher
+}

--- a/internal/runner/full_run_activation_package.go
+++ b/internal/runner/full_run_activation_package.go
@@ -43,15 +43,17 @@ type FullRunExecutionActivationPackageReceipt struct {
 	EvidenceKeyID                 string   `json:"evidenceKeyId"`
 	CollectorAuthorityDigest      string   `json:"collectorAuthorityDigest"`
 	CollectorCADigest             string   `json:"collectorCaDigest"`
+	ManagementAuthority           string   `json:"managementAuthority"`
 	PrivateFileCount              int      `json:"privateFileCount"`
 	ObjectKinds                   []string `json:"objectKinds"`
 	MutationAllowed               bool     `json:"mutationAllowed"`
 }
 
 type VerifiedFullRunExecutionActivationPackage struct {
-	raw      []byte
-	receipt  FullRunExecutionActivationPackageReceipt
-	verified bool
+	raw                 []byte
+	receipt             FullRunExecutionActivationPackageReceipt
+	managementAuthority string
+	verified            bool
 }
 
 // BuildFullRunExecutionActivationPackage binds the executor Secret, the
@@ -135,10 +137,13 @@ func BuildFullRunExecutionActivationPackage(config FullRunExecutionActivationPac
 		ManifestDigest: bundleReceipt.ManifestDigest, PlanDigest: bundleReceipt.PlanDigest,
 		EvidenceActivationDigest: evidenceReceipt.ActivationDigest, EvidenceKeyID: evidenceReceipt.EvidenceKeyID,
 		CollectorAuthorityDigest: evidenceReceipt.CollectorAuthorityDigest, CollectorCADigest: evidenceReceipt.CollectorCADigest,
-		PrivateFileCount: len(bundle.files) + evidenceReceipt.PrivateFileCount,
-		ObjectKinds:      []string{"Secret", "Secret", "NetworkPolicy", "Job"}, MutationAllowed: false,
+		ManagementAuthority: document.Plan.Expected.ManagementAuthority,
+		PrivateFileCount:    len(bundle.files) + evidenceReceipt.PrivateFileCount,
+		ObjectKinds:         []string{"Secret", "Secret", "NetworkPolicy", "Job"}, MutationAllowed: false,
 	}
-	return VerifiedFullRunExecutionActivationPackage{raw: packageRaw, receipt: receipt, verified: true}, nil
+	return VerifiedFullRunExecutionActivationPackage{
+		raw: packageRaw, receipt: receipt, managementAuthority: document.Plan.Expected.ManagementAuthority, verified: true,
+	}, nil
 }
 
 func (packaged VerifiedFullRunExecutionActivationPackage) PrivateBytes() ([]byte, error) {
@@ -161,6 +166,7 @@ func verifyFullRunExecutionActivationPackage(packaged VerifiedFullRunExecutionAc
 	receipt := packaged.receipt
 	if !packaged.verified || receipt.Format != FullRunExecutionActivationPackageFormat || receipt.State != "VERIFIED" || receipt.MutationAllowed ||
 		len(packaged.raw) == 0 || digest.SHA256(packaged.raw) != receipt.PackageDigest || receipt.ActivationSecret == receipt.EvidenceAuthoritySecret ||
+		receipt.ManagementAuthority == "" || receipt.ManagementAuthority != packaged.managementAuthority ||
 		receipt.PrivateFileCount != len(fullRunExecutionBundleFiles)+len(observabilityEvidenceAuthorityProjectedFiles) ||
 		len(receipt.ObjectKinds) != 4 || receipt.ObjectKinds[0] != "Secret" || receipt.ObjectKinds[1] != "Secret" ||
 		receipt.ObjectKinds[2] != "NetworkPolicy" || receipt.ObjectKinds[3] != "Job" {

--- a/internal/runner/full_run_activation_package_test.go
+++ b/internal/runner/full_run_activation_package_test.go
@@ -22,7 +22,7 @@ func TestBuildFullRunExecutionActivationPackageBindsBothAuthoritiesAndJob(t *tes
 	receipt, err := packaged.Receipt()
 	if err != nil || receipt.State != "VERIFIED" || receipt.MutationAllowed || receipt.PrivateFileCount != 30 ||
 		receipt.ActivationSecret != config.ActivationSecret || receipt.EvidenceAuthoritySecret != config.EvidenceAuthority.ActivationSecret ||
-		len(receipt.ObjectKinds) != 4 {
+		receipt.ManagementAuthority != "ok-mgmt" || len(receipt.ObjectKinds) != 4 {
 		t.Fatalf("unexpected full-run package receipt: %#v err=%v", receipt, err)
 	}
 	raw, err := packaged.PrivateBytes()


### PR DESCRIPTION
## Outcome

Adds the bounded single-use installer for the complete ephemeral Stage 1–12 activation package.

- derives an exact credential-free four-object installation plan
- verifies the package digest before opening the management credential
- completes all four exact-name absence GETs before the first write
- creates only executor Secret, Evidence Authority Secret, NetworkPolicy, then Job
- stops zero-write on existing state and preserves partial/unknown state without retry or cleanup
- emits only redaction-safe UID/resourceVersion digests

No live cluster or infrastructure mutation was performed.

## Verification

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`

All verification ran in the established unprivileged Linux container.