### PR TITLE
fix(ok147): bind authority service TLS identity

### DIFF
--- a/cmd/ok/stage_authority.go
+++ b/cmd/ok/stage_authority.go
@@ -34,6 +34,7 @@ func runAuthorityStagePackage(arguments []string, stdout, stderr io.Writer) erro
 	imageDigest := flags.String("image", "", "digest-pinned ok runner image")
 	storageClass := flags.String("storage-class", "", "bounded DEV storage class")
 	storageRequest := flags.String("storage-request", "", "bounded durable claim size")
+	serviceIP := flags.String("service-ip", "", "exact private ClusterIP for the bounded authority Service")
 	output := flags.String("output", "", "new private 0600 runtime package")
 	if err := flags.Parse(arguments); err != nil {
 		return err
@@ -43,7 +44,7 @@ func runAuthorityStagePackage(arguments []string, stdout, stderr io.Writer) erro
 	}
 	for _, input := range []string{
 		*policyPath, *expectedPolicyDigest, *privateKeyPath, *tokenFile, *tlsCertPath, *tlsKeyPath,
-		*templatePath, *templateDigest, *imageDigest, *storageClass, *storageRequest, *output,
+		*templatePath, *templateDigest, *imageDigest, *storageClass, *storageRequest, *serviceIP, *output,
 	} {
 		if input == "" {
 			return errors.New("all bounded stage-authority package inputs are required")
@@ -58,7 +59,7 @@ func runAuthorityStagePackage(arguments []string, stdout, stderr io.Writer) erro
 		TokenFile: *tokenFile, TLSCertPath: *tlsCertPath, TLSKeyPath: *tlsKeyPath,
 		Template: template, TemplateDigest: *templateDigest, ImageDigest: *imageDigest,
 		Namespace: "openkubes-execution-system", Name: "ok147-stage-authority", PrivateSecret: "ok147-stage-authority-private",
-		StorageClass: *storageClass, StorageRequest: *storageRequest,
+		StorageClass: *storageClass, StorageRequest: *storageRequest, ServiceIP: *serviceIP,
 	})
 	if err != nil {
 		return err

--- a/deploy/bounded-stage-authority.yaml.tpl
+++ b/deploy/bounded-stage-authority.yaml.tpl
@@ -23,6 +23,7 @@ metadata:
   name: "${OK147_AUTHORITY_NAME}"
   namespace: "${OK147_AUTHORITY_NAMESPACE}"
 spec:
+  clusterIP: "${OK147_AUTHORITY_SERVICE_IP}"
   selector:
     app.kubernetes.io/name: "${OK147_AUTHORITY_NAME}"
   ports:

--- a/docs/ok147-bounded-stage-authority.md
+++ b/docs/ok147-bounded-stage-authority.md
@@ -108,7 +108,7 @@ one client token and the pinned runtime template. The package contains exactly:
 immutable private Secret
 ServiceAccount without automounted token
 64Mi (configurable) restart-safe claim PVC
-ClusterIP Service
+Service with an exact private ClusterIP
 deny-by-default NetworkPolicy
 single-replica StatefulSet
 ```
@@ -120,8 +120,11 @@ private claim directory on the PVC. Partial materialization is preserved and
 never cleaned up or overwritten automatically.
 
 The package receipt contains only component digests, public key identity,
-image identity and object kinds. The package itself contains secrets and must
-remain a private `0600` artifact.
+image identity, a digest of the fixed Service IP and object kinds. The fixed
+address lets the TLS identity, runner authorization endpoint and single-address
+NetworkPolicy egress agree before any object is created; the raw address stays
+inside the private package. The package itself contains secrets and must remain
+a private `0600` artifact.
 
 ```bash
 ok authority stage package \
@@ -136,6 +139,7 @@ ok authority stage package \
   --image ghcr.io/openkubes/ok-cluster-runner@sha256:<image-digest> \
   --storage-class local-path \
   --storage-request 64Mi \
+  --service-ip <reviewed-unused-private-cluster-ip> \
   --output /private/ok147-stage-authority-package.yaml
 ```
 

--- a/internal/stageauthority/materializer_test.go
+++ b/internal/stageauthority/materializer_test.go
@@ -8,6 +8,7 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"math/big"
+	"net"
 	"os"
 	"path/filepath"
 	"testing"
@@ -106,7 +107,7 @@ func selfSignedTLS(t *testing.T) ([]byte, []byte) {
 		SerialNumber: big.NewInt(1), Subject: pkix.Name{CommonName: "ok147-stage-authority"},
 		NotBefore: time.Now().Add(-time.Minute), NotAfter: time.Now().Add(time.Hour),
 		KeyUsage: x509.KeyUsageDigitalSignature, ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
-		DNSNames: []string{"ok147-stage-authority"},
+		DNSNames: []string{"ok147-stage-authority"}, IPAddresses: []net.IP{net.ParseIP("10.43.250.147")},
 	}
 	certificateDER, err := x509.CreateCertificate(rand.Reader, template, template, &privateKey.PublicKey, privateKey)
 	if err != nil {

--- a/internal/stageauthority/package.go
+++ b/internal/stageauthority/package.go
@@ -3,16 +3,18 @@ package stageauthority
 import (
 	"bytes"
 	"crypto/tls"
+	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"net/netip"
 	"regexp"
 	"strings"
 
 	"github.com/openkubes/ok-cluster/internal/digest"
 )
 
-const RuntimePackageFormat = "ok147-bounded-stage-authority-runtime-package/v1"
+const RuntimePackageFormat = "ok147-bounded-stage-authority-runtime-package/v2"
 
 var (
 	imageDigestPattern    = regexp.MustCompile(`^[a-z0-9][a-z0-9./:_-]*@sha256:[0-9a-f]{64}$`)
@@ -35,22 +37,24 @@ type RuntimePackageConfig struct {
 	PrivateSecret        string
 	StorageClass         string
 	StorageRequest       string
+	ServiceIP            string
 }
 
 type RuntimePackageReceipt struct {
-	Format               string   `json:"format"`
-	State                string   `json:"state"`
-	PackageDigest        string   `json:"packageDigest"`
-	SecretObjectDigest   string   `json:"secretObjectDigest"`
-	RuntimeObjectsDigest string   `json:"runtimeObjectsDigest"`
-	TemplateDigest       string   `json:"templateDigest"`
-	PolicyDigest         string   `json:"policyDigest"`
-	KeyID                string   `json:"keyId"`
-	TLSIdentityDigest    string   `json:"tlsIdentityDigest"`
-	ImageDigest          string   `json:"imageDigest"`
-	PrivateFileCount     int      `json:"privateFileCount"`
-	ObjectKinds          []string `json:"objectKinds"`
-	MutationAllowed      bool     `json:"mutationAllowed"`
+	Format                string   `json:"format"`
+	State                 string   `json:"state"`
+	PackageDigest         string   `json:"packageDigest"`
+	SecretObjectDigest    string   `json:"secretObjectDigest"`
+	RuntimeObjectsDigest  string   `json:"runtimeObjectsDigest"`
+	TemplateDigest        string   `json:"templateDigest"`
+	PolicyDigest          string   `json:"policyDigest"`
+	KeyID                 string   `json:"keyId"`
+	TLSIdentityDigest     string   `json:"tlsIdentityDigest"`
+	ServiceIdentityDigest string   `json:"serviceIdentityDigest"`
+	ImageDigest           string   `json:"imageDigest"`
+	PrivateFileCount      int      `json:"privateFileCount"`
+	ObjectKinds           []string `json:"objectKinds"`
+	MutationAllowed       bool     `json:"mutationAllowed"`
 }
 
 type VerifiedRuntimePackage struct {
@@ -66,7 +70,7 @@ func BuildRuntimePackage(config RuntimePackageConfig) (VerifiedRuntimePackage, e
 		digest.SHA256(config.Template) != config.TemplateDigest || !imageDigestPattern.MatchString(config.ImageDigest) ||
 		config.Namespace != "openkubes-execution-system" || config.Name != "ok147-stage-authority" ||
 		config.PrivateSecret != "ok147-stage-authority-private" || !dnsLabelPattern.MatchString(config.StorageClass) ||
-		!storageRequestPattern.MatchString(config.StorageRequest) {
+		!storageRequestPattern.MatchString(config.StorageRequest) || !validRuntimeServiceIP(config.ServiceIP) {
 		return VerifiedRuntimePackage{}, errors.New("bounded stage authority runtime package binding is invalid")
 	}
 	policyRaw, err := readPrivateRegular(config.PolicyPath, maximumPolicyBytes, false)
@@ -105,6 +109,10 @@ func BuildRuntimePackage(config RuntimePackageConfig) (VerifiedRuntimePackage, e
 	if err != nil || len(certificate.Certificate) == 0 {
 		return VerifiedRuntimePackage{}, errors.New("bounded stage authority package TLS identity is invalid")
 	}
+	leaf, err := x509.ParseCertificate(certificate.Certificate[0])
+	if err != nil || !certificateBindsRuntimeServiceIP(leaf, config.ServiceIP) {
+		return VerifiedRuntimePackage{}, errors.New("bounded stage authority TLS identity does not bind the Service IP")
+	}
 	secret := map[string]any{
 		"apiVersion": "v1", "kind": "Secret", "immutable": true, "type": "Opaque",
 		"metadata": map[string]any{
@@ -124,7 +132,7 @@ func BuildRuntimePackage(config RuntimePackageConfig) (VerifiedRuntimePackage, e
 	}
 	runtimeRaw, err := RenderRuntimeTemplate(config.Template, RuntimeTemplateValues{
 		ImageDigest: config.ImageDigest, Namespace: config.Namespace, Name: config.Name, PrivateSecret: config.PrivateSecret,
-		PolicyDigest: policyDigest, KeyID: keyID, StorageClass: config.StorageClass, StorageRequest: config.StorageRequest,
+		PolicyDigest: policyDigest, KeyID: keyID, StorageClass: config.StorageClass, StorageRequest: config.StorageRequest, ServiceIP: config.ServiceIP,
 	})
 	if err != nil {
 		return VerifiedRuntimePackage{}, err
@@ -133,7 +141,8 @@ func BuildRuntimePackage(config RuntimePackageConfig) (VerifiedRuntimePackage, e
 	receipt := RuntimePackageReceipt{
 		Format: RuntimePackageFormat, State: "VERIFIED", PackageDigest: digest.SHA256(packageRaw),
 		SecretObjectDigest: digest.SHA256(secretRaw), RuntimeObjectsDigest: digest.SHA256(runtimeRaw), TemplateDigest: config.TemplateDigest,
-		PolicyDigest: policyDigest, KeyID: keyID, TLSIdentityDigest: digest.SHA256(certificate.Certificate[0]), ImageDigest: config.ImageDigest,
+		PolicyDigest: policyDigest, KeyID: keyID, TLSIdentityDigest: digest.SHA256(certificate.Certificate[0]),
+		ServiceIdentityDigest: digest.SHA256([]byte(config.ServiceIP)), ImageDigest: config.ImageDigest,
 		PrivateFileCount: 5, ObjectKinds: []string{"Secret", "ServiceAccount", "PersistentVolumeClaim", "Service", "NetworkPolicy", "StatefulSet"}, MutationAllowed: false,
 	}
 	return VerifiedRuntimePackage{raw: packageRaw, receipt: receipt, verified: true}, nil
@@ -161,7 +170,7 @@ func verifyRuntimePackage(packaged VerifiedRuntimePackage) error {
 		len(packaged.raw) == 0 || digest.SHA256(packaged.raw) != receipt.PackageDigest || receipt.PrivateFileCount != 5 || len(receipt.ObjectKinds) != 6 {
 		return errors.New("bounded stage authority runtime package was not produced by verification")
 	}
-	for _, value := range []string{receipt.PackageDigest, receipt.SecretObjectDigest, receipt.RuntimeObjectsDigest, receipt.TemplateDigest, receipt.PolicyDigest, receipt.KeyID, receipt.TLSIdentityDigest} {
+	for _, value := range []string{receipt.PackageDigest, receipt.SecretObjectDigest, receipt.RuntimeObjectsDigest, receipt.TemplateDigest, receipt.PolicyDigest, receipt.KeyID, receipt.TLSIdentityDigest, receipt.ServiceIdentityDigest} {
 		if !digestPattern.MatchString(value) {
 			return errors.New("bounded stage authority runtime package identity is invalid")
 		}
@@ -182,13 +191,14 @@ type RuntimeTemplateValues struct {
 	KeyID          string
 	StorageClass   string
 	StorageRequest string
+	ServiceIP      string
 }
 
 func RenderRuntimeTemplate(template []byte, values RuntimeTemplateValues) ([]byte, error) {
 	if len(template) == 0 || len(template) > 512*1024 || !imageDigestPattern.MatchString(values.ImageDigest) ||
 		values.Namespace != "openkubes-execution-system" || values.Name != "ok147-stage-authority" || values.PrivateSecret != "ok147-stage-authority-private" ||
 		!digestPattern.MatchString(values.PolicyDigest) || !digestPattern.MatchString(values.KeyID) || !dnsLabelPattern.MatchString(values.StorageClass) ||
-		!storageRequestPattern.MatchString(values.StorageRequest) {
+		!storageRequestPattern.MatchString(values.StorageRequest) || !validRuntimeServiceIP(values.ServiceIP) {
 		return nil, errors.New("bounded stage authority runtime template input is invalid")
 	}
 	replacements := map[string]string{
@@ -196,6 +206,7 @@ func RenderRuntimeTemplate(template []byte, values RuntimeTemplateValues) ([]byt
 		"${OK147_AUTHORITY_NAME}": values.Name, "${OK147_PRIVATE_SECRET}": values.PrivateSecret,
 		"${OK147_POLICY_DIGEST}": values.PolicyDigest, "${OK147_KEY_ID}": values.KeyID,
 		"${OK147_STORAGE_CLASS}": values.StorageClass, "${OK147_STORAGE_REQUEST}": values.StorageRequest,
+		"${OK147_AUTHORITY_SERVICE_IP}": values.ServiceIP,
 	}
 	result := string(template)
 	for placeholder, value := range replacements {
@@ -208,4 +219,23 @@ func RenderRuntimeTemplate(template []byte, values RuntimeTemplateValues) ([]byt
 		return nil, errors.New("bounded stage authority runtime template contains an unknown placeholder")
 	}
 	return []byte(result), nil
+}
+
+func validRuntimeServiceIP(raw string) bool {
+	address, err := netip.ParseAddr(raw)
+	return err == nil && address.Is4() && address.IsPrivate() && !address.IsLoopback() && !address.IsUnspecified()
+}
+
+func certificateBindsRuntimeServiceIP(certificate *x509.Certificate, raw string) bool {
+	expected, err := netip.ParseAddr(raw)
+	if err != nil || certificate == nil {
+		return false
+	}
+	for _, value := range certificate.IPAddresses {
+		observed, ok := netip.AddrFromSlice(value)
+		if ok && observed.Unmap() == expected.Unmap() {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/stageauthority/package_test.go
+++ b/internal/stageauthority/package_test.go
@@ -25,7 +25,8 @@ func TestBuildRuntimePackageBindsPrivateSecretAndRestartSafeRuntime(t *testing.T
 	if err != nil {
 		t.Fatal(err)
 	}
-	if receipt.State != "VERIFIED" || receipt.PackageDigest != digest.SHA256(raw) || receipt.PolicyDigest != config.ExpectedPolicyDigest ||
+	if receipt.Format != RuntimePackageFormat || receipt.State != "VERIFIED" || receipt.PackageDigest != digest.SHA256(raw) || receipt.PolicyDigest != config.ExpectedPolicyDigest ||
+		receipt.ServiceIdentityDigest != digest.SHA256([]byte(config.ServiceIP)) ||
 		receipt.PrivateFileCount != 5 || len(receipt.ObjectKinds) != 6 || receipt.MutationAllowed {
 		t.Fatalf("unexpected package receipt: %#v", receipt)
 	}
@@ -39,7 +40,7 @@ func TestBuildRuntimePackageBindsPrivateSecretAndRestartSafeRuntime(t *testing.T
 	}
 	runtime := string(parts[1])
 	for _, required := range []string{
-		"kind: PersistentVolumeClaim", "kind: StatefulSet", "replicas: 1", "automountServiceAccountToken: false",
+		"kind: PersistentVolumeClaim", "kind: StatefulSet", "replicas: 1", "automountServiceAccountToken: false", "clusterIP: \"" + config.ServiceIP + "\"",
 		"readOnlyRootFilesystem: true", "egress: []", "authority\n            - stage\n            - materialize",
 		"/var/lib/openkubes/stage-authority/claims", config.ImageDigest, config.ExpectedPolicyDigest,
 	} {
@@ -63,6 +64,16 @@ func TestBuildRuntimePackageRejectsChangedTemplateAndMutableIdentity(t *testing.
 	if _, err := BuildRuntimePackage(config); err == nil {
 		t.Fatal("mutable image was accepted")
 	}
+	config = runtimePackageFixture(t)
+	config.ServiceIP = "authority.openkubes-execution-system.svc"
+	if _, err := BuildRuntimePackage(config); err == nil {
+		t.Fatal("non-IP authority Service identity was accepted")
+	}
+	config = runtimePackageFixture(t)
+	config.ServiceIP = "10.43.250.148"
+	if _, err := BuildRuntimePackage(config); err == nil {
+		t.Fatal("TLS identity that does not bind the Service IP was accepted")
+	}
 }
 
 func runtimePackageFixture(t *testing.T) RuntimePackageConfig {
@@ -82,6 +93,6 @@ func runtimePackageFixture(t *testing.T) RuntimePackageConfig {
 		TLSCertPath: certPath, TLSKeyPath: tlsKeyPath, Template: template, TemplateDigest: digest.SHA256(template),
 		ImageDigest: "ghcr.io/openkubes/ok-cluster-runner@sha256:" + strings.Repeat("a", 64),
 		Namespace:   "openkubes-execution-system", Name: "ok147-stage-authority", PrivateSecret: "ok147-stage-authority-private",
-		StorageClass: "local-path", StorageRequest: "64Mi",
+		StorageClass: "local-path", StorageRequest: "64Mi", ServiceIP: "10.43.250.147",
 	}
 }

--- a/internal/stageauthority/runtime_installation.go
+++ b/internal/stageauthority/runtime_installation.go
@@ -171,7 +171,8 @@ func expectedRuntimeObjectIdentity(index int, kind, name string, value map[strin
 	case "Service":
 		spec, _ := value["spec"].(map[string]any)
 		selector, _ := spec["selector"].(map[string]any)
-		return selector["app.kubernetes.io/name"] == "ok147-stage-authority"
+		serviceIP, _ := spec["clusterIP"].(string)
+		return validRuntimeServiceIP(serviceIP) && digest.SHA256([]byte(serviceIP)) == receipt.ServiceIdentityDigest && selector["app.kubernetes.io/name"] == "ok147-stage-authority"
 	case "NetworkPolicy":
 		spec, _ := value["spec"].(map[string]any)
 		return spec != nil

--- a/internal/stageauthority/runtime_launcher_test.go
+++ b/internal/stageauthority/runtime_launcher_test.go
@@ -36,7 +36,7 @@ func TestPlanRuntimeInstallationBindsExactSixObjectOrder(t *testing.T) {
 		t.Fatal("runtime package accepted a non-management authority")
 	}
 	public, _ := json.Marshal(plan)
-	for _, forbidden := range []string{"token", "authority.key", "tls.key", "secretobjectdigest"} {
+	for _, forbidden := range []string{"token", "authority.key", "tls.key", "secretobjectdigest", "10.43.250.147"} {
 		if strings.Contains(strings.ToLower(string(public)), forbidden) {
 			t.Fatalf("plan disclosed %q", forbidden)
 		}


### PR DESCRIPTION
Closes the live activation identity gap discovered after the bounded launcher checkpoint.\n\n- upgrades the private authority runtime package to v2\n- requires an exact private Service ClusterIP\n- requires the TLS certificate IP SAN to contain that same address\n- binds only a SHA-256 Service identity in the public receipt\n- verifies the Service object carries the bound address\n- documents the fixed endpoint/TLS/NetworkPolicy relationship\n\nFull Go suite, vet, and race detector pass. No cluster contact or infrastructure mutation was performed.