### PR TITLE
fix(runner): verify full-run activation prerequisites

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -3337,10 +3337,12 @@ does not open a Kubernetes credential, contact an API or grant installation
 authority.
 
 The corresponding bounded installer derives a credential-free plan from that
-same verified package. It requires four exact absence GETs before its first
-write and then permits only this order:
+same verified package. It first requires the exact execution Namespace and
+tokenless runtime ServiceAccount, then four exact absence GETs before its
+first write and permits only this order:
 
 ```text
+GET Namespace and runtime ServiceAccount (both must match)
 GET executor Secret, Evidence Authority Secret, NetworkPolicy, Job
         ↓ all four absent
 POST executor Secret

--- a/docs/ok147-operator-runbook.md
+++ b/docs/ok147-operator-runbook.md
@@ -12,16 +12,19 @@ bounded post-runtime suffix. It is neither a long-running operator nor a
 lifecycle source of truth. CAPI/CAPK, the selected Enablement mechanism and
 GitOps remain the owners of convergence.
 
-The live activation installs exactly three objects on `ok-mgmt`, in this order:
+The live activation installs exactly four objects on `ok-mgmt`, in this order:
 
 ```text
-immutable activation Secret
+immutable executor activation Secret
+        -> immutable Evidence Authority Secret
         -> deny-by-default NetworkPolicy
         -> non-retrying Job
 ```
 
-The launcher first reads all three exact names. Any existing object or failed
-read stops before the first write. Once a write has been attempted, an error or
+The launcher first verifies the exact execution Namespace and tokenless runtime
+ServiceAccount, then reads all four activation-object names. A missing or
+changed prerequisite, existing activation object or failed read stops before
+the first write. Once a write has been attempted, an error or
 uncertain response is preserved as `STOPPED_PARTIAL_OR_UNKNOWN`; do not retry,
 update, patch, apply, delete or clean up under the same authorization.
 
@@ -37,8 +40,9 @@ Before preparation, record and independently review:
 - one current signed authorization for every externally authorized stage;
 - short-lived, isolated credentials for the ledger, management, workload,
   GitOps and authorization endpoints;
-- the four exact `/32` egress destinations and ports;
-- the activation namespace, Secret, NetworkPolicy and Job names;
+- the six exact `/32` egress destinations and ports: infrastructure,
+  management, workload, Argo, authorization and independent evidence collector;
+- the activation namespace, both Secret names, NetworkPolicy and Job names;
 - independent observers, stop authority, recovery authority and evidence
   destination; and
 - the tested recovery procedure for the DEV environment.
@@ -58,11 +62,14 @@ must never be copied into public receipts, logs, commits or pull requests.
 2. Re-run the complete test suite and the offline activation-package tests.
 3. Verify every private input is a regular `0600` file below an existing private
    directory and that every credential is current and narrowly scoped.
-4. Run `post-runtime launch prepare` without installer credentials. Retain only
-   its redaction-safe package receipt and exact three-object installation plan.
+4. Run `full launch prepare` without installer credentials. Retain only its
+   redaction-safe package receipt and exact four-object installation plan.
 5. Compare the prepared package digest with the independently reviewed digest.
-6. Verify by exact-name reads that the activation Secret, NetworkPolicy and Job
-   are all absent. A missing observer or ambiguous result is a failed preflight.
+6. Verify by exact-name reads that Namespace `openkubes-execution-system` and
+   the exact tokenless `ok147-contract-executor-runtime` ServiceAccount exist,
+   then verify that both activation Secrets, NetworkPolicy and Job are absent.
+   A missing prerequisite, missing observer or ambiguous result is a failed
+   preflight.
 7. Confirm that no unrelated lifecycle change or failure injection is active.
 
 Preparation must not contact a cluster or consume the execution authorization.
@@ -70,7 +77,7 @@ Preparation must not contact a cluster or consume the execution authorization.
 ## Single-use launch
 
 Only after the preflight and explicit run authorization may the operator invoke
-`post-runtime launch execute --execute` with:
+`full launch execute --execute` with:
 
 - the exact expected package digest copied from the reviewed preparation;
 - the bound `ok-mgmt` installer endpoint and CA digest;
@@ -78,8 +85,9 @@ Only after the preflight and explicit run authorization may the operator invoke
 - the same immutable private activation inputs used during preparation.
 
 The command rebuilds the package, verifies its identity before opening the
-installer credential, repeats the complete absence preflight and performs at
-most the three ordered creates. Preserve its public receipt even when it stops.
+installer credential, repeats the complete prerequisite and absence preflight
+and performs at most the four ordered creates. Preserve its public receipt even
+when it stops.
 
 ## Observation and completion
 

--- a/docs/ok147-security-boundary.md
+++ b/docs/ok147-security-boundary.md
@@ -42,8 +42,9 @@ receipt alone grants no mutation authority.
 
 ## Credential boundary
 
-The activation Secret contains exactly the allowlisted private inputs for one
-run. A tokenless init container verifies their individual hashes and copies
+The two activation Secrets contain exactly the allowlisted executor and
+independent-evidence inputs for one run. Tokenless init containers verify their
+individual hashes and copy
 them from projected symlinks into a memory-backed `0700` workspace as regular
 `0600` files. The executor sees only that workspace.
 
@@ -54,19 +55,20 @@ The Job:
 - drops all Linux capabilities and forbids privilege escalation;
 - has no retry and a fixed active deadline;
 - uses only short-lived or stage-isolated credentials; and
-- has deny-by-default egress with four exact IP/port exceptions.
+- has deny-by-default egress with six exact IP/port exceptions.
 
-The immutable activation Secret retains credentials for the lifetime of the
-Job and Secret. Therefore its lifecycle is part of the operational risk: it
+The immutable activation Secrets retain credentials for their lifetime.
+Therefore their lifecycle is part of the operational risk: they
 must not be reused, copied to Git or treated as a durable credential store.
 Cleanup requires separate authority.
 
 ## Installation boundary
 
-The launcher can only perform exact-name `GET` and collection `POST` operations
-for one immutable Secret, one NetworkPolicy and one Job. All reads finish
-before the first write. It exposes no update, patch, apply, delete, list, watch,
-retry, rollback or cleanup operation.
+The launcher can only perform exact-name `GET` operations for the required
+Namespace, runtime ServiceAccount and four expected-absent activation objects,
+then collection `POST` operations for two immutable Secrets, one NetworkPolicy
+and one Job. All reads finish before the first write. It exposes no update,
+patch, apply, delete, list, watch, retry, rollback or cleanup operation.
 
 Kubernetes RBAC cannot prove create-body equality. The launcher therefore
 verifies the complete package digest before opening the installer credential,

--- a/internal/runner/full_run_activation_installation_plan.go
+++ b/internal/runner/full_run_activation_installation_plan.go
@@ -11,20 +11,32 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-const FullRunExecutionActivationInstallationPlanFormat = "ok147-full-run-execution-activation-installation-plan/v1"
+const FullRunExecutionActivationInstallationPlanFormat = "ok147-full-run-execution-activation-installation-plan/v2"
+
+type FullRunExecutionActivationPrerequisite struct {
+	Order       int    `json:"order"`
+	APIVersion  string `json:"apiVersion"`
+	Kind        string `json:"kind"`
+	Namespace   string `json:"namespace,omitempty"`
+	Name        string `json:"name"`
+	Method      string `json:"method"`
+	ObjectPath  string `json:"objectPath"`
+	ExpectState string `json:"expectState"`
+}
 
 // FullRunExecutionActivationInstallationPlan is the credential-free exact
 // absence/create sequence for the complete ephemeral Stage 1-12 execution.
 // It is evidence and grants no installation authority.
 type FullRunExecutionActivationInstallationPlan struct {
-	Format          string                      `json:"format"`
-	State           string                      `json:"state"`
-	RunID           string                      `json:"runId"`
-	PackageDigest   string                      `json:"packageDigest"`
-	PlanDigest      string                      `json:"planDigest"`
-	Authority       string                      `json:"authority"`
-	Creates         []SubmissionStageCreatePlan `json:"creates"`
-	MutationAllowed bool                        `json:"mutationAllowed"`
+	Format          string                                   `json:"format"`
+	State           string                                   `json:"state"`
+	RunID           string                                   `json:"runId"`
+	PackageDigest   string                                   `json:"packageDigest"`
+	PlanDigest      string                                   `json:"planDigest"`
+	Authority       string                                   `json:"authority"`
+	Prerequisites   []FullRunExecutionActivationPrerequisite `json:"prerequisites"`
+	Creates         []SubmissionStageCreatePlan              `json:"creates"`
+	MutationAllowed bool                                     `json:"mutationAllowed"`
 }
 
 // PlanFullRunExecutionActivationInstallation derives the exact
@@ -109,7 +121,14 @@ func PlanFullRunExecutionActivationInstallation(packaged VerifiedFullRunExecutio
 	return FullRunExecutionActivationInstallationPlan{
 		Format: FullRunExecutionActivationInstallationPlanFormat, State: "VERIFIED", RunID: runID,
 		PackageDigest: receipt.PackageDigest, PlanDigest: receipt.PlanDigest,
-		Authority: packaged.managementAuthority, Creates: creates, MutationAllowed: false,
+		Authority: packaged.managementAuthority,
+		Prerequisites: []FullRunExecutionActivationPrerequisite{
+			{Order: 1, APIVersion: "v1", Kind: "Namespace", Name: submissionStageInputNamespace, Method: http.MethodGet,
+				ObjectPath: "/api/v1/namespaces/" + submissionStageInputNamespace, ExpectState: "PRESENT"},
+			{Order: 2, APIVersion: "v1", Kind: "ServiceAccount", Namespace: submissionStageInputNamespace, Name: "ok147-contract-executor-runtime", Method: http.MethodGet,
+				ObjectPath: "/api/v1/namespaces/" + submissionStageInputNamespace + "/serviceaccounts/ok147-contract-executor-runtime", ExpectState: "PRESENT_EXACT_RUNTIME"},
+		},
+		Creates: creates, MutationAllowed: false,
 	}, nil
 }
 

--- a/internal/runner/full_run_activation_launcher.go
+++ b/internal/runner/full_run_activation_launcher.go
@@ -3,6 +3,7 @@ package runner
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -107,7 +108,8 @@ func newKubernetesFullRunExecutionActivationLauncher(config submissionStageInsta
 	}, nil
 }
 
-// Launch completes all four exact-name GETs before its first POST, then
+// Launch verifies the exact Namespace and runtime ServiceAccount, completes
+// all four exact-name absence GETs before its first POST, then
 // creates executor Secret, Evidence Authority Secret, NetworkPolicy and Job in
 // that order. It exposes no retry, update, patch, apply, delete or cleanup.
 func (launcher *KubernetesFullRunExecutionActivationLauncher) Launch(ctx context.Context) (FullRunExecutionActivationLaunchReceipt, error) {
@@ -122,6 +124,19 @@ func (launcher *KubernetesFullRunExecutionActivationLauncher) Launch(ctx context
 	}
 	launcher.used = true
 	launcher.mu.Unlock()
+
+	for _, prerequisite := range launcher.plan.Prerequisites {
+		raw, status, err := launcher.request(ctx, http.MethodGet, prerequisite.ObjectPath, nil)
+		if err != nil {
+			return stopFullRunExecutionActivation(receipt, "STOPPED_ZERO_WRITE", err)
+		}
+		if status != http.StatusOK {
+			return stopFullRunExecutionActivation(receipt, "STOPPED_ZERO_WRITE", fullRunActivationStatusError(http.MethodGet, status))
+		}
+		if !fullRunActivationPrerequisiteMatches(raw, prerequisite) {
+			return stopFullRunExecutionActivation(receipt, "STOPPED_ZERO_WRITE", errors.New("full-run activation prerequisite differs; zero-write preflight stopped"))
+		}
+	}
 
 	for _, object := range launcher.objects {
 		_, status, err := launcher.request(ctx, http.MethodGet, object.plan.ObjectPath, nil)
@@ -161,6 +176,29 @@ func (launcher *KubernetesFullRunExecutionActivationLauncher) Launch(ctx context
 	}
 	receipt.State = "ACTIVATED"
 	return receipt, nil
+}
+
+func fullRunActivationPrerequisiteMatches(raw []byte, prerequisite FullRunExecutionActivationPrerequisite) bool {
+	var object map[string]any
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	if err := decoder.Decode(&object); err != nil || object["apiVersion"] != prerequisite.APIVersion || object["kind"] != prerequisite.Kind {
+		return false
+	}
+	metadata, ok := object["metadata"].(map[string]any)
+	if !ok || metadata["name"] != prerequisite.Name {
+		return false
+	}
+	if prerequisite.Namespace != "" && metadata["namespace"] != prerequisite.Namespace {
+		return false
+	}
+	if prerequisite.ExpectState == "PRESENT_EXACT_RUNTIME" {
+		labels, _ := metadata["labels"].(map[string]any)
+		return object["automountServiceAccountToken"] == false &&
+			labels["app.kubernetes.io/name"] == "ok-cluster-contract-executor" &&
+			labels["openkubes.io/runtime-boundary"] == "submission-stage"
+	}
+	return prerequisite.ExpectState == "PRESENT"
 }
 
 func (launcher *KubernetesFullRunExecutionActivationLauncher) newReceipt() FullRunExecutionActivationLaunchReceipt {

--- a/internal/runner/full_run_activation_launcher_test.go
+++ b/internal/runner/full_run_activation_launcher_test.go
@@ -18,8 +18,12 @@ func TestPlanFullRunExecutionActivationInstallationBindsExactOrder(t *testing.T)
 		t.Fatal(err)
 	}
 	if plan.Format != FullRunExecutionActivationInstallationPlanFormat || plan.State != "VERIFIED" ||
-		plan.RunID != "ok147-full-run-01" || plan.Authority != "ok-mgmt" || plan.MutationAllowed || len(plan.Creates) != 4 {
+		plan.RunID != "ok147-full-run-01" || plan.Authority != "ok-mgmt" || plan.MutationAllowed || len(plan.Prerequisites) != 2 || len(plan.Creates) != 4 {
 		t.Fatalf("unexpected full-run activation plan: %#v", plan)
+	}
+	if plan.Prerequisites[0].Kind != "Namespace" || plan.Prerequisites[0].ExpectState != "PRESENT" ||
+		plan.Prerequisites[1].Kind != "ServiceAccount" || plan.Prerequisites[1].ExpectState != "PRESENT_EXACT_RUNTIME" {
+		t.Fatalf("unexpected full-run prerequisites: %#v", plan.Prerequisites)
 	}
 	for index, kind := range []string{"Secret", "Secret", "NetworkPolicy", "Job"} {
 		create := plan.Creates[index]
@@ -62,6 +66,7 @@ func TestPlanFullRunExecutionActivationInstallationFailsClosed(t *testing.T) {
 func TestFullRunExecutionActivationLauncherPreflightsThenCreates(t *testing.T) {
 	packaged := fullRunActivationLauncherPackage(t)
 	api := newSubmissionStageInstallerAPI(t)
+	seedFullRunActivationPrerequisites(api)
 	launcher := newFullRunActivationLauncher(t, packaged, api.client())
 	receipt, err := launcher.Launch(context.Background())
 	if err != nil || receipt.State != "ACTIVATED" || receipt.MutationState != "ATTEMPTED" || len(receipt.Results) != 4 {
@@ -72,11 +77,17 @@ func TestFullRunExecutionActivationLauncherPreflightsThenCreates(t *testing.T) {
 		receipt.PlanDigest != plan.PlanDigest || receipt.RunID != plan.RunID || receipt.Authority != "ok-mgmt" {
 		t.Fatalf("activation receipt identity differs: %#v", receipt)
 	}
-	if len(api.requests) != 8 {
-		t.Fatalf("requests=%d, want four GETs then four POSTs: %#v", len(api.requests), api.requests)
+	if len(api.requests) != 10 {
+		t.Fatalf("requests=%d, want two prerequisite GETs, four absence GETs, then four POSTs: %#v", len(api.requests), api.requests)
+	}
+	for index, prerequisite := range plan.Prerequisites {
+		request := api.requests[index]
+		if request.method != prerequisite.Method || request.path != prerequisite.ObjectPath || len(request.body) != 0 {
+			t.Fatalf("prerequisite %d differs: %#v", index, request)
+		}
 	}
 	for index, create := range plan.Creates {
-		preflight, submission := api.requests[index], api.requests[index+4]
+		preflight, submission := api.requests[index+2], api.requests[index+6]
 		if preflight.method != http.MethodGet || preflight.path != create.ObjectPath || len(preflight.body) != 0 {
 			t.Fatalf("preflight %d differs: %#v", index, preflight)
 		}
@@ -96,11 +107,12 @@ func TestFullRunExecutionActivationLauncherPreflightsThenCreates(t *testing.T) {
 func TestFullRunExecutionActivationLauncherStopsZeroWriteOnExistingObject(t *testing.T) {
 	packaged := fullRunActivationLauncherPackage(t)
 	api := newSubmissionStageInstallerAPI(t)
+	seedFullRunActivationPrerequisites(api)
 	plan, _ := PlanFullRunExecutionActivationInstallation(packaged)
 	api.objects[plan.Creates[3].ObjectPath] = map[string]any{"kind": "Job"}
 	launcher := newFullRunActivationLauncher(t, packaged, api.client())
 	receipt, err := launcher.Launch(context.Background())
-	if err == nil || receipt.State != "STOPPED_ZERO_WRITE" || receipt.MutationState != "NOT_ATTEMPTED" || api.posts != 0 || len(api.requests) != 4 {
+	if err == nil || receipt.State != "STOPPED_ZERO_WRITE" || receipt.MutationState != "NOT_ATTEMPTED" || api.posts != 0 || len(api.requests) != 6 {
 		t.Fatalf("existing activation object did not stop zero-write: %#v requests=%d posts=%d err=%v", receipt, len(api.requests), api.posts, err)
 	}
 }
@@ -108,6 +120,7 @@ func TestFullRunExecutionActivationLauncherStopsZeroWriteOnExistingObject(t *tes
 func TestFullRunExecutionActivationLauncherPreservesPartialAndCannotRetry(t *testing.T) {
 	packaged := fullRunActivationLauncherPackage(t)
 	api := newSubmissionStageInstallerAPI(t)
+	seedFullRunActivationPrerequisites(api)
 	api.failPost = 3
 	launcher := newFullRunActivationLauncher(t, packaged, api.client())
 	receipt, err := launcher.Launch(context.Background())
@@ -119,6 +132,28 @@ func TestFullRunExecutionActivationLauncherPreservesPartialAndCannotRetry(t *tes
 	retry, retryErr := launcher.Launch(context.Background())
 	if retryErr == nil || retry.State != "STOPPED_ZERO_WRITE" || retry.MutationState != "NOT_ATTEMPTED" || len(api.requests) != requestCount {
 		t.Fatalf("single-use activation boundary failed: %#v requests=%d/%d err=%v", retry, len(api.requests), requestCount, retryErr)
+	}
+}
+
+func TestFullRunExecutionActivationLauncherStopsZeroWriteOnMissingOrChangedPrerequisite(t *testing.T) {
+	packaged := fullRunActivationLauncherPackage(t)
+	for name, seed := range map[string]func(*submissionStageInstallerAPI){
+		"missing": func(api *submissionStageInstallerAPI) {},
+		"changed runtime": func(api *submissionStageInstallerAPI) {
+			seedFullRunActivationPrerequisites(api)
+			path := "/api/v1/namespaces/openkubes-execution-system/serviceaccounts/ok147-contract-executor-runtime"
+			api.objects[path]["automountServiceAccountToken"] = true
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			api := newSubmissionStageInstallerAPI(t)
+			seed(api)
+			launcher := newFullRunActivationLauncher(t, packaged, api.client())
+			receipt, err := launcher.Launch(context.Background())
+			if err == nil || receipt.State != "STOPPED_ZERO_WRITE" || receipt.MutationState != "NOT_ATTEMPTED" || api.posts != 0 {
+				t.Fatalf("unsafe prerequisite did not stop zero-write: %#v posts=%d err=%v", receipt, api.posts, err)
+			}
+		})
 	}
 }
 
@@ -168,4 +203,16 @@ func newFullRunActivationLauncher(t *testing.T, packaged VerifiedFullRunExecutio
 		t.Fatal(err)
 	}
 	return launcher
+}
+
+func seedFullRunActivationPrerequisites(api *submissionStageInstallerAPI) {
+	api.objects["/api/v1/namespaces/openkubes-execution-system"] = map[string]any{
+		"apiVersion": "v1", "kind": "Namespace", "metadata": map[string]any{"name": "openkubes-execution-system"},
+	}
+	api.objects["/api/v1/namespaces/openkubes-execution-system/serviceaccounts/ok147-contract-executor-runtime"] = map[string]any{
+		"apiVersion": "v1", "kind": "ServiceAccount", "automountServiceAccountToken": false,
+		"metadata": map[string]any{"name": "ok147-contract-executor-runtime", "namespace": "openkubes-execution-system", "labels": map[string]any{
+			"app.kubernetes.io/name": "ok-cluster-contract-executor", "openkubes.io/runtime-boundary": "submission-stage",
+		}},
+	}
 }


### PR DESCRIPTION
## Outcome

The full-run launcher now fails before its first write unless the exact execution Namespace and tokenless runtime ServiceAccount are present and match the required runtime boundary.

## Changes

- bump the credential-free installation plan to v2 and bind two required-present prerequisites
- verify Namespace and runtime ServiceAccount before all four expected-absent activation objects
- preserve the existing single-use, create-only, zero-write/partial-state behavior
- align the operator runbook and security boundary with four activation objects and six exact egress destinations

## Verification

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `git diff --check`

All Go checks passed in an unprivileged Linux container.

No cluster contact or infrastructure mutation was performed.