### PR TITLE
fix(runner): tolerate partial Node condition convergence

### DIFF
--- a/docs/ok147-r22-network-observation-diagnostic.md
+++ b/docs/ok147-r22-network-observation-diagnostic.md
@@ -1,0 +1,73 @@
+# OK-147 R22 network-observation diagnostic
+
+## Scope
+
+This checkpoint records only redacted, read-only evidence from the stopped
+R22 full run. It contains no Kubernetes object payloads, endpoints, UIDs,
+resource versions, credentials, tokens, kubeconfigs, Pod or Node names, IP
+addresses, or raw probe output.
+
+## Bound execution
+
+- Launch candidate: `sha256:b4cdbbe3e6bcc862deae6512ec5608325376ef8fce032efc90b3d3d3fcfea66c`
+- Package: `sha256:b722b2f85cc3db048d14faa82875a245b3d24dae25240931b19071fc684c9315`
+- Bundle: `sha256:401f5633e0fe6c261f10f5f6c042ed407632bf18efc39ea77304742ffac33908`
+- Plan: `sha256:aee818c3699f6657a214ee5fd216bd0ad50c223ff1502328df61f665b61114b4`
+- Execution attempt: `sha256:027922ac87de8e37f0f087f51267193ba6c05bc94e0352a3b300f0b010f14adb`
+- Runner: `ghcr.io/openkubes/ok-cluster-runner@sha256:8b8a5555f6ab2f2c2efc13c330cba2174931dd2703efc2cd7ccf4807265d667e`
+
+The create-only launch activated successfully. Provider prerequisites,
+cluster lifecycle, lifecycle observation, and enablement completed
+successfully. The executor then stopped fail closed at
+`network-observation`. Runtime binding, target access, target credentials,
+target registration, platform applications, platform observation, and
+aggregate evidence were not attempted.
+
+## Read-only findings
+
+The executor stopped less than three minutes after Job start, during the
+transition from lifecycle convergence to Cilium readiness. The add-on source
+became ready shortly afterwards and the CAPI Cluster then reported all bound
+availability Conditions as true.
+
+A bounded diagnostic of the retained disposable Cluster found:
+
+- two of two Nodes Ready;
+- two of two Cilium agent Pods Running and Ready, with no restarts;
+- the agent, Envoy, and operator rollouts fully available at their exact
+  digest-pinned images;
+- exactly one deployed and Ready Helm release proxy; and
+- one UID-bound functional Cilium probe with two Nodes, eight fresh paths,
+  and successful latency-bearing results for every path.
+
+This excludes a persistent Cilium, image, rollout, Node-readiness, and
+functional-connectivity failure. The stop occurred while Kubernetes was
+publishing the two Node network Conditions independently. The collector
+already treated an entirely absent Condition set as convergence, but treated
+an intermediate one-of-two set as an operational source error. The bounded
+poller therefore stopped instead of waiting for the second Condition.
+
+## Corrective boundary
+
+The collector now preserves whichever of `Ready` or `NetworkUnavailable` is
+already present and normalizes only the missing half to an empty value. The
+existing readiness gate keeps the functional probe closed and the evaluator
+returns `Unknown` until both Conditions prove the expected state.
+
+This does not weaken a terminal invariant: duplicate Conditions, foreign
+identities, invalid field types, transport failures, probe failures, image
+mismatches, and failed functional paths remain fail closed. It adds no
+mutation, repair, discovery, arbitrary query, or second-owner path.
+
+## Verification
+
+- `go test ./internal/observation`: PASS
+- direct Network-/Polling-runner tests: PASS
+- regression coverage includes both publication orders for the two Node
+  network Conditions and confirms that no functional probe runs early
+- duplicate Node Conditions remain a hard source error
+
+The broad runner suite still exposes the three previously documented
+synthetic client-certificate fixture failures under the developer
+workstation's Go 1.26.7 toolchain. The affected Network-/Polling tests pass;
+the published runner remains built by the pinned publisher toolchain.

