### PR TITLE
fix(runner): poll incomplete Cilium warmup paths (OK-147)

### DIFF
--- a/internal/observation/network_collector.go
+++ b/internal/observation/network_collector.go
@@ -13,6 +13,8 @@ import (
 
 const maximumNetworkSourceBytes = 4 * 1024 * 1024
 
+var errNetworkProbePathPending = errors.New("functional probe path is pending")
+
 // NetworkRawGetter deliberately exposes only GET. Concrete management and
 // workload adapters must each bind their own credential and API endpoint.
 type NetworkRawGetter interface {
@@ -164,6 +166,13 @@ func (collector *NetworkSourceCollector) Collect(ctx context.Context, policy Pol
 	}
 	probe, err := normalizeNetworkProbe(probeRaw, nodeNames)
 	if err != nil {
+		// Cilium can return a successful JSON document before every fixed
+		// primary-address path has been populated. That shape is a normal
+		// cache-warmup state and is safe to poll. All other schema and identity
+		// failures remain terminal.
+		if errors.Is(err, errNetworkProbePathPending) {
+			return NetworkSnapshot{}, transientNetworkSourceError{cause: errNetworkProbePathPending}
+		}
 		return NetworkSnapshot{}, err
 	}
 	snapshot.Probe = probe
@@ -489,7 +498,7 @@ func normalizeNetworkProbe(raw []byte, nodeNames map[string]string) (NetworkProb
 			for _, protocol := range []string{"http", "icmp"} {
 				path, ok := address[protocol].(map[string]any)
 				if !ok {
-					return NetworkProbe{}, errors.New("functional probe path is missing")
+					return NetworkProbe{}, errNetworkProbePathPending
 				}
 				statusRaw, present := path["status"]
 				status := ""

--- a/internal/observation/network_collector_test.go
+++ b/internal/observation/network_collector_test.go
@@ -258,6 +258,20 @@ func TestNetworkSourceCollectorClassifiesProbeExecutionFailureAsTransient(t *tes
 	}
 }
 
+func TestNetworkSourceCollectorClassifiesMissingWarmupProbePathAsTransient(t *testing.T) {
+	policy, profile, management, workload, probe := collectorFixture(t)
+	probe.response = mutateJSON(t, probe.response, func(value map[string]any) {
+		node := value["nodes"].([]any)[0].(map[string]any)
+		address := node["host"].(map[string]any)["primary-address"].(map[string]any)
+		delete(address, "http")
+	})
+	collector := mustNetworkCollector(t, policy, management, workload, probe)
+	_, err := collector.Observe(context.Background(), policy, profile)
+	if err == nil || !IsTransientNetworkSourceError(err) {
+		t.Fatalf("missing warmup probe path was not transient: %v", err)
+	}
+}
+
 const managementPathHCP = "/apis/addons.cluster.x-k8s.io/v1alpha1/namespaces/disposable-ok141/helmchartproxies/disposable-ok141-cilium"
 const managementPathHRP = "/apis/addons.cluster.x-k8s.io/v1alpha1/namespaces/disposable-ok141/helmreleaseproxies?labelSelector=cluster.x-k8s.io%2Fcluster-name%3Ddisposable-ok141%2Chelmreleaseproxy.addons.cluster.x-k8s.io%2Fhelmchartproxy-name%3Ddisposable-ok141-cilium"
 


### PR DESCRIPTION
## Summary
- classify only missing fixed Cilium health paths as transient cache warm-up
- keep malformed JSON, foreign nodes, invalid status types, and identity failures fail-closed
- add regression coverage for the R29 startup shape

## Verification
- `go test ./internal/observation`
- `go test ./internal/runner -run "TestNetworkStageObserver|TestBoundedPollingObserver" -count=1`
- `git diff --check`

Full `internal/runner` also ran; three unrelated TLS fixture tests fail under local Go 1.26 certificate verification.