### PR TITLE
feat(runner): correlate synthetic alert delivery

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -1866,6 +1866,14 @@ into a separate synthetic-fixture digest. The Pod executes only
 account token. Pod/container security contexts, resource bounds and the
 Prometheus release selector are fixed by the implementation.
 
+The alert-trigger sample is also correlation-complete. Its fixed label profile
+contains exactly `fixture_digest`, `run_id` and `target_cluster_uid`, in that
+order. Prometheus preserves these labels on the synthetic alert, so an
+independent delivery receiver can bind a webhook observation to this exact
+experiment instead of treating an alert name as proof. A changed or reordered
+label profile fails before the Pushgateway request. These labels contain
+identities only; they grant no authority and carry no credential or endpoint.
+
 This checkpoint still performs no Kubernetes request. Exact absence/create,
 UID/resourceVersion observation, service-proxy checks and guarded cleanup will
 consume this generated fixture in later transport checkpoints.

--- a/internal/runner/observability_backend_client.go
+++ b/internal/runner/observability_backend_client.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/url"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -127,7 +128,13 @@ func (client *kubernetesObservabilityBackendClient) pushMetrics(ctx context.Cont
 	if err := client.validateFixture(run, fixture); err != nil {
 		return observabilityBackendResponse{}, err
 	}
-	body := []byte(fmt.Sprintf("%s 1\n%s 1\n", fixture.MetricName, fixture.AlertTriggerMetric))
+	if len(fixture.AlertCorrelationLabels) != 3 || fixture.AlertCorrelationLabels[0] != "fixture_digest" ||
+		fixture.AlertCorrelationLabels[1] != "run_id" || fixture.AlertCorrelationLabels[2] != "target_cluster_uid" {
+		return observabilityBackendResponse{}, errors.New("observability alert correlation profile is invalid")
+	}
+	labels := "fixture_digest=" + strconv.Quote(fixture.FixtureDigest) + ",run_id=" + strconv.Quote(run.RunID) +
+		",target_cluster_uid=" + strconv.Quote(run.TargetClusterUID)
+	body := []byte(fmt.Sprintf("%s 1\n%s{%s} 1\n", fixture.MetricName, fixture.AlertTriggerMetric, labels))
 	path := client.serviceProxyPath(observabilityServiceBinding{Name: fixture.MetricsWorkload, Port: 9091, Scheme: "http"}, "metrics/job/"+fixture.MetricsWorkload)
 	return client.request(ctx, http.MethodPost, path, nil, body, "", "", false)
 }

--- a/internal/runner/observability_backend_client_test.go
+++ b/internal/runner/observability_backend_client_test.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
+	"strconv"
 	"testing"
 )
 
