### PR TITLE
fix(runner): preserve full-run manifest diagnostics

### DIFF
--- a/cmd/ok/full_run.go
+++ b/cmd/ok/full_run.go
@@ -372,8 +372,13 @@ func runClusterStageRunFullExecute(ctx context.Context, arguments []string, stdo
 		return errors.New("--manifest, --independent-evidence-public-key and a lowercase SHA-256 --expected-manifest-digest are required")
 	}
 	verified, err := prepareFullRunExecutionManifest(*manifestPath)
-	if err != nil || verified.Format != runner.FullRunExecutionManifestReceiptFormat || verified.State != "VERIFIED" ||
-		verified.MutationAllowed || verified.ManifestDigest != *expectedManifestDigest {
+	if err != nil {
+		return fmt.Errorf("prepare full-run manifest: %w", err)
+	}
+	if verified.Format != runner.FullRunExecutionManifestReceiptFormat || verified.State != "VERIFIED" || verified.MutationAllowed {
+		return errors.New("full-run manifest preparation did not produce a verified identity")
+	}
+	if verified.ManifestDigest != *expectedManifestDigest {
 		return errors.New("full-run manifest differs from the prepared identity")
 	}
 	activation, prepared, err := openKubernetesObservabilityFullRunActivation(*manifestPath, *evidencePublicKey)
@@ -381,8 +386,10 @@ func runClusterStageRunFullExecute(ctx context.Context, arguments []string, stdo
 		return err
 	}
 	if activation == nil || prepared.Format != runner.FullRunExecutionActivationReceiptFormat || prepared.State != "PREPARED" ||
-		prepared.Execution != nil || prepared.Manifest.State != "VERIFIED" || prepared.Manifest.MutationAllowed ||
-		prepared.Manifest != verified {
+		prepared.Execution != nil || prepared.Manifest.State != "VERIFIED" || prepared.Manifest.MutationAllowed {
+		return errors.New("full-run activation did not produce a prepared identity")
+	}
+	if prepared.Manifest != verified {
 		return errors.New("full-run manifest differs from the prepared identity")
 	}
 	bounded, cancel := context.WithTimeout(ctx, fullRunExecutionTimeout)

--- a/cmd/ok/full_run_test.go
+++ b/cmd/ok/full_run_test.go
@@ -397,6 +397,15 @@ func TestFullRunExecuteFailsClosedBeforeRun(t *testing.T) {
 	if err := run(valid, &bytes.Buffer{}, &bytes.Buffer{}); err == nil || runs != 0 {
 		t.Fatalf("foreign prepared identity reached execution: opens=%d runs=%d err=%v", opens, runs, err)
 	}
+
+	prepareFullRunExecutionManifest = func(string) (runner.FullRunExecutionManifestReceipt, error) {
+		return runner.FullRunExecutionManifestReceipt{}, errors.New("specific manifest rejection")
+	}
+	opensBefore := opens
+	err := run(valid, &bytes.Buffer{}, &bytes.Buffer{})
+	if err == nil || !strings.Contains(err.Error(), "specific manifest rejection") || opens != opensBefore || runs != 0 {
+		t.Fatalf("manifest rejection was not preserved before activation: opens=%d runs=%d err=%v", opens, runs, err)
+	}
 }
 
 type fullRunActivationRunnerFunc func(context.Context) (runner.FullRunExecutionActivationReceipt, error)


### PR DESCRIPTION
## Outcome

Preserves the exact fail-closed manifest preparation error during Full-Run execution instead of collapsing loader failures, invalid receipts, and digest mismatches into one generic message.

## Evidence

- R4 private handoff materialization completed successfully
- executor stopped before Stage 1 with the previous generic manifest message
- targeted command and runner tests pass
- no cluster mutation is performed by this change

The live R4 partial state remains untouched.
