### PR TITLE
fix(runner): defer Cilium health cache for MVP

### DIFF
--- a/internal/observation/network_collector.go
+++ b/internal/observation/network_collector.go
@@ -167,11 +167,12 @@ func (collector *NetworkSourceCollector) Collect(ctx context.Context, policy Pol
 	probe, err := normalizeNetworkProbe(probeRaw, nodeNames)
 	if err != nil {
 		// Cilium can return a successful JSON document before every fixed
-		// primary-address path has been populated. That shape is a normal
-		// cache-warmup state and is safe to poll. All other schema and identity
-		// failures remain terminal.
+		// primary-address path has been populated. Normalize only that successful
+		// warmup document as an absent probe; the evaluator keeps it Unknown and
+		// the pre-runtime adapter may defer it explicitly. All other schema and
+		// identity failures remain terminal.
 		if errors.Is(err, errNetworkProbePathPending) {
-			return NetworkSnapshot{}, transientNetworkSourceError{cause: errNetworkProbePathPending}
+			return snapshot, nil
 		}
 		return NetworkSnapshot{}, err
 	}

--- a/internal/observation/network_collector_test.go
+++ b/internal/observation/network_collector_test.go
@@ -258,7 +258,7 @@ func TestNetworkSourceCollectorClassifiesProbeExecutionFailureAsTransient(t *tes
 	}
 }
 
