### PR TITLE
fix(runner): bound network convergence window (OK-147)

### DIFF
--- a/docs/ok147-r26-network-observation-diagnostic.md
+++ b/docs/ok147-r26-network-observation-diagnostic.md
@@ -1,0 +1,35 @@
+# OK-147 R26 network-observation diagnostic
+
+## Outcome
+
+R26 completed provider prerequisites, cluster lifecycle, lifecycle observation,
+and enablement, then stopped fail closed at `network-observation`. No
+network-observation Ledger record was persisted, and no later stage ran.
+
+## Read-only correlation
+
+The retained environment subsequently reached the intended network baseline
+without runner repair:
+
+- both expected Nodes were present;
+- both Cilium agent Pods were Running and Ready;
+- the Cilium, Envoy, and operator workloads were available;
+- the bound HCP and its single HRP were Ready; and
+- the fixed bounded Cilium health probe succeeded.
+
+The diagnostic performed no mutation or retry. Its redacted summary digest is
+`sha256:5c1c60a610ddddec4b33eb964f135ac680c1aa0cf4e1511dc70606f0edfd1de5`.
+
+## Cause and correction
+
+R26 already contained the bounded transient-read handling proven after R25.
+The execution manifest nevertheless gave lifecycle observation 45 minutes and
+the later network observation only 30 minutes. Normal CAAPH and Cilium
+convergence therefore exhausted the shorter network deadline before reaching
+the healthy state seen by the correlation diagnostic.
+
+The full-run manifest boundary now rejects a network polling timeout shorter
+than its lifecycle polling timeout. This keeps polling bounded and fail closed,
+does not reinterpret negative evidence, and grants no repair or mutation path.
+For the next run the existing 45-minute lifecycle window therefore implies a
+network window of at least 45 minutes.

--- a/internal/runner/full_run_execution_manifest.go
+++ b/internal/runner/full_run_execution_manifest.go
@@ -291,6 +291,14 @@ func (manifest VerifiedFullRunExecutionManifest) ExecutionConfig(runtime FullRun
 	if err != nil {
 		return FullRunExecutionConfig{}, errors.New("parse full-run network polling")
 	}
+	// Network convergence starts only after lifecycle observation and
+	// enablement have completed. A shorter network window makes the later,
+	// normally slower CAAPH/Cilium convergence boundary less tolerant than the
+	// lifecycle boundary that precedes it and repeatedly turns healthy late
+	// convergence into a stopped full run.
+	if networkTimeout < lifecycleTimeout {
+		return FullRunExecutionConfig{}, errors.New("full-run network polling timeout is shorter than lifecycle polling timeout")
+	}
 	platformInterval, platformTimeout, err := parsePostRuntimePolling(document.PlatformObservation.PollInterval, document.PlatformObservation.PollTimeout)
 	if err != nil {
 		return FullRunExecutionConfig{}, errors.New("parse full-run platform polling")

--- a/internal/runner/full_run_execution_manifest_test.go
+++ b/internal/runner/full_run_execution_manifest_test.go
@@ -168,6 +168,38 @@ func TestOpenFullRunExecutionManifestStopsBeforeAnyRuntimeAction(t *testing.T) {
 	}
 }
 
+func TestFullRunExecutionManifestRejectsNetworkWindowShorterThanLifecycle(t *testing.T) {
+	manifestPath, cleanup := fullRunExecutionManifestFixture(t)
+	defer cleanup()
+	raw, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var document map[string]any
+	if err := json.Unmarshal(raw, &document); err != nil {
+		t.Fatal(err)
+	}
+	document["lifecycleObservation"].(map[string]any)["pollTimeout"] = "2m"
+	document["networkObservation"].(map[string]any)["pollTimeout"] = "1m"
+	path := writeBundleFile(t, filepath.Dir(manifestPath), "short-network-window.json", mustJSON(t, document))
+	manifest, _, err := LoadFullRunExecutionManifest(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	clock := func() time.Time { return time.Date(2026, 9, 3, 5, 0, 0, 0, time.UTC) }
+	probe := &recordingPlatformCapabilityProbe{result: PlatformCapabilityProbeResult{Passed: true}}
+	capability, _ := NewFirstRunPlatformCapabilityResolver(probe, clock)
+	_, err = manifest.ExecutionConfig(FullRunExecutionManifestRuntime{
+		PlatformCapability: FullRunPlatformCapabilityFactoryFunc(func(FullRunPlatformCapabilityBinding) (PlatformCapabilityResolver, error) {
+			return capability, nil
+		}),
+		Clock: clock, Wait: WaitWithTimer,
+	})
+	if err == nil || !strings.Contains(err.Error(), "network polling timeout is shorter") {
+		t.Fatalf("shorter network convergence window was accepted: %v", err)
+	}
+}
+
 func TestFullRunExecutionManifestFailsClosed(t *testing.T) {
 	manifest, cleanup := fullRunExecutionManifestFixture(t)
 	defer cleanup()


### PR DESCRIPTION
## Summary
- reject full-run manifests whose network convergence timeout is shorter than lifecycle convergence
- add a fail-closed regression test
- record the redacted R26 network-correlation result

## Verification
- targeted runner polling and manifest tests: PASS
- observation package tests: PASS
- full runner suite: only the three previously known Go 1.26 client-certificate fixture failures remain

## Safety
No private evidence, credentials, endpoints, Kubernetes objects, or cluster mutations are included.