### PR TITLE
fix(runner): defer incomplete cilium probe output

### DIFF
--- a/internal/runner/cilium_websocket.go
+++ b/internal/runner/cilium_websocket.go
@@ -120,11 +120,17 @@ func (executor *KubernetesCiliumWebSocketExecutor) Exec(ctx context.Context, req
 		}
 		return nil, errors.New("fixed Cilium WebSocket stream failed")
 	}
-	if stderr.Len() != 0 || stderr.Exceeded() {
-		return nil, errors.New("fixed Cilium WebSocket stream returned stderr")
+	if stderr.Exceeded() {
+		return nil, errors.New("fixed Cilium WebSocket stderr size is invalid")
 	}
-	if stdout.Len() == 0 || stdout.Exceeded() {
+	if stderr.Len() != 0 {
+		return nil, observation.NewFunctionalProbePendingError(errors.New("fixed Cilium command returned temporary stderr"))
+	}
+	if stdout.Exceeded() {
 		return nil, errors.New("fixed Cilium WebSocket stdout size is invalid")
+	}
+	if stdout.Len() == 0 {
+		return nil, observation.NewFunctionalProbePendingError(errors.New("fixed Cilium command returned no output"))
 	}
 	return append([]byte(nil), stdout.Bytes()...), nil
 }

--- a/internal/runner/cilium_websocket_test.go
+++ b/internal/runner/cilium_websocket_test.go
@@ -160,11 +160,6 @@ func TestKubernetesCiliumWebSocketExecutorFailsClosed(t *testing.T) {
 				stream.err = errors.New("sensitive remote status")
 			},
 		},
-		"stderr": {
-			configure: func(_ *KubernetesCiliumWebSocketExecutor, stream *fakeRemoteCommandExecutor) {
-				stream.stderr = []byte("sensitive diagnostic")
-			},
-		},
 		"oversized stdout": {
 			configure: func(_ *KubernetesCiliumWebSocketExecutor, stream *fakeRemoteCommandExecutor) {
 				stream.stdout = bytes.Repeat([]byte("x"), maximumCiliumExecOutputBytes+1)
@@ -195,6 +190,28 @@ func TestKubernetesCiliumWebSocketExecutorFailsClosed(t *testing.T) {
 			}
 			if name == "wrong command" && (identityCalls != 0 || stream.calls != 0) {
 				t.Fatal("invalid command crossed the API boundary")
+			}
+		})
+	}
+}
+
+func TestKubernetesCiliumWebSocketExecutorClassifiesIncompleteCommandOutputAsProbePending(t *testing.T) {
+	for name, stream := range map[string]*fakeRemoteCommandExecutor{
+		"temporary stderr": {stderr: []byte("sensitive warmup detail")},
+		"empty stdout":     {},
+	} {
+		t.Run(name, func(t *testing.T) {
+			client := &http.Client{Transport: ciliumRoundTripFunc(func(*http.Request) (*http.Response, error) {
+				return ciliumPodResponse("cilium-abc12", "pod-uid-1", "41"), nil
+			})}
+			executor := newTestCiliumWebSocketExecutor(t, client)
+			executor.factory = func(*rest.Config, string, string) (remotecommand.Executor, error) { return stream, nil }
+			_, err := executor.Exec(context.Background(), validCiliumExecRequest())
+			if err == nil || !observation.IsFunctionalProbePendingError(err) {
+				t.Fatalf("incomplete command output was not classified as pending: %v", err)
+			}
+			if strings.Contains(err.Error(), "sensitive") {
+				t.Fatalf("raw command detail leaked: %v", err)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- classify temporary stderr from the successfully reached fixed Cilium command as functional-probe warm-up
- classify an empty successful command response as functional-probe warm-up
- retain fail-closed handling for Pod identity, API/WebSocket transport, oversized output and malformed JSON
- feed only these narrow outcomes into the existing bounded NetworkReady deferral

## Verification

- `go test ./internal/observation`
- `go test ./internal/runner -run 'TestKubernetesCiliumWebSocketExecutor|TestNetworkStageObserver' -count=1`

Relates-to: OK-147