### PR TITLE
fix(runner): allow durable provider ensure without write

### DIFF
--- a/internal/execution/staged.go
+++ b/internal/execution/staged.go
@@ -174,8 +174,11 @@ func validateStageMutationResult(stageID string, result StageMutationResult, mut
 	if !oneOf(result.Outcome, "SUCCEEDED", "FAILED", "STOPPED") || !oneOf(result.MutationState, "NOT_ATTEMPTED", "ATTEMPTED", "UNKNOWN") || !stagedDigestPattern.MatchString(result.EvidenceDigest) {
 		return errors.New("stage mutator returned an invalid redaction-safe result")
 	}
-	if result.Outcome == "SUCCEEDED" && (result.MutationState != "ATTEMPTED" || mutationErr != nil) {
-		return errors.New("stage mutator reported an inconsistent successful result")
+	if result.Outcome == "SUCCEEDED" {
+		providerEnsureWithoutWrite := stageID == "provider-prerequisites" && result.MutationState == "NOT_ATTEMPTED"
+		if mutationErr != nil || (result.MutationState != "ATTEMPTED" && !providerEnsureWithoutWrite) {
+			return errors.New("stage mutator reported an inconsistent successful result")
+		}
 	}
 	if stageID == "cluster-lifecycle" && result.Outcome == "SUCCEEDED" {
 		if !stagedDigestPattern.MatchString(result.TargetClusterUIDDigest) {

--- a/internal/execution/staged_test.go
+++ b/internal/execution/staged_test.go
@@ -112,6 +112,19 @@ func TestStagedOperationInvalidMutatorResultLeavesIndeterminateClaim(t *testing.
 	}
 }
 
+func TestStageMutationValidationAllowsOnlyProviderEnsureWithoutWrite(t *testing.T) {
+	result := StageMutationResult{Outcome: "SUCCEEDED", MutationState: "NOT_ATTEMPTED", EvidenceDigest: stagedSHA("e")}
+	if err := validateStageMutationResult("provider-prerequisites", result, nil); err != nil {
+		t.Fatalf("exact existing provider prerequisites were rejected: %v", err)
+	}
+	if err := validateStageMutationResult("cluster-lifecycle", result, nil); err == nil {
+		t.Fatal("Cluster lifecycle claimed success without a write")
+	}
+	if err := validateStageMutationResult("provider-prerequisites", result, errors.New("write uncertainty")); err == nil {
+		t.Fatal("provider prerequisites hid a mutation error behind no-write success")
+	}
+}
+
 func TestStagedOperationRejectsWrongMutatorBeforeClaim(t *testing.T) {
 	plan := stagedPlan(t)
 	at := time.Date(2026, 8, 16, 18, 0, 0, 0, time.UTC)


### PR DESCRIPTION
## Scope

Closes the remaining staged-operation validation boundary for durable provider prerequisites that already exist exactly.

- permits `provider-prerequisites` success with `NOT_ATTEMPTED`
- still rejects no-write success for Cluster lifecycle
- still rejects any mutation error

## Evidence

- focused execution/ledger/receipt tests: PASS
- full `go test ./...` outside the restricted local-listener sandbox: PASS
- R13 stopped before Cluster lifecycle with zero lifecycle writes

No secrets, endpoints, raw runtime evidence, or cluster objects are included.
