### PR TITLE
fix(runner): encode activation payloads as Secret data

### DIFF
--- a/internal/runner/full_run_activation_installation_plan.go
+++ b/internal/runner/full_run_activation_installation_plan.go
@@ -146,9 +146,9 @@ func fullRunActivationSecretMatches(object map[string]any, name, stageID, bundle
 	metadata, _ := object["metadata"].(map[string]any)
 	annotations, _ := metadata["annotations"].(map[string]any)
 	labels, _ := metadata["labels"].(map[string]any)
-	binaryData, _ := object["binaryData"].(map[string]any)
+	data, _ := object["data"].(map[string]any)
 	if metadata["name"] != name || object["immutable"] != true || object["type"] != "Opaque" ||
-		labels["openkubes.io/stage-id"] != stageID || annotations["openkubes.io/manifest-digest"] != manifestDigest || len(binaryData) != fileCount {
+		labels["openkubes.io/stage-id"] != stageID || annotations["openkubes.io/manifest-digest"] != manifestDigest || len(data) != fileCount {
 		return false
 	}
 	if bundleDigest != "" && annotations["openkubes.io/bundle-digest"] != bundleDigest {

--- a/internal/runner/full_run_activation_package.go
+++ b/internal/runner/full_run_activation_package.go
@@ -96,7 +96,7 @@ func BuildFullRunExecutionActivationPackage(config FullRunExecutionActivationPac
 		binaryData[strings.ReplaceAll(path, "/", ".")] = base64.StdEncoding.EncodeToString(raw)
 	}
 	secret := postRuntimeActivationSecret{
-		APIVersion: "v1", Kind: "Secret", Immutable: true, Type: "Opaque", BinaryData: binaryData,
+		APIVersion: "v1", Kind: "Secret", Immutable: true, Type: "Opaque", Data: binaryData,
 		Metadata: postRuntimeActivationSecretMetadata{
 			Name: config.ActivationSecret, Namespace: submissionStageInputNamespace,
 			Labels:      map[string]string{"app.kubernetes.io/name": "ok-cluster-contract-executor", "openkubes.io/stage-id": "full-run"},

--- a/internal/runner/full_run_activation_package_test.go
+++ b/internal/runner/full_run_activation_package_test.go
@@ -34,6 +34,15 @@ func TestBuildFullRunExecutionActivationPackageBindsBothAuthoritiesAndJob(t *tes
 	if len(parts) != 3 {
 		t.Fatalf("unexpected package component count: %d", len(parts))
 	}
+	for index, part := range parts[:2] {
+		var object map[string]any
+		if err := json.Unmarshal(part, &object); err != nil {
+			t.Fatal(err)
+		}
+		if object["data"] == nil || object["binaryData"] != nil {
+			t.Fatalf("Kubernetes Secret %d must use data and never binaryData", index)
+		}
+	}
 	var activationSecret, evidenceSecret postRuntimeActivationSecret
 	if err := json.Unmarshal(parts[0], &activationSecret); err != nil {
 		t.Fatal(err)
@@ -41,8 +50,8 @@ func TestBuildFullRunExecutionActivationPackageBindsBothAuthoritiesAndJob(t *tes
 	if err := json.Unmarshal(parts[1], &evidenceSecret); err != nil {
 		t.Fatal(err)
 	}
-	if !activationSecret.Immutable || len(activationSecret.BinaryData) != len(fullRunExecutionBundleFiles)+1 ||
-		!evidenceSecret.Immutable || len(evidenceSecret.BinaryData) != 4 ||
+	if !activationSecret.Immutable || len(activationSecret.Data) != len(fullRunExecutionBundleFiles)+1 ||
+		!evidenceSecret.Immutable || len(evidenceSecret.Data) != 4 ||
 		activationSecret.Metadata.Name == evidenceSecret.Metadata.Name {
 		t.Fatalf("private Secret boundary differs: activation=%#v evidence=%#v", activationSecret.Metadata, evidenceSecret.Metadata)
 	}

--- a/internal/runner/observability_collector_activation_materializer_test.go
+++ b/internal/runner/observability_collector_activation_materializer_test.go
@@ -159,7 +159,7 @@ func collectorActivationProjectionFixture(t *testing.T) (ObservabilityCollectorA
 		t.Fatal(err)
 	}
 	for _, name := range observabilityCollectorProjectedFiles {
-		decoded, decodeErr := base64.StdEncoding.DecodeString(secret.BinaryData[name])
+		decoded, decodeErr := base64.StdEncoding.DecodeString(secret.Data[name])
 		if decodeErr != nil {
 			t.Fatal(decodeErr)
 		}

--- a/internal/runner/observability_collector_activation_package.go
+++ b/internal/runner/observability_collector_activation_package.go
@@ -269,7 +269,7 @@ func BuildObservabilityCollectorActivationPackage(config ObservabilityCollectorA
 		observabilityCollectorTLSKeyKey:     base64.StdEncoding.EncodeToString(privateKeyRaw),
 	}
 	secret := postRuntimeActivationSecret{
-		APIVersion: "v1", Kind: "Secret", Immutable: true, Type: "Opaque", BinaryData: binaryData,
+		APIVersion: "v1", Kind: "Secret", Immutable: true, Type: "Opaque", Data: binaryData,
 		Metadata: postRuntimeActivationSecretMetadata{
 			Name: config.ActivationSecret, Namespace: submissionStageInputNamespace,
 			Labels: map[string]string{
@@ -345,7 +345,7 @@ func verifyObservabilityCollectorActivationPackage(packaged VerifiedObservabilit
 	var secret postRuntimeActivationSecret
 	if err := jsonstrict.Decode(packaged.raw, &secret); err != nil || secret.APIVersion != "v1" || secret.Kind != "Secret" ||
 		!secret.Immutable || secret.Type != "Opaque" || secret.Metadata.Name != receipt.ActivationSecret ||
-		secret.Metadata.Namespace != submissionStageInputNamespace || len(secret.BinaryData) != receipt.PrivateFileCount ||
+		secret.Metadata.Namespace != submissionStageInputNamespace || len(secret.Data) != receipt.PrivateFileCount ||
 		secret.Metadata.Labels["app.kubernetes.io/name"] != "ok147-observability-evidence-collector" ||
 		secret.Metadata.Labels["openkubes.io/stage-id"] != "independent-evidence" ||
 		secret.Metadata.Annotations["openkubes.io/manifest-digest"] != receipt.ManifestDigest ||
@@ -353,7 +353,7 @@ func verifyObservabilityCollectorActivationPackage(packaged VerifiedObservabilit
 		return errors.New("observability collector activation Secret identity differs")
 	}
 	decode := func(key string) ([]byte, error) {
-		raw, err := base64.StdEncoding.Strict().DecodeString(secret.BinaryData[key])
+		raw, err := base64.StdEncoding.Strict().DecodeString(secret.Data[key])
 		if err != nil || len(raw) == 0 {
 			return nil, errors.New("observability collector activation private file is invalid")
 		}

--- a/internal/runner/observability_collector_activation_package_test.go
+++ b/internal/runner/observability_collector_activation_package_test.go
@@ -48,10 +48,10 @@ func TestBuildObservabilityCollectorActivationPackageBindsPrivateRuntime(t *test
 	if err := json.Unmarshal(privateRaw, &secret); err != nil {
 		t.Fatal(err)
 	}
-	if !secret.Immutable || secret.Metadata.Name != config.ActivationSecret || len(secret.BinaryData) != 7 {
+	if !secret.Immutable || secret.Metadata.Name != config.ActivationSecret || len(secret.Data) != 7 {
 		t.Fatalf("unexpected collector activation Secret: %#v", secret.Metadata)
 	}
-	activationRaw, err := base64.StdEncoding.DecodeString(secret.BinaryData[observabilityCollectorActivationKey])
+	activationRaw, err := base64.StdEncoding.DecodeString(secret.Data[observabilityCollectorActivationKey])
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -365,7 +365,7 @@ func pemEncodeECPrivateKey(raw []byte) []byte {
 
 func mustDecodeCollectorSecret(t *testing.T, secret postRuntimeActivationSecret, key string) []byte {
 	t.Helper()
-	raw, err := base64.StdEncoding.DecodeString(secret.BinaryData[key])
+	raw, err := base64.StdEncoding.DecodeString(secret.Data[key])
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/runner/observability_collector_runtime_launcher.go
+++ b/internal/runner/observability_collector_runtime_launcher.go
@@ -114,10 +114,10 @@ func PlanObservabilityCollectorRuntimeInstallation(packaged VerifiedObservabilit
 		case "Secret":
 			annotations, _ := metadata["annotations"].(map[string]any)
 			labels, _ := metadata["labels"].(map[string]any)
-			binaryData, _ := object["binaryData"].(map[string]any)
+			data, _ := object["data"].(map[string]any)
 			if name != receipt.ActivationSecret || object["immutable"] != true || object["type"] != "Opaque" ||
 				labels["openkubes.io/stage-id"] != "independent-evidence" || annotations["openkubes.io/manifest-digest"] != receipt.ManifestDigest ||
-				annotations["openkubes.io/activation-digest"] != receipt.ActivationDigest || len(binaryData) != 7 {
+				annotations["openkubes.io/activation-digest"] != receipt.ActivationDigest || len(data) != 7 {
 				return ObservabilityCollectorRuntimeInstallationPlan{}, errors.New("observability collector Secret semantics differ")
 			}
 		case "Service":

--- a/internal/runner/observability_collector_runtime_package.go
+++ b/internal/runner/observability_collector_runtime_package.go
@@ -205,7 +205,7 @@ func observabilityCollectorActivationFromSecret(raw []byte) (ObservabilityCollec
 	if err := jsonstrict.Decode(raw, &secret); err != nil || secret.Kind != "Secret" || !secret.Immutable {
 		return ObservabilityCollectorActivation{}, errors.New("decode observability collector activation Secret")
 	}
-	activationRaw, err := base64.StdEncoding.Strict().DecodeString(secret.BinaryData[observabilityCollectorActivationKey])
+	activationRaw, err := base64.StdEncoding.Strict().DecodeString(secret.Data[observabilityCollectorActivationKey])
 	if err != nil {
 		return ObservabilityCollectorActivation{}, errors.New("decode observability collector activation")
 	}

--- a/internal/runner/observability_evidence_authority_activation_test.go
+++ b/internal/runner/observability_evidence_authority_activation_test.go
@@ -39,7 +39,7 @@ func TestObservabilityEvidenceAuthorityActivationRunsOneBoundedProduction(t *tes
 	if err := json.Unmarshal(raw, &secret); err != nil {
 		t.Fatal(err)
 	}
-	for key, encoded := range secret.BinaryData {
+	for key, encoded := range secret.Data {
 		content, err := base64.StdEncoding.DecodeString(encoded)
 		if err != nil {
 			t.Fatal(err)
@@ -113,7 +113,7 @@ func TestOpenObservabilityEvidenceAuthorityActivationFailsClosed(t *testing.T) {
 	if err := json.Unmarshal(raw, &secret); err != nil {
 		t.Fatal(err)
 	}
-	for key, encoded := range secret.BinaryData {
+	for key, encoded := range secret.Data {
 		content, _ := base64.StdEncoding.DecodeString(encoded)
 		if err := os.WriteFile(filepath.Join(authorityRoot, key), content, 0o600); err != nil {
 			t.Fatal(err)

--- a/internal/runner/observability_evidence_authority_materializer_test.go
+++ b/internal/runner/observability_evidence_authority_materializer_test.go
@@ -107,7 +107,7 @@ func observabilityEvidenceAuthorityMaterializerFixture(t *testing.T) (Observabil
 		t.Fatal(err)
 	}
 	for _, name := range observabilityEvidenceAuthorityProjectedFiles {
-		decoded, decodeErr := base64.StdEncoding.DecodeString(secret.BinaryData[name])
+		decoded, decodeErr := base64.StdEncoding.DecodeString(secret.Data[name])
 		if decodeErr != nil {
 			t.Fatal(decodeErr)
 		}

--- a/internal/runner/observability_evidence_authority_package.go
+++ b/internal/runner/observability_evidence_authority_package.go
@@ -158,7 +158,7 @@ func BuildObservabilityEvidenceAuthorityPackage(config ObservabilityEvidenceAuth
 		observabilityEvidenceAuthorityCollectorCA:    base64.StdEncoding.EncodeToString(caRaw),
 	}
 	secret := postRuntimeActivationSecret{
-		APIVersion: "v1", Kind: "Secret", Immutable: true, Type: "Opaque", BinaryData: binaryData,
+		APIVersion: "v1", Kind: "Secret", Immutable: true, Type: "Opaque", Data: binaryData,
 		Metadata: postRuntimeActivationSecretMetadata{
 			Name: config.ActivationSecret, Namespace: submissionStageInputNamespace,
 			Labels: map[string]string{
@@ -218,10 +218,10 @@ func verifyObservabilityEvidenceAuthorityPackage(packaged VerifiedObservabilityE
 		secret.Metadata.Labels["openkubes.io/stage-id"] != "independent-evidence" ||
 		secret.Metadata.Annotations["openkubes.io/manifest-digest"] != receipt.ManifestDigest ||
 		secret.Metadata.Annotations["openkubes.io/activation-digest"] != receipt.ActivationDigest ||
-		len(secret.BinaryData) != receipt.PrivateFileCount {
+		len(secret.Data) != receipt.PrivateFileCount {
 		return errors.New("observability evidence authority Secret identity differs")
 	}
-	activationRaw, err := base64.StdEncoding.DecodeString(secret.BinaryData[observabilityEvidenceAuthorityActivationKey])
+	activationRaw, err := base64.StdEncoding.DecodeString(secret.Data[observabilityEvidenceAuthorityActivationKey])
 	if err != nil || digest.SHA256(activationRaw) != receipt.ActivationDigest {
 		return errors.New("observability evidence authority activation identity differs")
 	}
@@ -234,7 +234,7 @@ func verifyObservabilityEvidenceAuthorityPackage(packaged VerifiedObservabilityE
 		activation.CollectorCADigest != receipt.CollectorCADigest || digest.SHA256([]byte(activation.CollectorEndpoint)) != receipt.CollectorAuthorityDigest {
 		return errors.New("observability evidence authority activation differs from receipt")
 	}
-	privateKeyRaw, err := base64.StdEncoding.DecodeString(secret.BinaryData[observabilityEvidenceAuthorityPrivateKeyKey])
+	privateKeyRaw, err := base64.StdEncoding.DecodeString(secret.Data[observabilityEvidenceAuthorityPrivateKeyKey])
 	if err != nil {
 		return errors.New("decode observability evidence authority private key")
 	}
@@ -244,8 +244,8 @@ func verifyObservabilityEvidenceAuthorityPackage(packaged VerifiedObservabilityE
 		digest.SHA256(ed25519.PrivateKey(privateKey).Public().(ed25519.PublicKey)) != receipt.EvidenceKeyID {
 		return errors.New("observability evidence authority key identity differs")
 	}
-	tokenRaw, tokenErr := base64.StdEncoding.DecodeString(secret.BinaryData[observabilityEvidenceAuthorityCollectorToken])
-	caRaw, caErr := base64.StdEncoding.DecodeString(secret.BinaryData[observabilityEvidenceAuthorityCollectorCA])
+	tokenRaw, tokenErr := base64.StdEncoding.DecodeString(secret.Data[observabilityEvidenceAuthorityCollectorToken])
+	caRaw, caErr := base64.StdEncoding.DecodeString(secret.Data[observabilityEvidenceAuthorityCollectorCA])
 	if tokenErr != nil || len(tokenRaw) == 0 || caErr != nil || digest.SHA256(caRaw) != receipt.CollectorCADigest {
 		return errors.New("observability evidence authority collector material differs")
 	}

--- a/internal/runner/observability_evidence_authority_package_test.go
+++ b/internal/runner/observability_evidence_authority_package_test.go
@@ -52,10 +52,10 @@ func TestBuildObservabilityEvidenceAuthorityPackageBindsPrivateAuthority(t *test
 		t.Fatal(err)
 	}
 	if secret.Kind != "Secret" || !secret.Immutable || secret.Metadata.Namespace != submissionStageInputNamespace ||
-		secret.Metadata.Name != config.ActivationSecret || len(secret.BinaryData) != 4 {
+		secret.Metadata.Name != config.ActivationSecret || len(secret.Data) != 4 {
 		t.Fatalf("unexpected evidence authority Secret: %#v", secret)
 	}
-	activationRaw, err := base64.StdEncoding.DecodeString(secret.BinaryData[observabilityEvidenceAuthorityActivationKey])
+	activationRaw, err := base64.StdEncoding.DecodeString(secret.Data[observabilityEvidenceAuthorityActivationKey])
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -72,9 +72,9 @@ func TestBuildObservabilityEvidenceAuthorityPackageBindsPrivateAuthority(t *test
 		activation.CollectorEndpoint != config.CollectorEndpoint || activation.IdentityWaitTimeout != "30m0s" {
 		t.Fatalf("evidence authority activation differs: %#v", activation)
 	}
-	privateKey, _ := base64.StdEncoding.DecodeString(secret.BinaryData[observabilityEvidenceAuthorityPrivateKeyKey])
-	token, _ := base64.StdEncoding.DecodeString(secret.BinaryData[observabilityEvidenceAuthorityCollectorToken])
-	ca, _ := base64.StdEncoding.DecodeString(secret.BinaryData[observabilityEvidenceAuthorityCollectorCA])
+	privateKey, _ := base64.StdEncoding.DecodeString(secret.Data[observabilityEvidenceAuthorityPrivateKeyKey])
+	token, _ := base64.StdEncoding.DecodeString(secret.Data[observabilityEvidenceAuthorityCollectorToken])
+	ca, _ := base64.StdEncoding.DecodeString(secret.Data[observabilityEvidenceAuthorityCollectorCA])
 	if len(privateKey) == 0 || string(token) != "independent-evidence-token" || digest.SHA256(ca) != receipt.CollectorCADigest {
 		t.Fatal("private evidence authority material differs from verified sources")
 	}

--- a/internal/runner/post_runtime_activation_installation_plan.go
+++ b/internal/runner/post_runtime_activation_installation_plan.go
@@ -90,10 +90,10 @@ func PlanPostRuntimeExecutionActivationInstallation(packaged VerifiedPostRuntime
 		case "Secret":
 			annotations, _ := metadata["annotations"].(map[string]any)
 			labels, _ := metadata["labels"].(map[string]any)
-			binaryData, _ := object["binaryData"].(map[string]any)
+			data, _ := object["data"].(map[string]any)
 			if name != receipt.ActivationSecret || object["immutable"] != true || object["type"] != "Opaque" ||
 				labels["openkubes.io/stage-id"] != "post-runtime" || annotations["openkubes.io/bundle-digest"] != receipt.BundleDigest ||
-				annotations["openkubes.io/manifest-digest"] != receipt.ManifestDigest || len(binaryData) != receipt.PrivateFileCount+1 {
+				annotations["openkubes.io/manifest-digest"] != receipt.ManifestDigest || len(data) != receipt.PrivateFileCount+1 {
 				return PostRuntimeExecutionActivationInstallationPlan{}, errors.New("post-runtime activation Secret semantics differ")
 			}
 		case "NetworkPolicy":

--- a/internal/runner/post_runtime_activation_package.go
+++ b/internal/runner/post_runtime_activation_package.go
@@ -75,7 +75,7 @@ type postRuntimeActivationSecret struct {
 	Metadata   postRuntimeActivationSecretMetadata `json:"metadata"`
 	Immutable  bool                                `json:"immutable"`
 	Type       string                              `json:"type"`
-	BinaryData map[string]string                   `json:"binaryData"`
+	Data       map[string]string                   `json:"data"`
 }
 
 type postRuntimeActivationSecretMetadata struct {
@@ -150,7 +150,7 @@ func BuildPostRuntimeExecutionActivationPackage(config PostRuntimeExecutionActiv
 		binaryData[strings.ReplaceAll(path, "/", ".")] = base64.StdEncoding.EncodeToString(files[path])
 	}
 	secret := postRuntimeActivationSecret{
-		APIVersion: "v1", Kind: "Secret", Immutable: true, Type: "Opaque", BinaryData: binaryData,
+		APIVersion: "v1", Kind: "Secret", Immutable: true, Type: "Opaque", Data: binaryData,
 		Metadata: postRuntimeActivationSecretMetadata{
 			Name: config.ActivationSecret, Namespace: submissionStageInputNamespace,
 			Labels: map[string]string{

--- a/internal/runner/post_runtime_activation_package_test.go
+++ b/internal/runner/post_runtime_activation_package_test.go
@@ -51,10 +51,10 @@ func TestBuildPostRuntimeExecutionActivationPackageBindsPrivateSecretAndJob(t *t
 		t.Fatal(err)
 	}
 	if secret.Kind != "Secret" || !secret.Immutable || secret.Type != "Opaque" || secret.Metadata.Name != config.ActivationSecret ||
-		len(secret.BinaryData) != len(postRuntimeExecutionBundleFiles)+1 {
+		len(secret.Data) != len(postRuntimeExecutionBundleFiles)+1 {
 		t.Fatalf("unexpected private activation Secret: %#v", secret)
 	}
-	indexRaw, err := base64.StdEncoding.DecodeString(secret.BinaryData[postRuntimeExecutionBundleIndexName])
+	indexRaw, err := base64.StdEncoding.DecodeString(secret.Data[postRuntimeExecutionBundleIndexName])
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -91,12 +91,12 @@ func TestPostRuntimeExecutionActivationPackageMaterializesExactSecret(t *testing
 	if err := os.Mkdir(source, 0o700); err != nil {
 		t.Fatal(err)
 	}
-	indexRaw, _ := base64.StdEncoding.DecodeString(secret.BinaryData[postRuntimeExecutionBundleIndexName])
+	indexRaw, _ := base64.StdEncoding.DecodeString(secret.Data[postRuntimeExecutionBundleIndexName])
 	if err := os.WriteFile(filepath.Join(source, postRuntimeExecutionBundleIndexName), indexRaw, 0o440); err != nil {
 		t.Fatal(err)
 	}
 	for _, path := range postRuntimeExecutionBundleFiles {
-		encoded := secret.BinaryData[strings.ReplaceAll(path, "/", ".")]
+		encoded := secret.Data[strings.ReplaceAll(path, "/", ".")]
 		content, err := base64.StdEncoding.DecodeString(encoded)
 		if err != nil {
 			t.Fatal(err)
@@ -141,7 +141,7 @@ func TestPostRuntimeExecutionRecoveryActivationCarriesHistoricalReceipts(t *test
 	if len(parts) != 2 || json.Unmarshal(parts[0], &secret) != nil {
 		t.Fatal("decode recovery activation Secret")
 	}
-	indexRaw, err := base64.StdEncoding.DecodeString(secret.BinaryData[postRuntimeExecutionBundleIndexName])
+	indexRaw, err := base64.StdEncoding.DecodeString(secret.Data[postRuntimeExecutionBundleIndexName])
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -151,7 +151,7 @@ func TestPostRuntimeExecutionRecoveryActivationCarriesHistoricalReceipts(t *test
 		t.Fatalf("unexpected recovery bundle index: %#v", index)
 	}
 	for _, relative := range postRuntimeExecutionRecoveryReceiptFiles {
-		if secret.BinaryData[strings.ReplaceAll(relative, "/", ".")] == "" {
+		if secret.Data[strings.ReplaceAll(relative, "/", ".")] == "" {
 			t.Fatalf("recovery receipt %s is absent from private activation", relative)
 		}
 	}
@@ -169,7 +169,7 @@ func TestPostRuntimeExecutionRecoveryActivationCarriesHistoricalReceipts(t *test
 		t.Fatal(err)
 	}
 	for _, file := range index.Files {
-		encoded := secret.BinaryData[strings.ReplaceAll(file.Path, "/", ".")]
+		encoded := secret.Data[strings.ReplaceAll(file.Path, "/", ".")]
 		content, err := base64.StdEncoding.DecodeString(encoded)
 		if err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
## Summary

- encode bounded activation payloads using the Kubernetes Secret `data` field
- update all shared activation package validators/materializers consistently
- add a regression assertion that rejects `binaryData` on Secret objects

## Evidence

The OK-147 full-run launch stopped fail-closed after Kubernetes pruned the unsupported Secret `binaryData` field. No lifecycle Job was launched.

## Validation

```text
CGO_ENABLED=0 go test ./...
PASS
```