### PR TITLE
feat(runner): observe workload autonomy

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -3059,6 +3059,20 @@ is unavailable. It therefore cannot turn webhook receipt or API reachability
 into an autonomy claim. Packaging this receiver and implementing the real
 cluster-local autonomy observer remain the next checkpoints.
 
+The autonomy source now has a concrete read-only Kubernetes observer. It is
+bound to one runtime Cluster UID, pinned CA and the standard profile and can
+issue only eight requests: exact GETs for Prometheus, Grafana, OpenSearch and
+Alertmanager Services plus four EndpointSlice collections constrained by the
+corresponding fixed service-name label. A service counts as local only when it
+is a non-headless `ClusterIP` with the expected port and no ExternalName,
+external IP or load-balancer ingress. A ready endpoint counts only when its
+target is a Pod in `ok-observability`; foreign or unowned endpoints increment
+the explicit dependency count. The resulting autonomy-profile digest binds
+these rules independently of the capability profile. This proves the bounded
+runtime service/endpoint topology; it does not claim outage testing or inspect
+an arbitrary application dependency graph. The observer has no mutation,
+discovery, watch, unrestricted list, redirect or retry surface.
+
 The separately operated issuer no longer accepts the run ID, target Cluster
 UID, fixture digest or profile digest as manually repeated command arguments.
 After Stage 6, a local-only materializer derives those values from the exact

