### PR TITLE
fix(runner): require exact ledger boundary

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -3337,12 +3337,13 @@ does not open a Kubernetes credential, contact an API or grant installation
 authority.
 
 The corresponding bounded installer derives a credential-free plan from that
-same verified package. It first requires the exact execution Namespace and
-tokenless runtime ServiceAccount, then four exact absence GETs before its
-first write and permits only this order:
+same verified package. It first requires the exact execution Namespace,
+tokenless runtime ServiceAccount and Ledger writer/admission boundary, then
+four exact absence GETs before its first write and permits only this order:
 
 ```text
-GET Namespace and runtime ServiceAccount (both must match)
+GET Namespace, runtime ServiceAccount and Ledger writer/admission prerequisites
+        ↓ all seven prerequisites match
 GET executor Secret, Evidence Authority Secret, NetworkPolicy, Job
         ↓ all four absent
 POST executor Secret

--- a/docs/ok147-operator-runbook.md
+++ b/docs/ok147-operator-runbook.md
@@ -21,10 +21,11 @@ immutable executor activation Secret
         -> non-retrying Job
 ```
 
-The launcher first verifies the exact execution Namespace and tokenless runtime
-ServiceAccount, then reads all four activation-object names. A missing or
-changed prerequisite, existing activation object or failed read stops before
-the first write. Once a write has been attempted, an error or
+The launcher first verifies the exact execution Namespace, tokenless runtime
+ServiceAccount and complete Ledger writer/admission boundary, then reads all
+four activation-object names. A missing or changed prerequisite, existing
+activation object or failed read stops before the first write. Once a write has
+been attempted, an error or
 uncertain response is preserved as `STOPPED_PARTIAL_OR_UNKNOWN`; do not retry,
 update, patch, apply, delete or clean up under the same authorization.
 
@@ -65,11 +66,12 @@ must never be copied into public receipts, logs, commits or pull requests.
 4. Run `full launch prepare` without installer credentials. Retain only its
    redaction-safe package receipt and exact four-object installation plan.
 5. Compare the prepared package digest with the independently reviewed digest.
-6. Verify by exact-name reads that Namespace `openkubes-execution-system` and
-   the exact tokenless `ok147-contract-executor-runtime` ServiceAccount exist,
-   then verify that both activation Secrets, NetworkPolicy and Job are absent.
-   A missing prerequisite, missing observer or ambiguous result is a failed
-   preflight.
+6. Verify by exact-name reads that Namespace `openkubes-execution-system`, the
+   exact tokenless `ok147-contract-executor-runtime` ServiceAccount, Ledger
+   writer ServiceAccount/Role/RoleBinding and fail-closed Ledger admission
+   policy/binding exist. Then verify that both activation Secrets,
+   NetworkPolicy and Job are absent. A missing prerequisite, missing observer
+   or ambiguous result is a failed preflight.
 7. Confirm that no unrelated lifecycle change or failure injection is active.
 
 Preparation must not contact a cluster or consume the execution authorization.

--- a/docs/ok147-security-boundary.md
+++ b/docs/ok147-security-boundary.md
@@ -65,10 +65,12 @@ Cleanup requires separate authority.
 ## Installation boundary
 
 The launcher can only perform exact-name `GET` operations for the required
-Namespace, runtime ServiceAccount and four expected-absent activation objects,
-then collection `POST` operations for two immutable Secrets, one NetworkPolicy
-and one Job. All reads finish before the first write. It exposes no update,
-patch, apply, delete, list, watch, retry, rollback or cleanup operation.
+Namespace, runtime ServiceAccount, Ledger writer ServiceAccount/RBAC and
+fail-closed Ledger admission policy/binding plus four expected-absent activation
+objects. It then permits collection `POST` operations for two immutable
+Secrets, one NetworkPolicy and one Job. All reads finish before the first
+write. It exposes no update, patch, apply, delete, list, watch, retry, rollback
+or cleanup operation.
 
 Kubernetes RBAC cannot prove create-body equality. The launcher therefore
 verifies the complete package digest before opening the installer credential,

