### PR TITLE
feat(runner): bind execution attempts across stage protocol

### DIFF
--- a/cmd/ok/full_run.go
+++ b/cmd/ok/full_run.go
@@ -307,7 +307,7 @@ func runClusterStageRunFullPrepare(arguments []string, stdout, stderr io.Writer)
 	if err != nil {
 		return err
 	}
-	if manifest.Format != runner.FullRunExecutionManifestReceiptFormat || manifest.State != "VERIFIED" || manifest.MutationAllowed {
+	if !validFullRunManifestReceiptFormat(manifest.Format) || manifest.State != "VERIFIED" || manifest.MutationAllowed {
 		return errors.New("full-run manifest preparation did not verify")
 	}
 	receipt := runner.FullRunExecutionActivationReceipt{
@@ -375,7 +375,7 @@ func runClusterStageRunFullExecute(ctx context.Context, arguments []string, stdo
 	if err != nil {
 		return fmt.Errorf("prepare full-run manifest: %w", err)
 	}
-	if verified.Format != runner.FullRunExecutionManifestReceiptFormat || verified.State != "VERIFIED" || verified.MutationAllowed {
+	if !validFullRunManifestReceiptFormat(verified.Format) || verified.State != "VERIFIED" || verified.MutationAllowed {
 		return errors.New("full-run manifest preparation did not produce a verified identity")
 	}
 	if verified.ManifestDigest != *expectedManifestDigest {
@@ -402,4 +402,8 @@ func runClusterStageRunFullExecute(ctx context.Context, arguments []string, stdo
 		return err
 	}
 	return runErr
+}
+
+func validFullRunManifestReceiptFormat(format string) bool {
+	return format == runner.FullRunExecutionManifestReceiptFormat || format == runner.FullRunExecutionManifestReceiptFormatV2
 }

--- a/cmd/ok/main.go
+++ b/cmd/ok/main.go
@@ -292,7 +292,7 @@ type stageBundleFlags struct {
 	expectedStage                                                 *string
 	planPath, contractNamespace, contractName                     *string
 	intentRevision, enablementRevision, platformRevision          *string
-	executionFixture                                              *string
+	executionFixture, executionAttempt                            *string
 	infrastructureAuthority, managementAuthority, gitOpsAuthority *string
 	grantPath, grantKeyPath, projectionManifest, projectionRoot   *string
 	evaluationTime                                                *string
@@ -303,7 +303,7 @@ type stageBundleFlags struct {
 type stageResumeFlags struct {
 	planPath, contractNamespace, contractName                     *string
 	intentRevision, enablementRevision, platformRevision          *string
-	executionFixture                                              *string
+	executionFixture, executionAttempt                            *string
 	infrastructureAuthority, managementAuthority, gitOpsAuthority *string
 	receipts                                                      receiptFlags
 	receiptPrefix, receiptPrefixDigest                            *string
@@ -318,6 +318,7 @@ func addStageResumeFlags(flags *flag.FlagSet) *stageResumeFlags {
 	values.enablementRevision = flags.String("enablement-revision", "", "expected Enablement revision E")
 	values.platformRevision = flags.String("platform-revision", "", "expected Platform revision P")
 	values.executionFixture = flags.String("execution-fixture", "", "expected execution FixtureDigest")
+	values.executionAttempt = flags.String("execution-attempt-digest", "", "expected execution-attempt digest for plan v2")
 	values.infrastructureAuthority = flags.String("infrastructure-authority", "", "expected infrastructure authority identity")
 	values.managementAuthority = flags.String("management-authority", "", "expected management authority identity")
 	values.gitOpsAuthority = flags.String("gitops-authority", "", "expected GitOps authority identity")
@@ -365,6 +366,7 @@ func (values *stageResumeFlags) config() (runner.StageResumeConfig, error) {
 			ContractIdentity: contract.Identity{Namespace: *values.contractNamespace, Name: *values.contractName},
 			IntentRevision:   *values.intentRevision, EnablementRevision: *values.enablementRevision,
 			PlatformRevision: *values.platformRevision, ExecutionFixture: *values.executionFixture,
+			ExecutionAttemptDigest:  *values.executionAttempt,
 			InfrastructureAuthority: *values.infrastructureAuthority, ManagementAuthority: *values.managementAuthority, GitOpsAuthority: *values.gitOpsAuthority,
 		},
 		Receipts: receipts,
@@ -381,6 +383,7 @@ func addStageBundleFlags(flags *flag.FlagSet) *stageBundleFlags {
 	values.enablementRevision = flags.String("enablement-revision", "", "expected Enablement revision E")
 	values.platformRevision = flags.String("platform-revision", "", "expected Platform revision P")
 	values.executionFixture = flags.String("execution-fixture", "", "expected execution FixtureDigest")
+	values.executionAttempt = flags.String("execution-attempt-digest", "", "expected execution-attempt digest for plan v2")
 	values.infrastructureAuthority = flags.String("infrastructure-authority", "", "expected infrastructure authority identity")
 	values.managementAuthority = flags.String("management-authority", "", "expected management authority identity")
 	values.gitOpsAuthority = flags.String("gitops-authority", "", "expected GitOps authority identity")
@@ -442,6 +445,7 @@ func (values *stageBundleFlags) config() (runner.SubmissionStageBundleConfig, er
 			ContractIdentity: contract.Identity{Namespace: *values.contractNamespace, Name: *values.contractName},
 			IntentRevision:   *values.intentRevision, EnablementRevision: *values.enablementRevision,
 			PlatformRevision: *values.platformRevision, ExecutionFixture: *values.executionFixture,
+			ExecutionAttemptDigest:  *values.executionAttempt,
 			InfrastructureAuthority: *values.infrastructureAuthority, ManagementAuthority: *values.managementAuthority, GitOpsAuthority: *values.gitOpsAuthority,
 		},
 		Receipts: receipts, GrantPath: *values.grantPath, GrantPublicKeyPath: *values.grantKeyPath,
@@ -693,6 +697,9 @@ func runContext(ctx context.Context, arguments []string, stdout, stderr io.Write
 	if len(arguments) >= 3 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "inspect" {
 		return runClusterStageInspect(arguments[3:], stdout, stderr)
 	}
+	if len(arguments) >= 4 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "attempt" && arguments[3] == "verify" {
+		return runClusterStageAttemptVerify(arguments[4:], stdout, stderr)
+	}
 	if len(arguments) >= 3 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "resume" {
 		return runClusterStageResume(arguments[3:], stdout, stderr)
 	}
@@ -843,7 +850,7 @@ func runContext(ctx context.Context, arguments []string, stdout, stderr io.Write
 	if len(arguments) >= 4 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "launch" && arguments[3] == "execute" {
 		return runClusterStageLaunchExecute(ctx, arguments[4:], stdout, stderr)
 	}
-	return errors.New("usage: ok authority stage policy ... | ok authority stage package ... | ok authority stage materialize ... | ok authority stage launch prepare ... | ok authority stage launch execute ... | ok authority stage serve ... | ok evidence observability serve ... | ok cluster create ... | ok cluster stage inspect ... | ok cluster stage resume ... | ok cluster stage receipt materialize ... | ok cluster stage observe lifecycle ... | ok cluster stage observe network ... | ok cluster stage observe platform ... | ok cluster stage evaluate aggregate ... | ok cluster stage evidence observability identity materialize ... | ok cluster stage evidence observability authority materialize ... | ok cluster stage evidence observability collector package ... | ok cluster stage evidence observability collector launch prepare ... | ok cluster stage evidence observability collector launch execute ... | ok cluster stage evidence observability collector materialize ... | ok cluster stage evidence observability produce ... | ok cluster stage bind runtime ... | ok cluster stage bind runtime launch prepare ... | ok cluster stage bind runtime launch execute ... | ok cluster stage observe network package ... | ok cluster stage observe network launch prepare ... | ok cluster stage observe network launch execute ... | ok cluster stage observe lifecycle package ... | ok cluster stage observe lifecycle launch prepare ... | ok cluster stage observe lifecycle launch execute ... | ok cluster stage run ... | ok cluster stage run full bind-v3 ... | ok cluster stage run full prepare ... | ok cluster stage run full package ... | ok cluster stage run full launch prepare ... | ok cluster stage run full launch execute ... | ok cluster stage run full materialize ... | ok cluster stage run full execute ... | ok cluster stage run enablement ... | ok cluster stage run target-access ... | ok cluster stage run platform-applications ... | ok cluster stage run post-runtime package ... | ok cluster stage run post-runtime materialize ... | ok cluster stage run post-runtime launch prepare ... | ok cluster stage run post-runtime launch execute ... | ok cluster stage run post-runtime prepare ... | ok cluster stage run post-runtime execute ... | ok cluster stage run aggregate-evidence launch prepare ... | ok cluster stage run aggregate-evidence launch execute ... | ok cluster stage run enablement package ... | ok cluster stage run enablement launch prepare ... | ok cluster stage run enablement launch execute ... | ok cluster stage package ... | ok cluster stage launch prepare ... | ok cluster stage launch execute ...")
+	return errors.New("usage: ok authority stage policy ... | ok authority stage package ... | ok authority stage materialize ... | ok authority stage launch prepare ... | ok authority stage launch execute ... | ok authority stage serve ... | ok evidence observability serve ... | ok cluster create ... | ok cluster stage attempt verify ... | ok cluster stage inspect ... | ok cluster stage resume ... | ok cluster stage receipt materialize ... | ok cluster stage observe lifecycle ... | ok cluster stage observe network ... | ok cluster stage observe platform ... | ok cluster stage evaluate aggregate ... | ok cluster stage evidence observability identity materialize ... | ok cluster stage evidence observability authority materialize ... | ok cluster stage evidence observability collector package ... | ok cluster stage evidence observability collector launch prepare ... | ok cluster stage evidence observability collector launch execute ... | ok cluster stage evidence observability collector materialize ... | ok cluster stage evidence observability produce ... | ok cluster stage bind runtime ... | ok cluster stage bind runtime launch prepare ... | ok cluster stage bind runtime launch execute ... | ok cluster stage observe network package ... | ok cluster stage observe network launch prepare ... | ok cluster stage observe network launch execute ... | ok cluster stage observe lifecycle package ... | ok cluster stage observe lifecycle launch prepare ... | ok cluster stage observe lifecycle launch execute ... | ok cluster stage run ... | ok cluster stage run full bind-v3 ... | ok cluster stage run full prepare ... | ok cluster stage run full package ... | ok cluster stage run full launch prepare ... | ok cluster stage run full launch execute ... | ok cluster stage run full materialize ... | ok cluster stage run full execute ... | ok cluster stage run enablement ... | ok cluster stage run target-access ... | ok cluster stage run platform-applications ... | ok cluster stage run post-runtime package ... | ok cluster stage run post-runtime materialize ... | ok cluster stage run post-runtime launch prepare ... | ok cluster stage run post-runtime launch execute ... | ok cluster stage run post-runtime prepare ... | ok cluster stage run post-runtime execute ... | ok cluster stage run aggregate-evidence launch prepare ... | ok cluster stage run aggregate-evidence launch execute ... | ok cluster stage run enablement package ... | ok cluster stage run enablement launch prepare ... | ok cluster stage run enablement launch execute ... | ok cluster stage package ... | ok cluster stage launch prepare ... | ok cluster stage launch execute ...")
 }
 
 func runClusterCreate(arguments []string, stdout, stderr io.Writer) error {

--- a/cmd/ok/main_test.go
+++ b/cmd/ok/main_test.go
@@ -1617,6 +1617,23 @@ func stageInspectArguments() []string {
 	}
 }
 
+func TestStageInspectPropagatesOptionalExecutionAttempt(t *testing.T) {
+	previous := inspectSubmissionStage
+	defer func() { inspectSubmissionStage = previous }()
+	var captured runner.SubmissionStageBundleConfig
+	inspectSubmissionStage = func(config runner.SubmissionStageBundleConfig) (stageInspection, error) {
+		captured = config
+		return stageInspection{Format: "ok147-stage-inspection/v1", Decision: stagecursor.Decision{Format: stagecursor.DecisionFormat, State: "NEXT"}, AuthorizationState: "VERIFIED"}, nil
+	}
+	arguments := append(stageInspectArguments(), "--execution-attempt-digest", testSHA("e"))
+	if err := run(arguments, &bytes.Buffer{}, &bytes.Buffer{}); err != nil {
+		t.Fatal(err)
+	}
+	if captured.PlanExpected.ExecutionAttemptDigest != testSHA("e") {
+		t.Fatalf("execution attempt was not propagated: %#v", captured.PlanExpected)
+	}
+}
+
 func stageResumeArguments() []string {
 	return []string{
 		"cluster", "stage", "resume",

--- a/cmd/ok/stage_attempt.go
+++ b/cmd/ok/stage_attempt.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"io"
+	"os"
+
+	"github.com/openkubes/ok-cluster/internal/stageattempt"
+)
+
+const maximumExecutionAttemptBytes = 64 * 1024
+
+func runClusterStageAttemptVerify(arguments []string, stdout, stderr io.Writer) error {
+	flags := flag.NewFlagSet("ok cluster stage attempt verify", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	path := flags.String("attempt", "", "strict redaction-safe execution-attempt document")
+	attemptID := flags.String("attempt-id", "", "independently expected attempt identifier")
+	sourceFixture := flags.String("source-fixture-digest", "", "independently expected source FixtureDigest")
+	sourcePlan := flags.String("source-plan-semantic-digest", "", "independently expected source plan identity")
+	runnerImage := flags.String("runner-image", "", "independently expected digest-pinned runner image")
+	activationPackage := flags.String("activation-package-digest", "", "independently expected activation package digest")
+	predecessorAttempt := flags.String("predecessor-attempt-digest", "", "expected predecessor attempt for recovery")
+	stoppedEvidence := flags.String("stopped-evidence-digest", "", "expected stopped evidence for recovery")
+	decisionWindow := flags.String("decision-window-digest", "", "independently expected decision-window identity")
+	if err := flags.Parse(arguments); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return errors.New("positional arguments are not accepted")
+	}
+	for _, value := range []string{*path, *attemptID, *sourceFixture, *sourcePlan, *runnerImage, *activationPackage, *decisionWindow} {
+		if value == "" {
+			return errors.New("all non-recovery execution-attempt inputs are required")
+		}
+	}
+	info, err := os.Lstat(*path)
+	if err != nil || !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 || info.Size() <= 0 || info.Size() > maximumExecutionAttemptBytes {
+		return errors.New("execution-attempt document metadata is invalid")
+	}
+	raw, err := os.ReadFile(*path)
+	if err != nil || len(raw) > maximumExecutionAttemptBytes {
+		return errors.New("read bounded execution-attempt document")
+	}
+	receipt, err := stageattempt.Verify(raw, stageattempt.Expected{
+		AttemptID: *attemptID, SourceFixtureDigest: *sourceFixture, SourcePlanSemanticDigest: *sourcePlan,
+		RunnerImage: *runnerImage, ActivationPackageDigest: *activationPackage,
+		PredecessorAttemptDigest: *predecessorAttempt, StoppedEvidenceDigest: *stoppedEvidence,
+		DecisionWindowDigest: *decisionWindow,
+	})
+	if err != nil {
+		return err
+	}
+	encoder := json.NewEncoder(stdout)
+	encoder.SetEscapeHTML(false)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(receipt)
+}

--- a/cmd/ok/stage_attempt_test.go
+++ b/cmd/ok/stage_attempt_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/openkubes/ok-cluster/internal/stageattempt"
+)
+
+func TestClusterStageAttemptVerifyEmitsNonAuthorizingIdentity(t *testing.T) {
+	document := map[string]any{
+		"format": stageattempt.Format, "attemptId": "ok147-full-run-r11",
+		"sourceFixtureDigest": testSHA("1"), "sourcePlanSemanticDigest": testSHA("2"),
+		"runnerImage":             "ghcr.io/openkubes/ok-cluster-runner@" + testSHA("3"),
+		"activationPackageDigest": testSHA("4"), "mode": stageattempt.Mode,
+		"predecessorAttemptDigest": testSHA("5"), "stoppedEvidenceDigest": testSHA("6"),
+		"decisionWindowDigest": testSHA("7"), "maxAttempts": 1,
+	}
+	raw, _ := json.Marshal(document)
+	path := filepath.Join(t.TempDir(), "attempt.json")
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	arguments := []string{
+		"cluster", "stage", "attempt", "verify", "--attempt", path, "--attempt-id", "ok147-full-run-r11",
+		"--source-fixture-digest", testSHA("1"), "--source-plan-semantic-digest", testSHA("2"),
+		"--runner-image", "ghcr.io/openkubes/ok-cluster-runner@" + testSHA("3"), "--activation-package-digest", testSHA("4"),
+		"--predecessor-attempt-digest", testSHA("5"), "--stopped-evidence-digest", testSHA("6"), "--decision-window-digest", testSHA("7"),
+	}
+	var stdout bytes.Buffer
+	if err := run(arguments, &stdout, &bytes.Buffer{}); err != nil {
+		t.Fatal(err)
+	}
+	var receipt stageattempt.Receipt
+	if err := json.Unmarshal(stdout.Bytes(), &receipt); err != nil || receipt.State != "VERIFIED" || receipt.MutationAllowed || receipt.ExecutionAttemptDigest == "" {
+		t.Fatalf("unexpected attempt receipt: %#v %v", receipt, err)
+	}
+	if err := run(removeArgumentWithValue(arguments, "--stopped-evidence-digest"), &bytes.Buffer{}, &bytes.Buffer{}); err == nil {
+		t.Fatal("incomplete recovery lineage was accepted")
+	}
+}

--- a/cmd/ok/stage_authority.go
+++ b/cmd/ok/stage_authority.go
@@ -122,6 +122,7 @@ func runAuthorityStagePolicy(arguments []string, stdout, stderr io.Writer) error
 	enablementRevision := flags.String("enablement-revision", "", "expected Enablement revision E")
 	platformRevision := flags.String("platform-revision", "", "expected Platform revision P")
 	executionFixture := flags.String("execution-fixture", "", "expected execution FixtureDigest")
+	executionAttempt := flags.String("execution-attempt-digest", "", "expected execution-attempt digest for plan v2")
 	infrastructureAuthority := flags.String("infrastructure-authority", "", "expected infrastructure authority")
 	managementAuthority := flags.String("management-authority", "", "expected management authority")
 	gitOpsAuthority := flags.String("gitops-authority", "", "expected GitOps authority")
@@ -144,6 +145,7 @@ func runAuthorityStagePolicy(arguments []string, stdout, stderr io.Writer) error
 		ContractIdentity: contract.Identity{Namespace: *contractNamespace, Name: *contractName},
 		IntentRevision:   *intentRevision, EnablementRevision: *enablementRevision,
 		PlatformRevision: *platformRevision, ExecutionFixture: *executionFixture,
+		ExecutionAttemptDigest:  *executionAttempt,
 		InfrastructureAuthority: *infrastructureAuthority, ManagementAuthority: *managementAuthority, GitOpsAuthority: *gitOpsAuthority,
 	})
 	if err != nil {

--- a/docs/contract-executor-mvp.md
+++ b/docs/contract-executor-mvp.md
@@ -762,10 +762,18 @@ provider prerequisites (ok-infra)
 
 The runner therefore verifies a strict twelve-stage
 `ok147-staged-execution-plan/v1` document before any future orchestration can
-use it. The plan binds `R`, `E`, `P`, `FixtureDigest`, the distinct
+use it. The additive `ok147-staged-execution-plan/v2` additionally binds one
+verified `ExecutionAttemptDigest`, allowing a separately reviewed new attempt
+without deleting historical single-use claims. The plan binds `R`, `E`, `P`, `FixtureDigest`, the distinct
 infrastructure, management and GitOps authorities, exact stage dependencies,
 one immutable input set per stage and a separate operation name for every
 mutating stage. Its canonical digest identifies the complete experiment.
+
+Plan v1 rejects an attempt field. Plan v2 requires the exact independently
+verified attempt digest; that identity flows through authority policy v2,
+authorization request and grant v2, full-run manifest v4 and their receipts.
+Same-attempt replay remains rejected, while a new reviewed attempt produces a
+new PlanDigest and request identity. There is no automatic retry or claim reset.
 
 The plan must remain `authorizationState: NO-GO`; it is never a grant. It
 contains no manifest content, credentials, endpoints, commands or rendering

--- a/docs/ok147-bounded-stage-authority.md
+++ b/docs/ok147-bounded-stage-authority.md
@@ -23,6 +23,7 @@ plan:
 ```text
 verified Plan
     -> exact R / E / P / FixtureDigest
+    -> exact ExecutionAttemptDigest for plan v2
     -> exact mutating stage identities and digests
     -> bounded authority policy
 ```
@@ -47,6 +48,12 @@ Invalid credentials, changed identities, non-canonical JSON, unsupported media
 types and replay fail closed. A claim is never removed automatically. There is
 no retry, rollback, cleanup, Kubernetes credential or generic proxy surface.
 
+The additive v2 protocol permits a separately reviewed new execution attempt
+without resetting that claim. The canonical attempt digest is part of plan v2,
+the authority policy, request identity and signed grant. Replaying the same
+attempt still returns HTTP 409; a foreign or unbound attempt fails before a
+claim is written. Historical v1 policy and claim evidence is not reinterpreted.
+
 The first implementation deliberately rejects target-credential and
 target-registration recovery media types. Recovery requires a separate policy
 checkpoint and must not inherit normal-stage authorization implicitly.
@@ -65,6 +72,7 @@ ok authority stage policy \
   --enablement-revision sha256:<E> \
   --platform-revision sha256:<P> \
   --execution-fixture sha256:<FixtureDigest> \
+  --execution-attempt-digest sha256:<ExecutionAttemptDigest> \
   --infrastructure-authority ok-infra \
   --management-authority ok-mgmt \
   --gitops-authority ok-shared \

--- a/docs/ok147-execution-attempt-v2-implementation.md
+++ b/docs/ok147-execution-attempt-v2-implementation.md
@@ -1,0 +1,93 @@
+# OK-147 execution-attempt v2 implementation checkpoint
+
+## Outcome
+
+The R10 stop exposed a correct but incomplete boundary: the stage authority
+durably rejected a second Stage-1 request whose deterministic request digest
+had already been claimed by R9. This checkpoint implements the selected
+additive recovery model without deleting or resetting any historical claim.
+
+```text
+historical plan v1 + consumed claim
+        -> remains immutable and replay-protected
+
+verified execution-attempt document
+        -> ExecutionAttemptDigest
+        -> staged plan v2 / new PlanDigest
+        -> authority policy v2
+        -> request + signed grant v2
+        -> isolated single-use claim identity
+```
+
+No Kubernetes API was contacted and no infrastructure object was changed.
+
+## Attempt identity
+
+`ok147-execution-attempt/v1` is a strict, redaction-safe document that binds:
+
+- an explicit attempt identifier;
+- source FixtureDigest and source staged-plan semantic identity;
+- an immutable runner image;
+- the activation-package digest;
+- the exact `create-converge-observe/v1` mode;
+- predecessor-attempt and stopped-evidence digests together for recovery;
+- a decision-window digest; and
+- `maxAttempts: 1`.
+
+The verifier accepts only independently supplied expected identities. It
+canonicalizes the document and returns `ExecutionAttemptDigest`; the document
+is not a grant and its receipt has `mutationAllowed: false`.
+
+## Additive protocol formats
+
+The implementation adds these formats while preserving every v1 format:
+
+```text
+ok147-staged-execution-plan/v2
+ok147-verified-staged-execution-plan/v2
+ok147-bounded-stage-authority-policy/v2
+ok147-stage-authorization-request/v2
+ok147-stage-authorization/v2
+ok147-full-run-execution-manifest/v4
+```
+
+Their redaction-safe receipts also carry `executionAttemptDigest`. A v1 plan,
+policy, request or full-run manifest rejects an attempt field. A v2 plan or v4
+full-run manifest rejects a missing, malformed or foreign attempt identity.
+
+The command-line stage and authority-policy boundaries accept the optional
+`--execution-attempt-digest` expected input. It must be absent for plan v1 and
+must exactly match plan v2.
+
+## Proven behavior
+
+Offline tests establish:
+
+1. equivalent attempt documents produce the same digest;
+2. a changed bound runner identity produces a different digest;
+3. incomplete recovery lineage, mutable runner images and `maxAttempts != 1`
+   fail closed;
+4. a changed attempt produces a different PlanDigest, policy and request;
+5. the signed grant carries the same attempt identity;
+6. same-attempt replay remains HTTP 409;
+7. a request from another attempt is rejected;
+8. predecessor receipts remain PlanDigest-bound, preventing cross-attempt
+   receipt splicing; and
+9. historical plan-v1 and full-run-v3 fixtures remain accepted only with no
+   attempt field.
+
+## Classification
+
+```text
+Attempt recovery mechanism: implemented offline
+Historical claims:          retained
+Automatic retry:            absent
+Claim reset/delete:         absent
+RequiresReconciler:         no
+Infrastructure mutation:    none
+Next full-run attempt:      NOT GRANTED
+```
+
+The next live step requires a reviewed attempt document, plan v2, authority
+policy v2, full-run manifest v4, a freshly published runner image and a new
+explicit launch checkpoint.

--- a/docs/ok147-stage-attempt-recovery-evaluation.md
+++ b/docs/ok147-stage-attempt-recovery-evaluation.md
@@ -169,6 +169,9 @@ checkpoint.
 
 ## Implementation checkpoint
 
+Implemented by the additive checkpoint documented in
+[`ok147-execution-attempt-v2-implementation.md`](ok147-execution-attempt-v2-implementation.md).
+
 The implementation follow-up must prove offline:
 
 1. identical attempt inputs produce the same `ExecutionAttemptDigest`;
@@ -186,9 +189,9 @@ The implementation follow-up must prove offline:
 Observed R10 stop:          expected fail-closed replay protection
 Automatic retry:           rejected
 Claim deletion/reset:      rejected as normal recovery
-Attempt identity:          required before another full run
+Attempt identity:          implemented offline
 Selected mechanism:        additive Plan/Policy/Grant v2 binding
 RequiresReconciler:        no
-Infrastructure mutation:   NO-GO
+Infrastructure mutation:   none in implementation checkpoint
 Next full-run attempt:      NOT GRANTED
 ```

--- a/internal/authorization/stage.go
+++ b/internal/authorization/stage.go
@@ -21,6 +21,7 @@ import (
 
 const (
 	StageFormat   = "ok147-stage-authorization/v1"
+	StageFormatV2 = "ok147-stage-authorization/v2"
 	StageAudience = "ok-cluster-staged-executor"
 
 	maximumStageGrantBytes = 128 * 1024
@@ -44,6 +45,7 @@ type StagePayload struct {
 	EnablementRevision string             `json:"enablementRevision"`
 	PlatformRevision   string             `json:"platformRevision"`
 	ExecutionFixture   string             `json:"executionFixture"`
+	ExecutionAttempt   string             `json:"executionAttemptDigest,omitempty"`
 	StageID            string             `json:"stageId"`
 	StageOrder         int                `json:"stageOrder"`
 	StageDigest        string             `json:"stageDigest"`
@@ -80,6 +82,7 @@ type StageReceipt struct {
 	PredecessorDigest   string `json:"predecessorDigest"`
 	NotAfter            string `json:"notAfter"`
 	MaxUses             int    `json:"maxUses"`
+	ExecutionAttempt    string `json:"executionAttemptDigest,omitempty"`
 }
 
 type StageConsumptionBinding struct {
@@ -95,6 +98,7 @@ type StageConsumptionBinding struct {
 	ContractRevision    string
 	NotBefore           string
 	NotAfter            string
+	ExecutionAttempt    string
 }
 
 type VerifiedStageGrant struct {
@@ -130,7 +134,7 @@ func BindStageGrant(grant VerifiedStageGrant, plan stageplan.Binding, expectedSt
 	if err != nil {
 		return StageConsumptionBinding{}, err
 	}
-	if binding.PlanDigest != plan.PlanDigest || binding.StageID != stage.ID || binding.StageDigest != stageDigest || binding.Operation != stage.GrantOperation || binding.Authority != stage.Authority || binding.PredecessorDigest != predecessorDigest || binding.ContractRevision != plan.IntentRevision {
+	if binding.PlanDigest != plan.PlanDigest || binding.StageID != stage.ID || binding.StageDigest != stageDigest || binding.Operation != stage.GrantOperation || binding.Authority != stage.Authority || binding.PredecessorDigest != predecessorDigest || binding.ContractRevision != plan.IntentRevision || binding.ExecutionAttempt != plan.ExecutionAttempt {
 		return StageConsumptionBinding{}, errors.New("verified stage grant differs from the selected stage cursor")
 	}
 	return binding, nil
@@ -165,8 +169,11 @@ func VerifyStage(raw, publicKeyRaw []byte, plan stageplan.Binding, expectedStage
 	if err := jsonstrict.Decode(raw, &document); err != nil {
 		return VerifiedStageGrant{}, fmt.Errorf("decode stage authorization: %w", err)
 	}
-	if document.Format != StageFormat {
+	if document.Format != StageFormat && document.Format != StageFormatV2 {
 		return VerifiedStageGrant{}, fmt.Errorf("stage authorization format %q is not supported", document.Format)
+	}
+	if plan.Format == stageplan.BindingFormat && document.Format != StageFormat || plan.Format == stageplan.BindingFormatV2 && document.Format != StageFormatV2 {
+		return VerifiedStageGrant{}, errors.New("stage authorization format differs from the staged plan")
 	}
 	publicKey, keyID, err := parsePublicKey(publicKeyRaw)
 	if err != nil {
@@ -190,13 +197,18 @@ func VerifyStage(raw, publicKeyRaw []byte, plan stageplan.Binding, expectedStage
 	if err != nil {
 		return VerifiedStageGrant{}, err
 	}
+	receiptFormat := "ok147-stage-authorization-receipt/v1"
+	if document.Format == StageFormatV2 {
+		receiptFormat = "ok147-stage-authorization-receipt/v2"
+	}
 	receipt := StageReceipt{
-		Format: "ok147-stage-authorization-receipt/v1", State: "VERIFIED",
+		Format: receiptFormat, State: "VERIFIED",
 		AuthorizationDigest: digest.SHA256(raw), GrantID: document.Payload.GrantID, KeyID: keyID,
 		PlanDigest: plan.PlanDigest, StageID: stage.ID, StageDigest: stageDigest,
 		Operation: stage.GrantOperation, Authority: stage.Authority,
 		PredecessorDigest: predecessorDigest,
 		NotAfter:          document.Payload.NotAfter, MaxUses: document.Payload.MaxUses,
+		ExecutionAttempt: document.Payload.ExecutionAttempt,
 	}
 	return VerifiedStageGrant{
 		receipt: receipt,
@@ -206,6 +218,7 @@ func VerifyStage(raw, publicKeyRaw []byte, plan stageplan.Binding, expectedStage
 			Operation: stage.GrantOperation, Authority: stage.Authority,
 			PredecessorDigest: predecessorDigest,
 			ContractRevision:  plan.IntentRevision, NotBefore: document.Payload.NotBefore, NotAfter: document.Payload.NotAfter,
+			ExecutionAttempt: document.Payload.ExecutionAttempt,
 		},
 		verified: true,
 	}, nil
@@ -234,6 +247,9 @@ func verifyStagePayload(payload StagePayload, plan stageplan.Binding, stage stag
 	}
 	if payload.PlanDigest != plan.PlanDigest || payload.ContractIdentity != plan.ContractIdentity || payload.ContractRevision != plan.IntentRevision || payload.EnablementRevision != plan.EnablementRevision || payload.PlatformRevision != plan.PlatformRevision || payload.ExecutionFixture != plan.ExecutionFixture {
 		return "", errors.New("stage authorization plan or Contract bindings differ")
+	}
+	if payload.ExecutionAttempt != plan.ExecutionAttempt {
+		return "", errors.New("stage authorization execution attempt differs")
 	}
 	if payload.StageID != stage.ID || payload.StageOrder != stage.Order || payload.StageDigest != stageDigest || payload.Operation != stage.GrantOperation || payload.Authority != stage.Authority {
 		return "", errors.New("stage authorization does not bind the exact stage")

--- a/internal/runner/full_run_activation.go
+++ b/internal/runner/full_run_activation.go
@@ -56,11 +56,15 @@ func openFullRunExecutionActivation(path string, runtime FullRunExecutionManifes
 	}
 	execution, manifest, err := factories.open(path, runtime)
 	receipt.Manifest = manifest
-	if err != nil || execution == nil || manifest.Format != FullRunExecutionManifestReceiptFormat || manifest.State != "VERIFIED" || manifest.MutationAllowed {
+	if err != nil || execution == nil || !validFullRunExecutionManifestReceiptFormat(manifest.Format) || manifest.State != "VERIFIED" || manifest.MutationAllowed {
 		return nil, receipt, errors.New("open verified full-run activation")
 	}
 	receipt.State = "PREPARED"
 	return &FullRunExecutionActivation{execution: execution, manifest: manifest}, receipt, nil
+}
+
+func validFullRunExecutionManifestReceiptFormat(format string) bool {
+	return format == FullRunExecutionManifestReceiptFormat || format == FullRunExecutionManifestReceiptFormatV2
 }
 
 // Run consumes the prepared activation before invoking the concrete executor.

--- a/internal/runner/full_run_activation_test.go
+++ b/internal/runner/full_run_activation_test.go
@@ -64,6 +64,21 @@ func TestFullRunExecutionActivationPreservesStoppedExecution(t *testing.T) {
 	}
 }
 
+func TestFullRunExecutionActivationAcceptsAttemptBoundManifestReceipt(t *testing.T) {
+	execution := &recordingFullRunManifestExecution{receipt: successfulFullRunActivationExecutionReceipt()}
+	receipt := verifiedFullRunActivationManifestReceipt()
+	receipt.Format = FullRunExecutionManifestReceiptFormatV2
+	receipt.ExecutionAttemptDigest = runnerStageSHA("2")
+	activation, prepared, err := openFullRunExecutionActivation("/private/full-run-v4.json", FullRunExecutionManifestRuntime{}, fullRunExecutionActivationFactories{
+		open: func(string, FullRunExecutionManifestRuntime) (fullRunManifestExecution, FullRunExecutionManifestReceipt, error) {
+			return execution, receipt, nil
+		},
+	})
+	if err != nil || activation == nil || prepared.State != "PREPARED" || prepared.Manifest != receipt {
+		t.Fatalf("attempt-bound activation was rejected: activation=%#v receipt=%#v err=%v", activation, prepared, err)
+	}
+}
+
 func TestFullRunExecutionActivationRetainsRedactedPostPrefixReceipt(t *testing.T) {
 	execution := &recordingFullRunManifestExecution{receipt: successfulFullRunActivationExecutionReceipt()}
 	postPrefix := ObservabilityCollectorPostPrefixReceipt{

--- a/internal/runner/full_run_execution_manifest.go
+++ b/internal/runner/full_run_execution_manifest.go
@@ -21,9 +21,11 @@ import (
 )
 
 const (
-	FullRunExecutionManifestFormat        = "ok147-full-run-execution-manifest/v3"
-	FullRunExecutionManifestReceiptFormat = "ok147-full-run-execution-manifest-receipt/v1"
-	maximumFullRunExecutionManifestBytes  = 1024 * 1024
+	FullRunExecutionManifestFormat          = "ok147-full-run-execution-manifest/v3"
+	FullRunExecutionManifestFormatV4        = "ok147-full-run-execution-manifest/v4"
+	FullRunExecutionManifestReceiptFormat   = "ok147-full-run-execution-manifest-receipt/v1"
+	FullRunExecutionManifestReceiptFormatV2 = "ok147-full-run-execution-manifest-receipt/v2"
+	maximumFullRunExecutionManifestBytes    = 1024 * 1024
 )
 
 type fullRunPlanDocument struct {
@@ -193,6 +195,7 @@ type FullRunExecutionManifestReceipt struct {
 	State                     string `json:"state"`
 	ManifestDigest            string `json:"manifestDigest"`
 	PlanDigest                string `json:"planDigest"`
+	ExecutionAttemptDigest    string `json:"executionAttemptDigest,omitempty"`
 	ProjectionManifestDigest  string `json:"projectionManifestDigest"`
 	ProjectionAuthorityDigest string `json:"projectionAuthorityDigest"`
 	NetworkProfileDigest      string `json:"networkProfileDigest"`
@@ -277,7 +280,7 @@ func (manifest VerifiedFullRunExecutionManifest) ExecutionConfig(runtime FullRun
 	expected := fullRunPlanExpected(document.Plan.Expected)
 	if plan.PlanDigest != manifest.receipt.PlanDigest || plan.IntentRevision != expected.IntentRevision ||
 		plan.EnablementRevision != expected.EnablementRevision || plan.PlatformRevision != expected.PlatformRevision ||
-		plan.ExecutionFixture != expected.ExecutionFixture {
+		plan.ExecutionFixture != expected.ExecutionFixture || plan.ExecutionAttempt != expected.ExecutionAttemptDigest {
 		return FullRunExecutionConfig{}, errors.New("verified full-run manifest plan changed after loading")
 	}
 	lifecycleInterval, lifecycleTimeout, err := parsePostRuntimePolling(document.LifecycleObservation.PollInterval, document.LifecycleObservation.PollTimeout)
@@ -484,6 +487,7 @@ func LoadFullRunExecutionManifest(path string) (VerifiedFullRunExecutionManifest
 		ContractIdentity: document.Plan.Expected.ContractIdentity,
 		IntentRevision:   document.Plan.Expected.IntentRevision, EnablementRevision: document.Plan.Expected.EnablementRevision,
 		PlatformRevision: document.Plan.Expected.PlatformRevision, ExecutionFixture: document.Plan.Expected.ExecutionFixture,
+		ExecutionAttemptDigest:  document.Plan.Expected.ExecutionAttemptDigest,
 		InfrastructureAuthority: document.Plan.Expected.InfrastructureAuthority,
 		ManagementAuthority:     document.Plan.Expected.ManagementAuthority, GitOpsAuthority: document.Plan.Expected.GitOpsAuthority,
 	}
@@ -496,6 +500,10 @@ func LoadFullRunExecutionManifest(path string) (VerifiedFullRunExecutionManifest
 		return VerifiedFullRunExecutionManifest{}, receipt, errors.New("full-run manifest requires the exact empty Stage-1 cursor")
 	}
 	receipt.PlanDigest = plan.PlanDigest
+	receipt.ExecutionAttemptDigest = plan.ExecutionAttempt
+	if plan.Format == stageplan.BindingFormatV2 {
+		receipt.Format = FullRunExecutionManifestReceiptFormatV2
+	}
 
 	projected, err := projection.Verify(document.Projection.ManifestPath, document.Projection.Root, plan.IntentRevision, plan.ContractIdentity)
 	if err != nil {
@@ -566,8 +574,9 @@ func fullRunPlanExpected(document postRuntimePlanExpectedDocument) stageplan.Exp
 	return stageplan.Expected{
 		ContractIdentity: document.ContractIdentity, IntentRevision: document.IntentRevision,
 		EnablementRevision: document.EnablementRevision, PlatformRevision: document.PlatformRevision,
-		ExecutionFixture: document.ExecutionFixture, InfrastructureAuthority: document.InfrastructureAuthority,
-		ManagementAuthority: document.ManagementAuthority, GitOpsAuthority: document.GitOpsAuthority,
+		ExecutionFixture: document.ExecutionFixture, ExecutionAttemptDigest: document.ExecutionAttemptDigest,
+		InfrastructureAuthority: document.InfrastructureAuthority,
+		ManagementAuthority:     document.ManagementAuthority, GitOpsAuthority: document.GitOpsAuthority,
 	}
 }
 
@@ -605,8 +614,12 @@ func loadFullRunExecutionManifest(path string) (fullRunExecutionManifestDocument
 	if err := jsonstrict.Decode(raw, &document); err != nil {
 		return fullRunExecutionManifestDocument{}, "", errors.New("decode strict full-run execution manifest")
 	}
-	if document.Format != FullRunExecutionManifestFormat {
+	if document.Format != FullRunExecutionManifestFormat && document.Format != FullRunExecutionManifestFormatV4 {
 		return fullRunExecutionManifestDocument{}, "", errors.New("full-run execution manifest format is not supported")
+	}
+	if document.Format == FullRunExecutionManifestFormat && document.Plan.Expected.ExecutionAttemptDigest != "" ||
+		document.Format == FullRunExecutionManifestFormatV4 && !stageReceiptPrefixDigestPattern.MatchString(document.Plan.Expected.ExecutionAttemptDigest) {
+		return fullRunExecutionManifestDocument{}, "", errors.New("full-run execution manifest attempt identity differs from its format")
 	}
 	encoded, err := json.Marshal(document)
 	if err != nil {

--- a/internal/runner/full_run_execution_manifest_test.go
+++ b/internal/runner/full_run_execution_manifest_test.go
@@ -45,6 +45,57 @@ func TestLoadFullRunExecutionManifestBindsFreshPrivateContract(t *testing.T) {
 	}
 }
 
+func TestLoadFullRunExecutionManifestV4BindsExecutionAttempt(t *testing.T) {
+	manifest, cleanup := fullRunExecutionManifestFixture(t)
+	defer cleanup()
+	attempt := runnerStageSHA("5")
+	upgradeFullRunExecutionManifestToV4(t, manifest, attempt, attempt)
+
+	verified, receipt, err := LoadFullRunExecutionManifest(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	retained, err := verified.Receipt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if receipt != retained || receipt.Format != FullRunExecutionManifestReceiptFormatV2 ||
+		receipt.ExecutionAttemptDigest != attempt || receipt.PlanDigest == "" || receipt.State != "VERIFIED" {
+		t.Fatalf("unexpected attempt-bound full-run receipt: %#v", receipt)
+	}
+}
+
+func TestFullRunExecutionManifestAttemptFormatFailsClosed(t *testing.T) {
+	tests := map[string]func(*fullRunExecutionManifestDocument, map[string]any){
+		"v3 cannot acquire attempt": func(document *fullRunExecutionManifestDocument, plan map[string]any) {
+			document.Plan.Expected.ExecutionAttemptDigest = runnerStageSHA("5")
+		},
+		"v4 requires attempt": func(document *fullRunExecutionManifestDocument, plan map[string]any) {
+			document.Format = FullRunExecutionManifestFormatV4
+			plan["format"] = stageplan.FormatV2
+		},
+		"v4 rejects foreign plan attempt": func(document *fullRunExecutionManifestDocument, plan map[string]any) {
+			document.Format = FullRunExecutionManifestFormatV4
+			document.Plan.Expected.ExecutionAttemptDigest = runnerStageSHA("5")
+			plan["format"] = stageplan.FormatV2
+			plan["executionAttemptDigest"] = runnerStageSHA("6")
+		},
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			manifest, cleanup := fullRunExecutionManifestFixture(t)
+			defer cleanup()
+			document, plan := readFullRunExecutionFixture(t, manifest)
+			mutate(&document, plan)
+			writeBundleFile(t, filepath.Dir(document.Plan.Path), filepath.Base(document.Plan.Path), mustJSON(t, plan))
+			writeBundleFile(t, filepath.Dir(manifest), filepath.Base(manifest), mustJSON(t, document))
+			if _, _, err := LoadFullRunExecutionManifest(manifest); err == nil {
+				t.Fatal("attempt/format mismatch was accepted")
+			}
+		})
+	}
+}
+
 func TestVerifiedFullRunExecutionManifestBuildsConcreteConfiguration(t *testing.T) {
 	manifestPath, cleanup := fullRunExecutionManifestFixture(t)
 	defer cleanup()
@@ -473,11 +524,44 @@ func fullRunExecutionManifestFixture(t *testing.T) (string, func()) {
 	return writeBundleFile(t, root, "full-run-manifest.json", mustJSON(t, document)), cleanup
 }
 
+func readFullRunExecutionFixture(t *testing.T, manifest string) (fullRunExecutionManifestDocument, map[string]any) {
+	t.Helper()
+	manifestRaw, err := os.ReadFile(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var document fullRunExecutionManifestDocument
+	if err := json.Unmarshal(manifestRaw, &document); err != nil {
+		t.Fatal(err)
+	}
+	planRaw, err := os.ReadFile(document.Plan.Path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var plan map[string]any
+	if err := json.Unmarshal(planRaw, &plan); err != nil {
+		t.Fatal(err)
+	}
+	return document, plan
+}
+
+func upgradeFullRunExecutionManifestToV4(t *testing.T, manifest, expectedAttempt, planAttempt string) {
+	t.Helper()
+	document, plan := readFullRunExecutionFixture(t, manifest)
+	document.Format = FullRunExecutionManifestFormatV4
+	document.Plan.Expected.ExecutionAttemptDigest = expectedAttempt
+	plan["format"] = stageplan.FormatV2
+	plan["executionAttemptDigest"] = planAttempt
+	writeBundleFile(t, filepath.Dir(document.Plan.Path), filepath.Base(document.Plan.Path), mustJSON(t, plan))
+	writeBundleFile(t, filepath.Dir(manifest), filepath.Base(manifest), mustJSON(t, document))
+}
+
 func stagePlanExpected(document postRuntimePlanExpectedDocument) stageplan.Expected {
 	return stageplan.Expected{
 		ContractIdentity: document.ContractIdentity,
 		IntentRevision:   document.IntentRevision, EnablementRevision: document.EnablementRevision,
 		PlatformRevision: document.PlatformRevision, ExecutionFixture: document.ExecutionFixture,
+		ExecutionAttemptDigest:  document.ExecutionAttemptDigest,
 		InfrastructureAuthority: document.InfrastructureAuthority, ManagementAuthority: document.ManagementAuthority,
 		GitOpsAuthority: document.GitOpsAuthority,
 	}

--- a/internal/runner/observability_collector_activation_package.go
+++ b/internal/runner/observability_collector_activation_package.go
@@ -158,13 +158,13 @@ func BuildObservabilityCollectorActivationPackage(config ObservabilityCollectorA
 		}
 	}
 	if err != nil || digest.SHA256(manifestReceiptRaw) != config.ExpectedReceiptDigest ||
-		manifestReceipt.Format != FullRunExecutionManifestReceiptFormat || manifestReceipt.State != "VERIFIED" ||
+		!validFullRunExecutionManifestReceiptFormat(manifestReceipt.Format) || manifestReceipt.State != "VERIFIED" ||
 		manifestReceipt.MutationAllowed || manifestReceipt.ManifestDigest != manifestDigest {
 		return VerifiedObservabilityCollectorActivationPackage{}, errors.New("observability collector manifest receipt is invalid")
 	}
 	expected := fullRunPlanExpected(document.Plan.Expected)
 	plan, err := stageplan.Load(document.Plan.Path, expected)
-	if err != nil || plan.PlanDigest != manifestReceipt.PlanDigest {
+	if err != nil || plan.PlanDigest != manifestReceipt.PlanDigest || plan.ExecutionAttempt != manifestReceipt.ExecutionAttemptDigest {
 		return VerifiedObservabilityCollectorActivationPackage{}, errors.New("observability collector manifest plan differs from receipt")
 	}
 	runtimeBinding, err := LoadRuntimeBindingMaterialFiles(config.RuntimeBinding)

--- a/internal/runner/post_runtime_execution_manifest.go
+++ b/internal/runner/post_runtime_execution_manifest.go
@@ -17,10 +17,11 @@ import (
 )
 
 const (
-	PostRuntimeExecutionManifestFormat         = "ok147-post-runtime-execution-manifest/v1"
-	PostRuntimeExecutionRecoveryManifestFormat = "ok147-post-runtime-execution-manifest/v2"
-	PostRuntimeExecutionManifestReceiptFormat  = "ok147-post-runtime-execution-manifest-receipt/v1"
-	maximumPostRuntimeExecutionManifestBytes   = 512 * 1024
+	PostRuntimeExecutionManifestFormat          = "ok147-post-runtime-execution-manifest/v1"
+	PostRuntimeExecutionRecoveryManifestFormat  = "ok147-post-runtime-execution-manifest/v2"
+	PostRuntimeExecutionManifestReceiptFormat   = "ok147-post-runtime-execution-manifest-receipt/v1"
+	PostRuntimeExecutionManifestReceiptFormatV2 = "ok147-post-runtime-execution-manifest-receipt/v2"
+	maximumPostRuntimeExecutionManifestBytes    = 512 * 1024
 )
 
 type postRuntimePlanExpectedDocument struct {
@@ -29,6 +30,7 @@ type postRuntimePlanExpectedDocument struct {
 	EnablementRevision      string            `json:"enablementRevision"`
 	PlatformRevision        string            `json:"platformRevision"`
 	ExecutionFixture        string            `json:"executionFixture"`
+	ExecutionAttemptDigest  string            `json:"executionAttemptDigest,omitempty"`
 	InfrastructureAuthority string            `json:"infrastructureAuthority"`
 	ManagementAuthority     string            `json:"managementAuthority"`
 	GitOpsAuthority         string            `json:"gitOpsAuthority"`
@@ -170,6 +172,7 @@ type PostRuntimeExecutionManifestReceipt struct {
 	State                  string `json:"state"`
 	ManifestDigest         string `json:"manifestDigest"`
 	PlanDigest             string `json:"planDigest"`
+	ExecutionAttemptDigest string `json:"executionAttemptDigest,omitempty"`
 	InitialReceiptCount    int    `json:"initialReceiptCount"`
 	TargetIdentityDigest   string `json:"targetIdentityDigest"`
 	NetworkProfileDigest   string `json:"networkProfileDigest"`
@@ -199,6 +202,7 @@ func openPostRuntimeExecutionManifest(path string, factories postRuntimeExecutio
 		ContractIdentity: document.Plan.Expected.ContractIdentity,
 		IntentRevision:   document.Plan.Expected.IntentRevision, EnablementRevision: document.Plan.Expected.EnablementRevision,
 		PlatformRevision: document.Plan.Expected.PlatformRevision, ExecutionFixture: document.Plan.Expected.ExecutionFixture,
+		ExecutionAttemptDigest:  document.Plan.Expected.ExecutionAttemptDigest,
 		InfrastructureAuthority: document.Plan.Expected.InfrastructureAuthority, ManagementAuthority: document.Plan.Expected.ManagementAuthority,
 		GitOpsAuthority: document.Plan.Expected.GitOpsAuthority,
 	}
@@ -216,6 +220,10 @@ func openPostRuntimeExecutionManifest(path string, factories postRuntimeExecutio
 		return nil, receipt, errors.New("post-runtime manifest does not select the exact Stage-8 cursor")
 	}
 	receipt.PlanDigest, receipt.InitialReceiptCount = plan.PlanDigest, len(prefix)
+	receipt.ExecutionAttemptDigest = plan.ExecutionAttempt
+	if plan.Format == stageplan.BindingFormatV2 {
+		receipt.Format = PostRuntimeExecutionManifestReceiptFormatV2
+	}
 	lifecycle, err := prefix[1].Receipt()
 	if err != nil || !stageReceiptPrefixDigestPattern.MatchString(lifecycle.TargetClusterUIDDigest) {
 		return nil, receipt, errors.New("post-runtime manifest lacks durable target identity")

--- a/internal/runner/stage_authorization_resolver.go
+++ b/internal/runner/stage_authorization_resolver.go
@@ -18,8 +18,10 @@ import (
 )
 
 const (
-	StageAuthorizationRequestFormat         = "ok147-stage-authorization-request/v1"
-	ResolvedStageAuthorizationReceiptFormat = "ok147-resolved-stage-authorization/v1"
+	StageAuthorizationRequestFormat           = "ok147-stage-authorization-request/v1"
+	StageAuthorizationRequestFormatV2         = "ok147-stage-authorization-request/v2"
+	ResolvedStageAuthorizationReceiptFormat   = "ok147-resolved-stage-authorization/v1"
+	ResolvedStageAuthorizationReceiptFormatV2 = "ok147-resolved-stage-authorization/v2"
 )
 
 var stageAuthorizationRequestNamePattern = regexp.MustCompile(`^[a-z0-9][a-z0-9.-]{1,127}$`)
@@ -37,6 +39,7 @@ type StageAuthorizationRequest struct {
 	EnablementRevision string                    `json:"enablementRevision"`
 	PlatformRevision   string                    `json:"platformRevision"`
 	ExecutionFixture   string                    `json:"executionFixture"`
+	ExecutionAttempt   string                    `json:"executionAttemptDigest,omitempty"`
 	StageID            string                    `json:"stageId"`
 	StageOrder         int                       `json:"stageOrder"`
 	StageDigest        string                    `json:"stageDigest"`
@@ -55,6 +58,7 @@ type stageAuthorizationRequestPayload struct {
 	EnablementRevision string                    `json:"enablementRevision"`
 	PlatformRevision   string                    `json:"platformRevision"`
 	ExecutionFixture   string                    `json:"executionFixture"`
+	ExecutionAttempt   string                    `json:"executionAttemptDigest,omitempty"`
 	StageID            string                    `json:"stageId"`
 	StageOrder         int                       `json:"stageOrder"`
 	StageDigest        string                    `json:"stageDigest"`
@@ -97,6 +101,7 @@ type ResolvedStageAuthorizationReceipt struct {
 	PredecessorDigest   string `json:"predecessorDigest"`
 	NotAfter            string `json:"notAfter"`
 	MaxUses             int    `json:"maxUses"`
+	ExecutionAttempt    string `json:"executionAttemptDigest,omitempty"`
 }
 
 type ResolvedStageAuthorization struct {
@@ -108,11 +113,18 @@ type ResolvedStageAuthorization struct {
 
 func (request StageAuthorizationRequest) Bytes() ([]byte, error) {
 	requestDigest, err := stageAuthorizationRequestDigest(request)
-	if err != nil || request.RequestDigest != requestDigest || request.Format != StageAuthorizationRequestFormat ||
+	if err != nil || request.RequestDigest != requestDigest || request.Format != StageAuthorizationRequestFormat && request.Format != StageAuthorizationRequestFormatV2 ||
 		request.Audience != authorization.StageAudience || request.MaxUses != 1 || request.StageOrder < 1 ||
 		!stageAuthorizationRequestNamePattern.MatchString(request.StageID) || strings.TrimSpace(request.Operation) != request.Operation || request.Operation == "" ||
 		!stageAuthorizationRequestNamePattern.MatchString(request.Authority) || request.Predecessors == nil {
 		return nil, errors.New("stage authorization request was not produced by verification")
+	}
+	if request.Format == StageAuthorizationRequestFormat {
+		if request.ExecutionAttempt != "" {
+			return nil, errors.New("stage authorization request v1 cannot bind an execution attempt")
+		}
+	} else if !stageReceiptPrefixDigestPattern.MatchString(request.ExecutionAttempt) {
+		return nil, errors.New("stage authorization request execution attempt is invalid")
 	}
 	for _, value := range []string{
 		request.RequestDigest, request.PlanDigest, request.ContractRevision, request.EnablementRevision,
@@ -188,14 +200,18 @@ func ResolveStageAuthorization(ctx context.Context, resume StageResumeConfig, re
 		return ResolvedStageAuthorization{}, errors.New("bind resolved stage authorization")
 	}
 	grantReceipt := grant.Receipt()
+	receiptFormat := ResolvedStageAuthorizationReceiptFormat
+	if request.Format == StageAuthorizationRequestFormatV2 {
+		receiptFormat = ResolvedStageAuthorizationReceiptFormatV2
+	}
 	receipt := ResolvedStageAuthorizationReceipt{
-		Format: ResolvedStageAuthorizationReceiptFormat, State: "VERIFIED",
+		Format: receiptFormat, State: "VERIFIED",
 		RequestDigest: request.RequestDigest, AuthorizationDigest: grantReceipt.AuthorizationDigest,
 		GrantID: grantReceipt.GrantID, KeyID: grantReceipt.KeyID, PlanDigest: grantReceipt.PlanDigest,
 		StageID: grantReceipt.StageID, StageDigest: grantReceipt.StageDigest,
 		Operation: grantReceipt.Operation, Authority: grantReceipt.Authority,
 		PredecessorDigest: grantReceipt.PredecessorDigest, NotAfter: grantReceipt.NotAfter,
-		MaxUses: grantReceipt.MaxUses,
+		MaxUses: grantReceipt.MaxUses, ExecutionAttempt: request.ExecutionAttempt,
 	}
 	return ResolvedStageAuthorization{request: request, source: source, receipt: receipt, verified: true}, nil
 }
@@ -227,12 +243,17 @@ func newStageAuthorizationRequest(plan stageplan.Binding, decision stagecursor.D
 			return StageAuthorizationRequest{}, errors.New("stage authorization request predecessor is invalid")
 		}
 	}
+	requestFormat := StageAuthorizationRequestFormat
+	if plan.Format == stageplan.BindingFormatV2 {
+		requestFormat = StageAuthorizationRequestFormatV2
+	}
 	request := StageAuthorizationRequest{
-		Format: StageAuthorizationRequestFormat, Audience: authorization.StageAudience,
+		Format: requestFormat, Audience: authorization.StageAudience,
 		PlanDigest: plan.PlanDigest, ContractIdentity: plan.ContractIdentity,
 		ContractRevision: plan.IntentRevision, EnablementRevision: plan.EnablementRevision,
 		PlatformRevision: plan.PlatformRevision, ExecutionFixture: plan.ExecutionFixture,
-		StageID: stage.ID, StageOrder: stage.Order, StageDigest: stageDigest,
+		ExecutionAttempt: plan.ExecutionAttempt,
+		StageID:          stage.ID, StageOrder: stage.Order, StageDigest: stageDigest,
 		Operation: stage.GrantOperation, Authority: stage.Authority,
 		Predecessors: append([]stagecursor.Predecessor{}, decision.Predecessors...), MaxUses: 1,
 	}
@@ -249,12 +270,15 @@ func cloneStageAuthorizationRequest(request StageAuthorizationRequest) StageAuth
 }
 
 func verifyResolvedStageAuthorization(resolved ResolvedStageAuthorization) error {
-	if !resolved.verified || resolved.receipt.Format != ResolvedStageAuthorizationReceiptFormat || resolved.receipt.State != "VERIFIED" ||
+	if !resolved.verified || resolved.receipt.Format != ResolvedStageAuthorizationReceiptFormat && resolved.receipt.Format != ResolvedStageAuthorizationReceiptFormatV2 || resolved.receipt.State != "VERIFIED" ||
 		resolved.receipt.RequestDigest != resolved.request.RequestDigest || resolved.receipt.PlanDigest != resolved.request.PlanDigest ||
 		resolved.receipt.StageID != resolved.request.StageID || resolved.receipt.StageDigest != resolved.request.StageDigest ||
 		resolved.receipt.Operation != resolved.request.Operation || resolved.receipt.Authority != resolved.request.Authority ||
 		resolved.receipt.MaxUses != 1 || resolved.source.GrantPath == "" || resolved.source.PublicKeyPath == "" || resolved.source.EvaluationTime.IsZero() {
 		return errors.New("stage authorization resolution was not produced by verification")
+	}
+	if resolved.receipt.ExecutionAttempt != resolved.request.ExecutionAttempt {
+		return errors.New("resolved stage authorization execution attempt changed after verification")
 	}
 	for _, value := range []string{
 		resolved.receipt.RequestDigest, resolved.receipt.AuthorizationDigest, resolved.receipt.PlanDigest,
@@ -277,7 +301,8 @@ func stageAuthorizationRequestDigest(request StageAuthorizationRequest) (string,
 		ContractIdentity: request.ContractIdentity, ContractRevision: request.ContractRevision,
 		EnablementRevision: request.EnablementRevision, PlatformRevision: request.PlatformRevision,
 		ExecutionFixture: request.ExecutionFixture, StageID: request.StageID, StageOrder: request.StageOrder,
-		StageDigest: request.StageDigest, Operation: request.Operation, Authority: request.Authority,
+		ExecutionAttempt: request.ExecutionAttempt,
+		StageDigest:      request.StageDigest, Operation: request.Operation, Authority: request.Authority,
 		Predecessors: append([]stagecursor.Predecessor{}, request.Predecessors...), MaxUses: request.MaxUses,
 	}
 	raw, err := json.Marshal(payload)

--- a/internal/stageattempt/attempt.go
+++ b/internal/stageattempt/attempt.go
@@ -1,0 +1,156 @@
+// Package stageattempt verifies the redaction-safe identity of one bounded
+// execution attempt. An attempt is neither desired Cluster state nor a grant.
+package stageattempt
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"regexp"
+
+	"github.com/openkubes/ok-cluster/internal/contract"
+	"github.com/openkubes/ok-cluster/internal/digest"
+	"github.com/openkubes/ok-cluster/internal/jsonstrict"
+)
+
+const (
+	Format        = "ok147-execution-attempt/v1"
+	ReceiptFormat = "ok147-verified-execution-attempt/v1"
+	Mode          = "create-converge-observe/v1"
+)
+
+var (
+	digestPattern = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
+	namePattern   = regexp.MustCompile(`^[a-z0-9][a-z0-9.-]{1,127}$`)
+	imagePattern  = regexp.MustCompile(`^[a-z0-9][a-z0-9./_-]*@sha256:[0-9a-f]{64}$`)
+)
+
+// Document contains only reviewed, redaction-safe identities. In particular,
+// it never carries a credential, endpoint, raw manifest or command.
+type Document struct {
+	Format                   string `json:"format"`
+	AttemptID                string `json:"attemptId"`
+	SourceFixtureDigest      string `json:"sourceFixtureDigest"`
+	SourcePlanSemanticDigest string `json:"sourcePlanSemanticDigest"`
+	RunnerImage              string `json:"runnerImage"`
+	ActivationPackageDigest  string `json:"activationPackageDigest"`
+	Mode                     string `json:"mode"`
+	PredecessorAttemptDigest string `json:"predecessorAttemptDigest,omitempty"`
+	StoppedEvidenceDigest    string `json:"stoppedEvidenceDigest,omitempty"`
+	DecisionWindowDigest     string `json:"decisionWindowDigest"`
+	MaxAttempts              int    `json:"maxAttempts"`
+}
+
+// Expected is independently supplied from reviewed fixture, runner,
+// activation and stopped-evidence checkpoints.
+type Expected struct {
+	AttemptID                string
+	SourceFixtureDigest      string
+	SourcePlanSemanticDigest string
+	RunnerImage              string
+	ActivationPackageDigest  string
+	PredecessorAttemptDigest string
+	StoppedEvidenceDigest    string
+	DecisionWindowDigest     string
+}
+
+// Receipt is safe to retain publicly. It grants no execution authority.
+type Receipt struct {
+	Format                  string `json:"format"`
+	State                   string `json:"state"`
+	ExecutionAttemptDigest  string `json:"executionAttemptDigest"`
+	SourceFixtureDigest     string `json:"sourceFixtureDigest"`
+	SourcePlanDigest        string `json:"sourcePlanSemanticDigest"`
+	RunnerImage             string `json:"runnerImage"`
+	ActivationPackageDigest string `json:"activationPackageDigest"`
+	Mode                    string `json:"mode"`
+	RecoveryBound           bool   `json:"recoveryBound"`
+	MaxAttempts             int    `json:"maxAttempts"`
+	MutationAllowed         bool   `json:"mutationAllowed"`
+}
+
+// Verify accepts only the exact independently expected attempt and returns
+// its canonical semantic identity.
+func Verify(raw []byte, expected Expected) (Receipt, error) {
+	if err := validateExpected(expected); err != nil {
+		return Receipt{}, err
+	}
+	var document Document
+	if err := jsonstrict.Decode(raw, &document); err != nil {
+		return Receipt{}, fmt.Errorf("decode execution attempt: %w", err)
+	}
+	if err := validateDocument(document); err != nil {
+		return Receipt{}, err
+	}
+	if document.AttemptID != expected.AttemptID || document.SourceFixtureDigest != expected.SourceFixtureDigest ||
+		document.SourcePlanSemanticDigest != expected.SourcePlanSemanticDigest || document.RunnerImage != expected.RunnerImage ||
+		document.ActivationPackageDigest != expected.ActivationPackageDigest || document.PredecessorAttemptDigest != expected.PredecessorAttemptDigest ||
+		document.StoppedEvidenceDigest != expected.StoppedEvidenceDigest || document.DecisionWindowDigest != expected.DecisionWindowDigest {
+		return Receipt{}, errors.New("execution attempt differs from independently verified inputs")
+	}
+	canonical, err := canonicalJSON(document)
+	if err != nil {
+		return Receipt{}, err
+	}
+	return Receipt{
+		Format: ReceiptFormat, State: "VERIFIED", ExecutionAttemptDigest: digest.SHA256(canonical),
+		SourceFixtureDigest: document.SourceFixtureDigest, SourcePlanDigest: document.SourcePlanSemanticDigest,
+		RunnerImage: document.RunnerImage, ActivationPackageDigest: document.ActivationPackageDigest,
+		Mode: document.Mode, RecoveryBound: document.PredecessorAttemptDigest != "", MaxAttempts: document.MaxAttempts,
+		MutationAllowed: false,
+	}, nil
+}
+
+func validateExpected(expected Expected) error {
+	if !namePattern.MatchString(expected.AttemptID) || !digestPattern.MatchString(expected.SourceFixtureDigest) ||
+		!digestPattern.MatchString(expected.SourcePlanSemanticDigest) || !imagePattern.MatchString(expected.RunnerImage) ||
+		!digestPattern.MatchString(expected.ActivationPackageDigest) || !digestPattern.MatchString(expected.DecisionWindowDigest) {
+		return errors.New("expected execution attempt identity is invalid")
+	}
+	if (expected.PredecessorAttemptDigest == "") != (expected.StoppedEvidenceDigest == "") {
+		return errors.New("expected recovery attempt lineage is incomplete")
+	}
+	for _, value := range []string{expected.PredecessorAttemptDigest, expected.StoppedEvidenceDigest} {
+		if value != "" && !digestPattern.MatchString(value) {
+			return errors.New("expected recovery attempt identity is invalid")
+		}
+	}
+	return nil
+}
+
+func validateDocument(document Document) error {
+	if document.Format != Format || document.Mode != Mode || document.MaxAttempts != 1 ||
+		!namePattern.MatchString(document.AttemptID) || !digestPattern.MatchString(document.SourceFixtureDigest) ||
+		!digestPattern.MatchString(document.SourcePlanSemanticDigest) || !imagePattern.MatchString(document.RunnerImage) ||
+		!digestPattern.MatchString(document.ActivationPackageDigest) || !digestPattern.MatchString(document.DecisionWindowDigest) {
+		return errors.New("execution attempt identity is invalid")
+	}
+	if (document.PredecessorAttemptDigest == "") != (document.StoppedEvidenceDigest == "") {
+		return errors.New("execution attempt recovery lineage is incomplete")
+	}
+	for _, value := range []string{document.PredecessorAttemptDigest, document.StoppedEvidenceDigest} {
+		if value != "" && !digestPattern.MatchString(value) {
+			return errors.New("execution attempt recovery identity is invalid")
+		}
+	}
+	return nil
+}
+
+func canonicalJSON(value any) ([]byte, error) {
+	raw, err := json.Marshal(value)
+	if err != nil {
+		return nil, errors.New("encode execution attempt")
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	var generic any
+	if err := decoder.Decode(&generic); err != nil {
+		return nil, errors.New("decode execution attempt identity")
+	}
+	canonical, err := contract.JCS(generic)
+	if err != nil {
+		return nil, errors.New("canonicalize execution attempt")
+	}
+	return canonical, nil
+}

--- a/internal/stageattempt/attempt_test.go
+++ b/internal/stageattempt/attempt_test.go
@@ -1,0 +1,77 @@
+package stageattempt
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestVerifyIsDeterministicAndInputBound(t *testing.T) {
+	document, expected := fixture()
+	raw, _ := json.Marshal(document)
+	first, err := Verify(raw, expected)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pretty, _ := json.MarshalIndent(document, "", "  ")
+	second, err := Verify(pretty, expected)
+	if err != nil || first != second || first.State != "VERIFIED" || first.MutationAllowed || first.MaxAttempts != 1 || !first.RecoveryBound {
+		t.Fatalf("attempt identity is not deterministic: %#v %#v %v", first, second, err)
+	}
+
+	changed := document
+	changed.RunnerImage = "ghcr.io/openkubes/ok-cluster-runner@" + sha("9")
+	changedExpected := expected
+	changedExpected.RunnerImage = changed.RunnerImage
+	changedRaw, _ := json.Marshal(changed)
+	changedReceipt, err := Verify(changedRaw, changedExpected)
+	if err != nil || changedReceipt.ExecutionAttemptDigest == first.ExecutionAttemptDigest {
+		t.Fatalf("changed attempt input retained its identity: %#v %v", changedReceipt, err)
+	}
+	if _, err := Verify(changedRaw, expected); err == nil {
+		t.Fatal("foreign attempt input was accepted")
+	}
+}
+
+func TestVerifyFailsClosed(t *testing.T) {
+	document, expected := fixture()
+	tests := map[string]func(*Document){
+		"unknown format":        func(value *Document) { value.Format = "ok147-execution-attempt/v2" },
+		"arbitrary mode":        func(value *Document) { value.Mode = "retry-forever" },
+		"more than one attempt": func(value *Document) { value.MaxAttempts = 2 },
+		"mutable image":         func(value *Document) { value.RunnerImage = "ghcr.io/openkubes/ok-cluster-runner:latest" },
+		"missing predecessor":   func(value *Document) { value.PredecessorAttemptDigest = "" },
+		"missing stopped proof": func(value *Document) { value.StoppedEvidenceDigest = "" },
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			candidate := document
+			mutate(&candidate)
+			raw, _ := json.Marshal(candidate)
+			if _, err := Verify(raw, expected); err == nil {
+				t.Fatal("unsafe attempt was accepted")
+			}
+		})
+	}
+	raw := []byte(`{"format":"ok147-execution-attempt/v1","unknown":true}`)
+	if _, err := Verify(raw, expected); err == nil {
+		t.Fatal("unknown attempt field was accepted")
+	}
+}
+
+func fixture() (Document, Expected) {
+	document := Document{
+		Format: Format, AttemptID: "ok147-full-run-r11", SourceFixtureDigest: sha("1"), SourcePlanSemanticDigest: sha("2"),
+		RunnerImage: "ghcr.io/openkubes/ok-cluster-runner@" + sha("3"), ActivationPackageDigest: sha("4"), Mode: Mode,
+		PredecessorAttemptDigest: sha("5"), StoppedEvidenceDigest: sha("6"), DecisionWindowDigest: sha("7"), MaxAttempts: 1,
+	}
+	expected := Expected{
+		AttemptID: document.AttemptID, SourceFixtureDigest: document.SourceFixtureDigest, SourcePlanSemanticDigest: document.SourcePlanSemanticDigest,
+		RunnerImage: document.RunnerImage, ActivationPackageDigest: document.ActivationPackageDigest,
+		PredecessorAttemptDigest: document.PredecessorAttemptDigest, StoppedEvidenceDigest: document.StoppedEvidenceDigest,
+		DecisionWindowDigest: document.DecisionWindowDigest,
+	}
+	return document, expected
+}
+
+func sha(value string) string { return "sha256:" + strings.Repeat(value, 64) }

--- a/internal/stageauthority/authority.go
+++ b/internal/stageauthority/authority.go
@@ -27,8 +27,10 @@ import (
 )
 
 const (
-	PolicyFormat  = "ok147-bounded-stage-authority-policy/v1"
-	ReceiptFormat = "ok147-bounded-stage-authority-receipt/v1"
+	PolicyFormat    = "ok147-bounded-stage-authority-policy/v1"
+	PolicyFormatV2  = "ok147-bounded-stage-authority-policy/v2"
+	ReceiptFormat   = "ok147-bounded-stage-authority-receipt/v1"
+	ReceiptFormatV2 = "ok147-bounded-stage-authority-receipt/v2"
 
 	requestMediaType  = "application/vnd.openkubes.stage-authorization-request+json"
 	responseMediaType = "application/vnd.openkubes.stage-authorization+json"
@@ -64,6 +66,7 @@ type Policy struct {
 	EnablementRevision string            `json:"enablementRevision"`
 	PlatformRevision   string            `json:"platformRevision"`
 	ExecutionFixture   string            `json:"executionFixture"`
+	ExecutionAttempt   string            `json:"executionAttemptDigest,omitempty"`
 	Stages             []StagePolicy     `json:"stages"`
 }
 
@@ -81,23 +84,25 @@ type Config struct {
 
 // Receipt is safe to record publicly after opening the authority.
 type Receipt struct {
-	Format          string `json:"format"`
-	State           string `json:"state"`
-	PolicyDigest    string `json:"policyDigest"`
-	KeyID           string `json:"keyId"`
-	StageCount      int    `json:"stageCount"`
-	GrantValidFor   string `json:"grantValidFor"`
-	SingleUseLedger string `json:"singleUseLedger"`
-	MutationAllowed bool   `json:"mutationAllowed"`
+	Format           string `json:"format"`
+	State            string `json:"state"`
+	PolicyDigest     string `json:"policyDigest"`
+	KeyID            string `json:"keyId"`
+	StageCount       int    `json:"stageCount"`
+	GrantValidFor    string `json:"grantValidFor"`
+	SingleUseLedger  string `json:"singleUseLedger"`
+	ExecutionAttempt string `json:"executionAttemptDigest,omitempty"`
+	MutationAllowed  bool   `json:"mutationAllowed"`
 }
 
 type PolicyReceipt struct {
-	Format          string `json:"format"`
-	State           string `json:"state"`
-	PolicyDigest    string `json:"policyDigest"`
-	PlanDigest      string `json:"planDigest"`
-	StageCount      int    `json:"stageCount"`
-	MutationAllowed bool   `json:"mutationAllowed"`
+	Format           string `json:"format"`
+	State            string `json:"state"`
+	PolicyDigest     string `json:"policyDigest"`
+	PlanDigest       string `json:"planDigest"`
+	StageCount       int    `json:"stageCount"`
+	ExecutionAttempt string `json:"executionAttemptDigest,omitempty"`
+	MutationAllowed  bool   `json:"mutationAllowed"`
 }
 
 type Authority struct {
@@ -138,10 +143,17 @@ func FromPlan(plan stageplan.Binding) ([]byte, PolicyReceipt, error) {
 	if !digestPattern.MatchString(plan.PlanDigest) || len(plan.Stages) == 0 {
 		return nil, PolicyReceipt{}, errors.New("verified staged plan is required")
 	}
+	policyFormat := PolicyFormat
+	policyReceiptFormat := "ok147-bounded-stage-authority-policy-receipt/v1"
+	if plan.Format == stageplan.BindingFormatV2 {
+		policyFormat = PolicyFormatV2
+		policyReceiptFormat = "ok147-bounded-stage-authority-policy-receipt/v2"
+	}
 	policy := Policy{
-		Format: PolicyFormat, PlanDigest: plan.PlanDigest, ContractIdentity: plan.ContractIdentity,
+		Format: policyFormat, PlanDigest: plan.PlanDigest, ContractIdentity: plan.ContractIdentity,
 		ContractRevision: plan.IntentRevision, EnablementRevision: plan.EnablementRevision,
 		PlatformRevision: plan.PlatformRevision, ExecutionFixture: plan.ExecutionFixture,
+		ExecutionAttempt: plan.ExecutionAttempt,
 	}
 	for _, candidate := range plan.Stages {
 		stage, stageDigest, err := plan.Stage(candidate.ID)
@@ -168,8 +180,9 @@ func FromPlan(plan stageplan.Binding) ([]byte, PolicyReceipt, error) {
 		return nil, PolicyReceipt{}, errors.New("verify derived bounded stage authority policy")
 	}
 	receipt := PolicyReceipt{
-		Format: "ok147-bounded-stage-authority-policy-receipt/v1", State: "VERIFIED",
+		Format: policyReceiptFormat, State: "VERIFIED",
 		PolicyDigest: policyDigest, PlanDigest: plan.PlanDigest, StageCount: len(policy.Stages), MutationAllowed: false,
+		ExecutionAttempt: plan.ExecutionAttempt,
 	}
 	return raw, receipt, nil
 }
@@ -221,10 +234,14 @@ func Open(config Config) (*Authority, Receipt, error) {
 		privateKey: privateKey, keyID: keyID, token: append([]byte(nil), token...),
 		stateDir: config.StateDirectory, grantValidFor: config.GrantValidFor, clock: config.Clock,
 	}
+	receiptFormat := ReceiptFormat
+	if policy.Format == PolicyFormatV2 {
+		receiptFormat = ReceiptFormatV2
+	}
 	receipt := Receipt{
-		Format: ReceiptFormat, State: "VERIFIED", PolicyDigest: policyDigest, KeyID: keyID,
+		Format: receiptFormat, State: "VERIFIED", PolicyDigest: policyDigest, KeyID: keyID,
 		StageCount: len(policy.Stages), GrantValidFor: config.GrantValidFor.String(),
-		SingleUseLedger: "create-only-local/v1", MutationAllowed: false,
+		SingleUseLedger: "create-only-local/v1", ExecutionAttempt: policy.ExecutionAttempt, MutationAllowed: false,
 	}
 	return authority, receipt, nil
 }
@@ -294,8 +311,12 @@ func (authority *Authority) ServeHTTP(response http.ResponseWriter, request *htt
 		http.Error(response, "authority unavailable", http.StatusInternalServerError)
 		return
 	}
+	grantFormat := authorization.StageFormat
+	if authority.policy.Format == PolicyFormatV2 {
+		grantFormat = authorization.StageFormatV2
+	}
 	envelope := stageEnvelope{
-		Format: authorization.StageFormat, Payload: payload,
+		Format: grantFormat, Payload: payload,
 		Signature: stageSignature{Algorithm: "Ed25519", KeyID: authority.keyID, Value: base64.StdEncoding.EncodeToString(ed25519.Sign(authority.privateKey, signed))},
 	}
 	responseRaw, err := json.Marshal(envelope)
@@ -309,6 +330,11 @@ func (authority *Authority) ServeHTTP(response http.ResponseWriter, request *htt
 }
 
 func (authority *Authority) verifyRequest(request runner.StageAuthorizationRequest) error {
+	if authority.policy.Format == PolicyFormat && request.Format != runner.StageAuthorizationRequestFormat ||
+		authority.policy.Format == PolicyFormatV2 && request.Format != runner.StageAuthorizationRequestFormatV2 ||
+		request.ExecutionAttempt != authority.policy.ExecutionAttempt {
+		return errors.New("request execution attempt differs")
+	}
 	if request.PlanDigest != authority.policy.PlanDigest || request.ContractIdentity != authority.policy.ContractIdentity ||
 		request.ContractRevision != authority.policy.ContractRevision || request.EnablementRevision != authority.policy.EnablementRevision ||
 		request.PlatformRevision != authority.policy.PlatformRevision || request.ExecutionFixture != authority.policy.ExecutionFixture || request.MaxUses != 1 {
@@ -331,7 +357,8 @@ func (authority *Authority) payload(request runner.StageAuthorizationRequest, no
 		Audience: request.Audience, GrantID: "ok147-dev-" + strings.TrimPrefix(request.RequestDigest, "sha256:")[:32], Decision: "ALLOW",
 		PlanDigest: request.PlanDigest, ContractIdentity: request.ContractIdentity, ContractRevision: request.ContractRevision,
 		EnablementRevision: request.EnablementRevision, PlatformRevision: request.PlatformRevision, ExecutionFixture: request.ExecutionFixture,
-		StageID: request.StageID, StageOrder: request.StageOrder, StageDigest: request.StageDigest, Operation: request.Operation, Authority: request.Authority,
+		ExecutionAttempt: request.ExecutionAttempt,
+		StageID:          request.StageID, StageOrder: request.StageOrder, StageDigest: request.StageDigest, Operation: request.Operation, Authority: request.Authority,
 		NotBefore: now.Format(time.RFC3339), NotAfter: now.Add(authority.grantValidFor).Format(time.RFC3339), MaxUses: 1,
 	}
 	payload.Predecessors = make([]authorization.StagePredecessor, len(request.Predecessors))
@@ -374,8 +401,15 @@ func verifyPolicy(raw []byte) (Policy, string, error) {
 	if err := jsonstrict.Decode(raw, &policy); err != nil {
 		return Policy{}, "", fmt.Errorf("decode bounded stage authority policy: %w", err)
 	}
-	if policy.Format != PolicyFormat || policy.ContractIdentity.Name == "" || policy.ContractIdentity.Namespace == "" || len(policy.Stages) == 0 {
+	if policy.Format != PolicyFormat && policy.Format != PolicyFormatV2 || policy.ContractIdentity.Name == "" || policy.ContractIdentity.Namespace == "" || len(policy.Stages) == 0 {
 		return Policy{}, "", errors.New("bounded stage authority policy identity is incomplete")
+	}
+	if policy.Format == PolicyFormat {
+		if policy.ExecutionAttempt != "" {
+			return Policy{}, "", errors.New("bounded stage authority policy v1 cannot bind an execution attempt")
+		}
+	} else if !digestPattern.MatchString(policy.ExecutionAttempt) {
+		return Policy{}, "", errors.New("bounded stage authority execution attempt identity is invalid")
 	}
 	for _, value := range []string{policy.PlanDigest, policy.ContractRevision, policy.EnablementRevision, policy.PlatformRevision, policy.ExecutionFixture} {
 		if !digestPattern.MatchString(value) {

--- a/internal/stageauthority/authority_test.go
+++ b/internal/stageauthority/authority_test.go
@@ -58,6 +58,39 @@ func TestAuthorityIssuesOneExactVerifiableGrant(t *testing.T) {
 	}
 }
 
+func TestAuthorityV2IssuesOneAttemptBoundGrantAndRejectsReplay(t *testing.T) {
+	material := testMaterialForPlan(t, verifiedPlanV2(t, testDigest("5")))
+	authority, receipt, err := Open(material.config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if receipt.Format != ReceiptFormatV2 || receipt.ExecutionAttempt != material.plan.ExecutionAttempt {
+		t.Fatalf("unexpected v2 authority receipt: %#v", receipt)
+	}
+	requestRaw := requestBytes(t, material.request)
+	response := performRequest(authority, material.token, requestMediaType, requestRaw)
+	if response.Code != http.StatusCreated {
+		t.Fatalf("v2 request returned %d: %s", response.Code, response.Body.String())
+	}
+	publicRaw := []byte(base64.StdEncoding.EncodeToString(material.publicKey))
+	verified, err := authorization.VerifyStage(response.Body.Bytes(), publicRaw, material.plan, material.request.StageID, []stagereceipt.Verified{}, material.now.Add(time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	grant := verified.Receipt()
+	if grant.Format != "ok147-stage-authorization-receipt/v2" || grant.ExecutionAttempt != material.plan.ExecutionAttempt {
+		t.Fatalf("unexpected v2 grant receipt: %#v", grant)
+	}
+	if replay := performRequest(authority, material.token, requestMediaType, requestRaw); replay.Code != http.StatusConflict {
+		t.Fatalf("same-attempt replay returned %d", replay.Code)
+	}
+
+	foreign := requestForPlan(t, verifiedPlanV2(t, testDigest("6")))
+	if response := performRequest(authority, material.token, requestMediaType, requestBytes(t, foreign)); response.Code != http.StatusForbidden {
+		t.Fatalf("foreign attempt returned %d", response.Code)
+	}
+}
+
 func TestFromPlanDerivesOnlyMutatingStagesDeterministically(t *testing.T) {
 	plan := verifiedPlan(t)
 	first, receipt, err := FromPlan(plan)
@@ -79,6 +112,33 @@ func TestFromPlanDerivesOnlyMutatingStagesDeterministically(t *testing.T) {
 		if stage.Operation == "" {
 			t.Fatalf("read-only stage entered authority policy: %#v", stage)
 		}
+	}
+}
+
+func TestFromPlanV2BindsExecutionAttemptAndChangesRequestIdentity(t *testing.T) {
+	first := verifiedPlanV2(t, testDigest("5"))
+	second := verifiedPlanV2(t, testDigest("6"))
+	firstRaw, firstReceipt, err := FromPlan(first)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondRaw, secondReceipt, err := FromPlan(second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Equal(firstRaw, secondRaw) || firstReceipt.PolicyDigest == secondReceipt.PolicyDigest ||
+		firstReceipt.Format != "ok147-bounded-stage-authority-policy-receipt/v2" || firstReceipt.ExecutionAttempt != first.ExecutionAttempt {
+		t.Fatalf("v2 policy did not bind the attempt: %#v %#v", firstReceipt, secondReceipt)
+	}
+	var firstPolicy Policy
+	if err := json.Unmarshal(firstRaw, &firstPolicy); err != nil || firstPolicy.Format != PolicyFormatV2 || firstPolicy.ExecutionAttempt != first.ExecutionAttempt {
+		t.Fatalf("unexpected v2 policy: %#v %v", firstPolicy, err)
+	}
+
+	firstRequest := requestForPlan(t, first)
+	secondRequest := requestForPlan(t, second)
+	if firstRequest.Format != runner.StageAuthorizationRequestFormatV2 || firstRequest.RequestDigest == secondRequest.RequestDigest {
+		t.Fatalf("attempt did not change request identity: %#v %#v", firstRequest, secondRequest)
 	}
 }
 
@@ -171,6 +231,11 @@ type testMaterialValue struct {
 
 func testMaterial(t *testing.T) testMaterialValue {
 	t.Helper()
+	return testMaterialForPlan(t, verifiedPlan(t))
+}
+
+func testMaterialForPlan(t *testing.T, plan stageplan.Binding) testMaterialValue {
+	t.Helper()
 	root := t.TempDir()
 	stateDir := filepath.Join(root, "state")
 	if err := os.Mkdir(stateDir, 0o700); err != nil {
@@ -180,26 +245,8 @@ func testMaterial(t *testing.T) testMaterialValue {
 	if err != nil {
 		t.Fatal(err)
 	}
-	plan := verifiedPlan(t)
-	stage, stageDigest, err := plan.Stage("provider-prerequisites")
-	if err != nil {
-		t.Fatal(err)
-	}
-	request := runner.StageAuthorizationRequest{
-		Format: runner.StageAuthorizationRequestFormat, Audience: authorization.StageAudience,
-		PlanDigest: plan.PlanDigest, ContractIdentity: plan.ContractIdentity, ContractRevision: plan.IntentRevision,
-		EnablementRevision: plan.EnablementRevision, PlatformRevision: plan.PlatformRevision, ExecutionFixture: plan.ExecutionFixture,
-		StageID: stage.ID, StageOrder: stage.Order, StageDigest: stageDigest, Operation: stage.GrantOperation, Authority: stage.Authority,
-		Predecessors: []stagecursor.Predecessor{}, MaxUses: 1,
-	}
-	request.RequestDigest = stageRequestDigest(t, request)
-	policy := Policy{
-		Format: PolicyFormat, PlanDigest: plan.PlanDigest, ContractIdentity: plan.ContractIdentity,
-		ContractRevision: plan.IntentRevision, EnablementRevision: plan.EnablementRevision,
-		PlatformRevision: plan.PlatformRevision, ExecutionFixture: plan.ExecutionFixture,
-		Stages: []StagePolicy{{StageID: stage.ID, StageOrder: stage.Order, StageDigest: stageDigest, Operation: stage.GrantOperation, Authority: stage.Authority, Requires: []string{}}},
-	}
-	policyRaw, err := json.Marshal(policy)
+	request := requestForPlan(t, plan)
+	policyRaw, _, err := FromPlan(plan)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -208,11 +255,7 @@ func testMaterial(t *testing.T) testMaterialValue {
 	token := "bounded-authority-token-0123456789abcdef"
 	tokenPath := writeFile(t, root, "token", []byte(token), 0o600)
 	now := time.Date(2026, 8, 21, 8, 0, 0, 0, time.UTC)
-	canonicalPolicy, err := canonicalJSON(policy)
-	if err != nil {
-		t.Fatal(err)
-	}
-	config := Config{PolicyPath: policyPath, ExpectedPolicyDigest: digest.SHA256(canonicalPolicy), PrivateKeyPath: privatePath, TokenFile: tokenPath, StateDirectory: stateDir, GrantValidFor: 10 * time.Minute, Clock: func() time.Time { return now }}
+	config := Config{PolicyPath: policyPath, ExpectedPolicyDigest: digest.SHA256(policyRaw), PrivateKeyPath: privatePath, TokenFile: tokenPath, StateDirectory: stateDir, GrantValidFor: 10 * time.Minute, Clock: func() time.Time { return now }}
 	authority, _, err := Open(config)
 	if err != nil {
 		t.Fatal(err)
@@ -249,6 +292,9 @@ func stageRequestDigest(t *testing.T, request runner.StageAuthorizationRequest) 
 		"stageDigest": request.StageDigest, "operation": request.Operation, "authority": request.Authority,
 		"predecessors": request.Predecessors, "maxUses": request.MaxUses,
 	}
+	if request.ExecutionAttempt != "" {
+		payload["executionAttemptDigest"] = request.ExecutionAttempt
+	}
 	canonical, err := canonicalJSON(payload)
 	if err != nil {
 		t.Fatal(err)
@@ -257,6 +303,15 @@ func stageRequestDigest(t *testing.T, request runner.StageAuthorizationRequest) 
 }
 
 func verifiedPlan(t *testing.T) stageplan.Binding {
+	return verifiedPlanWithAttempt(t, "")
+}
+
+func verifiedPlanV2(t *testing.T, attempt string) stageplan.Binding {
+	t.Helper()
+	return verifiedPlanWithAttempt(t, attempt)
+}
+
+func verifiedPlanWithAttempt(t *testing.T, attempt string) stageplan.Binding {
 	t.Helper()
 	identity := contract.Identity{Namespace: "disposable-ok147", Name: "disposable-ok147"}
 	r := testDigest("1")
@@ -283,24 +338,55 @@ func verifiedPlan(t *testing.T) stageplan.Binding {
 		rule["inputs"] = []map[string]string{{"name": "stage.input-" + string(rune('a'+index)), "digest": testDigest(string("abcdef012345"[index]))}}
 		stages[index] = rule
 	}
+	planFormat := stageplan.Format
+	if attempt != "" {
+		planFormat = stageplan.FormatV2
+	}
 	document := map[string]any{
-		"format": stageplan.Format, "contractIdentity": identity, "intentRevision": r, "enablementRevision": e,
+		"format": planFormat, "contractIdentity": identity, "intentRevision": r, "enablementRevision": e,
 		"platformRevision": p, "executionFixture": fixture, "authorizationState": "NO-GO",
 		"authorities": map[string]any{"infrastructure": "ok-infra", "management": "ok-mgmt", "gitOps": "ok-shared", "workloadIdentityMode": "capi-cluster-uid/v1", "runnerIdentityMode": "bounded-job/v1"},
 		"stages":      stages,
+	}
+	if attempt != "" {
+		document["executionAttemptDigest"] = attempt
 	}
 	raw, err := json.Marshal(document)
 	if err != nil {
 		t.Fatal(err)
 	}
-	plan, err := stageplan.Verify(raw, stageplan.Expected{
+	expected := stageplan.Expected{
 		ContractIdentity: identity, IntentRevision: r, EnablementRevision: e, PlatformRevision: p, ExecutionFixture: fixture,
 		InfrastructureAuthority: "ok-infra", ManagementAuthority: "ok-mgmt", GitOpsAuthority: "ok-shared",
-	})
+	}
+	expected.ExecutionAttemptDigest = attempt
+	plan, err := stageplan.Verify(raw, expected)
 	if err != nil {
 		t.Fatal(err)
 	}
 	return plan
+}
+
+func requestForPlan(t *testing.T, plan stageplan.Binding) runner.StageAuthorizationRequest {
+	t.Helper()
+	stage, stageDigest, err := plan.Stage("provider-prerequisites")
+	if err != nil {
+		t.Fatal(err)
+	}
+	requestFormat := runner.StageAuthorizationRequestFormat
+	if plan.Format == stageplan.BindingFormatV2 {
+		requestFormat = runner.StageAuthorizationRequestFormatV2
+	}
+	request := runner.StageAuthorizationRequest{
+		Format: requestFormat, Audience: authorization.StageAudience,
+		PlanDigest: plan.PlanDigest, ContractIdentity: plan.ContractIdentity, ContractRevision: plan.IntentRevision,
+		EnablementRevision: plan.EnablementRevision, PlatformRevision: plan.PlatformRevision,
+		ExecutionFixture: plan.ExecutionFixture, ExecutionAttempt: plan.ExecutionAttempt,
+		StageID: stage.ID, StageOrder: stage.Order, StageDigest: stageDigest, Operation: stage.GrantOperation,
+		Authority: stage.Authority, Predecessors: []stagecursor.Predecessor{}, MaxUses: 1,
+	}
+	request.RequestDigest = stageRequestDigest(t, request)
+	return request
 }
 
 func writeFile(t *testing.T, root, name string, raw []byte, mode os.FileMode) string {

--- a/internal/stageplan/plan.go
+++ b/internal/stageplan/plan.go
@@ -21,7 +21,9 @@ import (
 
 const (
 	Format           = "ok147-staged-execution-plan/v1"
+	FormatV2         = "ok147-staged-execution-plan/v2"
 	BindingFormat    = "ok147-verified-staged-execution-plan/v1"
+	BindingFormatV2  = "ok147-verified-staged-execution-plan/v2"
 	maximumPlanBytes = 128 * 1024
 )
 
@@ -38,6 +40,7 @@ type Expected struct {
 	EnablementRevision      string
 	PlatformRevision        string
 	ExecutionFixture        string
+	ExecutionAttemptDigest  string
 	InfrastructureAuthority string
 	ManagementAuthority     string
 	GitOpsAuthority         string
@@ -75,6 +78,7 @@ type document struct {
 	EnablementRevision string            `json:"enablementRevision"`
 	PlatformRevision   string            `json:"platformRevision"`
 	ExecutionFixture   string            `json:"executionFixture"`
+	ExecutionAttempt   string            `json:"executionAttemptDigest,omitempty"`
 	AuthorizationState string            `json:"authorizationState"`
 	Authorities        Authorities       `json:"authorities"`
 	Stages             []Stage           `json:"stages"`
@@ -90,12 +94,13 @@ type Binding struct {
 	EnablementRevision  string            `json:"enablementRevision"`
 	PlatformRevision    string            `json:"platformRevision"`
 	ExecutionFixture    string            `json:"executionFixture"`
+	ExecutionAttempt    string            `json:"executionAttemptDigest,omitempty"`
 	Authorities         Authorities       `json:"authorities"`
 	Stages              []Stage           `json:"stages"`
 	verified            bool
 	verifiedDigest      string
 	verifiedIdentity    contract.Identity
-	verifiedRevisions   [4]string
+	verifiedRevisions   [5]string
 	verifiedAuthorities Authorities
 	stageDigests        map[string]string
 }
@@ -157,8 +162,15 @@ func Verify(raw []byte, expected Expected) (Binding, error) {
 	if err := jsonstrict.Decode(raw, &source); err != nil {
 		return Binding{}, fmt.Errorf("decode staged execution plan: %w", err)
 	}
-	if source.Format != Format {
+	if source.Format != Format && source.Format != FormatV2 {
 		return Binding{}, fmt.Errorf("staged execution plan format %q is not supported", source.Format)
+	}
+	if source.Format == Format {
+		if source.ExecutionAttempt != "" || expected.ExecutionAttemptDigest != "" {
+			return Binding{}, errors.New("staged execution plan v1 cannot bind an execution attempt")
+		}
+	} else if !digestPattern.MatchString(source.ExecutionAttempt) || source.ExecutionAttempt != expected.ExecutionAttemptDigest {
+		return Binding{}, errors.New("staged execution plan execution attempt differs from verified input")
 	}
 	if source.AuthorizationState != "NO-GO" {
 		return Binding{}, errors.New("staged execution plan must remain non-authorizing (authorizationState NO-GO)")
@@ -190,14 +202,19 @@ func Verify(raw []byte, expected Expected) (Binding, error) {
 		}
 		stageDigests[stage.ID] = stageDigest
 	}
+	bindingFormat := BindingFormat
+	if source.Format == FormatV2 {
+		bindingFormat = BindingFormatV2
+	}
 	return Binding{
-		Format: BindingFormat, PlanDigest: planDigest,
+		Format: bindingFormat, PlanDigest: planDigest,
 		ContractIdentity: source.ContractIdentity,
 		IntentRevision:   source.IntentRevision, EnablementRevision: source.EnablementRevision,
 		PlatformRevision: source.PlatformRevision, ExecutionFixture: source.ExecutionFixture,
-		Authorities: source.Authorities, Stages: cloneStages(source.Stages),
+		ExecutionAttempt: source.ExecutionAttempt,
+		Authorities:      source.Authorities, Stages: cloneStages(source.Stages),
 		verified: true, verifiedDigest: planDigest, verifiedIdentity: source.ContractIdentity,
-		verifiedRevisions:   [4]string{source.IntentRevision, source.EnablementRevision, source.PlatformRevision, source.ExecutionFixture},
+		verifiedRevisions:   [5]string{source.IntentRevision, source.EnablementRevision, source.PlatformRevision, source.ExecutionFixture, source.ExecutionAttempt},
 		verifiedAuthorities: source.Authorities, stageDigests: stageDigests,
 	}, nil
 }
@@ -215,6 +232,9 @@ func ValidateExpected(expected Expected) error {
 		if !digestPattern.MatchString(value) {
 			return fmt.Errorf("expected %s is invalid", label)
 		}
+	}
+	if expected.ExecutionAttemptDigest != "" && !digestPattern.MatchString(expected.ExecutionAttemptDigest) {
+		return errors.New("expected execution attempt digest is invalid")
 	}
 	for label, value := range map[string]string{
 		"infrastructure authority": expected.InfrastructureAuthority,
@@ -316,10 +336,10 @@ func IsMutating(stage Stage) bool { return strings.TrimSpace(stage.GrantOperatio
 // Stage returns one stage and its canonical semantic digest after rechecking
 // that the in-memory binding still represents the originally verified plan.
 func (binding Binding) Stage(id string) (Stage, string, error) {
-	if !binding.verified || binding.Format != BindingFormat || binding.PlanDigest != binding.verifiedDigest || !digestPattern.MatchString(binding.PlanDigest) {
+	if !binding.verified || binding.Format != BindingFormat && binding.Format != BindingFormatV2 || binding.PlanDigest != binding.verifiedDigest || !digestPattern.MatchString(binding.PlanDigest) {
 		return Stage{}, "", errors.New("verified staged execution binding is required")
 	}
-	if binding.ContractIdentity != binding.verifiedIdentity || [4]string{binding.IntentRevision, binding.EnablementRevision, binding.PlatformRevision, binding.ExecutionFixture} != binding.verifiedRevisions || binding.Authorities != binding.verifiedAuthorities {
+	if binding.ContractIdentity != binding.verifiedIdentity || [5]string{binding.IntentRevision, binding.EnablementRevision, binding.PlatformRevision, binding.ExecutionFixture, binding.ExecutionAttempt} != binding.verifiedRevisions || binding.Authorities != binding.verifiedAuthorities {
 		return Stage{}, "", errors.New("staged execution top-level binding changed after verification")
 	}
 	if err := validateStages(binding.Stages); err != nil {

--- a/internal/stageplan/plan_test.go
+++ b/internal/stageplan/plan_test.go
@@ -27,6 +27,45 @@ func TestVerifyAcceptsExactBoundedSequence(t *testing.T) {
 	}
 }
 
+func TestVerifyV2BindsOneExecutionAttempt(t *testing.T) {
+	firstDocument := validDocument()
+	firstDocument.Format = FormatV2
+	firstDocument.ExecutionAttempt = sha("5")
+	firstExpected := expected()
+	firstExpected.ExecutionAttemptDigest = firstDocument.ExecutionAttempt
+
+	first, err := Verify(planJSON(t, firstDocument), firstExpected)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := Verify(planJSON(t, firstDocument), firstExpected)
+	if err != nil || first.PlanDigest != second.PlanDigest || first.Format != BindingFormatV2 || first.ExecutionAttempt != firstDocument.ExecutionAttempt {
+		t.Fatalf("v2 attempt identity is not deterministic: %#v %#v %v", first, second, err)
+	}
+
+	changedDocument := firstDocument
+	changedDocument.ExecutionAttempt = sha("6")
+	changedExpected := firstExpected
+	changedExpected.ExecutionAttemptDigest = changedDocument.ExecutionAttempt
+	changed, err := Verify(planJSON(t, changedDocument), changedExpected)
+	if err != nil || changed.PlanDigest == first.PlanDigest {
+		t.Fatalf("changed attempt did not change plan identity: %s %s %v", first.PlanDigest, changed.PlanDigest, err)
+	}
+
+	if _, err := Verify(planJSON(t, firstDocument), changedExpected); err == nil {
+		t.Fatal("foreign execution attempt was accepted")
+	}
+	missing := firstDocument
+	missing.ExecutionAttempt = ""
+	if _, err := Verify(planJSON(t, missing), firstExpected); err == nil {
+		t.Fatal("missing v2 execution attempt was accepted")
+	}
+	legacy := validDocument()
+	if _, err := Verify(planJSON(t, legacy), firstExpected); err == nil {
+		t.Fatal("legacy plan was silently reinterpreted as an attempt-bound plan")
+	}
+}
+
 func TestRequireInputBindsExactArtifactIdentity(t *testing.T) {
 	binding, err := Verify(planJSON(t, validDocument()), expected())
 	if err != nil {
@@ -146,6 +185,22 @@ func TestStageRechecksInMemoryBinding(t *testing.T) {
 	binding.Stages[3].Inputs[0].Digest = sha("0")
 	if _, _, err := binding.Stage("enablement"); err == nil {
 		t.Fatal("changed in-memory stage binding was accepted")
+	}
+}
+
+func TestStageRechecksV2AttemptBinding(t *testing.T) {
+	plan := validDocument()
+	plan.Format = FormatV2
+	plan.ExecutionAttempt = sha("5")
+	want := expected()
+	want.ExecutionAttemptDigest = plan.ExecutionAttempt
+	binding, err := Verify(planJSON(t, plan), want)
+	if err != nil {
+		t.Fatal(err)
+	}
+	binding.ExecutionAttempt = sha("6")
+	if _, _, err := binding.Stage("provider-prerequisites"); err == nil {
+		t.Fatal("changed in-memory execution attempt was accepted")
 	}
 }
 


### PR DESCRIPTION
## Outcome

Implements the additive OK-147 execution-attempt recovery boundary discovered after the R9/R10 durable replay stop. Historical v1 plans and claims remain immutable; a separately verified attempt produces a new plan/request/policy/grant identity.

## Scope

- strict redaction-safe execution-attempt verifier and CLI
- staged plan v2 with `executionAttemptDigest`
- authority policy/request/grant/receipt v2 bindings
- full-run manifest v4 and downstream activation support
- v1/v3 compatibility and fail-closed negative controls
- implementation evidence and operator documentation

## Verification

- `go test ./...` in `golang:1.24.6-bookworm`: PASS
- `go vet ./...` in `golang:1.24.6-bookworm`: PASS
- `git diff --check`: PASS

## Boundaries

- no Kubernetes API contact
- no infrastructure mutation
- no claim deletion/reset
- no automatic retry
- next full-run attempt remains NOT GRANTED
