### PR TITLE
fix(runner): bind provider access only to lifecycle stage

### DIFF
--- a/internal/runner/pre_runtime_execution.go
+++ b/internal/runner/pre_runtime_execution.go
@@ -450,7 +450,7 @@ func defaultPreRuntimeExecutionFactories() preRuntimeExecutionFactories {
 				ExpectedStageID: stageID, PlanPath: resume.PlanPath, PlanExpected: resume.PlanExpected, Receipts: resume.Receipts,
 				GrantPath: grant.GrantPath, GrantPublicKeyPath: grant.PublicKeyPath, EvaluationTime: grant.EvaluationTime,
 				ProjectionManifestPath: config.ProjectionManifestPath, ProjectionRoot: config.ProjectionRoot,
-				ProviderAccessPolicyPath: config.ProviderAccessPolicyPath,
+				ProviderAccessPolicyPath: preRuntimeProviderAccessPolicyPath(stageID, config.ProviderAccessPolicyPath),
 			})
 			if err != nil {
 				return preRuntimeStagedInvocation{}, err
@@ -545,6 +545,13 @@ func defaultPreRuntimeExecutionFactories() preRuntimeExecutionFactories {
 			return material.Persist(path)
 		},
 	}
+}
+
+func preRuntimeProviderAccessPolicyPath(stageID, path string) string {
+	if stageID == "cluster-lifecycle" {
+		return path
+	}
+	return ""
 }
 
 func stoppedPreRuntimeExecutionReceipt(stageID string, checkpoints []PreRuntimeStageCheckpoint, authorizations []ResolvedStageAuthorizationReceipt) PreRuntimeExecutionReceipt {

--- a/internal/runner/pre_runtime_execution_test.go
+++ b/internal/runner/pre_runtime_execution_test.go
@@ -453,3 +453,22 @@ func minInt(first, second int) int {
 	}
 	return second
 }
+
+func TestPreRuntimeProviderAccessPolicyIsBoundOnlyToClusterLifecycle(t *testing.T) {
+	const path = "/private/provider-access-policy.json"
+	for _, test := range []struct {
+		stageID string
+		want    string
+	}{
+		{stageID: "provider-prerequisites", want: ""},
+		{stageID: "cluster-lifecycle", want: path},
+		{stageID: "enablement", want: ""},
+		{stageID: "target-access", want: ""},
+	} {
+		t.Run(test.stageID, func(t *testing.T) {
+			if got := preRuntimeProviderAccessPolicyPath(test.stageID, path); got != test.want {
+				t.Fatalf("provider-access path differs: got %q want %q", got, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Outcome

Fixes the OK-147 R9 fail-closed stop at `provider-prerequisites` by passing the provider-access policy only to `cluster-lifecycle`, the stage that binds `stage.provider-access`.

## Evidence

- Focused pre-runtime/full-run regression tests: PASS
- `go test ./...` in `golang:1.24.6-bookworm` as unprivileged UID: PASS
- No private runtime evidence or credentials included

The stopped R9 runtime remains preserved; this PR performs no infrastructure mutation.