### PR TITLE
fix(runner): bound transient network read failures (OK-147)

### DIFF
--- a/docs/ok147-r25-network-observation-diagnostic.md
+++ b/docs/ok147-r25-network-observation-diagnostic.md
@@ -1,0 +1,47 @@
+# OK-147 R25 network-observation diagnostic
+
+## Outcome
+
+R25 completed provider prerequisites, cluster lifecycle, lifecycle observation,
+and enablement, then stopped fail closed at `network-observation`. The
+deterministic network-observation Ledger slot was absent, so runtime binding and
+all later stages were not attempted. No retry, cleanup, rollback, or diagnostic
+mutation was performed.
+
+## Read-only correlation
+
+The retained environment converged without runner repair:
+
+- both expected Nodes became available;
+- both Cilium agent Pods were Running and Ready;
+- the Cilium, Envoy, and operator workloads were fully available;
+- the bound HCP and its single HRP were Ready; and
+- the fixed, bounded Cilium health probe succeeded.
+
+The final HCP/HRP readiness transitions occurred 36 seconds after the executor
+stopped. Reconstructing the CAAPH Conditions visible before that transition and
+replaying them against the published collector produced a verified `Unknown`
+result, proving that this schema-valid partial representation is already
+pollable.
+
+## Correction
+
+The remaining failure window is a later transient source failure after an
+initial verified convergence result. The generic polling primitive now has an
+opt-in boundary that permits such an error to remain bounded only when a prior
+verified result already established the source and authority path. The network
+observer enables that boundary; other observers do not.
+
+An error on the first read still stops immediately. Terminal success still
+stops immediately, invalid or unverified results still stop, and the existing
+poll deadline still returns the last verified fail-closed result. This adds no
+mutation, repair, credential reuse, arbitrary query, or unbounded retry path.
+
+## Verification
+
+- focused bounded-poller and network-stage tests: PASS
+- focused network collector tests, including the reconstructed R25 CAAPH
+  partial state: PASS
+- the three known synthetic client-certificate fixture failures remain under
+  the workstation Go toolchain and are independent of this change
+

--- a/internal/observation/r25_diagnostic_test.go
+++ b/internal/observation/r25_diagnostic_test.go
@@ -1,0 +1,40 @@
+package observation
+
+import (
+	"context"
+	"testing"
+)
+
+func TestR25ReconstructedCAAPHPartialConditionsRemainPollable(t *testing.T) {
+	policy, profile, management, workload, probe := collectorFixture(t)
+	collector := mustNetworkCollector(t, policy, management, workload, probe)
+
+	hcpPath, hrpPath := managementNetworkPaths("disposable-ok141", "disposable-ok141", "disposable-ok141-cilium")
+	management.responses[hcpPath] = mutateJSON(t, management.responses[hcpPath], func(value map[string]any) {
+		status := value["status"].(map[string]any)
+		conditions := status["conditions"].([]any)
+		for _, condition := range conditions {
+			candidate := condition.(map[string]any)
+			if candidate["type"] == "HelmReleaseProxySpecsUpToDate" {
+				status["conditions"] = []any{candidate}
+				return
+			}
+		}
+		t.Fatal("fixture lacks HCP specs condition")
+	})
+	management.responses[hrpPath] = mutateJSON(t, management.responses[hrpPath], func(value map[string]any) {
+		item := value["items"].([]any)[0].(map[string]any)
+		status := item["status"].(map[string]any)
+		status["conditions"] = []any{map[string]any{
+			"type": "ClusterAvailable", "status": "True", "observedGeneration": float64(1),
+		}}
+	})
+
+	evidence, err := collector.Observe(context.Background(), policy, profile)
+	if err != nil {
+		t.Fatalf("reconstructed R25 partial CAAPH shape failed: %v", err)
+	}
+	if evidence.Status != "Unknown" {
+		t.Fatalf("partial CAAPH shape must remain pollable, got %q", evidence.Status)
+	}
+}

