### PR TITLE
fix(runner): poll transient Cilium probe failures (OK-147)

### DIFF
--- a/internal/observation/network_collector.go
+++ b/internal/observation/network_collector.go
@@ -155,7 +155,12 @@ func (collector *NetworkSourceCollector) Collect(ctx context.Context, policy Pol
 	}
 	probeRaw, err := collector.probe.Probe(ctx, selectedName, selectedUID)
 	if err != nil {
-		return NetworkSnapshot{}, errors.New("fixed Cilium functional probe failed")
+		// The command, Pod identity and container are fixed by the probe
+		// boundary. A non-zero execution while Cilium's health cache is still
+		// warming is therefore an operational convergence signal, not an
+		// authorization or input failure. Keep it redacted and let the bounded
+		// observer poll it; malformed successful output remains terminal below.
+		return NetworkSnapshot{}, transientNetworkSourceError{cause: errors.New("fixed Cilium functional probe failed")}
 	}
 	probe, err := normalizeNetworkProbe(probeRaw, nodeNames)
 	if err != nil {

--- a/internal/observation/network_collector_test.go
+++ b/internal/observation/network_collector_test.go
@@ -231,9 +231,6 @@ func TestNetworkSourceCollectorFailsClosed(t *testing.T) {
 		"source transport error": func(management, _ *fakeNetworkGetter, _ *fakeFixedProbe) {
 			management.errors = map[string]error{managementPathHCP: errors.New("https://sensitive-endpoint:6443/token")}
 		},
-		"probe execution error": func(_ *fakeNetworkGetter, _ *fakeNetworkGetter, probe *fakeFixedProbe) {
-			probe.err = errors.New("sensitive raw failure")
-		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			policy, profile, management, workload, probe := collectorFixture(t)
@@ -241,10 +238,23 @@ func TestNetworkSourceCollectorFailsClosed(t *testing.T) {
 			collector := mustNetworkCollector(t, policy, management, workload, probe)
 			if _, err := collector.Observe(context.Background(), policy, profile); err == nil {
 				t.Fatal("malformed or foreign network source accepted")
-			} else if (name == "probe execution error" || name == "source transport error") && strings.Contains(err.Error(), "sensitive") {
+			} else if name == "source transport error" && strings.Contains(err.Error(), "sensitive") {
 				t.Fatalf("raw source error leaked: %v", err)
 			}
 		})
+	}
+}
+
+func TestNetworkSourceCollectorClassifiesProbeExecutionFailureAsTransient(t *testing.T) {
+	policy, profile, management, workload, probe := collectorFixture(t)
+	probe.err = errors.New("sensitive raw failure")
+	collector := mustNetworkCollector(t, policy, management, workload, probe)
+	_, err := collector.Observe(context.Background(), policy, profile)
+	if err == nil || !IsTransientNetworkSourceError(err) {
+		t.Fatalf("probe execution failure was not transient: %v", err)
+	}
+	if strings.Contains(err.Error(), "sensitive") {
+		t.Fatalf("raw probe error leaked: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- classify only fixed Cilium health-probe execution failures as transient convergence
- preserve fail-closed handling for malformed output, identity, TLS, RBAC and schema failures
- add focused redaction and classification coverage

## Verification

- `go test ./internal/observation`
- targeted bounded polling/network observer tests
- `git diff --check`

The full runner suite still has the three known unrelated Go 1.26 certificate-fixture failures. No private evidence is included.