@@ -15,6 +17,7 @@ type observabilityBackendRecordedRequest struct {
 	requestURI    string
 	authorization string
 	contentType   string
+	body          string
 }
 
 func TestKubernetesObservabilityBackendClientUsesOnlyBoundExactRequests(t *testing.T) {
@@ -23,7 +26,8 @@ func TestKubernetesObservabilityBackendClientUsesOnlyBoundExactRequests(t *testi
 	profile, _ := StandardObservabilityCapabilityCheckProfile("ok-observability")
 	var requests []observabilityBackendRecordedRequest
 	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
-		requests = append(requests, observabilityBackendRecordedRequest{method: request.Method, requestURI: request.URL.RequestURI(), authorization: request.Header.Get("Authorization"), contentType: request.Header.Get("Content-Type")})
+		body, _ := io.ReadAll(request.Body)
+		requests = append(requests, observabilityBackendRecordedRequest{method: request.Method, requestURI: request.URL.RequestURI(), authorization: request.Header.Get("Authorization"), contentType: request.Header.Get("Content-Type"), body: string(body)})
 		if request.URL.Path == "/api/v1/namespaces/ok-observability/secrets/ok-observability-credentials" {
 			writeObservabilityBackendJSON(writer, http.StatusOK, map[string]any{
 				"apiVersion": "v1", "kind": "Secret", "metadata": map[string]any{"name": "ok-observability-credentials", "namespace": "ok-observability"},
@@ -75,15 +79,40 @@ func TestKubernetesObservabilityBackendClientUsesOnlyBoundExactRequests(t *testi
 	expected := []observabilityBackendRecordedRequest{
 		{method: "GET", requestURI: "/api/v1/namespaces/ok-observability/secrets/ok-observability-credentials"},
 		{method: "GET", requestURI: "/api/v1/namespaces/ok-observability/configmaps/ok-observability-dashboard-platform-overview"},
-		{method: "POST", requestURI: "/api/v1/namespaces/ok-observability/services/http:" + fixture.MetricsWorkload + ":9091/proxy/metrics/job/" + fixture.MetricsWorkload, contentType: "text/plain; version=0.0.4"},
+		{
+			method:      "POST",
+			requestURI:  "/api/v1/namespaces/ok-observability/services/http:" + fixture.MetricsWorkload + ":9091/proxy/metrics/job/" + fixture.MetricsWorkload,
+			contentType: "text/plain; version=0.0.4",
+			body: fixture.MetricName + " 1\n" + fixture.AlertTriggerMetric +
+				"{fixture_digest=" + strconv.Quote(fixture.FixtureDigest) + ",run_id=" + strconv.Quote(run.RunID) +
+				",target_cluster_uid=" + strconv.Quote(run.TargetClusterUID) + "} 1\n",
+		},
 		{method: "GET", requestURI: "/api/v1/namespaces/ok-observability/services/http:ok-observability-prometheus:9090/proxy/api/v1/query?query=" + fixture.MetricName},
 		{method: "GET", requestURI: "/api/v1/namespaces/ok-observability/services/http:ok-observability-grafana:80/proxy/api/datasources", authorization: "Basic YWRtaW46Z3JhZmFuYS1wYXNzd29yZA=="},
 		{method: "GET", requestURI: "/api/v1/namespaces/ok-observability/services/http:ok-observability-grafana:80/proxy/api/datasources/proxy/uid/prometheus-uid/api/v1/query?query=" + fixture.MetricName, authorization: "Basic YWRtaW46Z3JhZmFuYS1wYXNzd29yZA=="},
-		{method: "POST", requestURI: "/api/v1/namespaces/ok-observability/services/https:opensearch-cluster-master:9200/proxy/ok-observability-logs%2A/_search", authorization: "Basic YWRtaW46b3BlbnNlYXJjaC1wYXNzd29yZA==", contentType: "application/json"},
+		{
+			method: "POST", requestURI: "/api/v1/namespaces/ok-observability/services/https:opensearch-cluster-master:9200/proxy/ok-observability-logs%2A/_search",
+			authorization: "Basic YWRtaW46b3BlbnNlYXJjaC1wYXNzd29yZA==", contentType: "application/json",
+			body: "{\"query\":{\"match_phrase\":{\"log\":" + strconv.Quote(fixture.LogMarker) + "}}}",
+		},
 		{method: "GET", requestURI: "/api/v1/namespaces/ok-observability/services/http:ok-observability-alertmanager:9093/proxy/api/v2/alerts"},
 	}
 	if !reflect.DeepEqual(requests, expected) {
 		t.Fatalf("backend request surface changed:\nobserved=%#v\nexpected=%#v", requests, expected)
+	}
+}
+
+func TestKubernetesObservabilityBackendClientRejectsAlertCorrelationProfileDrift(t *testing.T) {
+	run, _ := observabilityCapabilityRun(observabilityProbeRequest(), "ok-observability")
+	profile, _ := StandardObservabilityCapabilityCheckProfile("ok-observability")
+	client, _ := newKubernetesObservabilityBackendClient(KubernetesObservabilityBackendClientConfig{
+		Endpoint: "http://127.0.0.1:12345", ClientCertificate: true, AuthorityIdentity: run.TargetClusterUID, Client: &http.Client{}, Profile: profile,
+	})
+	fixture, _ := BuildObservabilitySyntheticFixture(run, capabilityFixtureConfig())
+	fixture.AlertCorrelationLabels = []string{"run_id", "fixture_digest", "target_cluster_uid"}
+	fixture.FixtureDigest, _ = ObservabilitySyntheticFixtureDigest(fixture)
+	if _, err := client.pushMetrics(context.Background(), run, fixture); err == nil {
+		t.Fatal("changed alert correlation profile reached the service proxy")
 	}
 }
 

--- a/internal/runner/observability_fixture.go
+++ b/internal/runner/observability_fixture.go
@@ -36,16 +36,17 @@ type CapabilityObject struct {
 }
 
 type ObservabilitySyntheticFixture struct {
-	Format             string             `json:"format"`
-	RunID              string             `json:"runId"`
-	Namespace          string             `json:"namespace"`
-	MetricsWorkload    string             `json:"metricsWorkload"`
-	LogEmitter         string             `json:"logEmitter"`
-	MetricName         string             `json:"metricName"`
-	AlertTriggerMetric string             `json:"alertTriggerMetric"`
-	LogMarker          string             `json:"logMarker"`
-	Objects            []CapabilityObject `json:"objects"`
-	FixtureDigest      string             `json:"fixtureDigest"`
+	Format                 string             `json:"format"`
+	RunID                  string             `json:"runId"`
+	Namespace              string             `json:"namespace"`
+	MetricsWorkload        string             `json:"metricsWorkload"`
+	LogEmitter             string             `json:"logEmitter"`
+	MetricName             string             `json:"metricName"`
+	AlertTriggerMetric     string             `json:"alertTriggerMetric"`
+	AlertCorrelationLabels []string           `json:"alertCorrelationLabels"`
+	LogMarker              string             `json:"logMarker"`
+	Objects                []CapabilityObject `json:"objects"`
+	FixtureDigest          string             `json:"fixtureDigest"`
 }
 
 // BuildObservabilitySyntheticFixture is the only manifest constructor for the
@@ -62,9 +63,10 @@ func BuildObservabilitySyntheticFixture(run ObservabilityCapabilityRun, config O
 	fixture := ObservabilitySyntheticFixture{
 		Format: ObservabilitySyntheticFixtureFormat, RunID: run.RunID, Namespace: run.Namespace,
 		MetricsWorkload: "ok147-metrics-" + suffix, LogEmitter: "ok147-log-" + suffix,
-		MetricName:         "ok_observability_contract_metric_" + suffix,
-		AlertTriggerMetric: "ok_observability_synthetic_alert_trigger",
-		LogMarker:          "OK147_OBSERVABILITY_LOG_" + suffix,
+		MetricName:             "ok_observability_contract_metric_" + suffix,
+		AlertTriggerMetric:     "ok_observability_synthetic_alert_trigger",
+		AlertCorrelationLabels: []string{"fixture_digest", "run_id", "target_cluster_uid"},
+		LogMarker:              "OK147_OBSERVABILITY_LOG_" + suffix,
 	}
 	metadata := func(name string) map[string]any {
 		return map[string]any{


### PR DESCRIPTION
## Outcome

The synthetic alert now carries the exact fixture digest, run ID, and target Cluster UID. This lets an independent receiver prove delivery for one bounded experiment instead of treating the alert name as evidence.

## Safety

- fixed three-label profile
- changed or reordered labels fail before any request
- no authority, credentials, or endpoints in labels
- no live cluster mutation

## Verification

- full Go test suite PASS
- go vet PASS
- git diff check PASS