### PR TITLE
feat(runner): bind collector runtime authority

### DIFF
--- a/deploy/observability-collector-runtime-authority.yaml
+++ b/deploy/observability-collector-runtime-authority.yaml
@@ -1,0 +1,69 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openkubes-execution-system
+  labels:
+    openkubes.io/runtime-boundary: independent-evidence
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ok147-contract-executor-runtime
+  namespace: openkubes-execution-system
+  labels:
+    app.kubernetes.io/name: ok-cluster-contract-executor
+    openkubes.io/runtime-boundary: submission-stage
+automountServiceAccountToken: false
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ok147-observability-collector-installer
+  namespace: openkubes-execution-system
+  labels:
+    app.kubernetes.io/name: ok-cluster-contract-executor
+    openkubes.io/runtime-boundary: independent-evidence-installer
+automountServiceAccountToken: false
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ok147-observability-collector-runtime
+  namespace: openkubes-execution-system
+  labels:
+    app.kubernetes.io/name: ok-cluster-contract-executor
+    openkubes.io/runtime-boundary: independent-evidence
+rules:
+  - apiGroups: [""]
+    resources: [serviceaccounts]
+    resourceNames: [ok147-contract-executor-runtime]
+    verbs: [get]
+  - apiGroups: [""]
+    resources: [secrets, services]
+    verbs: [get, create]
+  - apiGroups: [networking.k8s.io]
+    resources: [networkpolicies]
+    verbs: [get, create]
+  - apiGroups: [batch]
+    resources: [jobs]
+    verbs: [get, create]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ok147-observability-collector-runtime
+  namespace: openkubes-execution-system
+  labels:
+    app.kubernetes.io/name: ok-cluster-contract-executor
+    openkubes.io/runtime-boundary: independent-evidence
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ok147-observability-collector-runtime
+subjects:
+  - kind: ServiceAccount
+    name: ok147-observability-collector-installer
+    namespace: openkubes-execution-system

--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -3149,7 +3149,8 @@ This closes the offline post-runtime packaging and activation boundaries
 without turning the collector into a lifecycle owner. The package builder and
 materializer perform no API request or mutation. The single-use launcher first
 replays the exact public receipt and private `0600` package, verifies the
-runtime target identity, then completes two exact prerequisite GETs and all
+runtime target identity, then completes one exact runtime-ServiceAccount
+prerequisite GET and all
 four exact-name absence GETs before its first write. It can create only Secret,
 Service, NetworkPolicy and Job in that order. Existing state stops zero-write;
 any failure after the first POST is retained as partial or unknown state, and
@@ -3167,22 +3168,35 @@ workload authority before building the package.
 
 It no longer accepts a persisted installer-token file. Instead, after package
 and target correlation have passed, a single-use issuer performs exactly one
-30-minute, server-default-audience TokenRequest for
-`openkubes-execution-system/ok147-contract-executor-runtime`. The response must
+30-minute, server-default-audience TokenRequest for the dedicated
+`openkubes-execution-system/ok147-observability-collector-installer`. The response must
 carry the exact ServiceAccount subject, audience set, expiry and bounded
 lifetime. The token is retained only in process memory and is handed directly
 to the existing single-use collector launcher. The redacted receipt exposes
 only target, ServiceAccount, request and CA digests plus timestamps; no token,
 CA, endpoint, kubeconfig or source path is retained.
 
-The live composition remains fail-closed until the workload-side runtime
-ServiceAccount and its exact collector create permissions are themselves
-projected and installed by a separately verified boundary. The existing
-Stage-7 target-access artifact does not currently contain that prerequisite;
-credential issuance therefore cannot be mistaken for runtime authorization.
-Wiring that exact prerequisite package and all private factory inputs into the
-full-run CLI/Job activation remains the next prerequisite before a complete
-fresh run.
+That workload-side prerequisite is now represented by an exact five-object
+package: restricted `openkubes-execution-system` Namespace, tokenless and
+unbound `ok147-contract-executor-runtime` ServiceAccount, distinct tokenless
+`ok147-observability-collector-installer` ServiceAccount, one namespaced Role
+and its single-subject installer RoleBinding. The Role can only get the exact
+runtime ServiceAccount and get/create Secrets, Services, NetworkPolicies and
+Jobs in the otherwise dedicated execution namespace. It contains no wildcard,
+list, watch, update, patch, delete, bind, escalate or cluster-scoped permission.
+The running collector therefore receives no installer RBAC and still mounts no
+ServiceAccount token.
+
+The corresponding single-use installer uses only the already correlated
+lifecycle workload authority. It performs all five exact-name absence GETs
+before its first POST, creates Namespace -> runtime ServiceAccount -> installer
+ServiceAccount -> Role -> RoleBinding, retains a redacted successful prefix on
+partial failure and has no
+retry, adoption, update, patch, delete, rollback or cleanup operation. Package
+verification and installation planning are offline; no live cluster has been
+contacted. Wiring this verified prerequisite package ahead of the TokenRequest
+and all private factory inputs into the full-run CLI/Job activation remains the
+next prerequisite before a complete fresh run.
 
 Fresh-Run v3 now also has one fail-closed offline image/package correlation
 boundary:

