### PR TITLE
fix(runner): poll transient network failures to bound

### DIFF
--- a/internal/runner/network_stage_observer.go
+++ b/internal/runner/network_stage_observer.go
@@ -100,6 +100,7 @@ func (observer *NetworkStageObserver) Observe(ctx context.Context) (execution.St
 	polling, err := NewBoundedPollingObserver(BoundedPollingObserverConfig{
 		Source:   &networkPollingSource{source: observer.source, profile: observer.profile, clock: observer.clock},
 		Interval: observer.pollInterval, Timeout: observer.pollLimit, Clock: observer.clock, Wait: observer.wait,
+		ContinueOnFalse: true,
 	})
 	if err != nil {
 		return execution.StageObservationResult{}, err

--- a/internal/runner/network_stage_observer_test.go
+++ b/internal/runner/network_stage_observer_test.go
@@ -42,13 +42,14 @@ func TestNetworkStageObserverBindsHistoricalTargetAndConverges(t *testing.T) {
 	}
 }
 
-func TestNetworkStageObserverReturnsTerminalFalseAndBoundedUnknown(t *testing.T) {
+func TestNetworkStageObserverWaitsThroughFalseUntilConvergedOrBounded(t *testing.T) {
 	for name, testCase := range map[string]struct {
 		statuses []string
 		want     string
 		calls    int
 	}{
-		"terminal false":  {statuses: []string{"False"}, want: "FAILED", calls: 1},
+		"transient false": {statuses: []string{"False", "True"}, want: "SUCCEEDED", calls: 2},
+		"bounded false":   {statuses: []string{"False"}, want: "FAILED", calls: 3},
 		"bounded unknown": {statuses: []string{"Unknown"}, want: "STOPPED", calls: 3},
 	} {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

- continue bounded NetworkReady polling through transient `False`
- retain fail-closed terminal `False` after the configured timeout
- add regression coverage for transient and bounded-failure paths

## Evidence

- R17 completed provider prerequisites, cluster lifecycle, lifecycle observation, and enablement
- R17 then stopped at network observation on the first transient `False`
- `go test ./...` passes

No cluster mutation, retry, cleanup, raw evidence, or credentials are included.