### PR TITLE
feat(runner): activate collector from runtime prefix

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -3159,9 +3159,15 @@ runtime handoff now use the explicit `FullRunPostPrefixActivator` seam. The
 orchestrator passes that seam the exact seven-receipt private prefix,
 lifecycle-derived target identity and workload authority under the same run
 context, and cannot open Stage 8 until activation returns successfully. The
-concrete factory that builds the collector package and launcher from those
-fresh runtime inputs remains the next prerequisite before a complete fresh
-run.
+concrete `KubernetesObservabilityCollectorPostPrefix` factory now consumes
+those fresh inputs. It replays only the first six receipts into runtime-binding
+verification, derives the package materialization time from the run clock,
+requires the target UID digest, workload endpoint and CA to match the distinct
+installer credential, then builds the package and opens the single-use
+launcher. Its receipt retains only package, runtime-binding and target digests,
+launch state and created-object count. Wiring all private factory inputs into
+the full-run CLI/Job activation remains the next prerequisite before a
+complete fresh run.
 
 Fresh-Run v3 now also has one fail-closed offline image/package correlation
 boundary:
@@ -3583,7 +3589,7 @@ durable receipts. This is not yet the OK-147 Definition of Done:
 - the independent-evidence collector has an exact private package replay,
   non-authorizing installation plan and single-use workload-cluster launcher;
   the Stage-7-to-Stage-8 handoff now has an ordered fail-closed activator seam,
-  while its concrete package/launcher factory remains explicit;
+  and its concrete package/launcher factory is single-use and runtime-bound;
 - the standalone Stage-12 launcher has not yet been executed as part of the
   complete predecessor-bound stage chain;
 - the current staged-library source is published as the immutable multi-platform
@@ -3606,8 +3612,8 @@ private `0600` files with the binding last. It has no list, watch, discovery,
 Kubernetes mutation, retry or cleanup surface. The verified full-run manifest
 now opens that materializer, all concrete Stage 1-12 adapters and the shared
 single-execution Platform capability session without contacting a cluster.
-The remaining implementation work is the concrete post-prefix factory that
-builds and installs the verified collector after Stage 7; Stage 8-12 is now
+The remaining implementation work is binding the concrete post-prefix factory
+inputs into the local/Job activation package and CLI. Stage 8-12 is already
 structurally unable to open before that activator succeeds. This is not a new
 controller or reconciliation mechanism.
 After that, live closure must