--- a/internal/observation/network_collector.go
+++ b/internal/observation/network_collector.go
@@ -540,8 +540,17 @@ func exactNodeConditions(status map[string]any) (map[string]any, map[string]any,
 	if ready == nil && network == nil {
 		return map[string]any{}, map[string]any{}, nil
 	}
-	if ready == nil || network == nil {
-		return nil, nil, errors.New("Node network Conditions are incomplete")
+	// Kubernetes publishes Node Conditions independently. During normal CNI
+	// convergence one of Ready or NetworkUnavailable can therefore be visible
+	// before the other. Preserve the observed Condition and normalize the
+	// missing half to an empty value; networkRuntimeReadyForProbe then keeps the
+	// fixed functional probe closed and the evaluator reports Unknown. Duplicate
+	// Conditions remain malformed and fail closed above.
+	if ready == nil {
+		ready = map[string]any{}
+	}
+	if network == nil {
+		network = map[string]any{}
 	}
 	return ready, network, nil
 }

--- a/internal/observation/network_collector_test.go
+++ b/internal/observation/network_collector_test.go
@@ -80,6 +80,22 @@ func TestNetworkSourceCollectorNormalizesTransientConvergenceWithoutEarlyProbe(t
 				}
 			})
 		},
+		"Node Ready published before NetworkUnavailable": func(_ *fakeNetworkGetter, workload *fakeNetworkGetter) {
+			workload.responses["/api/v1/nodes"] = mutateJSON(t, workload.responses["/api/v1/nodes"], func(value map[string]any) {
+				for _, item := range value["items"].([]any) {
+					conditions := item.(map[string]any)["status"].(map[string]any)["conditions"].([]any)
+					item.(map[string]any)["status"].(map[string]any)["conditions"] = conditions[:1]
+				}
+			})
+		},
+		"Node NetworkUnavailable published before Ready": func(_ *fakeNetworkGetter, workload *fakeNetworkGetter) {
+			workload.responses["/api/v1/nodes"] = mutateJSON(t, workload.responses["/api/v1/nodes"], func(value map[string]any) {
+				for _, item := range value["items"].([]any) {
+					conditions := item.(map[string]any)["status"].(map[string]any)["conditions"].([]any)
+					item.(map[string]any)["status"].(map[string]any)["conditions"] = conditions[1:]
+				}
+			})
+		},
 		"Cilium Pods not created": func(_ *fakeNetworkGetter, workload *fakeNetworkGetter) {
 			workload.responses["/api/v1/namespaces/kube-system/pods?labelSelector=k8s-app%3Dcilium"] = mutateJSON(t, workload.responses["/api/v1/namespaces/kube-system/pods?labelSelector=k8s-app%3Dcilium"], func(value map[string]any) {
 				value["items"] = []any{}
@@ -152,11 +168,11 @@ func TestNetworkSourceCollectorFailsClosed(t *testing.T) {
 				value["metadata"].(map[string]any)["name"] = "other"
 			})
 		},
-		"malformed Node condition": func(_ *fakeNetworkGetter, workload *fakeNetworkGetter, _ *fakeFixedProbe) {
+		"duplicated Node condition": func(_ *fakeNetworkGetter, workload *fakeNetworkGetter, _ *fakeFixedProbe) {
 			workload.responses["/api/v1/nodes"] = mutateJSON(t, workload.responses["/api/v1/nodes"], func(value map[string]any) {
 				node := value["items"].([]any)[0].(map[string]any)
 				conditions := node["status"].(map[string]any)["conditions"].([]any)
-				node["status"].(map[string]any)["conditions"] = conditions[:1]
+				node["status"].(map[string]any)["conditions"] = append(conditions, conditions[0])
 			})
 		},
 		"malformed HCP matchingClusters": func(management, _ *fakeNetworkGetter, _ *fakeFixedProbe) {


### PR DESCRIPTION
## Summary
- normalize one-of-two Node network Conditions as bounded convergence
- keep the Cilium functional probe closed until both Conditions prove readiness
- record the redacted R22 diagnostic and retain duplicate-Condition rejection

## Verification
- `go test ./internal/observation`
- `go test ./internal/runner -run 'Network|Polling'`\n\nThe broad runner suite still exposes the three previously documented Go 1.26.7 synthetic client-certificate fixture failures; the directly affected suites pass.