### PR TITLE
fix(runner): tolerate transient network source readiness

### DIFF
--- a/docs/ok147-r21-network-observation-diagnostic.md
+++ b/docs/ok147-r21-network-observation-diagnostic.md
@@ -1,0 +1,77 @@
+# OK-147 R21 network-observation diagnostic
+
+## Scope
+
+This checkpoint records only redacted, read-only evidence from the stopped
+R21 full run. It contains no Kubernetes object payloads, endpoints, UIDs,
+resource versions, credentials, tokens, kubeconfigs, Pod names, Node names,
+IP addresses, or raw probe output.
+
+## Bound execution
+
+- Launch candidate: `sha256:be4aa70e9beed31d68b3deaee43b09c9802d1a0c4b4e4d7cc91923b5464e065f`
+- Package: `sha256:6c52f7f4fa4f540da14724c08b0450dc27363324a69daee097fd82b67bb4e840`
+- Bundle: `sha256:044c72829cea22421477644dfa55a74587903abe699718340e0682ae6a0e2b80`
+- Plan: `sha256:495baaeb13357c95d95533c582c42c8fb802603f24e16772f51d9ec34434f00e`
+- Execution attempt: `sha256:fa1b9444a184a1758d99fe73228f1eb6f6dcb226710dae9589f5b870310db11d`
+- Runner: `ghcr.io/openkubes/ok-cluster-runner@sha256:1c14031972bec08db5ff0da7ff3728eade028a44a4b66670b0e5a867f06743ae`
+- Canonical launch receipt: `sha256:7d4ade2d0201060e2e25e531574ad2bfe57c821219c0c61dc7886062970d5da9`
+
+The create-only launch activated successfully. Provider prerequisites,
+cluster lifecycle, lifecycle observation, and enablement completed
+successfully. The executor then stopped fail closed at
+`network-observation`. No retry, cleanup, rollback, or further mutation was
+performed.
+
+## Read-only findings
+
+The deterministic immutable ledger slot for the R21 network-observation
+receipt was absent. Therefore the stage did not end in a bounded
+`NetworkReady=False` or `NetworkReady=Unknown` result; source collection
+failed before a verified observation receipt could be persisted.
+
+A later bounded diagnostic repeated the exact two management reads, five
+workload reads, and fixed Cilium functional probe:
+
+- both management reads succeeded and exactly one release object existed;
+- all five workload reads succeeded;
+- the workload contained two Nodes and two Cilium agent Pods;
+- the UID-bound fixed probe exited successfully and returned valid JSON;
+- the probe contained two Nodes and eight unique paths;
+- all eight paths used the proven success representation in which `status`
+  is absent.
+
+The executor had stopped roughly three minutes after Pod start, while CAAPH
+and Cilium status were still converging. The collector required initialized
+status arrays and attempted the functional probe during this transient
+window. Those normal convergence gaps were returned as an operational source
+error, which the bounded poller correctly does not retry.
+
+## Corrective boundary
+
+The collector now:
+
+1. normalizes absent, not-yet-initialized CAAPH and Cilium status collections
+   into a redaction-safe partial snapshot;
+2. lets the evaluator classify that snapshot as `Unknown`;
+3. avoids workload collection until the bound add-on source is ready;
+4. avoids the fixed Cilium probe until Nodes, Cilium components, and agent
+   Pods are ready; and
+5. continues to reject malformed fields, foreign identities, duplicate or
+   incomplete initialized Conditions, transport failures, and probe errors.
+
+This changes convergence handling only. It adds no mutation, discovery,
+arbitrary query, retry of operational errors, repair, or second-owner path.
+
+## Verification
+
+- `go test ./internal/observation`: PASS
+- direct network-stage and network-observation runner tests: PASS
+- new regression cases cover uninitialized HCP status, absent HRP, empty Node
+  Conditions, absent Cilium Pods, malformed HCP selection, and malformed Pod
+  container status.
+
+The full local suite additionally exposes three pre-existing synthetic
+certificate-test failures under the developer workstation's Go 1.26.7
+toolchain. The published runner remains built with pinned Go 1.24.6; those
+certificate fixtures are independent of this network-observation change.