--- a/internal/runner/observability_collector_installer_credential.go
+++ b/internal/runner/observability_collector_installer_credential.go
@@ -21,7 +21,8 @@ import (
 const (
 	ObservabilityCollectorInstallerCredentialReceiptFormat = "ok147-observability-collector-installer-credential-receipt/v1"
 	observabilityCollectorInstallerNamespace               = "openkubes-execution-system"
-	observabilityCollectorInstallerServiceAccount          = "ok147-contract-executor-runtime"
+	observabilityCollectorInstallerServiceAccount          = "ok147-observability-collector-installer"
+	observabilityCollectorRuntimeServiceAccount            = "ok147-contract-executor-runtime"
 	observabilityCollectorInstallerLifetime                = 30 * time.Minute
 	minimumObservabilityCollectorInstallerLifetime         = 25 * time.Minute
 )

--- a/internal/runner/observability_collector_installer_credential_test.go
+++ b/internal/runner/observability_collector_installer_credential_test.go
@@ -22,7 +22,7 @@ func TestObservabilityCollectorInstallerCredentialIssuesOnceInMemory(t *testing.
 	client := &http.Client{Transport: submissionStageLauncherRoundTripFunc(func(request *http.Request) (*http.Response, error) {
 		requests++
 		body, _ := io.ReadAll(request.Body)
-		if request.Method != http.MethodPost || request.URL.Path != "/api/v1/namespaces/openkubes-execution-system/serviceaccounts/ok147-contract-executor-runtime/token" ||
+		if request.Method != http.MethodPost || request.URL.Path != "/api/v1/namespaces/openkubes-execution-system/serviceaccounts/ok147-observability-collector-installer/token" ||
 			request.Header.Get("Authorization") != "Bearer workload-admin" || request.Header.Get("Content-Type") != "application/json" ||
 			bytes.Contains(body, []byte("audiences")) {
 			t.Fatalf("unexpected collector installer TokenRequest: %s %s %s", request.Method, request.URL.Path, body)
@@ -78,10 +78,10 @@ func TestObservabilityCollectorInstallerCredentialFailsClosed(t *testing.T) {
 		status    int
 	}{
 		"foreign subject":  {subject: "system:serviceaccount:openkubes-execution-system:foreign", expires: now.Add(30 * time.Minute), audiences: []string{"default"}, status: http.StatusCreated},
-		"short lifetime":   {subject: "system:serviceaccount:openkubes-execution-system:ok147-contract-executor-runtime", expires: now.Add(10 * time.Minute), audiences: []string{"default"}, status: http.StatusCreated},
-		"missing audience": {subject: "system:serviceaccount:openkubes-execution-system:ok147-contract-executor-runtime", expires: now.Add(30 * time.Minute), audiences: []string{}, status: http.StatusCreated},
-		"foreign audience": {subject: "system:serviceaccount:openkubes-execution-system:ok147-contract-executor-runtime", expires: now.Add(30 * time.Minute), audiences: []string{"foreign"}, status: http.StatusCreated},
-		"wrong status":     {subject: "system:serviceaccount:openkubes-execution-system:ok147-contract-executor-runtime", expires: now.Add(30 * time.Minute), audiences: []string{"default"}, status: http.StatusForbidden},
+		"short lifetime":   {subject: "system:serviceaccount:openkubes-execution-system:ok147-observability-collector-installer", expires: now.Add(10 * time.Minute), audiences: []string{"default"}, status: http.StatusCreated},
+		"missing audience": {subject: "system:serviceaccount:openkubes-execution-system:ok147-observability-collector-installer", expires: now.Add(30 * time.Minute), audiences: []string{}, status: http.StatusCreated},
+		"foreign audience": {subject: "system:serviceaccount:openkubes-execution-system:ok147-observability-collector-installer", expires: now.Add(30 * time.Minute), audiences: []string{"foreign"}, status: http.StatusCreated},
+		"wrong status":     {subject: "system:serviceaccount:openkubes-execution-system:ok147-observability-collector-installer", expires: now.Add(30 * time.Minute), audiences: []string{"default"}, status: http.StatusForbidden},
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {

--- a/internal/runner/observability_collector_runtime_authority.go
+++ b/internal/runner/observability_collector_runtime_authority.go
@@ -1,0 +1,487 @@
+package runner
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"net/url"
+	"sync"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+const (
+	ObservabilityCollectorRuntimeAuthorityPackageFormat = "ok147-observability-collector-runtime-authority-package/v1"
+	ObservabilityCollectorRuntimeAuthorityPlanFormat    = "ok147-observability-collector-runtime-authority-plan/v1"
+	ObservabilityCollectorRuntimeAuthorityReceiptFormat = "ok147-observability-collector-runtime-authority-installation-receipt/v1"
+	observabilityCollectorRuntimeRole                   = "ok147-observability-collector-runtime"
+)
+
+type ObservabilityCollectorRuntimeAuthorityPackageConfig struct {
+	Manifest               []byte
+	ExpectedManifestDigest string
+	TargetIdentityDigest   string
+}
+
+type ObservabilityCollectorRuntimeAuthorityPackageReceipt struct {
+	Format               string   `json:"format"`
+	State                string   `json:"state"`
+	PackageDigest        string   `json:"packageDigest"`
+	ManifestDigest       string   `json:"manifestDigest"`
+	TargetIdentityDigest string   `json:"targetIdentityDigest"`
+	ObjectDigests        []string `json:"objectDigests"`
+	MutationAllowed      bool     `json:"mutationAllowed"`
+}
+
+type VerifiedObservabilityCollectorRuntimeAuthorityPackage struct {
+	raw      []byte
+	receipt  ObservabilityCollectorRuntimeAuthorityPackageReceipt
+	verified bool
+}
+
+type ObservabilityCollectorRuntimeAuthorityPlan struct {
+	Format               string                      `json:"format"`
+	State                string                      `json:"state"`
+	PackageDigest        string                      `json:"packageDigest"`
+	ManifestDigest       string                      `json:"manifestDigest"`
+	TargetIdentityDigest string                      `json:"targetIdentityDigest"`
+	Creates              []SubmissionStageCreatePlan `json:"creates"`
+	MutationAllowed      bool                        `json:"mutationAllowed"`
+}
+
+type ObservabilityCollectorRuntimeAuthorityInstallationReceipt struct {
+	Format               string                           `json:"format"`
+	PackageDigest        string                           `json:"packageDigest"`
+	TargetIdentityDigest string                           `json:"targetIdentityDigest"`
+	State                string                           `json:"state"`
+	MutationState        string                           `json:"mutationState"`
+	Results              []SubmissionStageInstalledObject `json:"results"`
+}
+
+type observabilityCollectorRuntimeAuthorityClientConfig struct {
+	Endpoint          string
+	BearerToken       string
+	ClientCertificate bool
+	TargetIdentity    string
+	Client            *http.Client
+}
+
+type KubernetesObservabilityCollectorRuntimeAuthorityInstaller struct {
+	mu                sync.Mutex
+	used              bool
+	endpoint          *url.URL
+	token             string
+	clientCertificate bool
+	client            *http.Client
+	plan              ObservabilityCollectorRuntimeAuthorityPlan
+	objects           []submissionStageInstallObject
+}
+
+// BuildObservabilityCollectorRuntimeAuthorityPackage verifies the exact five
+// workload-side objects needed before a short-lived collector installer token
+// can exist. It performs no API request and grants no mutation authority.
+func BuildObservabilityCollectorRuntimeAuthorityPackage(config ObservabilityCollectorRuntimeAuthorityPackageConfig) (VerifiedObservabilityCollectorRuntimeAuthorityPackage, error) {
+	if len(config.Manifest) == 0 || !stageReceiptPrefixDigestPattern.MatchString(config.ExpectedManifestDigest) ||
+		digest.SHA256(config.Manifest) != config.ExpectedManifestDigest || !stageReceiptPrefixDigestPattern.MatchString(config.TargetIdentityDigest) {
+		return VerifiedObservabilityCollectorRuntimeAuthorityPackage{}, errors.New("collector runtime authority package binding is invalid")
+	}
+	objects, err := decodeFullRunActivationObjects(config.Manifest, 5)
+	if err != nil {
+		return VerifiedObservabilityCollectorRuntimeAuthorityPackage{}, errors.New("decode collector runtime authority package")
+	}
+	if err := verifyObservabilityCollectorRuntimeAuthorityObjects(objects); err != nil {
+		return VerifiedObservabilityCollectorRuntimeAuthorityPackage{}, err
+	}
+	objectDigests := make([]string, 0, len(objects))
+	for _, object := range objects {
+		raw, err := json.Marshal(object)
+		if err != nil {
+			return VerifiedObservabilityCollectorRuntimeAuthorityPackage{}, errors.New("encode collector runtime authority object")
+		}
+		objectDigests = append(objectDigests, digest.SHA256(raw))
+	}
+	return VerifiedObservabilityCollectorRuntimeAuthorityPackage{
+		raw: append([]byte(nil), config.Manifest...), verified: true,
+		receipt: ObservabilityCollectorRuntimeAuthorityPackageReceipt{
+			Format: ObservabilityCollectorRuntimeAuthorityPackageFormat, State: "VERIFIED",
+			PackageDigest: digest.SHA256(config.Manifest), ManifestDigest: config.ExpectedManifestDigest,
+			TargetIdentityDigest: config.TargetIdentityDigest, ObjectDigests: objectDigests, MutationAllowed: false,
+		},
+	}, nil
+}
+
+func (packaged VerifiedObservabilityCollectorRuntimeAuthorityPackage) Receipt() (ObservabilityCollectorRuntimeAuthorityPackageReceipt, error) {
+	if err := verifyObservabilityCollectorRuntimeAuthorityPackage(packaged); err != nil {
+		return ObservabilityCollectorRuntimeAuthorityPackageReceipt{}, err
+	}
+	receipt := packaged.receipt
+	receipt.ObjectDigests = append([]string(nil), receipt.ObjectDigests...)
+	return receipt, nil
+}
+
+func verifyObservabilityCollectorRuntimeAuthorityPackage(packaged VerifiedObservabilityCollectorRuntimeAuthorityPackage) error {
+	if !packaged.verified || packaged.receipt.Format != ObservabilityCollectorRuntimeAuthorityPackageFormat || packaged.receipt.State != "VERIFIED" ||
+		packaged.receipt.MutationAllowed || len(packaged.raw) == 0 || len(packaged.receipt.ObjectDigests) != 5 ||
+		digest.SHA256(packaged.raw) != packaged.receipt.PackageDigest || packaged.receipt.ManifestDigest != packaged.receipt.PackageDigest ||
+		!stageReceiptPrefixDigestPattern.MatchString(packaged.receipt.TargetIdentityDigest) {
+		return errors.New("collector runtime authority package was not produced by verification")
+	}
+	objects, err := decodeFullRunActivationObjects(packaged.raw, 5)
+	if err != nil || verifyObservabilityCollectorRuntimeAuthorityObjects(objects) != nil {
+		return errors.New("collector runtime authority package changed after verification")
+	}
+	for index, object := range objects {
+		raw, err := json.Marshal(object)
+		if err != nil || digest.SHA256(raw) != packaged.receipt.ObjectDigests[index] {
+			return errors.New("collector runtime authority object identity changed after verification")
+		}
+	}
+	return nil
+}
+
+func PlanObservabilityCollectorRuntimeAuthorityInstallation(packaged VerifiedObservabilityCollectorRuntimeAuthorityPackage) (ObservabilityCollectorRuntimeAuthorityPlan, error) {
+	receipt, err := packaged.Receipt()
+	if err != nil {
+		return ObservabilityCollectorRuntimeAuthorityPlan{}, err
+	}
+	objects, err := decodeFullRunActivationObjects(packaged.raw, 5)
+	if err != nil {
+		return ObservabilityCollectorRuntimeAuthorityPlan{}, err
+	}
+	creates := make([]SubmissionStageCreatePlan, 0, 4)
+	for index, object := range objects {
+		apiVersion, _ := object["apiVersion"].(string)
+		kind, _ := object["kind"].(string)
+		metadata, _ := object["metadata"].(map[string]any)
+		name, _ := metadata["name"].(string)
+		namespace, _ := metadata["namespace"].(string)
+		collection, objectPath, err := observabilityCollectorRuntimeAuthorityPaths(apiVersion, kind, namespace, name)
+		if err != nil {
+			return ObservabilityCollectorRuntimeAuthorityPlan{}, err
+		}
+		raw, err := json.Marshal(object)
+		if err != nil || digest.SHA256(raw) != receipt.ObjectDigests[index] {
+			return ObservabilityCollectorRuntimeAuthorityPlan{}, errors.New("collector runtime authority plan object differs")
+		}
+		creates = append(creates, SubmissionStageCreatePlan{
+			Order: index + 1, APIVersion: apiVersion, Kind: kind, Namespace: namespace, Name: name,
+			PreflightMethod: http.MethodGet, ObjectPath: objectPath, CreateMethod: http.MethodPost,
+			CollectionPath: collection, ObjectDigest: receipt.ObjectDigests[index],
+		})
+	}
+	return ObservabilityCollectorRuntimeAuthorityPlan{
+		Format: ObservabilityCollectorRuntimeAuthorityPlanFormat, State: "VERIFIED",
+		PackageDigest: receipt.PackageDigest, ManifestDigest: receipt.ManifestDigest,
+		TargetIdentityDigest: receipt.TargetIdentityDigest, Creates: creates, MutationAllowed: false,
+	}, nil
+}
+
+func OpenKubernetesObservabilityCollectorRuntimeAuthorityInstaller(workload WorkloadAuthorityFileResolverConfig, packaged VerifiedObservabilityCollectorRuntimeAuthorityPackage) (*KubernetesObservabilityCollectorRuntimeAuthorityInstaller, error) {
+	receipt, err := packaged.Receipt()
+	if err != nil {
+		return nil, err
+	}
+	binding, authority, err := loadWorkloadAuthorityFiles(workload)
+	if err != nil || digest.SHA256([]byte(binding.TargetClusterUID)) != receipt.TargetIdentityDigest {
+		return nil, errors.New("collector runtime authority installer differs from workload target")
+	}
+	transport, err := openBoundedKubernetesAuthorityTransport(authority)
+	if err != nil || digest.SHA256(transport.caData) != authority.CABundleDigest {
+		return nil, errors.New("open collector runtime authority workload credential")
+	}
+	return newKubernetesObservabilityCollectorRuntimeAuthorityInstaller(observabilityCollectorRuntimeAuthorityClientConfig{
+		Endpoint: authority.Endpoint, BearerToken: transport.bearerToken, ClientCertificate: transport.clientCertificate,
+		TargetIdentity: receipt.TargetIdentityDigest, Client: transport.client,
+	}, packaged)
+}
+
+func newKubernetesObservabilityCollectorRuntimeAuthorityInstaller(config observabilityCollectorRuntimeAuthorityClientConfig, packaged VerifiedObservabilityCollectorRuntimeAuthorityPackage) (*KubernetesObservabilityCollectorRuntimeAuthorityInstaller, error) {
+	plan, objects, err := prepareObservabilityCollectorRuntimeAuthorityInstallation(packaged)
+	if err != nil || config.TargetIdentity != plan.TargetIdentityDigest {
+		return nil, errors.New("collector runtime authority installer target differs")
+	}
+	endpoint, err := normalizeSubmissionStageLaunchEndpoint(config.Endpoint)
+	if err != nil || config.Client == nil || (config.BearerToken != "") == config.ClientCertificate {
+		return nil, errors.New("collector runtime authority installer credential is invalid")
+	}
+	parsed, err := url.Parse(endpoint)
+	if err != nil {
+		return nil, errors.New("parse collector runtime authority endpoint")
+	}
+	client := *config.Client
+	client.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+	return &KubernetesObservabilityCollectorRuntimeAuthorityInstaller{
+		endpoint: parsed, token: config.BearerToken, clientCertificate: config.ClientCertificate,
+		client: &client, plan: plan, objects: objects,
+	}, nil
+}
+
+func (installer *KubernetesObservabilityCollectorRuntimeAuthorityInstaller) Install(ctx context.Context) (ObservabilityCollectorRuntimeAuthorityInstallationReceipt, error) {
+	receipt := installer.newReceipt()
+	if installer == nil || installer.client == nil {
+		return receipt, errors.New("collector runtime authority installer is required")
+	}
+	installer.mu.Lock()
+	if installer.used {
+		installer.mu.Unlock()
+		return stopObservabilityCollectorRuntimeAuthority(receipt, "STOPPED_ZERO_WRITE", errors.New("collector runtime authority installer is single-use"))
+	}
+	installer.used = true
+	installer.mu.Unlock()
+	for _, object := range installer.objects {
+		_, status, err := installer.request(ctx, http.MethodGet, object.plan.ObjectPath, nil)
+		if err != nil || status != http.StatusNotFound {
+			if err == nil {
+				err = fmt.Errorf("collector runtime authority preflight returned HTTP %d", status)
+			}
+			return stopObservabilityCollectorRuntimeAuthority(receipt, "STOPPED_ZERO_WRITE", err)
+		}
+	}
+	receipt.State = "INSTALLING"
+	for _, object := range installer.objects {
+		receipt.MutationState = "ATTEMPTED_UNKNOWN"
+		raw, status, err := installer.request(ctx, http.MethodPost, object.plan.CollectionPath, object.raw)
+		if err != nil || status != http.StatusCreated {
+			if err == nil {
+				err = fmt.Errorf("collector runtime authority create returned HTTP %d", status)
+			}
+			return stopObservabilityCollectorRuntimeAuthority(receipt, "STOPPED_PARTIAL_OR_UNKNOWN", err)
+		}
+		uid, resourceVersion, err := verifySubmissionStageCreatedObject(raw, object)
+		if err != nil {
+			return stopObservabilityCollectorRuntimeAuthority(receipt, "STOPPED_PARTIAL_OR_UNKNOWN", errors.New("created collector runtime authority object differs"))
+		}
+		receipt.MutationState = "ATTEMPTED"
+		receipt.Results = append(receipt.Results, SubmissionStageInstalledObject{
+			Order: object.plan.Order, APIVersion: object.plan.APIVersion, Kind: object.plan.Kind,
+			Namespace: object.plan.Namespace, Name: object.plan.Name, ObjectDigest: object.plan.ObjectDigest,
+			UIDDigest: digest.SHA256([]byte(uid)), ResourceVersionDigest: digest.SHA256([]byte(resourceVersion)), State: "CREATED",
+		})
+	}
+	receipt.State = "INSTALLED"
+	return receipt, nil
+}
+
+func (installer *KubernetesObservabilityCollectorRuntimeAuthorityInstaller) newReceipt() ObservabilityCollectorRuntimeAuthorityInstallationReceipt {
+	receipt := ObservabilityCollectorRuntimeAuthorityInstallationReceipt{
+		Format: ObservabilityCollectorRuntimeAuthorityReceiptFormat, State: "PREFLIGHT", MutationState: "NOT_ATTEMPTED",
+		Results: []SubmissionStageInstalledObject{},
+	}
+	if installer != nil {
+		receipt.PackageDigest = installer.plan.PackageDigest
+		receipt.TargetIdentityDigest = installer.plan.TargetIdentityDigest
+	}
+	return receipt
+}
+
+func stopObservabilityCollectorRuntimeAuthority(receipt ObservabilityCollectorRuntimeAuthorityInstallationReceipt, state string, err error) (ObservabilityCollectorRuntimeAuthorityInstallationReceipt, error) {
+	receipt.State = state
+	return receipt, err
+}
+
+func (installer *KubernetesObservabilityCollectorRuntimeAuthorityInstaller) request(ctx context.Context, method, path string, body []byte) ([]byte, int, error) {
+	endpoint := *installer.endpoint
+	endpoint.Path = path
+	request, err := http.NewRequestWithContext(ctx, method, endpoint.String(), bytes.NewReader(body))
+	if err != nil {
+		return nil, 0, errors.New("construct collector runtime authority request")
+	}
+	request.Header.Set("Accept", "application/json")
+	if !installer.clientCertificate {
+		request.Header.Set("Authorization", "Bearer "+installer.token)
+	}
+	if body != nil {
+		request.Header.Set("Content-Type", "application/json")
+	}
+	response, err := installer.client.Do(request)
+	if err != nil {
+		return nil, 0, fmt.Errorf("collector runtime authority %s request failed", method)
+	}
+	defer response.Body.Close()
+	raw, readErr := io.ReadAll(io.LimitReader(response.Body, maximumStageInstallationResponseBytes+1))
+	if readErr != nil || len(raw) > maximumStageInstallationResponseBytes {
+		return nil, 0, errors.New("collector runtime authority response exceeds accepted size")
+	}
+	if len(raw) > 0 {
+		mediaType, _, err := mime.ParseMediaType(response.Header.Get("Content-Type"))
+		if err != nil || mediaType != "application/json" {
+			return nil, 0, errors.New("collector runtime authority response is not JSON")
+		}
+	}
+	return raw, response.StatusCode, nil
+}
+
+func prepareObservabilityCollectorRuntimeAuthorityInstallation(packaged VerifiedObservabilityCollectorRuntimeAuthorityPackage) (ObservabilityCollectorRuntimeAuthorityPlan, []submissionStageInstallObject, error) {
+	plan, err := PlanObservabilityCollectorRuntimeAuthorityInstallation(packaged)
+	if err != nil {
+		return ObservabilityCollectorRuntimeAuthorityPlan{}, nil, err
+	}
+	values, err := decodeFullRunActivationObjects(packaged.raw, 5)
+	if err != nil {
+		return ObservabilityCollectorRuntimeAuthorityPlan{}, nil, err
+	}
+	objects := make([]submissionStageInstallObject, 0, 5)
+	for index, value := range values {
+		raw, err := json.Marshal(value)
+		if err != nil || digest.SHA256(raw) != plan.Creates[index].ObjectDigest {
+			return ObservabilityCollectorRuntimeAuthorityPlan{}, nil, errors.New("collector runtime authority object differs from plan")
+		}
+		objects = append(objects, submissionStageInstallObject{plan: plan.Creates[index], raw: raw})
+	}
+	return plan, objects, nil
+}
+
+func observabilityCollectorRuntimeAuthorityPaths(apiVersion, kind, namespace, name string) (string, string, error) {
+	var collection string
+	switch {
+	case apiVersion == "v1" && kind == "Namespace" && namespace == "":
+		collection = "/api/v1/namespaces"
+	case apiVersion == "v1" && kind == "ServiceAccount":
+		collection = "/api/v1/namespaces/" + namespace + "/serviceaccounts"
+	case apiVersion == "rbac.authorization.k8s.io/v1" && kind == "Role":
+		collection = "/apis/rbac.authorization.k8s.io/v1/namespaces/" + namespace + "/roles"
+	case apiVersion == "rbac.authorization.k8s.io/v1" && kind == "RoleBinding":
+		collection = "/apis/rbac.authorization.k8s.io/v1/namespaces/" + namespace + "/rolebindings"
+	default:
+		return "", "", errors.New("collector runtime authority object kind is invalid")
+	}
+	return collection, collection + "/" + name, nil
+}
+
+func verifyObservabilityCollectorRuntimeAuthorityObjects(objects []map[string]any) error {
+	if len(objects) != 5 {
+		return errors.New("collector runtime authority requires exactly five objects")
+	}
+	want := []struct{ apiVersion, kind, namespace, name string }{
+		{"v1", "Namespace", "", observabilityCollectorInstallerNamespace},
+		{"v1", "ServiceAccount", observabilityCollectorInstallerNamespace, observabilityCollectorRuntimeServiceAccount},
+		{"v1", "ServiceAccount", observabilityCollectorInstallerNamespace, observabilityCollectorInstallerServiceAccount},
+		{"rbac.authorization.k8s.io/v1", "Role", observabilityCollectorInstallerNamespace, observabilityCollectorRuntimeRole},
+		{"rbac.authorization.k8s.io/v1", "RoleBinding", observabilityCollectorInstallerNamespace, observabilityCollectorRuntimeRole},
+	}
+	for index, expected := range want {
+		metadata, ok := objects[index]["metadata"].(map[string]any)
+		if !ok || objects[index]["apiVersion"] != expected.apiVersion || objects[index]["kind"] != expected.kind ||
+			metadata["name"] != expected.name || textValue(metadata["namespace"]) != expected.namespace {
+			return errors.New("collector runtime authority object identity or labels differ")
+		}
+		for _, forbidden := range []string{"generateName", "uid", "resourceVersion", "generation", "creationTimestamp", "deletionTimestamp", "managedFields", "ownerReferences", "finalizers"} {
+			if _, exists := metadata[forbidden]; exists {
+				return errors.New("collector runtime authority contains runtime metadata")
+			}
+		}
+	}
+	if !exactCollectorRuntimeAuthorityLabels(objects[0]["metadata"].(map[string]any)["labels"], "independent-evidence", true) ||
+		!exactCollectorRuntimeAuthorityLabels(objects[1]["metadata"].(map[string]any)["labels"], "submission-stage", false) ||
+		!exactCollectorRuntimeAuthorityLabels(objects[2]["metadata"].(map[string]any)["labels"], "independent-evidence-installer", false) ||
+		!exactCollectorRuntimeAuthorityLabels(objects[3]["metadata"].(map[string]any)["labels"], "independent-evidence", false) ||
+		!exactCollectorRuntimeAuthorityLabels(objects[4]["metadata"].(map[string]any)["labels"], "independent-evidence", false) {
+		return errors.New("collector runtime authority object labels differ")
+	}
+	if !exactStringMapKeys(objects[0], "apiVersion", "kind", "metadata") {
+		return errors.New("collector runtime authority Namespace shape differs")
+	}
+	namespaceLabels := objects[0]["metadata"].(map[string]any)["labels"].(map[string]any)
+	for _, key := range []string{"pod-security.kubernetes.io/enforce", "pod-security.kubernetes.io/audit", "pod-security.kubernetes.io/warn"} {
+		if namespaceLabels[key] != "restricted" {
+			return errors.New("collector runtime authority Namespace is not restricted")
+		}
+	}
+	if !exactStringMapKeys(objects[1], "apiVersion", "kind", "metadata", "automountServiceAccountToken") || objects[1]["automountServiceAccountToken"] != false {
+		return errors.New("collector runtime authority ServiceAccount shape differs")
+	}
+	if !exactStringMapKeys(objects[2], "apiVersion", "kind", "metadata", "automountServiceAccountToken") || objects[2]["automountServiceAccountToken"] != false {
+		return errors.New("collector runtime authority installer ServiceAccount shape differs")
+	}
+	if !exactStringMapKeys(objects[3], "apiVersion", "kind", "metadata", "rules") || !exactCollectorRuntimeAuthorityRules(objects[3]["rules"]) {
+		return errors.New("collector runtime authority Role exceeds exact permissions")
+	}
+	if !exactStringMapKeys(objects[4], "apiVersion", "kind", "metadata", "roleRef", "subjects") || !exactCollectorRuntimeAuthorityBinding(objects[4]) {
+		return errors.New("collector runtime authority RoleBinding differs")
+	}
+	return nil
+}
+
+func exactCollectorRuntimeAuthorityLabels(raw any, boundary string, namespace bool) bool {
+	labels, ok := raw.(map[string]any)
+	if !ok || labels["openkubes.io/runtime-boundary"] != boundary {
+		return false
+	}
+	if namespace {
+		return len(labels) == 4
+	}
+	return len(labels) == 2 && labels["app.kubernetes.io/name"] == "ok-cluster-contract-executor"
+}
+
+func exactCollectorRuntimeAuthorityRules(raw any) bool {
+	rules, ok := raw.([]any)
+	if !ok || len(rules) != 4 {
+		return false
+	}
+	want := []struct {
+		apiGroups, resources, resourceNames, verbs []string
+	}{
+		{[]string{""}, []string{"serviceaccounts"}, []string{observabilityCollectorRuntimeServiceAccount}, []string{"get"}},
+		{[]string{""}, []string{"secrets", "services"}, nil, []string{"get", "create"}},
+		{[]string{"networking.k8s.io"}, []string{"networkpolicies"}, nil, []string{"get", "create"}},
+		{[]string{"batch"}, []string{"jobs"}, nil, []string{"get", "create"}},
+	}
+	for index, expected := range want {
+		rule, ok := rules[index].(map[string]any)
+		if !ok || !exactStringList(rule["apiGroups"], expected.apiGroups) || !exactStringList(rule["resources"], expected.resources) || !exactStringList(rule["verbs"], expected.verbs) {
+			return false
+		}
+		if expected.resourceNames == nil {
+			if len(rule) != 3 {
+				return false
+			}
+		} else if len(rule) != 4 || !exactStringList(rule["resourceNames"], expected.resourceNames) {
+			return false
+		}
+	}
+	return true
+}
+
+func exactCollectorRuntimeAuthorityBinding(object map[string]any) bool {
+	roleRef, ok := object["roleRef"].(map[string]any)
+	if !ok || !exactStringMapKeys(roleRef, "apiGroup", "kind", "name") || roleRef["apiGroup"] != "rbac.authorization.k8s.io" || roleRef["kind"] != "Role" || roleRef["name"] != observabilityCollectorRuntimeRole {
+		return false
+	}
+	subjects, ok := object["subjects"].([]any)
+	if !ok || len(subjects) != 1 {
+		return false
+	}
+	subject, ok := subjects[0].(map[string]any)
+	return ok && exactStringMapKeys(subject, "kind", "name", "namespace") && subject["kind"] == "ServiceAccount" &&
+		subject["name"] == observabilityCollectorInstallerServiceAccount && subject["namespace"] == observabilityCollectorInstallerNamespace
+}
+
+func exactStringMapKeys(value map[string]any, keys ...string) bool {
+	if len(value) != len(keys) {
+		return false
+	}
+	for _, key := range keys {
+		if _, exists := value[key]; !exists {
+			return false
+		}
+	}
+	return true
+}
+
+func exactStringList(raw any, expected []string) bool {
+	values, ok := raw.([]any)
+	if !ok || len(values) != len(expected) {
+		return false
+	}
+	for index := range expected {
+		if values[index] != expected[index] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/runner/observability_collector_runtime_authority_test.go
+++ b/internal/runner/observability_collector_runtime_authority_test.go
@@ -1,0 +1,195 @@
+package runner
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+func TestObservabilityCollectorRuntimeAuthorityPackageIsExact(t *testing.T) {
+	packaged := collectorRuntimeAuthorityPackageFixture(t)
+	receipt, err := packaged.Receipt()
+	if err != nil || receipt.Format != ObservabilityCollectorRuntimeAuthorityPackageFormat || receipt.State != "VERIFIED" ||
+		len(receipt.ObjectDigests) != 5 || receipt.MutationAllowed || receipt.PackageDigest != receipt.ManifestDigest {
+		t.Fatalf("unexpected collector runtime authority package: %#v %v", receipt, err)
+	}
+	plan, err := PlanObservabilityCollectorRuntimeAuthorityInstallation(packaged)
+	if err != nil || plan.Format != ObservabilityCollectorRuntimeAuthorityPlanFormat || len(plan.Creates) != 5 || plan.MutationAllowed {
+		t.Fatalf("unexpected collector runtime authority plan: %#v %v", plan, err)
+	}
+	wantKinds := []string{"Namespace", "ServiceAccount", "ServiceAccount", "Role", "RoleBinding"}
+	for index, create := range plan.Creates {
+		if create.Order != index+1 || create.Kind != wantKinds[index] || create.PreflightMethod != http.MethodGet || create.CreateMethod != http.MethodPost || create.ObjectPath == "" || create.CollectionPath == "" {
+			t.Fatalf("unexpected collector runtime authority create %d: %#v", index+1, create)
+		}
+	}
+}
+
+func TestObservabilityCollectorRuntimeAuthorityPackageFailsClosed(t *testing.T) {
+	raw := collectorRuntimeAuthorityManifest(t)
+	target := digest.SHA256([]byte("collector-runtime-target"))
+	tests := map[string][]byte{
+		"automatic token":  bytes.Replace(raw, []byte("automountServiceAccountToken: false"), []byte("automountServiceAccountToken: true"), 1),
+		"wildcard verb":    bytes.Replace(raw, []byte("verbs: [get, create]"), []byte("verbs: ['*']"), 1),
+		"foreign subject":  bytes.Replace(raw, []byte("name: ok147-observability-collector-installer\n    namespace: openkubes-execution-system"), []byte("name: foreign\n    namespace: openkubes-execution-system"), 1),
+		"extra permission": bytes.Replace(raw, []byte("verbs: [get, create]\n---"), []byte("verbs: [get, create]\n  - apiGroups: ['']\n    resources: [pods]\n    verbs: [delete]\n---"), 1),
+	}
+	for name, changed := range tests {
+		t.Run(name, func(t *testing.T) {
+			if _, err := BuildObservabilityCollectorRuntimeAuthorityPackage(ObservabilityCollectorRuntimeAuthorityPackageConfig{
+				Manifest: changed, ExpectedManifestDigest: digest.SHA256(changed), TargetIdentityDigest: target,
+			}); err == nil {
+				t.Fatal("unsafe collector runtime authority package was accepted")
+			}
+		})
+	}
+	if _, err := BuildObservabilityCollectorRuntimeAuthorityPackage(ObservabilityCollectorRuntimeAuthorityPackageConfig{
+		Manifest: raw, ExpectedManifestDigest: digest.SHA256([]byte("foreign")), TargetIdentityDigest: target,
+	}); err == nil {
+		t.Fatal("changed collector runtime authority manifest digest was accepted")
+	}
+}
+
+func TestObservabilityCollectorRuntimeAuthorityInstallerPreflightsAndCreatesOnce(t *testing.T) {
+	packaged := collectorRuntimeAuthorityPackageFixture(t)
+	receipt, _ := packaged.Receipt()
+	api := &collectorRuntimeAuthorityAPI{}
+	installer, err := newKubernetesObservabilityCollectorRuntimeAuthorityInstaller(observabilityCollectorRuntimeAuthorityClientConfig{
+		Endpoint: "https://127.0.0.1:12345", BearerToken: "workload-admin", TargetIdentity: receipt.TargetIdentityDigest,
+		Client: &http.Client{Transport: api},
+	}, packaged)
+	if err != nil {
+		t.Fatal(err)
+	}
+	installed, err := installer.Install(context.Background())
+	if err != nil || installed.State != "INSTALLED" || installed.MutationState != "ATTEMPTED" || len(installed.Results) != 5 || api.posts != 5 || len(api.requests) != 10 {
+		t.Fatalf("collector runtime authority was not installed exactly: %#v api=%#v err=%v", installed, api, err)
+	}
+	for index := 0; index < 5; index++ {
+		if !strings.HasPrefix(api.requests[index], "GET ") || !strings.HasPrefix(api.requests[index+5], "POST ") {
+			t.Fatalf("global preflight barrier differs: %#v", api.requests)
+		}
+	}
+	if _, err := installer.Install(context.Background()); err == nil || api.posts != 5 {
+		t.Fatal("collector runtime authority installer retried")
+	}
+}
+
+func TestObservabilityCollectorRuntimeAuthorityInstallerStopsZeroWriteAndPartial(t *testing.T) {
+	packaged := collectorRuntimeAuthorityPackageFixture(t)
+	receipt, _ := packaged.Receipt()
+	for name, api := range map[string]*collectorRuntimeAuthorityAPI{
+		"existing": {existingGET: 2},
+		"partial":  {failPOST: 2},
+	} {
+		t.Run(name, func(t *testing.T) {
+			installer, err := newKubernetesObservabilityCollectorRuntimeAuthorityInstaller(observabilityCollectorRuntimeAuthorityClientConfig{
+				Endpoint: "https://127.0.0.1:12345", BearerToken: "workload-admin", TargetIdentity: receipt.TargetIdentityDigest,
+				Client: &http.Client{Transport: api},
+			}, packaged)
+			if err != nil {
+				t.Fatal(err)
+			}
+			result, err := installer.Install(context.Background())
+			if err == nil {
+				t.Fatal("collector runtime authority failure was accepted")
+			}
+			if name == "existing" && (result.State != "STOPPED_ZERO_WRITE" || api.posts != 0) {
+				t.Fatalf("existing object crossed zero-write barrier: %#v %#v", result, api)
+			}
+			if name == "partial" && (result.State != "STOPPED_PARTIAL_OR_UNKNOWN" || len(result.Results) != 1 || api.posts != 2) {
+				t.Fatalf("partial state was not retained: %#v %#v", result, api)
+			}
+		})
+	}
+}
+
+func TestOpenObservabilityCollectorRuntimeAuthorityInstallerBindsWorkloadTarget(t *testing.T) {
+	fixture := targetCredentialBundleFixture(t)
+	runtime := targetAccessRuntime(t, fixture.plan)
+	binding, err := loadWorkloadAuthorityBinding(runtime.Workload.Path, runtime.Workload.ExpectedBindingDigest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw := collectorRuntimeAuthorityManifest(t)
+	packaged, err := BuildObservabilityCollectorRuntimeAuthorityPackage(ObservabilityCollectorRuntimeAuthorityPackageConfig{
+		Manifest: raw, ExpectedManifestDigest: digest.SHA256(raw), TargetIdentityDigest: digest.SHA256([]byte(binding.TargetClusterUID)),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := OpenKubernetesObservabilityCollectorRuntimeAuthorityInstaller(runtime.Workload, packaged); err != nil {
+		t.Fatal(err)
+	}
+	foreign, err := BuildObservabilityCollectorRuntimeAuthorityPackage(ObservabilityCollectorRuntimeAuthorityPackageConfig{
+		Manifest: raw, ExpectedManifestDigest: digest.SHA256(raw), TargetIdentityDigest: digest.SHA256([]byte("foreign")),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := OpenKubernetesObservabilityCollectorRuntimeAuthorityInstaller(runtime.Workload, foreign); err == nil {
+		t.Fatal("foreign target opened collector runtime authority installer")
+	}
+}
+
+func collectorRuntimeAuthorityPackageFixture(t *testing.T) VerifiedObservabilityCollectorRuntimeAuthorityPackage {
+	t.Helper()
+	raw := collectorRuntimeAuthorityManifest(t)
+	packaged, err := BuildObservabilityCollectorRuntimeAuthorityPackage(ObservabilityCollectorRuntimeAuthorityPackageConfig{
+		Manifest: raw, ExpectedManifestDigest: digest.SHA256(raw), TargetIdentityDigest: digest.SHA256([]byte("collector-runtime-target")),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return packaged
+}
+
+func collectorRuntimeAuthorityManifest(t *testing.T) []byte {
+	t.Helper()
+	raw, err := os.ReadFile("../../deploy/observability-collector-runtime-authority.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return raw
+}
+
+type collectorRuntimeAuthorityAPI struct {
+	requests    []string
+	posts       int
+	existingGET int
+	failPOST    int
+}
+
+func (api *collectorRuntimeAuthorityAPI) RoundTrip(request *http.Request) (*http.Response, error) {
+	api.requests = append(api.requests, request.Method+" "+request.URL.Path)
+	if request.Header.Get("Authorization") != "Bearer workload-admin" {
+		return targetCredentialTestResponse(http.StatusUnauthorized, map[string]any{"kind": "Status"}), nil
+	}
+	if request.Method == http.MethodGet {
+		getIndex := len(api.requests)
+		if api.existingGET == getIndex {
+			return targetCredentialTestResponse(http.StatusOK, map[string]any{"apiVersion": "v1", "kind": "Namespace", "metadata": map[string]any{"name": "foreign"}}), nil
+		}
+		return targetCredentialTestResponse(http.StatusNotFound, map[string]any{"kind": "Status"}), nil
+	}
+	api.posts++
+	if api.failPOST == api.posts {
+		return targetCredentialTestResponse(http.StatusForbidden, map[string]any{"kind": "Status"}), nil
+	}
+	body, _ := io.ReadAll(request.Body)
+	var object map[string]any
+	if json.Unmarshal(body, &object) != nil {
+		return targetCredentialTestResponse(http.StatusBadRequest, map[string]any{"kind": "Status"}), nil
+	}
+	metadata := object["metadata"].(map[string]any)
+	metadata["uid"] = "collector-runtime-uid-" + string(rune('0'+api.posts))
+	metadata["resourceVersion"] = "collector-runtime-rv-" + string(rune('0'+api.posts))
+	return targetCredentialTestResponse(http.StatusCreated, object), nil
+}

--- a/internal/runner/observability_collector_runtime_launcher.go
+++ b/internal/runner/observability_collector_runtime_launcher.go
@@ -155,9 +155,7 @@ func PlanObservabilityCollectorRuntimeInstallation(packaged VerifiedObservabilit
 		PackageDigest: receipt.PackageDigest, ManifestDigest: receipt.ManifestDigest, RuntimeBindingDigest: receipt.RuntimeBindingDigest,
 		TargetIdentityDigest: targetIdentity, Authority: targetIdentity,
 		Prerequisites: []FullRunExecutionActivationPrerequisite{
-			{Order: 1, APIVersion: "v1", Kind: "Namespace", Name: submissionStageInputNamespace, Method: http.MethodGet,
-				ObjectPath: "/api/v1/namespaces/" + submissionStageInputNamespace, ExpectState: "PRESENT"},
-			{Order: 2, APIVersion: "v1", Kind: "ServiceAccount", Namespace: submissionStageInputNamespace, Name: "ok147-contract-executor-runtime", Method: http.MethodGet,
+			{Order: 1, APIVersion: "v1", Kind: "ServiceAccount", Namespace: submissionStageInputNamespace, Name: "ok147-contract-executor-runtime", Method: http.MethodGet,
 				ObjectPath: "/api/v1/namespaces/" + submissionStageInputNamespace + "/serviceaccounts/ok147-contract-executor-runtime", ExpectState: "PRESENT_EXACT_RUNTIME"},
 		},
 		Creates: creates, MutationAllowed: false,

--- a/internal/runner/observability_collector_runtime_launcher_test.go
+++ b/internal/runner/observability_collector_runtime_launcher_test.go
@@ -21,7 +21,7 @@ func TestPlanObservabilityCollectorRuntimeInstallationBindsExactOrder(t *testing
 	}
 	if plan.Format != ObservabilityCollectorRuntimeInstallationPlanFormat || plan.State != "VERIFIED" ||
 		plan.RunID != "ok147-evidence-collector-01" || plan.Authority != plan.TargetIdentityDigest ||
-		!stageReceiptPrefixDigestPattern.MatchString(plan.Authority) || plan.MutationAllowed || len(plan.Prerequisites) != 2 || len(plan.Creates) != 4 {
+		!stageReceiptPrefixDigestPattern.MatchString(plan.Authority) || plan.MutationAllowed || len(plan.Prerequisites) != 1 || len(plan.Creates) != 4 {
 		t.Fatalf("unexpected collector installation plan: %#v", plan)
 	}
 	for index, kind := range []string{"Secret", "Service", "NetworkPolicy", "Job"} {
@@ -120,11 +120,11 @@ func TestObservabilityCollectorRuntimeLauncherPreflightsThenCreates(t *testing.T
 		receipt.TargetIdentityDigest != plan.TargetIdentityDigest || receipt.Authority != plan.Authority {
 		t.Fatalf("collector launch identity differs: %#v", receipt)
 	}
-	if len(api.requests) != 10 {
-		t.Fatalf("requests=%d, want two prerequisite GETs, four absence GETs and four POSTs: %#v", len(api.requests), api.requests)
+	if len(api.requests) != 9 {
+		t.Fatalf("requests=%d, want one prerequisite GET, four absence GETs and four POSTs: %#v", len(api.requests), api.requests)
 	}
 	for index, create := range plan.Creates {
-		preflight, submission := api.requests[index+2], api.requests[index+6]
+		preflight, submission := api.requests[index+1], api.requests[index+5]
 		if preflight.method != http.MethodGet || preflight.path != create.ObjectPath || len(preflight.body) != 0 {
 			t.Fatalf("preflight %d differs: %#v", index, preflight)
 		}
@@ -197,9 +197,6 @@ func newObservabilityCollectorRuntimeLauncher(t *testing.T, packaged VerifiedObs
 }
 
 func seedObservabilityCollectorRuntimePrerequisites(api *submissionStageInstallerAPI) {
-	api.objects["/api/v1/namespaces/openkubes-execution-system"] = map[string]any{
-		"apiVersion": "v1", "kind": "Namespace", "metadata": map[string]any{"name": "openkubes-execution-system"},
-	}
 	api.objects["/api/v1/namespaces/openkubes-execution-system/serviceaccounts/ok147-contract-executor-runtime"] = map[string]any{
 		"apiVersion": "v1", "kind": "ServiceAccount", "automountServiceAccountToken": false,
 		"metadata": map[string]any{"name": "ok147-contract-executor-runtime", "namespace": "openkubes-execution-system", "labels": map[string]any{


### PR DESCRIPTION
## Outcome

- adds an exact five-object workload authority package for the independent evidence collector
- separates the short-lived installer ServiceAccount from the tokenless, unbound collector runtime ServiceAccount
- limits the installer Role to exact runtime-SA get plus get/create for Secret, Service, NetworkPolicy and Job in the dedicated execution namespace
- adds a single-use create-only installer with a global five-object absence barrier, preserved partial receipt and no retry/update/patch/delete/rollback/cleanup path
- removes the cluster-scoped Namespace GET from the later collector token; the exact namespaced runtime-SA GET proves the namespace prerequisite

## Verification

- full Go test suite
- go vet
- internal/runner race tests

No live cluster contact or infrastructure mutation was performed.