--- a/internal/runner/full_run_activation_installation_plan.go
+++ b/internal/runner/full_run_activation_installation_plan.go
@@ -11,7 +11,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-const FullRunExecutionActivationInstallationPlanFormat = "ok147-full-run-execution-activation-installation-plan/v2"
+const FullRunExecutionActivationInstallationPlanFormat = "ok147-full-run-execution-activation-installation-plan/v3"
 
 type FullRunExecutionActivationPrerequisite struct {
 	Order       int    `json:"order"`
@@ -127,6 +127,16 @@ func PlanFullRunExecutionActivationInstallation(packaged VerifiedFullRunExecutio
 				ObjectPath: "/api/v1/namespaces/" + submissionStageInputNamespace, ExpectState: "PRESENT"},
 			{Order: 2, APIVersion: "v1", Kind: "ServiceAccount", Namespace: submissionStageInputNamespace, Name: "ok147-contract-executor-runtime", Method: http.MethodGet,
 				ObjectPath: "/api/v1/namespaces/" + submissionStageInputNamespace + "/serviceaccounts/ok147-contract-executor-runtime", ExpectState: "PRESENT_EXACT_RUNTIME"},
+			{Order: 3, APIVersion: "v1", Kind: "ServiceAccount", Namespace: submissionStageInputNamespace, Name: "ok147-contract-executor", Method: http.MethodGet,
+				ObjectPath: "/api/v1/namespaces/" + submissionStageInputNamespace + "/serviceaccounts/ok147-contract-executor", ExpectState: "PRESENT_EXACT_LEDGER_WRITER"},
+			{Order: 4, APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role", Namespace: submissionStageInputNamespace, Name: "ok147-ledger-writer", Method: http.MethodGet,
+				ObjectPath: "/apis/rbac.authorization.k8s.io/v1/namespaces/" + submissionStageInputNamespace + "/roles/ok147-ledger-writer", ExpectState: "PRESENT_EXACT_LEDGER_WRITER_ROLE"},
+			{Order: 5, APIVersion: "rbac.authorization.k8s.io/v1", Kind: "RoleBinding", Namespace: submissionStageInputNamespace, Name: "ok147-ledger-writer", Method: http.MethodGet,
+				ObjectPath: "/apis/rbac.authorization.k8s.io/v1/namespaces/" + submissionStageInputNamespace + "/rolebindings/ok147-ledger-writer", ExpectState: "PRESENT_EXACT_LEDGER_WRITER_BINDING"},
+			{Order: 6, APIVersion: "admissionregistration.k8s.io/v1", Kind: "ValidatingAdmissionPolicy", Name: "ok147-contract-executor-ledger", Method: http.MethodGet,
+				ObjectPath: "/apis/admissionregistration.k8s.io/v1/validatingadmissionpolicies/ok147-contract-executor-ledger", ExpectState: "PRESENT_EXACT_LEDGER_POLICY"},
+			{Order: 7, APIVersion: "admissionregistration.k8s.io/v1", Kind: "ValidatingAdmissionPolicyBinding", Name: "ok147-contract-executor-ledger", Method: http.MethodGet,
+				ObjectPath: "/apis/admissionregistration.k8s.io/v1/validatingadmissionpolicybindings/ok147-contract-executor-ledger", ExpectState: "PRESENT_EXACT_LEDGER_POLICY_BINDING"},
 		},
 		Creates: creates, MutationAllowed: false,
 	}, nil

--- a/internal/runner/full_run_activation_launcher.go
+++ b/internal/runner/full_run_activation_launcher.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -198,7 +199,119 @@ func fullRunActivationPrerequisiteMatches(raw []byte, prerequisite FullRunExecut
 			labels["app.kubernetes.io/name"] == "ok-cluster-contract-executor" &&
 			labels["openkubes.io/runtime-boundary"] == "submission-stage"
 	}
