### PR TITLE
feat(runner): retain collector post-prefix receipt

### DIFF
--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -8,14 +8,12 @@ observation and evaluation components and offline Kubernetes workload
 packaging. The stages are now composed into a typed in-process Stage 1-7 prefix,
 a Stage 8-12 suffix and a receipt-bound, single-use full-run execution seam. The
 Stage 1-7 prefix and Stage 8-12 suffix both have concrete single-use execution
-adapters; only the post-runtime suffix currently has a bounded ephemeral Job
-activation path.
-That Job path is fully exercised offline and against fake APIs, but has not yet
-been run on the DEV management plane. The full-run library is not yet exposed
-as one local or Job-based CreateCluster activation. A strict private full-run
-manifest now verifies the complete fresh-run input boundary offline, but does
-not yet open that execution. It is still an MVP rather than a general lifecycle
-runner or controller.
+adapters. The joined path has local prepare/execute commands and one bounded
+ephemeral Job activation package. That path is fully exercised offline and
+against fake APIs, but has not yet been run on the DEV management plane. A
+strict private full-run manifest v2 verifies and opens the complete fresh-run
+input boundary, including the post-Stage-7 independent-evidence collector. It
+is still an MVP rather than a general lifecycle runner or controller.
 
 ```text
 versioned contract + test schema
@@ -3649,8 +3647,8 @@ durable receipts. This is not yet the OK-147 Definition of Done:
   separate prepare/execute CLI;
 - the independent-evidence collector has an exact private package replay,
   non-authorizing installation plan and single-use workload-cluster launcher;
-  the Stage-7-to-Stage-8 handoff now has an ordered fail-closed activator seam,
-  and its concrete package/launcher factory is single-use and runtime-bound;
+  the Stage-7-to-Stage-8 handoff opens that concrete runtime-bound factory
+  directly from the private manifest v2 and blocks Stage 8 until activation;
 - the standalone Stage-12 launcher has not yet been executed as part of the
   complete predecessor-bound stage chain;
 - the current staged-library source is published as the immutable multi-platform
@@ -3673,11 +3671,12 @@ private `0600` files with the binding last. It has no list, watch, discovery,
 Kubernetes mutation, retry or cleanup surface. The verified full-run manifest
 now opens that materializer, all concrete Stage 1-12 adapters and the shared
 single-execution Platform capability session without contacting a cluster.
-The remaining implementation work is binding the concrete post-prefix factory
-inputs into the local/Job activation package and CLI. Stage 8-12 is already
-structurally unable to open before that activator succeeds. This is not a new
-controller or reconciliation mechanism.
-After that, live closure must
+The full-run activation receipt now retains the collector's redaction-safe
+post-prefix receipt after execution. Its authority/package, observer credential,
+installer credential, runtime-binding and launch identities are therefore
+reviewable without exposing tokens, endpoints or private paths. This is not a
+new controller or reconciliation mechanism.
+Live closure must next
 publish the current image, construct fresh short-lived private inputs, run the
 exact bounded activation on `ok-mgmt`, preserve a stopped partial state without
 automatic retry, and separately repeat disposable-cluster and

--- a/internal/runner/full_run_activation.go
+++ b/internal/runner/full_run_activation.go
@@ -12,10 +12,11 @@ const FullRunExecutionActivationReceiptFormat = "ok147-full-run-execution-activa
 // by local and future Job activation adapters. It contains no credentials,
 // endpoints, runtime target identity or private paths.
 type FullRunExecutionActivationReceipt struct {
-	Format    string                          `json:"format"`
-	State     string                          `json:"state"`
-	Manifest  FullRunExecutionManifestReceipt `json:"manifest"`
-	Execution *FullRunOrchestrationReceipt    `json:"execution,omitempty"`
+	Format     string                                   `json:"format"`
+	State      string                                   `json:"state"`
+	Manifest   FullRunExecutionManifestReceipt          `json:"manifest"`
+	PostPrefix *ObservabilityCollectorPostPrefixReceipt `json:"postPrefix,omitempty"`
+	Execution  *FullRunOrchestrationReceipt             `json:"execution,omitempty"`
 }
 
 type fullRunManifestExecution interface {
@@ -31,8 +32,9 @@ type fullRunExecutionActivationFactories struct {
 // single-use and delegates exactly once to the already bounded Stage 1-12
 // executor. It adds no retry, rollback or cleanup surface.
 type FullRunExecutionActivation struct {
-	execution fullRunManifestExecution
-	manifest  FullRunExecutionManifestReceipt
+	execution         fullRunManifestExecution
+	manifest          FullRunExecutionManifestReceipt
+	postPrefixReceipt func() ObservabilityCollectorPostPrefixReceipt
 
 	mu   sync.Mutex
 	used bool
@@ -85,6 +87,12 @@ func (activation *FullRunExecutionActivation) Run(ctx context.Context) (FullRunE
 	}
 	executed, err := execution.Run(ctx)
 	receipt.Execution = &executed
+	if activation.postPrefixReceipt != nil {
+		postPrefix := activation.postPrefixReceipt()
+		if postPrefix.State != "PREPARED" {
+			receipt.PostPrefix = &postPrefix
+		}
+	}
 	if err != nil {
 		if executed.State == "STOPPED" {
 			receipt.State = "STOPPED"

--- a/internal/runner/full_run_activation_test.go
+++ b/internal/runner/full_run_activation_test.go
@@ -64,6 +64,30 @@ func TestFullRunExecutionActivationPreservesStoppedExecution(t *testing.T) {
 	}
 }
 
+func TestFullRunExecutionActivationRetainsRedactedPostPrefixReceipt(t *testing.T) {
+	execution := &recordingFullRunManifestExecution{receipt: successfulFullRunActivationExecutionReceipt()}
+	postPrefix := ObservabilityCollectorPostPrefixReceipt{
+		Format: ObservabilityCollectorPostPrefixReceiptFormat, State: "ACTIVATED",
+		PackageDigest: runnerStageSHA("1"), RuntimeBindingDigest: runnerStageSHA("2"), TargetIdentityDigest: runnerStageSHA("3"),
+		RuntimeAuthorityPackageDigest: runnerStageSHA("4"), RuntimeAuthorityReceiptDigest: runnerStageSHA("5"), RuntimeAuthorityCreatedObjects: 5,
+		ObserverCredentialReceiptDigest: runnerStageSHA("6"), CredentialReceiptDigest: runnerStageSHA("a"),
+		LaunchState: "ACTIVATED", CreatedObjects: 4,
+	}
+	activation := &FullRunExecutionActivation{
+		execution: execution, manifest: verifiedFullRunActivationManifestReceipt(),
+		postPrefixReceipt: func() ObservabilityCollectorPostPrefixReceipt { return postPrefix },
+	}
+	receipt, err := activation.Run(context.Background())
+	if err != nil || receipt.State != "SUCCEEDED" || receipt.PostPrefix == nil || !reflect.DeepEqual(*receipt.PostPrefix, postPrefix) {
+		t.Fatalf("post-prefix receipt was not retained: %#v err=%v", receipt, err)
+	}
+	raw, err := json.Marshal(receipt)
+	if err != nil || strings.Contains(strings.ToLower(string(raw)), "token") || strings.Contains(strings.ToLower(string(raw)), "endpoint") ||
+		strings.Contains(strings.ToLower(string(raw)), "kubeconfig") || strings.Contains(strings.ToLower(string(raw)), "certificate") {
+		t.Fatalf("post-prefix receipt disclosed private material: %s err=%v", raw, err)
+	}
+}
+
 func TestFullRunExecutionActivationAllowsOneConcurrentRun(t *testing.T) {
 	started := make(chan struct{})
 	release := make(chan struct{})

--- a/internal/runner/full_run_observability_activation.go
+++ b/internal/runner/full_run_observability_activation.go
@@ -81,7 +81,11 @@ func OpenKubernetesObservabilityFullRunActivation(path string, runtime Kubernete
 		return nil, receipt, errors.New("open concrete Kubernetes observability full-run execution")
 	}
 	receipt.State = "PREPARED"
-	return &FullRunExecutionActivation{execution: execution, manifest: manifestReceipt}, receipt, nil
+	activation := &FullRunExecutionActivation{execution: execution, manifest: manifestReceipt}
+	if collector, ok := postPrefix.(*KubernetesObservabilityCollectorPostPrefix); ok {
+		activation.postPrefixReceipt = collector.Receipt
+	}
+	return activation, receipt, nil
 }
 
 func (manifest VerifiedFullRunExecutionManifest) openObservabilityCollectorPostPrefix(manifestPath string, clock func() time.Time) (FullRunPostPrefixActivator, error) {


### PR DESCRIPTION
## Outcome

- retains the concrete collector post-prefix result in the outer full-run activation receipt
- exposes only redaction-safe package, authority, runtime-binding, observer-credential, installer-credential and launch identities
- omits the post-prefix field when execution never reaches the activation boundary
- preserves the same single-use full-run state and stage receipts
- updates the implementation boundary to reflect the completed manifest-v2/CLI/Job wiring

## Verification

- runner and CLI tests: PASS
- `go vet ./...`: PASS
- `go test -race ./internal/runner`: PASS

No live cluster contact or infrastructure mutation was performed.
