### PR TITLE
fix(runner): tolerate null empty HRP lists (OK-147)

### DIFF
--- a/docs/ok147-r24-network-observation-diagnostic.md
+++ b/docs/ok147-r24-network-observation-diagnostic.md
@@ -1,0 +1,35 @@
+# OK-147 R24 network-observation diagnostic
+
+## Outcome
+
+R24 passed provider prerequisites, cluster lifecycle, lifecycle observation,
+and enablement, then stopped fail-closed before persisting a network-observation
+receipt. No retry or cleanup was performed.
+
+The retained CAAPH state became fully ready 21 seconds after the executor
+stopped. This repeated the R23 timing pattern but exposed a second valid
+Kubernetes representation of the pre-ready state: an empty
+`HelmReleaseProxyList` may carry `items: null`, not only `items: []`.
+
+## Correction
+
+`normalizeHRPList` now treats an absent or explicit-null `items` field as the
+same bounded zero-object collection as an empty array. This produces a
+pollable pre-ready snapshot and does not contact the workload cluster early.
+Non-null non-array values, oversized collections, foreign objects, and
+ambiguous multi-object collections remain fail-closed.
+
+Regression coverage proves that explicit-null HRP collections behave like the
+already covered empty HRP collection while the functional probe remains
+uninvoked.
+
+## Classification
+
+```text
+R24 result:                       STOPPED at network-observation
+Network receipt persisted:       no
+CAAPH ready after executor stop:  21 seconds
+Root cause:                       valid empty-list representation rejected
+Infrastructure repair performed: no
+Retry performed:                 no
+```

--- a/internal/observation/network_collector.go
+++ b/internal/observation/network_collector.go
@@ -269,7 +269,10 @@ func normalizeHRPList(list map[string]any, namespace, clusterName, hcpName, hcpU
 	if text(list["apiVersion"]) != "addons.cluster.x-k8s.io/v1alpha1" || text(list["kind"]) != "HelmReleaseProxyList" {
 		return 0, NetworkAddonSource{}, errors.New("HRP collection identity is invalid")
 	}
-	items, err := requiredObjectSlice(list, "items", 10)
+	// Kubernetes may serialize an empty list as either [] or null while the
+	// controller has not created the first HRP yet. Both representations mean
+	// "zero matching objects" and are a normal, pollable pre-ready state.
+	items, err := optionalObjectSlice(list, "items", 10)
 	if err != nil {
 		return 0, NetworkAddonSource{}, errors.New("HRP collection is invalid or exceeds bounded size")
 	}

--- a/internal/observation/network_collector_test.go
+++ b/internal/observation/network_collector_test.go
@@ -78,6 +78,11 @@ func TestNetworkSourceCollectorNormalizesTransientConvergenceWithoutEarlyProbe(t
 				value["items"] = []any{}
 			})
 		},
+		"HRP collection explicitly null": func(management, _ *fakeNetworkGetter) {
+			management.responses[managementPathHRP] = mutateJSON(t, management.responses[managementPathHRP], func(value map[string]any) {
+				value["items"] = nil
+			})
+		},
 		"HRP conditions explicitly null": func(management, _ *fakeNetworkGetter) {
 			management.responses[managementPathHRP] = mutateJSON(t, management.responses[managementPathHRP], func(value map[string]any) {
 				item := value["items"].([]any)[0].(map[string]any)


### PR DESCRIPTION
## Summary

- normalize a Kubernetes `HelmReleaseProxyList` with `items: null` as a bounded zero-object pre-ready state
- preserve fail-closed behavior for malformed, oversized, foreign, and ambiguous collections
- add regression coverage and the redacted R24 diagnostic checkpoint

## Verification

- `go test ./internal/observation`
- `go test ./internal/runner -run TestNetworkStageObserver -count=1`
- `git diff --check`

Private runtime evidence and credentials remain excluded.