-	return prerequisite.ExpectState == "PRESENT"
+	switch prerequisite.ExpectState {
+	case "PRESENT":
+		return true
+	case "PRESENT_EXACT_LEDGER_WRITER":
+		return object["automountServiceAccountToken"] == false
+	case "PRESENT_EXACT_LEDGER_WRITER_ROLE":
+		return fullRunLedgerWriterRoleMatches(object)
+	case "PRESENT_EXACT_LEDGER_WRITER_BINDING":
+		return fullRunLedgerWriterBindingMatches(object)
+	case "PRESENT_EXACT_LEDGER_POLICY":
+		return fullRunLedgerPolicyMatches(object)
+	case "PRESENT_EXACT_LEDGER_POLICY_BINDING":
+		return fullRunLedgerPolicyBindingMatches(object)
+	default:
+		return false
+	}
+}
+
+func fullRunLedgerWriterRoleMatches(object map[string]any) bool {
+	rules, ok := object["rules"].([]any)
+	if !ok || len(rules) != 1 {
+		return false
+	}
+	rule, ok := rules[0].(map[string]any)
+	return ok && exactStringSet(rule["apiGroups"], "") && exactStringSet(rule["resources"], "configmaps") &&
+		exactStringSet(rule["verbs"], "create", "get") && rule["resourceNames"] == nil && rule["nonResourceURLs"] == nil
+}
+
+func fullRunLedgerWriterBindingMatches(object map[string]any) bool {
+	roleRef, _ := object["roleRef"].(map[string]any)
+	subjects, ok := object["subjects"].([]any)
+	if !ok || len(subjects) != 1 || roleRef["apiGroup"] != "rbac.authorization.k8s.io" || roleRef["kind"] != "Role" || roleRef["name"] != "ok147-ledger-writer" {
+		return false
+	}
+	subject, _ := subjects[0].(map[string]any)
+	return subject["kind"] == "ServiceAccount" && subject["name"] == "ok147-contract-executor" && subject["namespace"] == submissionStageInputNamespace
+}
+
+func fullRunLedgerPolicyMatches(object map[string]any) bool {
+	spec, _ := object["spec"].(map[string]any)
+	constraints, _ := spec["matchConstraints"].(map[string]any)
+	rules, ok := constraints["resourceRules"].([]any)
+	if spec["failurePolicy"] != "Fail" || !ok || len(rules) != 1 {
+		return false
+	}
+	rule, _ := rules[0].(map[string]any)
+	if !exactStringSet(rule["apiGroups"], "") || !exactStringSet(rule["apiVersions"], "v1") ||
+		!exactStringSet(rule["operations"], "CREATE") || !exactStringSet(rule["resources"], "configmaps") || rule["scope"] != "Namespaced" {
+		return false
+	}
+	conditions, ok := spec["matchConditions"].([]any)
+	if !ok || len(conditions) != 1 {
+		return false
+	}
+	condition, _ := conditions[0].(map[string]any)
+	if condition["name"] != "exact-ledger-namespace" || strings.Join(strings.Fields(textValue(condition["expression"])), " ") != "request.namespace == 'openkubes-execution-system'" {
+		return false
+	}
+	validations, ok := spec["validations"].([]any)
+	if !ok || len(validations) != len(fullRunLedgerValidationExpressions) {
+		return false
+	}
+	actual := make([]string, 0, len(validations))
+	for _, value := range validations {
+		validation, _ := value.(map[string]any)
+		actual = append(actual, strings.Join(strings.Fields(textValue(validation["expression"])), " "))
+	}
+	sort.Strings(actual)
+	expected := append([]string(nil), fullRunLedgerValidationExpressions...)
+	sort.Strings(expected)
+	return equalStringList(actual, expected)
+}
+
+var fullRunLedgerValidationExpressions = []string{
+	"request.userInfo.username == 'system:serviceaccount:openkubes-execution-system:ok147-contract-executor'",
+	"object.metadata.name.matches('^ok147-(claim|outcome|receipt)-[0-9a-f]{48}$')",
+	"has(object.immutable) && object.immutable == true",
+	"has(object.data) && size(object.data) == 1 && 'receipt.json' in object.data && (!has(object.binaryData) || size(object.binaryData) == 0)",
+	"has(object.metadata.labels) && size(object.metadata.labels) == 2 && object.metadata.labels['app.kubernetes.io/managed-by'] == 'ok-cluster-contract-executor' && object.metadata.labels['openkubes.io/ledger-record'] in ['claim', 'outcome', 'stage-receipt']",
+	"(object.metadata.name.startsWith('ok147-claim-') && object.metadata.labels['openkubes.io/ledger-record'] == 'claim') || (object.metadata.name.startsWith('ok147-outcome-') && object.metadata.labels['openkubes.io/ledger-record'] == 'outcome') || (object.metadata.name.startsWith('ok147-receipt-') && object.metadata.labels['openkubes.io/ledger-record'] == 'stage-receipt')",
+	"has(object.metadata.annotations) && size(object.metadata.annotations) == 2 && object.metadata.annotations['openkubes.io/record-key'].matches('^[0-9a-f]{64}$') && object.metadata.annotations['openkubes.io/content-digest'].matches('^sha256:[0-9a-f]{64}$')",
+}
+
+func fullRunLedgerPolicyBindingMatches(object map[string]any) bool {
+	spec, _ := object["spec"].(map[string]any)
+	resources, _ := spec["matchResources"].(map[string]any)
+	selector, _ := resources["namespaceSelector"].(map[string]any)
+	labels, _ := selector["matchLabels"].(map[string]any)
+	return spec["policyName"] == "ok147-contract-executor-ledger" && exactStringSet(spec["validationActions"], "Deny") &&
+		len(labels) == 1 && labels["kubernetes.io/metadata.name"] == submissionStageInputNamespace
+}
+
+func exactStringSet(value any, expected ...string) bool {
+	values, ok := value.([]any)
+	if !ok || len(values) != len(expected) {
+		return false
+	}
+	actual := make([]string, 0, len(values))
+	for _, item := range values {
+		text, ok := item.(string)
+		if !ok {
+			return false
+		}
+		actual = append(actual, text)
+	}
+	sort.Strings(actual)
+	sort.Strings(expected)
+	return equalStringList(actual, expected)
+}
+
+func textValue(value any) string {
+	text, _ := value.(string)
+	return text
 }
 
 func (launcher *KubernetesFullRunExecutionActivationLauncher) newReceipt() FullRunExecutionActivationLaunchReceipt {

--- a/internal/runner/full_run_activation_launcher_test.go
+++ b/internal/runner/full_run_activation_launcher_test.go
@@ -4,11 +4,17 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
+	"io"
 	"net/http"
+	"os"
+	"path/filepath"
+	goruntime "runtime"
 	"strings"
 	"testing"
 
 	"github.com/openkubes/ok-cluster/internal/digest"
+	"gopkg.in/yaml.v3"
 )
 
 func TestPlanFullRunExecutionActivationInstallationBindsExactOrder(t *testing.T) {
@@ -18,11 +24,12 @@ func TestPlanFullRunExecutionActivationInstallationBindsExactOrder(t *testing.T)
 		t.Fatal(err)
 	}
 	if plan.Format != FullRunExecutionActivationInstallationPlanFormat || plan.State != "VERIFIED" ||