--- a/internal/runner/observability_autonomy_observer.go
+++ b/internal/runner/observability_autonomy_observer.go
@@ -1,0 +1,271 @@
+package runner
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"net/url"
+	"sort"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+const (
+	ObservabilityAutonomyProfileFormat = "ok147-observability-autonomy-profile/v1"
+	maximumAutonomyResponseBytes       = 2 * 1024 * 1024
+)
+
+type KubernetesObservabilityAutonomyObserverConfig struct {
+	Endpoint         string
+	TokenFile        string
+	CAFile           string
+	CABundleDigest   string
+	TargetClusterUID string
+	Profile          ObservabilityCapabilityCheckProfile
+}
+
+// KubernetesObservabilityAutonomyObserver reads only the standard profile's
+// four Services and their four service-name-scoped EndpointSlice collections.
+// It has no discovery, arbitrary list, mutation, repair or retry surface.
+type KubernetesObservabilityAutonomyObserver struct {
+	endpoint         *url.URL
+	token            string
+	targetClusterUID string
+	profile          ObservabilityCapabilityCheckProfile
+	profileDigest    string
+	client           *http.Client
+}
+
+type observabilityAutonomyProfileDocument struct {
+	Format             string                        `json:"format"`
+	CapabilityProfile  string                        `json:"capabilityProfile"`
+	Namespace          string                        `json:"namespace"`
+	Services           []observabilityServiceBinding `json:"services"`
+	ServiceType        string                        `json:"serviceType"`
+	EndpointTargetKind string                        `json:"endpointTargetKind"`
+	EndpointNamespace  string                        `json:"endpointNamespace"`
+	ExternalFields     []string                      `json:"externalFields"`
+}
+
+type autonomyService struct {
+	APIVersion string `json:"apiVersion"`
+	Kind       string `json:"kind"`
+	Metadata   struct {
+		Name      string `json:"name"`
+		Namespace string `json:"namespace"`
+	} `json:"metadata"`
+	Spec struct {
+		Type         string   `json:"type"`
+		ClusterIP    string   `json:"clusterIP"`
+		ExternalName string   `json:"externalName"`
+		ExternalIPs  []string `json:"externalIPs"`
+		Ports        []struct {
+			Port     int    `json:"port"`
+			Protocol string `json:"protocol"`
+		} `json:"ports"`
+	} `json:"spec"`
+	Status struct {
+		LoadBalancer struct {
+			Ingress []json.RawMessage `json:"ingress"`
+		} `json:"loadBalancer"`
+	} `json:"status"`
+}
+
+type autonomyEndpointSliceList struct {
+	APIVersion string                  `json:"apiVersion"`
+	Kind       string                  `json:"kind"`
+	Items      []autonomyEndpointSlice `json:"items"`
+}
+
+type autonomyEndpointSlice struct {
+	AddressType string `json:"addressType"`
+	Metadata    struct {
+		Namespace string            `json:"namespace"`
+		Labels    map[string]string `json:"labels"`
+	} `json:"metadata"`
+	Ports []struct {
+		Port     *int   `json:"port"`
+		Protocol string `json:"protocol"`
+	} `json:"ports"`
+	Endpoints []struct {
+		Addresses  []string `json:"addresses"`
+		Conditions struct {
+			Ready       *bool `json:"ready"`
+			Terminating *bool `json:"terminating"`
+		} `json:"conditions"`
+		TargetRef *struct {
+			Kind      string `json:"kind"`
+			Namespace string `json:"namespace"`
+			Name      string `json:"name"`
+		} `json:"targetRef"`
+	} `json:"endpoints"`
+}
+
+func OpenKubernetesObservabilityAutonomyObserver(config KubernetesObservabilityAutonomyObserverConfig) (*KubernetesObservabilityAutonomyObserver, error) {
+	standard, err := StandardObservabilityCapabilityCheckProfile("ok-observability")
+	endpoint, parseErr := url.Parse(config.Endpoint)
+	if err != nil || parseErr != nil || endpoint.Scheme != "https" || endpoint.Host == "" || endpoint.User != nil ||
+		endpoint.Path != "" && endpoint.Path != "/" || endpoint.RawQuery != "" || endpoint.Fragment != "" ||
+		!runtimeInputUIDPattern.MatchString(config.TargetClusterUID) || config.Profile.Digest() == "" || config.Profile.Digest() != standard.Digest() ||
+		config.TokenFile == "" || config.CAFile == "" || !platformInputDigestPattern.MatchString(config.CABundleDigest) {
+		return nil, errors.New("observability autonomy observer binding is invalid")
+	}
+	token, ca, boundedClient, err := openBoundedKubernetesMaterial(config.TokenFile, config.CAFile)
+	if err != nil || digest.SHA256(ca) != config.CABundleDigest {
+		return nil, errors.New("open observability autonomy Kubernetes authority")
+	}
+	client := boundedClient
+	client.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+	profileDigest, err := observabilityAutonomyProfileDigest(config.Profile)
+	if err != nil {
+		return nil, errors.New("derive observability autonomy profile")
+	}
+	endpoint.Path, endpoint.RawPath = "", ""
+	return &KubernetesObservabilityAutonomyObserver{
+		endpoint: endpoint, token: token, targetClusterUID: config.TargetClusterUID,
+		profile: config.Profile, profileDigest: profileDigest, client: client,
+	}, nil
+}
+
+func (observer *KubernetesObservabilityAutonomyObserver) Observe(ctx context.Context, request ObservabilityIndependentEvidenceCollectionRequest) (ObservabilityCollectorAutonomyObservation, error) {
+	if observer == nil || observer.endpoint == nil || observer.client == nil || observer.token == "" ||
+		request.TargetClusterUID != observer.targetClusterUID || request.ProfileDigest != observer.profile.Digest() || request.AlertName != observer.profile.alertName {
+		return ObservabilityCollectorAutonomyObservation{}, errors.New("observability autonomy observation identity is invalid")
+	}
+	if _, _, err := canonicalObservabilityIndependentEvidenceCollectionRequest(request); err != nil {
+		return ObservabilityCollectorAutonomyObservation{}, errors.New("observability autonomy collection request is invalid")
+	}
+	if _, ok := ctx.Deadline(); !ok || ctx.Err() != nil {
+		return ObservabilityCollectorAutonomyObservation{}, errors.New("observability autonomy observation requires a live deadline")
+	}
+	bindings := []observabilityServiceBinding{observer.profile.prometheus, observer.profile.grafana, observer.profile.opensearch, observer.profile.alertmanager}
+	ready, externalDependencies := true, 0
+	for _, binding := range bindings {
+		serviceRaw, err := observer.get(ctx, "/api/v1/namespaces/"+observer.profile.namespace+"/services/"+binding.Name, "")
+		if err != nil {
+			return ObservabilityCollectorAutonomyObservation{}, errors.New("read exact observability Service")
+		}
+		serviceReady, serviceExternal, err := evaluateAutonomyService(serviceRaw, observer.profile.namespace, binding)
+		if err != nil {
+			return ObservabilityCollectorAutonomyObservation{}, err
+		}
+		slicesPath := "/apis/discovery.k8s.io/v1/namespaces/" + observer.profile.namespace + "/endpointslices"
+		slicesQuery := "labelSelector=" + url.QueryEscape("kubernetes.io/service-name="+binding.Name)
+		slicesRaw, err := observer.get(ctx, slicesPath, slicesQuery)
+		if err != nil {
+			return ObservabilityCollectorAutonomyObservation{}, errors.New("read bounded observability EndpointSlices")
+		}
+		endpointsReady, endpointExternal, err := evaluateAutonomyEndpointSlices(slicesRaw, observer.profile.namespace, binding.Name)
+		if err != nil {
+			return ObservabilityCollectorAutonomyObservation{}, err
+		}
+		ready = ready && serviceReady && endpointsReady
+		externalDependencies += serviceExternal + endpointExternal
+	}
+	return ObservabilityCollectorAutonomyObservation{
+		ClusterLocalServicesReady:   ready && externalDependencies == 0,
+		ExternalClusterDependencies: externalDependencies, AutonomyProfileDigest: observer.profileDigest,
+	}, nil
+}
+
+func (observer *KubernetesObservabilityAutonomyObserver) get(ctx context.Context, path, rawQuery string) ([]byte, error) {
+	endpoint := *observer.endpoint
+	endpoint.Path = path
+	endpoint.RawQuery = rawQuery
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint.String(), nil)
+	if err != nil {
+		return nil, errors.New("construct observability autonomy request")
+	}
+	request.Header.Set("Authorization", "Bearer "+observer.token)
+	request.Header.Set("Accept", "application/json")
+	response, err := observer.client.Do(request)
+	if err != nil {
+		return nil, errors.New("request observability autonomy source")
+	}
+	defer response.Body.Close()
+	mediaType, _, mediaErr := mime.ParseMediaType(response.Header.Get("Content-Type"))
+	if response.StatusCode != http.StatusOK || mediaErr != nil || mediaType != "application/json" {
+		return nil, errors.New("observability autonomy source response is invalid")
+	}
+	raw, err := io.ReadAll(io.LimitReader(response.Body, maximumAutonomyResponseBytes+1))
+	if err != nil || len(raw) == 0 || len(raw) > maximumAutonomyResponseBytes {
+		return nil, errors.New("observability autonomy source response exceeds accepted size")
+	}
+	return raw, nil
+}
+
+func evaluateAutonomyService(raw []byte, namespace string, binding observabilityServiceBinding) (bool, int, error) {
+	var service autonomyService
+	if err := json.Unmarshal(raw, &service); err != nil || service.APIVersion != "v1" || service.Kind != "Service" ||
+		service.Metadata.Name != binding.Name || service.Metadata.Namespace != namespace {
+		return false, 0, errors.New("observability Service identity is invalid")
+	}
+	external := 0
+	if service.Spec.Type != "ClusterIP" || service.Spec.ClusterIP == "" || service.Spec.ClusterIP == "None" || service.Spec.ExternalName != "" {
+		external++
+	}
+	external += len(service.Spec.ExternalIPs) + len(service.Status.LoadBalancer.Ingress)
+	portReady := false
+	for _, port := range service.Spec.Ports {
+		if port.Port == binding.Port && (port.Protocol == "" || port.Protocol == "TCP") {
+			portReady = true
+		}
+	}
+	return portReady && external == 0, external, nil
+}
+
+func evaluateAutonomyEndpointSlices(raw []byte, namespace, serviceName string) (bool, int, error) {
+	var list autonomyEndpointSliceList
+	if err := json.Unmarshal(raw, &list); err != nil || list.APIVersion != "discovery.k8s.io/v1" || list.Kind != "EndpointSliceList" {
+		return false, 0, errors.New("observability EndpointSlice collection is invalid")
+	}
+	readyEndpoints, external := 0, 0
+	for _, slice := range list.Items {
+		if slice.Metadata.Namespace != namespace || slice.Metadata.Labels["kubernetes.io/service-name"] != serviceName ||
+			slice.AddressType != "IPv4" && slice.AddressType != "IPv6" {
+			return false, 0, errors.New("observability EndpointSlice identity is invalid")
+		}
+		portReady := false
+		for _, port := range slice.Ports {
+			if port.Port != nil && *port.Port > 0 && (port.Protocol == "" || port.Protocol == "TCP") {
+				portReady = true
+			}
+		}
+		if !portReady {
+			continue
+		}
+		for _, endpoint := range slice.Endpoints {
+			terminating := endpoint.Conditions.Terminating != nil && *endpoint.Conditions.Terminating
+			isReady := endpoint.Conditions.Ready == nil || *endpoint.Conditions.Ready
+			if endpoint.TargetRef == nil || endpoint.TargetRef.Kind != "Pod" || endpoint.TargetRef.Namespace != namespace || endpoint.TargetRef.Name == "" {
+				external++
+				continue
+			}
+			if isReady && !terminating && len(endpoint.Addresses) > 0 {
+				readyEndpoints++
+			}
+		}
+	}
+	return readyEndpoints > 0 && external == 0, external, nil
+}
+
+func observabilityAutonomyProfileDigest(profile ObservabilityCapabilityCheckProfile) (string, error) {
+	services := []observabilityServiceBinding{profile.prometheus, profile.grafana, profile.opensearch, profile.alertmanager}
+	sort.Slice(services, func(left, right int) bool { return services[left].Name < services[right].Name })
+	document := observabilityAutonomyProfileDocument{
+		Format: ObservabilityAutonomyProfileFormat, CapabilityProfile: profile.Digest(), Namespace: profile.namespace,
+		Services: services, ServiceType: "ClusterIP", EndpointTargetKind: "Pod", EndpointNamespace: profile.namespace,
+		ExternalFields: []string{"spec.externalIPs", "spec.externalName", "status.loadBalancer.ingress", "endpoint.targetRef.namespace"},
+	}
+	raw, err := json.Marshal(document)
+	if err != nil {
+		return "", fmt.Errorf("encode autonomy profile: %w", err)
+	}
+	return digest.SHA256(raw), nil
+}
+
+var _ ObservabilityCollectorAutonomyObserver = (*KubernetesObservabilityAutonomyObserver)(nil)

