### PR TITLE
fix(runner): poll transient lifecycle false states

### DIFF
--- a/internal/runner/lifecycle_stage_observer.go
+++ b/internal/runner/lifecycle_stage_observer.go
@@ -130,7 +130,7 @@ func (observer *LifecycleStageObserver) Observe(ctx context.Context) (execution.
 	source := &lifecyclePollingSource{first: &first, source: observer.source, clock: observer.clock}
 	polling, err := NewBoundedPollingObserver(BoundedPollingObserverConfig{
 		Source: source, Interval: observer.pollInterval, Timeout: observer.pollLimit,
-		Clock: observer.clock, Wait: observer.wait,
+		Clock: observer.clock, Wait: observer.wait, ContinueOnFalse: true,
 	})
 	if err != nil {
 		return execution.StageObservationResult{}, err

--- a/internal/runner/lifecycle_stage_observer_test.go
+++ b/internal/runner/lifecycle_stage_observer_test.go
@@ -38,12 +38,14 @@ func TestLifecycleStageObserverBindsSubmissionIdentityAndConverges(t *testing.T)
 	}
 }
 
-func TestLifecycleStageObserverReturnsTerminalFalseAndBoundedUnknown(t *testing.T) {
+func TestLifecycleStageObserverPollsFalseUntilConvergedOrBounded(t *testing.T) {
 	for name, testCase := range map[string]struct {
 		initial, followup, want string
+		collectCalls            int
 	}{
-		"terminal false":  {initial: "False", want: "FAILED"},
-		"bounded unknown": {initial: "Unknown", followup: "Unknown", want: "STOPPED"},
+		"transient false converges":   {initial: "False", followup: "True", want: "SUCCEEDED", collectCalls: 1},
+		"persistent false is bounded": {initial: "False", followup: "False", want: "FAILED", collectCalls: 2},
+		"bounded unknown":             {initial: "Unknown", followup: "Unknown", want: "STOPPED", collectCalls: 2},
 	} {
 		t.Run(name, func(t *testing.T) {
 			plan, cursor, runtimeUID := lifecycleObserverCursor(t, true)
@@ -61,8 +63,8 @@ func TestLifecycleStageObserverReturnsTerminalFalseAndBoundedUnknown(t *testing.
 			if err != nil || result.Outcome != testCase.want {
 				t.Fatalf("unexpected terminal lifecycle result: %#v %v", result, err)
 			}
-			if testCase.want == "FAILED" && source.collectCalls != 0 {
-				t.Fatal("terminal False lifecycle evidence was polled again")
+			if source.collectCalls != testCase.collectCalls {
+				t.Fatalf("unexpected lifecycle poll count: got %d want %d", source.collectCalls, testCase.collectCalls)
 			}
 		})
 	}

--- a/internal/runner/polling_observer.go
+++ b/internal/runner/polling_observer.go
@@ -15,11 +15,12 @@ type ObservationSource interface {
 type ObservationWaiter func(context.Context, time.Duration) error
 
 type BoundedPollingObserverConfig struct {
-	Source   ObservationSource
-	Interval time.Duration
-	Timeout  time.Duration
-	Clock    func() time.Time
-	Wait     ObservationWaiter
+	Source          ObservationSource
+	Interval        time.Duration
+	Timeout         time.Duration
+	Clock           func() time.Time
+	Wait            ObservationWaiter
+	ContinueOnFalse bool
 }
 
 // BoundedPollingObserver repeats only read-oriented aggregate observation.
@@ -56,10 +57,10 @@ func (observer *BoundedPollingObserver) Observe(ctx context.Context, policy obse
 			return observation.VerifiedResult{}, errors.New("aggregate observer returned an unverified result")
 		}
 		last = result
-		if receipt.Ready == "True" || receipt.Ready == "False" {
+		if receipt.Ready == "True" || (receipt.Ready == "False" && !observer.config.ContinueOnFalse) {
 			return result, nil
 		}
-		if receipt.Ready != "Unknown" {
+		if receipt.Ready != "Unknown" && receipt.Ready != "False" {
 			return observation.VerifiedResult{}, errors.New("aggregate observer returned an invalid readiness state")
 		}
 		now := observer.config.Clock()


### PR DESCRIPTION
## Summary

- keep lifecycle convergence polling when current CAPI readiness is False
- retain terminal False behavior for all other bounded observers
- keep persistent lifecycle False bounded by the configured timeout

## Evidence

R16 reached provider-prerequisites and cluster-lifecycle successfully, then stopped at lifecycle-observation while CAPI was still converging. A later exact read showed InfrastructureReady and ControlPlaneAvailable had become True.

## Validation

- go test ./internal/runner
- go test ./...

Both pass with an isolated local build cache.

## Safety

- no live retry
- no cleanup
- no infrastructure mutation
- R16 partial state remains preserved
