### PR TITLE
fix(authority): accept API-omitted empty egress

### DIFF
--- a/docs/ok147-bounded-stage-authority.md
+++ b/docs/ok147-bounded-stage-authority.md
@@ -172,6 +172,12 @@ fixed order. Existing state stops with zero writes. An attempted or uncertain
 write stops as partial state. The launcher is single-use and exposes no update,
 patch, apply, adoption, delete, cleanup, rollback, list, watch or retry path.
 
+The created-object check recognizes exactly one Kubernetes serialization
+equivalence: for the bounded NetworkPolicy, an API response may omit the
+explicitly empty `spec.egress` list. This is accepted only when the desired
+object binds `policyTypes: [Ingress, Egress]` and an empty egress list; all
+other fields remain subject to the exact desired-subset check.
+
 ```bash
 ok authority stage launch execute \
   --package /private/ok147-stage-authority-package.yaml \

--- a/internal/stageauthority/runtime_launcher.go
+++ b/internal/stageauthority/runtime_launcher.go
@@ -228,7 +228,8 @@ func (launcher *KubernetesRuntimeLauncher) request(ctx context.Context, method, 
 
 func verifyRuntimeCreatedObject(raw, desiredRaw []byte) (string, string, error) {
 	var observed, desired map[string]any
-	if json.Unmarshal(raw, &observed) != nil || json.Unmarshal(desiredRaw, &desired) != nil || !runtimeSubset(desired, observed) {
+	if json.Unmarshal(raw, &observed) != nil || json.Unmarshal(desiredRaw, &desired) != nil ||
+		!normalizeRuntimeAPIResponse(desired, observed) || !runtimeSubset(desired, observed) {
 		return "", "", errors.New("created bounded stage authority object differs from verified package")
 	}
 	metadata, _ := observed["metadata"].(map[string]any)
@@ -238,6 +239,29 @@ func verifyRuntimeCreatedObject(raw, desiredRaw []byte) (string, string, error) 
 		return "", "", errors.New("created bounded stage authority object lacks runtime identity")
 	}
 	return uid, resourceVersion, nil
+}
+
+// Kubernetes omits an explicitly empty NetworkPolicy egress list when it
+// serializes the stored object. With policyTypes containing Egress, omitted and
+// empty both mean deny all egress. Keep this equivalence deliberately scoped to
+// that one API field; every other desired field remains an exact subset check.
+func normalizeRuntimeAPIResponse(desired, observed map[string]any) bool {
+	if desired["apiVersion"] != "networking.k8s.io/v1" || desired["kind"] != "NetworkPolicy" {
+		return true
+	}
+	desiredSpec, desiredOK := desired["spec"].(map[string]any)
+	observedSpec, observedOK := observed["spec"].(map[string]any)
+	if !desiredOK || !observedOK {
+		return false
+	}
+	desiredEgress, bound := desiredSpec["egress"].([]any)
+	if !bound || len(desiredEgress) != 0 {
+		return true
+	}
+	if _, present := observedSpec["egress"]; !present {
+		observedSpec["egress"] = []any{}
+	}
+	return true
 }
 
 func runtimeSubset(expected, observed any) bool {

--- a/internal/stageauthority/runtime_launcher_test.go
+++ b/internal/stageauthority/runtime_launcher_test.go
@@ -99,6 +99,25 @@ func TestRuntimeLauncherPreflightsAllThenCreatesInOrder(t *testing.T) {
 	}
 }
 
+func TestVerifyRuntimeCreatedNetworkPolicyAcceptsOnlyOmittedEmptyEgress(t *testing.T) {
+	desired := []byte(`{"apiVersion":"networking.k8s.io/v1","kind":"NetworkPolicy","metadata":{"name":"ok147-stage-authority","namespace":"openkubes-execution-system"},"spec":{"podSelector":{},"policyTypes":["Ingress","Egress"],"ingress":[],"egress":[]}}`)
+	observed := []byte(`{"apiVersion":"networking.k8s.io/v1","kind":"NetworkPolicy","metadata":{"name":"ok147-stage-authority","namespace":"openkubes-execution-system","uid":"runtime-uid-123","resourceVersion":"1001"},"spec":{"podSelector":{},"policyTypes":["Ingress","Egress"],"ingress":[]}}`)
+	if _, _, err := verifyRuntimeCreatedObject(observed, desired); err != nil {
+		t.Fatalf("API-omitted empty egress was rejected: %v", err)
+	}
+
+	nonEmpty := []byte(`{"apiVersion":"networking.k8s.io/v1","kind":"NetworkPolicy","metadata":{"name":"ok147-stage-authority","namespace":"openkubes-execution-system"},"spec":{"podSelector":{},"policyTypes":["Ingress","Egress"],"ingress":[],"egress":[{"to":[]}]}}`)
+	if _, _, err := verifyRuntimeCreatedObject(observed, nonEmpty); err == nil {
+		t.Fatal("API-omitted non-empty egress was accepted")
+	}
+
+	serviceDesired := []byte(`{"apiVersion":"v1","kind":"Service","metadata":{"name":"ok147-stage-authority","namespace":"openkubes-execution-system"},"spec":{"selector":{},"ports":[]}}`)
+	serviceObserved := []byte(`{"apiVersion":"v1","kind":"Service","metadata":{"name":"ok147-stage-authority","namespace":"openkubes-execution-system","uid":"runtime-uid-123","resourceVersion":"1001"},"spec":{"selector":{}}}`)
+	if _, _, err := verifyRuntimeCreatedObject(serviceObserved, serviceDesired); err == nil {
+		t.Fatal("omitted empty list outside the bounded NetworkPolicy field was accepted")
+	}
+}
+
 func TestRuntimeLauncherStopsZeroWriteAndPreservesPartialWithoutRetry(t *testing.T) {
 	packaged := runtimeLauncherPackage(t)
 	plan, _ := PlanRuntimeInstallation(packaged, "ok-mgmt")


### PR DESCRIPTION
## Summary

- accept the one Kubernetes serialization equivalence observed by the live OK-147 authority install
- treat an omitted NetworkPolicy `spec.egress` as equivalent only when the verified desired field is explicitly empty
- retain exact desired-subset verification for every other field
- add positive and fail-closed regression cases

## Validation

- `go test ./...` PASS
- `go vet ./...` PASS
- race tests for `internal/stageauthority` and `cmd/ok` PASS

## Live boundary

The original single-use launcher stopped with partial state after the API server accepted the NetworkPolicy and omitted its empty egress list in the response. No retry or cleanup is included in this PR.