### PR TITLE
fix(runner): poll transient initial network reads (OK-147)

### DIFF
--- a/internal/observation/network_kubernetes.go
+++ b/internal/observation/network_kubernetes.go
@@ -32,6 +32,23 @@ type KubernetesNetworkReader struct {
 	allowed           map[string]struct{}
 }
 
+type transientNetworkSourceError struct {
+	cause error
+}
+
+func (err transientNetworkSourceError) Error() string {
+	return "temporary bounded network source failure"
+}
+func (err transientNetworkSourceError) Unwrap() error { return err.cause }
+
+// IsTransientNetworkSourceError reports only failures that are safe to poll
+// during bounded convergence. Authentication, authorization, TLS, identity,
+// schema and invariant failures deliberately remain terminal.
+func IsTransientNetworkSourceError(err error) bool {
+	var transient transientNetworkSourceError
+	return errors.As(err, &transient)
+}
+
 func NewKubernetesManagementNetworkReader(config KubernetesNetworkReaderConfig, namespace, name, hcpName string) (*KubernetesNetworkReader, error) {
 	if !validDNSLabel(namespace) || !validDNSLabel(name) || !validDNSLabel(hcpName) {
 		return nil, errors.New("management network reader object identity is invalid")
@@ -102,14 +119,20 @@ func (reader *KubernetesNetworkReader) Get(ctx context.Context, path string) ([]
 	}
 	response, err := reader.client.Do(request)
 	if err != nil {
-		return nil, errors.New("bounded network source request failed")
+		return nil, transientNetworkSourceError{cause: errors.New("bounded network source request failed")}
 	}
 	defer response.Body.Close()
 	raw, readErr := io.ReadAll(io.LimitReader(response.Body, maximumNetworkSourceBytes+1))
-	if readErr != nil || len(raw) > maximumNetworkSourceBytes {
+	if readErr != nil {
+		return nil, transientNetworkSourceError{cause: errors.New("bounded network source response read failed")}
+	}
+	if len(raw) > maximumNetworkSourceBytes {
 		return nil, errors.New("bounded network source response exceeds accepted size")
 	}
 	if response.StatusCode != http.StatusOK {
+		if response.StatusCode == http.StatusNotFound || response.StatusCode == http.StatusTooManyRequests || response.StatusCode >= http.StatusInternalServerError {
+			return nil, transientNetworkSourceError{cause: fmt.Errorf("bounded network source request returned HTTP %d", response.StatusCode)}
+		}
 		return nil, fmt.Errorf("bounded network source request returned HTTP %d", response.StatusCode)
 	}
 	mediaType, _, err := mime.ParseMediaType(response.Header.Get("Content-Type"))

--- a/internal/observation/network_kubernetes_test.go
+++ b/internal/observation/network_kubernetes_test.go
@@ -115,6 +115,41 @@ func TestKubernetesNetworkReaderFailsClosedAndRedacts(t *testing.T) {
 	}
 }
 
+func TestKubernetesNetworkReaderClassifiesOnlyConvergenceSafeFailuresAsTransient(t *testing.T) {
+	for name, testCase := range map[string]struct {
+		status    int
+		transport bool
+		want      bool
+	}{
+		"transport":       {transport: true, want: true},
+		"not found":       {status: http.StatusNotFound, want: true},
+		"rate limited":    {status: http.StatusTooManyRequests, want: true},
+		"server failure":  {status: http.StatusServiceUnavailable, want: true},
+		"unauthenticated": {status: http.StatusUnauthorized},
+		"unauthorized":    {status: http.StatusForbidden},
+		"invalid request": {status: http.StatusBadRequest},
+	} {
+		t.Run(name, func(t *testing.T) {
+			client := &http.Client{Transport: networkRoundTripFunc(func(*http.Request) (*http.Response, error) {
+				if testCase.transport {
+					return nil, errors.New("private transport detail")
+				}
+				return networkJSONResponse(testCase.status, `{}`), nil
+			})}
+			reader, err := NewKubernetesWorkloadNetworkReader(KubernetesNetworkReaderConfig{
+				Endpoint: "http://localhost:12345", BearerToken: "workload-token", Client: client,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, err = reader.Get(context.Background(), "/api/v1/nodes")
+			if err == nil || IsTransientNetworkSourceError(err) != testCase.want || strings.Contains(err.Error(), "private") {
+				t.Fatalf("unexpected classification: transient=%t err=%v", IsTransientNetworkSourceError(err), err)
+			}
+		})
+	}
+}
+
 func TestKubernetesFixedCiliumProbeBindsExactCommand(t *testing.T) {
 	executor := &fakeCiliumPodExecutor{response: []byte(`{"nodes":[]}`)}
 	probe, err := NewKubernetesFixedCiliumProbe(executor)

--- a/internal/runner/network_stage_observer.go
+++ b/internal/runner/network_stage_observer.go
@@ -101,6 +101,7 @@ func (observer *NetworkStageObserver) Observe(ctx context.Context) (execution.St
 		Source:   &networkPollingSource{source: observer.source, profile: observer.profile, clock: observer.clock},
 		Interval: observer.pollInterval, Timeout: observer.pollLimit, Clock: observer.clock, Wait: observer.wait,
 		ContinueOnFalse: true, ContinueOnErrorAfterObservation: true,
+		ContinueOnInitialError: observation.IsTransientNetworkSourceError,
 	})
 	if err != nil {
 		return execution.StageObservationResult{}, err

--- a/internal/runner/polling_observer.go
+++ b/internal/runner/polling_observer.go
@@ -26,6 +26,9 @@ type BoundedPollingObserverConfig struct {
 	// one verified result established the source and authority path. A first
 	// read failure remains fail-closed.
 	ContinueOnErrorAfterObservation bool
+	// ContinueOnInitialError permits only explicitly classified transient
+	// source failures to remain pollable before the first verified result.
+	ContinueOnInitialError func(error) bool
 }
 
 // BoundedPollingObserver repeats only read-oriented aggregate observation.
@@ -56,7 +59,8 @@ func (observer *BoundedPollingObserver) Observe(ctx context.Context, policy obse
 	for {
 		result, err := observer.config.Source.Observe(ctx, policy)
 		if err != nil {
-			if !observer.config.ContinueOnErrorAfterObservation || !haveLast {
+			initialTransient := !haveLast && observer.config.ContinueOnInitialError != nil && observer.config.ContinueOnInitialError(err)
+			if !initialTransient && (!observer.config.ContinueOnErrorAfterObservation || !haveLast) {
 				return observation.VerifiedResult{}, errors.New("bounded aggregate observation failed")
 			}
 		} else {

--- a/internal/runner/polling_observer_test.go
+++ b/internal/runner/polling_observer_test.go
@@ -132,6 +132,40 @@ func TestBoundedPollingObserverContinuesAfterLaterErrorOnlyWhenEnabled(t *testin
 	}
 }
 
+func TestBoundedPollingObserverContinuesOnlyClassifiedInitialError(t *testing.T) {
+	policy, _ := aggregateRunnerFixture()
+	ready := pollingResult(t, policy, "True")
+	current := time.Date(2026, 9, 3, 8, 0, 0, 0, time.UTC)
+	transient := errors.New("temporary")
+	source := &sequenceObservationSource{errors: []error{transient, nil}, results: []observation.VerifiedResult{ready}}
+	observer, err := NewBoundedPollingObserver(BoundedPollingObserverConfig{
+		Source: source, Interval: time.Second, Timeout: time.Minute, Clock: func() time.Time { return current },
+		Wait:                   func(_ context.Context, duration time.Duration) error { current = current.Add(duration); return nil },
+		ContinueOnInitialError: func(err error) bool { return errors.Is(err, transient) },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := observer.Observe(context.Background(), policy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, _ := result.Receipt()
+	if receipt.Ready != "True" || source.calls != 2 {
+		t.Fatalf("classified initial error was not polled: receipt=%#v calls=%d", receipt, source.calls)
+	}
+
+	terminal := &sequenceObservationSource{err: errors.New("terminal")}
+	observer, _ = NewBoundedPollingObserver(BoundedPollingObserverConfig{
+		Source: terminal, Interval: time.Second, Timeout: time.Minute, Clock: time.Now,
+		Wait:                   func(context.Context, time.Duration) error { return nil },
+		ContinueOnInitialError: func(error) bool { return false },
+	})
+	if _, err := observer.Observe(context.Background(), policy); err == nil || terminal.calls != 1 {
+		t.Fatalf("unclassified initial error was retried: calls=%d err=%v", terminal.calls, err)
+	}
+}
+
 func pollingResult(t *testing.T, policy observation.Policy, readiness string) observation.VerifiedResult {
 	t.Helper()
 	evidence := []observation.Evidence{}


### PR DESCRIPTION
## Summary
- classify only convergence-safe network source failures as transient
- permit bounded polling when the first network snapshot hits transport, 404, 429, or 5xx failures
- keep authentication, authorization, TLS, identity, schema, and invariant failures terminal

## Evidence
- R27 stopped at network-observation before persisting a network receipt
- subsequent read-only correlation showed HCP/HRP, Nodes, Cilium, Envoy, Operator, and the fixed health probe healthy
- packaged lifecycle and network polling windows were both 45 minutes

## Verification
- `go test ./internal/observation -run "TestKubernetesNetworkReader|TestNetworkSourceCollector"`
- `go test ./internal/runner -run "TestBoundedPollingObserver|TestNetworkStageObserver"`
- `git diff --check`

Private evidence, credentials, endpoints, UIDs, and raw cluster output are excluded.