### PR TITLE
fix(runner): preserve failed first create attempt

### DIFF
--- a/internal/execution/staged_submission.go
+++ b/internal/execution/staged_submission.go
@@ -144,7 +144,18 @@ func validateSubmissionPlaneOutcome(receipt submission.PlaneReceipt, plane submi
 			return "", errors.New("submission receipt object state is invalid")
 		}
 	}
-	if receipt.MutationState != wantMutation {
+	if stopped {
+		// A failed POST is an attempted mutation even when no object result can
+		// be appended. Completed results therefore provide only a lower bound
+		// for a stopped receipt's mutation state.
+		if receipt.MutationState != "NOT_ATTEMPTED" && receipt.MutationState != "ATTEMPTED" {
+			return "", errors.New("submission receipt mutation state is invalid")
+		}
+		if wantMutation == "ATTEMPTED" && receipt.MutationState != "ATTEMPTED" {
+			return "", errors.New("submission receipt mutation state loses a completed create")
+		}
+		return receipt.MutationState, nil
+	} else if receipt.MutationState != wantMutation {
 		return "", errors.New("submission receipt mutation state is inconsistent")
 	}
 	return wantMutation, nil

--- a/internal/execution/staged_submission_test.go
+++ b/internal/execution/staged_submission_test.go
@@ -151,6 +151,22 @@ func TestSubmissionPlaneMutatorPreservesPartialStoppedEvidence(t *testing.T) {
 	}
 }
 
+func TestSubmissionPlaneMutatorPreservesFailedFirstCreateAttempt(t *testing.T) {
+	plan := stagedPlan(t)
+	projected := stagedSubmissionPlan(plan.IntentRevision, plan.Authorities.Infrastructure, plan.Authorities.Management)
+	receipt := submission.PlaneReceipt{
+		Format: submission.PlaneReceiptFormat, Authority: projected.Management.Identity,
+		Role: projected.Management.Role, State: "STOPPED_PARTIAL_OR_UNKNOWN",
+		MutationState: "ATTEMPTED", Results: []submission.ObjectResult{},
+	}
+	submitter := &fakePlaneSubmitter{receipt: receipt, err: errors.New("sensitive API detail")}
+	mutator, _ := NewSubmissionPlaneMutator(plan, "cluster-lifecycle", projected, submitter)
+	result, err := mutator.Mutate(context.Background(), stagedMutationRequest(t, plan, mutator.Binding()))
+	if err == nil || err.Error() != "bounded submission stopped" || result.Outcome != "STOPPED" || result.MutationState != "ATTEMPTED" || result.EvidenceDigest == "" {
+		t.Fatalf("failed first create attempt was not durably classifiable: %#v %v", result, err)
+	}
+}
+
 func TestSubmissionPlaneMutatorRejectsWrongStageAuthorityAndRequest(t *testing.T) {
 	plan := stagedPlan(t)
 	projected := stagedSubmissionPlan(plan.IntentRevision, plan.Authorities.Infrastructure, plan.Authorities.Management)


### PR DESCRIPTION
## Summary

- preserve `ATTEMPTED` when the first bounded Kubernetes POST fails before an object result can be appended
- keep completed results as the lower bound for stopped submission receipts
- add regression coverage for a failed first lifecycle create

## Why

R11 reached `cluster-lifecycle`, durably claimed the stage, then stopped before writing an outcome. The bounded submitter correctly reported an attempted first POST with no completed result, but validation rejected that valid stopped receipt as internally inconsistent. This left the stage intentionally indeterminate instead of durably recording `STOPPED`.

## Verification

- `go test ./...` passes with external linking required by the local macOS Go 1.21 toolchain
- no runtime evidence, credentials, endpoints, or private artifacts are included

## Scope

Runner validation fix only. No retry, cleanup, lifecycle mutation, or evidence publication.
