### PR TITLE
fix(ok147): poll unpublished Cilium health nodes

### DIFF
--- a/internal/observation/network_collector.go
+++ b/internal/observation/network_collector.go
@@ -483,6 +483,14 @@ func normalizeNetworkProbe(raw []byte, nodeNames map[string]string) (NetworkProb
 		return NetworkProbe{}, errors.New("functional probe interval is invalid")
 	}
 	paths := make([]NetworkProbePath, 0, len(nodeNames)*4)
+	rawNodes, nodesPresent := value["nodes"]
+	// cilium-health can successfully publish the response envelope before its
+	// first Node cache snapshot. Missing or null nodes are therefore a bounded
+	// warmup state. A present value of any other type remains malformed and
+	// fails closed in requiredObjectSlice below.
+	if !nodesPresent || rawNodes == nil {
+		return NetworkProbe{}, errNetworkProbePathPending
+	}
 	probeNodes, err := requiredObjectSlice(value, "nodes", 100)
 	if err != nil {
 		return NetworkProbe{}, errors.New("functional probe Node collection is invalid")

--- a/internal/observation/network_collector_test.go
+++ b/internal/observation/network_collector_test.go
@@ -272,6 +272,27 @@ func TestNetworkSourceCollectorClassifiesMissingWarmupProbePathAsTransient(t *te
 	}
 }
 
+func TestNetworkSourceCollectorClassifiesUnpublishedWarmupNodesAsTransient(t *testing.T) {
+	for _, rawNodes := range []any{nil, "invalid"} {
+		name := "null"
+		wantTransient := true
+		if rawNodes != nil {
+			name, wantTransient = "invalid-type", false
+		}
+		t.Run(name, func(t *testing.T) {
+			policy, profile, management, workload, probe := collectorFixture(t)
+			probe.response = mutateJSON(t, probe.response, func(value map[string]any) {
+				value["nodes"] = rawNodes
+			})
+			collector := mustNetworkCollector(t, policy, management, workload, probe)
+			_, err := collector.Observe(context.Background(), policy, profile)
+			if err == nil || IsTransientNetworkSourceError(err) != wantTransient {
+				t.Fatalf("unexpected unpublished Node classification: transient=%t err=%v", IsTransientNetworkSourceError(err), err)
+			}
+		})
+	}
+}
+
 const managementPathHCP = "/apis/addons.cluster.x-k8s.io/v1alpha1/namespaces/disposable-ok141/helmchartproxies/disposable-ok141-cilium"
 const managementPathHRP = "/apis/addons.cluster.x-k8s.io/v1alpha1/namespaces/disposable-ok141/helmreleaseproxies?labelSelector=cluster.x-k8s.io%2Fcluster-name%3Ddisposable-ok141%2Chelmreleaseproxy.addons.cluster.x-k8s.io%2Fhelmchartproxy-name%3Ddisposable-ok141-cilium"
 


### PR DESCRIPTION
## Summary
- classify missing or null Cilium health node collections as bounded cache warmup
- keep present invalid node representations fail-closed
- add regression coverage for both classifications

## Verification
- `go test ./internal/observation`
- targeted network-stage and bounded-polling observer tests
- `git diff --check`

## Scope
No private evidence, credentials, endpoints, or live cluster output are included.