### PR TITLE
feat(runner): bind collector into full-run manifest

### DIFF
--- a/deploy/contract-executor-full-run-job.yaml.tpl
+++ b/deploy/contract-executor-full-run-job.yaml.tpl
@@ -190,6 +190,10 @@ spec:
               - {key: activation.full-run-manifest.json, path: activation/full-run-manifest.json}
               - {key: credentials.authorization-ca.crt, path: credentials/authorization-ca.crt}
               - {key: credentials.authorization-token, path: credentials/authorization-token}
+              - {key: credentials.collector-query-token, path: credentials/collector-query-token}
+              - {key: credentials.collector-tls.crt, path: credentials/collector-tls.crt}
+              - {key: credentials.collector-tls.key, path: credentials/collector-tls.key}
+              - {key: credentials.collector-webhook-token, path: credentials/collector-webhook-token}
               - {key: credentials.gitops-ca.crt, path: credentials/gitops-ca.crt}
               - {key: credentials.gitops-token, path: credentials/gitops-token}
               - {key: credentials.infrastructure-ca.crt, path: credentials/infrastructure-ca.crt}
@@ -200,6 +204,8 @@ spec:
               - {key: credentials.management-token, path: credentials/management-token}
               - {key: input.aggregate-profile.json, path: input/aggregate-profile.json}
               - {key: input.authorization-authority.pub, path: input/authorization-authority.pub}
+              - {key: input.collector-job.yaml, path: input/collector-job.yaml}
+              - {key: input.collector-runtime-authority.yaml, path: input/collector-runtime-authority.yaml}
               - {key: input.enablement.yaml, path: input/enablement.yaml}
               - {key: input.independent-evidence.pub, path: input/independent-evidence.pub}
               - {key: input.network-profile.json, path: input/network-profile.json}

--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -3211,9 +3211,24 @@ collector launcher; return only after the collector activation receipt is
 complete. A failed or partial authority install is retained in the redacted
 post-prefix receipt and cannot reach either TokenRequest or collector creation.
 An observer-credential, package, installer-credential or collector failure
-cannot open Stage 8 and has no implicit retry or cleanup path. Wiring the
-private authority manifest and remaining factory inputs into the full-run
-CLI/Job activation is now the next prerequisite before a complete fresh run.
+cannot open Stage 8 and has no implicit retry or cleanup path.
+
+The private full-run execution manifest is now version 2 and binds that
+factory completely. It carries the exact five-object runtime-authority
+manifest and digest, collector Job template and digest, run and image
+identities, workload and alert CIDRs, activation Secret name, endpoint/listen
+binding, maximum record age, distinct webhook/query token paths and TLS
+certificate/key paths. The activation bundle adds those six static/private
+files to its exact 32-file index and Secret projection. Bundle rewriting maps
+all six paths into the fixed executor workspace, and materialization rejects a
+different path set.
+
+`ok cluster stage run full execute` now opens the concrete post-prefix factory
+from that already verified private manifest whenever no test override is
+present. Opening remains inert: it reads and correlates only the digest-bound
+files. The runtime target UID, endpoint, CA and both observer/installer tokens
+still arise only after Stage 7. Consequently the Job needs no manually repeated
+collector flags and the production and test renderers cannot diverge.
 
 Fresh-Run v3 now also has one fail-closed offline image/package correlation
 boundary:

--- a/internal/runner/full_run_activation_bundle.go
+++ b/internal/runner/full_run_activation_bundle.go
@@ -30,6 +30,10 @@ var fullRunExecutionBundleFiles = []string{
 	"activation/full-run-manifest.json",
 	"credentials/authorization-ca.crt",
 	"credentials/authorization-token",
+	"credentials/collector-query-token",
+	"credentials/collector-tls.crt",
+	"credentials/collector-tls.key",
+	"credentials/collector-webhook-token",
 	"credentials/gitops-ca.crt",
 	"credentials/gitops-token",
 	"credentials/infrastructure-ca.crt",
@@ -40,6 +44,8 @@ var fullRunExecutionBundleFiles = []string{
 	"credentials/management-token",
 	"input/aggregate-profile.json",
 	"input/authorization-authority.pub",
+	"input/collector-job.yaml",
+	"input/collector-runtime-authority.yaml",
 	"input/enablement.yaml",
 	"input/independent-evidence.pub",
 	"input/network-profile.json",
@@ -192,6 +198,10 @@ func collectFullRunExecutionSources(document fullRunExecutionManifestDocument, e
 	paths := map[string]string{
 		"credentials/authorization-ca.crt":             document.Authorization.CAFile,
 		"credentials/authorization-token":              document.Authorization.TokenFile,
+		"credentials/collector-query-token":            document.ObservabilityCollector.QueryTokenPath,
+		"credentials/collector-tls.crt":                document.ObservabilityCollector.TLSCertificatePath,
+		"credentials/collector-tls.key":                document.ObservabilityCollector.TLSPrivateKeyPath,
+		"credentials/collector-webhook-token":          document.ObservabilityCollector.WebhookTokenPath,
 		"credentials/gitops-ca.crt":                    document.TargetRegistration.GitOps.CAFile,
 		"credentials/gitops-token":                     document.TargetRegistration.GitOps.TokenFile,
 		"credentials/infrastructure-ca.crt":            document.ProviderPrerequisites.Authority.CAFile,
@@ -202,6 +212,8 @@ func collectFullRunExecutionSources(document fullRunExecutionManifestDocument, e
 		"credentials/management-token":                 document.ClusterLifecycle.Authority.TokenFile,
 		"input/aggregate-profile.json":                 document.Profiles.Aggregate.Path,
 		"input/authorization-authority.pub":            document.Authorization.PublicKeyPath,
+		"input/collector-job.yaml":                     document.ObservabilityCollector.JobTemplatePath,
+		"input/collector-runtime-authority.yaml":       document.ObservabilityCollector.RuntimeAuthorityPath,
 		"input/enablement.yaml":                        document.Enablement.ArtifactPath,
 		"input/independent-evidence.pub":               evidencePublicKeyPath,
 		"input/network-profile.json":                   document.Profiles.Network.Path,
@@ -298,6 +310,12 @@ func rewriteFullRunExecutionBundle(document fullRunExecutionManifestDocument, so
 	document.PlatformObservation.Capability.IndependentEvidencePath = fullRunExecutionHandoffRoot + "/observability-evidence.json"
 	document.AggregateEvidence.Ledger, document.AggregateEvidence.Management, document.AggregateEvidence.Argo = ledger, management, gitOps
 	document.AggregateEvidence.WorkloadTokenFile, document.AggregateEvidence.WorkloadKubeconfigFile, document.AggregateEvidence.WorkloadCAFile = "", workload.KubeconfigFile, workload.CAFile
+	document.ObservabilityCollector.RuntimeAuthorityPath = path("input/collector-runtime-authority.yaml")
+	document.ObservabilityCollector.JobTemplatePath = path("input/collector-job.yaml")
+	document.ObservabilityCollector.WebhookTokenPath = path("credentials/collector-webhook-token")
+	document.ObservabilityCollector.QueryTokenPath = path("credentials/collector-query-token")
+	document.ObservabilityCollector.TLSCertificatePath = path("credentials/collector-tls.crt")
+	document.ObservabilityCollector.TLSPrivateKeyPath = path("credentials/collector-tls.key")
 	document.ReceiptDirectory = path("work/receipts")
 	manifestRaw, err := json.Marshal(document)
 	if err != nil {

--- a/internal/runner/full_run_activation_materializer.go
+++ b/internal/runner/full_run_activation_materializer.go
@@ -165,6 +165,12 @@ func validPackagedFullRunRuntimePaths(document fullRunExecutionManifestDocument)
 		document.TargetCredential.PolicyPath == path("input/target-credential-policy.json") && document.TargetCredential.Workload == workload &&
 		document.TargetRegistration.ArtifactPath == path("input/target-registration.yaml") && document.TargetRegistration.GitOps.TokenFile == path("credentials/gitops-token") && document.TargetRegistration.GitOps.CAFile == path("credentials/gitops-ca.crt") &&
 		document.PlatformApplications.ArtifactPath == path("input/platform-applications.yaml") && document.ReceiptDirectory == path("work/receipts") &&
+		document.ObservabilityCollector.RuntimeAuthorityPath == path("input/collector-runtime-authority.yaml") &&
+		document.ObservabilityCollector.JobTemplatePath == path("input/collector-job.yaml") &&
+		document.ObservabilityCollector.WebhookTokenPath == path("credentials/collector-webhook-token") &&
+		document.ObservabilityCollector.QueryTokenPath == path("credentials/collector-query-token") &&
+		document.ObservabilityCollector.TLSCertificatePath == path("credentials/collector-tls.crt") &&
+		document.ObservabilityCollector.TLSPrivateKeyPath == path("credentials/collector-tls.key") &&
 		document.AggregateEvidence.WorkloadTokenFile == "" && document.AggregateEvidence.WorkloadKubeconfigFile == workload.KubeconfigFile && document.AggregateEvidence.WorkloadCAFile == workload.CAFile &&
 		document.PlatformObservation.Capability.IndependentEvidenceIdentityPath == fullRunExecutionHandoffRoot+"/observability-evidence-identity.json" &&
 		document.PlatformObservation.Capability.IndependentEvidenceIdentityReceiptPath == fullRunExecutionHandoffRoot+"/observability-evidence-identity-receipt.json" &&

--- a/internal/runner/full_run_activation_package_test.go
+++ b/internal/runner/full_run_activation_package_test.go
@@ -20,7 +20,8 @@ func TestBuildFullRunExecutionActivationPackageBindsBothAuthoritiesAndJob(t *tes
 		t.Fatal(err)
 	}
 	receipt, err := packaged.Receipt()
-	if err != nil || receipt.State != "VERIFIED" || receipt.MutationAllowed || receipt.PrivateFileCount != 30 ||
+	if err != nil || receipt.State != "VERIFIED" || receipt.MutationAllowed ||
+		receipt.PrivateFileCount != len(fullRunExecutionBundleFiles)+len(observabilityEvidenceAuthorityProjectedFiles) ||
 		receipt.ActivationSecret != config.ActivationSecret || receipt.EvidenceAuthoritySecret != config.EvidenceAuthority.ActivationSecret ||
 		receipt.ManagementAuthority != "ok-mgmt" || receipt.ImageDigest != config.Job.ImageDigest || len(receipt.ObjectKinds) != 4 {
 		t.Fatalf("unexpected full-run package receipt: %#v err=%v", receipt, err)

--- a/internal/runner/full_run_execution_manifest.go
+++ b/internal/runner/full_run_execution_manifest.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/netip"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -20,7 +21,7 @@ import (
 )
 
 const (
-	FullRunExecutionManifestFormat        = "ok147-full-run-execution-manifest/v1"
+	FullRunExecutionManifestFormat        = "ok147-full-run-execution-manifest/v2"
 	FullRunExecutionManifestReceiptFormat = "ok147-full-run-execution-manifest-receipt/v1"
 	maximumFullRunExecutionManifestBytes  = 1024 * 1024
 )
@@ -140,25 +141,45 @@ type fullRunAggregateEvidenceDocument struct {
 	WorkloadCAFile         string                       `json:"workloadCAFile"`
 }
 
+type fullRunObservabilityCollectorDocument struct {
+	RuntimeAuthorityPath   string `json:"runtimeAuthorityPath"`
+	RuntimeAuthorityDigest string `json:"runtimeAuthorityDigest"`
+	JobTemplatePath        string `json:"jobTemplatePath"`
+	JobTemplateDigest      string `json:"jobTemplateDigest"`
+	RunID                  string `json:"runId"`
+	ImageDigest            string `json:"imageDigest"`
+	WorkloadAPICIDR        string `json:"workloadApiCidr"`
+	AlertSourceCIDR        string `json:"alertSourceCidr"`
+	ActivationSecret       string `json:"activationSecret"`
+	WebhookTokenPath       string `json:"webhookTokenPath"`
+	QueryTokenPath         string `json:"queryTokenPath"`
+	PublicEndpoint         string `json:"publicEndpoint"`
+	ListenAddress          string `json:"listenAddress"`
+	TLSCertificatePath     string `json:"tlsCertificatePath"`
+	TLSPrivateKeyPath      string `json:"tlsPrivateKeyPath"`
+	MaximumRecordAge       string `json:"maximumRecordAge"`
+}
+
 type fullRunExecutionManifestDocument struct {
-	Format                string                              `json:"format"`
-	Plan                  fullRunPlanDocument                 `json:"plan"`
-	Projection            fullRunProjectionDocument           `json:"projection"`
-	Authorization         postRuntimeAuthorizationDocument    `json:"authorization"`
-	Profiles              postRuntimeProfilesDocument         `json:"profiles"`
-	ProviderPrerequisites fullRunSubmissionRuntimeDocument    `json:"providerPrerequisites"`
-	ClusterLifecycle      fullRunSubmissionRuntimeDocument    `json:"clusterLifecycle"`
-	LifecycleObservation  fullRunLifecycleObservationDocument `json:"lifecycleObservation"`
-	Enablement            fullRunEnablementDocument           `json:"enablement"`
-	NetworkObservation    fullRunNetworkObservationDocument   `json:"networkObservation"`
-	RuntimeBinding        fullRunRuntimeBindingDocument       `json:"runtimeBinding"`
-	TargetAccess          fullRunTargetAccessDocument         `json:"targetAccess"`
-	TargetCredential      fullRunTargetCredentialDocument     `json:"targetCredential"`
-	TargetRegistration    fullRunTargetRegistrationDocument   `json:"targetRegistration"`
-	PlatformApplications  fullRunPlatformApplicationsDocument `json:"platformApplications"`
-	PlatformObservation   fullRunPlatformObservationDocument  `json:"platformObservation"`
-	AggregateEvidence     fullRunAggregateEvidenceDocument    `json:"aggregateEvidence"`
-	ReceiptDirectory      string                              `json:"receiptDirectory"`
+	Format                 string                                `json:"format"`
+	Plan                   fullRunPlanDocument                   `json:"plan"`
+	Projection             fullRunProjectionDocument             `json:"projection"`
+	Authorization          postRuntimeAuthorizationDocument      `json:"authorization"`
+	Profiles               postRuntimeProfilesDocument           `json:"profiles"`
+	ProviderPrerequisites  fullRunSubmissionRuntimeDocument      `json:"providerPrerequisites"`
+	ClusterLifecycle       fullRunSubmissionRuntimeDocument      `json:"clusterLifecycle"`
+	LifecycleObservation   fullRunLifecycleObservationDocument   `json:"lifecycleObservation"`
+	Enablement             fullRunEnablementDocument             `json:"enablement"`
+	NetworkObservation     fullRunNetworkObservationDocument     `json:"networkObservation"`
+	RuntimeBinding         fullRunRuntimeBindingDocument         `json:"runtimeBinding"`
+	TargetAccess           fullRunTargetAccessDocument           `json:"targetAccess"`
+	TargetCredential       fullRunTargetCredentialDocument       `json:"targetCredential"`
+	TargetRegistration     fullRunTargetRegistrationDocument     `json:"targetRegistration"`
+	PlatformApplications   fullRunPlatformApplicationsDocument   `json:"platformApplications"`
+	PlatformObservation    fullRunPlatformObservationDocument    `json:"platformObservation"`
+	AggregateEvidence      fullRunAggregateEvidenceDocument      `json:"aggregateEvidence"`
+	ObservabilityCollector fullRunObservabilityCollectorDocument `json:"observabilityCollector"`
+	ReceiptDirectory       string                                `json:"receiptDirectory"`
 }
 
 type FullRunExecutionManifestReceipt struct {
@@ -664,6 +685,58 @@ func verifyFullRunStaticArtifacts(document fullRunExecutionManifestDocument, pla
 	if _, err := submission.LoadPlatformApplications(document.PlatformApplications.ArtifactPath, applicationsExpected); err != nil {
 		return errors.New("verify full-run platform Applications template")
 	}
+	if err := verifyFullRunObservabilityCollector(document.ObservabilityCollector); err != nil {
+		return err
+	}
+	return nil
+}
+
+func verifyFullRunObservabilityCollector(document fullRunObservabilityCollectorDocument) error {
+	authority, err := readBoundedRegular(document.RuntimeAuthorityPath, maximumFullRunExecutionManifestBytes)
+	if err != nil || !stageReceiptPrefixDigestPattern.MatchString(document.RuntimeAuthorityDigest) ||
+		digest.SHA256(authority) != document.RuntimeAuthorityDigest {
+		return errors.New("verify full-run collector runtime authority identity")
+	}
+	if _, err := BuildObservabilityCollectorRuntimeAuthorityPackage(ObservabilityCollectorRuntimeAuthorityPackageConfig{
+		Manifest: authority, ExpectedManifestDigest: document.RuntimeAuthorityDigest,
+		TargetIdentityDigest: digest.SHA256([]byte("full-run-static-collector-target")),
+	}); err != nil {
+		return errors.New("verify full-run collector runtime authority package")
+	}
+	template, err := readBoundedRegular(document.JobTemplatePath, maximumFullRunExecutionManifestBytes)
+	if err != nil || !stageReceiptPrefixDigestPattern.MatchString(document.JobTemplateDigest) ||
+		digest.SHA256(template) != document.JobTemplateDigest {
+		return errors.New("verify full-run collector Job template identity")
+	}
+	prefix, err := netip.ParsePrefix(document.WorkloadAPICIDR)
+	if err != nil || !prefix.Addr().Is4() || prefix.Bits() != 32 {
+		return errors.New("full-run collector workload API CIDR is invalid")
+	}
+	if _, err := RenderObservabilityCollectorJobTemplate(template, ObservabilityCollectorJobValues{
+		RunID: document.RunID, ImageDigest: document.ImageDigest, ActivationSecret: document.ActivationSecret,
+		ActivationDigest: digest.SHA256([]byte("full-run-static-collector-activation")),
+		ManifestDigest:   digest.SHA256([]byte("full-run-static-collector-manifest")), RuntimeBindingDigest: digest.SHA256([]byte("full-run-static-collector-runtime")),
+		PublicEndpointDigest: digest.SHA256([]byte(document.PublicEndpoint)), PublicEndpoint: document.PublicEndpoint,
+		WorkloadAPIURL: "https://" + prefix.Addr().String() + ":6443", WorkloadAPICIDR: document.WorkloadAPICIDR,
+		AlertSourceCIDR: document.AlertSourceCIDR,
+	}); err != nil {
+		return errors.New("verify full-run collector Job values")
+	}
+	maximumRecordAge, err := time.ParseDuration(document.MaximumRecordAge)
+	if err != nil || maximumRecordAge < time.Minute || maximumRecordAge > maximumObservabilityIndependentEvidenceWindow ||
+		validateObservabilityCollectorNetwork(document.PublicEndpoint, document.ListenAddress) != nil {
+		return errors.New("full-run collector activation bounds are invalid")
+	}
+	webhook, webhookErr := readCollectorToken(document.WebhookTokenPath)
+	query, queryErr := readCollectorToken(document.QueryTokenPath)
+	if webhookErr != nil || queryErr != nil || bytes.Equal(webhook, query) {
+		return errors.New("full-run collector authority tokens are invalid")
+	}
+	for _, path := range []string{document.TLSCertificatePath, document.TLSPrivateKeyPath} {
+		if _, err := readBoundedRegular(path, 128*1024); err != nil {
+			return errors.New("full-run collector TLS material is invalid")
+		}
+	}
 	return nil
 }
 
@@ -674,6 +747,9 @@ func validateFullRunRuntimeBoundary(document fullRunExecutionManifestDocument, p
 		document.Profiles.Network.Path, document.Profiles.Platform.Path, document.Profiles.Aggregate.Path,
 		document.Enablement.ArtifactPath, document.TargetAccess.ArtifactPath, document.TargetCredential.PolicyPath,
 		document.TargetRegistration.ArtifactPath, document.PlatformApplications.ArtifactPath, document.ReceiptDirectory,
+		document.ObservabilityCollector.RuntimeAuthorityPath, document.ObservabilityCollector.JobTemplatePath,
+		document.ObservabilityCollector.WebhookTokenPath, document.ObservabilityCollector.QueryTokenPath,
+		document.ObservabilityCollector.TLSCertificatePath, document.ObservabilityCollector.TLSPrivateKeyPath,
 	}
 	for _, path := range paths {
 		if !validFullRunAbsolutePath(path) {

--- a/internal/runner/full_run_execution_manifest_test.go
+++ b/internal/runner/full_run_execution_manifest_test.go
@@ -2,6 +2,7 @@ package runner
 
 import (
 	"encoding/json"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
@@ -171,6 +172,19 @@ func TestFullRunExecutionManifestFailsClosed(t *testing.T) {
 		"duplicate runtime output": func(value map[string]any) {
 			binding := value["networkObservation"].(map[string]any)["workload"].(map[string]any)["bindingPath"]
 			value["runtimeBinding"].(map[string]any)["materialPath"] = binding
+		},
+		"wrong collector authority digest": func(value map[string]any) {
+			value["observabilityCollector"].(map[string]any)["runtimeAuthorityDigest"] = runnerStageSHA("f")
+		},
+		"mutable collector image": func(value map[string]any) {
+			value["observabilityCollector"].(map[string]any)["imageDigest"] = "ghcr.io/openkubes/ok-cluster:latest"
+		},
+		"broad collector alert source": func(value map[string]any) {
+			value["observabilityCollector"].(map[string]any)["alertSourceCidr"] = "0.0.0.0/0"
+		},
+		"shared collector authorities": func(value map[string]any) {
+			collector := value["observabilityCollector"].(map[string]any)
+			collector["queryTokenPath"] = collector["webhookTokenPath"]
 		},
 	}
 	for name, mutate := range tests {
@@ -367,6 +381,15 @@ func fullRunExecutionManifestFixture(t *testing.T) (string, func()) {
 	gitOpsAuthority.CABundleDigest = digest.SHA256(managementCA)
 	providerRuntime := fullRunSubmissionRuntimeDocument{Ledger: ledger, Authority: infrastructureAuthority}
 	managementRuntime := fullRunSubmissionRuntimeDocument{Ledger: ledger, Authority: managementAuthority}
+	collectorAuthority := collectorRuntimeAuthorityManifest(t)
+	collectorAuthorityPath := writeBundleFile(t, root, "collector-runtime-authority.yaml", collectorAuthority)
+	collectorJob := observabilityCollectorJobTemplate(t)
+	collectorJobPath := writeBundleFile(t, root, "collector-job.yaml", collectorJob)
+	collectorWebhookPath := writeBundleFile(t, root, "collector-webhook-token", []byte(strings.Repeat("w", 48)))
+	collectorQueryPath := writeBundleFile(t, root, "collector-query-token", []byte(strings.Repeat("q", 48)))
+	collectorCertificate, collectorKey := collectorServerCredential(t, time.Now().UTC(), net.ParseIP("192.0.2.44"))
+	collectorCertificatePath := writeBundleFile(t, root, "collector-tls.crt", collectorCertificate)
+	collectorKeyPath := writeBundleFile(t, root, "collector-tls.key", collectorKey)
 	document := fullRunExecutionManifestDocument{
 		Format:                FullRunExecutionManifestFormat,
 		Plan:                  fullRunPlanDocument{Path: planPath, Expected: expected},
@@ -408,7 +431,16 @@ func fullRunExecutionManifestFixture(t *testing.T) (string, func()) {
 			PollInterval: "1s", PollTimeout: "1m",
 		},
 		AggregateEvidence: fullRunAggregateEvidenceDocument{Ledger: ledger, Management: managementAuthority, Argo: gitOpsAuthority, WorkloadKubeconfigFile: workload.KubeconfigFile, WorkloadCAFile: workload.CAFile},
-		ReceiptDirectory:  receiptDirectory,
+		ObservabilityCollector: fullRunObservabilityCollectorDocument{
+			RuntimeAuthorityPath: collectorAuthorityPath, RuntimeAuthorityDigest: digest.SHA256(collectorAuthority),
+			JobTemplatePath: collectorJobPath, JobTemplateDigest: digest.SHA256(collectorJob),
+			RunID: "ok147-observability-collector-01", ImageDigest: capabilityFixtureConfig().PushgatewayImage,
+			WorkloadAPICIDR: "192.0.2.147/32", AlertSourceCIDR: "10.244.0.0/16",
+			ActivationSecret: "ok147-observability-collector-activation", WebhookTokenPath: collectorWebhookPath, QueryTokenPath: collectorQueryPath,
+			PublicEndpoint: "https://192.0.2.44:8443", ListenAddress: "0.0.0.0:8443",
+			TLSCertificatePath: collectorCertificatePath, TLSPrivateKeyPath: collectorKeyPath, MaximumRecordAge: "10m",
+		},
+		ReceiptDirectory: receiptDirectory,
 	}
 	return writeBundleFile(t, root, "full-run-manifest.json", mustJSON(t, document)), cleanup
 }

--- a/internal/runner/full_run_observability_activation.go
+++ b/internal/runner/full_run_observability_activation.go
@@ -1,8 +1,11 @@
 package runner
 
 import (
+	"encoding/json"
 	"errors"
 	"time"
+
+	"github.com/openkubes/ok-cluster/internal/digest"
 )
 
 // KubernetesObservabilityFullRunActivationConfig contains the only
@@ -58,8 +61,15 @@ func OpenKubernetesObservabilityFullRunActivation(path string, runtime Kubernete
 	if err != nil {
 		return nil, receipt, errors.New("open full-run Observability capability factory")
 	}
+	postPrefix := runtime.PostPrefixActivator
+	if postPrefix == nil {
+		postPrefix, err = manifest.openObservabilityCollectorPostPrefix(path, runtime.Clock)
+		if err != nil {
+			return nil, receipt, errors.New("open full-run Observability collector post-prefix")
+		}
+	}
 	config, err := manifest.ExecutionConfig(FullRunExecutionManifestRuntime{
-		PlatformCapability: capability, PostPrefixActivator: runtime.PostPrefixActivator,
+		PlatformCapability: capability, PostPrefixActivator: postPrefix,
 		Clock: runtime.Clock, Wait: runtime.Wait,
 	})
 	if err != nil {
@@ -72,4 +82,55 @@ func OpenKubernetesObservabilityFullRunActivation(path string, runtime Kubernete
 	}
 	receipt.State = "PREPARED"
 	return &FullRunExecutionActivation{execution: execution, manifest: manifestReceipt}, receipt, nil
+}
+
+func (manifest VerifiedFullRunExecutionManifest) openObservabilityCollectorPostPrefix(manifestPath string, clock func() time.Time) (FullRunPostPrefixActivator, error) {
+	if !manifest.verified || clock == nil || manifestPath == "" {
+		return nil, errors.New("verified collector manifest binding is incomplete")
+	}
+	document := manifest.document
+	collector := document.ObservabilityCollector
+	authority, err := readBoundedRegular(collector.RuntimeAuthorityPath, maximumFullRunExecutionManifestBytes)
+	if err != nil || digest.SHA256(authority) != collector.RuntimeAuthorityDigest {
+		return nil, errors.New("read bound collector runtime authority")
+	}
+	job, err := readBoundedRegular(collector.JobTemplatePath, maximumFullRunExecutionManifestBytes)
+	if err != nil || digest.SHA256(job) != collector.JobTemplateDigest {
+		return nil, errors.New("read bound collector Job template")
+	}
+	maximumRecordAge, err := time.ParseDuration(collector.MaximumRecordAge)
+	if err != nil {
+		return nil, errors.New("parse bound collector record age")
+	}
+	manifestReceipt := manifest.receipt
+	manifestReceiptRaw, err := json.Marshal(manifestReceipt)
+	if err != nil {
+		return nil, errors.New("encode bound collector manifest receipt")
+	}
+	expected := fullRunPlanExpected(document.Plan.Expected)
+	return NewKubernetesObservabilityCollectorPostPrefix(ObservabilityCollectorPostPrefixConfig{
+		Package: ObservabilityCollectorRuntimePackageConfig{
+			Activation: ObservabilityCollectorActivationPackageConfig{
+				ManifestPath: manifestPath, ExpectedManifestDigest: manifest.receipt.ManifestDigest,
+				ManifestReceipt: &manifestReceipt, ExpectedReceiptDigest: digest.SHA256(manifestReceiptRaw),
+				RuntimeBinding: RuntimeBindingMaterialFileConfig{
+					Bundle:       StageResumeConfig{PlanPath: document.Plan.Path, PlanExpected: expected},
+					MaterialPath: document.RuntimeBinding.MaterialPath, ReceiptPath: document.RuntimeBinding.ReceiptPath,
+				},
+				ActivationSecret:   collector.ActivationSecret,
+				ObserverCredential: SubmissionStageCredentialSource{CAFile: document.NetworkObservation.Workload.CAFile},
+				WebhookTokenPath:   collector.WebhookTokenPath, QueryTokenPath: collector.QueryTokenPath,
+				PublicEndpoint: collector.PublicEndpoint, ListenAddress: collector.ListenAddress,
+				TLSCertificatePath: collector.TLSCertificatePath, TLSPrivateKeyPath: collector.TLSPrivateKeyPath,
+				MaximumRecordAge: maximumRecordAge,
+			},
+			JobTemplate: job, JobTemplateDigest: collector.JobTemplateDigest,
+			RunID: collector.RunID, ImageDigest: collector.ImageDigest,
+			WorkloadAPICIDR: collector.WorkloadAPICIDR, AlertSourceCIDR: collector.AlertSourceCIDR,
+		},
+		RuntimeAuthority: ObservabilityCollectorRuntimeAuthorityPackageConfig{
+			Manifest: authority, ExpectedManifestDigest: collector.RuntimeAuthorityDigest,
+		},
+		Clock: clock,
+	})
 }

--- a/internal/runner/observability_collector_activation_package.go
+++ b/internal/runner/observability_collector_activation_package.go
@@ -45,6 +45,7 @@ type ObservabilityCollectorActivationPackageConfig struct {
 	ManifestPath           string
 	ExpectedManifestDigest string
 	ManifestReceiptPath    string
+	ManifestReceipt        *FullRunExecutionManifestReceipt
 	ExpectedReceiptDigest  string
 	RuntimeBinding         RuntimeBindingMaterialFileConfig
 	ActivationSecret       string
@@ -142,12 +143,21 @@ func BuildObservabilityCollectorActivationPackage(config ObservabilityCollectorA
 	if err != nil || manifestDigest != config.ExpectedManifestDigest {
 		return VerifiedObservabilityCollectorActivationPackage{}, errors.New("verify observability collector full-run manifest")
 	}
-	manifestReceiptRaw, err := readBoundedRegular(config.ManifestReceiptPath, maximumRuntimeBindingMaterialFileBytes)
-	if err != nil || digest.SHA256(manifestReceiptRaw) != config.ExpectedReceiptDigest {
-		return VerifiedObservabilityCollectorActivationPackage{}, errors.New("verify observability collector full-run manifest receipt")
-	}
 	var manifestReceipt FullRunExecutionManifestReceipt
-	if err := jsonstrict.Decode(manifestReceiptRaw, &manifestReceipt); err != nil ||
+	var manifestReceiptRaw []byte
+	if config.ManifestReceipt != nil {
+		if config.ManifestReceiptPath != "" {
+			return VerifiedObservabilityCollectorActivationPackage{}, errors.New("observability collector manifest receipt source is ambiguous")
+		}
+		manifestReceipt = *config.ManifestReceipt
+		manifestReceiptRaw, err = json.Marshal(manifestReceipt)
+	} else {
+		manifestReceiptRaw, err = readBoundedRegular(config.ManifestReceiptPath, maximumRuntimeBindingMaterialFileBytes)
+		if err == nil {
+			err = jsonstrict.Decode(manifestReceiptRaw, &manifestReceipt)
+		}
+	}
+	if err != nil || digest.SHA256(manifestReceiptRaw) != config.ExpectedReceiptDigest ||
 		manifestReceipt.Format != FullRunExecutionManifestReceiptFormat || manifestReceipt.State != "VERIFIED" ||
 		manifestReceipt.MutationAllowed || manifestReceipt.ManifestDigest != manifestDigest {
 		return VerifiedObservabilityCollectorActivationPackage{}, errors.New("observability collector manifest receipt is invalid")

--- a/internal/runner/observability_collector_activation_package_test.go
+++ b/internal/runner/observability_collector_activation_package_test.go
@@ -160,6 +160,28 @@ func TestBuildObservabilityCollectorActivationPackageAcceptsOnlyBoundInMemoryObs
 	}
 }
 
+func TestBuildObservabilityCollectorActivationPackageAcceptsVerifiedManifestReceiptInMemory(t *testing.T) {
+	config, cleanup := observabilityCollectorActivationFixture(t)
+	defer cleanup()
+	raw, err := os.ReadFile(config.ManifestReceiptPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var receipt FullRunExecutionManifestReceipt
+	if err := json.Unmarshal(raw, &receipt); err != nil {
+		t.Fatal(err)
+	}
+	config.ManifestReceiptPath = ""
+	config.ManifestReceipt = &receipt
+	if packaged, err := BuildObservabilityCollectorActivationPackage(config); err != nil || !packaged.verified {
+		t.Fatalf("verified in-memory manifest receipt was rejected: %v", err)
+	}
+	receipt.ManifestDigest = runnerStageSHA("f")
+	if packaged, err := BuildObservabilityCollectorActivationPackage(config); err == nil || packaged.verified {
+		t.Fatal("changed in-memory manifest receipt was accepted")
+	}
+}
+
 func observabilityCollectorActivationFixture(t *testing.T) (ObservabilityCollectorActivationPackageConfig, func()) {
 	t.Helper()
 	manifestPath, cleanup := fullRunExecutionManifestFixture(t)

--- a/internal/runner/observability_collector_post_prefix.go
+++ b/internal/runner/observability_collector_post_prefix.go
@@ -62,7 +62,7 @@ func NewKubernetesObservabilityCollectorPostPrefix(config ObservabilityCollector
 	if config.Clock == nil || config.Package.Activation.RuntimeBinding.Bundle.PlanPath == "" ||
 		config.Package.Activation.RuntimeBinding.MaterialPath == "" || config.Package.Activation.RuntimeBinding.ReceiptPath == "" ||
 		config.Package.Activation.ObserverCredential.CAFile == "" || len(config.Package.Activation.ObserverToken) != 0 ||
-		!stageReceiptPrefixDigestPattern.MatchString(config.Package.Activation.ObserverCredential.CABundleDigest) ||
+		(config.Package.Activation.ObserverCredential.CABundleDigest != "" && !stageReceiptPrefixDigestPattern.MatchString(config.Package.Activation.ObserverCredential.CABundleDigest)) ||
 		len(config.RuntimeAuthority.Manifest) == 0 || !stageReceiptPrefixDigestPattern.MatchString(config.RuntimeAuthority.ExpectedManifestDigest) ||
 		digest.SHA256(config.RuntimeAuthority.Manifest) != config.RuntimeAuthority.ExpectedManifestDigest || config.RuntimeAuthority.TargetIdentityDigest != "" {
 		return nil, errors.New("observability collector post-prefix configuration is incomplete")
@@ -113,8 +113,9 @@ func (activation *KubernetesObservabilityCollectorPostPrefix) ActivateFullRunPos
 		return errors.New("observability collector post-prefix binding is invalid")
 	}
 	binding, authority, err := activation.resolve(prefix.Workload)
+	expectedCA := activation.config.Package.Activation.ObserverCredential.CABundleDigest
 	if err != nil || digest.SHA256([]byte(binding.TargetClusterUID)) != prefix.TargetIdentity ||
-		authority.CABundleDigest != activation.config.Package.Activation.ObserverCredential.CABundleDigest ||
+		(expectedCA != "" && authority.CABundleDigest != expectedCA) ||
 		prefix.Workload.CAFile != activation.config.Package.Activation.ObserverCredential.CAFile {
 		activation.stop()
 		return errors.New("observability collector installer differs from runtime workload authority")


### PR DESCRIPTION
## Outcome

- upgrades the private full-run execution manifest to v2 and binds the complete post-Stage-7 collector factory
- adds exact collector runtime-authority and Job-template digests plus run, image, network, endpoint, token-path, TLS-path and record-age identities
- expands the immutable activation bundle to the exact 32-file set and projects all six new collector inputs into the full-run Job
- makes the normal `full execute` path construct the concrete Kubernetes collector post-prefix automatically
- retains lifecycle-derived target UID, endpoint and CA plus both short-lived tokens as runtime-only values
- supports an already verified manifest receipt in memory, avoiding an unbound duplicate receipt file

## Fail-closed coverage

The manifest rejects wrong collector digests, mutable images, broad alert CIDRs, shared authorities, invalid paths and changed bundle contents before mutation.

## Verification

- `go test ./...` with external linking: PASS
- `go vet ./...`: PASS
- `go test -race ./internal/runner` with external linking: PASS

No live cluster contact or infrastructure mutation was performed.
