### PR TITLE
feat(runner): issue collector observer credential in memory

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -3166,8 +3166,15 @@ verification, derives the package materialization time from the run clock,
 and requires the target UID digest and CA to match the lifecycle-derived
 workload authority before building the package.
 
-It no longer accepts a persisted installer-token file. Instead, after package
-and target correlation have passed, a single-use issuer performs exactly one
+It no longer accepts persisted installer- or observer-token files. After the
+five workload-side authority objects exist, a separate single-use issuer first
+performs exactly one one-hour, server-default-audience TokenRequest for
+`ok-observability/ok147-observability-autonomy`. The exact subject, audience,
+issuer, issued-at, not-before and expiry claims are verified. The token is
+passed directly into activation-package construction in process memory; the
+package still binds its digest and redacted TokenRequest evidence identity.
+Only after that package and target correlation have passed, another single-use
+issuer performs exactly one
 30-minute, server-default-audience TokenRequest for the dedicated
 `openkubes-execution-system/ok147-observability-collector-installer`. The response must
 carry the exact ServiceAccount subject, audience set, expiry and bounded
@@ -3197,15 +3204,16 @@ verification and installation planning are offline; no live cluster has been
 contacted.
 
 The concrete post-prefix factory now enforces the complete order under the
-same run context: build the collector package and exact authority package;
-install all five authority objects; issue the one short-lived installer token;
-open and execute the four-object collector launcher; return only after the
-collector activation receipt is complete. A failed or partial authority install
-is retained in the redacted post-prefix receipt and cannot reach TokenRequest
-or collector creation. A credential or collector failure cannot open Stage 8
-and has no implicit retry or cleanup path. Wiring the private authority manifest
-and remaining factory inputs into the full-run CLI/Job activation is now the
-next prerequisite before a complete fresh run.
+same run context: build the exact authority package; install all five authority
+objects; issue the one-hour observer token; build and correlate the collector
+package; issue the 30-minute installer token; open and execute the four-object
+collector launcher; return only after the collector activation receipt is
+complete. A failed or partial authority install is retained in the redacted
+post-prefix receipt and cannot reach either TokenRequest or collector creation.
+An observer-credential, package, installer-credential or collector failure
+cannot open Stage 8 and has no implicit retry or cleanup path. Wiring the
+private authority manifest and remaining factory inputs into the full-run
+CLI/Job activation is now the next prerequisite before a complete fresh run.
 
 Fresh-Run v3 now also has one fail-closed offline image/package correlation
 boundary:

--- a/internal/runner/observability_collector_activation_package.go
+++ b/internal/runner/observability_collector_activation_package.go
@@ -50,6 +50,7 @@ type ObservabilityCollectorActivationPackageConfig struct {
 	ActivationSecret       string
 	MaterializationTime    time.Time
 	ObserverCredential     SubmissionStageCredentialSource
+	ObserverToken          []byte
 	WebhookTokenPath       string
 	QueryTokenPath         string
 	PublicEndpoint         string
@@ -180,7 +181,7 @@ func BuildObservabilityCollectorActivationPackage(config ObservabilityCollectorA
 		return VerifiedObservabilityCollectorActivationPackage{}, errors.New("observability collector observer credential identity is invalid")
 	}
 	observerReceipt, workloadToken, err := loadObservabilityCollectorObserverCredential(
-		config.ObserverCredential, targetAuthority, expectedSubject, config.MaterializationTime.UTC(),
+		config.ObserverCredential, config.ObserverToken, targetAuthority, expectedSubject, config.MaterializationTime.UTC(),
 	)
 	if err != nil {
 		return VerifiedObservabilityCollectorActivationPackage{}, errors.New("verify observability collector observer credential")
@@ -485,14 +486,26 @@ func loadObservabilityCollectorTLS(certificatePath, privateKeyPath, publicEndpoi
 	return certificateRaw, privateKeyRaw, digest.SHA256(certificateRaw), nil
 }
 
-func loadObservabilityCollectorObserverCredential(source SubmissionStageCredentialSource, authority, expectedSubject string, now time.Time) (observabilityCollectorObserverCredential, []byte, error) {
-	if source.AuthorityIdentity != authority || authority == "" || source.TokenFile == "" || source.CAFile == "" ||
+func loadObservabilityCollectorObserverCredential(source SubmissionStageCredentialSource, inMemoryToken []byte, authority, expectedSubject string, now time.Time) (observabilityCollectorObserverCredential, []byte, error) {
+	if source.AuthorityIdentity != authority || authority == "" || source.CAFile == "" ||
 		!stageReceiptPrefixDigestPattern.MatchString(source.TokenDigest) ||
 		!stageReceiptPrefixDigestPattern.MatchString(source.CABundleDigest) ||
 		!stageReceiptPrefixDigestPattern.MatchString(source.TokenRequestEvidenceDigest) {
 		return observabilityCollectorObserverCredential{}, nil, errors.New("observability collector observer credential source is invalid")
 	}
-	token, err := readBoundedRegular(source.TokenFile, maximumTokenBytes)
+	var token []byte
+	var err error
+	if len(inMemoryToken) != 0 {
+		if source.TokenFile != "" || len(inMemoryToken) > maximumTokenBytes {
+			return observabilityCollectorObserverCredential{}, nil, errors.New("observability collector in-memory observer token is invalid")
+		}
+		token = append([]byte(nil), inMemoryToken...)
+	} else {
+		if source.TokenFile == "" {
+			return observabilityCollectorObserverCredential{}, nil, errors.New("observability collector observer token source is missing")
+		}
+		token, err = readBoundedRegular(source.TokenFile, maximumTokenBytes)
+	}
 	if err != nil || digest.SHA256(token) != source.TokenDigest {
 		return observabilityCollectorObserverCredential{}, nil, errors.New("observability collector observer token differs from source")
 	}

--- a/internal/runner/observability_collector_activation_package_test.go
+++ b/internal/runner/observability_collector_activation_package_test.go
@@ -136,6 +136,30 @@ func TestBuildObservabilityCollectorActivationPackageFailsClosed(t *testing.T) {
 	}
 }
 
+func TestBuildObservabilityCollectorActivationPackageAcceptsOnlyBoundInMemoryObserverToken(t *testing.T) {
+	config, cleanup := observabilityCollectorActivationFixture(t)
+	defer cleanup()
+	token, err := os.ReadFile(config.ObserverCredential.TokenFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	config.ObserverCredential.TokenFile = ""
+	config.ObserverToken = token
+	packaged, err := BuildObservabilityCollectorActivationPackage(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := packaged.Receipt()
+	if err != nil || receipt.ObserverTokenRequestEvidence != config.ObserverCredential.TokenRequestEvidenceDigest {
+		t.Fatalf("in-memory observer credential was not bound: %#v %v", receipt, err)
+	}
+	config.ObserverToken = append([]byte(nil), token...)
+	config.ObserverToken[len(config.ObserverToken)-1] ^= 1
+	if packaged, err := BuildObservabilityCollectorActivationPackage(config); err == nil || packaged.verified {
+		t.Fatal("changed in-memory observer credential was accepted")
+	}
+}
+
 func observabilityCollectorActivationFixture(t *testing.T) (ObservabilityCollectorActivationPackageConfig, func()) {
 	t.Helper()
 	manifestPath, cleanup := fullRunExecutionManifestFixture(t)

--- a/internal/runner/observability_collector_observer_credential.go
+++ b/internal/runner/observability_collector_observer_credential.go
@@ -1,0 +1,275 @@
+package runner
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/jsonstrict"
+)
+
+const (
+	ObservabilityCollectorObserverCredentialReceiptFormat = "ok147-observability-collector-observer-credential-receipt/v1"
+	observabilityCollectorObserverLifetime                = time.Hour
+	minimumObservabilityCollectorObserverLifetime         = 55 * time.Minute
+)
+
+type ObservabilityCollectorObserverCredentialConfig struct {
+	Workload             WorkloadAuthorityFileResolverConfig
+	ExpectedTargetDigest string
+	Clock                func() time.Time
+}
+
+type ObservabilityCollectorObserverCredentialReceipt struct {
+	Format                       string `json:"format"`
+	State                        string `json:"state"`
+	TargetIdentityDigest         string `json:"targetIdentityDigest"`
+	ServiceAccountIdentityDigest string `json:"serviceAccountIdentityDigest"`
+	RequestDigest                string `json:"requestDigest"`
+	CABundleDigest               string `json:"caBundleDigest"`
+	AudienceMode                 string `json:"audienceMode"`
+	IssuedAt                     string `json:"issuedAt"`
+	ExpiresAt                    string `json:"expiresAt"`
+	LifetimeSeconds              int64  `json:"lifetimeSeconds"`
+	CredentialBytesInReceipt     bool   `json:"credentialBytesInReceipt"`
+	MutationState                string `json:"mutationState"`
+}
+
+type VerifiedObservabilityCollectorObserverCredential struct {
+	token          []byte
+	caFile         string
+	targetIdentity string
+	caBundleDigest string
+	source         SubmissionStageCredentialSource
+	receipt        ObservabilityCollectorObserverCredentialReceipt
+	verified       bool
+}
+
+type observabilityCollectorObserverIssuerClientConfig struct {
+	Endpoint          string
+	BearerToken       string
+	ClientCertificate bool
+	CABundleDigest    string
+	CAFile            string
+	TargetIdentity    string
+	Client            *http.Client
+	Clock             func() time.Time
+}
+
+type KubernetesObservabilityCollectorObserverCredentialIssuer struct {
+	mu                sync.Mutex
+	used              bool
+	endpoint          *url.URL
+	authorityToken    string
+	clientCertificate bool
+	caBundleDigest    string
+	caFile            string
+	targetIdentity    string
+	client            *http.Client
+	clock             func() time.Time
+	request           []byte
+}
+
+// OpenKubernetesObservabilityCollectorObserverCredentialIssuer binds the
+// lifecycle-derived workload authority. Issue is the sole TokenRequest edge.
+func OpenKubernetesObservabilityCollectorObserverCredentialIssuer(config ObservabilityCollectorObserverCredentialConfig) (*KubernetesObservabilityCollectorObserverCredentialIssuer, error) {
+	if config.Clock == nil || !stageReceiptPrefixDigestPattern.MatchString(config.ExpectedTargetDigest) {
+		return nil, errors.New("collector observer credential binding is incomplete")
+	}
+	binding, authority, err := loadWorkloadAuthorityFiles(config.Workload)
+	if err != nil || digest.SHA256([]byte(binding.TargetClusterUID)) != config.ExpectedTargetDigest {
+		return nil, errors.New("collector observer credential differs from runtime workload authority")
+	}
+	transport, err := openBoundedKubernetesAuthorityTransport(authority)
+	if err != nil || digest.SHA256(transport.caData) != authority.CABundleDigest || authority.CAFile != config.Workload.CAFile {
+		return nil, errors.New("open bounded collector observer issuance authority")
+	}
+	return newKubernetesObservabilityCollectorObserverCredentialIssuer(observabilityCollectorObserverIssuerClientConfig{
+		Endpoint: authority.Endpoint, BearerToken: transport.bearerToken, ClientCertificate: transport.clientCertificate,
+		CABundleDigest: authority.CABundleDigest, CAFile: authority.CAFile, TargetIdentity: config.ExpectedTargetDigest,
+		Client: transport.client, Clock: config.Clock,
+	})
+}
+
+func newKubernetesObservabilityCollectorObserverCredentialIssuer(config observabilityCollectorObserverIssuerClientConfig) (*KubernetesObservabilityCollectorObserverCredentialIssuer, error) {
+	endpoint, err := normalizeSubmissionStageLaunchEndpoint(config.Endpoint)
+	if err != nil {
+		return nil, errors.New("collector observer credential endpoint is invalid")
+	}
+	tokenMode := config.BearerToken != ""
+	if tokenMode == config.ClientCertificate || strings.TrimSpace(config.BearerToken) != config.BearerToken ||
+		strings.ContainsAny(config.BearerToken, "\r\n") || config.CAFile == "" ||
+		!stageReceiptPrefixDigestPattern.MatchString(config.CABundleDigest) ||
+		!stageReceiptPrefixDigestPattern.MatchString(config.TargetIdentity) || config.Client == nil || config.Clock == nil {
+		return nil, errors.New("collector observer issuance authority is invalid")
+	}
+	requestRaw, err := json.Marshal(targetCredentialTokenRequest{
+		APIVersion: "authentication.k8s.io/v1", Kind: "TokenRequest",
+		Spec: targetCredentialTokenRequestSpec{ExpirationSeconds: int64(observabilityCollectorObserverLifetime / time.Second)},
+	})
+	if err != nil {
+		return nil, errors.New("encode collector observer TokenRequest")
+	}
+	parsed, err := url.Parse(endpoint)
+	if err != nil {
+		return nil, errors.New("parse collector observer credential endpoint")
+	}
+	client := *config.Client
+	client.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+	if client.Timeout == 0 {
+		client.Timeout = 15 * time.Second
+	}
+	return &KubernetesObservabilityCollectorObserverCredentialIssuer{
+		endpoint: parsed, authorityToken: config.BearerToken, clientCertificate: config.ClientCertificate,
+		caBundleDigest: config.CABundleDigest, caFile: config.CAFile, targetIdentity: config.TargetIdentity,
+		client: &client, clock: config.Clock, request: requestRaw,
+	}, nil
+}
+
+func (issuer *KubernetesObservabilityCollectorObserverCredentialIssuer) Issue(ctx context.Context) (VerifiedObservabilityCollectorObserverCredential, error) {
+	if issuer == nil || issuer.client == nil || issuer.clock == nil {
+		return VerifiedObservabilityCollectorObserverCredential{}, errors.New("collector observer credential issuer is required")
+	}
+	issuer.mu.Lock()
+	if issuer.used {
+		issuer.mu.Unlock()
+		return VerifiedObservabilityCollectorObserverCredential{}, errors.New("collector observer credential issuer is single-use")
+	}
+	issuer.used = true
+	issuer.mu.Unlock()
+	now := issuer.clock().UTC().Truncate(time.Second)
+	requestURL := *issuer.endpoint
+	requestURL.Path = fmt.Sprintf("/api/v1/namespaces/ok-observability/serviceaccounts/%s/token", observabilityCollectorObserverSA)
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, requestURL.String(), bytes.NewReader(issuer.request))
+	if err != nil {
+		return VerifiedObservabilityCollectorObserverCredential{}, errors.New("construct collector observer TokenRequest")
+	}
+	request.Header.Set("Accept", "application/json")
+	request.Header.Set("Content-Type", "application/json")
+	if !issuer.clientCertificate {
+		request.Header.Set("Authorization", "Bearer "+issuer.authorityToken)
+	}
+	response, err := issuer.client.Do(request)
+	if err != nil {
+		return VerifiedObservabilityCollectorObserverCredential{}, errors.New("collector observer TokenRequest failed")
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusCreated {
+		_, _ = io.Copy(io.Discard, io.LimitReader(response.Body, maximumTargetCredentialResponse))
+		return VerifiedObservabilityCollectorObserverCredential{}, errors.New("collector observer TokenRequest was not created")
+	}
+	mediaType, _, err := mime.ParseMediaType(response.Header.Get("Content-Type"))
+	if err != nil || mediaType != "application/json" {
+		return VerifiedObservabilityCollectorObserverCredential{}, errors.New("collector observer TokenRequest response media type is invalid")
+	}
+	raw, err := io.ReadAll(io.LimitReader(response.Body, maximumTargetCredentialResponse+1))
+	if err != nil || len(raw) == 0 || len(raw) > maximumTargetCredentialResponse {
+		return VerifiedObservabilityCollectorObserverCredential{}, errors.New("read bounded collector observer TokenRequest response")
+	}
+	var value targetCredentialTokenResponse
+	if err := jsonstrict.Decode(raw, &value); err != nil {
+		return VerifiedObservabilityCollectorObserverCredential{}, errors.New("decode collector observer TokenRequest response")
+	}
+	return issuer.verifyResponse(value, now)
+}
+
+func (issuer *KubernetesObservabilityCollectorObserverCredentialIssuer) verifyResponse(value targetCredentialTokenResponse, now time.Time) (VerifiedObservabilityCollectorObserverCredential, error) {
+	if value.APIVersion != "authentication.k8s.io/v1" || value.Kind != "TokenRequest" || len(value.Status.Token) < 80 ||
+		strings.TrimSpace(value.Status.Token) != value.Status.Token || strings.ContainsAny(value.Status.Token, "\r\n") ||
+		value.Spec.ExpirationSeconds != int64(observabilityCollectorObserverLifetime/time.Second) || len(value.Spec.Audiences) == 0 {
+		return VerifiedObservabilityCollectorObserverCredential{}, errors.New("collector observer TokenRequest response is invalid")
+	}
+	expiresAt, err := time.Parse(time.RFC3339, value.Status.ExpirationTimestamp)
+	if err != nil {
+		return VerifiedObservabilityCollectorObserverCredential{}, errors.New("collector observer credential expiration is invalid")
+	}
+	parts := strings.Split(value.Status.Token, ".")
+	if len(parts) != 3 {
+		return VerifiedObservabilityCollectorObserverCredential{}, errors.New("decode collector observer credential claims")
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return VerifiedObservabilityCollectorObserverCredential{}, errors.New("decode collector observer credential claims")
+	}
+	decoder := json.NewDecoder(bytes.NewReader(payload))
+	decoder.UseNumber()
+	var claims submissionStageTokenClaims
+	if err := decoder.Decode(&claims); err != nil {
+		return VerifiedObservabilityCollectorObserverCredential{}, errors.New("decode collector observer credential claims")
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		return VerifiedObservabilityCollectorObserverCredential{}, errors.New("decode collector observer credential claims")
+	}
+	issuedAtUnix, err := exactJWTUnix(claims.IssuedAt)
+	if err != nil {
+		return VerifiedObservabilityCollectorObserverCredential{}, errors.New("collector observer credential issued-at is invalid")
+	}
+	issuedAt := time.Unix(issuedAtUnix, 0).UTC()
+	lifetime := expiresAt.Sub(issuedAt)
+	wantSubject := "system:serviceaccount:ok-observability:" + observabilityCollectorObserverSA
+	audiences, audienceErr := tokenAudiences(claims.Audience)
+	exp, expErr := exactJWTUnix(claims.ExpiresAt)
+	nbf, nbfErr := exactJWTUnix(claims.NotBefore)
+	if audienceErr != nil || len(audiences) != 1 || audiences[0] != "https://kubernetes.default.svc" ||
+		expErr != nil || nbfErr != nil || claims.Issuer == "" || claims.Subject != wantSubject || exp != expiresAt.Unix() ||
+		nbf != issuedAtUnix || issuedAt.After(now.Add(5*time.Second)) || issuedAt.Before(now.Add(-5*time.Minute)) ||
+		lifetime < minimumObservabilityCollectorObserverLifetime || lifetime > observabilityCollectorObserverLifetime {
+		return VerifiedObservabilityCollectorObserverCredential{}, errors.New("collector observer credential claims differ from bounded identity")
+	}
+	receipt := ObservabilityCollectorObserverCredentialReceipt{
+		Format: ObservabilityCollectorObserverCredentialReceiptFormat, State: "ISSUED",
+		TargetIdentityDigest:         issuer.targetIdentity,
+		ServiceAccountIdentityDigest: digest.SHA256([]byte(wantSubject)), RequestDigest: digest.SHA256(issuer.request),
+		CABundleDigest: issuer.caBundleDigest, AudienceMode: "server-default",
+		IssuedAt: issuedAt.Format(time.RFC3339), ExpiresAt: expiresAt.UTC().Format(time.RFC3339),
+		LifetimeSeconds: int64(lifetime / time.Second), CredentialBytesInReceipt: false, MutationState: "ATTEMPTED",
+	}
+	receiptRaw, err := json.Marshal(receipt)
+	if err != nil {
+		return VerifiedObservabilityCollectorObserverCredential{}, errors.New("encode collector observer credential receipt")
+	}
+	source := SubmissionStageCredentialSource{
+		AuthorityIdentity: issuer.targetIdentity, TokenDigest: digest.SHA256([]byte(value.Status.Token)),
+		CAFile: issuer.caFile, CABundleDigest: issuer.caBundleDigest, TokenRequestEvidenceDigest: digest.SHA256(receiptRaw),
+		ExpectedIssuer: claims.Issuer, ExpectedSubject: wantSubject, ExpectedAudiences: []string{"https://kubernetes.default.svc"},
+		IssuedAt: issuedAt, ExpiresAt: expiresAt.UTC(),
+	}
+	if _, err := verifyStageCredentialJWTWithSubject([]byte(value.Status.Token), source, now, func(subject string) bool {
+		return subject == wantSubject
+	}); err != nil {
+		return VerifiedObservabilityCollectorObserverCredential{}, errors.New("verify collector observer credential")
+	}
+	return VerifiedObservabilityCollectorObserverCredential{
+		token: []byte(value.Status.Token), caFile: issuer.caFile, targetIdentity: issuer.targetIdentity,
+		caBundleDigest: issuer.caBundleDigest, source: source, receipt: receipt, verified: true,
+	}, nil
+}
+
+func (credential VerifiedObservabilityCollectorObserverCredential) Material() (SubmissionStageCredentialSource, []byte, ObservabilityCollectorObserverCredentialReceipt, error) {
+	if !credential.verified || len(credential.token) < 80 || credential.source.TokenFile != "" ||
+		credential.source.TokenDigest != digest.SHA256(credential.token) || credential.source.CAFile != credential.caFile ||
+		credential.source.CABundleDigest != credential.caBundleDigest || credential.source.AuthorityIdentity != credential.targetIdentity ||
+		credential.receipt.Format != ObservabilityCollectorObserverCredentialReceiptFormat || credential.receipt.State != "ISSUED" ||
+		credential.receipt.CredentialBytesInReceipt || credential.receipt.MutationState != "ATTEMPTED" {
+		return SubmissionStageCredentialSource{}, nil, ObservabilityCollectorObserverCredentialReceipt{}, errors.New("collector observer credential was not produced by verification")
+	}
+	receiptRaw, err := json.Marshal(credential.receipt)
+	if err != nil || credential.source.TokenRequestEvidenceDigest != digest.SHA256(receiptRaw) {
+		return SubmissionStageCredentialSource{}, nil, ObservabilityCollectorObserverCredentialReceipt{}, errors.New("collector observer credential evidence differs")
+	}
+	source := credential.source
+	source.ExpectedAudiences = append([]string(nil), credential.source.ExpectedAudiences...)
+	return source, append([]byte(nil), credential.token...), credential.receipt, nil
+}

--- a/internal/runner/observability_collector_observer_credential_test.go
+++ b/internal/runner/observability_collector_observer_credential_test.go
@@ -1,0 +1,92 @@
+package runner
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
+)
+
+func TestObservabilityCollectorObserverCredentialIssuesOnceInMemory(t *testing.T) {
+	now := time.Date(2026, 8, 22, 12, 0, 0, 0, time.UTC)
+	target := digest.SHA256([]byte("collector-observer-target"))
+	token := string(stageCredentialJWT(t, "https://kubernetes.default.svc.cluster.local", "system:serviceaccount:ok-observability:"+observabilityCollectorObserverSA,
+		[]string{"https://kubernetes.default.svc"}, now, now.Add(time.Hour), 'o'))
+	requests := 0
+	client := &http.Client{Transport: submissionStageLauncherRoundTripFunc(func(request *http.Request) (*http.Response, error) {
+		requests++
+		body, _ := io.ReadAll(request.Body)
+		if request.Method != http.MethodPost || request.URL.Path != "/api/v1/namespaces/ok-observability/serviceaccounts/ok147-observability-autonomy/token" ||
+			request.Header.Get("Authorization") != "Bearer workload-admin" || bytes.Contains(body, []byte("audiences")) {
+			t.Fatalf("unexpected collector observer TokenRequest: %s %s %s", request.Method, request.URL.Path, body)
+		}
+		return targetCredentialTestResponse(http.StatusCreated, map[string]any{
+			"apiVersion": "authentication.k8s.io/v1", "kind": "TokenRequest", "metadata": map[string]any{},
+			"spec":   map[string]any{"audiences": []string{"https://kubernetes.default.svc"}, "expirationSeconds": 3600},
+			"status": map[string]any{"token": token, "expirationTimestamp": now.Add(time.Hour).Format(time.RFC3339)},
+		}), nil
+	})}
+	issuer, err := newKubernetesObservabilityCollectorObserverCredentialIssuer(observabilityCollectorObserverIssuerClientConfig{
+		Endpoint: "https://127.0.0.1:12345", BearerToken: "workload-admin", CABundleDigest: runnerStageSHA("a"),
+		CAFile: "/private/tmp/workload-ca.crt", TargetIdentity: target, Client: client, Clock: func() time.Time { return now },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	credential, err := issuer.Issue(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	source, privateToken, receipt, err := credential.Material()
+	if err != nil || receipt.Format != ObservabilityCollectorObserverCredentialReceiptFormat || receipt.State != "ISSUED" ||
+		receipt.TargetIdentityDigest != target || receipt.LifetimeSeconds != 3600 || receipt.CredentialBytesInReceipt ||
+		source.TokenFile != "" || source.TokenDigest != digest.SHA256([]byte(token)) || string(privateToken) != token || requests != 1 {
+		t.Fatalf("unexpected observer credential: %#v %#v requests=%d err=%v", source, receipt, requests, err)
+	}
+	public, _ := json.Marshal(receipt)
+	if bytes.Contains(public, []byte(token)) || bytes.Contains(public, []byte("workload-admin")) {
+		t.Fatal("observer credential receipt exposed private material")
+	}
+	if _, err := issuer.Issue(context.Background()); err == nil || requests != 1 {
+		t.Fatal("single-use collector observer credential issuer retried")
+	}
+}
+
+func TestObservabilityCollectorObserverCredentialFailsClosed(t *testing.T) {
+	now := time.Date(2026, 8, 22, 12, 0, 0, 0, time.UTC)
+	target := digest.SHA256([]byte("collector-observer-target"))
+	for name, subject := range map[string]string{
+		"foreign subject": "system:serviceaccount:ok-observability:foreign",
+		"wrong namespace": "system:serviceaccount:openkubes-execution-system:" + observabilityCollectorObserverSA,
+	} {
+		t.Run(name, func(t *testing.T) {
+			token := string(stageCredentialJWT(t, "https://kubernetes.default.svc.cluster.local", subject,
+				[]string{"https://kubernetes.default.svc"}, now, now.Add(time.Hour), 'o'))
+			client := &http.Client{Transport: submissionStageLauncherRoundTripFunc(func(*http.Request) (*http.Response, error) {
+				return targetCredentialTestResponse(http.StatusCreated, map[string]any{
+					"apiVersion": "authentication.k8s.io/v1", "kind": "TokenRequest", "metadata": map[string]any{},
+					"spec":   map[string]any{"audiences": []string{"https://kubernetes.default.svc"}, "expirationSeconds": 3600},
+					"status": map[string]any{"token": token, "expirationTimestamp": now.Add(time.Hour).Format(time.RFC3339)},
+				}), nil
+			})}
+			issuer, err := newKubernetesObservabilityCollectorObserverCredentialIssuer(observabilityCollectorObserverIssuerClientConfig{
+				Endpoint: "https://127.0.0.1:12345", BearerToken: "workload-admin", CABundleDigest: runnerStageSHA("a"),
+				CAFile: "/private/tmp/workload-ca.crt", TargetIdentity: target, Client: client, Clock: func() time.Time { return now },
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := issuer.Issue(context.Background()); err == nil {
+				t.Fatal("foreign collector observer identity was accepted")
+			}
+		})
+	}
+	if _, _, _, err := (VerifiedObservabilityCollectorObserverCredential{}).Material(); err == nil {
+		t.Fatal("unverified observer credential exposed private material")
+	}
+}

--- a/internal/runner/observability_collector_post_prefix.go
+++ b/internal/runner/observability_collector_post_prefix.go
@@ -19,17 +19,18 @@ type ObservabilityCollectorPostPrefixConfig struct {
 }
 
 type ObservabilityCollectorPostPrefixReceipt struct {
-	Format                         string `json:"format"`
-	State                          string `json:"state"`
-	PackageDigest                  string `json:"packageDigest,omitempty"`
-	RuntimeBindingDigest           string `json:"runtimeBindingDigest,omitempty"`
-	TargetIdentityDigest           string `json:"targetIdentityDigest,omitempty"`
-	RuntimeAuthorityPackageDigest  string `json:"runtimeAuthorityPackageDigest,omitempty"`
-	RuntimeAuthorityReceiptDigest  string `json:"runtimeAuthorityReceiptDigest,omitempty"`
-	RuntimeAuthorityCreatedObjects int    `json:"runtimeAuthorityCreatedObjects"`
-	CredentialReceiptDigest        string `json:"credentialReceiptDigest,omitempty"`
-	LaunchState                    string `json:"launchState,omitempty"`
-	CreatedObjects                 int    `json:"createdObjects"`
+	Format                          string `json:"format"`
+	State                           string `json:"state"`
+	PackageDigest                   string `json:"packageDigest,omitempty"`
+	RuntimeBindingDigest            string `json:"runtimeBindingDigest,omitempty"`
+	TargetIdentityDigest            string `json:"targetIdentityDigest,omitempty"`
+	RuntimeAuthorityPackageDigest   string `json:"runtimeAuthorityPackageDigest,omitempty"`
+	RuntimeAuthorityReceiptDigest   string `json:"runtimeAuthorityReceiptDigest,omitempty"`
+	RuntimeAuthorityCreatedObjects  int    `json:"runtimeAuthorityCreatedObjects"`
+	ObserverCredentialReceiptDigest string `json:"observerCredentialReceiptDigest,omitempty"`
+	CredentialReceiptDigest         string `json:"credentialReceiptDigest,omitempty"`
+	LaunchState                     string `json:"launchState,omitempty"`
+	CreatedObjects                  int    `json:"createdObjects"`
 }
 
 type observabilityCollectorRuntimeLauncher interface {
@@ -51,6 +52,7 @@ type KubernetesObservabilityCollectorPostPrefix struct {
 	build          func(ObservabilityCollectorRuntimePackageConfig) (VerifiedObservabilityCollectorRuntimePackage, error)
 	buildAuthority func(ObservabilityCollectorRuntimeAuthorityPackageConfig) (VerifiedObservabilityCollectorRuntimeAuthorityPackage, error)
 	openAuthority  func(WorkloadAuthorityFileResolverConfig, VerifiedObservabilityCollectorRuntimeAuthorityPackage) (observabilityCollectorRuntimeAuthorityInstaller, error)
+	issueObserver  func(context.Context, ObservabilityCollectorObserverCredentialConfig) (VerifiedObservabilityCollectorObserverCredential, error)
 	issue          func(context.Context, ObservabilityCollectorInstallerCredentialConfig) (VerifiedObservabilityCollectorInstallerCredential, error)
 	open           func(submissionStageInstallerClientConfig, VerifiedObservabilityCollectorRuntimePackage) (observabilityCollectorRuntimeLauncher, error)
 	resolve        func(WorkloadAuthorityFileResolverConfig) (WorkloadAuthorityBinding, KubernetesAuthorityConfig, error)
@@ -59,7 +61,7 @@ type KubernetesObservabilityCollectorPostPrefix struct {
 func NewKubernetesObservabilityCollectorPostPrefix(config ObservabilityCollectorPostPrefixConfig) (*KubernetesObservabilityCollectorPostPrefix, error) {
 	if config.Clock == nil || config.Package.Activation.RuntimeBinding.Bundle.PlanPath == "" ||
 		config.Package.Activation.RuntimeBinding.MaterialPath == "" || config.Package.Activation.RuntimeBinding.ReceiptPath == "" ||
-		config.Package.Activation.ObserverCredential.CAFile == "" ||
+		config.Package.Activation.ObserverCredential.CAFile == "" || len(config.Package.Activation.ObserverToken) != 0 ||
 		!stageReceiptPrefixDigestPattern.MatchString(config.Package.Activation.ObserverCredential.CABundleDigest) ||
 		len(config.RuntimeAuthority.Manifest) == 0 || !stageReceiptPrefixDigestPattern.MatchString(config.RuntimeAuthority.ExpectedManifestDigest) ||
 		digest.SHA256(config.RuntimeAuthority.Manifest) != config.RuntimeAuthority.ExpectedManifestDigest || config.RuntimeAuthority.TargetIdentityDigest != "" {
@@ -72,6 +74,13 @@ func NewKubernetesObservabilityCollectorPostPrefix(config ObservabilityCollector
 		buildAuthority: BuildObservabilityCollectorRuntimeAuthorityPackage,
 		openAuthority: func(workload WorkloadAuthorityFileResolverConfig, packaged VerifiedObservabilityCollectorRuntimeAuthorityPackage) (observabilityCollectorRuntimeAuthorityInstaller, error) {
 			return OpenKubernetesObservabilityCollectorRuntimeAuthorityInstaller(workload, packaged)
+		},
+		issueObserver: func(ctx context.Context, config ObservabilityCollectorObserverCredentialConfig) (VerifiedObservabilityCollectorObserverCredential, error) {
+			issuer, err := OpenKubernetesObservabilityCollectorObserverCredentialIssuer(config)
+			if err != nil {
+				return VerifiedObservabilityCollectorObserverCredential{}, err
+			}
+			return issuer.Issue(ctx)
 		},
 		issue: func(ctx context.Context, config ObservabilityCollectorInstallerCredentialConfig) (VerifiedObservabilityCollectorInstallerCredential, error) {
 			issuer, err := OpenKubernetesObservabilityCollectorInstallerCredentialIssuer(config)
@@ -110,25 +119,6 @@ func (activation *KubernetesObservabilityCollectorPostPrefix) ActivateFullRunPos
 		activation.stop()
 		return errors.New("observability collector installer differs from runtime workload authority")
 	}
-	packageConfig := activation.config.Package
-	packageConfig.Activation.RuntimeBinding.Bundle.Receipts = append([]StageReceiptSource(nil), prefix.ReceiptPrefix[:6]...)
-	packageConfig.Activation.MaterializationTime = activation.config.Clock().UTC().Truncate(time.Second)
-	packageConfig.Activation.ObserverCredential.AuthorityIdentity = prefix.TargetIdentity
-	packaged, err := activation.build(packageConfig)
-	if err != nil {
-		activation.stop()
-		return errors.New("build observability collector post-prefix package")
-	}
-	packageReceipt, err := packaged.Receipt()
-	if err != nil {
-		activation.stop()
-		return errors.New("verify observability collector post-prefix package")
-	}
-	plan, err := PlanObservabilityCollectorRuntimeInstallation(packaged)
-	if err != nil || plan.TargetIdentityDigest != prefix.TargetIdentity || plan.RuntimeBindingDigest != packageReceipt.RuntimeBindingDigest {
-		activation.stop()
-		return errors.New("observability collector package differs from fresh runtime prefix")
-	}
 	authorityConfig := activation.config.RuntimeAuthority
 	authorityConfig.TargetIdentityDigest = prefix.TargetIdentity
 	authorityPackage, err := activation.buildAuthority(authorityConfig)
@@ -159,6 +149,43 @@ func (activation *KubernetesObservabilityCollectorPostPrefix) ActivateFullRunPos
 		authorityInstallReceipt.TargetIdentityDigest != prefix.TargetIdentity || authorityInstallReceipt.PackageDigest != authorityPackageReceipt.PackageDigest {
 		activation.stop()
 		return errors.New("install observability collector runtime authority")
+	}
+	observerCredential, err := activation.issueObserver(ctx, ObservabilityCollectorObserverCredentialConfig{
+		Workload: prefix.Workload, ExpectedTargetDigest: prefix.TargetIdentity, Clock: activation.config.Clock,
+	})
+	if err != nil {
+		activation.stop()
+		return errors.New("issue observability collector observer credential")
+	}
+	observerSource, observerToken, observerReceipt, err := observerCredential.Material()
+	if err != nil || observerSource.AuthorityIdentity != prefix.TargetIdentity || observerSource.CABundleDigest != authority.CABundleDigest {
+		activation.stop()
+		return errors.New("verify observability collector observer credential")
+	}
+	observerReceiptRaw, err := json.Marshal(observerReceipt)
+	if err != nil {
+		activation.stop()
+		return errors.New("encode observability collector observer credential receipt")
+	}
+	packageConfig := activation.config.Package
+	packageConfig.Activation.RuntimeBinding.Bundle.Receipts = append([]StageReceiptSource(nil), prefix.ReceiptPrefix[:6]...)
+	packageConfig.Activation.MaterializationTime = activation.config.Clock().UTC().Truncate(time.Second)
+	packageConfig.Activation.ObserverCredential = observerSource
+	packageConfig.Activation.ObserverToken = observerToken
+	packaged, err := activation.build(packageConfig)
+	if err != nil {
+		activation.stop()
+		return errors.New("build observability collector post-prefix package")
+	}
+	packageReceipt, err := packaged.Receipt()
+	if err != nil {
+		activation.stop()
+		return errors.New("verify observability collector post-prefix package")
+	}
+	plan, err := PlanObservabilityCollectorRuntimeInstallation(packaged)
+	if err != nil || plan.TargetIdentityDigest != prefix.TargetIdentity || plan.RuntimeBindingDigest != packageReceipt.RuntimeBindingDigest {
+		activation.stop()
+		return errors.New("observability collector package differs from fresh runtime prefix")
 	}
 	credential, err := activation.issue(ctx, ObservabilityCollectorInstallerCredentialConfig{
 		Workload: prefix.Workload, ExpectedTargetDigest: prefix.TargetIdentity, Clock: activation.config.Clock,
@@ -192,6 +219,7 @@ func (activation *KubernetesObservabilityCollectorPostPrefix) ActivateFullRunPos
 	activation.receipt.PackageDigest = packageReceipt.PackageDigest
 	activation.receipt.RuntimeBindingDigest = packageReceipt.RuntimeBindingDigest
 	activation.receipt.TargetIdentityDigest = prefix.TargetIdentity
+	activation.receipt.ObserverCredentialReceiptDigest = digest.SHA256(observerReceiptRaw)
 	activation.receipt.CredentialReceiptDigest = digest.SHA256(credentialReceiptRaw)
 	activation.receipt.LaunchState = launchReceipt.State
 	activation.receipt.CreatedObjects = len(launchReceipt.Results)

--- a/internal/runner/observability_collector_post_prefix_test.go
+++ b/internal/runner/observability_collector_post_prefix_test.go
@@ -3,8 +3,10 @@ package runner
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
+	"os"
 	"testing"
 	"time"
 
@@ -79,6 +81,13 @@ func TestObservabilityCollectorPostPrefixBuildsAndLaunchesFreshBindingOnce(t *te
 		}
 		return authorityInstaller, nil
 	}
+	observerCredential := collectorObserverCredentialFixture(t, config)
+	activator.issueObserver = func(_ context.Context, received ObservabilityCollectorObserverCredentialConfig) (VerifiedObservabilityCollectorObserverCredential, error) {
+		if received.ExpectedTargetDigest != target || received.Clock == nil {
+			t.Fatalf("observer credential binding differs: %#v", received)
+		}
+		return observerCredential, nil
+	}
 	credential := collectorInstallerCredentialFixture(t, target, config.Activation.ObserverCredential.CABundleDigest, config.Activation.MaterializationTime)
 	activator.issue = func(_ context.Context, received ObservabilityCollectorInstallerCredentialConfig) (VerifiedObservabilityCollectorInstallerCredential, error) {
 		if received.ExpectedTargetDigest != target || received.Clock == nil {
@@ -104,11 +113,39 @@ func TestObservabilityCollectorPostPrefixBuildsAndLaunchesFreshBindingOnce(t *te
 	if receipt.State != "ACTIVATED" || receipt.PackageDigest != packageReceipt.PackageDigest || receipt.CreatedObjects != 4 ||
 		receipt.RuntimeAuthorityCreatedObjects != 5 || !stageReceiptPrefixDigestPattern.MatchString(receipt.RuntimeAuthorityPackageDigest) ||
 		!stageReceiptPrefixDigestPattern.MatchString(receipt.RuntimeAuthorityReceiptDigest) ||
+		!stageReceiptPrefixDigestPattern.MatchString(receipt.ObserverCredentialReceiptDigest) ||
 		!stageReceiptPrefixDigestPattern.MatchString(receipt.CredentialReceiptDigest) || buildCalls != 1 || authorityOpenCalls != 1 || authorityInstaller.calls != 1 || openCalls != 1 || launcher.calls != 1 {
 		t.Fatalf("unexpected post-prefix receipt: %#v calls=%d/%d/%d/%d", receipt, buildCalls, authorityOpenCalls, openCalls, launcher.calls)
 	}
 	if err := activator.ActivateFullRunPostPrefix(context.Background(), prefix); err == nil || buildCalls != 1 || launcher.calls != 1 {
 		t.Fatal("post-prefix activation was replayed")
+	}
+}
+
+func collectorObserverCredentialFixture(t *testing.T, config ObservabilityCollectorRuntimePackageConfig) VerifiedObservabilityCollectorObserverCredential {
+	t.Helper()
+	token, err := os.ReadFile(config.Activation.ObserverCredential.TokenFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	source := config.Activation.ObserverCredential
+	source.TokenFile = ""
+	receipt := ObservabilityCollectorObserverCredentialReceipt{
+		Format: ObservabilityCollectorObserverCredentialReceiptFormat, State: "ISSUED",
+		TargetIdentityDigest:         source.AuthorityIdentity,
+		ServiceAccountIdentityDigest: digest.SHA256([]byte(source.ExpectedSubject)),
+		RequestDigest:                runnerStageSHA("c"), CABundleDigest: source.CABundleDigest, AudienceMode: "server-default",
+		IssuedAt: source.IssuedAt.UTC().Format(time.RFC3339), ExpiresAt: source.ExpiresAt.UTC().Format(time.RFC3339),
+		LifetimeSeconds: int64(source.ExpiresAt.Sub(source.IssuedAt) / time.Second), CredentialBytesInReceipt: false, MutationState: "ATTEMPTED",
+	}
+	receiptRaw, err := json.Marshal(receipt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	source.TokenRequestEvidenceDigest = digest.SHA256(receiptRaw)
+	return VerifiedObservabilityCollectorObserverCredential{
+		token: token, caFile: source.CAFile, targetIdentity: source.AuthorityIdentity,
+		caBundleDigest: source.CABundleDigest, source: source, receipt: receipt, verified: true,
 	}
 }
 


### PR DESCRIPTION
## Outcome

- issues one exact one-hour default-audience observer TokenRequest only after the five-object workload authority installation succeeds
- verifies observer issuer, subject, audience, issued-at, not-before, expiry, target identity and CA identity fail closed
- keeps the observer token exclusively in process memory while binding its digest and redacted TokenRequest evidence into the collector activation
- preserves the separate 30-minute installer credential and orders authority → observer credential → package → installer credential → collector launch before Stage 8
- adds single-use, foreign-identity, replay, in-memory binding and tampering tests

## Ownership boundary

This adds no OpenKubes lifecycle reconciliation. Kubernetes issues the bounded credential; the runner only verifies, correlates and hands it to the existing collector package.

## Verification

- `go test ./...` with external linking: PASS
- `go vet ./...`: PASS
- `go test -race ./internal/runner` with external linking: PASS

No live cluster contact or infrastructure mutation was performed.