--- a/internal/runner/observability_collector_post_prefix.go
+++ b/internal/runner/observability_collector_post_prefix.go
@@ -1,0 +1,151 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+const ObservabilityCollectorPostPrefixReceiptFormat = "ok147-observability-collector-post-prefix-receipt/v1"
+
+type ObservabilityCollectorPostPrefixConfig struct {
+	Package   ObservabilityCollectorRuntimePackageConfig
+	Installer KubernetesAuthorityConfig
+	Clock     func() time.Time
+}
+
+type ObservabilityCollectorPostPrefixReceipt struct {
+	Format               string `json:"format"`
+	State                string `json:"state"`
+	PackageDigest        string `json:"packageDigest,omitempty"`
+	RuntimeBindingDigest string `json:"runtimeBindingDigest,omitempty"`
+	TargetIdentityDigest string `json:"targetIdentityDigest,omitempty"`
+	LaunchState          string `json:"launchState,omitempty"`
+	CreatedObjects       int    `json:"createdObjects"`
+}
+
+type observabilityCollectorRuntimeLauncher interface {
+	Launch(context.Context) (ObservabilityCollectorRuntimeLaunchReceipt, error)
+}
+
+// KubernetesObservabilityCollectorPostPrefix builds and installs the exact
+// collector only after the fresh seven-stage prefix exists. It is single-use
+// and retains only a redaction-safe receipt.
+type KubernetesObservabilityCollectorPostPrefix struct {
+	mu      sync.Mutex
+	used    bool
+	config  ObservabilityCollectorPostPrefixConfig
+	receipt ObservabilityCollectorPostPrefixReceipt
+	build   func(ObservabilityCollectorRuntimePackageConfig) (VerifiedObservabilityCollectorRuntimePackage, error)
+	open    func(ObservabilityCollectorRuntimeLauncherConfig, VerifiedObservabilityCollectorRuntimePackage) (observabilityCollectorRuntimeLauncher, error)
+	resolve func(WorkloadAuthorityFileResolverConfig) (WorkloadAuthorityBinding, KubernetesAuthorityConfig, error)
+}
+
+func NewKubernetesObservabilityCollectorPostPrefix(config ObservabilityCollectorPostPrefixConfig) (*KubernetesObservabilityCollectorPostPrefix, error) {
+	if config.Clock == nil || config.Package.Activation.RuntimeBinding.Bundle.PlanPath == "" ||
+		config.Package.Activation.RuntimeBinding.MaterialPath == "" || config.Package.Activation.RuntimeBinding.ReceiptPath == "" ||
+		config.Installer.Endpoint == "" || config.Installer.TokenFile == "" || config.Installer.CAFile == "" ||
+		!stageReceiptPrefixDigestPattern.MatchString(config.Installer.CABundleDigest) {
+		return nil, errors.New("observability collector post-prefix configuration is incomplete")
+	}
+	return &KubernetesObservabilityCollectorPostPrefix{
+		config:  config,
+		receipt: ObservabilityCollectorPostPrefixReceipt{Format: ObservabilityCollectorPostPrefixReceiptFormat, State: "PREPARED"},
+		build:   BuildObservabilityCollectorRuntimePackage,
+		open: func(config ObservabilityCollectorRuntimeLauncherConfig, packaged VerifiedObservabilityCollectorRuntimePackage) (observabilityCollectorRuntimeLauncher, error) {
+			return OpenKubernetesObservabilityCollectorRuntimeLauncher(config, packaged)
+		},
+		resolve: loadWorkloadAuthorityFiles,
+	}, nil
+}
+
+func (activation *KubernetesObservabilityCollectorPostPrefix) ActivateFullRunPostPrefix(ctx context.Context, prefix FullRunPostPrefixActivation) error {
+	if activation == nil {
+		return errors.New("observability collector post-prefix activation is required")
+	}
+	activation.mu.Lock()
+	if activation.used {
+		activation.mu.Unlock()
+		return errors.New("observability collector post-prefix activation is single-use")
+	}
+	activation.used = true
+	activation.mu.Unlock()
+	if err := ctx.Err(); err != nil || len(prefix.ReceiptPrefix) != len(preRuntimeStageOrder) ||
+		!stageReceiptPrefixDigestPattern.MatchString(prefix.TargetIdentity) {
+		activation.stop()
+		return errors.New("observability collector post-prefix binding is invalid")
+	}
+	binding, authority, err := activation.resolve(prefix.Workload)
+	if err != nil || digest.SHA256([]byte(binding.TargetClusterUID)) != prefix.TargetIdentity ||
+		authority.Endpoint != activation.config.Installer.Endpoint || authority.CABundleDigest != activation.config.Installer.CABundleDigest ||
+		prefix.Workload.CAFile != activation.config.Package.Activation.ObserverCredential.CAFile ||
+		activation.config.Installer.TokenFile == activation.config.Package.Activation.ObserverCredential.TokenFile {
+		activation.stop()
+		return errors.New("observability collector installer differs from runtime workload authority")
+	}
+	packageConfig := activation.config.Package
+	packageConfig.Activation.RuntimeBinding.Bundle.Receipts = append([]StageReceiptSource(nil), prefix.ReceiptPrefix[:6]...)
+	packageConfig.Activation.MaterializationTime = activation.config.Clock().UTC().Truncate(time.Second)
+	packageConfig.Activation.ObserverCredential.AuthorityIdentity = prefix.TargetIdentity
+	packaged, err := activation.build(packageConfig)
+	if err != nil {
+		activation.stop()
+		return errors.New("build observability collector post-prefix package")
+	}
+	packageReceipt, err := packaged.Receipt()
+	if err != nil {
+		activation.stop()
+		return errors.New("verify observability collector post-prefix package")
+	}
+	plan, err := PlanObservabilityCollectorRuntimeInstallation(packaged)
+	if err != nil || plan.TargetIdentityDigest != prefix.TargetIdentity || plan.RuntimeBindingDigest != packageReceipt.RuntimeBindingDigest {
+		activation.stop()
+		return errors.New("observability collector package differs from fresh runtime prefix")
+	}
+	installer := activation.config.Installer
+	installer.AuthorityIdentity = prefix.TargetIdentity
+	launcher, err := activation.open(ObservabilityCollectorRuntimeLauncherConfig{
+		Authority: installer, ExpectedPackageDigest: packageReceipt.PackageDigest,
+	}, packaged)
+	if err != nil {
+		activation.stop()
+		return errors.New("open observability collector post-prefix launcher")
+	}
+	launchReceipt, err := launcher.Launch(ctx)
+	activation.mu.Lock()
+	activation.receipt.PackageDigest = packageReceipt.PackageDigest
+	activation.receipt.RuntimeBindingDigest = packageReceipt.RuntimeBindingDigest
+	activation.receipt.TargetIdentityDigest = prefix.TargetIdentity
+	activation.receipt.LaunchState = launchReceipt.State
+	activation.receipt.CreatedObjects = len(launchReceipt.Results)
+	if err == nil && launchReceipt.State == "ACTIVATED" && len(launchReceipt.Results) == 4 {
+		activation.receipt.State = "ACTIVATED"
+	} else {
+		activation.receipt.State = "STOPPED"
+	}
+	activation.mu.Unlock()
+	if err != nil || launchReceipt.State != "ACTIVATED" || len(launchReceipt.Results) != 4 {
+		return errors.New("activate observability collector post-prefix package")
+	}
+	return nil
+}
+
+func (activation *KubernetesObservabilityCollectorPostPrefix) Receipt() ObservabilityCollectorPostPrefixReceipt {
+	if activation == nil {
+		return ObservabilityCollectorPostPrefixReceipt{Format: ObservabilityCollectorPostPrefixReceiptFormat, State: "STOPPED"}
+	}
+	activation.mu.Lock()
+	defer activation.mu.Unlock()
+	return activation.receipt
+}
+
+func (activation *KubernetesObservabilityCollectorPostPrefix) stop() {
+	activation.mu.Lock()
+	activation.receipt.State = "STOPPED"
+	activation.mu.Unlock()
+}
+
+var _ FullRunPostPrefixActivator = (*KubernetesObservabilityCollectorPostPrefix)(nil)

