### PR TITLE
fix(runner): accept existing provider prerequisites (OK-147)

### DIFF
--- a/internal/execution/staged_submission.go
+++ b/internal/execution/staged_submission.go
@@ -92,6 +92,13 @@ func (mutator *SubmissionPlaneMutator) Mutate(ctx context.Context, request Stage
 		return StageMutationResult{Outcome: "STOPPED", MutationState: mutationState, EvidenceDigest: evidenceDigest}, errors.New("bounded submission stopped")
 	}
 	if mutationState != "ATTEMPTED" {
+		// Provider prerequisites are intentionally durable across disposable
+		// Cluster attempts. An exact all-UNCHANGED plane is therefore a
+		// successful idempotent ensure, while Cluster lifecycle and every other
+		// mutating stage still require an actual write.
+		if mutator.binding.StageID == "provider-prerequisites" && mutationState == "NOT_ATTEMPTED" {
+			return StageMutationResult{Outcome: "SUCCEEDED", MutationState: mutationState, EvidenceDigest: evidenceDigest}, nil
+		}
 		return StageMutationResult{Outcome: "STOPPED", MutationState: mutationState, EvidenceDigest: evidenceDigest}, nil
 	}
 	result := StageMutationResult{Outcome: "SUCCEEDED", MutationState: mutationState, EvidenceDigest: evidenceDigest}

--- a/internal/execution/staged_submission_test.go
+++ b/internal/execution/staged_submission_test.go
@@ -108,6 +108,20 @@ func TestSubmissionPlaneMutatorNoWriteCannotClaimStageSuccess(t *testing.T) {
 	}
 }
 