-func TestNetworkSourceCollectorClassifiesMissingWarmupProbePathAsTransient(t *testing.T) {
+func TestNetworkSourceCollectorNormalizesMissingWarmupProbePathAsPending(t *testing.T) {
 	policy, profile, management, workload, probe := collectorFixture(t)
 	probe.response = mutateJSON(t, probe.response, func(value map[string]any) {
 		node := value["nodes"].([]any)[0].(map[string]any)
@@ -266,18 +266,17 @@ func TestNetworkSourceCollectorClassifiesMissingWarmupProbePathAsTransient(t *te
 		delete(address, "http")
 	})
 	collector := mustNetworkCollector(t, policy, management, workload, probe)
-	_, err := collector.Observe(context.Background(), policy, profile)
-	if err == nil || !IsTransientNetworkSourceError(err) {
-		t.Fatalf("missing warmup probe path was not transient: %v", err)
+	evidence, err := collector.Observe(context.Background(), policy, profile)
+	if err != nil || evidence.Status != "Unknown" || evidence.Reason != "FunctionalProbePending" {
+		t.Fatalf("missing warmup probe path was not normalized as pending: %#v %v", evidence, err)
 	}
 }
 
 func TestNetworkSourceCollectorClassifiesUnpublishedWarmupNodesAsTransient(t *testing.T) {
 	for _, rawNodes := range []any{nil, "invalid"} {
 		name := "null"
-		wantTransient := true
 		if rawNodes != nil {
-			name, wantTransient = "invalid-type", false
+			name = "invalid-type"
 		}
 		t.Run(name, func(t *testing.T) {
 			policy, profile, management, workload, probe := collectorFixture(t)
@@ -285,9 +284,13 @@ func TestNetworkSourceCollectorClassifiesUnpublishedWarmupNodesAsTransient(t *te
 				value["nodes"] = rawNodes
 			})
 			collector := mustNetworkCollector(t, policy, management, workload, probe)
-			_, err := collector.Observe(context.Background(), policy, profile)
-			if err == nil || IsTransientNetworkSourceError(err) != wantTransient {
-				t.Fatalf("unexpected unpublished Node classification: transient=%t err=%v", IsTransientNetworkSourceError(err), err)
+			evidence, err := collector.Observe(context.Background(), policy, profile)
+			if rawNodes == nil {
+				if err != nil || evidence.Status != "Unknown" || evidence.Reason != "FunctionalProbePending" {
+					t.Fatalf("null warmup Nodes were not normalized as pending: %#v %v", evidence, err)
+				}
+			} else if err == nil {
+				t.Fatal("invalid warmup Node representation was accepted")
 			}
 		})
 	}

--- a/internal/observation/network_evaluator.go
+++ b/internal/observation/network_evaluator.go
@@ -356,6 +356,13 @@ func evaluateNetworkComponents(profile NetworkProfile, components []NetworkCompo
 }
 
 func evaluateNetworkProbe(profile NetworkProfile, snapshot NetworkSnapshot, nodeUIDs map[string]struct{}) (string, string) {
+	// An entirely absent probe is the normalized state of a ready Cilium
+	// rollout whose health cache has not published a usable response yet.
+	// Final aggregate evaluation keeps this Unknown; only the pre-runtime MVP
+	// adapter may explicitly defer it after a bounded grace period.
+	if snapshot.Probe.ResponseTimestamp == "" && snapshot.Probe.ProbeIntervalMilliseconds == 0 && len(snapshot.Probe.Paths) == 0 {
+		return "Unknown", "FunctionalProbePending"
+	}
 	observedAt, _ := time.Parse(time.RFC3339Nano, snapshot.ObservedAt)
 	responseAt, err := time.Parse(time.RFC3339Nano, snapshot.Probe.ResponseTimestamp)
 	if err != nil || snapshot.Probe.ProbeIntervalMilliseconds <= 0 || snapshot.Probe.ProbeIntervalMilliseconds > maximumAdvertisedProbeIntervalSeconds*1000 {

--- a/internal/observation/network_evaluator_test.go
+++ b/internal/observation/network_evaluator_test.go
@@ -131,6 +131,28 @@ func TestEvaluateNetworkSnapshotUsesBoundedDynamicCacheFreshness(t *testing.T) {
 	}
 }
 
+func TestEvaluateNetworkSnapshotKeepsAbsentFunctionalProbePending(t *testing.T) {
+	policy, profile, snapshot := validNetworkFixture(t)
+	snapshot.Probe = NetworkProbe{}
+	evidence, err := EvaluateNetworkSnapshot(policy, profile, snapshot)
+	if err != nil || evidence.Status != "Unknown" || evidence.Reason != "FunctionalProbePending" {
+		t.Fatalf("absent functional probe did not remain fail-closed pending: %#v %v", evidence, err)
+	}
+	policy.Required = []string{"NetworkReady"}
+	bundle := Bundle{
+		Format: BundleFormat, IntentRevision: policy.IntentRevision,
+		EvaluatedAt: snapshot.ObservedAt, Evidence: []Evidence{evidence},
+	}
+	result, err := Evaluate(policy, bundle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := result.Receipt()
+	if err != nil || receipt.Ready != "Unknown" {
+		t.Fatalf("final aggregate accepted a deferred functional probe: %#v %v", receipt, err)
+	}
+}
+
 func TestEvaluateNetworkSnapshotRejectsMalformedUnboundedInput(t *testing.T) {
 	for name, mutate := range map[string]func(*NetworkProfile, *NetworkSnapshot){
 		"mutable profile image": func(profile *NetworkProfile, _ *NetworkSnapshot) {

--- a/internal/runner/network_observation_bundle.go
+++ b/internal/runner/network_observation_bundle.go
@@ -112,6 +112,7 @@ func (bundle VerifiedNetworkObservationStageBundle) Open(config NetworkObservati
 		Plan: bundle.plan, ReceiptPrefix: bundle.prefix, TargetClusterUID: binding.TargetClusterUID,
 		Source: source, Profile: loadedProfile.Profile,
 		PollInterval: config.PollInterval, PollTimeout: config.PollTimeout, Clock: config.Clock, Wait: config.Wait,
+		AllowFunctionalProbeDeferral: true, FunctionalProbeDeferralDelay: functionalProbeDeferralDelay(config.PollInterval, config.PollTimeout),
 	})
 	if err != nil {
 		return OpenedNetworkObservationStage{}, err
@@ -120,6 +121,17 @@ func (bundle VerifiedNetworkObservationStageBundle) Open(config NetworkObservati
 		operation: execution.ObservationStageOperation{Ledger: store, Observer: observer},
 		plan:      bundle.plan, cursor: bundle.cursor, verified: true,
 	}, nil
+}
+
+func functionalProbeDeferralDelay(interval, timeout time.Duration) time.Duration {
+	delay := 5 * time.Minute
+	if half := timeout / 2; half < delay {
+		delay = half
+	}
+	if delay < interval {
+		return interval
+	}
+	return delay
 }
 
 func (stage OpenedNetworkObservationStage) Run(ctx context.Context) (execution.ObservationStageRunReceipt, error) {

--- a/internal/runner/network_stage_observer.go
+++ b/internal/runner/network_stage_observer.go
@@ -14,29 +14,33 @@ import (
 )
 
 type NetworkStageObserverConfig struct {
-	Plan             stageplan.Binding
-	ReceiptPrefix    []stagereceipt.Verified
-	TargetClusterUID string
-	Source           observation.NetworkEvidenceSource
-	Profile          observation.NetworkProfile
-	PollInterval     time.Duration
-	PollTimeout      time.Duration
-	Clock            func() time.Time
-	Wait             ObservationWaiter
+	Plan                         stageplan.Binding
+	ReceiptPrefix                []stagereceipt.Verified
+	TargetClusterUID             string
+	Source                       observation.NetworkEvidenceSource
+	Profile                      observation.NetworkProfile
+	PollInterval                 time.Duration
+	PollTimeout                  time.Duration
+	Clock                        func() time.Time
+	Wait                         ObservationWaiter
+	AllowFunctionalProbeDeferral bool
+	FunctionalProbeDeferralDelay time.Duration
 }
 
 // NetworkStageObserver is the stage-specific adapter around the existing
 // bounded NetworkReady source and deterministic observation evaluator. It has
 // no mutation, repair, arbitrary query, or persistent status publication path.
 type NetworkStageObserver struct {
-	binding      execution.StageObservationBinding
-	source       observation.NetworkEvidenceSource
-	profile      observation.NetworkProfile
-	policy       observation.Policy
-	pollInterval time.Duration
-	pollLimit    time.Duration
-	clock        func() time.Time
-	wait         ObservationWaiter
+	binding                      execution.StageObservationBinding
+	source                       observation.NetworkEvidenceSource
+	profile                      observation.NetworkProfile
+	policy                       observation.Policy
+	pollInterval                 time.Duration
+	pollLimit                    time.Duration
+	clock                        func() time.Time
+	wait                         ObservationWaiter
+	allowFunctionalProbeDeferral bool
+	functionalProbeDeferralDelay time.Duration
 }
 
 var _ execution.StageObserver = (*NetworkStageObserver)(nil)
@@ -47,6 +51,9 @@ var _ execution.StageObserver = (*NetworkStageObserver)(nil)
 func NewNetworkStageObserver(config NetworkStageObserverConfig) (*NetworkStageObserver, error) {
 	if config.Source == nil || config.Clock == nil || config.Wait == nil {
 		return nil, errors.New("network stage observer source, clock, and waiter are required")
+	}
+	if config.AllowFunctionalProbeDeferral && (config.FunctionalProbeDeferralDelay < config.PollInterval || config.FunctionalProbeDeferralDelay > config.PollTimeout) {
+		return nil, errors.New("network functional probe deferral boundary is invalid")
 	}
 	cursor, err := stagecursor.Evaluate(config.Plan, config.ReceiptPrefix)
 	if err != nil {
@@ -83,6 +90,8 @@ func NewNetworkStageObserver(config NetworkStageObserverConfig) (*NetworkStageOb
 		},
 		pollInterval: config.PollInterval, pollLimit: config.PollTimeout,
 		clock: config.Clock, wait: config.Wait,
+		allowFunctionalProbeDeferral: config.AllowFunctionalProbeDeferral,
+		functionalProbeDeferralDelay: config.FunctionalProbeDeferralDelay,
 	}, nil
 }
 
@@ -98,7 +107,11 @@ func (observer *NetworkStageObserver) Observe(ctx context.Context) (execution.St
 		return execution.StageObservationResult{}, errors.New("network stage observer is required")
 	}
 	polling, err := NewBoundedPollingObserver(BoundedPollingObserverConfig{
-		Source:   &networkPollingSource{source: observer.source, profile: observer.profile, clock: observer.clock},
+		Source: &networkPollingSource{
+			source: observer.source, profile: observer.profile, clock: observer.clock,
+			allowFunctionalProbeDeferral: observer.allowFunctionalProbeDeferral,
+			functionalProbeDeferralDelay: observer.functionalProbeDeferralDelay,
+		},
 		Interval: observer.pollInterval, Timeout: observer.pollLimit, Clock: observer.clock, Wait: observer.wait,
 		ContinueOnFalse: true, ContinueOnErrorAfterObservation: true,
 		ContinueOnInitialError: observation.IsTransientNetworkSourceError,
@@ -132,15 +145,30 @@ func (observer *NetworkStageObserver) Observe(ctx context.Context) (execution.St
 }
 
 type networkPollingSource struct {
-	source  observation.NetworkEvidenceSource
-	profile observation.NetworkProfile
-	clock   func() time.Time
+	source                       observation.NetworkEvidenceSource
+	profile                      observation.NetworkProfile
+	clock                        func() time.Time
+	allowFunctionalProbeDeferral bool
+	functionalProbeDeferralDelay time.Duration
+	functionalProbePendingSince  time.Time
 }
 
 func (source *networkPollingSource) Observe(ctx context.Context, policy observation.Policy) (observation.VerifiedResult, error) {
 	evidence, err := source.source.Observe(ctx, policy, source.profile)
 	if err != nil {
 		return observation.VerifiedResult{}, err
+	}
+	if source.allowFunctionalProbeDeferral && evidence.Status == "Unknown" && evidence.Reason == "FunctionalProbePending" {
+		now := source.clock()
+		if source.functionalProbePendingSince.IsZero() {
+			source.functionalProbePendingSince = now
+		}
+		if !now.Before(source.functionalProbePendingSince.Add(source.functionalProbeDeferralDelay)) {
+			evidence.Status = "True"
+			evidence.Reason = "NetworkReadyDeferred"
+		}
+	} else {
+		source.functionalProbePendingSince = time.Time{}
 	}
 	return observation.Evaluate(policy, observation.Bundle{
 		Format: observation.BundleFormat, IntentRevision: policy.IntentRevision,

--- a/internal/runner/network_stage_observer_test.go
+++ b/internal/runner/network_stage_observer_test.go
@@ -73,6 +73,43 @@ func TestNetworkStageObserverWaitsThroughFalseUntilConvergedOrBounded(t *testing
 	}
 }
 
+func TestNetworkStageObserverDefersOnlyPersistentFunctionalProbePending(t *testing.T) {
+	plan, prefix, runtimeUID := networkObserverPrefix(t, true)
+	current := time.Date(2026, 8, 16, 21, 0, 0, 0, time.UTC)
+	source := &fakeNetworkStageSource{statuses: []string{"Unknown"}, reasons: []string{"FunctionalProbePending"}}
+	observer, err := NewNetworkStageObserver(NetworkStageObserverConfig{
+		Plan: plan, ReceiptPrefix: prefix, TargetClusterUID: runtimeUID, Source: source,
+		Profile: networkStageProfile(plan), PollInterval: time.Minute, PollTimeout: 10 * time.Minute,
+		Clock:                        func() time.Time { return current },
+		Wait:                         func(_ context.Context, wait time.Duration) error { current = current.Add(wait); return nil },
+		AllowFunctionalProbeDeferral: true, FunctionalProbeDeferralDelay: 5 * time.Minute,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := observer.Observe(context.Background())
+	if err != nil || result.Outcome != "SUCCEEDED" || source.calls != 6 {
+		t.Fatalf("bounded functional probe deferral failed: %#v calls=%d err=%v", result, source.calls, err)
+	}
+
+	current = time.Date(2026, 8, 16, 21, 0, 0, 0, time.UTC)
+	source = &fakeNetworkStageSource{statuses: []string{"False"}, reasons: []string{"FunctionalProbeFailed"}}
+	observer, err = NewNetworkStageObserver(NetworkStageObserverConfig{
+		Plan: plan, ReceiptPrefix: prefix, TargetClusterUID: runtimeUID, Source: source,
+		Profile: networkStageProfile(plan), PollInterval: time.Minute, PollTimeout: 6 * time.Minute,
+		Clock:                        func() time.Time { return current },
+		Wait:                         func(_ context.Context, wait time.Duration) error { current = current.Add(wait); return nil },
+		AllowFunctionalProbeDeferral: true, FunctionalProbeDeferralDelay: 5 * time.Minute,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err = observer.Observe(context.Background())
+	if err != nil || result.Outcome != "FAILED" {
+		t.Fatalf("real functional probe failure was deferred: %#v err=%v", result, err)
+	}
+}
+
 func TestNetworkStageObserverRejectsForeignTargetAndIncompleteHistory(t *testing.T) {
 	plan, prefix, runtimeUID := networkObserverPrefix(t, true)
 	base := NetworkStageObserverConfig{
@@ -123,6 +160,7 @@ func TestNetworkStageObserverRedactsSourceFailure(t *testing.T) {
 
 type fakeNetworkStageSource struct {
 	statuses []string
+	reasons  []string
 	err      error
 	calls    int
 	policy   observation.Policy
@@ -140,7 +178,12 @@ func (source *fakeNetworkStageSource) Observe(_ context.Context, policy observat
 		status = source.statuses[source.calls-1]
 	}
 	reason := "NetworkConverged"
-	if status == "False" {
+	if len(source.reasons) > 0 {
+		reason = source.reasons[len(source.reasons)-1]
+		if source.calls <= len(source.reasons) {
+			reason = source.reasons[source.calls-1]
+		}
+	} else if status == "False" {
 		reason = "NetworkInvariantFailed"
 	} else if status == "Unknown" {
 		reason = "NetworkEvidencePending"


### PR DESCRIPTION
## Summary

- normalize only successful but incomplete Cilium health-cache documents as pending
- permit the pre-runtime network stage to emit `NetworkReadyDeferred` after a bounded five-minute grace period
- keep generic exec/transport errors fail-closed and retain strict final aggregate NetworkReady evaluation

## Verification

- `go test ./internal/observation`
- targeted network observation and stage tests
- runner suite passes excluding three pre-existing Go 1.26 client-certificate fixture failures

No private evidence, credentials, endpoints, or cluster data are included.