--- a/internal/runner/observability_autonomy_observer_test.go
+++ b/internal/runner/observability_autonomy_observer_test.go
@@ -1,0 +1,138 @@
+package runner
+
+import (
+	"context"
+	"encoding/json"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+func TestKubernetesObservabilityAutonomyObserverUsesEightBoundedReads(t *testing.T) {
+	var requests []string
+	observer, request, closeServer := testAutonomyObserver(t, false, func(httpRequest *http.Request) {
+		requests = append(requests, httpRequest.URL.RequestURI())
+		if httpRequest.Method != http.MethodGet || httpRequest.Header.Get("Authorization") != "Bearer ok147-autonomy-token-0123456789abcdef" || httpRequest.Header.Get("Accept") != "application/json" {
+			t.Errorf("unexpected authority or method")
+		}
+	})
+	defer closeServer()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	observation, err := observer.Observe(ctx, request)
+	if err != nil || !observation.ClusterLocalServicesReady || observation.ExternalClusterDependencies != 0 || !platformInputDigestPattern.MatchString(observation.AutonomyProfileDigest) {
+		t.Fatalf("autonomy observation differs: %#v err=%v", observation, err)
+	}
+	expected := []string{}
+	for _, name := range []string{"ok-observability-prometheus", "ok-observability-grafana", "opensearch-cluster-master", "ok-observability-alertmanager"} {
+		expected = append(expected,
+			"/api/v1/namespaces/ok-observability/services/"+name,
+			"/apis/discovery.k8s.io/v1/namespaces/ok-observability/endpointslices?labelSelector=kubernetes.io%2Fservice-name%3D"+name,
+		)
+	}
+	if !reflect.DeepEqual(requests, expected) {
+		t.Fatalf("autonomy request surface changed:\nobserved=%#v\nexpected=%#v", requests, expected)
+	}
+}
+
+func TestKubernetesObservabilityAutonomyObserverReportsForeignEndpoint(t *testing.T) {
+	observer, request, closeServer := testAutonomyObserver(t, true, nil)
+	defer closeServer()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	observation, err := observer.Observe(ctx, request)
+	if err != nil || observation.ClusterLocalServicesReady || observation.ExternalClusterDependencies != 4 {
+		t.Fatalf("foreign endpoint was not reported fail-closed: %#v err=%v", observation, err)
+	}
+}
+
+func TestKubernetesObservabilityAutonomyObserverRejectsUnboundedOrForeignClaim(t *testing.T) {
+	requests := 0
+	observer, request, closeServer := testAutonomyObserver(t, false, func(*http.Request) { requests++ })
+	defer closeServer()
+	if _, err := observer.Observe(context.Background(), request); err == nil || requests != 0 {
+		t.Fatal("unbounded autonomy observation reached Kubernetes")
+	}
+	foreign := request
+	foreign.TargetClusterUID = "foreign-cluster"
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if _, err := observer.Observe(ctx, foreign); err == nil || requests != 0 {
+		t.Fatal("foreign autonomy claim reached Kubernetes")
+	}
+}
+
+func testAutonomyObserver(t *testing.T, foreignEndpoints bool, observe func(*http.Request)) (*KubernetesObservabilityAutonomyObserver, ObservabilityIndependentEvidenceCollectionRequest, func()) {
+	t.Helper()
+	profile, _ := StandardObservabilityCapabilityCheckProfile("ok-observability")
+	ports := map[string]int{
+		profile.prometheus.Name: profile.prometheus.Port, profile.grafana.Name: profile.grafana.Port,
+		profile.opensearch.Name: profile.opensearch.Port, profile.alertmanager.Name: profile.alertmanager.Port,
+	}
+	server := httptest.NewTLSServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		if observe != nil {
+			observe(request)
+		}
+		response.Header().Set("Content-Type", "application/json")
+		if strings.Contains(request.URL.Path, "/services/") {
+			name := filepath.Base(request.URL.Path)
+			_ = json.NewEncoder(response).Encode(map[string]any{
+				"apiVersion": "v1", "kind": "Service", "metadata": map[string]any{"name": name, "namespace": "ok-observability"},
+				"spec": map[string]any{"type": "ClusterIP", "clusterIP": "10.96.0.10", "ports": []any{map[string]any{"port": ports[name], "protocol": "TCP"}}},
+			})
+			return
+		}
+		selector := request.URL.Query().Get("labelSelector")
+		name := strings.TrimPrefix(selector, "kubernetes.io/service-name=")
+		targetNamespace := "ok-observability"
+		if foreignEndpoints {
+			targetNamespace = "foreign-cluster"
+		}
+		ready, port := true, 9090
+		_ = json.NewEncoder(response).Encode(map[string]any{
+			"apiVersion": "discovery.k8s.io/v1", "kind": "EndpointSliceList",
+			"items": []any{map[string]any{
+				"addressType": "IPv4", "metadata": map[string]any{"namespace": "ok-observability", "labels": map[string]string{"kubernetes.io/service-name": name}},
+				"ports": []any{map[string]any{"port": port, "protocol": "TCP"}},
+				"endpoints": []any{map[string]any{
+					"addresses": []string{"10.244.0.10"}, "conditions": map[string]any{"ready": ready, "terminating": false},
+					"targetRef": map[string]any{"kind": "Pod", "namespace": targetNamespace, "name": name + "-0"},
+				}},
+			}},
+		})
+	}))
+	root := t.TempDir()
+	tokenPath := filepath.Join(root, "token")
+	caPath := filepath.Join(root, "ca.crt")
+	token := []byte("ok147-autonomy-token-0123456789abcdef")
+	ca := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: server.Certificate().Raw})
+	if err := os.WriteFile(tokenPath, token, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(caPath, ca, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	run, _ := observabilityCapabilityRun(observabilityProbeRequest(), "ok-observability")
+	fixture, _ := BuildObservabilitySyntheticFixture(run, capabilityFixtureConfig())
+	observer, err := OpenKubernetesObservabilityAutonomyObserver(KubernetesObservabilityAutonomyObserverConfig{
+		Endpoint: server.URL, TokenFile: tokenPath, CAFile: caPath, CABundleDigest: digest.SHA256(ca),
+		TargetClusterUID: run.TargetClusterUID, Profile: profile,
+	})
+	if err != nil {
+		server.Close()
+		t.Fatal(err)
+	}
+	request := ObservabilityIndependentEvidenceCollectionRequest{
+		Format: ObservabilityIndependentEvidenceCollectionRequestFormat, RunID: run.RunID, TargetClusterUID: run.TargetClusterUID,
+		FixtureDigest: fixture.FixtureDigest, ProfileDigest: profile.Digest(), AlertName: profile.alertName,
+	}
+	return observer, request, server.Close
+}


### PR DESCRIPTION
## Outcome

Adds a read-only Kubernetes autonomy observer bound to one target Cluster UID and the standard Observability profile.

## Exact observation surface

- four exact Service GETs
- four service-name-scoped EndpointSlice collection GETs
- local ClusterIP, expected port, and same-namespace Pod endpoint rules
- explicit visible external dependency count
- separate autonomy-profile digest

## Boundaries

- no mutation, repair, discovery, watch, unrestricted list, redirect, or retry
- no arbitrary service or namespace selection
- proves bounded runtime service and endpoint topology only
- does not claim outage testing or an arbitrary dependency-graph scan

## Verification

- full Go test suite PASS
- go vet PASS
- git diff and secret checks PASS