### PR TITLE
fix(runner): support legacy stopped-evidence migration

### DIFF
--- a/docs/ok147-execution-attempt-v2-implementation.md
+++ b/docs/ok147-execution-attempt-v2-implementation.md
@@ -30,7 +30,9 @@ No Kubernetes API was contacted and no infrastructure object was changed.
 - an immutable runner image;
 - the activation-package digest;
 - the exact `create-converge-observe/v1` mode;
-- predecessor-attempt and stopped-evidence digests together for recovery;
+- predecessor-attempt and/or stopped-evidence digests for recovery (a
+  historical v1 predecessor has no attempt digest, so its stopped evidence is
+  sufficient and no synthetic predecessor identity is invented);
 - a decision-window digest; and
 - `maxAttempts: 1`.
 
@@ -65,8 +67,8 @@ Offline tests establish:
 
 1. equivalent attempt documents produce the same digest;
 2. a changed bound runner identity produces a different digest;
-3. incomplete recovery lineage, mutable runner images and `maxAttempts != 1`
-   fail closed;
+3. malformed recovery lineage, mutable runner images and `maxAttempts != 1`
+   fail closed, while stopped-evidence-only v1 migration remains possible;
 4. a changed attempt produces a different PlanDigest, policy and request;
 5. the signed grant carries the same attempt identity;
 6. same-attempt replay remains HTTP 409;

--- a/docs/ok147-stage-attempt-recovery-evaluation.md
+++ b/docs/ok147-stage-attempt-recovery-evaluation.md
@@ -117,7 +117,7 @@ that binds at least:
 - reviewed runner image digest;
 - activation-package digest;
 - bounded operational mode (`create + converge + observe` for this scope);
-- explicit predecessor attempt or stopped-evidence digest when applicable;
+- explicit predecessor attempt and/or stopped-evidence digest when applicable;
 - expiry or decision-window identity; and
 - `maxAttempts: 1`.
 

--- a/internal/stageattempt/attempt.go
+++ b/internal/stageattempt/attempt.go
@@ -97,7 +97,7 @@ func Verify(raw []byte, expected Expected) (Receipt, error) {
 		Format: ReceiptFormat, State: "VERIFIED", ExecutionAttemptDigest: digest.SHA256(canonical),
 		SourceFixtureDigest: document.SourceFixtureDigest, SourcePlanDigest: document.SourcePlanSemanticDigest,
 		RunnerImage: document.RunnerImage, ActivationPackageDigest: document.ActivationPackageDigest,
-		Mode: document.Mode, RecoveryBound: document.PredecessorAttemptDigest != "", MaxAttempts: document.MaxAttempts,
+		Mode: document.Mode, RecoveryBound: document.PredecessorAttemptDigest != "" || document.StoppedEvidenceDigest != "", MaxAttempts: document.MaxAttempts,
 		MutationAllowed: false,
 	}, nil
 }
@@ -107,9 +107,6 @@ func validateExpected(expected Expected) error {
 		!digestPattern.MatchString(expected.SourcePlanSemanticDigest) || !imagePattern.MatchString(expected.RunnerImage) ||
 		!digestPattern.MatchString(expected.ActivationPackageDigest) || !digestPattern.MatchString(expected.DecisionWindowDigest) {
 		return errors.New("expected execution attempt identity is invalid")
-	}
-	if (expected.PredecessorAttemptDigest == "") != (expected.StoppedEvidenceDigest == "") {
-		return errors.New("expected recovery attempt lineage is incomplete")
 	}
 	for _, value := range []string{expected.PredecessorAttemptDigest, expected.StoppedEvidenceDigest} {
 		if value != "" && !digestPattern.MatchString(value) {
@@ -125,9 +122,6 @@ func validateDocument(document Document) error {
 		!digestPattern.MatchString(document.SourcePlanSemanticDigest) || !imagePattern.MatchString(document.RunnerImage) ||
 		!digestPattern.MatchString(document.ActivationPackageDigest) || !digestPattern.MatchString(document.DecisionWindowDigest) {
 		return errors.New("execution attempt identity is invalid")
-	}
-	if (document.PredecessorAttemptDigest == "") != (document.StoppedEvidenceDigest == "") {
-		return errors.New("execution attempt recovery lineage is incomplete")
 	}
 	for _, value := range []string{document.PredecessorAttemptDigest, document.StoppedEvidenceDigest} {
 		if value != "" && !digestPattern.MatchString(value) {

--- a/internal/stageattempt/attempt_test.go
+++ b/internal/stageattempt/attempt_test.go
@@ -59,6 +59,25 @@ func TestVerifyFailsClosed(t *testing.T) {
 	}
 }
 
+func TestVerifySupportsHistoricalV1RecoveryWithoutInventedAttemptIdentity(t *testing.T) {
+	document, expected := fixture()
+	document.PredecessorAttemptDigest = ""
+	expected.PredecessorAttemptDigest = ""
+	raw, _ := json.Marshal(document)
+	receipt, err := Verify(raw, expected)
+	if err != nil || !receipt.RecoveryBound || receipt.ExecutionAttemptDigest == "" {
+		t.Fatalf("stopped-evidence-only v1 migration was rejected: %#v %v", receipt, err)
+	}
+
+	document.StoppedEvidenceDigest = ""
+	expected.StoppedEvidenceDigest = ""
+	raw, _ = json.Marshal(document)
+	receipt, err = Verify(raw, expected)
+	if err != nil || receipt.RecoveryBound {
+		t.Fatalf("initial attempt without lineage was rejected: %#v %v", receipt, err)
+	}
+}
+
 func fixture() (Document, Expected) {
 	document := Document{
 		Format: Format, AttemptID: "ok147-full-run-r11", SourceFixtureDigest: sha("1"), SourcePlanSemanticDigest: sha("2"),


### PR DESCRIPTION
## Outcome

Corrects the first v1-to-v2 execution-attempt migration boundary discovered while preparing R11. A historical v1 run has no predecessor `ExecutionAttemptDigest`; its exact stopped-evidence digest can therefore bind recovery without inventing a synthetic attempt identity.

## Behavior

- initial attempt: no lineage allowed
- legacy v1 recovery: stopped evidence alone allowed
- v2 recovery: predecessor attempt and/or stopped evidence allowed
- every supplied lineage digest remains independently expected and exact

## Verification

- targeted Linux tests: PASS
- targeted Linux vet: PASS
- no cluster contact or mutation

The waiting publisher was cancelled before build/publication and will be restarted only after this fix is on main.