--- a/internal/runner/network_stage_observer.go
+++ b/internal/runner/network_stage_observer.go
@@ -100,7 +100,7 @@ func (observer *NetworkStageObserver) Observe(ctx context.Context) (execution.St
 	polling, err := NewBoundedPollingObserver(BoundedPollingObserverConfig{
 		Source:   &networkPollingSource{source: observer.source, profile: observer.profile, clock: observer.clock},
 		Interval: observer.pollInterval, Timeout: observer.pollLimit, Clock: observer.clock, Wait: observer.wait,
-		ContinueOnFalse: true,
+		ContinueOnFalse: true, ContinueOnErrorAfterObservation: true,
 	})
 	if err != nil {
 		return execution.StageObservationResult{}, err

--- a/internal/runner/polling_observer.go
+++ b/internal/runner/polling_observer.go
@@ -21,6 +21,11 @@ type BoundedPollingObserverConfig struct {
 	Clock           func() time.Time
 	Wait            ObservationWaiter
 	ContinueOnFalse bool
+	// ContinueOnErrorAfterObservation permits bounded read-only convergence
+	// polling to survive a later operational source failure only after at least
+	// one verified result established the source and authority path. A first
+	// read failure remains fail-closed.
+	ContinueOnErrorAfterObservation bool
 }
 
 // BoundedPollingObserver repeats only read-oriented aggregate observation.
@@ -47,21 +52,25 @@ func (observer *BoundedPollingObserver) Observe(ctx context.Context, policy obse
 	started := observer.config.Clock()
 	deadline := started.Add(observer.config.Timeout)
 	var last observation.VerifiedResult
+	haveLast := false
 	for {
 		result, err := observer.config.Source.Observe(ctx, policy)
 		if err != nil {
-			return observation.VerifiedResult{}, errors.New("bounded aggregate observation failed")
-		}
-		receipt, err := result.Receipt()
-		if err != nil {
-			return observation.VerifiedResult{}, errors.New("aggregate observer returned an unverified result")
-		}
-		last = result
-		if receipt.Ready == "True" || (receipt.Ready == "False" && !observer.config.ContinueOnFalse) {
-			return result, nil
-		}
-		if receipt.Ready != "Unknown" && receipt.Ready != "False" {
-			return observation.VerifiedResult{}, errors.New("aggregate observer returned an invalid readiness state")
+			if !observer.config.ContinueOnErrorAfterObservation || !haveLast {
+				return observation.VerifiedResult{}, errors.New("bounded aggregate observation failed")
+			}
+		} else {
+			receipt, receiptErr := result.Receipt()
+			if receiptErr != nil {
+				return observation.VerifiedResult{}, errors.New("aggregate observer returned an unverified result")
+			}
+			last, haveLast = result, true
+			if receipt.Ready == "True" || (receipt.Ready == "False" && !observer.config.ContinueOnFalse) {
+				return result, nil
+			}
+			if receipt.Ready != "Unknown" && receipt.Ready != "False" {
+				return observation.VerifiedResult{}, errors.New("aggregate observer returned an invalid readiness state")
+			}
 		}
 		now := observer.config.Clock()
 		if !now.Before(deadline) {

--- a/internal/runner/polling_observer_test.go
+++ b/internal/runner/polling_observer_test.go
@@ -92,6 +92,46 @@ func TestBoundedPollingObserverDoesNotRetryFalseOrOperationalError(t *testing.T)
 	}
 }
 
+func TestBoundedPollingObserverContinuesAfterLaterErrorOnlyWhenEnabled(t *testing.T) {
+	policy, _ := aggregateRunnerFixture()
+	unknown := pollingResult(t, policy, "Unknown")
+	ready := pollingResult(t, policy, "True")
+	current := time.Date(2026, 9, 2, 19, 0, 0, 0, time.UTC)
+	source := &sequenceObservationSource{
+		results: []observation.VerifiedResult{unknown, ready},
+		errors:  []error{nil, errors.New("transient private source detail"), nil},
+	}
+	observer, err := NewBoundedPollingObserver(BoundedPollingObserverConfig{
+		Source: source, Interval: time.Second, Timeout: time.Minute,
+		Clock:                           func() time.Time { return current },
+		Wait:                            func(_ context.Context, duration time.Duration) error { current = current.Add(duration); return nil },
+		ContinueOnErrorAfterObservation: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := observer.Observe(context.Background(), policy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, _ := result.Receipt()
+	if receipt.Ready != "True" || source.calls != 3 {
+		t.Fatalf("later transient failure did not remain bounded and pollable: receipt=%#v calls=%d", receipt, source.calls)
+	}
+
+	firstError := &sequenceObservationSource{err: errors.New("initial private source detail")}
+	observer, err = NewBoundedPollingObserver(BoundedPollingObserverConfig{
+		Source: firstError, Interval: time.Second, Timeout: time.Minute, Clock: time.Now,
+		Wait: func(context.Context, time.Duration) error { return nil }, ContinueOnErrorAfterObservation: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := observer.Observe(context.Background(), policy); err == nil || strings.Contains(err.Error(), "private") || firstError.calls != 1 {
+		t.Fatalf("initial source failure did not remain fail-closed and redacted: calls=%d err=%v", firstError.calls, err)
+	}
+}
+
 func pollingResult(t *testing.T, policy observation.Policy, readiness string) observation.VerifiedResult {
 	t.Helper()
 	evidence := []observation.Evidence{}
@@ -118,11 +158,15 @@ type sequenceObservationSource struct {
 	results  []observation.VerifiedResult
 	fallback observation.VerifiedResult
 	err      error
+	errors   []error
 	calls    int
 }
 
 func (source *sequenceObservationSource) Observe(context.Context, observation.Policy) (observation.VerifiedResult, error) {
 	source.calls++
+	if source.calls <= len(source.errors) && source.errors[source.calls-1] != nil {
+		return observation.VerifiedResult{}, source.errors[source.calls-1]
+	}
 	if source.err != nil {
 		return observation.VerifiedResult{}, source.err
 	}


### PR DESCRIPTION
## Summary
- keep a later transient network source failure bounded only after a verified convergence observation
- preserve immediate fail-closed behavior for first-read failures
- add reconstructed R25 CAAPH regression coverage and redacted diagnostic checkpoint

## Verification
- `go test ./internal/runner -run "TestBoundedPollingObserver|TestNetworkStageObserver" -count=1`
- `go test ./internal/observation -run "TestR25Reconstructed|TestNetworkSourceCollector" -count=1`

Private runtime evidence is excluded.