### PR TITLE
feat(runner): issue collector installer credential in memory

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -3162,12 +3162,27 @@ context, and cannot open Stage 8 until activation returns successfully. The
 concrete `KubernetesObservabilityCollectorPostPrefix` factory now consumes
 those fresh inputs. It replays only the first six receipts into runtime-binding
 verification, derives the package materialization time from the run clock,
-requires the target UID digest, workload endpoint and CA to match the distinct
-installer credential, then builds the package and opens the single-use
-launcher. Its receipt retains only package, runtime-binding and target digests,
-launch state and created-object count. Wiring all private factory inputs into
-the full-run CLI/Job activation remains the next prerequisite before a
-complete fresh run.
+and requires the target UID digest and CA to match the lifecycle-derived
+workload authority before building the package.
+
+It no longer accepts a persisted installer-token file. Instead, after package
+and target correlation have passed, a single-use issuer performs exactly one
+30-minute, server-default-audience TokenRequest for
+`openkubes-execution-system/ok147-contract-executor-runtime`. The response must
+carry the exact ServiceAccount subject, audience set, expiry and bounded
+lifetime. The token is retained only in process memory and is handed directly
+to the existing single-use collector launcher. The redacted receipt exposes
+only target, ServiceAccount, request and CA digests plus timestamps; no token,
+CA, endpoint, kubeconfig or source path is retained.
+
+The live composition remains fail-closed until the workload-side runtime
+ServiceAccount and its exact collector create permissions are themselves
+projected and installed by a separately verified boundary. The existing
+Stage-7 target-access artifact does not currently contain that prerequisite;
+credential issuance therefore cannot be mistaken for runtime authorization.
+Wiring that exact prerequisite package and all private factory inputs into the
+full-run CLI/Job activation remains the next prerequisite before a complete
+fresh run.
 
 Fresh-Run v3 now also has one fail-closed offline image/package correlation
 boundary:

