### PR TITLE
feat(runner): persist independent alert delivery

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -3045,6 +3045,20 @@ non-JSON responses fail closed and there is no retry or arbitrary URL surface.
 The external service implementation remains a separate operational component;
 this client neither invents delivery evidence nor performs an outage test.
 
+The delivery half of that external service now also has a bounded server
+implementation. It accepts only the fixed Alertmanager webhook path under a
+dedicated bearer authority, extracts exactly one firing synthetic alert and
+requires the correlated `fixture_digest`, `run_id` and `target_cluster_uid`
+labels plus the standard profile and receiver identity. Successful delivery is
+stored create-only in a private directory and survives process restart;
+duplicate notification is idempotent, while ambiguity, truncation, malformed
+identity and historical records fail closed. A separate query token protects
+the canonical evidence endpoint. The server deliberately requires an injected
+independent autonomy observer and returns no collection result when that source
+is unavailable. It therefore cannot turn webhook receipt or API reachability
+into an autonomy claim. Packaging this receiver and implementing the real
+cluster-local autonomy observer remain the next checkpoints.
+
 The separately operated issuer no longer accepts the run ID, target Cluster
 UID, fixture digest or profile digest as manually repeated command arguments.
 After Stage 6, a local-only materializer derives those values from the exact

--- a/internal/runner/observability_independent_evidence_collector_server.go
+++ b/internal/runner/observability_independent_evidence_collector_server.go
@@ -1,0 +1,369 @@
+package runner
+
+import (
+	"bytes"
+	"context"
+	"crypto/subtle"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/contract"
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/jsonstrict"
+)
+
+const (
+	ObservabilityAlertDeliveryRecordFormat = "ok147-observability-alert-delivery-record/v1"
+	observabilityAlertmanagerWebhookPath   = "/v1/observability/alertmanager-webhook"
+	maximumAlertmanagerWebhookBytes        = 256 * 1024
+	maximumAlertDeliveryRecordBytes        = 32 * 1024
+	maximumCollectorTokenBytes             = 8 * 1024
+)
+
+type ObservabilityCollectorAutonomyObservation struct {
+	ClusterLocalServicesReady   bool
+	ExternalClusterDependencies int
+	AutonomyProfileDigest       string
+}
+
+// ObservabilityCollectorAutonomyObserver is intentionally separate from alert
+// delivery. An implementation must independently observe the workload-local
+// service set and its external dependencies; the collector never infers this
+// claim from webhook delivery or API reachability.
+type ObservabilityCollectorAutonomyObserver interface {
+	Observe(context.Context, ObservabilityIndependentEvidenceCollectionRequest) (ObservabilityCollectorAutonomyObservation, error)
+}
+
+type ObservabilityIndependentEvidenceCollectorServerConfig struct {
+	WebhookTokenFile string
+	QueryTokenFile   string
+	StateDirectory   string
+	ReceiverName     string
+	Profile          ObservabilityCapabilityCheckProfile
+	MaximumRecordAge time.Duration
+	Clock            func() time.Time
+	AutonomyObserver ObservabilityCollectorAutonomyObserver
+}
+
+type ObservabilityIndependentEvidenceCollectorServer struct {
+	webhookToken     []byte
+	queryToken       []byte
+	stateDirectory   string
+	receiverName     string
+	receiverIdentity string
+	profileDigest    string
+	alertName        string
+	maximumRecordAge time.Duration
+	clock            func() time.Time
+	autonomy         ObservabilityCollectorAutonomyObserver
+}
+
+type observabilityAlertmanagerWebhook struct {
+	Version           string                           `json:"version"`
+	GroupKey          string                           `json:"groupKey"`
+	TruncatedAlerts   int                              `json:"truncatedAlerts,omitempty"`
+	Status            string                           `json:"status"`
+	Receiver          string                           `json:"receiver"`
+	GroupLabels       map[string]string                `json:"groupLabels"`
+	CommonLabels      map[string]string                `json:"commonLabels"`
+	CommonAnnotations map[string]string                `json:"commonAnnotations"`
+	ExternalURL       string                           `json:"externalURL"`
+	Alerts            []observabilityAlertmanagerAlert `json:"alerts"`
+}
+
+type observabilityAlertmanagerAlert struct {
+	Status       string            `json:"status"`
+	Labels       map[string]string `json:"labels"`
+	Annotations  map[string]string `json:"annotations"`
+	StartsAt     string            `json:"startsAt"`
+	EndsAt       string            `json:"endsAt"`
+	GeneratorURL string            `json:"generatorURL"`
+	Fingerprint  string            `json:"fingerprint"`
+}
+
+type observabilityAlertDeliveryRecord struct {
+	Format                 string `json:"format"`
+	RunID                  string `json:"runId"`
+	TargetClusterUID       string `json:"targetClusterUid"`
+	FixtureDigest          string `json:"fixtureDigest"`
+	ProfileDigest          string `json:"profileDigest"`
+	AlertName              string `json:"alertName"`
+	ReceiverIdentityDigest string `json:"receiverIdentityDigest"`
+	ObservedAt             string `json:"observedAt"`
+}
+
+func OpenObservabilityIndependentEvidenceCollectorServer(config ObservabilityIndependentEvidenceCollectorServerConfig) (*ObservabilityIndependentEvidenceCollectorServer, error) {
+	standard, err := StandardObservabilityCapabilityCheckProfile("ok-observability")
+	if err != nil || config.Clock == nil || config.AutonomyObserver == nil || config.ReceiverName == "" ||
+		!runtimeInputUIDPattern.MatchString(config.ReceiverName) || config.Profile.Digest() == "" || config.Profile.Digest() != standard.Digest() ||
+		config.MaximumRecordAge < time.Minute || config.MaximumRecordAge > maximumObservabilityIndependentEvidenceWindow {
+		return nil, errors.New("observability independent evidence collector server binding is invalid")
+	}
+	stateInfo, err := os.Lstat(config.StateDirectory)
+	if err != nil || !filepath.IsAbs(config.StateDirectory) || filepath.Clean(config.StateDirectory) != config.StateDirectory ||
+		!stateInfo.IsDir() || stateInfo.Mode()&os.ModeSymlink != 0 || stateInfo.Mode().Perm()&0o077 != 0 {
+		return nil, errors.New("observability independent evidence collector state directory is not private")
+	}
+	webhookToken, err := readCollectorToken(config.WebhookTokenFile)
+	if err != nil {
+		return nil, errors.New("read observability collector webhook token")
+	}
+	queryToken, err := readCollectorToken(config.QueryTokenFile)
+	if err != nil || subtle.ConstantTimeCompare(webhookToken, queryToken) == 1 {
+		return nil, errors.New("read distinct observability collector query token")
+	}
+	receiverIdentity := digest.SHA256([]byte("ok147-observability-alert-receiver/v1\n" + config.ReceiverName))
+	return &ObservabilityIndependentEvidenceCollectorServer{
+		webhookToken: webhookToken, queryToken: queryToken, stateDirectory: config.StateDirectory,
+		receiverName: config.ReceiverName, receiverIdentity: receiverIdentity,
+		profileDigest: config.Profile.Digest(), alertName: config.Profile.alertName,
+		maximumRecordAge: config.MaximumRecordAge, clock: config.Clock, autonomy: config.AutonomyObserver,
+	}, nil
+}
+
+func (server *ObservabilityIndependentEvidenceCollectorServer) ServeHTTP(response http.ResponseWriter, request *http.Request) {
+	response.Header().Set("Cache-Control", "no-store")
+	response.Header().Set("X-Content-Type-Options", "nosniff")
+	if server == nil || server.clock == nil || server.autonomy == nil {
+		http.Error(response, "collector unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	if request.Method != http.MethodPost || request.URL.RawQuery != "" || request.URL.Fragment != "" {
+		http.Error(response, "request not accepted", http.StatusNotFound)
+		return
+	}
+	switch request.URL.Path {
+	case observabilityAlertmanagerWebhookPath:
+		server.receiveAlertmanagerWebhook(response, request)
+	case observabilityIndependentEvidenceCollectionPath:
+		server.collectIndependentEvidence(response, request)
+	default:
+		http.Error(response, "request not accepted", http.StatusNotFound)
+	}
+}
+
+func (server *ObservabilityIndependentEvidenceCollectorServer) receiveAlertmanagerWebhook(response http.ResponseWriter, request *http.Request) {
+	if !collectorAuthorized(request, server.webhookToken) || request.Header.Get("Content-Type") != "application/json" {
+		http.Error(response, "request not authorized", http.StatusUnauthorized)
+		return
+	}
+	raw, err := io.ReadAll(io.LimitReader(request.Body, maximumAlertmanagerWebhookBytes+1))
+	if err != nil || len(raw) == 0 || len(raw) > maximumAlertmanagerWebhookBytes {
+		http.Error(response, "webhook not accepted", http.StatusBadRequest)
+		return
+	}
+	var webhook observabilityAlertmanagerWebhook
+	if err := jsonstrict.Decode(raw, &webhook); err != nil || webhook.Version != "4" || webhook.Receiver != server.receiverName || webhook.TruncatedAlerts != 0 {
+		http.Error(response, "webhook not accepted", http.StatusBadRequest)
+		return
+	}
+	var synthetic *observabilityAlertmanagerAlert
+	for index := range webhook.Alerts {
+		alert := &webhook.Alerts[index]
+		if alert.Labels["alertname"] != server.alertName {
+			continue
+		}
+		if synthetic != nil {
+			http.Error(response, "ambiguous synthetic delivery", http.StatusConflict)
+			return
+		}
+		synthetic = alert
+	}
+	if synthetic == nil || webhook.Status == "resolved" || synthetic.Status == "resolved" {
+		response.WriteHeader(http.StatusAccepted)
+		return
+	}
+	if webhook.Status != "firing" || synthetic.Status != "firing" || synthetic.Labels["severity"] != "none" {
+		http.Error(response, "synthetic delivery state is invalid", http.StatusBadRequest)
+		return
+	}
+	record := observabilityAlertDeliveryRecord{
+		Format: ObservabilityAlertDeliveryRecordFormat, RunID: synthetic.Labels["run_id"],
+		TargetClusterUID: synthetic.Labels["target_cluster_uid"], FixtureDigest: synthetic.Labels["fixture_digest"],
+		ProfileDigest: server.profileDigest, AlertName: server.alertName,
+		ReceiverIdentityDigest: server.receiverIdentity, ObservedAt: server.clock().UTC().Truncate(time.Second).Format(time.RFC3339),
+	}
+	if !validAlertDeliveryRecord(record) {
+		http.Error(response, "synthetic delivery identity is invalid", http.StatusBadRequest)
+		return
+	}
+	if server.persistDelivery(record) != nil {
+		http.Error(response, "synthetic delivery was not persisted", http.StatusInternalServerError)
+		return
+	}
+	response.WriteHeader(http.StatusCreated)
+}
+
+func (server *ObservabilityIndependentEvidenceCollectorServer) collectIndependentEvidence(response http.ResponseWriter, request *http.Request) {
+	if !collectorAuthorized(request, server.queryToken) || request.Header.Get("Content-Type") != "application/json" || request.Header.Get("Accept") != "application/json" {
+		http.Error(response, "request not authorized", http.StatusUnauthorized)
+		return
+	}
+	raw, err := io.ReadAll(io.LimitReader(request.Body, maximumObservabilityIndependentEvidenceCollectionBytes+1))
+	if err != nil || len(raw) == 0 || len(raw) > maximumObservabilityIndependentEvidenceCollectionBytes {
+		http.Error(response, "collection request not accepted", http.StatusBadRequest)
+		return
+	}
+	var document ObservabilityIndependentEvidenceCollectionRequest
+	if err := jsonstrict.Decode(raw, &document); err != nil {
+		http.Error(response, "collection request not accepted", http.StatusBadRequest)
+		return
+	}
+	canonical, requestDigest, err := canonicalObservabilityIndependentEvidenceCollectionRequest(document)
+	if err != nil || !bytes.Equal(canonical, raw) || document.ProfileDigest != server.profileDigest || document.AlertName != server.alertName {
+		http.Error(response, "collection request not permitted", http.StatusForbidden)
+		return
+	}
+	autonomy, err := server.autonomy.Observe(request.Context(), document)
+	if err != nil || autonomy.ExternalClusterDependencies < 0 || !platformInputDigestPattern.MatchString(autonomy.AutonomyProfileDigest) {
+		http.Error(response, "autonomy evidence unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	delivered := server.deliveryCurrent(document)
+	documentResponse := ObservabilityIndependentEvidenceCollectionResponse{
+		Format: ObservabilityIndependentEvidenceCollectionResponseFormat, RequestDigest: requestDigest,
+		ReceiverDeliveryObserved: delivered, ReceiverIdentityDigest: server.receiverIdentity,
+		ClusterLocalServicesReady:   autonomy.ClusterLocalServicesReady,
+		ExternalClusterDependencies: autonomy.ExternalClusterDependencies, AutonomyProfileDigest: autonomy.AutonomyProfileDigest,
+	}
+	responseRaw, err := json.Marshal(documentResponse)
+	if err != nil {
+		http.Error(response, "collector unavailable", http.StatusInternalServerError)
+		return
+	}
+	response.Header().Set("Content-Type", "application/json")
+	response.WriteHeader(http.StatusOK)
+	_, _ = response.Write(responseRaw)
+}
+
+func (server *ObservabilityIndependentEvidenceCollectorServer) persistDelivery(record observabilityAlertDeliveryRecord) error {
+	raw, key, err := canonicalAlertDeliveryRecord(record)
+	if err != nil {
+		return err
+	}
+	path := filepath.Join(server.stateDirectory, strings.TrimPrefix(key, "sha256:")+".json")
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if errors.Is(err, os.ErrExist) {
+		stored, readErr := readBoundedRegular(path, maximumAlertDeliveryRecordBytes)
+		if readErr != nil || !bytes.Equal(stored, raw) {
+			return errors.New("existing alert delivery record differs")
+		}
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if _, err := file.Write(raw); err != nil {
+		_ = file.Close()
+		return err
+	}
+	if err := file.Sync(); err != nil {
+		_ = file.Close()
+		return err
+	}
+	return file.Close()
+}
+
+func (server *ObservabilityIndependentEvidenceCollectorServer) deliveryCurrent(request ObservabilityIndependentEvidenceCollectionRequest) bool {
+	record := observabilityAlertDeliveryRecord{
+		Format: ObservabilityAlertDeliveryRecordFormat, RunID: request.RunID, TargetClusterUID: request.TargetClusterUID,
+		FixtureDigest: request.FixtureDigest, ProfileDigest: request.ProfileDigest, AlertName: request.AlertName,
+		ReceiverIdentityDigest: server.receiverIdentity,
+	}
+	_, key, err := canonicalAlertDeliveryRecord(record)
+	if err != nil {
+		return false
+	}
+	path := filepath.Join(server.stateDirectory, strings.TrimPrefix(key, "sha256:")+".json")
+	raw, err := readBoundedRegular(path, maximumAlertDeliveryRecordBytes)
+	if err != nil {
+		return false
+	}
+	var stored observabilityAlertDeliveryRecord
+	if err := jsonstrict.Decode(raw, &stored); err != nil || !validAlertDeliveryRecord(stored) || stored.RunID != record.RunID ||
+		stored.TargetClusterUID != record.TargetClusterUID || stored.FixtureDigest != record.FixtureDigest || stored.ProfileDigest != record.ProfileDigest ||
+		stored.AlertName != record.AlertName || stored.ReceiverIdentityDigest != record.ReceiverIdentityDigest {
+		return false
+	}
+	observedAt, err := time.Parse(time.RFC3339, stored.ObservedAt)
+	now := server.clock().UTC()
+	return err == nil && stored.ObservedAt == observedAt.UTC().Format(time.RFC3339) && !now.Before(observedAt) && now.Sub(observedAt) <= server.maximumRecordAge
+}
+
+func canonicalAlertDeliveryRecord(record observabilityAlertDeliveryRecord) ([]byte, string, error) {
+	identityRecord := record
+	identityRecord.ObservedAt = ""
+	if !validAlertDeliveryRecordIdentity(identityRecord) {
+		return nil, "", errors.New("alert delivery identity is invalid")
+	}
+	raw, err := json.Marshal(record)
+	if err != nil {
+		return nil, "", err
+	}
+	var value any
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	if err := decoder.Decode(&value); err != nil {
+		return nil, "", err
+	}
+	canonical, err := contract.JCS(value)
+	if err != nil {
+		return nil, "", err
+	}
+	identityRaw, err := json.Marshal(identityRecord)
+	if err != nil {
+		return nil, "", err
+	}
+	return canonical, digest.SHA256(identityRaw), nil
+}
+
+func validAlertDeliveryRecord(record observabilityAlertDeliveryRecord) bool {
+	if !validAlertDeliveryRecordIdentity(record) || record.ObservedAt == "" {
+		return false
+	}
+	observedAt, err := time.Parse(time.RFC3339, record.ObservedAt)
+	return err == nil && record.ObservedAt == observedAt.UTC().Format(time.RFC3339)
+}
+
+func validAlertDeliveryRecordIdentity(record observabilityAlertDeliveryRecord) bool {
+	return record.Format == ObservabilityAlertDeliveryRecordFormat && validObservabilityObservationIdentity(ObservabilityCapabilityObservationIdentity{
+		RunID: record.RunID, TargetClusterUID: record.TargetClusterUID, FixtureDigest: record.FixtureDigest, ProfileDigest: record.ProfileDigest,
+	}) && record.AlertName != "" && runtimeInputUIDPattern.MatchString(record.AlertName) && platformInputDigestPattern.MatchString(record.ReceiverIdentityDigest)
+}
+
+func readCollectorToken(path string) ([]byte, error) {
+	info, err := os.Lstat(path)
+	if err != nil || info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() || info.Mode().Perm()&0o077 != 0 {
+		return nil, errors.New("collector token file is not private")
+	}
+	raw, err := readBoundedRegular(path, maximumCollectorTokenBytes)
+	raw = bytes.TrimSuffix(raw, []byte("\n"))
+	if err != nil || !validCollectorToken(raw) {
+		return nil, errors.New("collector token is invalid")
+	}
+	return append([]byte(nil), raw...), nil
+}
+
+func validCollectorToken(token []byte) bool {
+	if len(token) < 32 || len(token) > maximumCollectorTokenBytes || !bytes.Equal(token, bytes.TrimSpace(token)) || bytes.ContainsAny(token, "\r\n") {
+		return false
+	}
+	for _, value := range token {
+		if value >= 'a' && value <= 'z' || value >= 'A' && value <= 'Z' || value >= '0' && value <= '9' || strings.ContainsRune("._~-", rune(value)) {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func collectorAuthorized(request *http.Request, expected []byte) bool {
+	presented := strings.TrimPrefix(request.Header.Get("Authorization"), "Bearer ")
+	return presented != request.Header.Get("Authorization") && subtle.ConstantTimeCompare([]byte(presented), expected) == 1
+}

--- a/internal/runner/observability_independent_evidence_collector_server_test.go
+++ b/internal/runner/observability_independent_evidence_collector_server_test.go
@@ -1,0 +1,218 @@
+package runner
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+type fixedCollectorAutonomyObserver struct {
+	observation ObservabilityCollectorAutonomyObservation
+	calls       int
+}
+
+func (observer *fixedCollectorAutonomyObserver) Observe(_ context.Context, _ ObservabilityIndependentEvidenceCollectionRequest) (ObservabilityCollectorAutonomyObservation, error) {
+	observer.calls++
+	return observer.observation, nil
+}
+
+type independentCollectorServerMaterial struct {
+	server       *ObservabilityIndependentEvidenceCollectorServer
+	config       ObservabilityIndependentEvidenceCollectorServerConfig
+	identity     ObservabilityCapabilityObservationIdentity
+	alertName    string
+	webhookToken string
+	queryToken   string
+	clock        *time.Time
+	autonomy     *fixedCollectorAutonomyObserver
+}
+
+func TestIndependentCollectorPersistsAndReturnsExactAlertDelivery(t *testing.T) {
+	material := newIndependentCollectorServerMaterial(t)
+	webhook := performCollectorWebhook(t, material, material.identity, material.webhookToken)
+	if webhook.Code != http.StatusCreated {
+		t.Fatalf("webhook returned %d: %s", webhook.Code, webhook.Body.String())
+	}
+	entries, err := os.ReadDir(material.config.StateDirectory)
+	if err != nil || len(entries) != 1 {
+		t.Fatalf("durable delivery record differs: entries=%d err=%v", len(entries), err)
+	}
+
+	response := performCollectorQuery(t, material, material.identity, material.queryToken)
+	if response.Code != http.StatusOK {
+		t.Fatalf("query returned %d: %s", response.Code, response.Body.String())
+	}
+	var document ObservabilityIndependentEvidenceCollectionResponse
+	if err := json.Unmarshal(response.Body.Bytes(), &document); err != nil {
+		t.Fatal(err)
+	}
+	if !document.ReceiverDeliveryObserved || !document.ClusterLocalServicesReady || document.ExternalClusterDependencies != 0 ||
+		document.ReceiverIdentityDigest != material.server.receiverIdentity || document.AutonomyProfileDigest != material.autonomy.observation.AutonomyProfileDigest || material.autonomy.calls != 1 {
+		t.Fatalf("collector response differs: %#v calls=%d", document, material.autonomy.calls)
+	}
+
+	reopened, err := OpenObservabilityIndependentEvidenceCollectorServer(material.config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	material.server = reopened
+	replay := performCollectorWebhook(t, material, material.identity, material.webhookToken)
+	if replay.Code != http.StatusCreated {
+		t.Fatalf("idempotent webhook replay returned %d", replay.Code)
+	}
+	entries, _ = os.ReadDir(material.config.StateDirectory)
+	if len(entries) != 1 {
+		t.Fatalf("webhook replay added state: %d", len(entries))
+	}
+}
+
+func TestIndependentCollectorFailsClosedForForeignDeliveryAndStaleHistory(t *testing.T) {
+	material := newIndependentCollectorServerMaterial(t)
+	foreign := material.identity
+	foreign.FixtureDigest = "sha256:not-a-digest"
+	response := performCollectorWebhook(t, material, foreign, material.webhookToken)
+	if response.Code != http.StatusBadRequest {
+		t.Fatalf("foreign correlation returned %d", response.Code)
+	}
+	entries, _ := os.ReadDir(material.config.StateDirectory)
+	if len(entries) != 0 {
+		t.Fatalf("foreign correlation persisted state: %d", len(entries))
+	}
+
+	if response := performCollectorWebhook(t, material, material.identity, material.webhookToken); response.Code != http.StatusCreated {
+		t.Fatalf("valid webhook returned %d", response.Code)
+	}
+	advanced := material.clock.Add(11 * time.Minute)
+	*material.clock = advanced
+	query := performCollectorQuery(t, material, material.identity, material.queryToken)
+	var document ObservabilityIndependentEvidenceCollectionResponse
+	if query.Code != http.StatusOK || json.Unmarshal(query.Body.Bytes(), &document) != nil || document.ReceiverDeliveryObserved {
+		t.Fatalf("stale historical delivery was accepted: code=%d document=%#v", query.Code, document)
+	}
+}
+
+func TestIndependentCollectorSeparatesWebhookAndQueryAuthority(t *testing.T) {
+	material := newIndependentCollectorServerMaterial(t)
+	if response := performCollectorWebhook(t, material, material.identity, material.queryToken); response.Code != http.StatusUnauthorized {
+		t.Fatalf("query token authorized webhook: %d", response.Code)
+	}
+	if response := performCollectorQuery(t, material, material.identity, material.webhookToken); response.Code != http.StatusUnauthorized {
+		t.Fatalf("webhook token authorized query: %d", response.Code)
+	}
+	entries, _ := os.ReadDir(material.config.StateDirectory)
+	if len(entries) != 0 || material.autonomy.calls != 0 {
+		t.Fatalf("unauthorized request reached state or observer: entries=%d calls=%d", len(entries), material.autonomy.calls)
+	}
+}
+
+func TestIndependentCollectorRejectsUnsafeRuntimeBinding(t *testing.T) {
+	material := newIndependentCollectorServerMaterial(t)
+	t.Run("shared token", func(t *testing.T) {
+		config := material.config
+		config.QueryTokenFile = config.WebhookTokenFile
+		if _, err := OpenObservabilityIndependentEvidenceCollectorServer(config); err == nil {
+			t.Fatal("shared webhook/query authority was accepted")
+		}
+	})
+	t.Run("public state", func(t *testing.T) {
+		config := material.config
+		if err := os.Chmod(config.StateDirectory, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := OpenObservabilityIndependentEvidenceCollectorServer(config); err == nil {
+			t.Fatal("public collector state directory was accepted")
+		}
+	})
+}
+
+func newIndependentCollectorServerMaterial(t *testing.T) independentCollectorServerMaterial {
+	t.Helper()
+	root := t.TempDir()
+	stateDirectory := filepath.Join(root, "state")
+	if err := os.Mkdir(stateDirectory, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	webhookToken := "ok147-webhook-token-0123456789abcdef"
+	queryToken := "ok147-query-token-0123456789abcdefgh"
+	webhookTokenFile := filepath.Join(root, "webhook-token")
+	queryTokenFile := filepath.Join(root, "query-token")
+	if err := os.WriteFile(webhookTokenFile, []byte(webhookToken), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(queryTokenFile, []byte(queryToken), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	profile, _ := StandardObservabilityCapabilityCheckProfile("ok-observability")
+	now := time.Date(2026, 8, 21, 19, 30, 0, 0, time.UTC)
+	autonomy := &fixedCollectorAutonomyObserver{observation: ObservabilityCollectorAutonomyObservation{
+		ClusterLocalServicesReady: true, ExternalClusterDependencies: 0, AutonomyProfileDigest: digest.SHA256([]byte("bounded-autonomy-profile")),
+	}}
+	config := ObservabilityIndependentEvidenceCollectorServerConfig{
+		WebhookTokenFile: webhookTokenFile, QueryTokenFile: queryTokenFile, StateDirectory: stateDirectory,
+		ReceiverName: "ok147-independent-evidence", Profile: profile, MaximumRecordAge: 10 * time.Minute,
+		Clock: func() time.Time { return now }, AutonomyObserver: autonomy,
+	}
+	server, err := OpenObservabilityIndependentEvidenceCollectorServer(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	run, _ := observabilityCapabilityRun(observabilityProbeRequest(), "ok-observability")
+	fixture, _ := BuildObservabilitySyntheticFixture(run, capabilityFixtureConfig())
+	identity := ObservabilityCapabilityObservationIdentity{
+		RunID: run.RunID, TargetClusterUID: run.TargetClusterUID, FixtureDigest: fixture.FixtureDigest, ProfileDigest: profile.Digest(),
+	}
+	config.Clock = func() time.Time { return now }
+	return independentCollectorServerMaterial{
+		server: server, config: config, identity: identity, alertName: profile.alertName,
+		webhookToken: webhookToken, queryToken: queryToken, clock: &now, autonomy: autonomy,
+	}
+}
+
+func performCollectorWebhook(t *testing.T, material independentCollectorServerMaterial, identity ObservabilityCapabilityObservationIdentity, token string) *httptest.ResponseRecorder {
+	t.Helper()
+	payload := map[string]any{
+		"version": "4", "groupKey": "synthetic", "status": "firing", "receiver": material.config.ReceiverName,
+		"groupLabels": map[string]string{"alertname": material.alertName}, "commonLabels": map[string]string{}, "commonAnnotations": map[string]string{}, "externalURL": "https://redacted.invalid",
+		"alerts": []any{map[string]any{
+			"status": "firing", "labels": map[string]string{
+				"alertname": material.alertName, "severity": "none", "fixture_digest": identity.FixtureDigest,
+				"run_id": identity.RunID, "target_cluster_uid": identity.TargetClusterUID,
+			},
+			"annotations": map[string]string{}, "startsAt": "2026-08-21T19:30:00Z", "endsAt": "0001-01-01T00:00:00Z", "generatorURL": "https://redacted.invalid", "fingerprint": "abcdef",
+		}},
+	}
+	raw, _ := json.Marshal(payload)
+	request := httptest.NewRequest(http.MethodPost, observabilityAlertmanagerWebhookPath, bytes.NewReader(raw))
+	request.Header.Set("Authorization", "Bearer "+token)
+	request.Header.Set("Content-Type", "application/json")
+	response := httptest.NewRecorder()
+	material.server.ServeHTTP(response, request)
+	return response
+}
+
+func performCollectorQuery(t *testing.T, material independentCollectorServerMaterial, identity ObservabilityCapabilityObservationIdentity, token string) *httptest.ResponseRecorder {
+	t.Helper()
+	document := ObservabilityIndependentEvidenceCollectionRequest{
+		Format: ObservabilityIndependentEvidenceCollectionRequestFormat, RunID: identity.RunID, TargetClusterUID: identity.TargetClusterUID,
+		FixtureDigest: identity.FixtureDigest, ProfileDigest: identity.ProfileDigest, AlertName: material.alertName,
+	}
+	raw, _, err := canonicalObservabilityIndependentEvidenceCollectionRequest(document)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request := httptest.NewRequest(http.MethodPost, observabilityIndependentEvidenceCollectionPath, bytes.NewReader(raw))
+	request.Header.Set("Authorization", "Bearer "+token)
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("Accept", "application/json")
+	response := httptest.NewRecorder()
+	material.server.ServeHTTP(response, request)
+	return response
+}


### PR DESCRIPTION
## Outcome

Adds the bounded server half of independent Observability evidence collection. Alertmanager delivery is correlated to one run, fixture, target Cluster UID, profile, alert, and receiver, then stored create-only across restarts.

## Boundaries

- distinct webhook and query bearer authorities
- exact fixed endpoints and strict bounded JSON
- durable idempotent delivery record
- stale, ambiguous, truncated, malformed, or foreign delivery fails closed
- independent autonomy observer remains mandatory
- webhook receipt and API reachability cannot become autonomy evidence
- no live infrastructure mutation

## Verification

- full Go test suite PASS
- go vet PASS
- git diff check PASS