### PR TITLE
fix(runner): allow exact Stage Authority pod egress

### DIFF
--- a/deploy/contract-executor-full-run-job.yaml.tpl
+++ b/deploy/contract-executor-full-run-job.yaml.tpl
@@ -18,7 +18,11 @@ spec:
       ports: [{protocol: TCP, port: ${OK147_WORKLOAD_API_PORT}}]
     - to: [{ipBlock: {cidr: "${OK147_ARGO_API_CIDR}"}}]
       ports: [{protocol: TCP, port: ${OK147_ARGO_API_PORT}}]
-    - to: [{ipBlock: {cidr: "${OK147_AUTHORIZATION_API_CIDR}"}}]
+    - to:
+        - ipBlock: {cidr: "${OK147_AUTHORIZATION_API_CIDR}"}
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: ok147-stage-authority
       ports: [{protocol: TCP, port: ${OK147_AUTHORIZATION_API_PORT}}]
     - to: [{ipBlock: {cidr: "${OK147_COLLECTOR_API_CIDR}"}}]
       ports: [{protocol: TCP, port: ${OK147_COLLECTOR_API_PORT}}]

--- a/deploy/contract-executor-post-runtime-job.yaml.tpl
+++ b/deploy/contract-executor-post-runtime-job.yaml.tpl
@@ -16,7 +16,11 @@ spec:
       ports: [{protocol: TCP, port: ${OK147_WORKLOAD_API_PORT}}]
     - to: [{ipBlock: {cidr: "${OK147_ARGO_API_CIDR}"}}]
       ports: [{protocol: TCP, port: ${OK147_ARGO_API_PORT}}]
-    - to: [{ipBlock: {cidr: "${OK147_AUTHORIZATION_API_CIDR}"}}]
+    - to:
+        - ipBlock: {cidr: "${OK147_AUTHORIZATION_API_CIDR}"}
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: ok147-stage-authority
       ports: [{protocol: TCP, port: ${OK147_AUTHORIZATION_API_PORT}}]
 ---
 apiVersion: batch/v1

--- a/internal/runner/full_run_job_test.go
+++ b/internal/runner/full_run_job_test.go
@@ -96,14 +96,33 @@ func TestRenderFullRunExecutionJobTemplateIsolatesExecutorAndEvidenceAuthority(t
 	if evidenceSecret["secretName"] != values.EvidenceAuthoritySecret || len(arrayAt(t, evidenceSecret, "items")) != 4 {
 		t.Fatalf("evidence authority projection differs: %#v", evidenceSecret)
 	}
-	if egress := arrayAt(t, objectAt(t, objects["NetworkPolicy"], "spec"), "egress"); len(egress) != 6 {
+	egress := arrayAt(t, objectAt(t, objects["NetworkPolicy"], "spec"), "egress")
+	if len(egress) != 6 {
 		t.Fatalf("full-run egress is not exact: %#v", egress)
 	}
+	assertStageAuthorityEgressPeers(t, egress[4].(map[string]any), values.AuthorizationAPICIDR)
 	text := string(raw)
 	for _, forbidden := range []string{"latest", "system:masters", "privileged: true", "automountServiceAccountToken: true", "restartPolicy: Always"} {
 		if strings.Contains(text, forbidden) {
 			t.Fatalf("full-run Job contains forbidden value %q", forbidden)
 		}
+	}
+}
+
+func assertStageAuthorityEgressPeers(t *testing.T, rule map[string]any, authorizationCIDR string) {
+	t.Helper()
+	peers := arrayAt(t, rule, "to")
+	if len(peers) != 2 {
+		t.Fatalf("stage authority egress peers differ: %#v", peers)
+	}
+	ipBlock := objectAt(t, peers[0].(map[string]any), "ipBlock")
+	if ipBlock["cidr"] != authorizationCIDR {
+		t.Fatalf("stage authority Service CIDR differs: %#v", ipBlock)
+	}
+	podSelector := objectAt(t, peers[1].(map[string]any), "podSelector")
+	labels := objectAt(t, podSelector, "matchLabels")
+	if !reflect.DeepEqual(labels, map[string]any{"app.kubernetes.io/name": "ok147-stage-authority"}) {
+		t.Fatalf("stage authority Pod selector differs: %#v", labels)
 	}
 }
 

--- a/internal/runner/post_runtime_job_test.go
+++ b/internal/runner/post_runtime_job_test.go
@@ -74,6 +74,7 @@ func TestRenderPostRuntimeExecutionJobTemplateBindsPrivateInitAndSingleExecution
 	if len(egress) != 4 {
 		t.Fatalf("post-runtime Job egress is not exact: %#v", egress)
 	}
+	assertStageAuthorityEgressPeers(t, egress[3].(map[string]any), values.AuthorizationAPICIDR)
 	text := string(raw)
 	for _, forbidden := range []string{"latest", "system:masters", "privileged: true", "automountServiceAccountToken: true", "restartPolicy: Always"} {
 		if strings.Contains(text, forbidden) {


### PR DESCRIPTION
## Outcome\n\nAllows the bounded executor to reach the exact Stage Authority backend after Service DNAT while retaining the existing Service-VIP binding.\n\n## Scope\n\n- add same-namespace podSelector for app.kubernetes.io/name=ok147-stage-authority\n- keep the exact authorization Service CIDR and port\n- apply consistently to full-run and post-runtime jobs\n- add semantic regression assertions\n\n## Validation\n\n- CGO_ENABLED=0 go test ./internal/runner\n- CGO_ENABLED=0 go test ./...\n\nNo live mutation or R8 cleanup is included.