### PR TITLE
fix(runner): defer transient cilium probe exits

### DIFF
--- a/internal/observation/network_collector.go
+++ b/internal/observation/network_collector.go
@@ -157,6 +157,9 @@ func (collector *NetworkSourceCollector) Collect(ctx context.Context, policy Pol
 	}
 	probeRaw, err := collector.probe.Probe(ctx, selectedName, selectedUID)
 	if err != nil {
+		if IsFunctionalProbePendingError(err) {
+			return snapshot, nil
+		}
 		// The command, Pod identity and container are fixed by the probe
 		// boundary. A non-zero execution while Cilium's health cache is still
 		// warming is therefore an operational convergence signal, not an

--- a/internal/observation/network_collector_test.go
+++ b/internal/observation/network_collector_test.go
@@ -258,6 +258,16 @@ func TestNetworkSourceCollectorClassifiesProbeExecutionFailureAsTransient(t *tes
 	}
 }
 
+func TestNetworkSourceCollectorNormalizesProbeWarmupExitAsPending(t *testing.T) {
+	policy, profile, management, workload, probe := collectorFixture(t)
+	probe.err = NewFunctionalProbePendingError(errors.New("sensitive raw failure"))
+	collector := mustNetworkCollector(t, policy, management, workload, probe)
+	evidence, err := collector.Observe(context.Background(), policy, profile)
+	if err != nil || evidence.Status != "Unknown" || evidence.Reason != "FunctionalProbePending" {
+		t.Fatalf("probe warmup exit was not normalized as pending: %#v %v", evidence, err)
+	}
+}
+
 func TestNetworkSourceCollectorNormalizesMissingWarmupProbePathAsPending(t *testing.T) {
 	policy, profile, management, workload, probe := collectorFixture(t)
 	probe.response = mutateJSON(t, probe.response, func(value map[string]any) {

--- a/internal/observation/network_kubernetes.go
+++ b/internal/observation/network_kubernetes.go
@@ -36,6 +36,28 @@ type transientNetworkSourceError struct {
 	cause error
 }
 
+type functionalProbePendingError struct {
+	cause error
+}
+
+func (err functionalProbePendingError) Error() string {
+	return "fixed Cilium functional probe is not ready"
+}
+func (err functionalProbePendingError) Unwrap() error { return err.cause }
+
+// NewFunctionalProbePendingError marks only a successfully reached fixed
+// Cilium command that exited non-zero while its runtime cache was converging.
+// Transport, identity, authorization and schema failures must not use it.
+func NewFunctionalProbePendingError(cause error) error {
+	return functionalProbePendingError{cause: cause}
+}
+
+// IsFunctionalProbePendingError identifies the narrow probe warm-up outcome.
+func IsFunctionalProbePendingError(err error) bool {
+	var pending functionalProbePendingError
+	return errors.As(err, &pending)
+}
+
 func (err transientNetworkSourceError) Error() string {
 	return "temporary bounded network source failure"
 }
@@ -201,6 +223,9 @@ func (probe *KubernetesFixedCiliumProbe) Probe(ctx context.Context, podName, pod
 	}
 	raw, err := probe.executor.Exec(ctx, request)
 	if err != nil {
+		if IsFunctionalProbePendingError(err) {
+			return nil, NewFunctionalProbePendingError(errors.New("fixed Cilium command exited non-zero"))
+		}
 		return nil, errors.New("fixed Cilium Pod exec failed")
 	}
 	if len(raw) == 0 || len(raw) > maximumNetworkSourceBytes {

--- a/internal/runner/cilium_websocket.go
+++ b/internal/runner/cilium_websocket.go
@@ -16,6 +16,7 @@ import (
 	"github.com/openkubes/ok-cluster/internal/observation"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/remotecommand"
+	kubeexec "k8s.io/client-go/util/exec"
 )
 
 const (
@@ -109,11 +110,15 @@ func (executor *KubernetesCiliumWebSocketExecutor) Exec(ctx context.Context, req
 	stderr := newBoundedExecBuffer(maximumCiliumExecErrorBytes)
 	streamErr := stream.StreamWithContext(bounded, remotecommand.StreamOptions{Stdout: stdout, Stderr: stderr, Tty: false})
 	postErr := executor.verifyPodUID(bounded, request.PodName, request.PodUID)
-	if streamErr != nil {
-		return nil, errors.New("fixed Cilium WebSocket stream failed")
-	}
 	if postErr != nil {
 		return nil, postErr
+	}
+	if streamErr != nil {
+		var exitError kubeexec.ExitError
+		if errors.As(streamErr, &exitError) && exitError.Exited() {
+			return nil, observation.NewFunctionalProbePendingError(errors.New("fixed Cilium command exited non-zero"))
+		}
+		return nil, errors.New("fixed Cilium WebSocket stream failed")
 	}
 	if stderr.Len() != 0 || stderr.Exceeded() {
 		return nil, errors.New("fixed Cilium WebSocket stream returned stderr")

--- a/internal/runner/cilium_websocket_test.go
+++ b/internal/runner/cilium_websocket_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/openkubes/ok-cluster/internal/observation"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/remotecommand"
+	kubeexec "k8s.io/client-go/util/exec"
 )
 
 func TestKubernetesCiliumWebSocketExecutorUsesRemoteCommandV5(t *testing.T) {
@@ -211,6 +212,41 @@ func TestKubernetesCiliumWebSocketExecutorRejectsForeignInitialPod(t *testing.T)
 	}
 	if _, err := executor.Exec(context.Background(), validCiliumExecRequest()); err == nil || factoryCalls != 0 {
 		t.Fatalf("foreign initial Pod reached WebSocket exec: factory=%d err=%v", factoryCalls, err)
+	}
+}
+
+func TestKubernetesCiliumWebSocketExecutorClassifiesCommandExitAsProbePending(t *testing.T) {
+	client := &http.Client{Transport: ciliumRoundTripFunc(func(*http.Request) (*http.Response, error) {
+		return ciliumPodResponse("cilium-abc12", "pod-uid-1", "41"), nil
+	})}
+	executor := newTestCiliumWebSocketExecutor(t, client)
+	stream := &fakeRemoteCommandExecutor{err: kubeexec.CodeExitError{Err: errors.New("sensitive command failure"), Code: 1}}
+	executor.factory = func(*rest.Config, string, string) (remotecommand.Executor, error) { return stream, nil }
+	_, err := executor.Exec(context.Background(), validCiliumExecRequest())
+	if err == nil || !observation.IsFunctionalProbePendingError(err) {
+		t.Fatalf("command exit was not classified as probe pending: %v", err)
+	}
+	if strings.Contains(err.Error(), "sensitive") {
+		t.Fatalf("raw command error leaked: %v", err)
+	}
+}
+
+func TestKubernetesCiliumWebSocketExecutorPrioritizesIdentityRaceOverCommandExit(t *testing.T) {
+	identityCalls := 0
+	client := &http.Client{Transport: ciliumRoundTripFunc(func(*http.Request) (*http.Response, error) {
+		identityCalls++
+		uid := "pod-uid-1"
+		if identityCalls == 2 {
+			uid = "replacement-uid"
+		}
+		return ciliumPodResponse("cilium-abc12", uid, "41"), nil
+	})}
+	executor := newTestCiliumWebSocketExecutor(t, client)
+	stream := &fakeRemoteCommandExecutor{err: kubeexec.CodeExitError{Err: errors.New("sensitive command failure"), Code: 1}}
+	executor.factory = func(*rest.Config, string, string) (remotecommand.Executor, error) { return stream, nil }
+	_, err := executor.Exec(context.Background(), validCiliumExecRequest())
+	if err == nil || observation.IsFunctionalProbePendingError(err) || !strings.Contains(err.Error(), "runtime identity") {
+		t.Fatalf("Pod identity race did not override probe-pending classification: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- classify only a reached fixed Cilium command's non-zero exit as functional-probe warm-up
- feed that narrow outcome into the existing bounded NetworkReady deferral
- keep Pod identity, API/WebSocket transport, authorization, TLS and schema failures fail-closed
- prioritize post-exec Pod UID verification over probe-exit classification

## Verification

- `go test ./internal/observation`
- `go test ./internal/runner -run 'TestKubernetesCiliumWebSocketExecutor|TestNetworkStageObserver' -count=1`

The full runner suite still exposes pre-existing Go 1.26 certificate fixture and integration-fixture failures unrelated to this change.

Relates-to: OK-147