--- a/internal/runner/observability_collector_post_prefix_test.go
+++ b/internal/runner/observability_collector_post_prefix_test.go
@@ -1,0 +1,111 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+type fakeCollectorRuntimeLauncher struct {
+	receipt ObservabilityCollectorRuntimeLaunchReceipt
+	err     error
+	calls   int
+}
+
+func (launcher *fakeCollectorRuntimeLauncher) Launch(context.Context) (ObservabilityCollectorRuntimeLaunchReceipt, error) {
+	launcher.calls++
+	return launcher.receipt, launcher.err
+}
+
+func TestObservabilityCollectorPostPrefixBuildsAndLaunchesFreshBindingOnce(t *testing.T) {
+	config := observabilityCollectorRuntimePackageFixture(t)
+	packaged, err := BuildObservabilityCollectorRuntimePackage(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	packageReceipt, _ := packaged.Receipt()
+	target := digest.SHA256([]byte("collector-target-cluster-uid"))
+	installerToken := writeBundleFile(t, t.TempDir(), "installer-token", []byte("distinct-installer-token"))
+	activator, err := NewKubernetesObservabilityCollectorPostPrefix(ObservabilityCollectorPostPrefixConfig{
+		Package: config, Installer: KubernetesAuthorityConfig{
+			Endpoint: "https://192.0.2.147:6443", TokenFile: installerToken,
+			CAFile: config.Activation.ObserverCredential.CAFile, CABundleDigest: config.Activation.ObserverCredential.CABundleDigest,
+		}, Clock: func() time.Time { return config.Activation.MaterializationTime },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	buildCalls, openCalls := 0, 0
+	launcher := &fakeCollectorRuntimeLauncher{receipt: ObservabilityCollectorRuntimeLaunchReceipt{
+		Format: ObservabilityCollectorRuntimeLaunchReceiptFormat, State: "ACTIVATED",
+		Results: make([]SubmissionStageInstalledObject, 4),
+	}}
+	activator.build = func(received ObservabilityCollectorRuntimePackageConfig) (VerifiedObservabilityCollectorRuntimePackage, error) {
+		buildCalls++
+		if len(received.Activation.RuntimeBinding.Bundle.Receipts) != 6 || received.Activation.ObserverCredential.AuthorityIdentity != target {
+			t.Fatalf("fresh prefix was not bound into package: %#v", received.Activation)
+		}
+		return packaged, nil
+	}
+	activator.resolve = func(WorkloadAuthorityFileResolverConfig) (WorkloadAuthorityBinding, KubernetesAuthorityConfig, error) {
+		return WorkloadAuthorityBinding{TargetClusterUID: "collector-target-cluster-uid"}, KubernetesAuthorityConfig{
+			Endpoint: "https://192.0.2.147:6443", CABundleDigest: config.Activation.ObserverCredential.CABundleDigest,
+		}, nil
+	}
+	activator.open = func(received ObservabilityCollectorRuntimeLauncherConfig, value VerifiedObservabilityCollectorRuntimePackage) (observabilityCollectorRuntimeLauncher, error) {
+		openCalls++
+		if received.ExpectedPackageDigest != packageReceipt.PackageDigest || received.Authority.AuthorityIdentity != target {
+			t.Fatalf("launcher identity differs: %#v", received)
+		}
+		return launcher, nil
+	}
+	prefix := FullRunPostPrefixActivation{
+		ReceiptPrefix: make([]StageReceiptSource, 7), TargetIdentity: target,
+		Workload: WorkloadAuthorityFileResolverConfig{CAFile: config.Activation.ObserverCredential.CAFile},
+	}
+	if err := activator.ActivateFullRunPostPrefix(context.Background(), prefix); err != nil {
+		t.Fatal(err)
+	}
+	receipt := activator.Receipt()
+	if receipt.State != "ACTIVATED" || receipt.PackageDigest != packageReceipt.PackageDigest || receipt.CreatedObjects != 4 ||
+		buildCalls != 1 || openCalls != 1 || launcher.calls != 1 {
+		t.Fatalf("unexpected post-prefix receipt: %#v calls=%d/%d/%d", receipt, buildCalls, openCalls, launcher.calls)
+	}
+	if err := activator.ActivateFullRunPostPrefix(context.Background(), prefix); err == nil || buildCalls != 1 || launcher.calls != 1 {
+		t.Fatal("post-prefix activation was replayed")
+	}
+}
+
+func TestObservabilityCollectorPostPrefixStopsBeforeBuildOnForeignRuntime(t *testing.T) {
+	config := observabilityCollectorRuntimePackageFixture(t)
+	installerToken := writeBundleFile(t, t.TempDir(), "installer-token", []byte("distinct-installer-token"))
+	activator, err := NewKubernetesObservabilityCollectorPostPrefix(ObservabilityCollectorPostPrefixConfig{
+		Package: config, Installer: KubernetesAuthorityConfig{
+			Endpoint: "https://192.0.2.147:6443", TokenFile: installerToken,
+			CAFile: config.Activation.ObserverCredential.CAFile, CABundleDigest: config.Activation.ObserverCredential.CABundleDigest,
+		}, Clock: func() time.Time { return config.Activation.MaterializationTime },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	buildCalls := 0
+	activator.build = func(ObservabilityCollectorRuntimePackageConfig) (VerifiedObservabilityCollectorRuntimePackage, error) {
+		buildCalls++
+		return VerifiedObservabilityCollectorRuntimePackage{}, errors.New("must not build")
+	}
+	activator.resolve = func(WorkloadAuthorityFileResolverConfig) (WorkloadAuthorityBinding, KubernetesAuthorityConfig, error) {
+		return WorkloadAuthorityBinding{TargetClusterUID: "foreign-target"}, KubernetesAuthorityConfig{
+			Endpoint: "https://192.0.2.147:6443", CABundleDigest: config.Activation.ObserverCredential.CABundleDigest,
+		}, nil
+	}
+	err = activator.ActivateFullRunPostPrefix(context.Background(), FullRunPostPrefixActivation{
+		ReceiptPrefix: make([]StageReceiptSource, 7), TargetIdentity: digest.SHA256([]byte("collector-target-cluster-uid")),
+		Workload: WorkloadAuthorityFileResolverConfig{CAFile: config.Activation.ObserverCredential.CAFile},
+	})
+	if err == nil || buildCalls != 0 || activator.Receipt().State != "STOPPED" {
+		t.Fatalf("foreign runtime reached package build: calls=%d receipt=%#v err=%v", buildCalls, activator.Receipt(), err)
+	}
+}


### PR DESCRIPTION
## Outcome

Adds the concrete single-use collector factory behind the Stage-7 post-prefix seam.

- consumes the exact seven-receipt private prefix
- replays the first six receipts into runtime-binding verification
- correlates target UID digest, workload API endpoint and CA
- requires a distinct installer token
- builds the four-object collector package only after fresh runtime binding
- opens the existing exact create-only launcher
- retains only a redaction-safe activation receipt
- stops before Stage 8 on any mismatch or partial launch

No Kubernetes API was contacted by this checkpoint.

## Verification

- full Go test suite passed
- go vet passed
- runner race test passed