--- a/internal/observation/network_collector.go
+++ b/internal/observation/network_collector.go
@@ -94,6 +94,18 @@ func (collector *NetworkSourceCollector) Collect(ctx context.Context, policy Pol
 	if err != nil {
 		return NetworkSnapshot{}, err
 	}
+	snapshot := NetworkSnapshot{
+		Format: NetworkSnapshotFormat, ObservedAt: collector.config.Clock().UTC().Format(time.RFC3339Nano),
+		TargetClusterUID: policy.TargetClusterUID, IntentRevision: policy.IntentRevision,
+		EnablementRevision: hcp.EnablementRevision, HCP: hcp, HRPCount: hrpCount, HRP: hrp,
+	}
+	// CAAPH objects are created before their status is initialized and before
+	// the workload API is necessarily reachable. Preserve that as a bounded
+	// Unknown snapshot instead of turning normal convergence into an
+	// operational source failure or attempting the functional probe too early.
+	if !networkAddonReadyForWorkloadCollection(hcp, hrpCount, hrp) {
+		return snapshot, nil
+	}
 
 	nodesObject, err := getNetworkObject(ctx, collector.workload, "/api/v1/nodes")
 	if err != nil {
@@ -133,6 +145,14 @@ func (collector *NetworkSourceCollector) Collect(ctx context.Context, policy Pol
 	if err != nil {
 		return NetworkSnapshot{}, err
 	}
+	snapshot.Nodes, snapshot.Components, snapshot.AgentPods = nodes, components, pods
+	// Pod/container status and Node network Conditions are eventually
+	// populated. The evaluator can classify those normalized gaps as Unknown;
+	// executing cilium-health before they converge would instead manufacture
+	// an operational error that the bounded observer must not retry.
+	if !networkRuntimeReadyForProbe(nodes, components, pods) {
+		return snapshot, nil
+	}
 	probeRaw, err := collector.probe.Probe(ctx, selectedName, selectedUID)
 	if err != nil {
 		return NetworkSnapshot{}, errors.New("fixed Cilium functional probe failed")
@@ -141,12 +161,51 @@ func (collector *NetworkSourceCollector) Collect(ctx context.Context, policy Pol
 	if err != nil {
 		return NetworkSnapshot{}, err
 	}
-	return NetworkSnapshot{
-		Format: NetworkSnapshotFormat, ObservedAt: collector.config.Clock().UTC().Format(time.RFC3339Nano),
-		TargetClusterUID: policy.TargetClusterUID, IntentRevision: policy.IntentRevision,
-		EnablementRevision: hcp.EnablementRevision, HCP: hcp, HRPCount: hrpCount, HRP: hrp,
-		Nodes: nodes, Components: components, AgentPods: pods, Probe: probe,
-	}, nil
+	snapshot.Probe = probe
+	return snapshot, nil
+}
+
+func networkAddonReadyForWorkloadCollection(hcp NetworkAddonSource, hrpCount int, hrp NetworkAddonSource) bool {
+	ready := func(source NetworkAddonSource, required ...string) bool {
+		if source.Generation <= 0 || source.StatusObservedGeneration != source.Generation || !source.TargetSelected {
+			return false
+		}
+		conditions := make(map[string]NetworkSourceCondition, len(source.Conditions))
+		for _, condition := range source.Conditions {
+			conditions[condition.Type] = condition
+		}
+		for _, name := range required {
+			condition, exists := conditions[name]
+			if !exists || condition.Status != "True" || condition.ObservedGeneration != source.Generation {
+				return false
+			}
+		}
+		return true
+	}
+	return ready(hcp, "Ready", "HelmReleaseProxySpecsUpToDate", "HelmReleaseProxiesReady") &&
+		hrpCount == 1 && ready(hrp, "Ready", "HelmReleaseReady") && hrp.ReleaseStatus == "deployed" && hrp.ReleaseRevision > 0
+}
+
+func networkRuntimeReadyForProbe(nodes []NetworkNode, components []NetworkComponent, pods []NetworkAgentPod) bool {
+	if len(nodes) == 0 || len(components) != 3 || len(pods) != len(nodes) {
+		return false
+	}
+	for _, node := range nodes {
+		if node.ProviderID == "" || node.Ready != "True" || node.NetworkUnavailable != "False" || node.NetworkUnavailableReason != "CiliumIsUp" {
+			return false
+		}
+	}
+	for _, component := range components {
+		if component.Generation <= 0 || component.ObservedGeneration != component.Generation || component.Desired <= 0 || component.Updated != component.Desired || component.Available != component.Desired || component.Ready != component.Desired {
+			return false
+		}
+	}
+	for _, pod := range pods {
+		if pod.Phase != "Running" || !pod.Ready {
+			return false
+		}
+	}
+	return true
 }
 
 func getNetworkObject(ctx context.Context, source NetworkRawGetter, path string) (map[string]any, error) {
@@ -187,7 +246,7 @@ func normalizeHCP(object map[string]any, namespace, hcpName, clusterName string,
 		return NetworkAddonSource{}, err
 	}
 	status, _ := objectMap(object, "status")
-	matching, err := requiredObjectSlice(status, "matchingClusters", 10)
+	matching, err := optionalObjectSlice(status, "matchingClusters", 10)
 	if err != nil {
 		return NetworkAddonSource{}, errors.New("HCP target selection is invalid")
 	}
@@ -348,8 +407,11 @@ func normalizeAgentPods(list map[string]any, nodeNames map[string]string) ([]Net
 		return nil, "", "", errors.New("Cilium Pod collection identity is invalid")
 	}
 	items, err := requiredObjectSlice(list, "items", 100)
-	if err != nil || len(items) == 0 {
+	if err != nil {
 		return nil, "", "", errors.New("Cilium Pod collection size is invalid")
+	}
+	if len(items) == 0 {
+		return []NetworkAgentPod{}, "", "", nil
 	}
 	type namedPod struct {
 		name string
@@ -366,7 +428,7 @@ func normalizeAgentPods(list map[string]any, nodeNames map[string]string) ([]Net
 			return nil, "", "", errors.New("Cilium Pod runtime identity is invalid")
 		}
 		ready := false
-		containerStatuses, statusErr := requiredObjectSlice(status, "containerStatuses", 20)
+		containerStatuses, statusErr := optionalObjectSlice(status, "containerStatuses", 20)
 		if statusErr != nil {
 			return nil, "", "", errors.New("Cilium Pod container status is invalid")
 		}
@@ -443,7 +505,7 @@ func normalizeNetworkProbe(raw []byte, nodeNames map[string]string) (NetworkProb
 }
 
 func normalizeSourceConditions(status map[string]any) ([]NetworkSourceCondition, error) {
-	items, err := requiredObjectSlice(status, "conditions", 16)
+	items, err := optionalObjectSlice(status, "conditions", 16)
 	if err != nil {
 		return nil, errors.New("add-on source Conditions are invalid")
 	}
@@ -474,6 +536,9 @@ func exactNodeConditions(status map[string]any) (map[string]any, map[string]any,
 			}
 			network = item
 		}
+	}
+	if ready == nil && network == nil {
+		return map[string]any{}, map[string]any{}, nil
 	}
 	if ready == nil || network == nil {
 		return nil, nil, errors.New("Node network Conditions are incomplete")
@@ -534,6 +599,13 @@ func requiredObjectSlice(parent map[string]any, key string, maximum int) ([]map[
 		result = append(result, object)
 	}
 	return result, nil
+}
+
+func optionalObjectSlice(parent map[string]any, key string, maximum int) ([]map[string]any, error) {
+	if _, exists := parent[key]; !exists {
+		return []map[string]any{}, nil
+	}
+	return requiredObjectSlice(parent, key, maximum)
 }
 
 func textMap(parent map[string]any, key string) string { return text(parent[key]) }

--- a/internal/observation/network_collector_test.go
+++ b/internal/observation/network_collector_test.go
@@ -61,6 +61,46 @@ func TestNetworkSourceCollectorNormalizesOrderDeterministically(t *testing.T) {
 	}
 }
 
+func TestNetworkSourceCollectorNormalizesTransientConvergenceWithoutEarlyProbe(t *testing.T) {
+	for name, mutate := range map[string]func(*fakeNetworkGetter, *fakeNetworkGetter){
+		"HCP status not initialized": func(management, _ *fakeNetworkGetter) {
+			management.responses[managementPathHCP] = mutateJSON(t, management.responses[managementPathHCP], func(value map[string]any) {
+				delete(value, "status")
+			})
+		},
+		"HRP not created": func(management, _ *fakeNetworkGetter) {
+			management.responses[managementPathHRP] = mutateJSON(t, management.responses[managementPathHRP], func(value map[string]any) {
+				value["items"] = []any{}
+			})
+		},
+		"Node conditions not initialized": func(_ *fakeNetworkGetter, workload *fakeNetworkGetter) {
+			workload.responses["/api/v1/nodes"] = mutateJSON(t, workload.responses["/api/v1/nodes"], func(value map[string]any) {
+				for _, item := range value["items"].([]any) {
+					item.(map[string]any)["status"].(map[string]any)["conditions"] = []any{}
+				}
+			})
+		},
+		"Cilium Pods not created": func(_ *fakeNetworkGetter, workload *fakeNetworkGetter) {
+			workload.responses["/api/v1/namespaces/kube-system/pods?labelSelector=k8s-app%3Dcilium"] = mutateJSON(t, workload.responses["/api/v1/namespaces/kube-system/pods?labelSelector=k8s-app%3Dcilium"], func(value map[string]any) {
+				value["items"] = []any{}
+			})
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			policy, profile, management, workload, probe := collectorFixture(t)
+			mutate(management, workload)
+			collector := mustNetworkCollector(t, policy, management, workload, probe)
+			evidence, err := collector.Observe(context.Background(), policy, profile)
+			if err != nil || evidence.Status != "Unknown" {
+				t.Fatalf("transient convergence was not normalized to Unknown: evidence=%#v err=%v", evidence, err)
+			}
+			if probe.calls != 0 {
+				t.Fatalf("functional probe ran before prerequisites converged: calls=%d", probe.calls)
+			}
+		})
+	}
+}
+
 func TestAddonSpecDigestNormalizesCAAPHDefaultedFalse(t *testing.T) {
 	requested := map[string]any{
 		"chartName": "cilium", "repoURL": "oci://quay.io/cilium/charts", "version": "1.19.6",
@@ -119,6 +159,17 @@ func TestNetworkSourceCollectorFailsClosed(t *testing.T) {
 				node["status"].(map[string]any)["conditions"] = conditions[:1]
 			})
 		},
+		"malformed HCP matchingClusters": func(management, _ *fakeNetworkGetter, _ *fakeFixedProbe) {
+			management.responses[managementPathHCP] = mutateJSON(t, management.responses[managementPathHCP], func(value map[string]any) {
+				value["status"].(map[string]any)["matchingClusters"] = "invalid"
+			})
+		},
+		"malformed Cilium containerStatuses": func(_ *fakeNetworkGetter, workload *fakeNetworkGetter, _ *fakeFixedProbe) {
+			path := "/api/v1/namespaces/kube-system/pods?labelSelector=k8s-app%3Dcilium"
+			workload.responses[path] = mutateJSON(t, workload.responses[path], func(value map[string]any) {
+				value["items"].([]any)[0].(map[string]any)["status"].(map[string]any)["containerStatuses"] = "invalid"
+			})
+		},
 		"foreign probe Node": func(_ *fakeNetworkGetter, _ *fakeNetworkGetter, probe *fakeFixedProbe) {
 			probe.response = mutateJSON(t, probe.response, func(value map[string]any) {
 				value["nodes"].([]any)[0].(map[string]any)["name"] = "foreign"
@@ -161,6 +212,7 @@ func TestNetworkSourceCollectorFailsClosed(t *testing.T) {
 }
 
 const managementPathHCP = "/apis/addons.cluster.x-k8s.io/v1alpha1/namespaces/disposable-ok141/helmchartproxies/disposable-ok141-cilium"
+const managementPathHRP = "/apis/addons.cluster.x-k8s.io/v1alpha1/namespaces/disposable-ok141/helmreleaseproxies?labelSelector=cluster.x-k8s.io%2Fcluster-name%3Ddisposable-ok141%2Chelmreleaseproxy.addons.cluster.x-k8s.io%2Fhelmchartproxy-name%3Ddisposable-ok141-cilium"
 
 type fakeNetworkGetter struct {
 	responses map[string][]byte

--- a/internal/observation/network_evaluator.go
+++ b/internal/observation/network_evaluator.go
@@ -298,11 +298,14 @@ func evaluateNetworkState(policy Policy, profile NetworkProfile, snapshot Networ
 }
 
 func evaluateAddonSource(source NetworkAddonSource, targetUID, ownerUID, specDigest string, policy Policy, required []string, reasonPrefix string) (string, string) {
-	if !validUID(source.UID) || source.SpecDigest != specDigest || source.IntentRevision != policy.IntentRevision || source.EnablementRevision != policy.EnablementRevision || source.TargetClusterUID != targetUID || !source.TargetSelected || source.OwnerUID != ownerUID {
+	if !validUID(source.UID) || source.SpecDigest != specDigest || source.IntentRevision != policy.IntentRevision || source.EnablementRevision != policy.EnablementRevision || source.TargetClusterUID != targetUID || source.OwnerUID != ownerUID {
 		return "False", reasonPrefix + "IdentityMismatch"
 	}
 	if source.Generation <= 0 || source.StatusObservedGeneration != source.Generation {
 		return "Unknown", reasonPrefix + "NotReady"
+	}
+	if !source.TargetSelected {
+		return "False", reasonPrefix + "IdentityMismatch"
 	}
 	conditions := make(map[string]NetworkSourceCondition, len(source.Conditions))
 	for _, condition := range source.Conditions {


### PR DESCRIPTION
## Summary
- normalize not-yet-initialized CAAPH and Cilium status as bounded Unknown evidence
- delay workload collection and the fixed Cilium probe until their prerequisites are ready
- keep malformed identity/schema, transport, and probe failures fail closed
- record the redacted R21 diagnostic checkpoint

## Verification
- `go test ./internal/observation`
- `go test ./internal/runner -run 'Test(NetworkStage|NetworkObservation)' -count=1`
- full local suite otherwise passes except three pre-existing synthetic certificate fixture failures under local Go 1.26.7; the pinned publication build uses Go 1.24.6

No cluster mutation, retry, cleanup, rollback, or raw evidence is included.