### PR TITLE
fix(runner): preserve safe stage authorization cause

### DIFF
--- a/internal/runner/full_run_orchestrator.go
+++ b/internal/runner/full_run_orchestrator.go
@@ -3,6 +3,7 @@ package runner
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 
 	"github.com/openkubes/ok-cluster/internal/stagereceipt"
@@ -92,11 +93,15 @@ func (orchestration *FullRunOrchestration) Run(ctx context.Context) (FullRunOrch
 	}
 
 	prefix, prefixErr := orchestration.PreRuntime.Run(ctx)
+	if prefixErr != nil && prefix.State == "STOPPED" && prefix.StoppedAt == preRuntimeStageOrder[0] &&
+		prefix.PlanDigest == "" && len(prefix.Checkpoints) == 0 {
+		return stopFullRunOrchestrationWithCause(receipt, prefix.StoppedAt, prefixErr)
+	}
 	if err := appendFullRunPrefix(&receipt, prefix); err != nil {
 		return stopFullRunOrchestration(receipt, nextFullRunStage(receipt.Checkpoints))
 	}
 	if prefixErr != nil || prefix.State != "SUCCEEDED" {
-		return stopFullRunOrchestration(receipt, prefix.StoppedAt)
+		return stopFullRunOrchestrationWithCause(receipt, prefix.StoppedAt, prefixErr)
 	}
 	if err := ctx.Err(); err != nil {
 		return stopFullRunOrchestration(receipt, postRuntimeStageOrder[0])
@@ -241,6 +246,17 @@ func stopFullRunOrchestration(receipt FullRunOrchestrationReceipt, stageID strin
 	}
 	receipt.State, receipt.StoppedAt = "STOPPED", stageID
 	return receipt, errors.New("full-run orchestration stopped at " + stageID)
+}
+
+func stopFullRunOrchestrationWithCause(receipt FullRunOrchestrationReceipt, stageID string, cause error) (FullRunOrchestrationReceipt, error) {
+	if stageID == "" {
+		stageID = nextFullRunStage(receipt.Checkpoints)
+	}
+	receipt.State, receipt.StoppedAt = "STOPPED", stageID
+	if cause == nil {
+		return receipt, errors.New("full-run orchestration stopped at " + stageID)
+	}
+	return receipt, fmt.Errorf("full-run orchestration stopped at %s: %w", stageID, cause)
 }
 
 func oneOfString(value string, options ...string) bool {

--- a/internal/runner/full_run_orchestrator_test.go
+++ b/internal/runner/full_run_orchestrator_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"reflect"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -100,7 +101,7 @@ func TestFullRunOrchestrationAllowsExactlyOneConcurrentInvocation(t *testing.T) 
 func TestFullRunOrchestrationStopsBeforeContinuationWhenPrefixStops(t *testing.T) {
 	calls := []string{}
 	prefix := successfulPreRuntimeOrchestration(&calls)
-	prefix.RunEnablement = func(context.Context, execution.ObservationStageRunReceipt) (execution.StagedOperationReceipt, error) {
+	prefix.RunProviderPrerequisites = func(context.Context) (execution.StagedOperationReceipt, error) {
 		return execution.StagedOperationReceipt{}, errors.New("private failure")
 	}
 	bindCalls := 0
@@ -112,8 +113,11 @@ func TestFullRunOrchestrationStopsBeforeContinuationWhenPrefixStops(t *testing.T
 		},
 	}
 	receipt, err := orchestration.Run(context.Background())
-	if err == nil || receipt.State != "STOPPED" || receipt.StoppedAt != "enablement" || len(receipt.Checkpoints) != 3 || bindCalls != 0 {
+	if err == nil || receipt.State != "STOPPED" || receipt.StoppedAt != "provider-prerequisites" || len(receipt.Checkpoints) != 0 || bindCalls != 0 {
 		t.Fatalf("stopped prefix reached continuation: %#v bindCalls=%d err=%v", receipt, bindCalls, err)
+	}
+	if !strings.Contains(err.Error(), "private failure") {
+		t.Fatalf("prefix failure cause was not preserved: %v", err)
 	}
 }
 

--- a/internal/runner/pre_runtime_execution.go
+++ b/internal/runner/pre_runtime_execution.go
@@ -3,6 +3,7 @@ package runner
 import (
 	"context"
 	"errors"
+	"fmt"
 	"path/filepath"
 	"sync"
 
@@ -211,7 +212,10 @@ func (executor *PreRuntimeExecution) Run(ctx context.Context) (PreRuntimeExecuti
 			return execution.StagedOperationReceipt{}, err
 		}
 		invocation, err := executor.factories.submission(executor.resume(receipts), "provider-prerequisites", source, executor.config)
-		if err != nil || invocation.run == nil || invocation.store == nil {
+		if err != nil {
+			return execution.StagedOperationReceipt{}, fmt.Errorf("open provider-prerequisites stage: %w", err)
+		}
+		if invocation.run == nil || invocation.store == nil {
 			return execution.StagedOperationReceipt{}, errors.New("open provider-prerequisites stage")
 		}
 		run, err := invocation.run(ctx)

--- a/internal/runner/pre_runtime_orchestrator.go
+++ b/internal/runner/pre_runtime_orchestrator.go
@@ -3,6 +3,7 @@ package runner
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/openkubes/ok-cluster/internal/execution"
 )
@@ -68,8 +69,15 @@ func (orchestration PreRuntimeOrchestration) Run(ctx context.Context) (PreRuntim
 	}
 
 	providerReceipt, runErr := orchestration.RunProviderPrerequisites(ctx)
-	if err := appendPreRuntimeCheckpoint(&receipt, preRuntimeStageOrder[0], execution.StagedReceiptFormat, providerReceipt.Format, providerReceipt.State, providerReceipt.PlanDigest, providerReceipt.StageID, providerReceipt.StageReceiptDigest); err != nil || runErr != nil {
-		return stopPreRuntimeOrchestration(receipt, preRuntimeStageOrder[0])
+	appendErr := appendPreRuntimeCheckpoint(&receipt, preRuntimeStageOrder[0], execution.StagedReceiptFormat, providerReceipt.Format, providerReceipt.State, providerReceipt.PlanDigest, providerReceipt.StageID, providerReceipt.StageReceiptDigest)
+	if runErr != nil {
+		if appendErr == nil || providerReceipt == (execution.StagedOperationReceipt{}) {
+			return stopPreRuntimeOrchestrationWithCause(receipt, preRuntimeStageOrder[0], runErr)
+		}
+		return stopPreRuntimeOrchestrationWithCause(receipt, preRuntimeStageOrder[0], appendErr)
+	}
+	if appendErr != nil {
+		return stopPreRuntimeOrchestrationWithCause(receipt, preRuntimeStageOrder[0], appendErr)
 	}
 	if err := ctx.Err(); err != nil {
 		return stopPreRuntimeOrchestration(receipt, preRuntimeStageOrder[1])
@@ -142,4 +150,12 @@ func appendPreRuntimeCheckpoint(receipt *PreRuntimeOrchestrationReceipt, expecte
 func stopPreRuntimeOrchestration(receipt PreRuntimeOrchestrationReceipt, stageID string) (PreRuntimeOrchestrationReceipt, error) {
 	receipt.State, receipt.StoppedAt = "STOPPED", stageID
 	return receipt, errors.New("pre-runtime orchestration stopped at " + stageID)
+}
+
+func stopPreRuntimeOrchestrationWithCause(receipt PreRuntimeOrchestrationReceipt, stageID string, cause error) (PreRuntimeOrchestrationReceipt, error) {
+	receipt.State, receipt.StoppedAt = "STOPPED", stageID
+	if cause == nil {
+		return receipt, errors.New("pre-runtime orchestration stopped at " + stageID)
+	}
+	return receipt, fmt.Errorf("pre-runtime orchestration stopped at %s: %w", stageID, cause)
 }

--- a/internal/runner/pre_runtime_orchestrator_test.go
+++ b/internal/runner/pre_runtime_orchestrator_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/openkubes/ok-cluster/internal/execution"
@@ -123,6 +124,18 @@ func TestPreRuntimeOrchestrationStopsWithoutRetry(t *testing.T) {
 				t.Fatalf("stages were retried or invoked after stop: %v", calls)
 			}
 		})
+	}
+}
+
+func TestPreRuntimeOrchestrationPreservesProviderFailureCause(t *testing.T) {
+	orchestration := successfulPreRuntimeOrchestration(nil)
+	orchestration.RunProviderPrerequisites = func(context.Context) (execution.StagedOperationReceipt, error) {
+		return execution.StagedOperationReceipt{}, errors.New("safe provider authorization cause")
+	}
+	receipt, err := orchestration.Run(context.Background())
+	if err == nil || receipt.State != "STOPPED" || receipt.StoppedAt != "provider-prerequisites" ||
+		!strings.Contains(err.Error(), "safe provider authorization cause") {
+		t.Fatalf("provider failure cause was not preserved: %#v err=%v", receipt, err)
 	}
 }
 

--- a/internal/runner/stage_authorization_http_resolver.go
+++ b/internal/runner/stage_authorization_http_resolver.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -144,8 +145,11 @@ func (resolver *StageAuthorizationHTTPResolver) resolve(ctx context.Context, req
 	}
 	defer response.Body.Close()
 	grantRaw, readErr := io.ReadAll(io.LimitReader(response.Body, maximumStageAuthorizationHTTPResponseBytes+1))
+	if response.StatusCode != http.StatusCreated {
+		return StageAuthorizationSource{}, fmt.Errorf("stage authorization authority returned HTTP %d", response.StatusCode)
+	}
 	if readErr != nil || len(grantRaw) == 0 || len(grantRaw) > maximumStageAuthorizationHTTPResponseBytes ||
-		response.StatusCode != http.StatusCreated || response.Header.Get("Content-Type") != stageAuthorizationResponseMediaType {
+		response.Header.Get("Content-Type") != stageAuthorizationResponseMediaType {
 		return StageAuthorizationSource{}, errors.New("stage authorization authority response is not accepted")
 	}
 	file, err := os.OpenFile(outputPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)

--- a/internal/runner/stage_authorization_http_resolver_test.go
+++ b/internal/runner/stage_authorization_http_resolver_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -80,6 +81,36 @@ func TestStageAuthorizationHTTPResolverRequestsAndPersistsExactGrant(t *testing.
 	defer mu.Unlock()
 	if requests != 1 {
 		t.Fatalf("authority requests=%d, want 1", requests)
+	}
+}
+
+func TestStageAuthorizationHTTPResolverReportsOnlySafeHTTPStatus(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(response http.ResponseWriter, _ *http.Request) {
+		response.WriteHeader(http.StatusForbidden)
+		_, _ = response.Write([]byte("sensitive authority detail"))
+	}))
+	defer server.Close()
+	root := t.TempDir()
+	if err := os.Chmod(root, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	publicKey, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolver, err := OpenStageAuthorizationHTTPResolver(StageAuthorizationHTTPResolverConfig{
+		Endpoint: server.URL + "/v1/stage-authorizations", TokenFile: writeBundleFile(t, root, "token", []byte("authority-token")),
+		CAFile:          writeRuntimeBindingServerCA(t, root, "ca.crt", server),
+		PublicKeyPath:   writeBundleFile(t, root, "authority.pub", []byte(base64.StdEncoding.EncodeToString(publicKey)+"\n")),
+		OutputDirectory: root, Clock: time.Now,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	requestDigest := "sha256:" + strings.Repeat("a", 64)
+	_, err = resolver.resolve(context.Background(), requestDigest, []byte(`{}`), stageAuthorizationRequestMediaType)
+	if err == nil || !strings.Contains(err.Error(), "HTTP 403") || strings.Contains(err.Error(), "sensitive authority detail") || strings.Contains(err.Error(), server.URL) {
+		t.Fatalf("unsafe or incomplete HTTP error: %v", err)
 	}
 }
 

--- a/internal/runner/stage_authorization_resolver.go
+++ b/internal/runner/stage_authorization_resolver.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"regexp"
 	"strings"
 	"time"
@@ -167,7 +168,7 @@ func ResolveStageAuthorization(ctx context.Context, resume StageResumeConfig, re
 	}
 	source, err := resolver.ResolveStageAuthorization(ctx, cloneStageAuthorizationRequest(request))
 	if err != nil {
-		return ResolvedStageAuthorization{}, errors.New("resolve stage authorization")
+		return ResolvedStageAuthorization{}, fmt.Errorf("resolve stage authorization: %w", err)
 	}
 	if err := ctx.Err(); err != nil {
 		return ResolvedStageAuthorization{}, errors.New("stage authorization context became unavailable")


### PR DESCRIPTION
## Summary
- surface redaction-safe Stage Authority HTTP status through provider-prerequisites and full-run orchestration
- retain STOPPED receipts and completed provider checkpoints
- prove response bodies and authority endpoints never enter the error

## Evidence
- `CGO_ENABLED=0 go test ./...` PASS
- R6 and R7 tokens match the normalized live authority token; both failed with the same previously generic error

## Safety
- code-only checkpoint
- no cluster mutation
- no raw evidence, tokens, endpoints, or credentials
