### PR TITLE
fix(runner): break execution-attempt package digest cycle

### DIFF
--- a/cmd/ok/stage_attempt.go
+++ b/cmd/ok/stage_attempt.go
@@ -21,6 +21,7 @@ func runClusterStageAttemptVerify(arguments []string, stdout, stderr io.Writer) 
 	sourcePlan := flags.String("source-plan-semantic-digest", "", "independently expected source plan identity")
 	runnerImage := flags.String("runner-image", "", "independently expected digest-pinned runner image")
 	activationPackage := flags.String("activation-package-digest", "", "independently expected activation package digest")
+	sourceActivationPackage := flags.String("source-activation-package-digest", "", "independently expected pre-attempt activation package digest")
 	predecessorAttempt := flags.String("predecessor-attempt-digest", "", "expected predecessor attempt for recovery")
 	stoppedEvidence := flags.String("stopped-evidence-digest", "", "expected stopped evidence for recovery")
 	decisionWindow := flags.String("decision-window-digest", "", "independently expected decision-window identity")
@@ -30,10 +31,13 @@ func runClusterStageAttemptVerify(arguments []string, stdout, stderr io.Writer) 
 	if flags.NArg() != 0 {
 		return errors.New("positional arguments are not accepted")
 	}
-	for _, value := range []string{*path, *attemptID, *sourceFixture, *sourcePlan, *runnerImage, *activationPackage, *decisionWindow} {
+	for _, value := range []string{*path, *attemptID, *sourceFixture, *sourcePlan, *runnerImage, *decisionWindow} {
 		if value == "" {
 			return errors.New("all non-recovery execution-attempt inputs are required")
 		}
+	}
+	if (*activationPackage == "") == (*sourceActivationPackage == "") {
+		return errors.New("exactly one activation-package identity is required")
 	}
 	info, err := os.Lstat(*path)
 	if err != nil || !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 || info.Size() <= 0 || info.Size() > maximumExecutionAttemptBytes {
@@ -46,7 +50,8 @@ func runClusterStageAttemptVerify(arguments []string, stdout, stderr io.Writer) 
 	receipt, err := stageattempt.Verify(raw, stageattempt.Expected{
 		AttemptID: *attemptID, SourceFixtureDigest: *sourceFixture, SourcePlanSemanticDigest: *sourcePlan,
 		RunnerImage: *runnerImage, ActivationPackageDigest: *activationPackage,
-		PredecessorAttemptDigest: *predecessorAttempt, StoppedEvidenceDigest: *stoppedEvidence,
+		SourceActivationPackageDigest: *sourceActivationPackage,
+		PredecessorAttemptDigest:      *predecessorAttempt, StoppedEvidenceDigest: *stoppedEvidence,
 		DecisionWindowDigest: *decisionWindow,
 	})
 	if err != nil {

--- a/cmd/ok/stage_attempt_test.go
+++ b/cmd/ok/stage_attempt_test.go
@@ -14,8 +14,8 @@ func TestClusterStageAttemptVerifyEmitsNonAuthorizingIdentity(t *testing.T) {
 	document := map[string]any{
 		"format": stageattempt.Format, "attemptId": "ok147-full-run-r11",
 		"sourceFixtureDigest": testSHA("1"), "sourcePlanSemanticDigest": testSHA("2"),
-		"runnerImage":             "ghcr.io/openkubes/ok-cluster-runner@" + testSHA("3"),
-		"activationPackageDigest": testSHA("4"), "mode": stageattempt.Mode,
+		"runnerImage":                   "ghcr.io/openkubes/ok-cluster-runner@" + testSHA("3"),
+		"sourceActivationPackageDigest": testSHA("4"), "mode": stageattempt.Mode,
 		"predecessorAttemptDigest": testSHA("5"), "stoppedEvidenceDigest": testSHA("6"),
 		"decisionWindowDigest": testSHA("7"), "maxAttempts": 1,
 	}
@@ -27,7 +27,7 @@ func TestClusterStageAttemptVerifyEmitsNonAuthorizingIdentity(t *testing.T) {
 	arguments := []string{
 		"cluster", "stage", "attempt", "verify", "--attempt", path, "--attempt-id", "ok147-full-run-r11",
 		"--source-fixture-digest", testSHA("1"), "--source-plan-semantic-digest", testSHA("2"),
-		"--runner-image", "ghcr.io/openkubes/ok-cluster-runner@" + testSHA("3"), "--activation-package-digest", testSHA("4"),
+		"--runner-image", "ghcr.io/openkubes/ok-cluster-runner@" + testSHA("3"), "--source-activation-package-digest", testSHA("4"),
 		"--predecessor-attempt-digest", testSHA("5"), "--stopped-evidence-digest", testSHA("6"), "--decision-window-digest", testSHA("7"),
 	}
 	var stdout bytes.Buffer

--- a/docs/ok147-execution-attempt-v2-implementation.md
+++ b/docs/ok147-execution-attempt-v2-implementation.md
@@ -23,12 +23,12 @@ No Kubernetes API was contacted and no infrastructure object was changed.
 
 ## Attempt identity
 
-`ok147-execution-attempt/v1` is a strict, redaction-safe document that binds:
+`ok147-execution-attempt/v2` is a strict, redaction-safe document that binds:
 
 - an explicit attempt identifier;
 - source FixtureDigest and source staged-plan semantic identity;
 - an immutable runner image;
-- the activation-package digest;
+- the source activation-package digest from which the new attempt is derived;
 - the exact `create-converge-observe/v1` mode;
 - predecessor-attempt and/or stopped-evidence digests for recovery (a
   historical v1 predecessor has no attempt digest, so its stopped evidence is
@@ -39,6 +39,13 @@ No Kubernetes API was contacted and no infrastructure object was changed.
 The verifier accepts only independently supplied expected identities. It
 canonicalizes the document and returns `ExecutionAttemptDigest`; the document
 is not a grant and its receipt has `mutationAllowed: false`.
+
+The source qualifier is essential. The final activation package embeds plan
+v2, which embeds `ExecutionAttemptDigest`. Binding that final package inside
+the attempt document would create an impossible digest cycle. The final
+package is instead built after the attempt and is bound independently by the
+launch candidate. Historical attempt-v1 documents remain verifiable, but must
+not be used to create a new cyclic binding.
 
 ## Additive protocol formats
 

--- a/docs/ok147-stage-attempt-recovery-evaluation.md
+++ b/docs/ok147-stage-attempt-recovery-evaluation.md
@@ -115,11 +115,18 @@ that binds at least:
 - attempt format and identifier;
 - source FixtureDigest and staged-plan semantic identity;
 - reviewed runner image digest;
-- activation-package digest;
+- source activation-package digest (the immutable package from which this
+  attempt is derived);
 - bounded operational mode (`create + converge + observe` for this scope);
 - explicit predecessor attempt and/or stopped-evidence digest when applicable;
 - expiry or decision-window identity; and
 - `maxAttempts: 1`.
+
+The final activation package cannot be an input to this digest: it embeds the
+plan that carries `ExecutionAttemptDigest`, which would create a circular hash
+dependency. The final package is produced only after the attempt identity and
+is then independently pinned by the launch candidate. Attempt format v2 makes
+that ordering explicit; historical v1 remains verification-only.
 
 The attempt document is not itself a grant. The authority policy must bind its
 digest, and every normal stage authorization request and signed grant must

--- a/internal/stageattempt/attempt.go
+++ b/internal/stageattempt/attempt.go
@@ -15,9 +15,11 @@ import (
 )
 
 const (
-	Format        = "ok147-execution-attempt/v1"
-	ReceiptFormat = "ok147-verified-execution-attempt/v1"
-	Mode          = "create-converge-observe/v1"
+	LegacyFormat        = "ok147-execution-attempt/v1"
+	LegacyReceiptFormat = "ok147-verified-execution-attempt/v1"
+	Format              = "ok147-execution-attempt/v2"
+	ReceiptFormat       = "ok147-verified-execution-attempt/v2"
+	Mode                = "create-converge-observe/v1"
 )
 
 var (
@@ -34,40 +36,46 @@ type Document struct {
 	SourceFixtureDigest      string `json:"sourceFixtureDigest"`
 	SourcePlanSemanticDigest string `json:"sourcePlanSemanticDigest"`
 	RunnerImage              string `json:"runnerImage"`
-	ActivationPackageDigest  string `json:"activationPackageDigest"`
-	Mode                     string `json:"mode"`
-	PredecessorAttemptDigest string `json:"predecessorAttemptDigest,omitempty"`
-	StoppedEvidenceDigest    string `json:"stoppedEvidenceDigest,omitempty"`
-	DecisionWindowDigest     string `json:"decisionWindowDigest"`
-	MaxAttempts              int    `json:"maxAttempts"`
+	// ActivationPackageDigest is retained only for historical v1 documents.
+	// It cannot safely describe the final package because that package embeds
+	// the plan carrying the digest of this document.
+	ActivationPackageDigest       string `json:"activationPackageDigest,omitempty"`
+	SourceActivationPackageDigest string `json:"sourceActivationPackageDigest,omitempty"`
+	Mode                          string `json:"mode"`
+	PredecessorAttemptDigest      string `json:"predecessorAttemptDigest,omitempty"`
+	StoppedEvidenceDigest         string `json:"stoppedEvidenceDigest,omitempty"`
+	DecisionWindowDigest          string `json:"decisionWindowDigest"`
+	MaxAttempts                   int    `json:"maxAttempts"`
 }
 
 // Expected is independently supplied from reviewed fixture, runner,
 // activation and stopped-evidence checkpoints.
 type Expected struct {
-	AttemptID                string
-	SourceFixtureDigest      string
-	SourcePlanSemanticDigest string
-	RunnerImage              string
-	ActivationPackageDigest  string
-	PredecessorAttemptDigest string
-	StoppedEvidenceDigest    string
-	DecisionWindowDigest     string
+	AttemptID                     string
+	SourceFixtureDigest           string
+	SourcePlanSemanticDigest      string
+	RunnerImage                   string
+	ActivationPackageDigest       string
+	SourceActivationPackageDigest string
+	PredecessorAttemptDigest      string
+	StoppedEvidenceDigest         string
+	DecisionWindowDigest          string
 }
 
 // Receipt is safe to retain publicly. It grants no execution authority.
 type Receipt struct {
-	Format                  string `json:"format"`
-	State                   string `json:"state"`
-	ExecutionAttemptDigest  string `json:"executionAttemptDigest"`
-	SourceFixtureDigest     string `json:"sourceFixtureDigest"`
-	SourcePlanDigest        string `json:"sourcePlanSemanticDigest"`
-	RunnerImage             string `json:"runnerImage"`
-	ActivationPackageDigest string `json:"activationPackageDigest"`
-	Mode                    string `json:"mode"`
-	RecoveryBound           bool   `json:"recoveryBound"`
-	MaxAttempts             int    `json:"maxAttempts"`
-	MutationAllowed         bool   `json:"mutationAllowed"`
+	Format                        string `json:"format"`
+	State                         string `json:"state"`
+	ExecutionAttemptDigest        string `json:"executionAttemptDigest"`
+	SourceFixtureDigest           string `json:"sourceFixtureDigest"`
+	SourcePlanDigest              string `json:"sourcePlanSemanticDigest"`
+	RunnerImage                   string `json:"runnerImage"`
+	ActivationPackageDigest       string `json:"activationPackageDigest,omitempty"`
+	SourceActivationPackageDigest string `json:"sourceActivationPackageDigest,omitempty"`
+	Mode                          string `json:"mode"`
+	RecoveryBound                 bool   `json:"recoveryBound"`
+	MaxAttempts                   int    `json:"maxAttempts"`
+	MutationAllowed               bool   `json:"mutationAllowed"`
 }
 
 // Verify accepts only the exact independently expected attempt and returns
@@ -85,7 +93,9 @@ func Verify(raw []byte, expected Expected) (Receipt, error) {
 	}
 	if document.AttemptID != expected.AttemptID || document.SourceFixtureDigest != expected.SourceFixtureDigest ||
 		document.SourcePlanSemanticDigest != expected.SourcePlanSemanticDigest || document.RunnerImage != expected.RunnerImage ||
-		document.ActivationPackageDigest != expected.ActivationPackageDigest || document.PredecessorAttemptDigest != expected.PredecessorAttemptDigest ||
+		document.ActivationPackageDigest != expected.ActivationPackageDigest ||
+		document.SourceActivationPackageDigest != expected.SourceActivationPackageDigest ||
+		document.PredecessorAttemptDigest != expected.PredecessorAttemptDigest ||
 		document.StoppedEvidenceDigest != expected.StoppedEvidenceDigest || document.DecisionWindowDigest != expected.DecisionWindowDigest {
 		return Receipt{}, errors.New("execution attempt differs from independently verified inputs")
 	}
@@ -93,19 +103,31 @@ func Verify(raw []byte, expected Expected) (Receipt, error) {
 	if err != nil {
 		return Receipt{}, err
 	}
+	receiptFormat := ReceiptFormat
+	if document.Format == LegacyFormat {
+		receiptFormat = LegacyReceiptFormat
+	}
 	return Receipt{
-		Format: ReceiptFormat, State: "VERIFIED", ExecutionAttemptDigest: digest.SHA256(canonical),
-		SourceFixtureDigest: document.SourceFixtureDigest, SourcePlanDigest: document.SourcePlanSemanticDigest,
-		RunnerImage: document.RunnerImage, ActivationPackageDigest: document.ActivationPackageDigest,
-		Mode: document.Mode, RecoveryBound: document.PredecessorAttemptDigest != "" || document.StoppedEvidenceDigest != "", MaxAttempts: document.MaxAttempts,
-		MutationAllowed: false,
+		Format:                        receiptFormat,
+		State:                         "VERIFIED",
+		ExecutionAttemptDigest:        digest.SHA256(canonical),
+		SourceFixtureDigest:           document.SourceFixtureDigest,
+		SourcePlanDigest:              document.SourcePlanSemanticDigest,
+		RunnerImage:                   document.RunnerImage,
+		ActivationPackageDigest:       document.ActivationPackageDigest,
+		SourceActivationPackageDigest: document.SourceActivationPackageDigest,
+		Mode:                          document.Mode,
+		RecoveryBound:                 document.PredecessorAttemptDigest != "" || document.StoppedEvidenceDigest != "",
+		MaxAttempts:                   document.MaxAttempts,
+		MutationAllowed:               false,
 	}, nil
 }
 
 func validateExpected(expected Expected) error {
 	if !namePattern.MatchString(expected.AttemptID) || !digestPattern.MatchString(expected.SourceFixtureDigest) ||
 		!digestPattern.MatchString(expected.SourcePlanSemanticDigest) || !imagePattern.MatchString(expected.RunnerImage) ||
-		!digestPattern.MatchString(expected.ActivationPackageDigest) || !digestPattern.MatchString(expected.DecisionWindowDigest) {
+		!validActivationIdentity(expected.ActivationPackageDigest, expected.SourceActivationPackageDigest) ||
+		!digestPattern.MatchString(expected.DecisionWindowDigest) {
 		return errors.New("expected execution attempt identity is invalid")
 	}
 	for _, value := range []string{expected.PredecessorAttemptDigest, expected.StoppedEvidenceDigest} {
@@ -117,11 +139,16 @@ func validateExpected(expected Expected) error {
 }
 
 func validateDocument(document Document) error {
-	if document.Format != Format || document.Mode != Mode || document.MaxAttempts != 1 ||
+	if (document.Format != Format && document.Format != LegacyFormat) || document.Mode != Mode || document.MaxAttempts != 1 ||
 		!namePattern.MatchString(document.AttemptID) || !digestPattern.MatchString(document.SourceFixtureDigest) ||
 		!digestPattern.MatchString(document.SourcePlanSemanticDigest) || !imagePattern.MatchString(document.RunnerImage) ||
-		!digestPattern.MatchString(document.ActivationPackageDigest) || !digestPattern.MatchString(document.DecisionWindowDigest) {
+		!validActivationIdentity(document.ActivationPackageDigest, document.SourceActivationPackageDigest) ||
+		!digestPattern.MatchString(document.DecisionWindowDigest) {
 		return errors.New("execution attempt identity is invalid")
+	}
+	if (document.Format == LegacyFormat && document.ActivationPackageDigest == "") ||
+		(document.Format == Format && document.SourceActivationPackageDigest == "") {
+		return errors.New("execution attempt activation identity does not match its format")
 	}
 	for _, value := range []string{document.PredecessorAttemptDigest, document.StoppedEvidenceDigest} {
 		if value != "" && !digestPattern.MatchString(value) {
@@ -129,6 +156,11 @@ func validateDocument(document Document) error {
 		}
 	}
 	return nil
+}
+
+func validActivationIdentity(legacy, source string) bool {
+	return legacy != source && ((legacy != "" && source == "" && digestPattern.MatchString(legacy)) ||
+		(source != "" && legacy == "" && digestPattern.MatchString(source)))
 }
 
 func canonicalJSON(value any) ([]byte, error) {

--- a/internal/stageattempt/attempt_test.go
+++ b/internal/stageattempt/attempt_test.go
@@ -36,7 +36,7 @@ func TestVerifyIsDeterministicAndInputBound(t *testing.T) {
 func TestVerifyFailsClosed(t *testing.T) {
 	document, expected := fixture()
 	tests := map[string]func(*Document){
-		"unknown format":        func(value *Document) { value.Format = "ok147-execution-attempt/v2" },
+		"unknown format":        func(value *Document) { value.Format = "ok147-execution-attempt/v3" },
 		"arbitrary mode":        func(value *Document) { value.Mode = "retry-forever" },
 		"more than one attempt": func(value *Document) { value.MaxAttempts = 2 },
 		"mutable image":         func(value *Document) { value.RunnerImage = "ghcr.io/openkubes/ok-cluster-runner:latest" },
@@ -61,11 +61,16 @@ func TestVerifyFailsClosed(t *testing.T) {
 
 func TestVerifySupportsHistoricalV1RecoveryWithoutInventedAttemptIdentity(t *testing.T) {
 	document, expected := fixture()
+	document.Format = LegacyFormat
+	document.ActivationPackageDigest = document.SourceActivationPackageDigest
+	document.SourceActivationPackageDigest = ""
+	expected.ActivationPackageDigest = expected.SourceActivationPackageDigest
+	expected.SourceActivationPackageDigest = ""
 	document.PredecessorAttemptDigest = ""
 	expected.PredecessorAttemptDigest = ""
 	raw, _ := json.Marshal(document)
 	receipt, err := Verify(raw, expected)
-	if err != nil || !receipt.RecoveryBound || receipt.ExecutionAttemptDigest == "" {
+	if err != nil || receipt.Format != LegacyReceiptFormat || !receipt.RecoveryBound || receipt.ExecutionAttemptDigest == "" {
 		t.Fatalf("stopped-evidence-only v1 migration was rejected: %#v %v", receipt, err)
 	}
 
@@ -78,15 +83,32 @@ func TestVerifySupportsHistoricalV1RecoveryWithoutInventedAttemptIdentity(t *tes
 	}
 }
 
+func TestVerifyRejectsCyclicOrMixedActivationIdentity(t *testing.T) {
+	document, expected := fixture()
+	document.ActivationPackageDigest = sha("8")
+	raw, _ := json.Marshal(document)
+	if _, err := Verify(raw, expected); err == nil {
+		t.Fatal("mixed source and final activation-package identities were accepted")
+	}
+
+	document, expected = fixture()
+	document.SourceActivationPackageDigest = ""
+	expected.SourceActivationPackageDigest = ""
+	raw, _ = json.Marshal(document)
+	if _, err := Verify(raw, expected); err == nil {
+		t.Fatal("attempt without a non-cyclic source package identity was accepted")
+	}
+}
+
 func fixture() (Document, Expected) {
 	document := Document{
 		Format: Format, AttemptID: "ok147-full-run-r11", SourceFixtureDigest: sha("1"), SourcePlanSemanticDigest: sha("2"),
-		RunnerImage: "ghcr.io/openkubes/ok-cluster-runner@" + sha("3"), ActivationPackageDigest: sha("4"), Mode: Mode,
+		RunnerImage: "ghcr.io/openkubes/ok-cluster-runner@" + sha("3"), SourceActivationPackageDigest: sha("4"), Mode: Mode,
 		PredecessorAttemptDigest: sha("5"), StoppedEvidenceDigest: sha("6"), DecisionWindowDigest: sha("7"), MaxAttempts: 1,
 	}
 	expected := Expected{
 		AttemptID: document.AttemptID, SourceFixtureDigest: document.SourceFixtureDigest, SourcePlanSemanticDigest: document.SourcePlanSemanticDigest,
-		RunnerImage: document.RunnerImage, ActivationPackageDigest: document.ActivationPackageDigest,
+		RunnerImage: document.RunnerImage, SourceActivationPackageDigest: document.SourceActivationPackageDigest,
 		PredecessorAttemptDigest: document.PredecessorAttemptDigest, StoppedEvidenceDigest: document.StoppedEvidenceDigest,
 		DecisionWindowDigest: document.DecisionWindowDigest,
 	}


### PR DESCRIPTION
## Outcome

Makes the execution-attempt binding constructible before R11 packaging.

- adds strict `ok147-execution-attempt/v2`
- binds the immutable source activation package, not the final self-containing package
- retains attempt-v1 as verification-only history
- rejects mixed/cyclic activation identities fail-closed
- documents that the final package is independently pinned by the launch candidate

## Validation

- `go test ./...` in unprivileged `golang:1.24.6-bookworm`
- `go vet ./...` in the same container
- no cluster contact or infrastructure mutation

R11 remains not launched.