### PR TITLE
feat(runner): gate suffix on collector activation

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -3155,7 +3155,13 @@ Service, NetworkPolicy and Job in that order. Existing state stops zero-write;
 any failure after the first POST is retained as partial or unknown state, and
 the launcher exposes no retry, update, patch, delete, rollback or cleanup.
 Live receiver binding and ordered insertion immediately after the Stage-7
-runtime handoff remain separate prerequisites before a complete fresh run.
+runtime handoff now use the explicit `FullRunPostPrefixActivator` seam. The
+orchestrator passes that seam the exact seven-receipt private prefix,
+lifecycle-derived target identity and workload authority under the same run
+context, and cannot open Stage 8 until activation returns successfully. The
+concrete factory that builds the collector package and launcher from those
+fresh runtime inputs remains the next prerequisite before a complete fresh
+run.
 
 Fresh-Run v3 now also has one fail-closed offline image/package correlation
 boundary:
@@ -3576,7 +3582,8 @@ durable receipts. This is not yet the OK-147 Definition of Done:
   separate prepare/execute CLI;
 - the independent-evidence collector has an exact private package replay,
   non-authorizing installation plan and single-use workload-cluster launcher;
-  wiring that launcher into the Stage-7-to-Stage-8 handoff remains explicit;
+  the Stage-7-to-Stage-8 handoff now has an ordered fail-closed activator seam,
+  while its concrete package/launcher factory remains explicit;
 - the standalone Stage-12 launcher has not yet been executed as part of the
   complete predecessor-bound stage chain;
 - the current staged-library source is published as the immutable multi-platform
@@ -3599,9 +3606,10 @@ private `0600` files with the binding last. It has no list, watch, discovery,
 Kubernetes mutation, retry or cleanup surface. The verified full-run manifest
 now opens that materializer, all concrete Stage 1-12 adapters and the shared
 single-execution Platform capability session without contacting a cluster.
-The remaining implementation work is the ordered local/Job composition that
-installs the verified collector after Stage 7 and then activates the verified
-Stage 8-12 suffix; this is not a new controller or reconciliation mechanism.
+The remaining implementation work is the concrete post-prefix factory that
+builds and installs the verified collector after Stage 7; Stage 8-12 is now
+structurally unable to open before that activator succeeds. This is not a new
+controller or reconciliation mechanism.
 After that, live closure must
 publish the current image, construct fresh short-lived private inputs, run the
 exact bounded activation on `ok-mgmt`, preserve a stopped partial state without

--- a/internal/runner/full_run_execution.go
+++ b/internal/runner/full_run_execution.go
@@ -17,6 +17,20 @@ type FullRunExecutionConfig struct {
 	PostRuntime             PostRuntimeExecutionConfig
 	WorkloadAuthorityBinder FullRunWorkloadAuthorityBinder
 	EvidenceIdentityBinder  FullRunEvidenceIdentityBinder
+	PostPrefixActivator     FullRunPostPrefixActivator
+}
+
+type FullRunPostPrefixActivation struct {
+	ReceiptPrefix  []StageReceiptSource
+	TargetIdentity string
+	Workload       WorkloadAuthorityFileResolverConfig
+}
+
+// FullRunPostPrefixActivator is the only ordered seam between successful
+// Stage 7 and opening Stage 8. A collector installer implementation may use
+// it once; it must return only after its exact activation is established.
+type FullRunPostPrefixActivator interface {
+	ActivateFullRunPostPrefix(context.Context, FullRunPostPrefixActivation) error
 }
 
 // FullRunEvidenceIdentityBinder publishes only the private, derived
