### PR TITLE
feat(runner): bind observability autonomy identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Powered by [Cluster API (CAPI)](https://cluster-api.sigs.k8s.io/), [CAPK (KubeVi
   path. The boundary is covered only by local and fake-API tests at this
   checkpoint; no DEV runtime-binding Job has been launched.
   The next `target-access` stage now starts with a separate offline verifier
-  for one externally rendered eight-object workload RBAC set. It binds the
+  for one externally rendered eleven-object workload RBAC set. It binds the
   artifact to `R`, `P`, the execution fixture and immutable target identity,
   fixes object order and REST routes, rejects wildcard/non-resource access,
   foreign subjects and runtime metadata, and returns only a non-authorizing
@@ -144,18 +144,18 @@ Powered by [Cluster API (CAPI)](https://cluster-api.sigs.k8s.io/), [CAPK (KubeVi
   signed `CreateTargetAccess` grant before exposing a redacted verified bundle
   receipt. A typed runtime opener now correlates the private raw CAPI UID with
   that public target digest, requires distinct ledger and short-lived workload
-  credentials, and preconstructs exactly one eight-object create-only mutator.
+  credentials, and preconstructs exactly one eleven-object create-only mutator.
   Opening performs no API request or grant claim; only the returned crash-safe
   staged operation can claim and submit. The local
   `ok cluster stage run target-access --execute` boundary now requires the
-  exact six-receipt prefix, signed grant, eight independently named object
+  exact six-receipt prefix, signed grant, eleven independently named object
   identities, private runtime-binding digest and distinct ledger/workload
   files before it can invoke that operation. A separated TLS fake-API proof
-  covers the complete claim-to-submit path: exactly eight ordered
+  covers the complete claim-to-submit path: exactly eleven ordered
   `GET`/conditional-`POST` pairs, durable success replay without another write,
   and a durably stopped partial prefix without retry. Its first Job-package
   boundary is offline: one immutable ConfigMap binds the plan,
-  signed grant, exact six-receipt prefix and eight-object artifact while
+  signed grant, exact six-receipt prefix and eleven-object artifact while
   excluding the private runtime binding, CA and both credentials. A hardened
   NetworkPolicy and non-retrying Job bind only the exact management-ledger and
   workload API endpoints. Two distinct short-lived immutable Secrets carry the
@@ -169,6 +169,10 @@ Powered by [Cluster API (CAPI)](https://cluster-api.sigs.k8s.io/), [CAPK (KubeVi
   only `... launch execute --execute` can open the exact expiry-bound installer
   candidate. These activation paths are covered by local and fake-API tests;
   no DEV Target Access Job has been launched by the MVP.
+  The last three workload objects are a separate tokenless autonomy-observer
+  ServiceAccount, an exact read-only Role (`get` Services and `list`
+  EndpointSlices), and its RoleBinding. They are not shared with Argo CD and
+  cannot write workload resources.
   Stage 4 now has its first distinct path as well:
   `ok cluster stage run enablement --execute` binds the verified three-receipt
   prefix and signed `CreateEnablement` grant to exactly one externally rendered

--- a/cmd/ok/main.go
+++ b/cmd/ok/main.go
@@ -2003,7 +2003,7 @@ func runClusterStageRunTargetAccess(ctx context.Context, arguments []string, std
 	grantPath := flags.String("grant", "", "path to the signed single-stage grant")
 	grantKeyPath := flags.String("grant-key", "", "path to the trusted stage-authority public key")
 	evaluationTime := flags.String("evaluation-time", "", "explicit RFC3339 grant evaluation time")
-	artifactPath := flags.String("target-access-artifact", "", "path to the exact externally rendered eight-object target-access set")
+	artifactPath := flags.String("target-access-artifact", "", "path to the exact externally rendered eleven-object target-access set")
 	observabilityNamespace := flags.String("observability-namespace", "", "independently expected observability namespace")
 	managerServiceAccount := flags.String("manager-serviceaccount", "", "independently expected kube-system manager ServiceAccount")
 	clusterRole := flags.String("cluster-role", "", "independently expected cluster role")
@@ -2012,6 +2012,9 @@ func runClusterStageRunTargetAccess(ctx context.Context, arguments []string, std
 	platformRoleBinding := flags.String("platform-rolebinding", "", "independently expected observability namespace role binding")
 	kubeSystemRole := flags.String("kube-system-role", "", "independently expected kube-system role")
 	kubeSystemRoleBinding := flags.String("kube-system-rolebinding", "", "independently expected kube-system role binding")
+	observerServiceAccount := flags.String("observer-serviceaccount", "", "independently expected observability autonomy observer ServiceAccount")
+	observerRole := flags.String("observer-role", "", "independently expected observability autonomy observer Role")
+	observerRoleBinding := flags.String("observer-rolebinding", "", "independently expected observability autonomy observer RoleBinding")
 	execute := flags.Bool("execute", false, "claim and execute exactly the selected target-access stage")
 	ledgerAPIEndpoint := flags.String("ledger-api-endpoint", "", "TLS Kubernetes API endpoint for the durable ledger")
 	ledgerTokenFile := flags.String("ledger-token-file", "", "path to the short-lived ledger token")
@@ -2039,6 +2042,7 @@ func runClusterStageRunTargetAccess(ctx context.Context, arguments []string, std
 		{"--cluster-role", *clusterRole}, {"--cluster-rolebinding", *clusterRoleBinding},
 		{"--platform-role", *platformRole}, {"--platform-rolebinding", *platformRoleBinding},
 		{"--kube-system-role", *kubeSystemRole}, {"--kube-system-rolebinding", *kubeSystemRoleBinding},
+		{"--observer-serviceaccount", *observerServiceAccount}, {"--observer-role", *observerRole}, {"--observer-rolebinding", *observerRoleBinding},
 		{"--ledger-api-endpoint", *ledgerAPIEndpoint}, {"--ledger-token-file", *ledgerTokenFile}, {"--ledger-ca-file", *ledgerCAFile},
 		{"--workload-binding", *workloadBinding}, {"--workload-binding-digest", *workloadBindingDigest},
 		{"--workload-token-file", *workloadTokenFile}, {"--workload-ca-file", *workloadCAFile},
@@ -2051,7 +2055,7 @@ func runClusterStageRunTargetAccess(ctx context.Context, arguments []string, std
 	if err != nil {
 		return fmt.Errorf("parse evaluation time: %w", err)
 	}
-	expectedObjects := targetAccessExpectedObjects(*observabilityNamespace, *managerServiceAccount, *clusterRole, *clusterRoleBinding, *platformRole, *platformRoleBinding, *kubeSystemRole, *kubeSystemRoleBinding)
+	expectedObjects := targetAccessExpectedObjects(*observabilityNamespace, *managerServiceAccount, *clusterRole, *clusterRoleBinding, *platformRole, *platformRoleBinding, *kubeSystemRole, *kubeSystemRoleBinding, *observerServiceAccount, *observerRole, *observerRoleBinding)
 	bundleConfig := runner.TargetAccessStageBundleConfig{
 		PlanPath: resume.PlanPath, PlanExpected: resume.PlanExpected, Receipts: resume.Receipts,
 		GrantPath: *grantPath, GrantPublicKeyPath: *grantKeyPath, EvaluationTime: at,

--- a/cmd/ok/main_test.go
+++ b/cmd/ok/main_test.go
@@ -980,10 +980,10 @@ func TestTargetAccessStageRunBindsExactArtifactAndWorkloadRuntime(t *testing.T) 
 		if !bounded || time.Until(deadline) > stageRunTimeout || time.Until(deadline) < stageRunTimeout-time.Minute {
 			t.Fatalf("target-access context is not bounded: %s %t", deadline, bounded)
 		}
-		if bundle.PlanPath != "/tmp/plan.json" || len(bundle.Receipts) != 6 || bundle.ArtifactPath != "/tmp/target-access.yaml" || len(bundle.ExpectedObjects) != 8 {
+		if bundle.PlanPath != "/tmp/plan.json" || len(bundle.Receipts) != 6 || bundle.ArtifactPath != "/tmp/target-access.yaml" || len(bundle.ExpectedObjects) != 11 {
 			t.Fatalf("target-access bundle differs: %#v", bundle)
 		}
-		wantKinds := []string{"Namespace", "ServiceAccount", "ClusterRole", "ClusterRoleBinding", "Role", "RoleBinding", "Role", "RoleBinding"}
+		wantKinds := []string{"Namespace", "ServiceAccount", "ClusterRole", "ClusterRoleBinding", "Role", "RoleBinding", "Role", "RoleBinding", "ServiceAccount", "Role", "RoleBinding"}
 		for index, object := range bundle.ExpectedObjects {
 			if object.Kind != wantKinds[index] {
 				t.Fatalf("target-access identity %d differs: %#v", index, object)
@@ -1680,6 +1680,8 @@ func targetAccessStageRunArguments() []string {
 		"--cluster-role", "ok147-argocd-platform-cluster", "--cluster-rolebinding", "ok147-argocd-platform-cluster",
 		"--platform-role", "ok147-argocd-platform", "--platform-rolebinding", "ok147-argocd-platform",
 		"--kube-system-role", "ok147-argocd-kube-system", "--kube-system-rolebinding", "ok147-argocd-kube-system",
+		"--observer-serviceaccount", "ok147-observability-autonomy", "--observer-role", "ok147-observability-autonomy",
+		"--observer-rolebinding", "ok147-observability-autonomy",
 		"--execute",
 		"--ledger-api-endpoint", "https://192.0.2.12:6443", "--ledger-token-file", "/private/tmp/ledger-token", "--ledger-ca-file", "/private/tmp/ledger-ca",
 		"--workload-binding", "/private/tmp/runtime-binding.json", "--workload-binding-digest", testSHA("5"),

--- a/cmd/ok/target_access_launch.go
+++ b/cmd/ok/target_access_launch.go
@@ -59,7 +59,7 @@ type targetAccessLaunchPreparation struct {
 	MutationAllowed bool                                           `json:"mutationAllowed"`
 }
 
-func targetAccessExpectedObjects(observabilityNamespace, managerServiceAccount, clusterRole, clusterRoleBinding, platformRole, platformRoleBinding, kubeSystemRole, kubeSystemRoleBinding string) []projection.ResourceIdentity {
+func targetAccessExpectedObjects(observabilityNamespace, managerServiceAccount, clusterRole, clusterRoleBinding, platformRole, platformRoleBinding, kubeSystemRole, kubeSystemRoleBinding, observerServiceAccount, observerRole, observerRoleBinding string) []projection.ResourceIdentity {
 	return []projection.ResourceIdentity{
 		{APIVersion: "v1", Kind: "Namespace", Name: observabilityNamespace},
 		{APIVersion: "v1", Kind: "ServiceAccount", Namespace: "kube-system", Name: managerServiceAccount},
@@ -69,6 +69,9 @@ func targetAccessExpectedObjects(observabilityNamespace, managerServiceAccount, 
 		{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "RoleBinding", Namespace: observabilityNamespace, Name: platformRoleBinding},
 		{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role", Namespace: "kube-system", Name: kubeSystemRole},
 		{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "RoleBinding", Namespace: "kube-system", Name: kubeSystemRoleBinding},
+		{APIVersion: "v1", Kind: "ServiceAccount", Namespace: observabilityNamespace, Name: observerServiceAccount},
+		{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role", Namespace: observabilityNamespace, Name: observerRole},
+		{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "RoleBinding", Namespace: observabilityNamespace, Name: observerRoleBinding},
 	}
 }
 
@@ -79,7 +82,7 @@ func runClusterStageRunTargetAccessPackage(arguments []string, stdout, stderr io
 	grantPath := flags.String("grant", "", "path to the signed single-stage grant")
 	grantKeyPath := flags.String("grant-key", "", "path to the trusted stage-authority public key")
 	evaluationTime := flags.String("evaluation-time", "", "explicit RFC3339 grant evaluation time")
-	artifactPath := flags.String("target-access-artifact", "", "path to the exact externally rendered eight-object target-access set")
+	artifactPath := flags.String("target-access-artifact", "", "path to the exact externally rendered eleven-object target-access set")
 	observabilityNamespace := flags.String("observability-namespace", "", "independently expected observability namespace")
 	managerServiceAccount := flags.String("manager-serviceaccount", "", "independently expected kube-system manager ServiceAccount")
 	clusterRole := flags.String("cluster-role", "", "independently expected cluster role")
@@ -88,6 +91,9 @@ func runClusterStageRunTargetAccessPackage(arguments []string, stdout, stderr io
 	platformRoleBinding := flags.String("platform-rolebinding", "", "independently expected observability namespace role binding")
 	kubeSystemRole := flags.String("kube-system-role", "", "independently expected kube-system role")
 	kubeSystemRoleBinding := flags.String("kube-system-rolebinding", "", "independently expected kube-system role binding")
+	observerServiceAccount := flags.String("observer-serviceaccount", "", "independently expected observability autonomy observer ServiceAccount")
+	observerRole := flags.String("observer-role", "", "independently expected observability autonomy observer Role")
+	observerRoleBinding := flags.String("observer-rolebinding", "", "independently expected observability autonomy observer RoleBinding")
 	jobTemplate := flags.String("job-template", "", "path to the bounded target-access Job template")
 	jobTemplateDigest := flags.String("job-template-digest", "", "expected SHA-256 identity of the Job template")
 	output := flags.String("output", "", "new local file for the verified target-access package")
@@ -118,6 +124,7 @@ func runClusterStageRunTargetAccessPackage(arguments []string, stdout, stderr io
 		{"--cluster-role", *clusterRole}, {"--cluster-rolebinding", *clusterRoleBinding},
 		{"--platform-role", *platformRole}, {"--platform-rolebinding", *platformRoleBinding},
 		{"--kube-system-role", *kubeSystemRole}, {"--kube-system-rolebinding", *kubeSystemRoleBinding},
+		{"--observer-serviceaccount", *observerServiceAccount}, {"--observer-role", *observerRole}, {"--observer-rolebinding", *observerRoleBinding},
 		{"--job-template", *jobTemplate}, {"--job-template-digest", *jobTemplateDigest}, {"--output", *output},
 		{"--run-id", *runID}, {"--image", *imageDigest}, {"--input-configmap", *inputConfigMap},
 		{"--ledger-api-url", *ledgerAPIURL}, {"--ledger-api-cidr", *ledgerAPICIDR}, {"--ledger-credential-secret", *ledgerCredentialSecret},
@@ -136,7 +143,7 @@ func runClusterStageRunTargetAccessPackage(arguments []string, stdout, stderr io
 	if err != nil {
 		return fmt.Errorf("read target-access Job template: %w", err)
 	}
-	expectedObjects := targetAccessExpectedObjects(*observabilityNamespace, *managerServiceAccount, *clusterRole, *clusterRoleBinding, *platformRole, *platformRoleBinding, *kubeSystemRole, *kubeSystemRoleBinding)
+	expectedObjects := targetAccessExpectedObjects(*observabilityNamespace, *managerServiceAccount, *clusterRole, *clusterRoleBinding, *platformRole, *platformRoleBinding, *kubeSystemRole, *kubeSystemRoleBinding, *observerServiceAccount, *observerRole, *observerRoleBinding)
 	raw, receipt, err := materializeTargetAccessStagePackage(runner.TargetAccessStagePackageConfig{
 		Bundle: runner.TargetAccessStageBundleConfig{
 			PlanPath: resume.PlanPath, PlanExpected: resume.PlanExpected, Receipts: resume.Receipts,
@@ -149,6 +156,7 @@ func runClusterStageRunTargetAccessPackage(arguments []string, stdout, stderr io
 		ClusterRole: *clusterRole, ClusterRoleBinding: *clusterRoleBinding,
 		PlatformRole: *platformRole, PlatformRoleBinding: *platformRoleBinding,
 		KubeSystemRole: *kubeSystemRole, KubeSystemRoleBinding: *kubeSystemRoleBinding,
+		ObserverServiceAccount: *observerServiceAccount, ObserverRole: *observerRole, ObserverRoleBinding: *observerRoleBinding,
 		LedgerAPIURL: *ledgerAPIURL, LedgerAPICIDR: *ledgerAPICIDR, LedgerCredentialSecret: *ledgerCredentialSecret,
 		WorkloadAPIURL: *workloadAPIURL, WorkloadAPICIDR: *workloadAPICIDR, WorkloadCredentialSecret: *workloadCredentialSecret,
 		WorkloadBindingPath: *workloadBinding, ExpectedWorkloadBindingDigest: *workloadBindingDigest,
@@ -171,6 +179,7 @@ type targetAccessLaunchMaterialFlags struct {
 	observabilityNamespace, managerServiceAccount                                                     *string
 	clusterRole, clusterRoleBinding, platformRole, platformRoleBinding                                *string
 	kubeSystemRole, kubeSystemRoleBinding                                                             *string
+	observerServiceAccount, observerRole, observerRoleBinding                                         *string
 	jobTemplate, jobTemplateDigest, runID, imageDigest, inputConfigMap                                *string
 	ledgerAPIURL, ledgerAPICIDR, ledgerCredentialSecret                                               *string
 	workloadAPIURL, workloadAPICIDR, workloadCredentialSecret, workloadBinding, workloadBindingDigest *string
@@ -184,7 +193,7 @@ func addTargetAccessLaunchMaterialFlags(flags *flag.FlagSet) *targetAccessLaunch
 	values.grantPath = flags.String("grant", "", "path to the signed single-stage grant")
 	values.grantKeyPath = flags.String("grant-key", "", "path to the trusted stage-authority public key")
 	values.evaluationTime = flags.String("evaluation-time", "", "explicit RFC3339 grant evaluation time")
-	values.artifactPath = flags.String("target-access-artifact", "", "path to the exact externally rendered eight-object target-access set")
+	values.artifactPath = flags.String("target-access-artifact", "", "path to the exact externally rendered eleven-object target-access set")
 	values.observabilityNamespace = flags.String("observability-namespace", "", "independently expected observability namespace")
 	values.managerServiceAccount = flags.String("manager-serviceaccount", "", "independently expected kube-system manager ServiceAccount")
 	values.clusterRole = flags.String("cluster-role", "", "independently expected cluster role")
@@ -193,6 +202,9 @@ func addTargetAccessLaunchMaterialFlags(flags *flag.FlagSet) *targetAccessLaunch
 	values.platformRoleBinding = flags.String("platform-rolebinding", "", "independently expected observability namespace role binding")
 	values.kubeSystemRole = flags.String("kube-system-role", "", "independently expected kube-system role")
 	values.kubeSystemRoleBinding = flags.String("kube-system-rolebinding", "", "independently expected kube-system role binding")
+	values.observerServiceAccount = flags.String("observer-serviceaccount", "", "independently expected observability autonomy observer ServiceAccount")
+	values.observerRole = flags.String("observer-role", "", "independently expected observability autonomy observer Role")
+	values.observerRoleBinding = flags.String("observer-rolebinding", "", "independently expected observability autonomy observer RoleBinding")
 	values.jobTemplate = flags.String("job-template", "", "path to the bounded target-access Job template")
 	values.jobTemplateDigest = flags.String("job-template-digest", "", "expected SHA-256 identity of the Job template")
 	values.runID = flags.String("run-id", "", "bounded OK-147 target-access Job identity")
@@ -230,6 +242,7 @@ func (values *targetAccessLaunchMaterialFlags) config() (runner.TargetAccessStag
 		{"--cluster-role", *values.clusterRole}, {"--cluster-rolebinding", *values.clusterRoleBinding},
 		{"--platform-role", *values.platformRole}, {"--platform-rolebinding", *values.platformRoleBinding},
 		{"--kube-system-role", *values.kubeSystemRole}, {"--kube-system-rolebinding", *values.kubeSystemRoleBinding},
+		{"--observer-serviceaccount", *values.observerServiceAccount}, {"--observer-role", *values.observerRole}, {"--observer-rolebinding", *values.observerRoleBinding},
 		{"--job-template", *values.jobTemplate}, {"--job-template-digest", *values.jobTemplateDigest}, {"--run-id", *values.runID}, {"--image", *values.imageDigest},
 		{"--input-configmap", *values.inputConfigMap}, {"--ledger-api-url", *values.ledgerAPIURL}, {"--ledger-api-cidr", *values.ledgerAPICIDR},
 		{"--ledger-credential-secret", *values.ledgerCredentialSecret}, {"--workload-api-url", *values.workloadAPIURL},
@@ -272,7 +285,7 @@ func (values *targetAccessLaunchMaterialFlags) config() (runner.TargetAccessStag
 	if err != nil {
 		return runner.TargetAccessStageLaunchMaterialConfig{}, fmt.Errorf("read runtime manifest: %w", err)
 	}
-	expectedObjects := targetAccessExpectedObjects(*values.observabilityNamespace, *values.managerServiceAccount, *values.clusterRole, *values.clusterRoleBinding, *values.platformRole, *values.platformRoleBinding, *values.kubeSystemRole, *values.kubeSystemRoleBinding)
+	expectedObjects := targetAccessExpectedObjects(*values.observabilityNamespace, *values.managerServiceAccount, *values.clusterRole, *values.clusterRoleBinding, *values.platformRole, *values.platformRoleBinding, *values.kubeSystemRole, *values.kubeSystemRoleBinding, *values.observerServiceAccount, *values.observerRole, *values.observerRoleBinding)
 	return runner.TargetAccessStageLaunchMaterialConfig{
 		Package: runner.TargetAccessStagePackageConfig{
 			Bundle: runner.TargetAccessStageBundleConfig{
@@ -286,6 +299,7 @@ func (values *targetAccessLaunchMaterialFlags) config() (runner.TargetAccessStag
 			ClusterRole: *values.clusterRole, ClusterRoleBinding: *values.clusterRoleBinding,
 			PlatformRole: *values.platformRole, PlatformRoleBinding: *values.platformRoleBinding,
 			KubeSystemRole: *values.kubeSystemRole, KubeSystemRoleBinding: *values.kubeSystemRoleBinding,
+			ObserverServiceAccount: *values.observerServiceAccount, ObserverRole: *values.observerRole, ObserverRoleBinding: *values.observerRoleBinding,
 			LedgerAPIURL: *values.ledgerAPIURL, LedgerAPICIDR: *values.ledgerAPICIDR, LedgerCredentialSecret: *values.ledgerCredentialSecret,
 			WorkloadAPIURL: *values.workloadAPIURL, WorkloadAPICIDR: *values.workloadAPICIDR, WorkloadCredentialSecret: *values.workloadCredentialSecret,
 			WorkloadBindingPath: *values.workloadBinding, ExpectedWorkloadBindingDigest: *values.workloadBindingDigest,

--- a/cmd/ok/target_access_launch_test.go
+++ b/cmd/ok/target_access_launch_test.go
@@ -38,10 +38,10 @@ func TestTargetAccessStagePackageWritesVerifiedOfflineArtifact(t *testing.T) {
 	if err := run(arguments, &stdout, &stderr); err != nil {
 		t.Fatalf("run: %v; stderr=%s", err, stderr.String())
 	}
-	if captured.Bundle.PlanPath != "/tmp/plan.json" || len(captured.Bundle.Receipts) != 6 || len(captured.Bundle.ExpectedObjects) != 8 || captured.RunID != "ok147-target-access-20260817-01" {
+	if captured.Bundle.PlanPath != "/tmp/plan.json" || len(captured.Bundle.Receipts) != 6 || len(captured.Bundle.ExpectedObjects) != 11 || captured.RunID != "ok147-target-access-20260817-01" {
 		t.Fatalf("unexpected target-access package config: %#v", captured)
 	}
-	if captured.Bundle.ExpectedObjects[0].Name != "ok-observability" || captured.Bundle.ExpectedObjects[7].Namespace != "kube-system" || captured.Bundle.PlanExpected.GitOpsAuthority != "ok-shared" {
+	if captured.Bundle.ExpectedObjects[0].Name != "ok-observability" || captured.Bundle.ExpectedObjects[7].Namespace != "kube-system" || captured.Bundle.ExpectedObjects[10].Name != "ok147-observability-autonomy" || captured.Bundle.PlanExpected.GitOpsAuthority != "ok-shared" {
 		t.Fatalf("target-access authority or object identities differ: %#v", captured.Bundle)
 	}
 	if string(captured.JobTemplate) != "bounded-target-access-template" || captured.JobTemplateDigest != digest.SHA256([]byte("bounded-target-access-template")) || captured.LedgerCredentialSecret == captured.WorkloadCredentialSecret || captured.WorkloadBindingPath != "/private/tmp/runtime-binding.json" {
@@ -98,7 +98,7 @@ func TestTargetAccessLaunchPrepareBuildsOneNonMutatingCandidate(t *testing.T) {
 	if err := run(targetAccessLaunchPrepareArguments(template, runtimeManifest), &stdout, &stderr); err != nil {
 		t.Fatalf("run: %v; stderr=%s", err, stderr.String())
 	}
-	if captured.Package.Bundle.PlanExpected.GitOpsAuthority != "ok-shared" || len(captured.Package.Bundle.ExpectedObjects) != 8 || captured.Package.RunID != "ok147-target-access-20260817-01" {
+	if captured.Package.Bundle.PlanExpected.GitOpsAuthority != "ok-shared" || len(captured.Package.Bundle.ExpectedObjects) != 11 || captured.Package.RunID != "ok147-target-access-20260817-01" {
 		t.Fatalf("target-access package identity differs: %#v", captured.Package)
 	}
 	if string(captured.Package.JobTemplate) != "bounded-target-access-template" || string(captured.RuntimeManifest) != "bounded-runtime" {

--- a/deploy/contract-executor-target-access-job.yaml.tpl
+++ b/deploy/contract-executor-target-access-job.yaml.tpl
@@ -121,6 +121,12 @@ spec:
             - "${OK147_KUBE_SYSTEM_ROLE}"
             - --kube-system-rolebinding
             - "${OK147_KUBE_SYSTEM_ROLEBINDING}"
+            - --observer-serviceaccount
+            - "${OK147_OBSERVER_SERVICEACCOUNT}"
+            - --observer-role
+            - "${OK147_OBSERVER_ROLE}"
+            - --observer-rolebinding
+            - "${OK147_OBSERVER_ROLEBINDING}"
             - --ledger-api-endpoint
             - "${OK147_LEDGER_API_URL}"
             - --ledger-token-file

--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -2469,15 +2469,19 @@ the launcher after receiving the exact candidate digest and explicit
 ## Target-access verified projection
 
 The first `target-access` boundary is again side-effect free. One externally
-rendered artifact is accepted only when its digest and exact eight-object
+rendered artifact is accepted only when its digest and exact eleven-object
 identity list are independently supplied by the staged experiment. The plan
 binds `R`, `P`, `FixtureDigest` and the immutable workload target identity to a
 single workload authority plane.
 
 The allowlist fixes this order: Namespace, manager ServiceAccount,
 ClusterRole/ClusterRoleBinding, one namespaced Role/RoleBinding pair for the
-Platform namespace and one Role/RoleBinding pair for `kube-system`. Every
-binding must refer to the exact manager ServiceAccount and corresponding role.
+Platform namespace, one Role/RoleBinding pair for `kube-system`, and a
+dedicated autonomy-observer ServiceAccount/Role/RoleBinding in the Platform
+namespace. The observer ServiceAccount disables automatic token mounting and
+its Role is fixed to exactly `get` Services and `list` EndpointSlices. Manager
+bindings must refer to the exact manager ServiceAccount; the observer binding
+must refer only to the exact observer ServiceAccount and Role.
 Wildcard permissions, non-resource URLs, user/group subjects, runtime metadata,
 status, aliases, symlinks, additional or reordered objects fail closed. The
 verified output is `ok147-bounded-target-access-plan/v1` with
@@ -2496,14 +2500,14 @@ only plan, authorization, artifact, target and object digests and remains
 `mutationAllowed: false`.
 
 Bundle loading still does not claim the grant, open the durable ledger, read a
-workload credential or submit any of the eight objects.
+workload credential or submit any of the eleven objects.
 
 ## Target-access Job launch boundary
 
 The verified Target Access bundle can now be materialized as one immutable
 ConfigMap plus a deny-all NetworkPolicy and non-retrying Job. The package binds
 the exact six-receipt predecessor chain, signed `CreateTargetAccess` grant,
-eight-object workload artifact, private runtime-binding digest, immutable
+eleven-object workload artifact, private runtime-binding digest, immutable
 target identity, runner image and the distinct ledger/workload API endpoints.
 The private runtime binding, CA bundles and credentials are never embedded in
 the ConfigMap or exposed by its receipt.

--- a/internal/execution/target_access_stage.go
+++ b/internal/execution/target_access_stage.go
@@ -9,7 +9,7 @@ import (
 	"github.com/openkubes/ok-cluster/internal/submission"
 )
 
-// TargetAccessMutator is bound to the exact eight-object workload access set.
+// TargetAccessMutator is bound to the exact eleven-object workload access set.
 // It neither issues credentials nor registers the target with GitOps.
 type TargetAccessMutator struct {
 	binding   StageMutationBinding
@@ -37,13 +37,13 @@ func NewTargetAccessMutator(plan stageplan.Binding, projected submission.TargetA
 		return nil, err
 	}
 	plane := projected.Workload
-	if !stagedDigestPattern.MatchString(projected.TargetIdentityDigest) || plane.Identity != projected.TargetIdentityDigest || plane.Role != "target-access-writer" || len(plane.Objects) != 8 {
+	if !stagedDigestPattern.MatchString(projected.TargetIdentityDigest) || plane.Identity != projected.TargetIdentityDigest || plane.Role != "target-access-writer" || len(plane.Objects) != 11 {
 		return nil, errors.New("target-access projection authority or content differs from the selected stage")
 	}
-	expectedKinds := []string{"Namespace", "ServiceAccount", "ClusterRole", "ClusterRoleBinding", "Role", "RoleBinding", "Role", "RoleBinding"}
+	expectedKinds := []string{"Namespace", "ServiceAccount", "ClusterRole", "ClusterRoleBinding", "Role", "RoleBinding", "Role", "RoleBinding", "ServiceAccount", "Role", "RoleBinding"}
 	for index, object := range plane.Objects {
 		if object.Identity.Kind != expectedKinds[index] || !stagedDigestPattern.MatchString(object.Digest) || object.CollectionPath == "" || object.ObjectPath == "" || len(object.Raw) == 0 {
-			return nil, errors.New("target-access projection lacks the exact eight-object set")
+			return nil, errors.New("target-access projection lacks the exact eleven-object set")
 		}
 	}
 	return &TargetAccessMutator{

--- a/internal/execution/target_access_stage_test.go
+++ b/internal/execution/target_access_stage_test.go
@@ -23,7 +23,7 @@ func TestTargetAccessMutatorBindsExactWorkloadAccessSet(t *testing.T) {
 	if err != nil || result.Outcome != "SUCCEEDED" || result.MutationState != "ATTEMPTED" || result.EvidenceDigest == "" || submitter.calls != 1 {
 		t.Fatalf("target-access mutation did not complete: %#v calls=%d err=%v", result, submitter.calls, err)
 	}
-	if submitter.plane.Identity != stagedSHA("e") || len(submitter.plane.Objects) != 8 || submitter.plane.Objects[0].Identity.Kind != "Namespace" || string(submitter.plane.Objects[0].Raw) != `{"apiVersion":"v1","kind":"Namespace"}` {
+	if submitter.plane.Identity != stagedSHA("e") || len(submitter.plane.Objects) != 11 || submitter.plane.Objects[0].Identity.Kind != "Namespace" || string(submitter.plane.Objects[0].Raw) != `{"apiVersion":"v1","kind":"Namespace"}` {
 		t.Fatalf("mutator did not retain the verified workload plane: %#v", submitter.plane)
 	}
 }
@@ -47,12 +47,12 @@ func TestTargetAccessMutatorRejectsForeignProjectionAndRequest(t *testing.T) {
 	plan := stagedPlan(t)
 	valid := stagedTargetAccessPlan(plan.IntentRevision, plan.PlatformRevision, plan.ExecutionFixture, stagedSHA("e"))
 	tests := map[string]func(*submission.TargetAccessPlan){
-		"authorizing input": func(value *submission.TargetAccessPlan) { value.MutationAllowed = true },
-		"wrong P":           func(value *submission.TargetAccessPlan) { value.PlatformRevision = stagedSHA("1") },
-		"wrong artifact":    func(value *submission.TargetAccessPlan) { value.ArtifactDigest = stagedSHA("1") },
-		"wrong authority":   func(value *submission.TargetAccessPlan) { value.Workload.Identity = stagedSHA("1") },
-		"seventh object":    func(value *submission.TargetAccessPlan) { value.Workload.Objects = value.Workload.Objects[:7] },
-		"wrong kind":        func(value *submission.TargetAccessPlan) { value.Workload.Objects[0].Identity.Kind = "ConfigMap" },
+		"authorizing input":     func(value *submission.TargetAccessPlan) { value.MutationAllowed = true },
+		"wrong P":               func(value *submission.TargetAccessPlan) { value.PlatformRevision = stagedSHA("1") },
+		"wrong artifact":        func(value *submission.TargetAccessPlan) { value.ArtifactDigest = stagedSHA("1") },
+		"wrong authority":       func(value *submission.TargetAccessPlan) { value.Workload.Identity = stagedSHA("1") },
+		"incomplete object set": func(value *submission.TargetAccessPlan) { value.Workload.Objects = value.Workload.Objects[:10] },
+		"wrong kind":            func(value *submission.TargetAccessPlan) { value.Workload.Objects[0].Identity.Kind = "ConfigMap" },
 	}
 	for name, mutate := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -72,12 +72,12 @@ func TestTargetAccessMutatorRejectsForeignProjectionAndRequest(t *testing.T) {
 }
 
 func stagedTargetAccessPlan(r, p, fixture, targetDigest string) submission.TargetAccessPlan {
-	kinds := []string{"Namespace", "ServiceAccount", "ClusterRole", "ClusterRoleBinding", "Role", "RoleBinding", "Role", "RoleBinding"}
+	kinds := []string{"Namespace", "ServiceAccount", "ClusterRole", "ClusterRoleBinding", "Role", "RoleBinding", "Role", "RoleBinding", "ServiceAccount", "Role", "RoleBinding"}
 	objects := make([]submission.Object, len(kinds))
 	for index, kind := range kinds {
 		objects[index] = submission.Object{
 			Identity: projection.ResourceIdentity{APIVersion: "v1", Kind: kind, Name: "object"},
-			Digest:   stagedSHA(string("12345678"[index])), CollectionPath: "/api/v1/resources", ObjectPath: "/api/v1/resources/object",
+			Digest:   stagedSHA(string("123456789ab"[index])), CollectionPath: "/api/v1/resources", ObjectPath: "/api/v1/resources/object",
 			Raw: json.RawMessage(`{"apiVersion":"v1","kind":"` + kind + `"}`),
 		}
 	}

--- a/internal/runner/full_run_execution_manifest.go
+++ b/internal/runner/full_run_execution_manifest.go
@@ -615,7 +615,7 @@ func verifyFullRunStaticArtifacts(document fullRunExecutionManifestDocument, pla
 		TargetIdentityDigest: targetIdentity, WorkloadAuthority: targetIdentity,
 		Objects: append([]projection.ResourceIdentity(nil), document.TargetAccess.ExpectedObjects...),
 	})
-	if err != nil || len(access.Workload.Objects) != 8 || access.Workload.Objects[1].Identity.Kind != "ServiceAccount" {
+	if err != nil || len(access.Workload.Objects) != 11 || access.Workload.Objects[1].Identity.Kind != "ServiceAccount" || access.Workload.Objects[8].Identity.Kind != "ServiceAccount" {
 		return errors.New("verify full-run target-access artifact")
 	}
 	targetCredentialStage, _, err := plan.Stage("target-credential")

--- a/internal/runner/target_access_stage_bundle.go
+++ b/internal/runner/target_access_stage_bundle.go
@@ -17,7 +17,7 @@ import (
 const TargetAccessStageBundleReceiptFormat = "ok147-target-access-stage-bundle/v1"
 
 // TargetAccessStageBundleConfig binds the complete successful prefix, one
-// CreateTargetAccess grant and one externally rendered eight-object artifact.
+// CreateTargetAccess grant and one externally rendered eleven-object artifact.
 // Loading remains entirely offline.
 type TargetAccessStageBundleConfig struct {
 	PlanPath           string
@@ -144,7 +144,7 @@ func (bundle VerifiedTargetAccessStageBundle) Decision() (stagecursor.Decision, 
 }
 
 func (bundle VerifiedTargetAccessStageBundle) Receipt() (TargetAccessStageBundleReceipt, error) {
-	if !bundle.verified || bundle.receipt.Format != TargetAccessStageBundleReceiptFormat || bundle.receipt.State != "VERIFIED" || bundle.receipt.StageID != "target-access" || bundle.receipt.MutationAllowed || len(bundle.receipt.ObjectDigests) != 8 {
+	if !bundle.verified || bundle.receipt.Format != TargetAccessStageBundleReceiptFormat || bundle.receipt.State != "VERIFIED" || bundle.receipt.StageID != "target-access" || bundle.receipt.MutationAllowed || len(bundle.receipt.ObjectDigests) != 11 {
 		return TargetAccessStageBundleReceipt{}, errors.New("target-access stage bundle was not produced by verification")
 	}
 	receipt := bundle.receipt

--- a/internal/runner/target_access_stage_bundle_test.go
+++ b/internal/runner/target_access_stage_bundle_test.go
@@ -24,10 +24,10 @@ func TestLoadTargetAccessStageBundleBindsPrefixGrantArtifactAndTarget(t *testing
 		t.Fatalf("unexpected target-access decision: %#v %v", decision, err)
 	}
 	receipt, err := bundle.Receipt()
-	if err != nil || receipt.Format != TargetAccessStageBundleReceiptFormat || receipt.State != "VERIFIED" || receipt.PlanDigest != fixture.plan.PlanDigest || receipt.TargetIdentityDigest != digest.SHA256([]byte(targetAccessRuntimeUID)) || receipt.AuthorizationDigest == "" || len(receipt.ObjectDigests) != 8 || receipt.MutationAllowed {
+	if err != nil || receipt.Format != TargetAccessStageBundleReceiptFormat || receipt.State != "VERIFIED" || receipt.PlanDigest != fixture.plan.PlanDigest || receipt.TargetIdentityDigest != digest.SHA256([]byte(targetAccessRuntimeUID)) || receipt.AuthorizationDigest == "" || len(receipt.ObjectDigests) != 11 || receipt.MutationAllowed {
 		t.Fatalf("unexpected target-access bundle receipt: %#v %v", receipt, err)
 	}
-	if bundle.projection.Workload.Identity != digest.SHA256([]byte(targetAccessRuntimeUID)) || len(bundle.projection.Workload.Objects) != 8 {
+	if bundle.projection.Workload.Identity != digest.SHA256([]byte(targetAccessRuntimeUID)) || len(bundle.projection.Workload.Objects) != 11 {
 		t.Fatalf("target-access projection differs: %#v", bundle.projection)
 	}
 }
@@ -223,6 +223,9 @@ func runnerTargetAccessIdentities() []projection.ResourceIdentity {
 		{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "RoleBinding", Namespace: "ok-observability", Name: "ok147-argocd-platform"},
 		{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role", Namespace: "kube-system", Name: "ok147-argocd-kube-system"},
 		{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "RoleBinding", Namespace: "kube-system", Name: "ok147-argocd-kube-system"},
+		{APIVersion: "v1", Kind: "ServiceAccount", Namespace: "ok-observability", Name: "ok147-observability-autonomy"},
+		{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role", Namespace: "ok-observability", Name: "ok147-observability-autonomy"},
+		{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "RoleBinding", Namespace: "ok-observability", Name: "ok147-observability-autonomy"},
 	}
 }
 
@@ -273,5 +276,23 @@ kind: RoleBinding
 metadata: {name: ok147-argocd-kube-system, namespace: kube-system}
 roleRef: {apiGroup: rbac.authorization.k8s.io, kind: Role, name: ok147-argocd-kube-system}
 subjects: [{kind: ServiceAccount, name: ok147-argocd-manager, namespace: kube-system}]
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata: {name: ok147-observability-autonomy, namespace: ok-observability}
+automountServiceAccountToken: false
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata: {name: ok147-observability-autonomy, namespace: ok-observability}
+rules:
+  - {apiGroups: [""], resources: [services], verbs: [get]}
+  - {apiGroups: [discovery.k8s.io], resources: [endpointslices], verbs: [list]}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata: {name: ok147-observability-autonomy, namespace: ok-observability}
+roleRef: {apiGroup: rbac.authorization.k8s.io, kind: Role, name: ok147-observability-autonomy}
+subjects: [{kind: ServiceAccount, name: ok147-observability-autonomy, namespace: ok-observability}]
 `)
 }

--- a/internal/runner/target_access_stage_job.go
+++ b/internal/runner/target_access_stage_job.go
@@ -28,6 +28,9 @@ type TargetAccessStageJobValues struct {
 	PlatformRoleBinding      string
 	KubeSystemRole           string
 	KubeSystemRoleBinding    string
+	ObserverServiceAccount   string
+	ObserverRole             string
+	ObserverRoleBinding      string
 	LedgerAPIURL             string
 	LedgerAPICIDR            string
 	LedgerCredentialSecret   string
@@ -52,6 +55,7 @@ func RenderTargetAccessStageJobTemplate(template []byte, values TargetAccessStag
 		values.InputConfigMap, values.ObservabilityNamespace, values.ManagerServiceAccount,
 		values.ClusterRole, values.ClusterRoleBinding, values.PlatformRole,
 		values.PlatformRoleBinding, values.KubeSystemRole, values.KubeSystemRoleBinding,
+		values.ObserverServiceAccount, values.ObserverRole, values.ObserverRoleBinding,
 		values.LedgerCredentialSecret, values.WorkloadCredentialSecret,
 	}
 	for _, value := range names {
@@ -100,7 +104,9 @@ func RenderTargetAccessStageJobTemplate(template []byte, values TargetAccessStag
 		"${OK147_CLUSTER_ROLE}": values.ClusterRole, "${OK147_CLUSTER_ROLEBINDING}": values.ClusterRoleBinding,
 		"${OK147_PLATFORM_ROLE}": values.PlatformRole, "${OK147_PLATFORM_ROLEBINDING}": values.PlatformRoleBinding,
 		"${OK147_KUBE_SYSTEM_ROLE}": values.KubeSystemRole, "${OK147_KUBE_SYSTEM_ROLEBINDING}": values.KubeSystemRoleBinding,
-		"${OK147_LEDGER_API_URL}": values.LedgerAPIURL, "${OK147_LEDGER_API_CIDR}": values.LedgerAPICIDR,
+		"${OK147_OBSERVER_SERVICEACCOUNT}": values.ObserverServiceAccount, "${OK147_OBSERVER_ROLE}": values.ObserverRole,
+		"${OK147_OBSERVER_ROLEBINDING}": values.ObserverRoleBinding,
+		"${OK147_LEDGER_API_URL}":       values.LedgerAPIURL, "${OK147_LEDGER_API_CIDR}": values.LedgerAPICIDR,
 		"${OK147_LEDGER_API_PORT}": ledgerPort, "${OK147_LEDGER_CREDENTIAL_SECRET}": values.LedgerCredentialSecret,
 		"${OK147_WORKLOAD_API_CIDR}": values.WorkloadAPICIDR, "${OK147_WORKLOAD_API_PORT}": workloadPort,
 		"${OK147_WORKLOAD_CREDENTIAL_SECRET}": values.WorkloadCredentialSecret, "${OK147_WORKLOAD_BINDING_DIGEST}": values.WorkloadBindingDigest,

--- a/internal/runner/target_access_stage_job_test.go
+++ b/internal/runner/target_access_stage_job_test.go
@@ -56,6 +56,9 @@ func TestRenderTargetAccessStageJobBindsExactEnvelope(t *testing.T) {
 		"--platform-rolebinding":    values.PlatformRoleBinding,
 		"--kube-system-role":        values.KubeSystemRole,
 		"--kube-system-rolebinding": values.KubeSystemRoleBinding,
+		"--observer-serviceaccount": values.ObserverServiceAccount,
+		"--observer-role":           values.ObserverRole,
+		"--observer-rolebinding":    values.ObserverRoleBinding,
 	} {
 		if got := argumentValue(args, argument); got != want {
 			t.Fatalf("target-access Job %s=%q, want %q", argument, got, want)
@@ -127,6 +130,7 @@ func validTargetAccessStageJobValues() TargetAccessStageJobValues {
 		ClusterRole: "ok147-argocd-platform-cluster", ClusterRoleBinding: "ok147-argocd-platform-cluster",
 		PlatformRole: "ok147-argocd-platform", PlatformRoleBinding: "ok147-argocd-platform",
 		KubeSystemRole: "ok147-argocd-kube-system", KubeSystemRoleBinding: "ok147-argocd-kube-system",
+		ObserverServiceAccount: "ok147-observability-autonomy", ObserverRole: "ok147-observability-autonomy", ObserverRoleBinding: "ok147-observability-autonomy",
 		LedgerAPIURL: "https://192.0.2.12:6443", LedgerAPICIDR: "192.0.2.12/32", LedgerCredentialSecret: "ok147-ledger-credential",
 		WorkloadAPIURL: "https://192.0.2.13:6443", WorkloadAPICIDR: "192.0.2.13/32", WorkloadCredentialSecret: "ok147-workload-credential",
 		WorkloadBindingDigest: prefixSHA("f"),

--- a/internal/runner/target_access_stage_package.go
+++ b/internal/runner/target_access_stage_package.go
@@ -27,6 +27,9 @@ type TargetAccessStagePackageConfig struct {
 	PlatformRoleBinding           string
 	KubeSystemRole                string
 	KubeSystemRoleBinding         string
+	ObserverServiceAccount        string
+	ObserverRole                  string
+	ObserverRoleBinding           string
 	LedgerAPIURL                  string
 	LedgerAPICIDR                 string
 	LedgerCredentialSecret        string
@@ -38,7 +41,7 @@ type TargetAccessStagePackageConfig struct {
 }
 
 // TargetAccessStagePackageReceipt is a redaction-safe offline composition
-// proof. TargetAccessDigest covers the eight rendered target objects while
+// proof. TargetAccessDigest covers the eleven rendered target objects while
 // TargetIdentityDigest correlates the package to the CAPI-created workload.
 type TargetAccessStagePackageReceipt struct {
 	Format                string   `json:"format"`
@@ -84,6 +87,9 @@ func BuildTargetAccessStagePackage(config TargetAccessStagePackageConfig) (Verif
 		{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "RoleBinding", Namespace: config.ObservabilityNamespace, Name: config.PlatformRoleBinding},
 		{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role", Namespace: "kube-system", Name: config.KubeSystemRole},
 		{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "RoleBinding", Namespace: "kube-system", Name: config.KubeSystemRoleBinding},
+		{APIVersion: "v1", Kind: "ServiceAccount", Namespace: config.ObservabilityNamespace, Name: config.ObserverServiceAccount},
+		{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role", Namespace: config.ObservabilityNamespace, Name: config.ObserverRole},
+		{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "RoleBinding", Namespace: config.ObservabilityNamespace, Name: config.ObserverRoleBinding},
 	}
 	if len(config.Bundle.ExpectedObjects) != len(jobObjects) {
 		return VerifiedTargetAccessStagePackage{}, errors.New("target-access Job object identities differ from verified bundle")
@@ -129,6 +135,7 @@ func BuildTargetAccessStagePackage(config TargetAccessStagePackageConfig) (Verif
 		ClusterRole: config.ClusterRole, ClusterRoleBinding: config.ClusterRoleBinding,
 		PlatformRole: config.PlatformRole, PlatformRoleBinding: config.PlatformRoleBinding,
 		KubeSystemRole: config.KubeSystemRole, KubeSystemRoleBinding: config.KubeSystemRoleBinding,
+		ObserverServiceAccount: config.ObserverServiceAccount, ObserverRole: config.ObserverRole, ObserverRoleBinding: config.ObserverRoleBinding,
 		LedgerAPIURL: config.LedgerAPIURL, LedgerAPICIDR: config.LedgerAPICIDR, LedgerCredentialSecret: config.LedgerCredentialSecret,
 		WorkloadAPIURL: config.WorkloadAPIURL, WorkloadAPICIDR: config.WorkloadAPICIDR, WorkloadCredentialSecret: config.WorkloadCredentialSecret,
 		WorkloadBindingDigest: config.ExpectedWorkloadBindingDigest,

--- a/internal/runner/target_access_stage_package_test.go
+++ b/internal/runner/target_access_stage_package_test.go
@@ -101,6 +101,7 @@ func targetAccessStagePackageConfig(t *testing.T) TargetAccessStagePackageConfig
 		ClusterRole: values.ClusterRole, ClusterRoleBinding: values.ClusterRoleBinding,
 		PlatformRole: values.PlatformRole, PlatformRoleBinding: values.PlatformRoleBinding,
 		KubeSystemRole: values.KubeSystemRole, KubeSystemRoleBinding: values.KubeSystemRoleBinding,
+		ObserverServiceAccount: values.ObserverServiceAccount, ObserverRole: values.ObserverRole, ObserverRoleBinding: values.ObserverRoleBinding,
 		LedgerAPIURL: values.LedgerAPIURL, LedgerAPICIDR: values.LedgerAPICIDR, LedgerCredentialSecret: values.LedgerCredentialSecret,
 		WorkloadAPIURL: "https://192.0.2.147:6443", WorkloadAPICIDR: "192.0.2.147/32", WorkloadCredentialSecret: values.WorkloadCredentialSecret,
 		WorkloadBindingPath: runtimeConfig.Workload.Path, ExpectedWorkloadBindingDigest: runtimeConfig.Workload.ExpectedBindingDigest,

--- a/internal/runner/target_credential_stage_bundle.go
+++ b/internal/runner/target_credential_stage_bundle.go
@@ -146,7 +146,7 @@ func LoadTargetCredentialStageBundle(config TargetCredentialStageBundleConfig) (
 	if err != nil {
 		return VerifiedTargetCredentialStageBundle{}, err
 	}
-	if len(access.Workload.Objects) != 8 || access.Workload.Objects[1].Identity.Kind != "ServiceAccount" {
+	if len(access.Workload.Objects) != 11 || access.Workload.Objects[1].Identity.Kind != "ServiceAccount" || access.Workload.Objects[8].Identity.Kind != "ServiceAccount" {
 		return VerifiedTargetCredentialStageBundle{}, errors.New("target-access artifact lacks the credential ServiceAccount")
 	}
 	credentialStage, _, err := plan.Stage("target-credential")

--- a/internal/submission/target_access.go
+++ b/internal/submission/target_access.go
@@ -84,10 +84,10 @@ func validateTargetAccessExpected(expected TargetAccessExpected) error {
 	if expected.WorkloadAuthority != expected.TargetIdentityDigest {
 		return errors.New("target-access workload authority must equal the immutable target identity")
 	}
-	if len(expected.Objects) != 8 {
-		return errors.New("target-access requires exactly eight object identities")
+	if len(expected.Objects) != 11 {
+		return errors.New("target-access requires exactly eleven object identities")
 	}
-	expectedKinds := []string{"Namespace", "ServiceAccount", "ClusterRole", "ClusterRoleBinding", "Role", "RoleBinding", "Role", "RoleBinding"}
+	expectedKinds := []string{"Namespace", "ServiceAccount", "ClusterRole", "ClusterRoleBinding", "Role", "RoleBinding", "Role", "RoleBinding", "ServiceAccount", "Role", "RoleBinding"}
 	for index, identity := range expected.Objects {
 		if identity.Kind != expectedKinds[index] || !validName(identity.Name, 253) {
 			return errors.New("target-access expected object order or identity is invalid")
@@ -344,12 +344,12 @@ func rejectTargetAccessUnknownKeys(value map[string]any, description string, all
 }
 
 func validateTargetAccessRelationships(values []map[string]any, identities []projection.ResourceIdentity) error {
-	serviceAccount := identities[1]
+	managerServiceAccount := identities[1]
 	clusterRole := identities[2]
 	for _, index := range []int{3, 5, 7} {
 		roleRef := values[index]["roleRef"].(map[string]any)
 		subject := values[index]["subjects"].([]any)[0].(map[string]any)
-		if text(subject["name"]) != serviceAccount.Name || text(subject["namespace"]) != serviceAccount.Namespace {
+		if text(subject["name"]) != managerServiceAccount.Name || text(subject["namespace"]) != managerServiceAccount.Namespace {
 			return errors.New("target-access binding subject differs from the exact manager ServiceAccount")
 		}
 		wantKind, wantName := identities[index-1].Kind, identities[index-1].Name
@@ -360,7 +360,60 @@ func validateTargetAccessRelationships(values []map[string]any, identities []pro
 			return errors.New("target-access binding roleRef differs from its exact role")
 		}
 	}
+	observerServiceAccount := identities[8]
+	if automount, exists := values[8]["automountServiceAccountToken"]; !exists || automount != false {
+		return errors.New("target-access observer ServiceAccount must disable automatic token mounting")
+	}
+	if err := validateTargetAccessObserverRules(values[9]["rules"]); err != nil {
+		return err
+	}
+	roleRef := values[10]["roleRef"].(map[string]any)
+	subject := values[10]["subjects"].([]any)[0].(map[string]any)
+	if text(subject["name"]) != observerServiceAccount.Name || text(subject["namespace"]) != observerServiceAccount.Namespace {
+		return errors.New("target-access observer binding subject differs from the exact observer ServiceAccount")
+	}
+	if text(roleRef["kind"]) != identities[9].Kind || text(roleRef["name"]) != identities[9].Name {
+		return errors.New("target-access observer binding roleRef differs from its exact role")
+	}
 	return nil
+}
+
+func validateTargetAccessObserverRules(raw any) error {
+	rules, ok := raw.([]any)
+	if !ok || len(rules) != 2 {
+		return errors.New("target-access observer role must contain exactly two rules")
+	}
+	expected := []struct {
+		apiGroups []string
+		resources []string
+		verbs     []string
+	}{
+		{apiGroups: []string{""}, resources: []string{"services"}, verbs: []string{"get"}},
+		{apiGroups: []string{"discovery.k8s.io"}, resources: []string{"endpointslices"}, verbs: []string{"list"}},
+	}
+	for index, want := range expected {
+		rule, ok := rules[index].(map[string]any)
+		if !ok || !targetAccessStringListEquals(rule["apiGroups"], want.apiGroups) || !targetAccessStringListEquals(rule["resources"], want.resources) || !targetAccessStringListEquals(rule["verbs"], want.verbs) {
+			return errors.New("target-access observer role exceeds the exact read-only permission profile")
+		}
+		if _, exists := rule["resourceNames"]; exists {
+			return errors.New("target-access observer role must not contain resourceNames")
+		}
+	}
+	return nil
+}
+
+func targetAccessStringListEquals(raw any, expected []string) bool {
+	values, ok := raw.([]any)
+	if !ok || len(values) != len(expected) {
+		return false
+	}
+	for index := range expected {
+		if text(values[index]) != expected[index] {
+			return false
+		}
+	}
+	return true
 }
 
 func targetAccessCollectionPath(identity projection.ResourceIdentity) (string, error) {

--- a/internal/submission/target_access_test.go
+++ b/internal/submission/target_access_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/openkubes/ok-cluster/internal/projection"
 )
 
-func TestLoadTargetAccessBindsExactEightObjectSet(t *testing.T) {
+func TestLoadTargetAccessBindsExactElevenObjectSet(t *testing.T) {
 	raw := targetAccessYAML()
 	path := writeTargetAccessArtifact(t, raw)
 	expected := targetAccessExpected(raw)
@@ -22,7 +22,7 @@ func TestLoadTargetAccessBindsExactEightObjectSet(t *testing.T) {
 	if plan.Format != TargetAccessPlanFormat || plan.IntentRevision != expected.IntentRevision || plan.PlatformRevision != expected.PlatformRevision || plan.TargetIdentityDigest != expected.TargetIdentityDigest || plan.MutationAllowed {
 		t.Fatalf("unexpected target-access plan: %#v", plan)
 	}
-	if plan.Workload.Identity != expected.TargetIdentityDigest || plan.Workload.Role != "target-access-writer" || len(plan.Workload.Objects) != 8 {
+	if plan.Workload.Identity != expected.TargetIdentityDigest || plan.Workload.Role != "target-access-writer" || len(plan.Workload.Objects) != 11 {
 		t.Fatalf("unexpected target-access authority plane: %#v", plan.Workload)
 	}
 	for index, object := range plan.Workload.Objects {
@@ -32,7 +32,7 @@ func TestLoadTargetAccessBindsExactEightObjectSet(t *testing.T) {
 	}
 
 	again, err := LoadTargetAccess(path, expected)
-	if err != nil || again.ArtifactDigest != plan.ArtifactDigest || again.Workload.Objects[7].Digest != plan.Workload.Objects[7].Digest {
+	if err != nil || again.ArtifactDigest != plan.ArtifactDigest || again.Workload.Objects[10].Digest != plan.Workload.Objects[10].Digest {
 		t.Fatalf("target-access plan is not reproducible: %#v %v", again, err)
 	}
 }
@@ -61,6 +61,15 @@ func TestLoadTargetAccessFailsClosed(t *testing.T) {
 		},
 		"unknown rule field": func(raw []byte) []byte {
 			return []byte(strings.Replace(string(raw), "resources: [customresourcedefinitions]\n    verbs:", "resources: [customresourcedefinitions]\n    arbitrary: true\n    verbs:", 1))
+		},
+		"observer write permission": func(raw []byte) []byte {
+			return []byte(strings.Replace(string(raw), "resources: [services]\n    verbs: [get]\n  - apiGroups: [discovery.k8s.io]", "resources: [services]\n    verbs: [get, create]\n  - apiGroups: [discovery.k8s.io]", 1))
+		},
+		"observer automatic token": func(raw []byte) []byte {
+			return []byte(strings.Replace(string(raw), "name: ok147-observability-autonomy\n  namespace: ok-observability\nautomountServiceAccountToken: false", "name: ok147-observability-autonomy\n  namespace: ok-observability\nautomountServiceAccountToken: true", 1))
+		},
+		"observer bound to manager": func(raw []byte) []byte {
+			return []byte(strings.Replace(string(raw), "{kind: ServiceAccount, name: ok147-observability-autonomy, namespace: ok-observability}", "{kind: ServiceAccount, name: ok147-argocd-manager, namespace: kube-system}", 1))
 		},
 		"status": func(raw []byte) []byte { return append(raw, []byte("status: {}\n")...) },
 	} {
@@ -109,6 +118,9 @@ func targetAccessExpected(raw []byte) TargetAccessExpected {
 			{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "RoleBinding", Namespace: "ok-observability", Name: "ok147-argocd-platform"},
 			{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role", Namespace: "kube-system", Name: "ok147-argocd-kube-system"},
 			{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "RoleBinding", Namespace: "kube-system", Name: "ok147-argocd-kube-system"},
+			{APIVersion: "v1", Kind: "ServiceAccount", Namespace: "ok-observability", Name: "ok147-observability-autonomy"},
+			{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role", Namespace: "ok-observability", Name: "ok147-observability-autonomy"},
+			{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "RoleBinding", Namespace: "ok-observability", Name: "ok147-observability-autonomy"},
 		},
 	}
 }
@@ -202,6 +214,38 @@ roleRef:
   name: ok147-argocd-kube-system
 subjects:
   - {kind: ServiceAccount, name: ok147-argocd-manager, namespace: kube-system}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ok147-observability-autonomy
+  namespace: ok-observability
+automountServiceAccountToken: false
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ok147-observability-autonomy
+  namespace: ok-observability
+rules:
+  - apiGroups: [""]
+    resources: [services]
+    verbs: [get]
+  - apiGroups: [discovery.k8s.io]
+    resources: [endpointslices]
+    verbs: [list]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ok147-observability-autonomy
+  namespace: ok-observability
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ok147-observability-autonomy
+subjects:
+  - {kind: ServiceAccount, name: ok147-observability-autonomy, namespace: ok-observability}
 `)
 }
 


### PR DESCRIPTION
## Summary
- amend the target-access artifact from eight to eleven exact objects
- add a dedicated tokenless autonomy-observer ServiceAccount, Role and RoleBinding
- enforce exactly get Services and list EndpointSlices with no write permission
- propagate the amended identity through package, launch, credential and full-run verification

## Verification
- full go test suite passes
- go vet passes
- no cluster contact or infrastructure mutation

## Boundary
This checkpoint only binds the workload observer identity. It does not issue its token, activate the evidence collector or authorize a fresh run.