### PR TITLE
feat(runner): bind provider access before lifecycle

### DIFF
--- a/deploy/contract-executor-full-run-job.yaml.tpl
+++ b/deploy/contract-executor-full-run-job.yaml.tpl
@@ -202,6 +202,7 @@ spec:
               - {key: credentials.ledger-token, path: credentials/ledger-token}
               - {key: credentials.management-ca.crt, path: credentials/management-ca.crt}
               - {key: credentials.management-token, path: credentials/management-token}
+              - {key: credentials.provider-access-kubeconfig, path: credentials/provider-access-kubeconfig}
               - {key: input.aggregate-profile.json, path: input/aggregate-profile.json}
               - {key: input.authorization-authority.pub, path: input/authorization-authority.pub}
               - {key: input.collector-job.yaml, path: input/collector-job.yaml}
@@ -211,6 +212,7 @@ spec:
               - {key: input.network-profile.json, path: input/network-profile.json}
               - {key: input.platform-applications.yaml, path: input/platform-applications.yaml}
               - {key: input.platform-profile.json, path: input/platform-profile.json}
+              - {key: input.provider-access-policy.json, path: input/provider-access-policy.json}
               - {key: input.projection.authority-map.json, path: input/projection/authority-map.json}
               - {key: input.projection.ok-infra-prerequisites.yaml, path: input/projection/ok-infra-prerequisites.yaml}
               - {key: input.projection.ok-mgmt-lifecycle.yaml, path: input/projection/ok-mgmt-lifecycle.yaml}

