### PR TITLE
feat(runner): bind collector activation package

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,12 @@ Powered by [Cluster API (CAPI)](https://cluster-api.sigs.k8s.io/), [CAPK (KubeVi
   ServiceAccount, an exact read-only Role (`get` Services and `list`
   EndpointSlices), and its RoleBinding. They are not shared with Argo CD and
   cannot write workload resources.
+  After runtime binding, an offline collector-activation builder can package
+  that exact observer identity into one immutable private Secret together with
+  separate webhook/query authorities, a short-lived observer token, pinned
+  workload CA and TLS key pair. Its public receipt exposes only correlated
+  digests; package construction performs no cluster request or mutation. The
+  CLI and Kubernetes runtime envelope remain separate activation steps.
   Stage 4 now has its first distinct path as well:
   `ok cluster stage run enablement --execute` binds the verified three-receipt
   prefix and signed `CreateEnablement` grant to exactly one externally rendered

--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -3084,7 +3084,25 @@ CA/token/Cluster-UID tuple, the standard profile, a maximum record age and a
 literal listen address. It emits a redaction-safe verified receipt before
 serving and performs no Kubernetes request while opening. The command exposes
 no receiver-name, profile, namespace, Service, EndpointSlice selector or
-arbitrary URL override. A Kubernetes runtime package and fresh image remain
+arbitrary URL override.
+
+The collector now also has a deterministic private activation package. Its
+offline builder replays the exact verified full-run manifest receipt and Plan,
+then requires the lifecycle-produced runtime binding before accepting an
+observer credential. It emits one immutable Secret containing exactly seven
+files: canonical activation, distinct webhook and query authorities, a
+short-lived workload-observer token, the pinned workload CA and a matching TLS
+certificate/private key pair. The activation binds the raw target Cluster UID
+and workload endpoint privately; its public receipt retains only their safe
+digests, including separate manifest-receipt and public-endpoint identities.
+The three token authorities must be pairwise distinct, the server certificate
+must cover the literal public endpoint, and the observer must be the dedicated
+tokenless `ok147-observability-autonomy` ServiceAccount with the default
+Kubernetes audience. Construction performs no API request or mutation.
+
+This closes the post-runtime authority materialization boundary without
+turning the collector into a lifecycle owner. A Kubernetes Job/Service/
+NetworkPolicy envelope, CLI materialization boundary and fresh image remain
 separate prerequisites before this process may be deployed.
 
 The separately operated issuer no longer accepts the run ID, target Cluster

--- a/internal/runner/observability_collector_activation_package.go
+++ b/internal/runner/observability_collector_activation_package.go
@@ -1,0 +1,509 @@
+package runner
+
+import (
+	"bytes"
+	"crypto/subtle"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"net"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/contract"
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/jsonstrict"
+	"github.com/openkubes/ok-cluster/internal/stageplan"
+)
+
+const (
+	ObservabilityCollectorActivationFormat        = "ok147-observability-collector-activation/v1"
+	ObservabilityCollectorActivationPackageFormat = "ok147-observability-collector-activation-package/v1"
+	maximumObservabilityCollectorActivationBytes  = 512 * 1024
+
+	observabilityCollectorActivationKey = "activation.json"
+	observabilityCollectorWebhookKey    = "webhook-token"
+	observabilityCollectorQueryKey      = "query-token"
+	observabilityCollectorWorkloadKey   = "workload-token"
+	observabilityCollectorWorkloadCAKey = "workload-ca.crt"
+	observabilityCollectorTLSCertKey    = "tls.crt"
+	observabilityCollectorTLSKeyKey     = "tls.key"
+
+	observabilityCollectorRuntimeRoot = "/var/run/openkubes/collector"
+	observabilityCollectorStateRoot   = "/var/lib/openkubes/observability-evidence"
+	observabilityCollectorReceiver    = "ok147-independent-evidence"
+	observabilityCollectorObserverSA  = "ok147-observability-autonomy"
+)
+
+// ObservabilityCollectorActivationPackageConfig binds the collector only
+// after the workload runtime identity is durable. Construction performs local
+// verification only and does not contact or mutate Kubernetes.
+type ObservabilityCollectorActivationPackageConfig struct {
+	ManifestPath           string
+	ExpectedManifestDigest string
+	ManifestReceiptPath    string
+	ExpectedReceiptDigest  string
+	RuntimeBinding         RuntimeBindingMaterialFileConfig
+	ActivationSecret       string
+	MaterializationTime    time.Time
+	ObserverCredential     SubmissionStageCredentialSource
+	WebhookTokenPath       string
+	QueryTokenPath         string
+	PublicEndpoint         string
+	ListenAddress          string
+	TLSCertificatePath     string
+	TLSPrivateKeyPath      string
+	MaximumRecordAge       time.Duration
+}
+
+type ObservabilityCollectorActivation struct {
+	Format                    string `json:"format"`
+	State                     string `json:"state"`
+	ManifestDigest            string `json:"manifestDigest"`
+	ManifestReceiptDigest     string `json:"manifestReceiptDigest"`
+	PlanDigest                string `json:"planDigest"`
+	RuntimeBindingDigest      string `json:"runtimeBindingDigest"`
+	ExecutionFixture          string `json:"executionFixture"`
+	TargetClusterUID          string `json:"targetClusterUid"`
+	WorkloadEndpoint          string `json:"workloadEndpoint"`
+	WorkloadCADigest          string `json:"workloadCaDigest"`
+	ObserverCredentialExpires string `json:"observerCredentialExpires"`
+	ObserverEvidenceDigest    string `json:"observerEvidenceDigest"`
+	PublicEndpoint            string `json:"publicEndpoint"`
+	ListenAddress             string `json:"listenAddress"`
+	ReceiverName              string `json:"receiverName"`
+	ProfileDigest             string `json:"profileDigest"`
+	MaximumRecordAge          string `json:"maximumRecordAge"`
+	StateDirectory            string `json:"stateDirectory"`
+	WebhookTokenPath          string `json:"webhookTokenPath"`
+	QueryTokenPath            string `json:"queryTokenPath"`
+	WorkloadTokenPath         string `json:"workloadTokenPath"`
+	WorkloadCAPath            string `json:"workloadCaPath"`
+	TLSCertificatePath        string `json:"tlsCertificatePath"`
+	TLSPrivateKeyPath         string `json:"tlsPrivateKeyPath"`
+}
+
+type ObservabilityCollectorActivationPackageReceipt struct {
+	Format                       string   `json:"format"`
+	State                        string   `json:"state"`
+	PackageDigest                string   `json:"packageDigest"`
+	ActivationSecret             string   `json:"activationSecret"`
+	SecretObjectDigest           string   `json:"secretObjectDigest"`
+	ActivationDigest             string   `json:"activationDigest"`
+	ManifestDigest               string   `json:"manifestDigest"`
+	ManifestReceiptDigest        string   `json:"manifestReceiptDigest"`
+	PlanDigest                   string   `json:"planDigest"`
+	RuntimeBindingDigest         string   `json:"runtimeBindingDigest"`
+	ExecutionFixture             string   `json:"executionFixture"`
+	TargetClusterUIDDigest       string   `json:"targetClusterUidDigest"`
+	WorkloadCADigest             string   `json:"workloadCaDigest"`
+	ObserverCredentialExpires    string   `json:"observerCredentialExpires"`
+	ObserverTokenRequestEvidence string   `json:"observerTokenRequestEvidence"`
+	WebhookAuthorityDigest       string   `json:"webhookAuthorityDigest"`
+	QueryAuthorityDigest         string   `json:"queryAuthorityDigest"`
+	TLSCertificateDigest         string   `json:"tlsCertificateDigest"`
+	PublicEndpointDigest         string   `json:"publicEndpointDigest"`
+	ReceiverIdentityDigest       string   `json:"receiverIdentityDigest"`
+	ProfileDigest                string   `json:"profileDigest"`
+	PrivateFileCount             int      `json:"privateFileCount"`
+	ObjectKinds                  []string `json:"objectKinds"`
+	MutationAllowed              bool     `json:"mutationAllowed"`
+}
+
+type VerifiedObservabilityCollectorActivationPackage struct {
+	raw      []byte
+	receipt  ObservabilityCollectorActivationPackageReceipt
+	verified bool
+}
+
+type observabilityCollectorObserverCredential struct {
+	ExpiresAt                  string
+	TokenRequestEvidenceDigest string
+}
+
+// BuildObservabilityCollectorActivationPackage creates one immutable private
+// Secret containing the complete per-run collector activation. Raw target,
+// endpoint, token, CA and key material never enter the public receipt.
+func BuildObservabilityCollectorActivationPackage(config ObservabilityCollectorActivationPackageConfig) (VerifiedObservabilityCollectorActivationPackage, error) {
+	if !submissionStageInputNamePattern.MatchString(config.ActivationSecret) || !strings.HasPrefix(config.ActivationSecret, "ok147-") ||
+		len(config.ActivationSecret) > 63 || config.MaterializationTime.IsZero() ||
+		!config.MaterializationTime.Equal(config.MaterializationTime.UTC().Truncate(time.Second)) {
+		return VerifiedObservabilityCollectorActivationPackage{}, errors.New("observability collector activation identity is invalid")
+	}
+	document, manifestDigest, err := loadFullRunExecutionManifest(config.ManifestPath)
+	if err != nil || manifestDigest != config.ExpectedManifestDigest {
+		return VerifiedObservabilityCollectorActivationPackage{}, errors.New("verify observability collector full-run manifest")
+	}
+	manifestReceiptRaw, err := readBoundedRegular(config.ManifestReceiptPath, maximumRuntimeBindingMaterialFileBytes)
+	if err != nil || digest.SHA256(manifestReceiptRaw) != config.ExpectedReceiptDigest {
+		return VerifiedObservabilityCollectorActivationPackage{}, errors.New("verify observability collector full-run manifest receipt")
+	}
+	var manifestReceipt FullRunExecutionManifestReceipt
+	if err := jsonstrict.Decode(manifestReceiptRaw, &manifestReceipt); err != nil ||
+		manifestReceipt.Format != FullRunExecutionManifestReceiptFormat || manifestReceipt.State != "VERIFIED" ||
+		manifestReceipt.MutationAllowed || manifestReceipt.ManifestDigest != manifestDigest {
+		return VerifiedObservabilityCollectorActivationPackage{}, errors.New("observability collector manifest receipt is invalid")
+	}
+	expected := fullRunPlanExpected(document.Plan.Expected)
+	plan, err := stageplan.Load(document.Plan.Path, expected)
+	if err != nil || plan.PlanDigest != manifestReceipt.PlanDigest {
+		return VerifiedObservabilityCollectorActivationPackage{}, errors.New("observability collector manifest plan differs from receipt")
+	}
+	runtimeBinding, err := LoadRuntimeBindingMaterialFiles(config.RuntimeBinding)
+	if err != nil {
+		return VerifiedObservabilityCollectorActivationPackage{}, errors.New("verify observability collector runtime binding")
+	}
+	if config.RuntimeBinding.Bundle.PlanPath != document.Plan.Path ||
+		config.RuntimeBinding.MaterialPath != document.RuntimeBinding.MaterialPath ||
+		config.RuntimeBinding.ReceiptPath != document.RuntimeBinding.ReceiptPath {
+		return VerifiedObservabilityCollectorActivationPackage{}, errors.New("observability collector runtime binding paths differ from manifest")
+	}
+	runtimeReceipt, err := runtimeBinding.Receipt()
+	if err != nil || runtimeReceipt.PlanDigest != manifestReceipt.PlanDigest ||
+		runtimeBinding.material.ExecutionFixture != plan.ExecutionFixture {
+		return VerifiedObservabilityCollectorActivationPackage{}, errors.New("observability collector runtime binding differs from manifest")
+	}
+	targetAuthority := digest.SHA256([]byte(runtimeBinding.material.Target.CAPIClusterUID))
+	expectedSubject := "system:serviceaccount:ok-observability:" + observabilityCollectorObserverSA
+	if config.ObserverCredential.AuthorityIdentity != targetAuthority ||
+		config.ObserverCredential.ExpectedSubject != expectedSubject ||
+		len(config.ObserverCredential.ExpectedAudiences) != 1 ||
+		config.ObserverCredential.ExpectedAudiences[0] != "https://kubernetes.default.svc" ||
+		config.ObserverCredential.CABundleDigest != runtimeBinding.material.Target.WorkloadAPICADigest {
+		return VerifiedObservabilityCollectorActivationPackage{}, errors.New("observability collector observer credential identity is invalid")
+	}
+	observerReceipt, workloadToken, err := loadObservabilityCollectorObserverCredential(
+		config.ObserverCredential, targetAuthority, expectedSubject, config.MaterializationTime.UTC(),
+	)
+	if err != nil {
+		return VerifiedObservabilityCollectorActivationPackage{}, errors.New("verify observability collector observer credential")
+	}
+	workloadCA, err := readBoundedRegular(config.ObserverCredential.CAFile, maximumCABytes)
+	if err != nil {
+		return VerifiedObservabilityCollectorActivationPackage{}, errors.New("read observability collector workload CA")
+	}
+	expectedCA, err := base64.StdEncoding.Strict().DecodeString(runtimeBinding.material.Target.WorkloadAPICAData)
+	if err != nil || !bytes.Equal(workloadCA, expectedCA) || digest.SHA256(workloadCA) != runtimeReceipt.WorkloadAPICADigest {
+		return VerifiedObservabilityCollectorActivationPackage{}, errors.New("observability collector workload CA differs from runtime binding")
+	}
+	webhookToken, err := readCollectorToken(config.WebhookTokenPath)
+	if err != nil {
+		return VerifiedObservabilityCollectorActivationPackage{}, errors.New("verify observability collector webhook authority")
+	}
+	queryToken, err := readCollectorToken(config.QueryTokenPath)
+	if err != nil || subtle.ConstantTimeCompare(webhookToken, queryToken) == 1 ||
+		subtle.ConstantTimeCompare(webhookToken, workloadToken) == 1 ||
+		subtle.ConstantTimeCompare(queryToken, workloadToken) == 1 {
+		return VerifiedObservabilityCollectorActivationPackage{}, errors.New("observability collector authorities must be distinct")
+	}
+	certificateRaw, privateKeyRaw, certificateDigest, err := loadObservabilityCollectorTLS(
+		config.TLSCertificatePath, config.TLSPrivateKeyPath, config.PublicEndpoint, config.MaterializationTime.UTC(),
+	)
+	if err != nil {
+		return VerifiedObservabilityCollectorActivationPackage{}, err
+	}
+	if err := validateObservabilityCollectorNetwork(config.PublicEndpoint, config.ListenAddress); err != nil {
+		return VerifiedObservabilityCollectorActivationPackage{}, err
+	}
+	if config.MaximumRecordAge < time.Minute || config.MaximumRecordAge > maximumObservabilityIndependentEvidenceWindow {
+		return VerifiedObservabilityCollectorActivationPackage{}, errors.New("observability collector record age is invalid")
+	}
+	profile, err := StandardObservabilityCapabilityCheckProfile("ok-observability")
+	if err != nil {
+		return VerifiedObservabilityCollectorActivationPackage{}, errors.New("load standard observability collector profile")
+	}
+	activation := ObservabilityCollectorActivation{
+		Format: ObservabilityCollectorActivationFormat, State: "BOUND",
+		ManifestDigest:        manifestReceipt.ManifestDigest,
+		ManifestReceiptDigest: config.ExpectedReceiptDigest,
+		PlanDigest:            manifestReceipt.PlanDigest,
+		RuntimeBindingDigest:  runtimeReceipt.PrivateMaterialDigest, ExecutionFixture: plan.ExecutionFixture,
+		TargetClusterUID:          runtimeBinding.material.Target.CAPIClusterUID,
+		WorkloadEndpoint:          runtimeBinding.material.Target.WorkloadAPIEndpoint,
+		WorkloadCADigest:          runtimeReceipt.WorkloadAPICADigest,
+		ObserverCredentialExpires: observerReceipt.ExpiresAt,
+		ObserverEvidenceDigest:    observerReceipt.TokenRequestEvidenceDigest,
+		PublicEndpoint:            config.PublicEndpoint, ListenAddress: config.ListenAddress,
+		ReceiverName: observabilityCollectorReceiver, ProfileDigest: profile.Digest(),
+		MaximumRecordAge: config.MaximumRecordAge.String(), StateDirectory: observabilityCollectorStateRoot,
+		WebhookTokenPath:   observabilityCollectorRuntimeRoot + "/" + observabilityCollectorWebhookKey,
+		QueryTokenPath:     observabilityCollectorRuntimeRoot + "/" + observabilityCollectorQueryKey,
+		WorkloadTokenPath:  observabilityCollectorRuntimeRoot + "/" + observabilityCollectorWorkloadKey,
+		WorkloadCAPath:     observabilityCollectorRuntimeRoot + "/" + observabilityCollectorWorkloadCAKey,
+		TLSCertificatePath: observabilityCollectorRuntimeRoot + "/" + observabilityCollectorTLSCertKey,
+		TLSPrivateKeyPath:  observabilityCollectorRuntimeRoot + "/" + observabilityCollectorTLSKeyKey,
+	}
+	activationRaw, err := canonicalObservabilityCollectorActivation(activation)
+	if err != nil {
+		return VerifiedObservabilityCollectorActivationPackage{}, err
+	}
+	binaryData := map[string]string{
+		observabilityCollectorActivationKey: base64.StdEncoding.EncodeToString(activationRaw),
+		observabilityCollectorWebhookKey:    base64.StdEncoding.EncodeToString(webhookToken),
+		observabilityCollectorQueryKey:      base64.StdEncoding.EncodeToString(queryToken),
+		observabilityCollectorWorkloadKey:   base64.StdEncoding.EncodeToString(workloadToken),
+		observabilityCollectorWorkloadCAKey: base64.StdEncoding.EncodeToString(workloadCA),
+		observabilityCollectorTLSCertKey:    base64.StdEncoding.EncodeToString(certificateRaw),
+		observabilityCollectorTLSKeyKey:     base64.StdEncoding.EncodeToString(privateKeyRaw),
+	}
+	secret := postRuntimeActivationSecret{
+		APIVersion: "v1", Kind: "Secret", Immutable: true, Type: "Opaque", BinaryData: binaryData,
+		Metadata: postRuntimeActivationSecretMetadata{
+			Name: config.ActivationSecret, Namespace: submissionStageInputNamespace,
+			Labels: map[string]string{
+				"app.kubernetes.io/name": "ok147-observability-evidence-collector",
+				"openkubes.io/stage-id":  "independent-evidence",
+			},
+			Annotations: map[string]string{
+				"openkubes.io/manifest-digest":   manifestReceipt.ManifestDigest,
+				"openkubes.io/activation-digest": digest.SHA256(activationRaw),
+			},
+		},
+	}
+	raw, err := json.Marshal(secret)
+	if err != nil || len(raw) == 0 || len(raw) > maximumObservabilityCollectorActivationBytes {
+		return VerifiedObservabilityCollectorActivationPackage{}, errors.New("observability collector activation Secret exceeds bounded size")
+	}
+	receiverIdentity := digest.SHA256([]byte("ok147-observability-alert-receiver/v1\n" + observabilityCollectorReceiver))
+	receipt := ObservabilityCollectorActivationPackageReceipt{
+		Format: ObservabilityCollectorActivationPackageFormat, State: "VERIFIED",
+		PackageDigest: digest.SHA256(raw), ActivationSecret: config.ActivationSecret, SecretObjectDigest: digest.SHA256(raw),
+		ActivationDigest: digest.SHA256(activationRaw), ManifestDigest: manifestReceipt.ManifestDigest,
+		ManifestReceiptDigest: config.ExpectedReceiptDigest,
+		PlanDigest:            manifestReceipt.PlanDigest, RuntimeBindingDigest: runtimeReceipt.PrivateMaterialDigest,
+		ExecutionFixture: plan.ExecutionFixture, TargetClusterUIDDigest: targetAuthority,
+		WorkloadCADigest: runtimeReceipt.WorkloadAPICADigest, ObserverCredentialExpires: observerReceipt.ExpiresAt,
+		ObserverTokenRequestEvidence: observerReceipt.TokenRequestEvidenceDigest,
+		WebhookAuthorityDigest:       digest.SHA256(webhookToken), QueryAuthorityDigest: digest.SHA256(queryToken),
+		TLSCertificateDigest: certificateDigest, PublicEndpointDigest: digest.SHA256([]byte(config.PublicEndpoint)),
+		ReceiverIdentityDigest: receiverIdentity, ProfileDigest: profile.Digest(),
+		PrivateFileCount: len(binaryData), ObjectKinds: []string{"Secret"}, MutationAllowed: false,
+	}
+	packaged := VerifiedObservabilityCollectorActivationPackage{raw: raw, receipt: receipt, verified: true}
+	if err := verifyObservabilityCollectorActivationPackage(packaged); err != nil {
+		return VerifiedObservabilityCollectorActivationPackage{}, err
+	}
+	return packaged, nil
+}
+
+func (packaged VerifiedObservabilityCollectorActivationPackage) PrivateBytes() ([]byte, error) {
+	if err := verifyObservabilityCollectorActivationPackage(packaged); err != nil {
+		return nil, errors.New("observability collector activation package was not produced by verification")
+	}
+	return append([]byte(nil), packaged.raw...), nil
+}
+
+func (packaged VerifiedObservabilityCollectorActivationPackage) Receipt() (ObservabilityCollectorActivationPackageReceipt, error) {
+	if err := verifyObservabilityCollectorActivationPackage(packaged); err != nil {
+		return ObservabilityCollectorActivationPackageReceipt{}, errors.New("observability collector activation package was not produced by verification")
+	}
+	receipt := packaged.receipt
+	receipt.ObjectKinds = append([]string(nil), packaged.receipt.ObjectKinds...)
+	return receipt, nil
+}
+
+func verifyObservabilityCollectorActivationPackage(packaged VerifiedObservabilityCollectorActivationPackage) error {
+	receipt := packaged.receipt
+	if !packaged.verified || receipt.Format != ObservabilityCollectorActivationPackageFormat || receipt.State != "VERIFIED" ||
+		receipt.MutationAllowed || len(packaged.raw) == 0 || digest.SHA256(packaged.raw) != receipt.PackageDigest ||
+		receipt.SecretObjectDigest != receipt.PackageDigest || receipt.PrivateFileCount != 7 ||
+		len(receipt.ObjectKinds) != 1 || receipt.ObjectKinds[0] != "Secret" {
+		return errors.New("observability collector activation package identity is incomplete")
+	}
+	for _, value := range []string{
+		receipt.ActivationDigest, receipt.ManifestDigest, receipt.ManifestReceiptDigest, receipt.PlanDigest, receipt.RuntimeBindingDigest,
+		receipt.ExecutionFixture, receipt.TargetClusterUIDDigest, receipt.WorkloadCADigest,
+		receipt.ObserverTokenRequestEvidence, receipt.WebhookAuthorityDigest, receipt.QueryAuthorityDigest,
+		receipt.TLSCertificateDigest, receipt.PublicEndpointDigest, receipt.ReceiverIdentityDigest, receipt.ProfileDigest,
+	} {
+		if !stageReceiptPrefixDigestPattern.MatchString(value) {
+			return errors.New("observability collector activation package digest is invalid")
+		}
+	}
+	var secret postRuntimeActivationSecret
+	if err := jsonstrict.Decode(packaged.raw, &secret); err != nil || secret.APIVersion != "v1" || secret.Kind != "Secret" ||
+		!secret.Immutable || secret.Type != "Opaque" || secret.Metadata.Name != receipt.ActivationSecret ||
+		secret.Metadata.Namespace != submissionStageInputNamespace || len(secret.BinaryData) != receipt.PrivateFileCount ||
+		secret.Metadata.Labels["app.kubernetes.io/name"] != "ok147-observability-evidence-collector" ||
+		secret.Metadata.Labels["openkubes.io/stage-id"] != "independent-evidence" ||
+		secret.Metadata.Annotations["openkubes.io/manifest-digest"] != receipt.ManifestDigest ||
+		secret.Metadata.Annotations["openkubes.io/activation-digest"] != receipt.ActivationDigest {
+		return errors.New("observability collector activation Secret identity differs")
+	}
+	decode := func(key string) ([]byte, error) {
+		raw, err := base64.StdEncoding.Strict().DecodeString(secret.BinaryData[key])
+		if err != nil || len(raw) == 0 {
+			return nil, errors.New("observability collector activation private file is invalid")
+		}
+		return raw, nil
+	}
+	activationRaw, err := decode(observabilityCollectorActivationKey)
+	if err != nil || digest.SHA256(activationRaw) != receipt.ActivationDigest {
+		return errors.New("observability collector activation identity differs")
+	}
+	var activation ObservabilityCollectorActivation
+	if err := jsonstrict.Decode(activationRaw, &activation); err != nil {
+		return errors.New("decode strict observability collector activation")
+	}
+	canonical, err := canonicalObservabilityCollectorActivation(activation)
+	if err != nil || !bytes.Equal(canonical, activationRaw) || activation.ManifestDigest != receipt.ManifestDigest ||
+		activation.ManifestReceiptDigest != receipt.ManifestReceiptDigest ||
+		activation.PlanDigest != receipt.PlanDigest || activation.RuntimeBindingDigest != receipt.RuntimeBindingDigest ||
+		activation.ExecutionFixture != receipt.ExecutionFixture ||
+		digest.SHA256([]byte(activation.TargetClusterUID)) != receipt.TargetClusterUIDDigest ||
+		activation.WorkloadCADigest != receipt.WorkloadCADigest ||
+		activation.ObserverCredentialExpires != receipt.ObserverCredentialExpires ||
+		activation.ObserverEvidenceDigest != receipt.ObserverTokenRequestEvidence ||
+		digest.SHA256([]byte(activation.PublicEndpoint)) != receipt.PublicEndpointDigest ||
+		activation.ProfileDigest != receipt.ProfileDigest ||
+		digest.SHA256([]byte("ok147-observability-alert-receiver/v1\n"+activation.ReceiverName)) != receipt.ReceiverIdentityDigest {
+		return errors.New("observability collector activation differs from receipt")
+	}
+	webhook, webhookErr := decode(observabilityCollectorWebhookKey)
+	query, queryErr := decode(observabilityCollectorQueryKey)
+	workloadToken, workloadErr := decode(observabilityCollectorWorkloadKey)
+	workloadCA, caErr := decode(observabilityCollectorWorkloadCAKey)
+	certificateRaw, certErr := decode(observabilityCollectorTLSCertKey)
+	privateKeyRaw, keyErr := decode(observabilityCollectorTLSKeyKey)
+	if webhookErr != nil || queryErr != nil || workloadErr != nil || caErr != nil || certErr != nil || keyErr != nil ||
+		digest.SHA256(webhook) != receipt.WebhookAuthorityDigest || digest.SHA256(query) != receipt.QueryAuthorityDigest ||
+		digest.SHA256(workloadCA) != receipt.WorkloadCADigest || digest.SHA256(certificateRaw) != receipt.TLSCertificateDigest ||
+		subtle.ConstantTimeCompare(webhook, query) == 1 || subtle.ConstantTimeCompare(webhook, workloadToken) == 1 ||
+		subtle.ConstantTimeCompare(query, workloadToken) == 1 {
+		return errors.New("observability collector activation private authorities differ")
+	}
+	if _, err := tls.X509KeyPair(certificateRaw, privateKeyRaw); err != nil {
+		return errors.New("observability collector activation TLS key pair differs")
+	}
+	return nil
+}
+
+func canonicalObservabilityCollectorActivation(activation ObservabilityCollectorActivation) ([]byte, error) {
+	if activation.Format != ObservabilityCollectorActivationFormat || activation.State != "BOUND" ||
+		!stageReceiptPrefixDigestPattern.MatchString(activation.ManifestDigest) ||
+		!stageReceiptPrefixDigestPattern.MatchString(activation.ManifestReceiptDigest) ||
+		!stageReceiptPrefixDigestPattern.MatchString(activation.PlanDigest) ||
+		!stageReceiptPrefixDigestPattern.MatchString(activation.RuntimeBindingDigest) ||
+		!stageReceiptPrefixDigestPattern.MatchString(activation.ExecutionFixture) ||
+		!runtimeInputUIDPattern.MatchString(activation.TargetClusterUID) ||
+		!validFullRunKubernetesEndpoint(activation.WorkloadEndpoint) ||
+		!stageReceiptPrefixDigestPattern.MatchString(activation.WorkloadCADigest) ||
+		!stageReceiptPrefixDigestPattern.MatchString(activation.ObserverEvidenceDigest) ||
+		activation.ReceiverName != observabilityCollectorReceiver ||
+		!stageReceiptPrefixDigestPattern.MatchString(activation.ProfileDigest) ||
+		activation.StateDirectory != observabilityCollectorStateRoot ||
+		activation.WebhookTokenPath != observabilityCollectorRuntimeRoot+"/"+observabilityCollectorWebhookKey ||
+		activation.QueryTokenPath != observabilityCollectorRuntimeRoot+"/"+observabilityCollectorQueryKey ||
+		activation.WorkloadTokenPath != observabilityCollectorRuntimeRoot+"/"+observabilityCollectorWorkloadKey ||
+		activation.WorkloadCAPath != observabilityCollectorRuntimeRoot+"/"+observabilityCollectorWorkloadCAKey ||
+		activation.TLSCertificatePath != observabilityCollectorRuntimeRoot+"/"+observabilityCollectorTLSCertKey ||
+		activation.TLSPrivateKeyPath != observabilityCollectorRuntimeRoot+"/"+observabilityCollectorTLSKeyKey {
+		return nil, errors.New("observability collector activation identity is invalid")
+	}
+	if _, err := time.Parse(time.RFC3339, activation.ObserverCredentialExpires); err != nil {
+		return nil, errors.New("observability collector observer expiry is invalid")
+	}
+	maximumRecordAge, err := time.ParseDuration(activation.MaximumRecordAge)
+	if err != nil || maximumRecordAge < time.Minute || maximumRecordAge > maximumObservabilityIndependentEvidenceWindow {
+		return nil, errors.New("observability collector record age is invalid")
+	}
+	if err := validateObservabilityCollectorNetwork(activation.PublicEndpoint, activation.ListenAddress); err != nil {
+		return nil, err
+	}
+	raw, err := json.Marshal(activation)
+	if err != nil {
+		return nil, err
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	var value any
+	if err := decoder.Decode(&value); err != nil {
+		return nil, err
+	}
+	return contract.JCS(value)
+}
+
+func validateObservabilityCollectorNetwork(publicEndpoint, listenAddress string) error {
+	endpoint, err := url.Parse(publicEndpoint)
+	if err != nil || endpoint.Scheme != "https" || endpoint.User != nil || endpoint.RawQuery != "" || endpoint.Fragment != "" ||
+		(endpoint.Path != "" && endpoint.Path != "/") || endpoint.Port() == "" || net.ParseIP(endpoint.Hostname()) == nil {
+		return errors.New("observability collector public endpoint must be one literal HTTPS IP and port")
+	}
+	host, port, err := net.SplitHostPort(listenAddress)
+	if err != nil || net.ParseIP(host) == nil || port == "" || port != endpoint.Port() || strings.ContainsAny(listenAddress, "\r\n") {
+		return errors.New("observability collector listen address differs from public endpoint")
+	}
+	return nil
+}
+
+func loadObservabilityCollectorTLS(certificatePath, privateKeyPath, publicEndpoint string, now time.Time) ([]byte, []byte, string, error) {
+	if err := validateObservabilityEvidenceFile(certificatePath, 128*1024, false); err != nil ||
+		validateObservabilityEvidenceFile(privateKeyPath, 128*1024, true) != nil {
+		return nil, nil, "", errors.New("observability collector TLS file metadata is invalid")
+	}
+	certificateRaw, err := readBoundedRegular(certificatePath, 128*1024)
+	if err != nil {
+		return nil, nil, "", errors.New("read observability collector TLS certificate")
+	}
+	privateKeyRaw, err := readBoundedRegular(privateKeyPath, 128*1024)
+	if err != nil {
+		return nil, nil, "", errors.New("read observability collector TLS private key")
+	}
+	pair, err := tls.X509KeyPair(certificateRaw, privateKeyRaw)
+	if err != nil || len(pair.Certificate) == 0 {
+		return nil, nil, "", errors.New("observability collector TLS key pair is invalid")
+	}
+	leaf, err := x509.ParseCertificate(pair.Certificate[0])
+	if err != nil || now.Before(leaf.NotBefore) || !now.Before(leaf.NotAfter) ||
+		!observabilityCertificateHasUsage(leaf, x509.ExtKeyUsageServerAuth) {
+		return nil, nil, "", errors.New("observability collector TLS certificate is not currently valid for server use")
+	}
+	endpoint, err := url.Parse(publicEndpoint)
+	if err != nil || leaf.VerifyHostname(endpoint.Hostname()) != nil {
+		return nil, nil, "", errors.New("observability collector TLS certificate differs from public endpoint")
+	}
+	return certificateRaw, privateKeyRaw, digest.SHA256(certificateRaw), nil
+}
+
+func loadObservabilityCollectorObserverCredential(source SubmissionStageCredentialSource, authority, expectedSubject string, now time.Time) (observabilityCollectorObserverCredential, []byte, error) {
+	if source.AuthorityIdentity != authority || authority == "" || source.TokenFile == "" || source.CAFile == "" ||
+		!stageReceiptPrefixDigestPattern.MatchString(source.TokenDigest) ||
+		!stageReceiptPrefixDigestPattern.MatchString(source.CABundleDigest) ||
+		!stageReceiptPrefixDigestPattern.MatchString(source.TokenRequestEvidenceDigest) {
+		return observabilityCollectorObserverCredential{}, nil, errors.New("observability collector observer credential source is invalid")
+	}
+	token, err := readBoundedRegular(source.TokenFile, maximumTokenBytes)
+	if err != nil || digest.SHA256(token) != source.TokenDigest {
+		return observabilityCollectorObserverCredential{}, nil, errors.New("observability collector observer token differs from source")
+	}
+	ca, err := readBoundedRegular(source.CAFile, maximumCABytes)
+	if err != nil || digest.SHA256(ca) != source.CABundleDigest || !validStageCredentialCA(ca, now) {
+		return observabilityCollectorObserverCredential{}, nil, errors.New("observability collector observer CA differs from source")
+	}
+	claims, err := verifyStageCredentialJWTWithSubject(token, source, now, func(subject string) bool {
+		return subject == expectedSubject
+	})
+	if err != nil {
+		return observabilityCollectorObserverCredential{}, nil, err
+	}
+	audiences, err := tokenAudiences(claims.Audience)
+	if err != nil || len(audiences) != 1 || audiences[0] != "https://kubernetes.default.svc" {
+		return observabilityCollectorObserverCredential{}, nil, errors.New("observability collector observer audience differs")
+	}
+	return observabilityCollectorObserverCredential{
+		ExpiresAt:                  source.ExpiresAt.UTC().Format(time.RFC3339),
+		TokenRequestEvidenceDigest: source.TokenRequestEvidenceDigest,
+	}, append([]byte(nil), token...), nil
+}
+
+func observabilityCertificateHasUsage(certificate *x509.Certificate, usage x509.ExtKeyUsage) bool {
+	for _, value := range certificate.ExtKeyUsage {
+		if value == usage || value == x509.ExtKeyUsageAny {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/runner/observability_collector_activation_package_test.go
+++ b/internal/runner/observability_collector_activation_package_test.go
@@ -1,0 +1,327 @@
+package runner
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/stageplan"
+	"github.com/openkubes/ok-cluster/internal/stagereceipt"
+)
+
+func TestBuildObservabilityCollectorActivationPackageBindsPrivateRuntime(t *testing.T) {
+	config, cleanup := observabilityCollectorActivationFixture(t)
+	defer cleanup()
+	packaged, err := BuildObservabilityCollectorActivationPackage(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	privateRaw, err := packaged.PrivateBytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := packaged.Receipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if receipt.Format != ObservabilityCollectorActivationPackageFormat || receipt.State != "VERIFIED" ||
+		receipt.PackageDigest != digest.SHA256(privateRaw) || receipt.PrivateFileCount != 7 ||
+		receipt.PublicEndpointDigest != digest.SHA256([]byte(config.PublicEndpoint)) ||
+		receipt.MutationAllowed || len(receipt.ObjectKinds) != 1 || receipt.ObjectKinds[0] != "Secret" {
+		t.Fatalf("unexpected collector activation receipt: %#v", receipt)
+	}
+	var secret postRuntimeActivationSecret
+	if err := json.Unmarshal(privateRaw, &secret); err != nil {
+		t.Fatal(err)
+	}
+	if !secret.Immutable || secret.Metadata.Name != config.ActivationSecret || len(secret.BinaryData) != 7 {
+		t.Fatalf("unexpected collector activation Secret: %#v", secret.Metadata)
+	}
+	activationRaw, err := base64.StdEncoding.DecodeString(secret.BinaryData[observabilityCollectorActivationKey])
+	if err != nil {
+		t.Fatal(err)
+	}
+	var activation ObservabilityCollectorActivation
+	if err := json.Unmarshal(activationRaw, &activation); err != nil {
+		t.Fatal(err)
+	}
+	if activation.State != "BOUND" || activation.PublicEndpoint != config.PublicEndpoint ||
+		activation.ManifestReceiptDigest != config.ExpectedReceiptDigest ||
+		activation.ReceiverName != observabilityCollectorReceiver ||
+		activation.TargetClusterUID == "" || activation.WorkloadEndpoint == "" ||
+		digest.SHA256([]byte(activation.TargetClusterUID)) != receipt.TargetClusterUIDDigest {
+		t.Fatalf("collector activation lost runtime identity: %#v", activation)
+	}
+	publicRaw, err := json.Marshal(receipt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, privateValue := range []string{
+		activation.TargetClusterUID, activation.WorkloadEndpoint,
+		string(mustDecodeCollectorSecret(t, secret, observabilityCollectorWebhookKey)),
+		string(mustDecodeCollectorSecret(t, secret, observabilityCollectorQueryKey)),
+		string(mustDecodeCollectorSecret(t, secret, observabilityCollectorWorkloadKey)),
+	} {
+		if bytes.Contains(publicRaw, []byte(privateValue)) {
+			t.Fatal("collector activation receipt disclosed private runtime material")
+		}
+	}
+	privateRaw[0] = 'x'
+	again, err := packaged.PrivateBytes()
+	if err != nil || again[0] != '{' {
+		t.Fatal("caller mutated retained collector activation package")
+	}
+	receipt.ObjectKinds[0] = "Changed"
+	againReceipt, err := packaged.Receipt()
+	if err != nil || againReceipt.ObjectKinds[0] != "Secret" {
+		t.Fatal("caller mutated retained collector activation receipt")
+	}
+}
+
+func TestBuildObservabilityCollectorActivationPackageFailsClosed(t *testing.T) {
+	for name, mutate := range map[string]func(*ObservabilityCollectorActivationPackageConfig){
+		"foreign manifest": func(config *ObservabilityCollectorActivationPackageConfig) {
+			config.ExpectedManifestDigest = runnerStageSHA("f")
+		},
+		"foreign manifest receipt": func(config *ObservabilityCollectorActivationPackageConfig) {
+			config.ExpectedReceiptDigest = runnerStageSHA("f")
+		},
+		"foreign runtime path": func(config *ObservabilityCollectorActivationPackageConfig) {
+			config.RuntimeBinding.MaterialPath = filepath.Join(t.TempDir(), "runtime.json")
+		},
+		"foreign observer": func(config *ObservabilityCollectorActivationPackageConfig) {
+			config.ObserverCredential.ExpectedSubject = "system:serviceaccount:ok-observability:other"
+		},
+		"shared authorities": func(config *ObservabilityCollectorActivationPackageConfig) {
+			config.QueryTokenPath = config.WebhookTokenPath
+		},
+		"wrong endpoint": func(config *ObservabilityCollectorActivationPackageConfig) {
+			config.PublicEndpoint = "https://192.0.2.45:8443"
+		},
+		"broad listen mismatch": func(config *ObservabilityCollectorActivationPackageConfig) {
+			config.ListenAddress = "0.0.0.0:9443"
+		},
+		"stale observer": func(config *ObservabilityCollectorActivationPackageConfig) {
+			config.MaterializationTime = config.ObserverCredential.ExpiresAt.Add(-10 * time.Minute)
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			config, cleanup := observabilityCollectorActivationFixture(t)
+			defer cleanup()
+			mutate(&config)
+			if _, err := BuildObservabilityCollectorActivationPackage(config); err == nil {
+				t.Fatal("unsafe collector activation package was accepted")
+			}
+		})
+	}
+	if _, err := (VerifiedObservabilityCollectorActivationPackage{}).PrivateBytes(); err == nil {
+		t.Fatal("unverified collector activation bytes were exposed")
+	}
+	if _, err := (VerifiedObservabilityCollectorActivationPackage{}).Receipt(); err == nil {
+		t.Fatal("unverified collector activation receipt was exposed")
+	}
+}
+
+func observabilityCollectorActivationFixture(t *testing.T) (ObservabilityCollectorActivationPackageConfig, func()) {
+	t.Helper()
+	manifestPath, cleanup := fullRunExecutionManifestFixture(t)
+	manifest, manifestReceipt, err := LoadFullRunExecutionManifest(manifestPath)
+	if err != nil {
+		cleanup()
+		t.Fatal(err)
+	}
+	at := time.Date(2026, 8, 21, 10, 0, 0, 0, time.UTC)
+	manifestReceiptRaw, err := json.Marshal(manifestReceipt)
+	if err != nil {
+		cleanup()
+		t.Fatal(err)
+	}
+	manifestReceiptPath := writeBundleFile(t, t.TempDir(), "full-run-manifest-receipt.json", manifestReceiptRaw)
+	ca := collectorTestCA(t, at)
+	runtime := collectorRuntimeBindingFiles(t, manifest, ca, at)
+	root := t.TempDir()
+	issuedAt, expiresAt := at.Add(-time.Minute), at.Add(45*time.Minute)
+	subject := "system:serviceaccount:ok-observability:" + observabilityCollectorObserverSA
+	token := stageCredentialJWT(t, "https://kubernetes.default.svc.cluster.local", subject, []string{"https://kubernetes.default.svc"}, issuedAt, expiresAt, 'z')
+	tokenPath := writeBundleFile(t, root, "observer-token", token)
+	caPath := writeBundleFile(t, root, "workload-ca.crt", ca)
+	webhookPath := writeBundleFile(t, root, "webhook-token", []byte(strings.Repeat("w", 48)))
+	queryPath := writeBundleFile(t, root, "query-token", []byte(strings.Repeat("q", 48)))
+	certificate, privateKey := collectorServerCredential(t, at, net.ParseIP("192.0.2.44"))
+	certificatePath := writeBundleFile(t, root, "tls.crt", certificate)
+	privateKeyPath := writeBundleFile(t, root, "tls.key", privateKey)
+	return ObservabilityCollectorActivationPackageConfig{
+		ManifestPath: manifestPath, ExpectedManifestDigest: manifestReceipt.ManifestDigest,
+		ManifestReceiptPath: manifestReceiptPath, ExpectedReceiptDigest: digest.SHA256(manifestReceiptRaw),
+		RuntimeBinding: runtime, ActivationSecret: "ok147-observability-collector-activation",
+		MaterializationTime: at,
+		ObserverCredential: SubmissionStageCredentialSource{
+			AuthorityIdentity: digest.SHA256([]byte("collector-target-cluster-uid")),
+			TokenFile:         tokenPath, TokenDigest: digest.SHA256(token), CAFile: caPath, CABundleDigest: digest.SHA256(ca),
+			TokenRequestEvidenceDigest: runnerStageSHA("e"), ExpectedIssuer: "https://kubernetes.default.svc.cluster.local",
+			ExpectedSubject: subject, ExpectedAudiences: []string{"https://kubernetes.default.svc"},
+			IssuedAt: issuedAt, ExpiresAt: expiresAt,
+		},
+		WebhookTokenPath: webhookPath, QueryTokenPath: queryPath,
+		PublicEndpoint: "https://192.0.2.44:8443", ListenAddress: "0.0.0.0:8443",
+		TLSCertificatePath: certificatePath, TLSPrivateKeyPath: privateKeyPath, MaximumRecordAge: 10 * time.Minute,
+	}, cleanup
+}
+
+func collectorRuntimeBindingFiles(t *testing.T, manifest VerifiedFullRunExecutionManifest, ca []byte, at time.Time) RuntimeBindingMaterialFileConfig {
+	t.Helper()
+	plan := manifest.plan
+	root := t.TempDir()
+	predecessors := []stagereceipt.Verified{}
+	sources := make([]StageReceiptSource, 0, 6)
+	targetUID := "collector-target-cluster-uid"
+	var lifecycleEvidence, networkEvidence string
+	results := []struct {
+		id, mutation, operation, evidence string
+	}{
+		{"provider-prerequisites", "ATTEMPTED", runnerStageSHA("1"), runnerStageSHA("2")},
+		{"cluster-lifecycle", "ATTEMPTED", runnerStageSHA("3"), runnerStageSHA("4")},
+		{"lifecycle-observation", "NOT_APPLICABLE", "", runnerStageSHA("5")},
+		{"enablement", "ATTEMPTED", runnerStageSHA("6"), runnerStageSHA("7")},
+		{"network-observation", "NOT_APPLICABLE", "", runnerStageSHA("8")},
+		{"runtime-binding", "NOT_APPLICABLE", "", runnerStageSHA("9")},
+	}
+	for index, result := range results {
+		var verified stagereceipt.Verified
+		var err error
+		if result.id == "cluster-lifecycle" {
+			verified, err = stagereceipt.NewWithTargetClusterUIDDigest(plan, result.id, predecessors, "SUCCEEDED", result.mutation, result.operation, result.evidence, digest.SHA256([]byte(targetUID)), at.Add(time.Duration(index-7)*time.Minute))
+			lifecycleEvidence = result.evidence
+		} else {
+			verified, err = stagereceipt.New(plan, result.id, predecessors, "SUCCEEDED", result.mutation, result.operation, result.evidence, at.Add(time.Duration(index-7)*time.Minute))
+			if result.id == "network-observation" {
+				networkEvidence = result.evidence
+			}
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		sources = appendStageReceipt(t, root, sources, verified, result.id+".json")
+		predecessors = []stagereceipt.Verified{verified}
+	}
+	material := RuntimeBindingMaterial{
+		Format: RuntimeBindingMaterialFormat, State: "CURRENT_RUNTIME_BOUND",
+		PlanDigest: plan.PlanDigest, IntentRevision: plan.IntentRevision, EnablementRevision: plan.EnablementRevision,
+		PlatformRevision: plan.PlatformRevision, ExecutionFixture: plan.ExecutionFixture,
+		Target: RuntimeBindingTarget{
+			Name: plan.ContractIdentity.Name, CAPIClusterUID: targetUID, TargetIdentityScheme: "capi-cluster-uid/v1",
+			WorkloadAPIEndpoint: "https://192.0.2.147:6443", WorkloadAPICAData: base64.StdEncoding.EncodeToString(ca),
+			WorkloadAPICADigest: digest.SHA256(ca), KubeSystemUID: "collector-kube-system-uid",
+		},
+		Storage:  RuntimeBindingStorage{Name: "local-path", UID: "collector-storage-class-uid", Provisioner: "rancher.io/local-path"},
+		Evidence: RuntimeBindingEvidence{LifecycleEvidenceDigest: lifecycleEvidence, NetworkEvidenceDigest: networkEvidence},
+	}
+	materialRaw, err := canonicalRuntimeBinding(material)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt := RuntimeBindingMaterialReceipt{
+		Format: RuntimeBindingMaterialFormat, State: "VERIFIED", StageID: "runtime-binding",
+		PlanDigest: plan.PlanDigest, IntentRevision: plan.IntentRevision,
+		TargetClusterUIDDigest: digest.SHA256([]byte(targetUID)), WorkloadAPICADigest: digest.SHA256(ca),
+		KubeSystemUIDDigest:       digest.SHA256([]byte(material.Target.KubeSystemUID)),
+		LocalPathStorageUIDDigest: digest.SHA256([]byte(material.Storage.UID)),
+		LifecycleEvidenceDigest:   lifecycleEvidence, NetworkEvidenceDigest: networkEvidence,
+		PrivateMaterialDigest: digest.SHA256(materialRaw), PersistentMutationAllowed: false,
+	}
+	if err := os.WriteFile(manifest.document.RuntimeBinding.MaterialPath, materialRaw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	receiptRaw, err := json.Marshal(receipt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(manifest.document.RuntimeBinding.ReceiptPath, receiptRaw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return RuntimeBindingMaterialFileConfig{
+		Bundle: StageResumeConfig{
+			PlanPath: manifest.document.Plan.Path,
+			PlanExpected: stageplan.Expected{
+				ContractIdentity: plan.ContractIdentity, IntentRevision: plan.IntentRevision,
+				EnablementRevision: plan.EnablementRevision, PlatformRevision: plan.PlatformRevision,
+				ExecutionFixture: plan.ExecutionFixture, InfrastructureAuthority: plan.Authorities.Infrastructure,
+				ManagementAuthority: plan.Authorities.Management, GitOpsAuthority: plan.Authorities.GitOps,
+			},
+			Receipts: sources,
+		},
+		MaterialPath: manifest.document.RuntimeBinding.MaterialPath, ReceiptPath: manifest.document.RuntimeBinding.ReceiptPath,
+	}
+}
+
+func collectorTestCA(t *testing.T, at time.Time) []byte {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(401), Subject: pkix.Name{CommonName: "ok147-collector-test-ca"},
+		NotBefore: at.Add(-time.Hour), NotAfter: at.Add(24 * time.Hour),
+		IsCA: true, KeyUsage: x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature, BasicConstraintsValid: true,
+	}
+	raw, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return pemEncodeCertificate(raw)
+}
+
+func collectorServerCredential(t *testing.T, at time.Time, address net.IP) ([]byte, []byte) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(402), Subject: pkix.Name{CommonName: "ok147-collector"},
+		NotBefore: at.Add(-time.Hour), NotAfter: at.Add(24 * time.Hour),
+		KeyUsage: x509.KeyUsageDigitalSignature, ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IPAddresses: []net.IP{address},
+	}
+	raw, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	privateRaw, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return pemEncodeCertificate(raw), pemEncodeECPrivateKey(privateRaw)
+}
+
+func pemEncodeCertificate(raw []byte) []byte {
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: raw})
+}
+
+func pemEncodeECPrivateKey(raw []byte) []byte {
+	return pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: raw})
+}
+
+func mustDecodeCollectorSecret(t *testing.T, secret postRuntimeActivationSecret, key string) []byte {
+	t.Helper()
+	raw, err := base64.StdEncoding.DecodeString(secret.BinaryData[key])
+	if err != nil {
+		t.Fatal(err)
+	}
+	return raw
+}

--- a/internal/runner/submission_stage_credentials.go
+++ b/internal/runner/submission_stage_credentials.go
@@ -232,6 +232,13 @@ func buildSubmissionStageCredentialObject(stageID string, now time.Time, role, n
 }
 
 func verifyStageCredentialJWT(token []byte, source SubmissionStageCredentialSource, now time.Time) (submissionStageTokenClaims, error) {
+	return verifyStageCredentialJWTWithSubject(token, source, now, validStageCredentialSubject)
+}
+
+func verifyStageCredentialJWTWithSubject(token []byte, source SubmissionStageCredentialSource, now time.Time, subjectAllowed func(string) bool) (submissionStageTokenClaims, error) {
+	if subjectAllowed == nil {
+		return submissionStageTokenClaims{}, errors.New("stage credential subject policy is missing")
+	}
 	parts := strings.Split(string(token), ".")
 	if len(parts) != 3 || parts[0] == "" || parts[1] == "" || parts[2] == "" {
 		return submissionStageTokenClaims{}, errors.New("stage credential token is not a signed JWT")
@@ -276,7 +283,7 @@ func verifyStageCredentialJWT(token []byte, source SubmissionStageCredentialSour
 	if err != nil {
 		return submissionStageTokenClaims{}, errors.New("stage credential JWT not-before claim is invalid")
 	}
-	if source.ExpectedIssuer == "" || claims.Issuer != source.ExpectedIssuer || source.ExpectedSubject == "" || claims.Subject != source.ExpectedSubject || !validStageCredentialSubject(claims.Subject) {
+	if source.ExpectedIssuer == "" || claims.Issuer != source.ExpectedIssuer || source.ExpectedSubject == "" || claims.Subject != source.ExpectedSubject || !subjectAllowed(claims.Subject) {
 		return submissionStageTokenClaims{}, errors.New("stage credential JWT issuer or subject differs from bound source")
 	}
 	audiences, err := tokenAudiences(claims.Audience)


### PR DESCRIPTION
## Outcome

Adds the offline, post-runtime activation package for the independent observability evidence collector.

## Boundary

- verifies the exact full-run manifest receipt, Plan, and durable runtime binding
- binds the dedicated read-only autonomy observer identity
- emits one immutable private Secret with seven exact files
- keeps raw target identity, endpoint, tokens, CA, and TLS key out of the public receipt
- adds no CLI launch, Kubernetes runtime envelope, cluster contact, or mutation

## Verification

- full Go test suite passes
- go vet passes
- git diff --check passes