-		plan.RunID != "ok147-full-run-01" || plan.Authority != "ok-mgmt" || plan.MutationAllowed || len(plan.Prerequisites) != 2 || len(plan.Creates) != 4 {
+		plan.RunID != "ok147-full-run-01" || plan.Authority != "ok-mgmt" || plan.MutationAllowed || len(plan.Prerequisites) != 7 || len(plan.Creates) != 4 {
 		t.Fatalf("unexpected full-run activation plan: %#v", plan)
 	}
 	if plan.Prerequisites[0].Kind != "Namespace" || plan.Prerequisites[0].ExpectState != "PRESENT" ||
-		plan.Prerequisites[1].Kind != "ServiceAccount" || plan.Prerequisites[1].ExpectState != "PRESENT_EXACT_RUNTIME" {
+		plan.Prerequisites[1].Kind != "ServiceAccount" || plan.Prerequisites[1].ExpectState != "PRESENT_EXACT_RUNTIME" ||
+		plan.Prerequisites[5].Kind != "ValidatingAdmissionPolicy" || plan.Prerequisites[6].Kind != "ValidatingAdmissionPolicyBinding" {
 		t.Fatalf("unexpected full-run prerequisites: %#v", plan.Prerequisites)
 	}
 	for index, kind := range []string{"Secret", "Secret", "NetworkPolicy", "Job"} {
@@ -77,8 +84,8 @@ func TestFullRunExecutionActivationLauncherPreflightsThenCreates(t *testing.T) {
 		receipt.PlanDigest != plan.PlanDigest || receipt.RunID != plan.RunID || receipt.Authority != "ok-mgmt" {
 		t.Fatalf("activation receipt identity differs: %#v", receipt)
 	}
-	if len(api.requests) != 10 {
-		t.Fatalf("requests=%d, want two prerequisite GETs, four absence GETs, then four POSTs: %#v", len(api.requests), api.requests)
+	if len(api.requests) != 15 {
+		t.Fatalf("requests=%d, want seven prerequisite GETs, four absence GETs, then four POSTs: %#v", len(api.requests), api.requests)
 	}
 	for index, prerequisite := range plan.Prerequisites {
 		request := api.requests[index]
@@ -87,7 +94,7 @@ func TestFullRunExecutionActivationLauncherPreflightsThenCreates(t *testing.T) {
 		}
 	}
 	for index, create := range plan.Creates {
-		preflight, submission := api.requests[index+2], api.requests[index+6]
+		preflight, submission := api.requests[index+7], api.requests[index+11]
 		if preflight.method != http.MethodGet || preflight.path != create.ObjectPath || len(preflight.body) != 0 {
 			t.Fatalf("preflight %d differs: %#v", index, preflight)
 		}
@@ -112,7 +119,7 @@ func TestFullRunExecutionActivationLauncherStopsZeroWriteOnExistingObject(t *tes
 	api.objects[plan.Creates[3].ObjectPath] = map[string]any{"kind": "Job"}
 	launcher := newFullRunActivationLauncher(t, packaged, api.client())
 	receipt, err := launcher.Launch(context.Background())
-	if err == nil || receipt.State != "STOPPED_ZERO_WRITE" || receipt.MutationState != "NOT_ATTEMPTED" || api.posts != 0 || len(api.requests) != 6 {
+	if err == nil || receipt.State != "STOPPED_ZERO_WRITE" || receipt.MutationState != "NOT_ATTEMPTED" || api.posts != 0 || len(api.requests) != 11 {
 		t.Fatalf("existing activation object did not stop zero-write: %#v requests=%d posts=%d err=%v", receipt, len(api.requests), api.posts, err)
 	}
 }
@@ -143,6 +150,11 @@ func TestFullRunExecutionActivationLauncherStopsZeroWriteOnMissingOrChangedPrere
 			seedFullRunActivationPrerequisites(api)
 			path := "/api/v1/namespaces/openkubes-execution-system/serviceaccounts/ok147-contract-executor-runtime"
 			api.objects[path]["automountServiceAccountToken"] = true
+		},
+		"weakened ledger policy": func(api *submissionStageInstallerAPI) {
+			seedFullRunActivationPrerequisites(api)
+			path := "/apis/admissionregistration.k8s.io/v1/validatingadmissionpolicies/ok147-contract-executor-ledger"
+			api.objects[path]["spec"].(map[string]any)["failurePolicy"] = "Ignore"
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -206,13 +218,43 @@ func newFullRunActivationLauncher(t *testing.T, packaged VerifiedFullRunExecutio
 }
 
 func seedFullRunActivationPrerequisites(api *submissionStageInstallerAPI) {
-	api.objects["/api/v1/namespaces/openkubes-execution-system"] = map[string]any{
-		"apiVersion": "v1", "kind": "Namespace", "metadata": map[string]any{"name": "openkubes-execution-system"},
+	_, filename, _, ok := goruntime.Caller(0)
+	if !ok {
+		api.t.Fatal("cannot resolve full-run prerequisite fixture path")
 	}
-	api.objects["/api/v1/namespaces/openkubes-execution-system/serviceaccounts/ok147-contract-executor-runtime"] = map[string]any{
-		"apiVersion": "v1", "kind": "ServiceAccount", "automountServiceAccountToken": false,
-		"metadata": map[string]any{"name": "ok147-contract-executor-runtime", "namespace": "openkubes-execution-system", "labels": map[string]any{
-			"app.kubernetes.io/name": "ok-cluster-contract-executor", "openkubes.io/runtime-boundary": "submission-stage",
-		}},
+	wanted := map[string]string{
+		"Namespace//openkubes-execution-system":                                     "/api/v1/namespaces/openkubes-execution-system",
+		"ServiceAccount/openkubes-execution-system/ok147-contract-executor-runtime": "/api/v1/namespaces/openkubes-execution-system/serviceaccounts/ok147-contract-executor-runtime",
+		"ServiceAccount/openkubes-execution-system/ok147-contract-executor":         "/api/v1/namespaces/openkubes-execution-system/serviceaccounts/ok147-contract-executor",
+		"Role/openkubes-execution-system/ok147-ledger-writer":                       "/apis/rbac.authorization.k8s.io/v1/namespaces/openkubes-execution-system/roles/ok147-ledger-writer",
+		"RoleBinding/openkubes-execution-system/ok147-ledger-writer":                "/apis/rbac.authorization.k8s.io/v1/namespaces/openkubes-execution-system/rolebindings/ok147-ledger-writer",
+		"ValidatingAdmissionPolicy//ok147-contract-executor-ledger":                 "/apis/admissionregistration.k8s.io/v1/validatingadmissionpolicies/ok147-contract-executor-ledger",
+		"ValidatingAdmissionPolicyBinding//ok147-contract-executor-ledger":          "/apis/admissionregistration.k8s.io/v1/validatingadmissionpolicybindings/ok147-contract-executor-ledger",
+	}
+	for _, name := range []string{"contract-executor-ledger.yaml", "contract-executor-stage-runtime.yaml"} {
+		raw, err := os.ReadFile(filepath.Join(filepath.Dir(filename), "..", "..", "deploy", name))
+		if err != nil {
+			api.t.Fatal(err)
+		}
+		decoder := yaml.NewDecoder(bytes.NewReader(raw))
+		for {
+			var object map[string]any
+			err := decoder.Decode(&object)
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			if err != nil {
+				api.t.Fatal(err)
+			}
+			metadata, _ := object["metadata"].(map[string]any)
+			key := textValue(object["kind"]) + "/" + textValue(metadata["namespace"]) + "/" + textValue(metadata["name"])
+			if objectPath, required := wanted[key]; required {
+				api.objects[objectPath] = object
+				delete(wanted, key)
+			}
+		}
+	}
+	if len(wanted) != 0 {
+		api.t.Fatalf("full-run deployment fixtures lack prerequisites: %#v", wanted)
 	}
 }


### PR DESCRIPTION
## Outcome

The full-run launcher now fails with zero writes unless the complete live Ledger writer and admission boundary exactly matches the reviewed deployment contract.

## Changes

- bump the installation-plan format to v3 and bind seven required-present prerequisites
- verify Ledger writer ServiceAccount, Role and RoleBinding
- verify fail-closed ValidatingAdmissionPolicy and Binding, including the exact seven CEL invariants
- bind the tests directly to the checked-in deployment manifests
- align the runbook and security documentation

## Live read-only finding

The current DEV baseline has the runtime and Ledger writer objects, but the Ledger ValidatingAdmissionPolicy and Binding are absent. No live mutation was performed.

## Verification

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `git diff --check`

All Go checks passed in an unprivileged Linux container.