### PR TITLE
fix(runner): materialize private evidence handoff

### DIFF
--- a/cmd/ok/full_run_test.go
+++ b/cmd/ok/full_run_test.go
@@ -252,7 +252,7 @@ func TestFullRunMaterializeRequiresExplicitBoundIdentity(t *testing.T) {
 	materializeFullRunExecutionBundle = func(config runner.FullRunExecutionBundleMaterializationConfig) (runner.FullRunExecutionBundleMaterializationReceipt, error) {
 		calls++
 		if config.SourceDirectory != "/var/run/openkubes/source" || config.DestinationDirectory != "/var/run/openkubes/workspace" ||
-			config.HandoffDirectory != "/var/run/openkubes/handoff" || config.ExpectedBundleDigest != testSHA("1") {
+			config.HandoffDirectory != "/var/run/openkubes/handoff-volume/private" || config.ExpectedBundleDigest != testSHA("1") {
 			t.Fatalf("full-run materialization config differs: %#v", config)
 		}
 		return runner.FullRunExecutionBundleMaterializationReceipt{
@@ -263,7 +263,7 @@ func TestFullRunMaterializeRequiresExplicitBoundIdentity(t *testing.T) {
 	valid := []string{
 		"cluster", "stage", "run", "full", "materialize",
 		"--source", "/var/run/openkubes/source", "--destination", "/var/run/openkubes/workspace",
-		"--handoff", "/var/run/openkubes/handoff", "--expected-bundle-digest", testSHA("1"), "--materialize",
+		"--handoff", "/var/run/openkubes/handoff-volume/private", "--expected-bundle-digest", testSHA("1"), "--materialize",
 	}
 	var stdout bytes.Buffer
 	if err := run(valid, &stdout, &bytes.Buffer{}); err != nil {
@@ -276,7 +276,7 @@ func TestFullRunMaterializeRequiresExplicitBoundIdentity(t *testing.T) {
 	for name, arguments := range map[string][]string{
 		"missing activation": removeArgument(valid, "--materialize"),
 		"missing source":     removeArgument(valid, "/var/run/openkubes/source"),
-		"missing handoff":    removeArgument(valid, "/var/run/openkubes/handoff"),
+		"missing handoff":    removeArgument(valid, "/var/run/openkubes/handoff-volume/private"),
 		"bad digest":         replaceArgument(valid, "--expected-bundle-digest", "sha256:bad"),
 		"positional":         append(append([]string(nil), valid...), "extra"),
 	} {

--- a/deploy/contract-executor-full-run-job.yaml.tpl
+++ b/deploy/contract-executor-full-run-job.yaml.tpl
@@ -82,7 +82,7 @@ spec:
             - --destination
             - /var/run/openkubes/workspace
             - --handoff
-            - /var/run/openkubes/handoff
+            - /var/run/openkubes/handoff-volume/private
             - --expected-bundle-digest
             - "${OK147_BUNDLE_DIGEST}"
             - --materialize
@@ -96,7 +96,7 @@ spec:
           volumeMounts:
             - {name: activation-source, mountPath: /var/run/openkubes/source, readOnly: true}
             - {name: executor-private, mountPath: /var/run/openkubes}
-            - {name: evidence-handoff, mountPath: /var/run/openkubes/handoff}
+            - {name: evidence-handoff, mountPath: /var/run/openkubes/handoff-volume}
         - name: materialize-evidence-authority
           image: "${OK147_IMAGE_DIGEST}"
           imagePullPolicy: IfNotPresent
@@ -156,7 +156,7 @@ spec:
             capabilities: {drop: ["ALL"]}
           volumeMounts:
             - {name: executor-private, mountPath: /var/run/openkubes/workspace, subPath: workspace}
-            - {name: evidence-handoff, mountPath: /var/run/openkubes/handoff}
+            - {name: evidence-handoff, mountPath: /var/run/openkubes/handoff, subPath: private}
         - name: evidence-authority
           image: "${OK147_IMAGE_DIGEST}"
           imagePullPolicy: IfNotPresent
@@ -179,7 +179,7 @@ spec:
             capabilities: {drop: ["ALL"]}
           volumeMounts:
             - {name: authority-private, mountPath: /var/run/openkubes/evidence-authority, subPath: evidence-authority}
-            - {name: evidence-handoff, mountPath: /var/run/openkubes/handoff}
+            - {name: evidence-handoff, mountPath: /var/run/openkubes/handoff, subPath: private}
       volumes:
         - name: activation-source
           secret:

--- a/internal/runner/full_run_activation_bundle.go
+++ b/internal/runner/full_run_activation_bundle.go
@@ -22,6 +22,8 @@ const (
 	fullRunExecutionManifestPath        = "activation/full-run-manifest.json"
 	fullRunExecutionWorkspaceRoot       = "/var/run/openkubes/workspace"
 	fullRunExecutionHandoffRoot         = "/var/run/openkubes/handoff"
+	fullRunExecutionHandoffVolumeRoot   = "/var/run/openkubes/handoff-volume"
+	fullRunExecutionHandoffPrivateRoot  = "/var/run/openkubes/handoff-volume/private"
 	maximumFullRunExecutionBundleBytes  = 900 * 1024
 	maximumFullRunExecutionBundleFiles  = 34
 )

--- a/internal/runner/full_run_activation_materializer.go
+++ b/internal/runner/full_run_activation_materializer.go
@@ -40,7 +40,7 @@ type FullRunExecutionBundleMaterializationReceipt struct {
 // evidence handoff is a separate private emptyDir shared only with the
 // independent authority process.
 func MaterializeFullRunExecutionBundle(config FullRunExecutionBundleMaterializationConfig) (FullRunExecutionBundleMaterializationReceipt, error) {
-	if config.DestinationDirectory != fullRunExecutionWorkspaceRoot || config.HandoffDirectory != fullRunExecutionHandoffRoot {
+	if config.DestinationDirectory != fullRunExecutionWorkspaceRoot || config.HandoffDirectory != fullRunExecutionHandoffPrivateRoot {
 		return stoppedFullRunMaterializationReceipt(), errors.New("full-run bundle destinations differ from fixed runtime roots")
 	}
 	return materializeFullRunExecutionBundle(config)
@@ -57,13 +57,18 @@ func materializeFullRunExecutionBundle(config FullRunExecutionBundleMaterializat
 	if _, err := os.Lstat(config.DestinationDirectory); err == nil || !errors.Is(err, os.ErrNotExist) {
 		return receipt, errors.New("full-run bundle destination must be absent")
 	}
+	handoffMissing := false
 	handoffInfo, err := os.Lstat(config.HandoffDirectory)
-	if err != nil || !handoffInfo.IsDir() || handoffInfo.Mode()&os.ModeSymlink != 0 || handoffInfo.Mode().Perm()&0o007 != 0 {
+	if errors.Is(err, os.ErrNotExist) {
+		handoffMissing = true
+	} else if err != nil || !handoffInfo.IsDir() || handoffInfo.Mode()&os.ModeSymlink != 0 || handoffInfo.Mode().Perm() != 0o700 {
 		return receipt, errors.New("full-run evidence handoff is not a private directory")
 	}
-	entries, err := os.ReadDir(config.HandoffDirectory)
-	if err != nil || len(entries) != 0 {
-		return receipt, errors.New("full-run evidence handoff must be empty before materialization")
+	if !handoffMissing {
+		entries, readErr := os.ReadDir(config.HandoffDirectory)
+		if readErr != nil || len(entries) != 0 {
+			return receipt, errors.New("full-run evidence handoff must be empty before materialization")
+		}
 	}
 	indexRaw, err := readProjectedPostRuntimeBundleFile(config.SourceDirectory, fullRunExecutionBundleIndexName, 64*1024)
 	if err != nil {
@@ -101,6 +106,16 @@ func materializeFullRunExecutionBundle(config FullRunExecutionBundleMaterializat
 	}
 	receipt.EvidenceKeyID = publicKeyID
 
+	handoffParentInfo, err := os.Lstat(filepath.Dir(config.HandoffDirectory))
+	if err != nil || !handoffParentInfo.IsDir() || handoffParentInfo.Mode()&os.ModeSymlink != 0 {
+		return receipt, errors.New("full-run evidence handoff parent is invalid")
+	}
+	if handoffMissing {
+		receipt.State = "STOPPED_PARTIAL_OR_UNKNOWN"
+		if err := os.Mkdir(config.HandoffDirectory, 0o700); err != nil {
+			return receipt, errors.New("create private full-run evidence handoff")
+		}
+	}
 	parentInfo, err := os.Lstat(filepath.Dir(config.DestinationDirectory))
 	if err != nil || !parentInfo.IsDir() || parentInfo.Mode()&os.ModeSymlink != 0 {
 		return receipt, errors.New("full-run bundle destination parent is invalid")

--- a/internal/runner/full_run_activation_materializer_test.go
+++ b/internal/runner/full_run_activation_materializer_test.go
@@ -33,6 +33,37 @@ func TestMaterializeFullRunExecutionBundleCreatesPrivateWorkspace(t *testing.T) 
 	}
 }
 
+func TestMaterializeFullRunExecutionBundleCreatesPrivateHandoffAfterVerification(t *testing.T) {
+	config, _ := fullRunMaterializerFixture(t)
+	if err := os.Remove(config.HandoffDirectory); err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := materializeFullRunExecutionBundle(config)
+	if err != nil || receipt.State != "MATERIALIZED_VERIFIED" {
+		t.Fatalf("missing handoff was not safely materialized: %#v err=%v", receipt, err)
+	}
+	info, err := os.Lstat(config.HandoffDirectory)
+	if err != nil || !info.IsDir() || info.Mode().Perm() != 0o700 {
+		t.Fatalf("created handoff is not private: %#v err=%v", info, err)
+	}
+}
+
+func TestMaterializeFullRunExecutionBundleReportsPartialAfterCreatingHandoff(t *testing.T) {
+	config, _ := fullRunMaterializerFixture(t)
+	if err := os.Remove(config.HandoffDirectory); err != nil {
+		t.Fatal(err)
+	}
+	config.DestinationDirectory = filepath.Join(filepath.Dir(config.DestinationDirectory), "missing-parent", "workspace")
+	receipt, err := materializeFullRunExecutionBundle(config)
+	if err == nil || receipt.State != "STOPPED_PARTIAL_OR_UNKNOWN" {
+		t.Fatalf("local handoff write was not reported as partial: %#v err=%v", receipt, err)
+	}
+	info, statErr := os.Lstat(config.HandoffDirectory)
+	if statErr != nil || !info.IsDir() || info.Mode().Perm() != 0o700 {
+		t.Fatalf("created handoff is not private: %#v err=%v", info, statErr)
+	}
+}
+
 func TestMaterializeFullRunExecutionBundleFailsClosedBeforeWrite(t *testing.T) {
 	for name, mutate := range map[string]func(*testing.T, *FullRunExecutionBundleMaterializationConfig){
 		"wrong bundle digest": func(_ *testing.T, config *FullRunExecutionBundleMaterializationConfig) {

--- a/internal/runner/full_run_job_test.go
+++ b/internal/runner/full_run_job_test.go
@@ -41,7 +41,7 @@ func TestRenderFullRunExecutionJobTemplateIsolatesExecutorAndEvidenceAuthority(t
 	fullInit := inits[0].(map[string]any)
 	if got := stringArray(t, fullInit, "args"); !reflect.DeepEqual(got, []string{
 		"cluster", "stage", "run", "full", "materialize", "--source", "/var/run/openkubes/source",
-		"--destination", "/var/run/openkubes/workspace", "--handoff", "/var/run/openkubes/handoff",
+		"--destination", "/var/run/openkubes/workspace", "--handoff", "/var/run/openkubes/handoff-volume/private",
 		"--expected-bundle-digest", values.BundleDigest, "--materialize",
 	}) {
 		t.Fatalf("unexpected full-run initializer: %v", got)
@@ -71,8 +71,8 @@ func TestRenderFullRunExecutionJobTemplateIsolatesExecutorAndEvidenceAuthority(t
 	}) {
 		t.Fatalf("unexpected evidence authority command: %v", got)
 	}
-	assertFullRunContainerMounts(t, executor, map[string]string{"executor-private": "workspace", "evidence-handoff": ""})
-	assertFullRunContainerMounts(t, authority, map[string]string{"authority-private": "evidence-authority", "evidence-handoff": ""})
+	assertFullRunContainerMounts(t, executor, map[string]string{"executor-private": "workspace", "evidence-handoff": "private"})
+	assertFullRunContainerMounts(t, authority, map[string]string{"authority-private": "evidence-authority", "evidence-handoff": "private"})
 
 	volumes := arrayAt(t, podSpec, "volumes")
 	if len(volumes) != 5 {


### PR DESCRIPTION
## Outcome

Fixes the Full-Run Job envelope discovered by OK-147 Launch R3.1: Kubernetes does not guarantee a private mode for the root of an emptyDir mount.

The initializer now creates a verified private 0700 handoff subdirectory after bundle verification. Executor and evidence authority mount only that subdirectory at the unchanged semantic handoff path.

## Safety

- no R/E/P semantic change
- no cluster mutation in this PR
- fail-closed on unsafe existing handoff state
- partial local writes are reported as partial
- full Go test suite passes

The existing failed R3.1 partial state is intentionally untouched.