@@ -90,7 +104,7 @@ func openFullRunExecution(config FullRunExecutionConfig, factories fullRunExecut
 	prefix := &concretePreRuntimeContinuation{executor: preRuntime}
 	orchestration := &FullRunOrchestration{
 		PreRuntime: prefix,
-		BindPostRuntime: func(completed PreRuntimeOrchestrationReceipt) (PostRuntimeContinuation, error) {
+		BindPostRuntime: func(ctx context.Context, completed PreRuntimeOrchestrationReceipt) (PostRuntimeContinuation, error) {
 			privatePrefix, prefixErr := preRuntime.ReceiptPrefix()
 			if prefixErr != nil || len(privatePrefix) != len(completed.Checkpoints) || len(privatePrefix) != len(preRuntimeStageOrder) {
 				return nil, errors.New("load full-run private receipt prefix")
@@ -116,6 +130,16 @@ func openFullRunExecution(config FullRunExecutionConfig, factories fullRunExecut
 			if config.EvidenceIdentityBinder != nil {
 				if bindErr := config.EvidenceIdentityBinder.BindFullRunEvidenceIdentity(append([]StageReceiptSource(nil), privatePrefix[:6]...)); bindErr != nil {
 					return nil, errors.New("bind full-run independent evidence identity")
+				}
+			}
+			if config.PostPrefixActivator != nil {
+				activation := FullRunPostPrefixActivation{
+					ReceiptPrefix:  append([]StageReceiptSource(nil), privatePrefix...),
+					TargetIdentity: targetIdentity,
+					Workload:       workloadAuthority,
+				}
+				if activateErr := config.PostPrefixActivator.ActivateFullRunPostPrefix(ctx, activation); activateErr != nil {
+					return nil, errors.New("activate full-run post-prefix prerequisites")
 				}
 			}
 			bound := clonePostRuntimeExecutionConfigForFullRun(postRuntime)

--- a/internal/runner/full_run_execution_manifest.go
+++ b/internal/runner/full_run_execution_manifest.go
@@ -223,9 +223,10 @@ func (factory FullRunPlatformCapabilityFactoryFunc) OpenFullRunPlatformCapabilit
 // that cannot be serialized in the private manifest. Capability construction
 // is typed and runtime-bound; Clock and Wait make bounded polling testable.
 type FullRunExecutionManifestRuntime struct {
-	PlatformCapability FullRunPlatformCapabilityFactory
-	Clock              func() time.Time
-	Wait               ObservationWaiter
+	PlatformCapability  FullRunPlatformCapabilityFactory
+	PostPrefixActivator FullRunPostPrefixActivator
+	Clock               func() time.Time
+	Wait                ObservationWaiter
 }
 
 // Receipt returns the already verified, redaction-safe manifest identity. The
@@ -330,6 +331,7 @@ func (manifest VerifiedFullRunExecutionManifest) ExecutionConfig(runtime FullRun
 		SourceRepository: document.PlatformApplications.SourceRepository, Profile: clonePlatformProfile(manifest.platform),
 	}
 	config := FullRunExecutionConfig{
+		PostPrefixActivator: runtime.PostPrefixActivator,
 		EvidenceIdentityBinder: newFullRunObservabilityEvidenceIdentityBinder(
 			manifest,
 			document.PlatformObservation.Capability.IndependentEvidenceIdentityPath,

--- a/internal/runner/full_run_execution_manifest_test.go
+++ b/internal/runner/full_run_execution_manifest_test.go
@@ -58,12 +58,13 @@ func TestVerifiedFullRunExecutionManifestBuildsConcreteConfiguration(t *testing.
 		t.Fatal(err)
 	}
 	var capabilityBinding FullRunPlatformCapabilityBinding
+	postPrefix := &recordingFullRunPostPrefixActivator{}
 	config, err := manifest.ExecutionConfig(FullRunExecutionManifestRuntime{
 		PlatformCapability: FullRunPlatformCapabilityFactoryFunc(func(binding FullRunPlatformCapabilityBinding) (PlatformCapabilityResolver, error) {
 			capabilityBinding = binding
 			return capability, nil
 		}),
-		Clock: clock, Wait: WaitWithTimer,
+		PostPrefixActivator: postPrefix, Clock: clock, Wait: WaitWithTimer,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -73,7 +74,7 @@ func TestVerifiedFullRunExecutionManifestBuildsConcreteConfiguration(t *testing.
 	}
 	if config.PreRuntime.NetworkObservation.Workload.KubeconfigFile == "" || config.PreRuntime.NetworkObservation.Workload.TokenFile != "" ||
 		config.PostRuntime.TargetCredentialRun.Workload != config.PreRuntime.NetworkObservation.Workload ||
-		config.EvidenceIdentityBinder == nil ||
+		config.EvidenceIdentityBinder == nil || config.PostPrefixActivator != postPrefix ||
 		config.PostRuntime.PlatformObservation.Capability == nil || config.PostRuntime.AggregateEvidence.Capability == nil ||
 		config.PostRuntime.TargetRegistration.Expected.TargetIdentityDigest != "" ||
 		!config.PostRuntime.TargetRegistration.Runtime.MaterializationTime.IsZero() {

--- a/internal/runner/full_run_execution_test.go
+++ b/internal/runner/full_run_execution_test.go
@@ -177,6 +177,55 @@ func TestFullRunExecutionStopsBeforeSuffixWhenEvidenceIdentityBindingFails(t *te
 	}
 }
 
+func TestFullRunExecutionActivatesExactPostPrefixBeforeOpeningSuffix(t *testing.T) {
+	preRuntime := successfulFakeConcretePreRuntimeExecution(t)
+	activator := &recordingFullRunPostPrefixActivator{}
+	config := testFullRunExecutionConfig()
+	config.PostPrefixActivator = activator
+	postCalls := 0
+	execution, err := openFullRunExecution(config, fullRunExecutionFactories{
+		preRuntime: func(PreRuntimeExecutionConfig) (fullRunPreRuntimeExecution, error) { return preRuntime, nil },
+		postRuntime: func(PostRuntimeExecutionConfig) (PostRuntimeContinuation, error) {
+			postCalls++
+			if activator.calls != 1 || !reflect.DeepEqual(activator.activation.ReceiptPrefix, preRuntime.prefix) ||
+				activator.activation.TargetIdentity != preRuntime.target || activator.activation.Workload != preRuntime.workload {
+				t.Fatalf("suffix opened before exact post-prefix activation: %#v", activator)
+			}
+			return successfulFakePostRuntimeContinuation(), nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := execution.Run(context.Background())
+	if err != nil || receipt.State != "SUCCEEDED" || activator.calls != 1 || postCalls != 1 {
+		t.Fatalf("full run did not activate post-prefix once: receipt=%#v activator=%#v post=%d err=%v", receipt, activator, postCalls, err)
+	}
+}
+
+func TestFullRunExecutionStopsBeforeSuffixWhenPostPrefixActivationFails(t *testing.T) {
+	preRuntime := successfulFakeConcretePreRuntimeExecution(t)
+	activator := &recordingFullRunPostPrefixActivator{err: errors.New("collector activation rejected")}
+	config := testFullRunExecutionConfig()
+	config.PostPrefixActivator = activator
+	postCalls := 0
+	execution, err := openFullRunExecution(config, fullRunExecutionFactories{
+		preRuntime: func(PreRuntimeExecutionConfig) (fullRunPreRuntimeExecution, error) { return preRuntime, nil },
+		postRuntime: func(PostRuntimeExecutionConfig) (PostRuntimeContinuation, error) {
+			postCalls++
+			return successfulFakePostRuntimeContinuation(), nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := execution.Run(context.Background())
+	if err == nil || receipt.State != "STOPPED" || receipt.StoppedAt != "target-credential" ||
+		len(receipt.Checkpoints) != 7 || activator.calls != 1 || postCalls != 0 {
+		t.Fatalf("failed post-prefix activation opened suffix: receipt=%#v activator=%#v post=%d err=%v", receipt, activator, postCalls, err)
+	}
+}
+
 type recordingFullRunWorkloadAuthorityBinder struct {
 	bound WorkloadAuthorityFileResolverConfig
 	calls int
@@ -187,6 +236,19 @@ type recordingFullRunEvidenceIdentityBinder struct {
 	prefix []StageReceiptSource
 	calls  int
 	err    error
+}
+
+type recordingFullRunPostPrefixActivator struct {
+	activation FullRunPostPrefixActivation
+	calls      int
+	err        error
+}
+
+func (activator *recordingFullRunPostPrefixActivator) ActivateFullRunPostPrefix(_ context.Context, activation FullRunPostPrefixActivation) error {
+	activator.calls++
+	activator.activation = activation
+	activator.activation.ReceiptPrefix = append([]StageReceiptSource(nil), activation.ReceiptPrefix...)
+	return activator.err
 }
 
 func (binder *recordingFullRunEvidenceIdentityBinder) BindFullRunEvidenceIdentity(prefix []StageReceiptSource) error {

--- a/internal/runner/full_run_observability_activation.go
+++ b/internal/runner/full_run_observability_activation.go
@@ -10,6 +10,7 @@ import (
 // pinned public key used to verify independent Observability evidence.
 type KubernetesObservabilityFullRunActivationConfig struct {
 	IndependentEvidencePublicKeyPath string
+	PostPrefixActivator              FullRunPostPrefixActivator
 	Clock                            func() time.Time
 	Wait                             ObservationWaiter
 }
@@ -58,7 +59,8 @@ func OpenKubernetesObservabilityFullRunActivation(path string, runtime Kubernete
 		return nil, receipt, errors.New("open full-run Observability capability factory")
 	}
 	config, err := manifest.ExecutionConfig(FullRunExecutionManifestRuntime{
-		PlatformCapability: capability, Clock: runtime.Clock, Wait: runtime.Wait,
+		PlatformCapability: capability, PostPrefixActivator: runtime.PostPrefixActivator,
+		Clock: runtime.Clock, Wait: runtime.Wait,
 	})
 	if err != nil {
 		return nil, receipt, errors.New("open concrete full-run execution configuration")

--- a/internal/runner/full_run_orchestrator.go
+++ b/internal/runner/full_run_orchestrator.go
@@ -60,7 +60,7 @@ type PreRuntimeContinuation interface {
 // independently checked before Run.
 type FullRunOrchestration struct {
 	PreRuntime      PreRuntimeContinuation
-	BindPostRuntime func(PreRuntimeOrchestrationReceipt) (PostRuntimeContinuation, error)
+	BindPostRuntime func(context.Context, PreRuntimeOrchestrationReceipt) (PostRuntimeContinuation, error)
 
 	mu   sync.Mutex
 	used bool
@@ -102,7 +102,7 @@ func (orchestration *FullRunOrchestration) Run(ctx context.Context) (FullRunOrch
 		return stopFullRunOrchestration(receipt, postRuntimeStageOrder[0])
 	}
 
-	continuation, err := orchestration.BindPostRuntime(prefix)
+	continuation, err := orchestration.BindPostRuntime(ctx, prefix)
 	if err != nil || continuation == nil {
 		return stopFullRunOrchestration(receipt, postRuntimeStageOrder[0])
 	}

--- a/internal/runner/full_run_orchestrator_test.go
+++ b/internal/runner/full_run_orchestrator_test.go
@@ -35,7 +35,7 @@ func TestFullRunOrchestrationComposesExactTwelveStageChainOnce(t *testing.T) {
 	continuation := successfulFakePostRuntimeContinuation()
 	orchestration := &FullRunOrchestration{
 		PreRuntime: successfulPreRuntimeOrchestration(&calls),
-		BindPostRuntime: func(prefix PreRuntimeOrchestrationReceipt) (PostRuntimeContinuation, error) {
+		BindPostRuntime: func(_ context.Context, prefix PreRuntimeOrchestrationReceipt) (PostRuntimeContinuation, error) {
 			calls = append(calls, "bind-post-runtime")
 			if prefix.State != "SUCCEEDED" || len(prefix.Checkpoints) != 7 {
 				t.Fatal("post-runtime binder did not receive the completed prefix")
@@ -69,7 +69,7 @@ func TestFullRunOrchestrationAllowsExactlyOneConcurrentInvocation(t *testing.T) 
 	continuation := successfulFakePostRuntimeContinuation()
 	orchestration := &FullRunOrchestration{
 		PreRuntime: successfulPreRuntimeOrchestration(nil),
-		BindPostRuntime: func(PreRuntimeOrchestrationReceipt) (PostRuntimeContinuation, error) {
+		BindPostRuntime: func(context.Context, PreRuntimeOrchestrationReceipt) (PostRuntimeContinuation, error) {
 			return continuation, nil
 		},
 	}
@@ -106,7 +106,7 @@ func TestFullRunOrchestrationStopsBeforeContinuationWhenPrefixStops(t *testing.T
 	bindCalls := 0
 	orchestration := &FullRunOrchestration{
 		PreRuntime: prefix,
-		BindPostRuntime: func(PreRuntimeOrchestrationReceipt) (PostRuntimeContinuation, error) {
+		BindPostRuntime: func(context.Context, PreRuntimeOrchestrationReceipt) (PostRuntimeContinuation, error) {
 			bindCalls++
 			return successfulFakePostRuntimeContinuation(), nil
 		},
@@ -130,7 +130,7 @@ func TestFullRunOrchestrationPreservesCompletedPrefixCheckpointWhenBridgeStops(t
 	bindCalls := 0
 	orchestration := &FullRunOrchestration{
 		PreRuntime: prefix,
-		BindPostRuntime: func(PreRuntimeOrchestrationReceipt) (PostRuntimeContinuation, error) {
+		BindPostRuntime: func(context.Context, PreRuntimeOrchestrationReceipt) (PostRuntimeContinuation, error) {
 			bindCalls++
 			return successfulFakePostRuntimeContinuation(), nil
 		},
@@ -157,7 +157,7 @@ func TestFullRunOrchestrationRejectsForeignContinuationBeforeRun(t *testing.T) {
 			mutate(&continuation.binding)
 			orchestration := &FullRunOrchestration{
 				PreRuntime: successfulPreRuntimeOrchestration(nil),
-				BindPostRuntime: func(PreRuntimeOrchestrationReceipt) (PostRuntimeContinuation, error) {
+				BindPostRuntime: func(context.Context, PreRuntimeOrchestrationReceipt) (PostRuntimeContinuation, error) {
 					return continuation, nil
 				},
 			}
@@ -177,7 +177,7 @@ func TestFullRunOrchestrationPreservesBoundedSuffixStop(t *testing.T) {
 	continuation.err = errors.New("private suffix failure")
 	orchestration := &FullRunOrchestration{
 		PreRuntime: successfulPreRuntimeOrchestration(nil),
-		BindPostRuntime: func(PreRuntimeOrchestrationReceipt) (PostRuntimeContinuation, error) {
+		BindPostRuntime: func(context.Context, PreRuntimeOrchestrationReceipt) (PostRuntimeContinuation, error) {
 			return continuation, nil
 		},
 	}
@@ -195,7 +195,7 @@ func TestFullRunOrchestrationPreservesCompletedSuffixCheckpointWhenBridgeStops(t
 	continuation.err = errors.New("private receipt bridge failure")
 	orchestration := &FullRunOrchestration{
 		PreRuntime: successfulPreRuntimeOrchestration(nil),
-		BindPostRuntime: func(PreRuntimeOrchestrationReceipt) (PostRuntimeContinuation, error) {
+		BindPostRuntime: func(context.Context, PreRuntimeOrchestrationReceipt) (PostRuntimeContinuation, error) {
 			return continuation, nil
 		},
 	}
@@ -211,7 +211,7 @@ func TestFullRunOrchestrationRejectsMalformedSuffix(t *testing.T) {
 	continuation.receipt.Checkpoints[0].StageReceiptDigest = "bad"
 	orchestration := &FullRunOrchestration{
 		PreRuntime: successfulPreRuntimeOrchestration(nil),
-		BindPostRuntime: func(PreRuntimeOrchestrationReceipt) (PostRuntimeContinuation, error) {
+		BindPostRuntime: func(context.Context, PreRuntimeOrchestrationReceipt) (PostRuntimeContinuation, error) {
 			return continuation, nil
 		},
 	}


### PR DESCRIPTION
## Outcome

Adds the explicit fail-closed activation seam between successful Stage 7 and opening Stage 8.

- passes the exact seven-receipt private prefix
- passes the lifecycle-derived target identity and workload authority
- runs under the same bounded execution context
- opens the Stage 8-12 continuation only after activation succeeds
- stops with exactly seven checkpoints when activation fails
- propagates the seam through manifest and Kubernetes observability runtime configuration

This introduces no controller, retry, rollback, cleanup or live infrastructure action.

## Verification

- full Go test suite passed
- go vet passed
- runner race test passed