--- a/internal/runner/observability_collector_installer_credential.go
+++ b/internal/runner/observability_collector_installer_credential.go
@@ -1,0 +1,319 @@
+package runner
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/jsonstrict"
+)
+
+const (
+	ObservabilityCollectorInstallerCredentialReceiptFormat = "ok147-observability-collector-installer-credential-receipt/v1"
+	observabilityCollectorInstallerNamespace               = "openkubes-execution-system"
+	observabilityCollectorInstallerServiceAccount          = "ok147-contract-executor-runtime"
+	observabilityCollectorInstallerLifetime                = 30 * time.Minute
+	minimumObservabilityCollectorInstallerLifetime         = 25 * time.Minute
+)
+
+type ObservabilityCollectorInstallerCredentialConfig struct {
+	Workload             WorkloadAuthorityFileResolverConfig
+	ExpectedTargetDigest string
+	Clock                func() time.Time
+}
+
+type ObservabilityCollectorInstallerCredentialReceipt struct {
+	Format                       string `json:"format"`
+	State                        string `json:"state"`
+	TargetIdentityDigest         string `json:"targetIdentityDigest"`
+	ServiceAccountIdentityDigest string `json:"serviceAccountIdentityDigest"`
+	RequestDigest                string `json:"requestDigest"`
+	CABundleDigest               string `json:"caBundleDigest"`
+	AudienceMode                 string `json:"audienceMode"`
+	IssuedAt                     string `json:"issuedAt"`
+	ExpiresAt                    string `json:"expiresAt"`
+	LifetimeSeconds              int64  `json:"lifetimeSeconds"`
+	CredentialBytesInReceipt     bool   `json:"credentialBytesInReceipt"`
+	MutationState                string `json:"mutationState"`
+}
+
+type VerifiedObservabilityCollectorInstallerCredential struct {
+	token          []byte
+	endpoint       string
+	targetIdentity string
+	caBundleDigest string
+	client         *http.Client
+	expiresAt      time.Time
+	privateDigest  string
+	receipt        ObservabilityCollectorInstallerCredentialReceipt
+	verified       bool
+}
+
+type observabilityCollectorInstallerPrivateBinding struct {
+	Token          []byte `json:"token"`
+	Endpoint       string `json:"endpoint"`
+	TargetIdentity string `json:"targetIdentity"`
+	CABundleDigest string `json:"caBundleDigest"`
+	ExpiresAt      string `json:"expiresAt"`
+}
+
+type observabilityCollectorInstallerClientConfig struct {
+	Endpoint          string
+	BearerToken       string
+	ClientCertificate bool
+	CABundle          []byte
+	CABundleDigest    string
+	TargetIdentity    string
+	Client            *http.Client
+	Clock             func() time.Time
+}
+
+// KubernetesObservabilityCollectorInstallerCredentialIssuer performs one
+// exact TokenRequest after Stage 7. The resulting workload credential is held
+// only in memory for the immediately following collector launch.
+type KubernetesObservabilityCollectorInstallerCredentialIssuer struct {
+	mu                sync.Mutex
+	used              bool
+	endpoint          *url.URL
+	authorityToken    string
+	clientCertificate bool
+	caBundleDigest    string
+	targetIdentity    string
+	client            *http.Client
+	clock             func() time.Time
+	request           []byte
+}
+
+func OpenKubernetesObservabilityCollectorInstallerCredentialIssuer(config ObservabilityCollectorInstallerCredentialConfig) (*KubernetesObservabilityCollectorInstallerCredentialIssuer, error) {
+	if config.Clock == nil || !stageReceiptPrefixDigestPattern.MatchString(config.ExpectedTargetDigest) {
+		return nil, errors.New("collector installer credential binding is incomplete")
+	}
+	binding, authority, err := loadWorkloadAuthorityFiles(config.Workload)
+	if err != nil || digest.SHA256([]byte(binding.TargetClusterUID)) != config.ExpectedTargetDigest {
+		return nil, errors.New("collector installer credential differs from runtime workload authority")
+	}
+	transport, err := openBoundedKubernetesAuthorityTransport(authority)
+	if err != nil || digest.SHA256(transport.caData) != authority.CABundleDigest {
+		return nil, errors.New("open bounded collector installer issuance authority")
+	}
+	return newKubernetesObservabilityCollectorInstallerCredentialIssuer(observabilityCollectorInstallerClientConfig{
+		Endpoint: authority.Endpoint, BearerToken: transport.bearerToken, ClientCertificate: transport.clientCertificate,
+		CABundle: transport.caData, CABundleDigest: authority.CABundleDigest,
+		TargetIdentity: config.ExpectedTargetDigest, Client: transport.client, Clock: config.Clock,
+	})
+}
+
+func newKubernetesObservabilityCollectorInstallerCredentialIssuer(config observabilityCollectorInstallerClientConfig) (*KubernetesObservabilityCollectorInstallerCredentialIssuer, error) {
+	endpoint, err := normalizeSubmissionStageLaunchEndpoint(config.Endpoint)
+	if err != nil {
+		return nil, errors.New("collector installer credential endpoint is invalid")
+	}
+	tokenMode := config.BearerToken != ""
+	if tokenMode == config.ClientCertificate || strings.TrimSpace(config.BearerToken) != config.BearerToken ||
+		strings.ContainsAny(config.BearerToken, "\r\n") || len(config.CABundle) == 0 ||
+		digest.SHA256(config.CABundle) != config.CABundleDigest || !stageReceiptPrefixDigestPattern.MatchString(config.TargetIdentity) ||
+		config.Client == nil || config.Clock == nil {
+		return nil, errors.New("collector installer issuance authority is invalid")
+	}
+	requestRaw, err := json.Marshal(targetCredentialTokenRequest{
+		APIVersion: "authentication.k8s.io/v1", Kind: "TokenRequest",
+		Spec: targetCredentialTokenRequestSpec{ExpirationSeconds: int64(observabilityCollectorInstallerLifetime / time.Second)},
+	})
+	if err != nil {
+		return nil, errors.New("encode collector installer TokenRequest")
+	}
+	parsed, err := url.Parse(endpoint)
+	if err != nil {
+		return nil, errors.New("parse collector installer credential endpoint")
+	}
+	client := *config.Client
+	client.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+	if client.Timeout == 0 {
+		client.Timeout = 15 * time.Second
+	}
+	return &KubernetesObservabilityCollectorInstallerCredentialIssuer{
+		endpoint: parsed, authorityToken: config.BearerToken, clientCertificate: config.ClientCertificate,
+		caBundleDigest: config.CABundleDigest, targetIdentity: config.TargetIdentity,
+		client: &client, clock: config.Clock, request: requestRaw,
+	}, nil
+}
+
+func (issuer *KubernetesObservabilityCollectorInstallerCredentialIssuer) Issue(ctx context.Context) (VerifiedObservabilityCollectorInstallerCredential, error) {
+	if issuer == nil || issuer.client == nil || issuer.clock == nil {
+		return VerifiedObservabilityCollectorInstallerCredential{}, errors.New("collector installer credential issuer is required")
+	}
+	issuer.mu.Lock()
+	if issuer.used {
+		issuer.mu.Unlock()
+		return VerifiedObservabilityCollectorInstallerCredential{}, errors.New("collector installer credential issuer is single-use")
+	}
+	issuer.used = true
+	issuer.mu.Unlock()
+
+	now := issuer.clock().UTC().Truncate(time.Second)
+	requestURL := *issuer.endpoint
+	requestURL.Path = fmt.Sprintf("/api/v1/namespaces/%s/serviceaccounts/%s/token", observabilityCollectorInstallerNamespace, observabilityCollectorInstallerServiceAccount)
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, requestURL.String(), bytes.NewReader(issuer.request))
+	if err != nil {
+		return VerifiedObservabilityCollectorInstallerCredential{}, errors.New("construct collector installer TokenRequest")
+	}
+	request.Header.Set("Accept", "application/json")
+	request.Header.Set("Content-Type", "application/json")
+	if !issuer.clientCertificate {
+		request.Header.Set("Authorization", "Bearer "+issuer.authorityToken)
+	}
+	response, err := issuer.client.Do(request)
+	if err != nil {
+		return VerifiedObservabilityCollectorInstallerCredential{}, errors.New("collector installer TokenRequest failed")
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusCreated {
+		_, _ = io.Copy(io.Discard, io.LimitReader(response.Body, maximumTargetCredentialResponse))
+		return VerifiedObservabilityCollectorInstallerCredential{}, errors.New("collector installer TokenRequest was not created")
+	}
+	mediaType, _, err := mime.ParseMediaType(response.Header.Get("Content-Type"))
+	if err != nil || mediaType != "application/json" {
+		return VerifiedObservabilityCollectorInstallerCredential{}, errors.New("collector installer TokenRequest response media type is invalid")
+	}
+	raw, err := io.ReadAll(io.LimitReader(response.Body, maximumTargetCredentialResponse+1))
+	if err != nil || len(raw) == 0 || len(raw) > maximumTargetCredentialResponse {
+		return VerifiedObservabilityCollectorInstallerCredential{}, errors.New("read bounded collector installer TokenRequest response")
+	}
+	var value targetCredentialTokenResponse
+	if err := jsonstrict.Decode(raw, &value); err != nil {
+		return VerifiedObservabilityCollectorInstallerCredential{}, errors.New("decode collector installer TokenRequest response")
+	}
+	return issuer.verifyResponse(value, now)
+}
+
+func (issuer *KubernetesObservabilityCollectorInstallerCredentialIssuer) verifyResponse(value targetCredentialTokenResponse, now time.Time) (VerifiedObservabilityCollectorInstallerCredential, error) {
+	if value.APIVersion != "authentication.k8s.io/v1" || value.Kind != "TokenRequest" || len(value.Status.Token) < 80 ||
+		strings.TrimSpace(value.Status.Token) != value.Status.Token || strings.ContainsAny(value.Status.Token, "\r\n") ||
+		value.Spec.ExpirationSeconds != int64(observabilityCollectorInstallerLifetime/time.Second) || len(value.Spec.Audiences) == 0 {
+		return VerifiedObservabilityCollectorInstallerCredential{}, errors.New("collector installer TokenRequest response is invalid")
+	}
+	expiresAt, err := time.Parse(time.RFC3339, value.Status.ExpirationTimestamp)
+	if err != nil {
+		return VerifiedObservabilityCollectorInstallerCredential{}, errors.New("collector installer credential expiration is invalid")
+	}
+	lifetime := expiresAt.Sub(now)
+	if lifetime < minimumObservabilityCollectorInstallerLifetime || lifetime > observabilityCollectorInstallerLifetime {
+		return VerifiedObservabilityCollectorInstallerCredential{}, errors.New("collector installer credential lifetime is outside the bounded window")
+	}
+	claims, err := decodeTargetCredentialClaims(value.Status.Token)
+	if err != nil {
+		return VerifiedObservabilityCollectorInstallerCredential{}, errors.New("decode collector installer credential claims")
+	}
+	exp, err := claims.Expires.Int64()
+	wantSubject := "system:serviceaccount:" + observabilityCollectorInstallerNamespace + ":" + observabilityCollectorInstallerServiceAccount
+	if err != nil || claims.Subject != wantSubject || exp != expiresAt.Unix() || !exactTokenAudienceBinding(claims.Audience, value.Spec.Audiences) {
+		return VerifiedObservabilityCollectorInstallerCredential{}, errors.New("collector installer credential claims differ from bounded identity")
+	}
+	if claims.IssuedAt != "" {
+		iat, err := claims.IssuedAt.Int64()
+		if err != nil || time.Unix(iat, 0).After(now.Add(5*time.Second)) || time.Unix(iat, 0).Before(now.Add(-5*time.Minute)) {
+			return VerifiedObservabilityCollectorInstallerCredential{}, errors.New("collector installer credential issuance claim is invalid")
+		}
+	}
+	serviceAccountIdentity := digest.SHA256([]byte("system:serviceaccount:" + observabilityCollectorInstallerNamespace + ":" + observabilityCollectorInstallerServiceAccount))
+	material := VerifiedObservabilityCollectorInstallerCredential{
+		token: []byte(value.Status.Token), endpoint: issuer.endpoint.String(), targetIdentity: issuer.targetIdentity,
+		caBundleDigest: issuer.caBundleDigest, client: issuer.client, expiresAt: expiresAt.UTC(), verified: true,
+		receipt: ObservabilityCollectorInstallerCredentialReceipt{
+			Format: ObservabilityCollectorInstallerCredentialReceiptFormat, State: "ISSUED",
+			TargetIdentityDigest: issuer.targetIdentity, ServiceAccountIdentityDigest: serviceAccountIdentity,
+			RequestDigest: digest.SHA256(issuer.request), CABundleDigest: issuer.caBundleDigest, AudienceMode: "server-default",
+			IssuedAt: now.Format(time.RFC3339), ExpiresAt: expiresAt.UTC().Format(time.RFC3339),
+			LifetimeSeconds: int64(lifetime / time.Second), CredentialBytesInReceipt: false, MutationState: "ATTEMPTED",
+		},
+	}
+	material.privateDigest, err = observabilityCollectorInstallerPrivateDigest(material)
+	if err != nil {
+		return VerifiedObservabilityCollectorInstallerCredential{}, errors.New("bind private collector installer credential")
+	}
+	return material, nil
+}
+
+func (material VerifiedObservabilityCollectorInstallerCredential) Receipt() (ObservabilityCollectorInstallerCredentialReceipt, error) {
+	privateDigest, err := observabilityCollectorInstallerPrivateDigest(material)
+	if err != nil || privateDigest != material.privateDigest || !stageReceiptPrefixDigestPattern.MatchString(material.privateDigest) ||
+		!material.verified || len(material.token) < 80 || material.endpoint == "" || material.client == nil ||
+		!stageReceiptPrefixDigestPattern.MatchString(material.targetIdentity) || !stageReceiptPrefixDigestPattern.MatchString(material.caBundleDigest) || material.expiresAt.IsZero() ||
+		material.receipt.Format != ObservabilityCollectorInstallerCredentialReceiptFormat || material.receipt.State != "ISSUED" ||
+		material.receipt.TargetIdentityDigest != material.targetIdentity || material.receipt.CABundleDigest != material.caBundleDigest || material.receipt.ExpiresAt != material.expiresAt.UTC().Format(time.RFC3339) ||
+		material.receipt.AudienceMode != "server-default" || material.receipt.CredentialBytesInReceipt || material.receipt.MutationState != "ATTEMPTED" {
+		return ObservabilityCollectorInstallerCredentialReceipt{}, errors.New("collector installer credential was not produced by verification")
+	}
+	for _, value := range []string{material.receipt.TargetIdentityDigest, material.receipt.ServiceAccountIdentityDigest, material.receipt.RequestDigest, material.receipt.CABundleDigest} {
+		if !stageReceiptPrefixDigestPattern.MatchString(value) {
+			return ObservabilityCollectorInstallerCredentialReceipt{}, errors.New("collector installer credential receipt identity is invalid")
+		}
+	}
+	return material.receipt, nil
+}
+
+func (material VerifiedObservabilityCollectorInstallerCredential) launcherConfig() (submissionStageInstallerClientConfig, error) {
+	if _, err := material.Receipt(); err != nil {
+		return submissionStageInstallerClientConfig{}, err
+	}
+	return submissionStageInstallerClientConfig{
+		Endpoint: material.endpoint, BearerToken: string(material.token), AuthorityIdentity: material.targetIdentity, Client: material.client,
+	}, nil
+}
+
+func observabilityCollectorInstallerPrivateDigest(material VerifiedObservabilityCollectorInstallerCredential) (string, error) {
+	raw, err := json.Marshal(observabilityCollectorInstallerPrivateBinding{
+		Token: append([]byte(nil), material.token...), Endpoint: material.endpoint,
+		TargetIdentity: material.targetIdentity, CABundleDigest: material.caBundleDigest,
+		ExpiresAt: material.expiresAt.UTC().Format(time.RFC3339),
+	})
+	if err != nil {
+		return "", err
+	}
+	return digest.SHA256(raw), nil
+}
+
+func exactTokenAudienceBinding(raw json.RawMessage, expected []string) bool {
+	if len(raw) == 0 || bytes.Equal(bytes.TrimSpace(raw), []byte("null")) || len(expected) == 0 {
+		return false
+	}
+	var actual []string
+	if raw[0] == '"' {
+		var one string
+		if json.Unmarshal(raw, &one) != nil || one == "" {
+			return false
+		}
+		actual = []string{one}
+	} else if json.Unmarshal(raw, &actual) != nil || len(actual) == 0 {
+		return false
+	}
+	if len(actual) != len(expected) {
+		return false
+	}
+	seen := make(map[string]struct{}, len(actual))
+	for _, audience := range actual {
+		if audience == "" {
+			return false
+		}
+		if _, exists := seen[audience]; exists {
+			return false
+		}
+		seen[audience] = struct{}{}
+	}
+	for _, audience := range expected {
+		if _, exists := seen[audience]; !exists {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/runner/observability_collector_installer_credential_test.go
+++ b/internal/runner/observability_collector_installer_credential_test.go
@@ -1,0 +1,131 @@
+package runner
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+func TestObservabilityCollectorInstallerCredentialIssuesOnceInMemory(t *testing.T) {
+	now := time.Date(2026, 8, 22, 10, 0, 0, 0, time.UTC)
+	target := digest.SHA256([]byte("collector-installer-target"))
+	ca := []byte("collector-installer-ca")
+	token := targetCredentialTestJWT(t, now, now.Add(observabilityCollectorInstallerLifetime),
+		"system:serviceaccount:"+observabilityCollectorInstallerNamespace+":"+observabilityCollectorInstallerServiceAccount)
+	requests := 0
+	client := &http.Client{Transport: submissionStageLauncherRoundTripFunc(func(request *http.Request) (*http.Response, error) {
+		requests++
+		body, _ := io.ReadAll(request.Body)
+		if request.Method != http.MethodPost || request.URL.Path != "/api/v1/namespaces/openkubes-execution-system/serviceaccounts/ok147-contract-executor-runtime/token" ||
+			request.Header.Get("Authorization") != "Bearer workload-admin" || request.Header.Get("Content-Type") != "application/json" ||
+			bytes.Contains(body, []byte("audiences")) {
+			t.Fatalf("unexpected collector installer TokenRequest: %s %s %s", request.Method, request.URL.Path, body)
+		}
+		var requested targetCredentialTokenRequest
+		if err := json.Unmarshal(body, &requested); err != nil || requested.Spec.ExpirationSeconds != 1800 || len(requested.Spec.Audiences) != 0 {
+			t.Fatalf("unexpected TokenRequest body: %#v %v", requested, err)
+		}
+		return targetCredentialTestResponse(http.StatusCreated, map[string]any{
+			"apiVersion": "authentication.k8s.io/v1", "kind": "TokenRequest", "metadata": map[string]any{},
+			"spec":   map[string]any{"audiences": []string{"https://kubernetes.default.svc"}, "expirationSeconds": 1800},
+			"status": map[string]any{"token": token, "expirationTimestamp": now.Add(observabilityCollectorInstallerLifetime).Format(time.RFC3339)},
+		}), nil
+	})}
+	issuer, err := newKubernetesObservabilityCollectorInstallerCredentialIssuer(observabilityCollectorInstallerClientConfig{
+		Endpoint: "https://127.0.0.1:12345", BearerToken: "workload-admin", CABundle: ca, CABundleDigest: digest.SHA256(ca),
+		TargetIdentity: target, Client: client, Clock: func() time.Time { return now },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	material, err := issuer.Issue(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := material.Receipt()
+	if err != nil || receipt.Format != ObservabilityCollectorInstallerCredentialReceiptFormat || receipt.State != "ISSUED" ||
+		receipt.TargetIdentityDigest != target || receipt.CABundleDigest != digest.SHA256(ca) || receipt.AudienceMode != "server-default" ||
+		receipt.LifetimeSeconds != 1800 || receipt.CredentialBytesInReceipt || receipt.MutationState != "ATTEMPTED" || requests != 1 {
+		t.Fatalf("unexpected collector installer credential receipt: %#v requests=%d err=%v", receipt, requests, err)
+	}
+	launcher, err := material.launcherConfig()
+	if err != nil || launcher.BearerToken != token || launcher.Endpoint != "https://127.0.0.1:12345" || launcher.AuthorityIdentity != target || launcher.Client == nil {
+		t.Fatalf("private collector installer credential was not retained in memory: %#v %v", launcher, err)
+	}
+	public, _ := json.Marshal(receipt)
+	if bytes.Contains(public, []byte(token)) || bytes.Contains(public, []byte("workload-admin")) || bytes.Contains(public, ca) {
+		t.Fatal("collector installer credential receipt exposed private material")
+	}
+	if _, err := issuer.Issue(context.Background()); err == nil || requests != 1 {
+		t.Fatal("single-use collector installer credential issuer retried")
+	}
+}
+
+func TestObservabilityCollectorInstallerCredentialFailsClosed(t *testing.T) {
+	now := time.Date(2026, 8, 22, 10, 0, 0, 0, time.UTC)
+	target := digest.SHA256([]byte("collector-installer-target"))
+	ca := []byte("collector-installer-ca")
+	tests := map[string]struct {
+		subject   string
+		expires   time.Time
+		audiences []string
+		status    int
+	}{
+		"foreign subject":  {subject: "system:serviceaccount:openkubes-execution-system:foreign", expires: now.Add(30 * time.Minute), audiences: []string{"default"}, status: http.StatusCreated},
+		"short lifetime":   {subject: "system:serviceaccount:openkubes-execution-system:ok147-contract-executor-runtime", expires: now.Add(10 * time.Minute), audiences: []string{"default"}, status: http.StatusCreated},
+		"missing audience": {subject: "system:serviceaccount:openkubes-execution-system:ok147-contract-executor-runtime", expires: now.Add(30 * time.Minute), audiences: []string{}, status: http.StatusCreated},
+		"foreign audience": {subject: "system:serviceaccount:openkubes-execution-system:ok147-contract-executor-runtime", expires: now.Add(30 * time.Minute), audiences: []string{"foreign"}, status: http.StatusCreated},
+		"wrong status":     {subject: "system:serviceaccount:openkubes-execution-system:ok147-contract-executor-runtime", expires: now.Add(30 * time.Minute), audiences: []string{"default"}, status: http.StatusForbidden},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			token := targetCredentialTestJWT(t, now, test.expires, test.subject)
+			client := &http.Client{Transport: submissionStageLauncherRoundTripFunc(func(*http.Request) (*http.Response, error) {
+				return targetCredentialTestResponse(test.status, map[string]any{
+					"apiVersion": "authentication.k8s.io/v1", "kind": "TokenRequest", "metadata": map[string]any{},
+					"spec":   map[string]any{"audiences": test.audiences, "expirationSeconds": 1800},
+					"status": map[string]any{"token": token, "expirationTimestamp": test.expires.Format(time.RFC3339)},
+				}), nil
+			})}
+			issuer, err := newKubernetesObservabilityCollectorInstallerCredentialIssuer(observabilityCollectorInstallerClientConfig{
+				Endpoint: "https://127.0.0.1:12345", BearerToken: "workload-admin", CABundle: ca, CABundleDigest: digest.SHA256(ca),
+				TargetIdentity: target, Client: client, Clock: func() time.Time { return now },
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := issuer.Issue(context.Background()); err == nil {
+				t.Fatal("invalid collector installer credential response was accepted")
+			}
+		})
+	}
+	if _, err := (VerifiedObservabilityCollectorInstallerCredential{}).Receipt(); err == nil {
+		t.Fatal("unverified collector installer credential exposed receipt")
+	}
+}
+
+func TestOpenObservabilityCollectorInstallerCredentialIssuerBindsRuntimeTarget(t *testing.T) {
+	fixture := targetCredentialBundleFixture(t)
+	runtime := targetAccessRuntime(t, fixture.plan)
+	binding, err := loadWorkloadAuthorityBinding(runtime.Workload.Path, runtime.Workload.ExpectedBindingDigest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	target := digest.SHA256([]byte(binding.TargetClusterUID))
+	if _, err := OpenKubernetesObservabilityCollectorInstallerCredentialIssuer(ObservabilityCollectorInstallerCredentialConfig{
+		Workload: runtime.Workload, ExpectedTargetDigest: target, Clock: time.Now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := OpenKubernetesObservabilityCollectorInstallerCredentialIssuer(ObservabilityCollectorInstallerCredentialConfig{
+		Workload: runtime.Workload, ExpectedTargetDigest: digest.SHA256([]byte("foreign")), Clock: time.Now,
+	}); err == nil {
+		t.Fatal("foreign runtime target opened collector installer credential issuer")
+	}
+}

--- a/internal/runner/observability_collector_post_prefix.go
+++ b/internal/runner/observability_collector_post_prefix.go
@@ -2,6 +2,7 @@ package runner
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"sync"
 	"time"
@@ -12,19 +13,19 @@ import (
 const ObservabilityCollectorPostPrefixReceiptFormat = "ok147-observability-collector-post-prefix-receipt/v1"
 
 type ObservabilityCollectorPostPrefixConfig struct {
-	Package   ObservabilityCollectorRuntimePackageConfig
-	Installer KubernetesAuthorityConfig
-	Clock     func() time.Time
+	Package ObservabilityCollectorRuntimePackageConfig
+	Clock   func() time.Time
 }
 
 type ObservabilityCollectorPostPrefixReceipt struct {
-	Format               string `json:"format"`
-	State                string `json:"state"`
-	PackageDigest        string `json:"packageDigest,omitempty"`
-	RuntimeBindingDigest string `json:"runtimeBindingDigest,omitempty"`
-	TargetIdentityDigest string `json:"targetIdentityDigest,omitempty"`
-	LaunchState          string `json:"launchState,omitempty"`
-	CreatedObjects       int    `json:"createdObjects"`
+	Format                  string `json:"format"`
+	State                   string `json:"state"`
+	PackageDigest           string `json:"packageDigest,omitempty"`
+	RuntimeBindingDigest    string `json:"runtimeBindingDigest,omitempty"`
+	TargetIdentityDigest    string `json:"targetIdentityDigest,omitempty"`
+	CredentialReceiptDigest string `json:"credentialReceiptDigest,omitempty"`
+	LaunchState             string `json:"launchState,omitempty"`
+	CreatedObjects          int    `json:"createdObjects"`
 }
 
 type observabilityCollectorRuntimeLauncher interface {
@@ -40,23 +41,31 @@ type KubernetesObservabilityCollectorPostPrefix struct {
 	config  ObservabilityCollectorPostPrefixConfig
 	receipt ObservabilityCollectorPostPrefixReceipt
 	build   func(ObservabilityCollectorRuntimePackageConfig) (VerifiedObservabilityCollectorRuntimePackage, error)
-	open    func(ObservabilityCollectorRuntimeLauncherConfig, VerifiedObservabilityCollectorRuntimePackage) (observabilityCollectorRuntimeLauncher, error)
+	issue   func(context.Context, ObservabilityCollectorInstallerCredentialConfig) (VerifiedObservabilityCollectorInstallerCredential, error)
+	open    func(submissionStageInstallerClientConfig, VerifiedObservabilityCollectorRuntimePackage) (observabilityCollectorRuntimeLauncher, error)
 	resolve func(WorkloadAuthorityFileResolverConfig) (WorkloadAuthorityBinding, KubernetesAuthorityConfig, error)
 }
 
 func NewKubernetesObservabilityCollectorPostPrefix(config ObservabilityCollectorPostPrefixConfig) (*KubernetesObservabilityCollectorPostPrefix, error) {
 	if config.Clock == nil || config.Package.Activation.RuntimeBinding.Bundle.PlanPath == "" ||
 		config.Package.Activation.RuntimeBinding.MaterialPath == "" || config.Package.Activation.RuntimeBinding.ReceiptPath == "" ||
-		config.Installer.Endpoint == "" || config.Installer.TokenFile == "" || config.Installer.CAFile == "" ||
-		!stageReceiptPrefixDigestPattern.MatchString(config.Installer.CABundleDigest) {
+		config.Package.Activation.ObserverCredential.CAFile == "" ||
+		!stageReceiptPrefixDigestPattern.MatchString(config.Package.Activation.ObserverCredential.CABundleDigest) {
 		return nil, errors.New("observability collector post-prefix configuration is incomplete")
 	}
 	return &KubernetesObservabilityCollectorPostPrefix{
 		config:  config,
 		receipt: ObservabilityCollectorPostPrefixReceipt{Format: ObservabilityCollectorPostPrefixReceiptFormat, State: "PREPARED"},
 		build:   BuildObservabilityCollectorRuntimePackage,
-		open: func(config ObservabilityCollectorRuntimeLauncherConfig, packaged VerifiedObservabilityCollectorRuntimePackage) (observabilityCollectorRuntimeLauncher, error) {
-			return OpenKubernetesObservabilityCollectorRuntimeLauncher(config, packaged)
+		issue: func(ctx context.Context, config ObservabilityCollectorInstallerCredentialConfig) (VerifiedObservabilityCollectorInstallerCredential, error) {
+			issuer, err := OpenKubernetesObservabilityCollectorInstallerCredentialIssuer(config)
+			if err != nil {
+				return VerifiedObservabilityCollectorInstallerCredential{}, err
+			}
+			return issuer.Issue(ctx)
+		},
+		open: func(config submissionStageInstallerClientConfig, packaged VerifiedObservabilityCollectorRuntimePackage) (observabilityCollectorRuntimeLauncher, error) {
+			return newKubernetesObservabilityCollectorRuntimeLauncher(config, packaged)
 		},
 		resolve: loadWorkloadAuthorityFiles,
 	}, nil
@@ -80,9 +89,8 @@ func (activation *KubernetesObservabilityCollectorPostPrefix) ActivateFullRunPos
 	}
 	binding, authority, err := activation.resolve(prefix.Workload)
 	if err != nil || digest.SHA256([]byte(binding.TargetClusterUID)) != prefix.TargetIdentity ||
-		authority.Endpoint != activation.config.Installer.Endpoint || authority.CABundleDigest != activation.config.Installer.CABundleDigest ||
-		prefix.Workload.CAFile != activation.config.Package.Activation.ObserverCredential.CAFile ||
-		activation.config.Installer.TokenFile == activation.config.Package.Activation.ObserverCredential.TokenFile {
+		authority.CABundleDigest != activation.config.Package.Activation.ObserverCredential.CABundleDigest ||
+		prefix.Workload.CAFile != activation.config.Package.Activation.ObserverCredential.CAFile {
 		activation.stop()
 		return errors.New("observability collector installer differs from runtime workload authority")
 	}
@@ -105,11 +113,29 @@ func (activation *KubernetesObservabilityCollectorPostPrefix) ActivateFullRunPos
 		activation.stop()
 		return errors.New("observability collector package differs from fresh runtime prefix")
 	}
-	installer := activation.config.Installer
-	installer.AuthorityIdentity = prefix.TargetIdentity
-	launcher, err := activation.open(ObservabilityCollectorRuntimeLauncherConfig{
-		Authority: installer, ExpectedPackageDigest: packageReceipt.PackageDigest,
-	}, packaged)
+	credential, err := activation.issue(ctx, ObservabilityCollectorInstallerCredentialConfig{
+		Workload: prefix.Workload, ExpectedTargetDigest: prefix.TargetIdentity, Clock: activation.config.Clock,
+	})
+	if err != nil {
+		activation.stop()
+		return errors.New("issue observability collector installer credential")
+	}
+	credentialReceipt, err := credential.Receipt()
+	if err != nil || credentialReceipt.TargetIdentityDigest != prefix.TargetIdentity || credentialReceipt.CABundleDigest != authority.CABundleDigest {
+		activation.stop()
+		return errors.New("verify observability collector installer credential")
+	}
+	credentialReceiptRaw, err := json.Marshal(credentialReceipt)
+	if err != nil {
+		activation.stop()
+		return errors.New("encode observability collector installer credential receipt")
+	}
+	launcherConfig, err := credential.launcherConfig()
+	if err != nil {
+		activation.stop()
+		return errors.New("bind observability collector installer credential")
+	}
+	launcher, err := activation.open(launcherConfig, packaged)
 	if err != nil {
 		activation.stop()
 		return errors.New("open observability collector post-prefix launcher")
@@ -119,6 +145,7 @@ func (activation *KubernetesObservabilityCollectorPostPrefix) ActivateFullRunPos
 	activation.receipt.PackageDigest = packageReceipt.PackageDigest
 	activation.receipt.RuntimeBindingDigest = packageReceipt.RuntimeBindingDigest
 	activation.receipt.TargetIdentityDigest = prefix.TargetIdentity
+	activation.receipt.CredentialReceiptDigest = digest.SHA256(credentialReceiptRaw)
 	activation.receipt.LaunchState = launchReceipt.State
 	activation.receipt.CreatedObjects = len(launchReceipt.Results)
 	if err == nil && launchReceipt.State == "ACTIVATED" && len(launchReceipt.Results) == 4 {

--- a/internal/runner/observability_collector_post_prefix_test.go
+++ b/internal/runner/observability_collector_post_prefix_test.go
@@ -1,8 +1,10 @@
 package runner
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"net/http"
 	"testing"
 	"time"
 
@@ -28,12 +30,8 @@ func TestObservabilityCollectorPostPrefixBuildsAndLaunchesFreshBindingOnce(t *te
 	}
 	packageReceipt, _ := packaged.Receipt()
 	target := digest.SHA256([]byte("collector-target-cluster-uid"))
-	installerToken := writeBundleFile(t, t.TempDir(), "installer-token", []byte("distinct-installer-token"))
 	activator, err := NewKubernetesObservabilityCollectorPostPrefix(ObservabilityCollectorPostPrefixConfig{
-		Package: config, Installer: KubernetesAuthorityConfig{
-			Endpoint: "https://192.0.2.147:6443", TokenFile: installerToken,
-			CAFile: config.Activation.ObserverCredential.CAFile, CABundleDigest: config.Activation.ObserverCredential.CABundleDigest,
-		}, Clock: func() time.Time { return config.Activation.MaterializationTime },
+		Package: config, Clock: func() time.Time { return config.Activation.MaterializationTime },
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -55,9 +53,16 @@ func TestObservabilityCollectorPostPrefixBuildsAndLaunchesFreshBindingOnce(t *te
 			Endpoint: "https://192.0.2.147:6443", CABundleDigest: config.Activation.ObserverCredential.CABundleDigest,
 		}, nil
 	}
-	activator.open = func(received ObservabilityCollectorRuntimeLauncherConfig, value VerifiedObservabilityCollectorRuntimePackage) (observabilityCollectorRuntimeLauncher, error) {
+	credential := collectorInstallerCredentialFixture(t, target, config.Activation.ObserverCredential.CABundleDigest, config.Activation.MaterializationTime)
+	activator.issue = func(_ context.Context, received ObservabilityCollectorInstallerCredentialConfig) (VerifiedObservabilityCollectorInstallerCredential, error) {
+		if received.ExpectedTargetDigest != target || received.Clock == nil {
+			t.Fatalf("credential binding differs: %#v", received)
+		}
+		return credential, nil
+	}
+	activator.open = func(received submissionStageInstallerClientConfig, value VerifiedObservabilityCollectorRuntimePackage) (observabilityCollectorRuntimeLauncher, error) {
 		openCalls++
-		if received.ExpectedPackageDigest != packageReceipt.PackageDigest || received.Authority.AuthorityIdentity != target {
+		if received.AuthorityIdentity != target || received.BearerToken != string(credential.token) || received.Client == nil {
 			t.Fatalf("launcher identity differs: %#v", received)
 		}
 		return launcher, nil
@@ -71,7 +76,7 @@ func TestObservabilityCollectorPostPrefixBuildsAndLaunchesFreshBindingOnce(t *te
 	}
 	receipt := activator.Receipt()
 	if receipt.State != "ACTIVATED" || receipt.PackageDigest != packageReceipt.PackageDigest || receipt.CreatedObjects != 4 ||
-		buildCalls != 1 || openCalls != 1 || launcher.calls != 1 {
+		!stageReceiptPrefixDigestPattern.MatchString(receipt.CredentialReceiptDigest) || buildCalls != 1 || openCalls != 1 || launcher.calls != 1 {
 		t.Fatalf("unexpected post-prefix receipt: %#v calls=%d/%d/%d", receipt, buildCalls, openCalls, launcher.calls)
 	}
 	if err := activator.ActivateFullRunPostPrefix(context.Background(), prefix); err == nil || buildCalls != 1 || launcher.calls != 1 {
@@ -81,12 +86,8 @@ func TestObservabilityCollectorPostPrefixBuildsAndLaunchesFreshBindingOnce(t *te
 
 func TestObservabilityCollectorPostPrefixStopsBeforeBuildOnForeignRuntime(t *testing.T) {
 	config := observabilityCollectorRuntimePackageFixture(t)
-	installerToken := writeBundleFile(t, t.TempDir(), "installer-token", []byte("distinct-installer-token"))
 	activator, err := NewKubernetesObservabilityCollectorPostPrefix(ObservabilityCollectorPostPrefixConfig{
-		Package: config, Installer: KubernetesAuthorityConfig{
-			Endpoint: "https://192.0.2.147:6443", TokenFile: installerToken,
-			CAFile: config.Activation.ObserverCredential.CAFile, CABundleDigest: config.Activation.ObserverCredential.CABundleDigest,
-		}, Clock: func() time.Time { return config.Activation.MaterializationTime },
+		Package: config, Clock: func() time.Time { return config.Activation.MaterializationTime },
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -108,4 +109,27 @@ func TestObservabilityCollectorPostPrefixStopsBeforeBuildOnForeignRuntime(t *tes
 	if err == nil || buildCalls != 0 || activator.Receipt().State != "STOPPED" {
 		t.Fatalf("foreign runtime reached package build: calls=%d receipt=%#v err=%v", buildCalls, activator.Receipt(), err)
 	}
+}
+
+func collectorInstallerCredentialFixture(t *testing.T, target, caDigest string, now time.Time) VerifiedObservabilityCollectorInstallerCredential {
+	t.Helper()
+	material := VerifiedObservabilityCollectorInstallerCredential{
+		token: bytes.Repeat([]byte("t"), 100), endpoint: "http://127.0.0.1:12345", targetIdentity: target,
+		caBundleDigest: caDigest, client: &http.Client{}, expiresAt: now.Add(observabilityCollectorInstallerLifetime), verified: true,
+		receipt: ObservabilityCollectorInstallerCredentialReceipt{
+			Format: ObservabilityCollectorInstallerCredentialReceiptFormat, State: "ISSUED",
+			TargetIdentityDigest:         target,
+			ServiceAccountIdentityDigest: digest.SHA256([]byte("system:serviceaccount:" + observabilityCollectorInstallerNamespace + ":" + observabilityCollectorInstallerServiceAccount)),
+			RequestDigest:                digest.SHA256([]byte("collector-token-request")), CABundleDigest: caDigest,
+			AudienceMode: "server-default", IssuedAt: now.UTC().Format(time.RFC3339),
+			ExpiresAt:       now.Add(observabilityCollectorInstallerLifetime).UTC().Format(time.RFC3339),
+			LifetimeSeconds: int64(observabilityCollectorInstallerLifetime / time.Second), CredentialBytesInReceipt: false, MutationState: "ATTEMPTED",
+		},
+	}
+	var err error
+	material.privateDigest, err = observabilityCollectorInstallerPrivateDigest(material)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return material
 }


### PR DESCRIPTION
## Outcome

- replaces the persisted collector installer token with one exact 30-minute TokenRequest after the successful Stage-7 prefix
- binds the response to the lifecycle-derived target UID digest, workload CA, exact runtime ServiceAccount subject, server-default audience set and expiry
- retains credential bytes only in process memory and passes them directly to the existing single-use collector launcher
- adds only a redacted credential-receipt digest to the post-prefix receipt
- documents the newly exposed prerequisite: Stage 7 does not yet install the workload runtime ServiceAccount and its exact collector permissions, so live composition remains fail-closed until that separate boundary exists

## Verification

- full Go test suite
- go vet
- race tests for internal/runner

No live cluster contact or infrastructure mutation was performed.