+func TestProviderPrerequisitesExactExistingPlaneCompletesWithoutWrite(t *testing.T) {
+	plan := stagedPlan(t)
+	projected := stagedSubmissionPlan(plan.IntentRevision, plan.Authorities.Infrastructure, plan.Authorities.Management)
+	submitter := &fakePlaneSubmitter{receipt: successfulPlaneReceipt(projected.Infrastructure, "UNCHANGED", "NOT_ATTEMPTED")}
+	mutator, err := NewSubmissionPlaneMutator(plan, "provider-prerequisites", projected, submitter)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := mutator.Mutate(context.Background(), stagedMutationRequest(t, plan, mutator.Binding()))
+	if err != nil || result.Outcome != "SUCCEEDED" || result.MutationState != "NOT_ATTEMPTED" || result.EvidenceDigest == "" || submitter.calls != 1 {
+		t.Fatalf("exact durable provider prerequisites did not complete idempotently: %#v calls=%d err=%v", result, submitter.calls, err)
+	}
+}
+
 func TestSubmissionPlaneMutatorBindsLifecycleRuntimeIdentityWithoutExposingUID(t *testing.T) {
 	plan := stagedPlan(t)
 	projected := stagedSubmissionPlan(plan.IntentRevision, plan.Authorities.Infrastructure, plan.Authorities.Management)

--- a/internal/ledger/stage.go
+++ b/internal/ledger/stage.go
@@ -107,7 +107,7 @@ func (ledger *Ledger) CompleteStageWithTarget(ctx context.Context, claim StageCl
 	if !allowed(outcome, "SUCCEEDED", "FAILED", "STOPPED") || !allowed(mutationState, "NOT_ATTEMPTED", "ATTEMPTED", "UNKNOWN") {
 		return StageOutcomeReceipt{}, errors.New("stage completion state is invalid")
 	}
-	if outcome == "SUCCEEDED" && mutationState != "ATTEMPTED" {
+	if outcome == "SUCCEEDED" && mutationState != "ATTEMPTED" && !(claim.StageID == "provider-prerequisites" && mutationState == "NOT_ATTEMPTED") {
 		return StageOutcomeReceipt{}, errors.New("successful mutating stage requires mutationState ATTEMPTED")
 	}
 	if !validDigest(evidenceDigest) {
@@ -254,7 +254,7 @@ func validateStageOutcome(value StageOutcomeReceipt) error {
 	if _, err := time.Parse(time.RFC3339Nano, value.CompletedAt); err != nil {
 		return errors.New("stage outcome has an invalid timestamp")
 	}
-	if value.Outcome == "SUCCEEDED" && value.MutationState != "ATTEMPTED" {
+	if value.Outcome == "SUCCEEDED" && value.MutationState != "ATTEMPTED" && !(value.StageID == "provider-prerequisites" && value.MutationState == "NOT_ATTEMPTED") {
 		return errors.New("successful stage outcome lacks attempted mutation state")
 	}
 	return nil

--- a/internal/ledger/stage_test.go
+++ b/internal/ledger/stage_test.go
@@ -79,14 +79,11 @@ func TestStageCompletionIsBoundImmutableAndIdempotent(t *testing.T) {
 		t.Fatal(err)
 	}
 	evidence := stageSHA("e")
-	if _, err := store.CompleteStage(context.Background(), claim, "SUCCEEDED", "NOT_ATTEMPTED", evidence, at.Add(time.Second)); err == nil {
-		t.Fatal("successful stage without attempted mutation was accepted")
-	}
-	first, err := store.CompleteStage(context.Background(), claim, "SUCCEEDED", "ATTEMPTED", evidence, at.Add(time.Second))
+	first, err := store.CompleteStage(context.Background(), claim, "SUCCEEDED", "NOT_ATTEMPTED", evidence, at.Add(time.Second))
 	if err != nil {
 		t.Fatal(err)
 	}
-	second, err := store.CompleteStage(context.Background(), claim, "SUCCEEDED", "ATTEMPTED", evidence, at.Add(time.Second))
+	second, err := store.CompleteStage(context.Background(), claim, "SUCCEEDED", "NOT_ATTEMPTED", evidence, at.Add(time.Second))
 	if err != nil || second != first {
 		t.Fatalf("identical stage completion is not idempotent: %#v %v", second, err)
 	}
@@ -96,6 +93,24 @@ func TestStageCompletionIsBoundImmutableAndIdempotent(t *testing.T) {
 	inspection, err := store.InspectStage(context.Background(), grant)
 	if err != nil || inspection.State != "COMPLETED" || inspection.Outcome == nil || inspection.Outcome.Outcome != "SUCCEEDED" {
 		t.Fatalf("unexpected completed stage inspection: %#v %v", inspection, err)
+	}
+}
+
+func TestClusterLifecycleCompletionStillRequiresAttemptedMutation(t *testing.T) {
+	store, _ := Open(filepath.Join(t.TempDir(), "ledger"))
+	at := time.Date(2026, 8, 16, 15, 0, 0, 0, time.UTC)
+	plan := verifiedStagePlan(t)
+	provider, err := stagereceipt.New(plan, "provider-prerequisites", []stagereceipt.Verified{}, "SUCCEEDED", "NOT_ATTEMPTED", stageSHA("1"), stageSHA("e"), at)
+	if err != nil {
+		t.Fatal(err)
+	}
+	grant := verifiedStageGrantFor(t, plan, "cluster-lifecycle", []stagereceipt.Verified{provider}, at.Add(time.Second))
+	claim, err := store.ClaimStage(context.Background(), grant, at.Add(time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.CompleteStage(context.Background(), claim, "SUCCEEDED", "NOT_ATTEMPTED", stageSHA("f"), at.Add(2*time.Second)); err == nil {
+		t.Fatal("Cluster lifecycle succeeded without an attempted mutation")
 	}
 }
 

--- a/internal/stagereceipt/receipt.go
+++ b/internal/stagereceipt/receipt.go
@@ -192,7 +192,7 @@ func verifyReceipt(receipt Receipt, plan stageplan.Binding, predecessors []Verif
 		if !allowed(receipt.MutationState, "NOT_ATTEMPTED", "ATTEMPTED", "UNKNOWN") || !receiptDigestPattern.MatchString(receipt.OperationOutcomeDigest) {
 			return Verified{}, errors.New("mutating stage receipt lacks a valid operation outcome")
 		}
-		if receipt.State == "SUCCEEDED" && receipt.MutationState != "ATTEMPTED" {
+		if receipt.State == "SUCCEEDED" && receipt.MutationState != "ATTEMPTED" && !(stage.ID == "provider-prerequisites" && receipt.MutationState == "NOT_ATTEMPTED") {
 			return Verified{}, errors.New("successful mutating stage did not attempt mutation")
 		}
 	} else if receipt.MutationState != "NOT_APPLICABLE" || receipt.OperationOutcomeDigest != "" {

--- a/internal/stagereceipt/receipt_test.go
+++ b/internal/stagereceipt/receipt_test.go
@@ -65,10 +65,13 @@ func TestReceiptRejectsMissingForeignAndFailedPredecessors(t *testing.T) {
 func TestReceiptEnforcesMutationBoundary(t *testing.T) {
 	plan := receiptPlan(t)
 	at := time.Date(2026, 8, 16, 16, 0, 0, 0, time.UTC)
-	if _, err := New(plan, "provider-prerequisites", []Verified{}, "SUCCEEDED", "NOT_ATTEMPTED", receiptSHA("1"), receiptSHA("a"), at); err == nil {
-		t.Fatal("successful mutation without attempt was accepted")
+	provider, err := New(plan, "provider-prerequisites", []Verified{}, "SUCCEEDED", "NOT_ATTEMPTED", receiptSHA("1"), receiptSHA("a"), at)
+	if err != nil {
+		t.Fatalf("exact durable provider prerequisites were rejected: %v", err)
 	}
-	provider, _ := New(plan, "provider-prerequisites", []Verified{}, "SUCCEEDED", "ATTEMPTED", receiptSHA("1"), receiptSHA("a"), at)
+	if _, err := New(plan, "cluster-lifecycle", []Verified{provider}, "SUCCEEDED", "NOT_ATTEMPTED", receiptSHA("2"), receiptSHA("b"), at.Add(time.Second)); err == nil {
+		t.Fatal("successful Cluster lifecycle without attempt was accepted")
+	}
 	lifecycle, _ := New(plan, "cluster-lifecycle", []Verified{provider}, "SUCCEEDED", "ATTEMPTED", receiptSHA("2"), receiptSHA("b"), at)
 	if _, err := New(plan, "lifecycle-observation", []Verified{lifecycle}, "SUCCEEDED", "ATTEMPTED", receiptSHA("3"), receiptSHA("c"), at); err == nil {
 		t.Fatal("read-only stage with mutation state was accepted")


### PR DESCRIPTION
## Outcome

Allows the durable provider-prerequisites stage to complete idempotently as SUCCEEDED/NOT_ATTEMPTED when every projected object is already present and exact.

Cluster lifecycle and every other mutating stage remain fail-closed and still require an attempted mutation.

## Evidence

- R12 stopped before Cluster lifecycle with an exact-existing provider plane
- durable ledger outcome: STOPPED / NOT_ATTEMPTED
- targeted execution, ledger, and receipt tests pass
- full Go suite passes

## Scope

Runner code and tests only. No deployment, retry, cleanup, or cluster mutation.