--- a/internal/runner/full_run_activation_bundle.go
+++ b/internal/runner/full_run_activation_bundle.go
@@ -23,7 +23,7 @@ const (
 	fullRunExecutionWorkspaceRoot       = "/var/run/openkubes/workspace"
 	fullRunExecutionHandoffRoot         = "/var/run/openkubes/handoff"
 	maximumFullRunExecutionBundleBytes  = 900 * 1024
-	maximumFullRunExecutionBundleFiles  = 32
+	maximumFullRunExecutionBundleFiles  = 34
 )
 
 var fullRunExecutionBundleFiles = []string{
@@ -42,6 +42,7 @@ var fullRunExecutionBundleFiles = []string{
 	"credentials/ledger-token",
 	"credentials/management-ca.crt",
 	"credentials/management-token",
+	"credentials/provider-access-kubeconfig",
 	"input/aggregate-profile.json",
 	"input/authorization-authority.pub",
 	"input/collector-job.yaml",
@@ -51,6 +52,7 @@ var fullRunExecutionBundleFiles = []string{
 	"input/network-profile.json",
 	"input/platform-applications.yaml",
 	"input/platform-profile.json",
+	"input/provider-access-policy.json",
 	"input/projection/authority-map.json",
 	"input/projection/ok-infra-prerequisites.yaml",
 	"input/projection/ok-mgmt-lifecycle.yaml",
@@ -210,6 +212,7 @@ func collectFullRunExecutionSources(document fullRunExecutionManifestDocument, e
 		"credentials/ledger-token":                     document.ProviderPrerequisites.Ledger.TokenFile,
 		"credentials/management-ca.crt":                document.ClusterLifecycle.Authority.CAFile,
 		"credentials/management-token":                 document.ClusterLifecycle.Authority.TokenFile,
+		"credentials/provider-access-kubeconfig":       document.ProviderAccess.KubeconfigFile,
 		"input/aggregate-profile.json":                 document.Profiles.Aggregate.Path,
 		"input/authorization-authority.pub":            document.Authorization.PublicKeyPath,
 		"input/collector-job.yaml":                     document.ObservabilityCollector.JobTemplatePath,
@@ -219,6 +222,7 @@ func collectFullRunExecutionSources(document fullRunExecutionManifestDocument, e
 		"input/network-profile.json":                   document.Profiles.Network.Path,
 		"input/platform-applications.yaml":             document.PlatformApplications.ArtifactPath,
 		"input/platform-profile.json":                  document.Profiles.Platform.Path,
+		"input/provider-access-policy.json":            document.ProviderAccess.PolicyPath,
 		"input/projection/authority-map.json":          filepath.Join(document.Projection.Root, "authority-map.json"),
 		"input/projection/ok-infra-prerequisites.yaml": filepath.Join(document.Projection.Root, "ok-infra-prerequisites.yaml"),
 		"input/projection/ok-mgmt-lifecycle.yaml":      filepath.Join(document.Projection.Root, "ok-mgmt-lifecycle.yaml"),
@@ -294,6 +298,9 @@ func rewriteFullRunExecutionBundle(document fullRunExecutionManifestDocument, so
 	document.Authorization.PublicKeyPath, document.Authorization.OutputDirectory = path("input/authorization-authority.pub"), path("work/authorizations")
 	document.Profiles.Network.Path, document.Profiles.Platform.Path, document.Profiles.Aggregate.Path = path("input/network-profile.json"), path("input/platform-profile.json"), path("input/aggregate-profile.json")
 	document.ProviderPrerequisites = fullRunSubmissionRuntimeDocument{Ledger: ledger, Authority: infrastructure}
+	document.ProviderAccess = fullRunProviderAccessDocument{
+		PolicyPath: path("input/provider-access-policy.json"), KubeconfigFile: path("credentials/provider-access-kubeconfig"),
+	}
 	document.ClusterLifecycle = fullRunSubmissionRuntimeDocument{Ledger: ledger, Authority: management}
 	document.LifecycleObservation.Ledger, document.LifecycleObservation.Management = ledger, management
 	document.Enablement.ArtifactPath, document.Enablement.Runtime = path("input/enablement.yaml"), fullRunSubmissionRuntimeDocument{Ledger: ledger, Authority: management}

--- a/internal/runner/full_run_activation_bundle_test.go
+++ b/internal/runner/full_run_activation_bundle_test.go
@@ -46,6 +46,8 @@ func TestBuildFullRunExecutionBundleIsDeterministicAndSelfContained(t *testing.T
 	if rewritten.Plan.Path != path("input/staged-plan.json") ||
 		rewritten.Projection.Root != path("input/projection") ||
 		rewritten.ProviderPrerequisites.Authority.TokenFile != path("credentials/infrastructure-token") ||
+		rewritten.ProviderAccess.PolicyPath != path("input/provider-access-policy.json") ||
+		rewritten.ProviderAccess.KubeconfigFile != path("credentials/provider-access-kubeconfig") ||
 		rewritten.ClusterLifecycle.Authority.TokenFile != path("credentials/management-token") ||
 		rewritten.TargetRegistration.GitOps.TokenFile != path("credentials/gitops-token") ||
 		rewritten.NetworkObservation.Workload.BindingPath != path("work/workload-authority.json") ||
@@ -62,10 +64,12 @@ func TestBuildFullRunExecutionBundleIsDeterministicAndSelfContained(t *testing.T
 		t.Fatal("semantic full-run identity changed during path rewrite")
 	}
 	for relative, sourcePath := range map[string]string{
-		"input/staged-plan.json":           source.document.Plan.Path,
-		"input/enablement.yaml":            source.document.Enablement.ArtifactPath,
-		"input/platform-applications.yaml": source.document.PlatformApplications.ArtifactPath,
-		"input/independent-evidence.pub":   publicKeyPath,
+		"input/staged-plan.json":                 source.document.Plan.Path,
+		"input/enablement.yaml":                  source.document.Enablement.ArtifactPath,
+		"input/platform-applications.yaml":       source.document.PlatformApplications.ArtifactPath,
+		"input/provider-access-policy.json":      source.document.ProviderAccess.PolicyPath,
+		"credentials/provider-access-kubeconfig": source.document.ProviderAccess.KubeconfigFile,
+		"input/independent-evidence.pub":         publicKeyPath,
 	} {
 		want, readErr := os.ReadFile(sourcePath)
 		if readErr != nil || !bytes.Equal(bundle.files[relative], want) {

--- a/internal/runner/full_run_activation_materializer.go
+++ b/internal/runner/full_run_activation_materializer.go
@@ -158,6 +158,7 @@ func validPackagedFullRunRuntimePaths(document fullRunExecutionManifestDocument)
 		document.Authorization.PublicKeyPath == path("input/authorization-authority.pub") && document.Authorization.OutputDirectory == path("work/authorizations") &&
 		document.Profiles.Network.Path == path("input/network-profile.json") && document.Profiles.Platform.Path == path("input/platform-profile.json") && document.Profiles.Aggregate.Path == path("input/aggregate-profile.json") &&
 		document.ProviderPrerequisites.Ledger == ledger && document.ProviderPrerequisites.Authority.TokenFile == path("credentials/infrastructure-token") && document.ProviderPrerequisites.Authority.CAFile == path("credentials/infrastructure-ca.crt") &&
+		document.ProviderAccess.PolicyPath == path("input/provider-access-policy.json") && document.ProviderAccess.KubeconfigFile == path("credentials/provider-access-kubeconfig") &&
 		document.ClusterLifecycle.Ledger == ledger && document.ClusterLifecycle.Authority.TokenFile == path("credentials/management-token") && document.ClusterLifecycle.Authority.CAFile == path("credentials/management-ca.crt") &&
 		document.Enablement.ArtifactPath == path("input/enablement.yaml") && document.NetworkObservation.Workload == workload && document.RuntimeBinding.Workload == workload &&
 		document.RuntimeBinding.MaterialPath == path("work/runtime-binding.json") && document.RuntimeBinding.ReceiptPath == path("work/runtime-binding-receipt.json") &&

--- a/internal/runner/full_run_execution_manifest.go
+++ b/internal/runner/full_run_execution_manifest.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	FullRunExecutionManifestFormat        = "ok147-full-run-execution-manifest/v2"
+	FullRunExecutionManifestFormat        = "ok147-full-run-execution-manifest/v3"
 	FullRunExecutionManifestReceiptFormat = "ok147-full-run-execution-manifest-receipt/v1"
 	maximumFullRunExecutionManifestBytes  = 1024 * 1024
 )
@@ -39,6 +39,11 @@ type fullRunProjectionDocument struct {
 type fullRunSubmissionRuntimeDocument struct {
 	Ledger    postRuntimeLedgerDocument    `json:"ledger"`
 	Authority postRuntimeAuthorityDocument `json:"authority"`
+}
+
+type fullRunProviderAccessDocument struct {
+	PolicyPath     string `json:"policyPath"`
+	KubeconfigFile string `json:"kubeconfigFile"`
 }
 
 type fullRunLifecycleObservationDocument struct {
@@ -167,6 +172,7 @@ type fullRunExecutionManifestDocument struct {
 	Authorization          postRuntimeAuthorizationDocument      `json:"authorization"`
 	Profiles               postRuntimeProfilesDocument           `json:"profiles"`
 	ProviderPrerequisites  fullRunSubmissionRuntimeDocument      `json:"providerPrerequisites"`
+	ProviderAccess         fullRunProviderAccessDocument         `json:"providerAccess"`
 	ClusterLifecycle       fullRunSubmissionRuntimeDocument      `json:"clusterLifecycle"`
 	LifecycleObservation   fullRunLifecycleObservationDocument   `json:"lifecycleObservation"`
 	Enablement             fullRunEnablementDocument             `json:"enablement"`
@@ -361,9 +367,13 @@ func (manifest VerifiedFullRunExecutionManifest) ExecutionConfig(runtime FullRun
 		PreRuntime: PreRuntimeExecutionConfig{
 			PlanPath: document.Plan.Path, PlanExpected: expected,
 			ProjectionManifestPath: document.Projection.ManifestPath, ProjectionRoot: document.Projection.Root,
-			Authorization:         authorization,
-			ProviderPrerequisites: SubmissionStageRuntimeConfig{Ledger: ledger, Authority: authorityConfig(document.ProviderPrerequisites.Authority), Clock: runtime.Clock},
-			ClusterLifecycle:      SubmissionStageRuntimeConfig{Ledger: ledger, Authority: authorityConfig(document.ClusterLifecycle.Authority), Clock: runtime.Clock},
+			Authorization:            authorization,
+			ProviderAccessPolicyPath: document.ProviderAccess.PolicyPath,
+			ProviderPrerequisites:    SubmissionStageRuntimeConfig{Ledger: ledger, Authority: authorityConfig(document.ProviderPrerequisites.Authority), Clock: runtime.Clock},
+			ClusterLifecycle: SubmissionStageRuntimeConfig{
+				Ledger: ledger, Authority: authorityConfig(document.ClusterLifecycle.Authority),
+				ProviderAccessKubeconfigFile: document.ProviderAccess.KubeconfigFile, Clock: runtime.Clock,
+			},
 			LifecycleObservation: LifecycleObservationStageRuntimeConfig{
 				Ledger: ledger, Management: authorityConfig(document.LifecycleObservation.Management),
 				PollInterval: lifecycleInterval, PollTimeout: lifecycleTimeout, Clock: runtime.Clock, Wait: runtime.Wait,
@@ -616,6 +626,21 @@ func loadFullRunExecutionManifest(path string) (fullRunExecutionManifestDocument
 }
 
 func verifyFullRunStaticArtifacts(document fullRunExecutionManifestDocument, plan stageplan.Binding, platformProfile observation.PlatformProfile) error {
+	lifecycleStage, _, err := plan.Stage("cluster-lifecycle")
+	if err != nil || len(lifecycleStage.Inputs) != 2 || lifecycleStage.Inputs[0].Name != "projection.cluster-lifecycle" || lifecycleStage.Inputs[1].Name != "stage.provider-access" {
+		return errors.New("full-run cluster-lifecycle inputs are invalid")
+	}
+	providerPolicy, err := submission.LoadProviderAccessPolicy(document.ProviderAccess.PolicyPath, submission.ProviderAccessExpected{
+		PolicyDigest: lifecycleStage.Inputs[1].Digest, ContractIdentity: plan.ContractIdentity,
+		IntentRevision: plan.IntentRevision, ExecutionFixture: plan.ExecutionFixture,
+		ManagementAuthority: plan.Authorities.Management, ProviderAuthority: plan.Authorities.Infrastructure,
+	})
+	if err != nil {
+		return errors.New("verify full-run provider-access policy")
+	}
+	if _, err := providerPolicy.MaterializeSecret(document.ProviderAccess.KubeconfigFile); err != nil {
+		return errors.New("verify full-run provider-access credential")
+	}
 	enablementStage, _, err := plan.Stage("enablement")
 	if err != nil || len(enablementStage.Inputs) != 1 || enablementStage.Inputs[0].Name != "stage.enablement" {
 		return errors.New("full-run enablement input is invalid")
@@ -743,6 +768,7 @@ func verifyFullRunObservabilityCollector(document fullRunObservabilityCollectorD
 func validateFullRunRuntimeBoundary(document fullRunExecutionManifestDocument, plan stageplan.Binding) error {
 	paths := []string{
 		document.Plan.Path, document.Projection.ManifestPath, document.Projection.Root,
+		document.ProviderAccess.PolicyPath, document.ProviderAccess.KubeconfigFile,
 		document.Authorization.TokenFile, document.Authorization.CAFile, document.Authorization.PublicKeyPath, document.Authorization.OutputDirectory,
 		document.Profiles.Network.Path, document.Profiles.Platform.Path, document.Profiles.Aggregate.Path,
 		document.Enablement.ArtifactPath, document.TargetAccess.ArtifactPath, document.TargetCredential.PolicyPath,

--- a/internal/runner/full_run_execution_manifest_test.go
+++ b/internal/runner/full_run_execution_manifest_test.go
@@ -327,6 +327,18 @@ func fullRunExecutionManifestFixture(t *testing.T) (string, func()) {
 		"providerAccess": map[string]any{}, "source": map[string]any{},
 	})
 	projectionManifestPath := writeBundleFile(t, root, "full-projection-manifest.json", projectionManifest)
+	providerAccessPolicy := mustJSON(t, map[string]any{
+		"format": "ok147-provider-access-policy/v1", "contractIdentity": expected.ContractIdentity,
+		"intentRevision": expected.IntentRevision, "executionFixture": expected.ExecutionFixture,
+		"managementAuthority": expected.ManagementAuthority, "providerAuthority": expected.InfrastructureAuthority,
+		"secret": map[string]any{
+			"apiVersion": "v1", "kind": "Secret", "namespace": expected.ContractIdentity.Namespace,
+			"name": "external-infra-kubeconfig-" + expected.ContractIdentity.Name,
+			"type": "Opaque", "dataKey": "kubeconfig", "immutable": true,
+		},
+	})
+	providerAccessPolicyPath := writeBundleFile(t, root, "provider-access-policy.json", providerAccessPolicy)
+	providerAccessKubeconfigPath := writeBundleFile(t, root, "provider-access.kubeconfig", providerAccessBundleKubeconfig())
 
 	enablement := runnerEnablementYAML(stagePlanExpected(expected))
 	enablementPath := writeBundleFile(t, root, "enablement.yaml", enablement)
@@ -342,7 +354,10 @@ func fullRunExecutionManifestFixture(t *testing.T) (string, func()) {
 	}
 	stages := plan["stages"].([]any)
 	stages[0].(map[string]any)["inputs"] = []any{map[string]any{"name": "projection.provider-prerequisites", "digest": digest.SHA256(infra)}}
-	stages[1].(map[string]any)["inputs"] = []any{map[string]any{"name": "projection.cluster-lifecycle", "digest": digest.SHA256(management)}}
+	stages[1].(map[string]any)["inputs"] = []any{
+		map[string]any{"name": "projection.cluster-lifecycle", "digest": digest.SHA256(management)},
+		map[string]any{"name": "stage.provider-access", "digest": digest.SHA256(providerAccessPolicy)},
+	}
 	stages[3].(map[string]any)["inputs"] = []any{map[string]any{"name": "stage.enablement", "digest": digest.SHA256(enablement)}}
 	planPath := writeBundleFile(t, root, "full-staged-plan.json", mustJSON(t, plan))
 
@@ -397,8 +412,11 @@ func fullRunExecutionManifestFixture(t *testing.T) (string, func()) {
 		Authorization:         post.Authorization,
 		Profiles:              post.Profiles,
 		ProviderPrerequisites: providerRuntime,
-		ClusterLifecycle:      managementRuntime,
-		LifecycleObservation:  fullRunLifecycleObservationDocument{Ledger: ledger, Management: managementAuthority, PollInterval: "1s", PollTimeout: "1m"},
+		ProviderAccess: fullRunProviderAccessDocument{
+			PolicyPath: providerAccessPolicyPath, KubeconfigFile: providerAccessKubeconfigPath,
+		},
+		ClusterLifecycle:     managementRuntime,
+		LifecycleObservation: fullRunLifecycleObservationDocument{Ledger: ledger, Management: managementAuthority, PollInterval: "1s", PollTimeout: "1m"},
 		Enablement: fullRunEnablementDocument{
 			ArtifactPath:   enablementPath,
 			ExpectedObject: projection.ResourceIdentity{APIVersion: "addons.cluster.x-k8s.io/v1alpha1", Kind: "HelmChartProxy", Namespace: "disposable-ok147", Name: "disposable-ok147-cilium"},

--- a/internal/runner/pre_runtime_execution.go
+++ b/internal/runner/pre_runtime_execution.go
@@ -58,6 +58,7 @@ type PreRuntimeExecutionConfig struct {
 	PlanExpected              stageplan.Expected
 	ProjectionManifestPath    string
 	ProjectionRoot            string
+	ProviderAccessPolicyPath  string
 	Authorization             StageAuthorizationResolver
 	ProviderPrerequisites     SubmissionStageRuntimeConfig
 	ClusterLifecycle          SubmissionStageRuntimeConfig
@@ -445,6 +446,7 @@ func defaultPreRuntimeExecutionFactories() preRuntimeExecutionFactories {
 				ExpectedStageID: stageID, PlanPath: resume.PlanPath, PlanExpected: resume.PlanExpected, Receipts: resume.Receipts,
 				GrantPath: grant.GrantPath, GrantPublicKeyPath: grant.PublicKeyPath, EvaluationTime: grant.EvaluationTime,
 				ProjectionManifestPath: config.ProjectionManifestPath, ProjectionRoot: config.ProjectionRoot,
+				ProviderAccessPolicyPath: config.ProviderAccessPolicyPath,
 			})
 			if err != nil {
 				return preRuntimeStagedInvocation{}, err

--- a/internal/runner/staged_submission_bundle.go
+++ b/internal/runner/staged_submission_bundle.go
@@ -24,15 +24,16 @@ type StageReceiptSource struct {
 // paths, digests and expected identities. An explicit empty receipt slice is
 // required for the first stage.
 type SubmissionStageBundleConfig struct {
-	ExpectedStageID        string
-	PlanPath               string
-	PlanExpected           stageplan.Expected
-	Receipts               []StageReceiptSource
-	GrantPath              string
-	GrantPublicKeyPath     string
-	ProjectionManifestPath string
-	ProjectionRoot         string
-	EvaluationTime         time.Time
+	ExpectedStageID          string
+	PlanPath                 string
+	PlanExpected             stageplan.Expected
+	Receipts                 []StageReceiptSource
+	GrantPath                string
+	GrantPublicKeyPath       string
+	ProjectionManifestPath   string
+	ProjectionRoot           string
+	ProviderAccessPolicyPath string
+	EvaluationTime           time.Time
 }
 
 // VerifiedSubmissionStageBundle retains only values produced by verification.
@@ -43,14 +44,17 @@ type VerifiedSubmissionStageBundle struct {
 	grant             authorization.VerifiedStageGrant
 	projectionBinding projection.Binding
 	projection        submission.Plan
+	providerAccess    submission.VerifiedProviderAccessPolicy
+	hasProviderAccess bool
 	stageID           string
 	verified          bool
 }
 
 type SubmissionStageRuntimeConfig struct {
-	Ledger    KubernetesLedgerConfig
-	Authority KubernetesAuthorityConfig
-	Clock     func() time.Time
+	Ledger                       KubernetesLedgerConfig
+	Authority                    KubernetesAuthorityConfig
+	ProviderAccessKubeconfigFile string
+	Clock                        func() time.Time
 }
 
 type BoundSubmissionStage struct {
@@ -125,6 +129,10 @@ func LoadSubmissionStageBundle(config SubmissionStageBundleConfig) (VerifiedSubm
 	if err != nil {
 		return VerifiedSubmissionStageBundle{}, err
 	}
+	providerAccess, hasProviderAccess, err := loadSubmissionProviderAccessPolicy(config, plan, decision.StageID)
+	if err != nil {
+		return VerifiedSubmissionStageBundle{}, err
+	}
 	directPredecessors, err := cursor.Predecessors()
 	if err != nil {
 		return VerifiedSubmissionStageBundle{}, err
@@ -142,6 +150,8 @@ func LoadSubmissionStageBundle(config SubmissionStageBundleConfig) (VerifiedSubm
 		grant:             grant,
 		projectionBinding: projectionBinding,
 		projection:        projected,
+		providerAccess:    providerAccess,
+		hasProviderAccess: hasProviderAccess,
 		stageID:           decision.StageID,
 		verified:          true,
 	}, nil
@@ -160,14 +170,69 @@ func (bundle VerifiedSubmissionStageBundle) Open(config SubmissionStageRuntimeCo
 	if !bundle.verified {
 		return BoundSubmissionStage{}, errors.New("submission stage bundle was not produced by verification")
 	}
+	projectionPlan, err := bindSubmissionProviderAccess(bundle, config.ProviderAccessKubeconfigFile)
+	if err != nil {
+		return BoundSubmissionStage{}, err
+	}
 	operation, err := OpenKubernetesSubmissionStageOperation(KubernetesSubmissionStageOperationConfig{
 		Ledger: config.Ledger, Authority: config.Authority, Plan: bundle.plan,
-		StageID: bundle.stageID, Projection: bundle.projection, Clock: config.Clock,
+		StageID: bundle.stageID, Projection: projectionPlan, Clock: config.Clock,
 	})
 	if err != nil {
 		return BoundSubmissionStage{}, err
 	}
 	return BoundSubmissionStage{operation: operation, plan: bundle.plan, cursor: bundle.cursor, grant: bundle.grant, verified: true}, nil
+}
+
+func bindSubmissionProviderAccess(bundle VerifiedSubmissionStageBundle, kubeconfigFile string) (submission.Plan, error) {
+	projectionPlan := bundle.projection
+	if !bundle.hasProviderAccess {
+		if kubeconfigFile != "" {
+			return submission.Plan{}, errors.New("provider-access credential is not bound by the selected stage")
+		}
+		return projectionPlan, nil
+	}
+	if bundle.stageID != "cluster-lifecycle" || kubeconfigFile == "" {
+		return submission.Plan{}, errors.New("cluster-lifecycle provider-access runtime is incomplete")
+	}
+	object, err := bundle.providerAccess.MaterializeSecret(kubeconfigFile)
+	if err != nil {
+		return submission.Plan{}, err
+	}
+	projectionPlan.Management.Objects = append([]submission.Object{object}, projectionPlan.Management.Objects...)
+	return projectionPlan, nil
+}
+
+func loadSubmissionProviderAccessPolicy(config SubmissionStageBundleConfig, plan stageplan.Binding, stageID string) (submission.VerifiedProviderAccessPolicy, bool, error) {
+	stage, _, err := plan.Stage(stageID)
+	if err != nil {
+		return submission.VerifiedProviderAccessPolicy{}, false, err
+	}
+	providerDigest := ""
+	for _, input := range stage.Inputs {
+		if input.Name == "stage.provider-access" {
+			providerDigest = input.Digest
+			break
+		}
+	}
+	if providerDigest == "" {
+		if config.ProviderAccessPolicyPath != "" {
+			return submission.VerifiedProviderAccessPolicy{}, false, errors.New("provider-access policy is not bound by the selected stage")
+		}
+		return submission.VerifiedProviderAccessPolicy{}, false, nil
+	}
+	if stageID != "cluster-lifecycle" || config.ProviderAccessPolicyPath == "" {
+		return submission.VerifiedProviderAccessPolicy{}, false, errors.New("cluster-lifecycle provider-access policy is incomplete")
+	}
+	policy, err := submission.LoadProviderAccessPolicy(config.ProviderAccessPolicyPath, submission.ProviderAccessExpected{
+		PolicyDigest: providerDigest, ContractIdentity: plan.ContractIdentity,
+		IntentRevision: plan.IntentRevision, ExecutionFixture: plan.ExecutionFixture,
+		ManagementAuthority: plan.Authorities.Management, ProviderAuthority: plan.Authorities.Infrastructure,
+	})
+	if err != nil {
+		return submission.VerifiedProviderAccessPolicy{}, false, err
+	}
+	return policy, true, nil
 }
 
 func (stage BoundSubmissionStage) Run(ctx context.Context) (execution.StagedOperationReceipt, error) {

--- a/internal/runner/staged_submission_bundle_test.go
+++ b/internal/runner/staged_submission_bundle_test.go
@@ -87,12 +87,60 @@ func TestSubmissionStageBundleOpenIsOfflineAndRequiresDistinctCredentials(t *tes
 	}
 }
 
+func TestClusterLifecycleBundleRequiresBoundProviderAccessCredential(t *testing.T) {
+	fixture := submissionBundleFixtureWithProviderAccess(t)
+	bundle, err := LoadSubmissionStageBundle(fixture.config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runtime := submissionBundleRuntime(t, fixture.plan, "cluster-lifecycle")
+	if _, err := bundle.Open(runtime); err == nil || !strings.Contains(err.Error(), "provider-access runtime is incomplete") {
+		t.Fatalf("missing provider credential was accepted: %v", err)
+	}
+	credential := filepath.Join(t.TempDir(), "provider.kubeconfig")
+	if err := os.WriteFile(credential, providerAccessBundleKubeconfig(), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runtime.ProviderAccessKubeconfigFile = credential
+	boundPlan, err := bindSubmissionProviderAccess(bundle, credential)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(boundPlan.Management.Objects) != 2 || boundPlan.Management.Objects[0].Identity.Kind != "Secret" ||
+		boundPlan.Management.Objects[1].Identity.Kind != "Cluster" || len(bundle.projection.Management.Objects) != 1 {
+		t.Fatalf("provider Secret was not prepended without mutating the verified projection: %#v", boundPlan.Management.Objects)
+	}
+	opened, err := bundle.Open(runtime)
+	if err != nil || !opened.verified {
+		t.Fatalf("bound provider credential did not open lifecycle operation: %#v %v", opened, err)
+	}
+
+	legacy := submissionBundleFixture(t, true, "")
+	legacyBundle, err := LoadSubmissionStageBundle(legacy.config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	legacyRuntime := submissionBundleRuntime(t, legacy.plan, "cluster-lifecycle")
+	legacyRuntime.ProviderAccessKubeconfigFile = credential
+	if _, err := legacyBundle.Open(legacyRuntime); err == nil || !strings.Contains(err.Error(), "not bound") {
+		t.Fatalf("legacy lifecycle stage accepted an unbound provider credential: %v", err)
+	}
+}
+
 type submissionBundleTestFixture struct {
 	config SubmissionStageBundleConfig
 	plan   stageplan.Binding
 }
 
 func submissionBundleFixture(t *testing.T, completedProvider bool, overrideProviderDigest string) submissionBundleTestFixture {
+	return submissionBundleFixtureOptions(t, completedProvider, overrideProviderDigest, false)
+}
+
+func submissionBundleFixtureWithProviderAccess(t *testing.T) submissionBundleTestFixture {
+	return submissionBundleFixtureOptions(t, true, "", true)
+}
+
+func submissionBundleFixtureOptions(t *testing.T, completedProvider bool, overrideProviderDigest string, providerAccess bool) submissionBundleTestFixture {
 	t.Helper()
 	root := t.TempDir()
 	at := time.Date(2026, 8, 16, 14, 0, 0, 0, time.UTC)
@@ -137,7 +185,22 @@ func submissionBundleFixture(t *testing.T, completedProvider bool, overrideProvi
 		ContractIdentity: identity, IntentRevision: revision, EnablementRevision: bundleSHA("b"), PlatformRevision: bundleSHA("c"), ExecutionFixture: bundleSHA("d"),
 		InfrastructureAuthority: "ok-infra", ManagementAuthority: "ok-mgmt", GitOpsAuthority: "ok-shared",
 	}
-	planPath := writeBundleFile(t, root, "staged-plan.json", submissionBundlePlan(t, expected, providerDigest, digest.SHA256(management)))
+	providerAccessPath := ""
+	providerAccessDigest := ""
+	if providerAccess {
+		policy := mustJSON(t, map[string]any{
+			"format": "ok147-provider-access-policy/v1", "contractIdentity": identity,
+			"intentRevision": revision, "executionFixture": expected.ExecutionFixture,
+			"managementAuthority": "ok-mgmt", "providerAuthority": "ok-infra",
+			"secret": map[string]any{
+				"apiVersion": "v1", "kind": "Secret", "namespace": "disposable-ok147",
+				"name": "external-infra-kubeconfig-disposable-ok147", "type": "Opaque", "dataKey": "kubeconfig", "immutable": true,
+			},
+		})
+		providerAccessPath = writeBundleFile(t, root, "provider-access-policy.json", policy)
+		providerAccessDigest = digest.SHA256(policy)
+	}
+	planPath := writeBundleFile(t, root, "staged-plan.json", submissionBundlePlanWithProviderAccess(t, expected, providerDigest, digest.SHA256(management), providerAccessDigest))
 	plan, err := stageplan.Load(planPath, expected)
 	if err != nil {
 		t.Fatal(err)
@@ -166,13 +229,17 @@ func submissionBundleFixture(t *testing.T, completedProvider bool, overrideProvi
 	return submissionBundleTestFixture{
 		config: SubmissionStageBundleConfig{
 			ExpectedStageID: stageID, PlanPath: planPath, PlanExpected: expected, Receipts: receipts, GrantPath: grantPath, GrantPublicKeyPath: keyPath,
-			ProjectionManifestPath: manifestPath, ProjectionRoot: root, EvaluationTime: at,
+			ProjectionManifestPath: manifestPath, ProjectionRoot: root, ProviderAccessPolicyPath: providerAccessPath, EvaluationTime: at,
 		},
 		plan: plan,
 	}
 }
 
 func submissionBundlePlan(t *testing.T, expected stageplan.Expected, providerDigest, managementDigest string) []byte {
+	return submissionBundlePlanWithProviderAccess(t, expected, providerDigest, managementDigest, "")
+}
+
+func submissionBundlePlanWithProviderAccess(t *testing.T, expected stageplan.Expected, providerDigest, managementDigest, providerAccessDigest string) []byte {
 	t.Helper()
 	ids := []string{"provider-prerequisites", "cluster-lifecycle", "lifecycle-observation", "enablement", "network-observation", "runtime-binding", "target-access", "target-credential", "target-registration", "platform-applications", "platform-observation", "aggregate-evidence"}
 	kinds := []string{"Submission", "Submission", "Observation", "Submission", "Observation", "Binding", "Submission", "Credential", "Submission", "Submission", "Observation", "Evaluation"}
@@ -190,9 +257,13 @@ func submissionBundlePlan(t *testing.T, expected stageplan.Expected, providerDig
 		} else if index == 1 {
 			name, inputDigest = "projection.cluster-lifecycle", managementDigest
 		}
+		inputs := []map[string]any{{"name": name, "digest": inputDigest}}
+		if index == 1 && providerAccessDigest != "" {
+			inputs = append(inputs, map[string]any{"name": "stage.provider-access", "digest": providerAccessDigest})
+		}
 		stages[index] = map[string]any{
 			"id": ids[index], "order": index + 1, "kind": kinds[index], "authority": authorities[index], "requires": requires,
-			"inputs": []map[string]any{{"name": name, "digest": inputDigest}},
+			"inputs": inputs,
 		}
 		if operations[index] != "" {
 			stages[index]["grantOperation"] = operations[index]
@@ -205,6 +276,29 @@ func submissionBundlePlan(t *testing.T, expected stageplan.Expected, providerDig
 		"authorities":        map[string]any{"infrastructure": expected.InfrastructureAuthority, "management": expected.ManagementAuthority, "gitOps": expected.GitOpsAuthority, "workloadIdentityMode": "capi-cluster-uid/v1", "runnerIdentityMode": "bounded-job/v1"},
 		"stages":             stages,
 	})
+}
+
+func providerAccessBundleKubeconfig() []byte {
+	return []byte(`apiVersion: v1
+kind: Config
+current-context: provider
+clusters:
+  - name: provider-cluster
+    cluster:
+      server: https://provider.example.invalid:6443
+      certificate-authority-data: Y2E=
+users:
+  - name: provider-user
+    user:
+      client-certificate-data: Y2VydA==
+      client-key-data: a2V5
+contexts:
+  - name: provider
+    context:
+      cluster: provider-cluster
+      user: provider-user
+      namespace: ok-infra
+`)
 }
 
 func writeSubmissionStageGrant(t *testing.T, root string, plan stageplan.Binding, stageID string, predecessors []stagereceipt.Verified, at time.Time) (string, string) {

--- a/internal/submission/provider_access.go
+++ b/internal/submission/provider_access.go
@@ -112,10 +112,10 @@ func validateProviderAccessExpected(expected ProviderAccessExpected) error {
 	return nil
 }
 
-// MaterializeSecret reads one private 0600 kubeconfig, rewrites only the
-// current context namespace required by external CAPK, and produces one exact
-// immutable Secret object in memory. Credential bytes never enter errors or a
-// separate public receipt.
+// MaterializeSecret reads one private 0600 kubeconfig, retains only its
+// selected static context, rewrites that context namespace as required by
+// external CAPK, and produces one exact immutable Secret object in memory.
+// Credential bytes never enter errors or a separate public receipt.
 func (policy VerifiedProviderAccessPolicy) MaterializeSecret(kubeconfigPath string) (Object, error) {
 	if !policy.verified || policy.document.Format != ProviderAccessPolicyFormat || !immutableDigestPattern.MatchString(policy.digest) {
 		return Object{}, errors.New("provider-access policy was not produced by verification")
@@ -220,7 +220,7 @@ func rewriteProviderKubeconfigNamespace(raw []byte, namespace string) ([]byte, e
 	if err != nil {
 		return nil, errors.New("kubeconfig users are invalid")
 	}
-	var selected *yaml.Node
+	var selected, selectedEntry *yaml.Node
 	contextNames := map[string]struct{}{}
 	for _, entry := range contexts.Content {
 		if entry.Kind != yaml.MappingNode {
@@ -237,6 +237,7 @@ func rewriteProviderKubeconfigNamespace(raw []byte, namespace string) ([]byte, e
 		contextNames[name.Value] = struct{}{}
 		if name != nil && name.Value == current.Value {
 			selected = context
+			selectedEntry = entry
 		}
 	}
 	if selected == nil || selected.Kind != yaml.MappingNode {
@@ -244,9 +245,16 @@ func rewriteProviderKubeconfigNamespace(raw []byte, namespace string) ([]byte, e
 	}
 	cluster := providerMappingValue(selected, "cluster")
 	user := providerMappingValue(selected, "user")
-	if cluster == nil || user == nil || cluster.Value == "" || user.Value == "" ||
-		clusterEntries[cluster.Value] == nil || userEntries[user.Value] == nil {
+	if cluster == nil || user == nil || cluster.Value == "" || user.Value == "" || selectedEntry == nil {
 		return nil, errors.New("kubeconfig current context references are invalid")
+	}
+	selectedCluster := clusterEntries[cluster.Value]
+	selectedUser := userEntries[user.Value]
+	if selectedCluster == nil || selectedUser == nil {
+		return nil, errors.New("kubeconfig current context references are invalid")
+	}
+	if err := validateStaticProviderIdentity(selectedCluster, selectedUser); err != nil {
+		return nil, err
 	}
 	if existing := providerMappingValue(selected, "namespace"); existing != nil {
 		existing.Tag, existing.Kind, existing.Value = "!!str", yaml.ScalarNode, namespace
@@ -256,6 +264,11 @@ func rewriteProviderKubeconfigNamespace(raw []byte, namespace string) ([]byte, e
 			&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: namespace},
 		)
 	}
+	// The provider Secret must not transport credentials or endpoints unrelated
+	// to the selected authority, even when the source kubeconfig contains them.
+	contexts.Content = []*yaml.Node{selectedEntry}
+	clusters.Content = []*yaml.Node{selectedCluster}
+	users.Content = []*yaml.Node{selectedUser}
 	var output bytes.Buffer
 	encoder := yaml.NewEncoder(&output)
 	encoder.SetIndent(2)
@@ -266,6 +279,36 @@ func rewriteProviderKubeconfigNamespace(raw []byte, namespace string) ([]byte, e
 		return nil, errors.New("close kubeconfig encoder")
 	}
 	return output.Bytes(), nil
+}
+
+func validateStaticProviderIdentity(clusterEntry, userEntry *yaml.Node) error {
+	cluster := providerMappingNode(clusterEntry, "cluster")
+	user := providerMappingNode(userEntry, "user")
+	server := providerMappingValue(cluster, "server")
+	caData := providerMappingValue(cluster, "certificate-authority-data")
+	if cluster == nil || user == nil || server == nil || !strings.HasPrefix(server.Value, "https://") ||
+		caData == nil || caData.Value == "" || providerMappingNode(cluster, "proxy-url") != nil ||
+		providerMappingNode(cluster, "certificate-authority") != nil ||
+		providerMappingNode(cluster, "insecure-skip-tls-verify") != nil {
+		return errors.New("kubeconfig selected cluster transport is not static and verified")
+	}
+	for _, forbidden := range []string{
+		"exec", "auth-provider", "tokenFile", "token-file", "client-certificate", "client-key",
+		"username", "password", "as", "as-uid", "as-groups", "as-user-extra",
+	} {
+		if providerMappingNode(user, forbidden) != nil {
+			return errors.New("kubeconfig selected user authentication is not static and self-contained")
+		}
+	}
+	certificate := providerMappingValue(user, "client-certificate-data")
+	key := providerMappingValue(user, "client-key-data")
+	token := providerMappingValue(user, "token")
+	certificateMode := certificate != nil && certificate.Value != "" && key != nil && key.Value != ""
+	tokenMode := token != nil && token.Value != ""
+	if certificateMode == tokenMode {
+		return errors.New("kubeconfig selected user authentication mode is ambiguous")
+	}
+	return nil
 }
 
 func validateProviderYAMLNode(node *yaml.Node) error {

--- a/internal/submission/provider_access.go
+++ b/internal/submission/provider_access.go
@@ -1,0 +1,329 @@
+package submission
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/openkubes/ok-cluster/internal/contract"
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/projection"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	ProviderAccessPolicyFormat     = "ok147-provider-access-policy/v1"
+	maximumProviderKubeconfigBytes = 1024 * 1024
+)
+
+// ProviderAccessExpected is supplied from the verified staged plan and
+// Contract identity. It contains no credential material.
+type ProviderAccessExpected struct {
+	PolicyDigest        string
+	ContractIdentity    contract.Identity
+	IntentRevision      string
+	ExecutionFixture    string
+	ManagementAuthority string
+	ProviderAuthority   string
+}
+
+type providerAccessSecretPolicy struct {
+	APIVersion string `json:"apiVersion"`
+	Kind       string `json:"kind"`
+	Namespace  string `json:"namespace"`
+	Name       string `json:"name"`
+	Type       string `json:"type"`
+	DataKey    string `json:"dataKey"`
+	Immutable  bool   `json:"immutable"`
+}
+
+type providerAccessPolicyDocument struct {
+	Format              string                     `json:"format"`
+	ContractIdentity    contract.Identity          `json:"contractIdentity"`
+	IntentRevision      string                     `json:"intentRevision"`
+	ExecutionFixture    string                     `json:"executionFixture"`
+	ManagementAuthority string                     `json:"managementAuthority"`
+	ProviderAuthority   string                     `json:"providerAuthority"`
+	Secret              providerAccessSecretPolicy `json:"secret"`
+}
+
+// VerifiedProviderAccessPolicy retains only non-secret policy. The source
+// kubeconfig is read later, at the same runtime boundary as other credentials.
+type VerifiedProviderAccessPolicy struct {
+	document providerAccessPolicyDocument
+	digest   string
+	verified bool
+}
+
+// LoadProviderAccessPolicy verifies the public, credential-free policy bound
+// as the second cluster-lifecycle stage input. It performs no credential read.
+func LoadProviderAccessPolicy(path string, expected ProviderAccessExpected) (VerifiedProviderAccessPolicy, error) {
+	if err := validateProviderAccessExpected(expected); err != nil {
+		return VerifiedProviderAccessPolicy{}, err
+	}
+	raw, err := readBoundedRegularProviderFile(path, maximumProjectionArtifactBytes, false)
+	if err != nil {
+		return VerifiedProviderAccessPolicy{}, errors.New("read provider-access policy")
+	}
+	if digest.SHA256(raw) != expected.PolicyDigest {
+		return VerifiedProviderAccessPolicy{}, errors.New("provider-access policy digest differs from staged input")
+	}
+	var document providerAccessPolicyDocument
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&document); err != nil {
+		return VerifiedProviderAccessPolicy{}, errors.New("decode provider-access policy")
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		return VerifiedProviderAccessPolicy{}, errors.New("provider-access policy has trailing content")
+	}
+	if document.Format != ProviderAccessPolicyFormat || document.ContractIdentity != expected.ContractIdentity ||
+		document.IntentRevision != expected.IntentRevision || document.ExecutionFixture != expected.ExecutionFixture ||
+		document.ManagementAuthority != expected.ManagementAuthority || document.ProviderAuthority != expected.ProviderAuthority {
+		return VerifiedProviderAccessPolicy{}, errors.New("provider-access policy identity differs from expected binding")
+	}
+	secret := document.Secret
+	if secret.APIVersion != "v1" || secret.Kind != "Secret" || secret.Namespace != expected.ContractIdentity.Namespace ||
+		secret.Name != "external-infra-kubeconfig-"+expected.ContractIdentity.Name || secret.Type != "Opaque" ||
+		secret.DataKey != "kubeconfig" || !secret.Immutable {
+		return VerifiedProviderAccessPolicy{}, errors.New("provider-access Secret policy is invalid")
+	}
+	return VerifiedProviderAccessPolicy{document: document, digest: expected.PolicyDigest, verified: true}, nil
+}
+
+func validateProviderAccessExpected(expected ProviderAccessExpected) error {
+	for _, value := range []string{expected.PolicyDigest, expected.IntentRevision, expected.ExecutionFixture} {
+		if !immutableDigestPattern.MatchString(value) {
+			return errors.New("provider-access expected digest identity is invalid")
+		}
+	}
+	if !validName(expected.ContractIdentity.Namespace, 63) || strings.Contains(expected.ContractIdentity.Namespace, ".") ||
+		!validName(expected.ContractIdentity.Name, 253) || !validName(expected.ManagementAuthority, 63) ||
+		strings.Contains(expected.ManagementAuthority, ".") || !validName(expected.ProviderAuthority, 63) ||
+		strings.Contains(expected.ProviderAuthority, ".") || expected.ManagementAuthority == expected.ProviderAuthority {
+		return errors.New("provider-access authority or Contract identity is invalid")
+	}
+	return nil
+}
+
+// MaterializeSecret reads one private 0600 kubeconfig, rewrites only the
+// current context namespace required by external CAPK, and produces one exact
+// immutable Secret object in memory. Credential bytes never enter errors or a
+// separate public receipt.
+func (policy VerifiedProviderAccessPolicy) MaterializeSecret(kubeconfigPath string) (Object, error) {
+	if !policy.verified || policy.document.Format != ProviderAccessPolicyFormat || !immutableDigestPattern.MatchString(policy.digest) {
+		return Object{}, errors.New("provider-access policy was not produced by verification")
+	}
+	raw, err := readBoundedRegularProviderFile(kubeconfigPath, maximumProviderKubeconfigBytes, true)
+	if err != nil {
+		return Object{}, errors.New("read provider-access credential")
+	}
+	rewritten, err := rewriteProviderKubeconfigNamespace(raw, policy.document.Secret.Namespace)
+	if err != nil {
+		return Object{}, errors.New("validate provider-access credential")
+	}
+	secret := policy.document.Secret
+	value := map[string]any{
+		"apiVersion": secret.APIVersion,
+		"kind":       secret.Kind,
+		"metadata": map[string]any{
+			"name":      secret.Name,
+			"namespace": secret.Namespace,
+			"annotations": map[string]any{
+				"openkubes.io/contract-name":      policy.document.ContractIdentity.Name,
+				"openkubes.io/contract-namespace": policy.document.ContractIdentity.Namespace,
+				"openkubes.io/intent-revision":    policy.document.IntentRevision,
+				"openkubes.io/execution-fixture":  policy.document.ExecutionFixture,
+				"openkubes.io/provider-plane":     policy.document.ProviderAuthority,
+			},
+		},
+		"immutable": true,
+		"type":      secret.Type,
+		"data":      map[string]any{secret.DataKey: base64.StdEncoding.EncodeToString(rewritten)},
+	}
+	canonical, err := contract.JCS(value)
+	if err != nil {
+		return Object{}, errors.New("canonicalize provider-access Secret")
+	}
+	identity := projection.ResourceIdentity{APIVersion: "v1", Kind: "Secret", Namespace: secret.Namespace, Name: secret.Name}
+	collection := "/api/v1/namespaces/" + secret.Namespace + "/secrets"
+	return Object{
+		Identity: identity, Digest: digest.SHA256(canonical), CollectionPath: collection,
+		ObjectPath: collection + "/" + secret.Name, Raw: canonical,
+	}, nil
+}
+
+func readBoundedRegularProviderFile(path string, maximum int64, private bool) ([]byte, error) {
+	if path == "" {
+		return nil, errors.New("path is required")
+	}
+	info, err := os.Lstat(path)
+	if err != nil || !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 || info.Size() <= 0 || info.Size() > maximum {
+		return nil, errors.New("file metadata is invalid")
+	}
+	if private && info.Mode().Perm() != 0o600 {
+		return nil, errors.New("private file mode is invalid")
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, errors.New("open bounded file")
+	}
+	defer file.Close()
+	opened, err := file.Stat()
+	if err != nil || !opened.Mode().IsRegular() || opened.Size() != info.Size() || !os.SameFile(info, opened) {
+		return nil, errors.New("bounded file changed while opening")
+	}
+	raw, err := io.ReadAll(io.LimitReader(file, maximum+1))
+	if err != nil || len(raw) == 0 || int64(len(raw)) > maximum {
+		return nil, errors.New("read bounded file")
+	}
+	return raw, nil
+}
+
+func rewriteProviderKubeconfigNamespace(raw []byte, namespace string) ([]byte, error) {
+	decoder := yaml.NewDecoder(bytes.NewReader(raw))
+	var document yaml.Node
+	if err := decoder.Decode(&document); err != nil || len(document.Content) != 1 {
+		return nil, errors.New("kubeconfig YAML is invalid")
+	}
+	var trailing yaml.Node
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		return nil, errors.New("kubeconfig has trailing documents")
+	}
+	root := document.Content[0]
+	if err := validateProviderYAMLNode(root); err != nil || root.Kind != yaml.MappingNode {
+		return nil, errors.New("kubeconfig structure is invalid")
+	}
+	apiVersion := providerMappingValue(root, "apiVersion")
+	kind := providerMappingValue(root, "kind")
+	current := providerMappingValue(root, "current-context")
+	contexts := providerMappingNode(root, "contexts")
+	clusters := providerMappingNode(root, "clusters")
+	users := providerMappingNode(root, "users")
+	if apiVersion == nil || apiVersion.Value != "v1" || kind == nil || kind.Value != "Config" ||
+		current == nil || current.Kind != yaml.ScalarNode || current.Value == "" ||
+		contexts == nil || contexts.Kind != yaml.SequenceNode || clusters == nil || clusters.Kind != yaml.SequenceNode ||
+		users == nil || users.Kind != yaml.SequenceNode {
+		return nil, errors.New("kubeconfig identity is invalid")
+	}
+	clusterEntries, err := providerNamedEntries(clusters)
+	if err != nil {
+		return nil, errors.New("kubeconfig clusters are invalid")
+	}
+	userEntries, err := providerNamedEntries(users)
+	if err != nil {
+		return nil, errors.New("kubeconfig users are invalid")
+	}
+	var selected *yaml.Node
+	contextNames := map[string]struct{}{}
+	for _, entry := range contexts.Content {
+		if entry.Kind != yaml.MappingNode {
+			return nil, errors.New("kubeconfig context is invalid")
+		}
+		name := providerMappingValue(entry, "name")
+		context := providerMappingNode(entry, "context")
+		if name == nil || name.Value == "" || context == nil || context.Kind != yaml.MappingNode {
+			return nil, errors.New("kubeconfig context is invalid")
+		}
+		if _, exists := contextNames[name.Value]; exists {
+			return nil, errors.New("kubeconfig context name is duplicated")
+		}
+		contextNames[name.Value] = struct{}{}
+		if name != nil && name.Value == current.Value {
+			selected = context
+		}
+	}
+	if selected == nil || selected.Kind != yaml.MappingNode {
+		return nil, errors.New("kubeconfig current context is missing")
+	}
+	cluster := providerMappingValue(selected, "cluster")
+	user := providerMappingValue(selected, "user")
+	if cluster == nil || user == nil || cluster.Value == "" || user.Value == "" ||
+		clusterEntries[cluster.Value] == nil || userEntries[user.Value] == nil {
+		return nil, errors.New("kubeconfig current context references are invalid")
+	}
+	if existing := providerMappingValue(selected, "namespace"); existing != nil {
+		existing.Tag, existing.Kind, existing.Value = "!!str", yaml.ScalarNode, namespace
+	} else {
+		selected.Content = append(selected.Content,
+			&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "namespace"},
+			&yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: namespace},
+		)
+	}
+	var output bytes.Buffer
+	encoder := yaml.NewEncoder(&output)
+	encoder.SetIndent(2)
+	if err := encoder.Encode(&document); err != nil {
+		return nil, errors.New("encode kubeconfig")
+	}
+	if err := encoder.Close(); err != nil {
+		return nil, errors.New("close kubeconfig encoder")
+	}
+	return output.Bytes(), nil
+}
+
+func validateProviderYAMLNode(node *yaml.Node) error {
+	if node == nil || node.Kind == yaml.AliasNode || node.Anchor != "" {
+		return errors.New("YAML aliases and anchors are not accepted")
+	}
+	if node.Kind == yaml.MappingNode {
+		seen := map[string]struct{}{}
+		for index := 0; index < len(node.Content); index += 2 {
+			if index+1 >= len(node.Content) || node.Content[index].Kind != yaml.ScalarNode {
+				return errors.New("YAML mapping is invalid")
+			}
+			key := node.Content[index].Value
+			if _, exists := seen[key]; exists {
+				return fmt.Errorf("duplicate YAML key")
+			}
+			seen[key] = struct{}{}
+		}
+	}
+	for _, child := range node.Content {
+		if err := validateProviderYAMLNode(child); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func providerMappingNode(mapping *yaml.Node, key string) *yaml.Node {
+	if mapping == nil || mapping.Kind != yaml.MappingNode {
+		return nil
+	}
+	for index := 0; index+1 < len(mapping.Content); index += 2 {
+		if mapping.Content[index].Value == key {
+			return mapping.Content[index+1]
+		}
+	}
+	return nil
+}
+
+func providerMappingValue(mapping *yaml.Node, key string) *yaml.Node {
+	value := providerMappingNode(mapping, key)
+	if value == nil || value.Kind != yaml.ScalarNode {
+		return nil
+	}
+	return value
+}
+
+func providerNamedEntries(sequence *yaml.Node) (map[string]*yaml.Node, error) {
+	entries := make(map[string]*yaml.Node, len(sequence.Content))
+	for _, entry := range sequence.Content {
+		if entry.Kind != yaml.MappingNode {
+			return nil, errors.New("named entry is not a mapping")
+		}
+		name := providerMappingValue(entry, "name")
+		if name == nil || name.Value == "" || entries[name.Value] != nil {
+			return nil, errors.New("named entry identity is invalid")
+		}
+		entries[name.Value] = entry
+	}
+	return entries, nil
+}

--- a/internal/submission/provider_access_test.go
+++ b/internal/submission/provider_access_test.go
@@ -1,0 +1,215 @@
+package submission
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/openkubes/ok-cluster/internal/contract"
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"gopkg.in/yaml.v3"
+)
+
+func TestProviderAccessPolicyMaterializesExactSecretAndRewritesNamespace(t *testing.T) {
+	root := t.TempDir()
+	policyPath, expected := writeProviderAccessPolicy(t, root)
+	credentialPath := filepath.Join(root, "provider.kubeconfig")
+	if err := os.WriteFile(credentialPath, providerKubeconfig("ok-infra"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	policy, err := LoadProviderAccessPolicy(policyPath, expected)
+	if err != nil {
+		t.Fatal(err)
+	}
+	object, err := policy.MaterializeSecret(credentialPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if object.Identity.APIVersion != "v1" || object.Identity.Kind != "Secret" ||
+		object.Identity.Namespace != "disposable-ok147" || object.Identity.Name != "external-infra-kubeconfig-disposable-ok147" ||
+		object.CollectionPath != "/api/v1/namespaces/disposable-ok147/secrets" ||
+		object.ObjectPath != "/api/v1/namespaces/disposable-ok147/secrets/external-infra-kubeconfig-disposable-ok147" ||
+		digest.SHA256(object.Raw) != object.Digest {
+		t.Fatalf("provider Secret object is not exactly bound: %#v", object)
+	}
+	var secret struct {
+		Immutable bool              `json:"immutable"`
+		Type      string            `json:"type"`
+		Metadata  map[string]any    `json:"metadata"`
+		Data      map[string]string `json:"data"`
+	}
+	if err := json.Unmarshal(object.Raw, &secret); err != nil {
+		t.Fatal(err)
+	}
+	if !secret.Immutable || secret.Type != "Opaque" || len(secret.Data) != 1 || secret.Data["kubeconfig"] == "" {
+		t.Fatalf("provider Secret shape is invalid: %#v", secret)
+	}
+	rewritten, err := base64.StdEncoding.Strict().DecodeString(secret.Data["kubeconfig"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	var config struct {
+		CurrentContext string `yaml:"current-context"`
+		Contexts       []struct {
+			Name    string `yaml:"name"`
+			Context struct {
+				Namespace string `yaml:"namespace"`
+			} `yaml:"context"`
+		} `yaml:"contexts"`
+	}
+	if err := yaml.Unmarshal(rewritten, &config); err != nil {
+		t.Fatal(err)
+	}
+	if config.CurrentContext != "provider" || len(config.Contexts) != 1 || config.Contexts[0].Context.Namespace != "disposable-ok147" {
+		t.Fatalf("current context namespace was not rewritten exactly: %#v", config)
+	}
+	if bytes.Contains(object.Raw, []byte("ok-infra\n")) {
+		t.Fatal("old provider namespace remained visible in the materialized Secret")
+	}
+}
+
+func TestProviderAccessMaterializationIsDeterministic(t *testing.T) {
+	root := t.TempDir()
+	policyPath, expected := writeProviderAccessPolicy(t, root)
+	credentialPath := filepath.Join(root, "provider.kubeconfig")
+	if err := os.WriteFile(credentialPath, providerKubeconfig("another-namespace"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	policy, _ := LoadProviderAccessPolicy(policyPath, expected)
+	first, err := policy.MaterializeSecret(credentialPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := policy.MaterializeSecret(credentialPath)
+	if err != nil || !bytes.Equal(first.Raw, second.Raw) || first.Digest != second.Digest {
+		t.Fatalf("same provider credential did not produce one identity: first=%s second=%s err=%v", first.Digest, second.Digest, err)
+	}
+}
+
+func TestProviderAccessMaterializationFailsClosedWithoutLeakingCredential(t *testing.T) {
+	root := t.TempDir()
+	policyPath, expected := writeProviderAccessPolicy(t, root)
+	policy, _ := LoadProviderAccessPolicy(policyPath, expected)
+	secretMarker := "DO-NOT-LEAK-PRIVATE-KEY-MARKER"
+	cases := []struct {
+		name string
+		raw  []byte
+		mode os.FileMode
+	}{
+		{name: "bad mode", raw: providerKubeconfig("ok-infra"), mode: 0o644},
+		{name: "duplicate key", raw: []byte("apiVersion: v1\nkind: Config\nkind: " + secretMarker + "\n"), mode: 0o600},
+		{name: "missing current context", raw: []byte("apiVersion: v1\nkind: Config\ncurrent-context: missing\ncontexts: []\nclusters: []\nusers: []\nmarker: " + secretMarker + "\n"), mode: 0o600},
+		{name: "duplicate cluster identity", raw: []byte("apiVersion: v1\nkind: Config\ncurrent-context: provider\ncontexts:\n- name: provider\n  context: {cluster: duplicate, user: provider-user}\nclusters:\n- name: duplicate\n  cluster: {}\n- name: duplicate\n  cluster: {}\nusers:\n- name: provider-user\n  user: {token: " + secretMarker + "}\n"), mode: 0o600},
+		{name: "trailing document", raw: append(providerKubeconfig("ok-infra"), []byte("---\nmarker: "+secretMarker+"\n")...), mode: 0o600},
+	}
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			path := filepath.Join(root, strings.ReplaceAll(test.name, " ", "-")+".yaml")
+			if err := os.WriteFile(path, test.raw, test.mode); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := policy.MaterializeSecret(path); err == nil || strings.Contains(err.Error(), secretMarker) || strings.Contains(err.Error(), "client-key-data") {
+				t.Fatalf("unsafe provider credential did not fail closed and redacted: %v", err)
+			}
+		})
+	}
+
+	t.Run("symlink", func(t *testing.T) {
+		target := filepath.Join(root, "target.yaml")
+		link := filepath.Join(root, "link.yaml")
+		if err := os.WriteFile(target, providerKubeconfig("ok-infra"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(target, link); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := policy.MaterializeSecret(link); err == nil {
+			t.Fatal("provider credential symlink was accepted")
+		}
+	})
+}
+
+func TestProviderAccessPolicyRejectsUnboundOrMutableSecret(t *testing.T) {
+	root := t.TempDir()
+	policyPath, expected := writeProviderAccessPolicy(t, root)
+	raw, err := os.ReadFile(policyPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var document map[string]any
+	if err := json.Unmarshal(raw, &document); err != nil {
+		t.Fatal(err)
+	}
+	secret := document["secret"].(map[string]any)
+	secret["immutable"] = false
+	changed, _ := json.Marshal(document)
+	changedPath := filepath.Join(root, "mutable.json")
+	if err := os.WriteFile(changedPath, changed, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	expected.PolicyDigest = digest.SHA256(changed)
+	if _, err := LoadProviderAccessPolicy(changedPath, expected); err == nil {
+		t.Fatal("mutable provider Secret policy was accepted")
+	}
+
+	expected.PolicyDigest = digest.SHA256(raw)
+	expected.ProviderAuthority = expected.ManagementAuthority
+	if _, err := LoadProviderAccessPolicy(policyPath, expected); err == nil {
+		t.Fatal("same-plane provider and management authority was accepted")
+	}
+}
+
+func writeProviderAccessPolicy(t *testing.T, root string) (string, ProviderAccessExpected) {
+	t.Helper()
+	document := providerAccessPolicyDocument{
+		Format:              ProviderAccessPolicyFormat,
+		ContractIdentity:    contract.Identity{Namespace: "disposable-ok147", Name: "disposable-ok147"},
+		IntentRevision:      "sha256:" + strings.Repeat("a", 64),
+		ExecutionFixture:    "sha256:" + strings.Repeat("b", 64),
+		ManagementAuthority: "ok-mgmt",
+		ProviderAuthority:   "ok-infra",
+		Secret: providerAccessSecretPolicy{
+			APIVersion: "v1", Kind: "Secret", Namespace: "disposable-ok147",
+			Name: "external-infra-kubeconfig-disposable-ok147", Type: "Opaque", DataKey: "kubeconfig", Immutable: true,
+		},
+	}
+	raw, err := json.Marshal(document)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(root, "provider-access-policy.json")
+	if err := os.WriteFile(path, raw, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path, ProviderAccessExpected{
+		PolicyDigest: digest.SHA256(raw), ContractIdentity: document.ContractIdentity,
+		IntentRevision: document.IntentRevision, ExecutionFixture: document.ExecutionFixture,
+		ManagementAuthority: document.ManagementAuthority, ProviderAuthority: document.ProviderAuthority,
+	}
+}
+
+func providerKubeconfig(namespace string) []byte {
+	return []byte(`apiVersion: v1
+kind: Config
+current-context: provider
+clusters:
+  - name: provider-cluster
+    cluster:
+      server: https://provider.example.invalid:6443
+      certificate-authority-data: Y2E=
+users:
+  - name: provider-user
+    user:
+      client-certificate-data: Y2VydA==
+      client-key-data: cHJpdmF0ZS1rZXk=
+contexts:
+  - name: provider
+    context:
+      cluster: provider-cluster
+      user: provider-user
+      namespace: ` + namespace + "\n")
+}

--- a/internal/submission/provider_access_test.go
+++ b/internal/submission/provider_access_test.go
@@ -90,6 +90,52 @@ func TestProviderAccessMaterializationIsDeterministic(t *testing.T) {
 	}
 }
 
+func TestProviderAccessMaterializationRetainsOnlySelectedStaticIdentity(t *testing.T) {
+	root := t.TempDir()
+	policyPath, expected := writeProviderAccessPolicy(t, root)
+	credentialPath := filepath.Join(root, "provider.kubeconfig")
+	raw := []byte(`apiVersion: v1
+kind: Config
+current-context: provider
+clusters:
+- name: provider-cluster
+  cluster: {server: https://provider.example.invalid:6443, certificate-authority-data: Y2E=}
+- name: unrelated-cluster
+  cluster: {server: https://unrelated.example.invalid:6443, certificate-authority-data: dW5yZWxhdGVkLWNh}
+users:
+- name: provider-user
+  user: {client-certificate-data: Y2VydA==, client-key-data: cHJpdmF0ZS1rZXk=}
+- name: unrelated-user
+  user: {token: unrelated-private-token}
+contexts:
+- name: provider
+  context: {cluster: provider-cluster, user: provider-user, namespace: ok-infra}
+- name: unrelated
+  context: {cluster: unrelated-cluster, user: unrelated-user}
+`)
+	if err := os.WriteFile(credentialPath, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	policy, _ := LoadProviderAccessPolicy(policyPath, expected)
+	object, err := policy.MaterializeSecret(credentialPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var secret struct {
+		Data map[string]string `json:"data"`
+	}
+	if err := json.Unmarshal(object.Raw, &secret); err != nil {
+		t.Fatal(err)
+	}
+	rewritten, err := base64.StdEncoding.Strict().DecodeString(secret.Data["kubeconfig"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(rewritten, []byte("unrelated")) {
+		t.Fatal("unselected provider identity remained in materialized kubeconfig")
+	}
+}
+
 func TestProviderAccessMaterializationFailsClosedWithoutLeakingCredential(t *testing.T) {
 	root := t.TempDir()
 	policyPath, expected := writeProviderAccessPolicy(t, root)
@@ -105,6 +151,20 @@ func TestProviderAccessMaterializationFailsClosedWithoutLeakingCredential(t *tes
 		{name: "missing current context", raw: []byte("apiVersion: v1\nkind: Config\ncurrent-context: missing\ncontexts: []\nclusters: []\nusers: []\nmarker: " + secretMarker + "\n"), mode: 0o600},
 		{name: "duplicate cluster identity", raw: []byte("apiVersion: v1\nkind: Config\ncurrent-context: provider\ncontexts:\n- name: provider\n  context: {cluster: duplicate, user: provider-user}\nclusters:\n- name: duplicate\n  cluster: {}\n- name: duplicate\n  cluster: {}\nusers:\n- name: provider-user\n  user: {token: " + secretMarker + "}\n"), mode: 0o600},
 		{name: "trailing document", raw: append(providerKubeconfig("ok-infra"), []byte("---\nmarker: "+secretMarker+"\n")...), mode: 0o600},
+		{name: "exec credential", raw: []byte(`apiVersion: v1
+kind: Config
+current-context: provider
+clusters:
+- name: provider-cluster
+  cluster: {server: https://provider.example.invalid:6443, certificate-authority-data: Y2E=}
+users:
+- name: provider-user
+  user:
+    exec: {apiVersion: client.authentication.k8s.io/v1, command: credential-helper}
+contexts:
+- name: provider
+  context: {cluster: provider-cluster, user: provider-user}
+`), mode: 0o600},
 	}
 	for _, test := range cases {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
## Outcome

Binds the external infrastructure provider kubeconfig as an explicit, digest-bound cluster-lifecycle input before CAPI lifecycle submission.

## Security boundary

- accepts only an exact regular 0600 kubeconfig
- rejects symlinks, duplicate YAML keys, aliases, dynamic exec/auth-provider credentials, file-backed credentials, proxy and insecure TLS modes
- retains only the selected static context and rewrites only its namespace
- materializes one immutable provider-access Secret in memory
- carries the policy and private credential separately in Full Run manifest v3 and the activation bundle
- never emits credential bytes in receipts or errors

## Verification

- go vet ./...
- full go test ./... PASS
- no cluster contact
- no Stage Run
- no infrastructure mutation

## Follow-up

After merge and image publication, Fresh Run v7 will bind this new runner provenance, the provider-access policy and the fixed DEV workload API allocation.