### PR TITLE
feat(runner): activate collector authority after prefix

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -3194,8 +3194,17 @@ ServiceAccount -> Role -> RoleBinding, retains a redacted successful prefix on
 partial failure and has no
 retry, adoption, update, patch, delete, rollback or cleanup operation. Package
 verification and installation planning are offline; no live cluster has been
-contacted. Wiring this verified prerequisite package ahead of the TokenRequest
-and all private factory inputs into the full-run CLI/Job activation remains the
+contacted.
+
+The concrete post-prefix factory now enforces the complete order under the
+same run context: build the collector package and exact authority package;
+install all five authority objects; issue the one short-lived installer token;
+open and execute the four-object collector launcher; return only after the
+collector activation receipt is complete. A failed or partial authority install
+is retained in the redacted post-prefix receipt and cannot reach TokenRequest
+or collector creation. A credential or collector failure cannot open Stage 8
+and has no implicit retry or cleanup path. Wiring the private authority manifest
+and remaining factory inputs into the full-run CLI/Job activation is now the
 next prerequisite before a complete fresh run.
 
 Fresh-Run v3 now also has one fail-closed offline image/package correlation

--- a/internal/runner/observability_collector_post_prefix.go
+++ b/internal/runner/observability_collector_post_prefix.go
@@ -13,50 +13,66 @@ import (
 const ObservabilityCollectorPostPrefixReceiptFormat = "ok147-observability-collector-post-prefix-receipt/v1"
 
 type ObservabilityCollectorPostPrefixConfig struct {
-	Package ObservabilityCollectorRuntimePackageConfig
-	Clock   func() time.Time
+	Package          ObservabilityCollectorRuntimePackageConfig
+	RuntimeAuthority ObservabilityCollectorRuntimeAuthorityPackageConfig
+	Clock            func() time.Time
 }
 
 type ObservabilityCollectorPostPrefixReceipt struct {
-	Format                  string `json:"format"`
-	State                   string `json:"state"`
-	PackageDigest           string `json:"packageDigest,omitempty"`
-	RuntimeBindingDigest    string `json:"runtimeBindingDigest,omitempty"`
-	TargetIdentityDigest    string `json:"targetIdentityDigest,omitempty"`
-	CredentialReceiptDigest string `json:"credentialReceiptDigest,omitempty"`
-	LaunchState             string `json:"launchState,omitempty"`
-	CreatedObjects          int    `json:"createdObjects"`
+	Format                         string `json:"format"`
+	State                          string `json:"state"`
+	PackageDigest                  string `json:"packageDigest,omitempty"`
+	RuntimeBindingDigest           string `json:"runtimeBindingDigest,omitempty"`
+	TargetIdentityDigest           string `json:"targetIdentityDigest,omitempty"`
+	RuntimeAuthorityPackageDigest  string `json:"runtimeAuthorityPackageDigest,omitempty"`
+	RuntimeAuthorityReceiptDigest  string `json:"runtimeAuthorityReceiptDigest,omitempty"`
+	RuntimeAuthorityCreatedObjects int    `json:"runtimeAuthorityCreatedObjects"`
+	CredentialReceiptDigest        string `json:"credentialReceiptDigest,omitempty"`
+	LaunchState                    string `json:"launchState,omitempty"`
+	CreatedObjects                 int    `json:"createdObjects"`
 }
 
 type observabilityCollectorRuntimeLauncher interface {
 	Launch(context.Context) (ObservabilityCollectorRuntimeLaunchReceipt, error)
 }
 
+type observabilityCollectorRuntimeAuthorityInstaller interface {
+	Install(context.Context) (ObservabilityCollectorRuntimeAuthorityInstallationReceipt, error)
+}
+
 // KubernetesObservabilityCollectorPostPrefix builds and installs the exact
 // collector only after the fresh seven-stage prefix exists. It is single-use
 // and retains only a redaction-safe receipt.
 type KubernetesObservabilityCollectorPostPrefix struct {
-	mu      sync.Mutex
-	used    bool
-	config  ObservabilityCollectorPostPrefixConfig
-	receipt ObservabilityCollectorPostPrefixReceipt
-	build   func(ObservabilityCollectorRuntimePackageConfig) (VerifiedObservabilityCollectorRuntimePackage, error)
-	issue   func(context.Context, ObservabilityCollectorInstallerCredentialConfig) (VerifiedObservabilityCollectorInstallerCredential, error)
-	open    func(submissionStageInstallerClientConfig, VerifiedObservabilityCollectorRuntimePackage) (observabilityCollectorRuntimeLauncher, error)
-	resolve func(WorkloadAuthorityFileResolverConfig) (WorkloadAuthorityBinding, KubernetesAuthorityConfig, error)
+	mu             sync.Mutex
+	used           bool
+	config         ObservabilityCollectorPostPrefixConfig
+	receipt        ObservabilityCollectorPostPrefixReceipt
+	build          func(ObservabilityCollectorRuntimePackageConfig) (VerifiedObservabilityCollectorRuntimePackage, error)
+	buildAuthority func(ObservabilityCollectorRuntimeAuthorityPackageConfig) (VerifiedObservabilityCollectorRuntimeAuthorityPackage, error)
+	openAuthority  func(WorkloadAuthorityFileResolverConfig, VerifiedObservabilityCollectorRuntimeAuthorityPackage) (observabilityCollectorRuntimeAuthorityInstaller, error)
+	issue          func(context.Context, ObservabilityCollectorInstallerCredentialConfig) (VerifiedObservabilityCollectorInstallerCredential, error)
+	open           func(submissionStageInstallerClientConfig, VerifiedObservabilityCollectorRuntimePackage) (observabilityCollectorRuntimeLauncher, error)
+	resolve        func(WorkloadAuthorityFileResolverConfig) (WorkloadAuthorityBinding, KubernetesAuthorityConfig, error)
 }
 
 func NewKubernetesObservabilityCollectorPostPrefix(config ObservabilityCollectorPostPrefixConfig) (*KubernetesObservabilityCollectorPostPrefix, error) {
 	if config.Clock == nil || config.Package.Activation.RuntimeBinding.Bundle.PlanPath == "" ||
 		config.Package.Activation.RuntimeBinding.MaterialPath == "" || config.Package.Activation.RuntimeBinding.ReceiptPath == "" ||
 		config.Package.Activation.ObserverCredential.CAFile == "" ||
-		!stageReceiptPrefixDigestPattern.MatchString(config.Package.Activation.ObserverCredential.CABundleDigest) {
+		!stageReceiptPrefixDigestPattern.MatchString(config.Package.Activation.ObserverCredential.CABundleDigest) ||
+		len(config.RuntimeAuthority.Manifest) == 0 || !stageReceiptPrefixDigestPattern.MatchString(config.RuntimeAuthority.ExpectedManifestDigest) ||
+		digest.SHA256(config.RuntimeAuthority.Manifest) != config.RuntimeAuthority.ExpectedManifestDigest || config.RuntimeAuthority.TargetIdentityDigest != "" {
 		return nil, errors.New("observability collector post-prefix configuration is incomplete")
 	}
 	return &KubernetesObservabilityCollectorPostPrefix{
-		config:  config,
-		receipt: ObservabilityCollectorPostPrefixReceipt{Format: ObservabilityCollectorPostPrefixReceiptFormat, State: "PREPARED"},
-		build:   BuildObservabilityCollectorRuntimePackage,
+		config:         config,
+		receipt:        ObservabilityCollectorPostPrefixReceipt{Format: ObservabilityCollectorPostPrefixReceiptFormat, State: "PREPARED"},
+		build:          BuildObservabilityCollectorRuntimePackage,
+		buildAuthority: BuildObservabilityCollectorRuntimeAuthorityPackage,
+		openAuthority: func(workload WorkloadAuthorityFileResolverConfig, packaged VerifiedObservabilityCollectorRuntimeAuthorityPackage) (observabilityCollectorRuntimeAuthorityInstaller, error) {
+			return OpenKubernetesObservabilityCollectorRuntimeAuthorityInstaller(workload, packaged)
+		},
 		issue: func(ctx context.Context, config ObservabilityCollectorInstallerCredentialConfig) (VerifiedObservabilityCollectorInstallerCredential, error) {
 			issuer, err := OpenKubernetesObservabilityCollectorInstallerCredentialIssuer(config)
 			if err != nil {
@@ -112,6 +128,37 @@ func (activation *KubernetesObservabilityCollectorPostPrefix) ActivateFullRunPos
 	if err != nil || plan.TargetIdentityDigest != prefix.TargetIdentity || plan.RuntimeBindingDigest != packageReceipt.RuntimeBindingDigest {
 		activation.stop()
 		return errors.New("observability collector package differs from fresh runtime prefix")
+	}
+	authorityConfig := activation.config.RuntimeAuthority
+	authorityConfig.TargetIdentityDigest = prefix.TargetIdentity
+	authorityPackage, err := activation.buildAuthority(authorityConfig)
+	if err != nil {
+		activation.stop()
+		return errors.New("build observability collector runtime authority package")
+	}
+	authorityPackageReceipt, err := authorityPackage.Receipt()
+	if err != nil || authorityPackageReceipt.TargetIdentityDigest != prefix.TargetIdentity {
+		activation.stop()
+		return errors.New("verify observability collector runtime authority package")
+	}
+	authorityInstaller, err := activation.openAuthority(prefix.Workload, authorityPackage)
+	if err != nil {
+		activation.stop()
+		return errors.New("open observability collector runtime authority installer")
+	}
+	authorityInstallReceipt, err := authorityInstaller.Install(ctx)
+	authorityInstallReceiptRaw, encodeErr := json.Marshal(authorityInstallReceipt)
+	activation.mu.Lock()
+	activation.receipt.RuntimeAuthorityPackageDigest = authorityPackageReceipt.PackageDigest
+	activation.receipt.RuntimeAuthorityCreatedObjects = len(authorityInstallReceipt.Results)
+	if encodeErr == nil {
+		activation.receipt.RuntimeAuthorityReceiptDigest = digest.SHA256(authorityInstallReceiptRaw)
+	}
+	activation.mu.Unlock()
+	if err != nil || encodeErr != nil || authorityInstallReceipt.State != "INSTALLED" || len(authorityInstallReceipt.Results) != 5 ||
+		authorityInstallReceipt.TargetIdentityDigest != prefix.TargetIdentity || authorityInstallReceipt.PackageDigest != authorityPackageReceipt.PackageDigest {
+		activation.stop()
+		return errors.New("install observability collector runtime authority")
 	}
 	credential, err := activation.issue(ctx, ObservabilityCollectorInstallerCredentialConfig{
 		Workload: prefix.Workload, ExpectedTargetDigest: prefix.TargetIdentity, Clock: activation.config.Clock,

--- a/internal/runner/observability_collector_post_prefix_test.go
+++ b/internal/runner/observability_collector_post_prefix_test.go
@@ -17,6 +17,17 @@ type fakeCollectorRuntimeLauncher struct {
 	calls   int
 }
 
+type fakeCollectorRuntimeAuthorityInstaller struct {
+	receipt ObservabilityCollectorRuntimeAuthorityInstallationReceipt
+	err     error
+	calls   int
+}
+
+func (installer *fakeCollectorRuntimeAuthorityInstaller) Install(context.Context) (ObservabilityCollectorRuntimeAuthorityInstallationReceipt, error) {
+	installer.calls++
+	return installer.receipt, installer.err
+}
+
 func (launcher *fakeCollectorRuntimeLauncher) Launch(context.Context) (ObservabilityCollectorRuntimeLaunchReceipt, error) {
 	launcher.calls++
 	return launcher.receipt, launcher.err
@@ -31,12 +42,13 @@ func TestObservabilityCollectorPostPrefixBuildsAndLaunchesFreshBindingOnce(t *te
 	packageReceipt, _ := packaged.Receipt()
 	target := digest.SHA256([]byte("collector-target-cluster-uid"))
 	activator, err := NewKubernetesObservabilityCollectorPostPrefix(ObservabilityCollectorPostPrefixConfig{
-		Package: config, Clock: func() time.Time { return config.Activation.MaterializationTime },
+		Package: config, RuntimeAuthority: collectorRuntimeAuthorityPostPrefixConfig(t),
+		Clock: func() time.Time { return config.Activation.MaterializationTime },
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	buildCalls, openCalls := 0, 0
+	buildCalls, authorityOpenCalls, openCalls := 0, 0, 0
 	launcher := &fakeCollectorRuntimeLauncher{receipt: ObservabilityCollectorRuntimeLaunchReceipt{
 		Format: ObservabilityCollectorRuntimeLaunchReceiptFormat, State: "ACTIVATED",
 		Results: make([]SubmissionStageInstalledObject, 4),
@@ -52,6 +64,20 @@ func TestObservabilityCollectorPostPrefixBuildsAndLaunchesFreshBindingOnce(t *te
 		return WorkloadAuthorityBinding{TargetClusterUID: "collector-target-cluster-uid"}, KubernetesAuthorityConfig{
 			Endpoint: "https://192.0.2.147:6443", CABundleDigest: config.Activation.ObserverCredential.CABundleDigest,
 		}, nil
+	}
+	authorityInstaller := &fakeCollectorRuntimeAuthorityInstaller{}
+	activator.openAuthority = func(_ WorkloadAuthorityFileResolverConfig, authorityPackage VerifiedObservabilityCollectorRuntimeAuthorityPackage) (observabilityCollectorRuntimeAuthorityInstaller, error) {
+		authorityOpenCalls++
+		authorityReceipt, err := authorityPackage.Receipt()
+		if err != nil || authorityReceipt.TargetIdentityDigest != target {
+			t.Fatalf("runtime authority package differs: %#v %v", authorityReceipt, err)
+		}
+		authorityInstaller.receipt = ObservabilityCollectorRuntimeAuthorityInstallationReceipt{
+			Format: ObservabilityCollectorRuntimeAuthorityReceiptFormat, PackageDigest: authorityReceipt.PackageDigest,
+			TargetIdentityDigest: target, State: "INSTALLED", MutationState: "ATTEMPTED",
+			Results: make([]SubmissionStageInstalledObject, 5),
+		}
+		return authorityInstaller, nil
 	}
 	credential := collectorInstallerCredentialFixture(t, target, config.Activation.ObserverCredential.CABundleDigest, config.Activation.MaterializationTime)
 	activator.issue = func(_ context.Context, received ObservabilityCollectorInstallerCredentialConfig) (VerifiedObservabilityCollectorInstallerCredential, error) {
@@ -76,8 +102,10 @@ func TestObservabilityCollectorPostPrefixBuildsAndLaunchesFreshBindingOnce(t *te
 	}
 	receipt := activator.Receipt()
 	if receipt.State != "ACTIVATED" || receipt.PackageDigest != packageReceipt.PackageDigest || receipt.CreatedObjects != 4 ||
-		!stageReceiptPrefixDigestPattern.MatchString(receipt.CredentialReceiptDigest) || buildCalls != 1 || openCalls != 1 || launcher.calls != 1 {
-		t.Fatalf("unexpected post-prefix receipt: %#v calls=%d/%d/%d", receipt, buildCalls, openCalls, launcher.calls)
+		receipt.RuntimeAuthorityCreatedObjects != 5 || !stageReceiptPrefixDigestPattern.MatchString(receipt.RuntimeAuthorityPackageDigest) ||
+		!stageReceiptPrefixDigestPattern.MatchString(receipt.RuntimeAuthorityReceiptDigest) ||
+		!stageReceiptPrefixDigestPattern.MatchString(receipt.CredentialReceiptDigest) || buildCalls != 1 || authorityOpenCalls != 1 || authorityInstaller.calls != 1 || openCalls != 1 || launcher.calls != 1 {
+		t.Fatalf("unexpected post-prefix receipt: %#v calls=%d/%d/%d/%d", receipt, buildCalls, authorityOpenCalls, openCalls, launcher.calls)
 	}
 	if err := activator.ActivateFullRunPostPrefix(context.Background(), prefix); err == nil || buildCalls != 1 || launcher.calls != 1 {
 		t.Fatal("post-prefix activation was replayed")
@@ -87,7 +115,8 @@ func TestObservabilityCollectorPostPrefixBuildsAndLaunchesFreshBindingOnce(t *te
 func TestObservabilityCollectorPostPrefixStopsBeforeBuildOnForeignRuntime(t *testing.T) {
 	config := observabilityCollectorRuntimePackageFixture(t)
 	activator, err := NewKubernetesObservabilityCollectorPostPrefix(ObservabilityCollectorPostPrefixConfig{
-		Package: config, Clock: func() time.Time { return config.Activation.MaterializationTime },
+		Package: config, RuntimeAuthority: collectorRuntimeAuthorityPostPrefixConfig(t),
+		Clock: func() time.Time { return config.Activation.MaterializationTime },
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -109,6 +138,58 @@ func TestObservabilityCollectorPostPrefixStopsBeforeBuildOnForeignRuntime(t *tes
 	if err == nil || buildCalls != 0 || activator.Receipt().State != "STOPPED" {
 		t.Fatalf("foreign runtime reached package build: calls=%d receipt=%#v err=%v", buildCalls, activator.Receipt(), err)
 	}
+}
+
+func TestObservabilityCollectorPostPrefixStopsAfterAuthorityFailureBeforeCredential(t *testing.T) {
+	config := observabilityCollectorRuntimePackageFixture(t)
+	packaged, err := BuildObservabilityCollectorRuntimePackage(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	target := digest.SHA256([]byte("collector-target-cluster-uid"))
+	activator, err := NewKubernetesObservabilityCollectorPostPrefix(ObservabilityCollectorPostPrefixConfig{
+		Package: config, RuntimeAuthority: collectorRuntimeAuthorityPostPrefixConfig(t),
+		Clock: func() time.Time { return config.Activation.MaterializationTime },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	activator.build = func(ObservabilityCollectorRuntimePackageConfig) (VerifiedObservabilityCollectorRuntimePackage, error) {
+		return packaged, nil
+	}
+	activator.resolve = func(WorkloadAuthorityFileResolverConfig) (WorkloadAuthorityBinding, KubernetesAuthorityConfig, error) {
+		return WorkloadAuthorityBinding{TargetClusterUID: "collector-target-cluster-uid"}, KubernetesAuthorityConfig{
+			Endpoint: "https://192.0.2.147:6443", CABundleDigest: config.Activation.ObserverCredential.CABundleDigest,
+		}, nil
+	}
+	activator.openAuthority = func(_ WorkloadAuthorityFileResolverConfig, authorityPackage VerifiedObservabilityCollectorRuntimeAuthorityPackage) (observabilityCollectorRuntimeAuthorityInstaller, error) {
+		receipt, _ := authorityPackage.Receipt()
+		return &fakeCollectorRuntimeAuthorityInstaller{receipt: ObservabilityCollectorRuntimeAuthorityInstallationReceipt{
+			Format: ObservabilityCollectorRuntimeAuthorityReceiptFormat, PackageDigest: receipt.PackageDigest,
+			TargetIdentityDigest: target, State: "STOPPED_PARTIAL_OR_UNKNOWN", MutationState: "ATTEMPTED",
+			Results: make([]SubmissionStageInstalledObject, 2),
+		}, err: errors.New("partial authority")}, nil
+	}
+	issueCalls := 0
+	activator.issue = func(context.Context, ObservabilityCollectorInstallerCredentialConfig) (VerifiedObservabilityCollectorInstallerCredential, error) {
+		issueCalls++
+		return VerifiedObservabilityCollectorInstallerCredential{}, errors.New("must not issue")
+	}
+	err = activator.ActivateFullRunPostPrefix(context.Background(), FullRunPostPrefixActivation{
+		ReceiptPrefix: make([]StageReceiptSource, 7), TargetIdentity: target,
+		Workload: WorkloadAuthorityFileResolverConfig{CAFile: config.Activation.ObserverCredential.CAFile},
+	})
+	receipt := activator.Receipt()
+	if err == nil || issueCalls != 0 || receipt.State != "STOPPED" || receipt.RuntimeAuthorityCreatedObjects != 2 ||
+		!stageReceiptPrefixDigestPattern.MatchString(receipt.RuntimeAuthorityReceiptDigest) {
+		t.Fatalf("authority failure crossed credential boundary: %#v issue=%d err=%v", receipt, issueCalls, err)
+	}
+}
+
+func collectorRuntimeAuthorityPostPrefixConfig(t *testing.T) ObservabilityCollectorRuntimeAuthorityPackageConfig {
+	t.Helper()
+	raw := collectorRuntimeAuthorityManifest(t)
+	return ObservabilityCollectorRuntimeAuthorityPackageConfig{Manifest: raw, ExpectedManifestDigest: digest.SHA256(raw)}
 }
 
 func collectorInstallerCredentialFixture(t *testing.T, target, caDigest string, now time.Time) VerifiedObservabilityCollectorInstallerCredential {


### PR DESCRIPTION
## Outcome

- enforces the complete post-Stage-7 order in one run context
- builds and installs the exact five-object workload authority package before requesting a credential
- issues one 30-minute in-memory installer token only after authority installation succeeds
- opens and launches the exact four collector objects only after credential verification
- retains redacted authority package, installation receipt and credential receipt digests
- stops before TokenRequest, collector creation and Stage 8 on any authority failure or partial state

## Verification

- full Go test suite
- go vet
- internal/runner race tests

No live cluster contact or infrastructure mutation was performed.
