### PR TITLE
fix(runner): defer bounded MVP network warmup

### DIFF
--- a/cmd/ok/full_run.go
+++ b/cmd/ok/full_run.go
@@ -90,6 +90,8 @@ var openKubernetesObservabilityFullRunActivation = func(path, publicKeyPath stri
 	})
 }
 
+var writeFullRunExecutorTerminalMarker = runner.WriteFullRunExecutorTerminalMarker
+
 type fullRunActivationPackageFlags struct {
 	manifest, evidencePublicKey, activationSecret                 *string
 	evidenceAuthoritySecret, evidencePrivateKey                   *string
@@ -352,12 +354,13 @@ func runClusterStageRunFullMaterialize(arguments []string, stdout, stderr io.Wri
 	return err
 }
 
-func runClusterStageRunFullExecute(ctx context.Context, arguments []string, stdout, stderr io.Writer) error {
+func runClusterStageRunFullExecute(ctx context.Context, arguments []string, stdout, stderr io.Writer) (returnErr error) {
 	flags := flag.NewFlagSet("ok cluster stage run full execute", flag.ContinueOnError)
 	flags.SetOutput(stderr)
 	manifestPath := flags.String("manifest", "", "path to the private 0600 full-run execution manifest")
 	expectedManifestDigest := flags.String("expected-manifest-digest", "", "exact semantic digest emitted by prepare")
 	evidencePublicKey := flags.String("independent-evidence-public-key", "", "pinned independent Observability evidence public key")
+	terminalMarker := flags.String("terminal-marker", "", "create-only private executor terminal marker")
 	execute := flags.Bool("execute", false, "perform the exact single-use Stage 1-12 full run")
 	if err := flags.Parse(arguments); err != nil {
 		return err
@@ -368,9 +371,18 @@ func runClusterStageRunFullExecute(ctx context.Context, arguments []string, stdo
 	if !*execute {
 		return errors.New("full-run mutation requires explicit --execute")
 	}
-	if *manifestPath == "" || *evidencePublicKey == "" || !sha256DigestPattern.MatchString(*expectedManifestDigest) {
-		return errors.New("--manifest, --independent-evidence-public-key and a lowercase SHA-256 --expected-manifest-digest are required")
+	if *manifestPath == "" || *evidencePublicKey == "" || *terminalMarker == "" || !sha256DigestPattern.MatchString(*expectedManifestDigest) {
+		return errors.New("--manifest, --independent-evidence-public-key, --terminal-marker and a lowercase SHA-256 --expected-manifest-digest are required")
 	}
+	defer func() {
+		if markerErr := writeFullRunExecutorTerminalMarker(*terminalMarker); markerErr != nil {
+			if returnErr == nil {
+				returnErr = markerErr
+			} else {
+				returnErr = errors.New("full-run execution stopped and terminal marker could not be persisted")
+			}
+		}
+	}()
 	verified, err := prepareFullRunExecutionManifest(*manifestPath)
 	if err != nil {
 		return fmt.Errorf("prepare full-run manifest: %w", err)

--- a/cmd/ok/full_run_test.go
+++ b/cmd/ok/full_run_test.go
@@ -295,14 +295,25 @@ func TestFullRunMaterializeRequiresExplicitBoundIdentity(t *testing.T) {
 func TestFullRunExecuteRequiresPreparedIdentityAndRunsOnce(t *testing.T) {
 	previous := openKubernetesObservabilityFullRunActivation
 	previousPrepare := prepareFullRunExecutionManifest
+	previousMarker := writeFullRunExecutorTerminalMarker
 	defer func() {
 		openKubernetesObservabilityFullRunActivation = previous
 		prepareFullRunExecutionManifest = previousPrepare
+		writeFullRunExecutorTerminalMarker = previousMarker
 	}()
+	markers := 0
+	writeFullRunExecutorTerminalMarker = func(path string) error {
+		if path != "/private/executor-terminal" {
+			t.Fatalf("terminal marker path differs: %q", path)
+		}
+		markers++
+		return nil
+	}
 	prepareFullRunExecutionManifest = func(string) (runner.FullRunExecutionManifestReceipt, error) {
 		return fullRunCLITestManifestReceipt("VERIFIED"), nil
 	}
 	runs := 0
+	runFails := false
 	openKubernetesObservabilityFullRunActivation = func(path, publicKeyPath string) (fullRunActivationRunner, runner.FullRunExecutionActivationReceipt, error) {
 		if path != "/private/full-run.json" || publicKeyPath != "/private/evidence.pub" {
 			t.Fatalf("concrete activation input differs: path=%q key=%q", path, publicKeyPath)
@@ -313,10 +324,15 @@ func TestFullRunExecuteRequiresPreparedIdentityAndRunsOnce(t *testing.T) {
 				if !ok || time.Until(deadline) <= 0 || time.Until(deadline) > fullRunExecutionTimeout {
 					t.Fatalf("full-run execution was not bounded: %v %v", deadline, ok)
 				}
-				return runner.FullRunExecutionActivationReceipt{
+				receipt := runner.FullRunExecutionActivationReceipt{
 					Format: runner.FullRunExecutionActivationReceiptFormat, State: "SUCCEEDED",
 					Manifest: fullRunCLITestManifestReceipt("VERIFIED"),
-				}, nil
+				}
+				if runFails {
+					receipt.State = "STOPPED"
+					return receipt, errors.New("bounded executor stopped")
+				}
+				return receipt, nil
 			}), runner.FullRunExecutionActivationReceipt{
 				Format: runner.FullRunExecutionActivationReceiptFormat, State: "PREPARED",
 				Manifest: fullRunCLITestManifestReceipt("VERIFIED"),
@@ -324,30 +340,38 @@ func TestFullRunExecuteRequiresPreparedIdentityAndRunsOnce(t *testing.T) {
 	}
 	arguments := []string{
 		"cluster", "stage", "run", "full", "execute", "--manifest", "/private/full-run.json",
-		"--expected-manifest-digest", testSHA("1"), "--independent-evidence-public-key", "/private/evidence.pub", "--execute",
+		"--expected-manifest-digest", testSHA("1"), "--independent-evidence-public-key", "/private/evidence.pub",
+		"--terminal-marker", "/private/executor-terminal", "--execute",
 	}
 	var stdout bytes.Buffer
 	if err := run(arguments, &stdout, &bytes.Buffer{}); err != nil {
 		t.Fatal(err)
 	}
 	var receipt runner.FullRunExecutionActivationReceipt
-	if err := json.Unmarshal(stdout.Bytes(), &receipt); err != nil || receipt.State != "SUCCEEDED" || runs != 1 {
-		t.Fatalf("unexpected full-run execution receipt: %#v runs=%d err=%v", receipt, runs, err)
+	if err := json.Unmarshal(stdout.Bytes(), &receipt); err != nil || receipt.State != "SUCCEEDED" || runs != 1 || markers != 1 {
+		t.Fatalf("unexpected full-run execution receipt: %#v runs=%d markers=%d err=%v", receipt, runs, markers, err)
 	}
 	for _, forbidden := range []string{"/private/", "token", "endpoint", "kubeconfig", "certificate", "targetidentity"} {
 		if strings.Contains(strings.ToLower(stdout.String()), forbidden) {
 			t.Fatalf("full-run execution disclosed %q: %s", forbidden, stdout.String())
 		}
 	}
+	runFails = true
+	if err := run(arguments, &bytes.Buffer{}, &bytes.Buffer{}); err == nil || runs != 2 || markers != 2 {
+		t.Fatalf("stopped executor did not persist terminal marker: runs=%d markers=%d err=%v", runs, markers, err)
+	}
 }
 
 func TestFullRunExecuteFailsClosedBeforeRun(t *testing.T) {
 	previous := openKubernetesObservabilityFullRunActivation
 	previousPrepare := prepareFullRunExecutionManifest
+	previousMarker := writeFullRunExecutorTerminalMarker
 	defer func() {
 		openKubernetesObservabilityFullRunActivation = previous
 		prepareFullRunExecutionManifest = previousPrepare
+		writeFullRunExecutorTerminalMarker = previousMarker
 	}()
+	writeFullRunExecutorTerminalMarker = func(string) error { return nil }
 	prepareFullRunExecutionManifest = func(string) (runner.FullRunExecutionManifestReceipt, error) {
 		return fullRunCLITestManifestReceipt("VERIFIED"), nil
 	}
@@ -364,7 +388,8 @@ func TestFullRunExecuteFailsClosedBeforeRun(t *testing.T) {
 	}
 	valid := []string{
 		"cluster", "stage", "run", "full", "execute", "--manifest", "/private/full-run.json",
-		"--expected-manifest-digest", testSHA("1"), "--independent-evidence-public-key", "/private/evidence.pub", "--execute",
+		"--expected-manifest-digest", testSHA("1"), "--independent-evidence-public-key", "/private/evidence.pub",
+		"--terminal-marker", "/private/executor-terminal", "--execute",
 	}
 	for name, arguments := range map[string][]string{
 		"missing execute":    removeArgument(valid, "--execute"),
@@ -372,6 +397,7 @@ func TestFullRunExecuteFailsClosedBeforeRun(t *testing.T) {
 		"bad digest":         replaceArgument(valid, "--expected-manifest-digest", "sha256:bad"),
 		"wrong digest":       replaceArgument(valid, "--expected-manifest-digest", testSHA("2")),
 		"missing public key": removeArgument(valid, "/private/evidence.pub"),
+		"missing marker":     removeArgumentWithValue(valid, "--terminal-marker"),
 		"positional":         append(append([]string(nil), valid...), "extra"),
 	} {
 		t.Run(name, func(t *testing.T) {

--- a/deploy/contract-executor-full-run-job.yaml.tpl
+++ b/deploy/contract-executor-full-run-job.yaml.tpl
@@ -150,6 +150,8 @@ spec:
             - "${OK147_MANIFEST_DIGEST}"
             - --independent-evidence-public-key
             - /var/run/openkubes/workspace/input/independent-evidence.pub
+            - --terminal-marker
+            - /var/run/openkubes/handoff/executor-terminal
             - --execute
           resources:
             requests: {cpu: 50m, memory: 96Mi, ephemeral-storage: 32Mi}

--- a/internal/runner/full_run_job_test.go
+++ b/internal/runner/full_run_job_test.go
@@ -62,7 +62,8 @@ func TestRenderFullRunExecutionJobTemplateIsolatesExecutorAndEvidenceAuthority(t
 	executor, authority := containers[0].(map[string]any), containers[1].(map[string]any)
 	if got := stringArray(t, executor, "args"); !reflect.DeepEqual(got, []string{
 		"cluster", "stage", "run", "full", "execute", "--manifest", "/var/run/openkubes/workspace/activation/full-run-manifest.json",
-		"--expected-manifest-digest", values.ManifestDigest, "--independent-evidence-public-key", "/var/run/openkubes/workspace/input/independent-evidence.pub", "--execute",
+		"--expected-manifest-digest", values.ManifestDigest, "--independent-evidence-public-key", "/var/run/openkubes/workspace/input/independent-evidence.pub",
+		"--terminal-marker", "/var/run/openkubes/handoff/executor-terminal", "--execute",
 	}) {
 		t.Fatalf("unexpected executor command: %v", got)
 	}

--- a/internal/runner/network_observation_bundle.go
+++ b/internal/runner/network_observation_bundle.go
@@ -112,7 +112,7 @@ func (bundle VerifiedNetworkObservationStageBundle) Open(config NetworkObservati
 		Plan: bundle.plan, ReceiptPrefix: bundle.prefix, TargetClusterUID: binding.TargetClusterUID,
 		Source: source, Profile: loadedProfile.Profile,
 		PollInterval: config.PollInterval, PollTimeout: config.PollTimeout, Clock: config.Clock, Wait: config.Wait,
-		AllowFunctionalProbeDeferral: true, FunctionalProbeDeferralDelay: functionalProbeDeferralDelay(config.PollInterval, config.PollTimeout),
+		AllowMVPWarmupDeferral: true, MVPWarmupDeferralDelay: mvpNetworkWarmupDeferralDelay(config.PollInterval, config.PollTimeout),
 	})
 	if err != nil {
 		return OpenedNetworkObservationStage{}, err
@@ -123,7 +123,7 @@ func (bundle VerifiedNetworkObservationStageBundle) Open(config NetworkObservati
 	}, nil
 }
 
-func functionalProbeDeferralDelay(interval, timeout time.Duration) time.Duration {
+func mvpNetworkWarmupDeferralDelay(interval, timeout time.Duration) time.Duration {
 	delay := 5 * time.Minute
 	if half := timeout / 2; half < delay {
 		delay = half

--- a/internal/runner/network_stage_observer.go
+++ b/internal/runner/network_stage_observer.go
@@ -14,33 +14,33 @@ import (
 )
 
 type NetworkStageObserverConfig struct {
-	Plan                         stageplan.Binding
-	ReceiptPrefix                []stagereceipt.Verified
-	TargetClusterUID             string
-	Source                       observation.NetworkEvidenceSource
-	Profile                      observation.NetworkProfile
-	PollInterval                 time.Duration
-	PollTimeout                  time.Duration
-	Clock                        func() time.Time
-	Wait                         ObservationWaiter
-	AllowFunctionalProbeDeferral bool
-	FunctionalProbeDeferralDelay time.Duration
+	Plan                   stageplan.Binding
+	ReceiptPrefix          []stagereceipt.Verified
+	TargetClusterUID       string
+	Source                 observation.NetworkEvidenceSource
+	Profile                observation.NetworkProfile
+	PollInterval           time.Duration
+	PollTimeout            time.Duration
+	Clock                  func() time.Time
+	Wait                   ObservationWaiter
+	AllowMVPWarmupDeferral bool
+	MVPWarmupDeferralDelay time.Duration
 }
 
 // NetworkStageObserver is the stage-specific adapter around the existing
 // bounded NetworkReady source and deterministic observation evaluator. It has
 // no mutation, repair, arbitrary query, or persistent status publication path.
 type NetworkStageObserver struct {
-	binding                      execution.StageObservationBinding
-	source                       observation.NetworkEvidenceSource
-	profile                      observation.NetworkProfile
-	policy                       observation.Policy
-	pollInterval                 time.Duration
-	pollLimit                    time.Duration
-	clock                        func() time.Time
-	wait                         ObservationWaiter
-	allowFunctionalProbeDeferral bool
-	functionalProbeDeferralDelay time.Duration
+	binding                execution.StageObservationBinding
+	source                 observation.NetworkEvidenceSource
+	profile                observation.NetworkProfile
+	policy                 observation.Policy
+	pollInterval           time.Duration
+	pollLimit              time.Duration
+	clock                  func() time.Time
+	wait                   ObservationWaiter
+	allowMVPWarmupDeferral bool
+	mvpWarmupDeferralDelay time.Duration
 }
 
 var _ execution.StageObserver = (*NetworkStageObserver)(nil)
@@ -52,8 +52,8 @@ func NewNetworkStageObserver(config NetworkStageObserverConfig) (*NetworkStageOb
 	if config.Source == nil || config.Clock == nil || config.Wait == nil {
 		return nil, errors.New("network stage observer source, clock, and waiter are required")
 	}
-	if config.AllowFunctionalProbeDeferral && (config.FunctionalProbeDeferralDelay < config.PollInterval || config.FunctionalProbeDeferralDelay > config.PollTimeout) {
-		return nil, errors.New("network functional probe deferral boundary is invalid")
+	if config.AllowMVPWarmupDeferral && (config.MVPWarmupDeferralDelay < config.PollInterval || config.MVPWarmupDeferralDelay > config.PollTimeout) {
+		return nil, errors.New("network MVP warmup deferral boundary is invalid")
 	}
 	cursor, err := stagecursor.Evaluate(config.Plan, config.ReceiptPrefix)
 	if err != nil {
@@ -90,8 +90,8 @@ func NewNetworkStageObserver(config NetworkStageObserverConfig) (*NetworkStageOb
 		},
 		pollInterval: config.PollInterval, pollLimit: config.PollTimeout,
 		clock: config.Clock, wait: config.Wait,
-		allowFunctionalProbeDeferral: config.AllowFunctionalProbeDeferral,
-		functionalProbeDeferralDelay: config.FunctionalProbeDeferralDelay,
+		allowMVPWarmupDeferral: config.AllowMVPWarmupDeferral,
+		mvpWarmupDeferralDelay: config.MVPWarmupDeferralDelay,
 	}, nil
 }
 
@@ -109,8 +109,8 @@ func (observer *NetworkStageObserver) Observe(ctx context.Context) (execution.St
 	polling, err := NewBoundedPollingObserver(BoundedPollingObserverConfig{
 		Source: &networkPollingSource{
 			source: observer.source, profile: observer.profile, clock: observer.clock,
-			allowFunctionalProbeDeferral: observer.allowFunctionalProbeDeferral,
-			functionalProbeDeferralDelay: observer.functionalProbeDeferralDelay,
+			allowMVPWarmupDeferral: observer.allowMVPWarmupDeferral,
+			mvpWarmupDeferralDelay: observer.mvpWarmupDeferralDelay,
 		},
 		Interval: observer.pollInterval, Timeout: observer.pollLimit, Clock: observer.clock, Wait: observer.wait,
 		ContinueOnFalse: true, ContinueOnErrorAfterObservation: true,
@@ -145,12 +145,12 @@ func (observer *NetworkStageObserver) Observe(ctx context.Context) (execution.St
 }
 
 type networkPollingSource struct {
-	source                       observation.NetworkEvidenceSource
-	profile                      observation.NetworkProfile
-	clock                        func() time.Time
-	allowFunctionalProbeDeferral bool
-	functionalProbeDeferralDelay time.Duration
-	functionalProbePendingSince  time.Time
+	source                 observation.NetworkEvidenceSource
+	profile                observation.NetworkProfile
+	clock                  func() time.Time
+	allowMVPWarmupDeferral bool
+	mvpWarmupDeferralDelay time.Duration
+	mvpWarmupPendingSince  time.Time
 }
 
 func (source *networkPollingSource) Observe(ctx context.Context, policy observation.Policy) (observation.VerifiedResult, error) {
@@ -158,20 +158,38 @@ func (source *networkPollingSource) Observe(ctx context.Context, policy observat
 	if err != nil {
 		return observation.VerifiedResult{}, err
 	}
-	if source.allowFunctionalProbeDeferral && evidence.Status == "Unknown" && evidence.Reason == "FunctionalProbePending" {
+	if source.allowMVPWarmupDeferral && isMVPNetworkWarmup(evidence) {
 		now := source.clock()
-		if source.functionalProbePendingSince.IsZero() {
-			source.functionalProbePendingSince = now
+		if source.mvpWarmupPendingSince.IsZero() {
+			source.mvpWarmupPendingSince = now
 		}
-		if !now.Before(source.functionalProbePendingSince.Add(source.functionalProbeDeferralDelay)) {
+		if !now.Before(source.mvpWarmupPendingSince.Add(source.mvpWarmupDeferralDelay)) {
 			evidence.Status = "True"
-			evidence.Reason = "NetworkReadyDeferred"
+			evidence.Reason = "MVPNetworkWarmupDeferred"
 		}
 	} else {
-		source.functionalProbePendingSince = time.Time{}
+		source.mvpWarmupPendingSince = time.Time{}
 	}
 	return observation.Evaluate(policy, observation.Bundle{
 		Format: observation.BundleFormat, IntentRevision: policy.IntentRevision,
 		EvaluatedAt: source.clock().UTC().Format(time.RFC3339Nano), Evidence: []observation.Evidence{evidence},
 	})
+}
+
+// isMVPNetworkWarmup is deliberately narrower than Status=Unknown. It permits
+// only the normal CAAPH/Cilium rollout states already proven to converge late
+// in DEV. Source, transport, authorization, TLS, identity and schema errors do
+// not produce evidence and therefore cannot enter this deferral path. False
+// evidence remains terminal as well.
+func isMVPNetworkWarmup(evidence observation.Evidence) bool {
+	if evidence.Type != "NetworkReady" || evidence.Source != "BoundedNetworkEvaluator" || evidence.Status != "Unknown" {
+		return false
+	}
+	switch evidence.Reason {
+	case "EnablementSourceNotReady", "EnablementReleaseNotReady", "NodeInventoryNotReady",
+		"NodeNetworkNotReady", "CiliumRolloutNotReady", "CiliumAgentPodsNotReady", "FunctionalProbePending":
+		return true
+	default:
+		return false
+	}
 }

--- a/internal/runner/network_stage_observer_test.go
+++ b/internal/runner/network_stage_observer_test.go
@@ -73,16 +73,19 @@ func TestNetworkStageObserverWaitsThroughFalseUntilConvergedOrBounded(t *testing
 	}
 }
 
-func TestNetworkStageObserverDefersOnlyPersistentFunctionalProbePending(t *testing.T) {
+func TestNetworkStageObserverDefersKnownMVPWarmupAcrossReasonChanges(t *testing.T) {
 	plan, prefix, runtimeUID := networkObserverPrefix(t, true)
 	current := time.Date(2026, 8, 16, 21, 0, 0, 0, time.UTC)
-	source := &fakeNetworkStageSource{statuses: []string{"Unknown"}, reasons: []string{"FunctionalProbePending"}}
+	source := &fakeNetworkStageSource{
+		statuses: []string{"Unknown"},
+		reasons:  []string{"NodeNetworkNotReady", "CiliumRolloutNotReady", "CiliumAgentPodsNotReady", "FunctionalProbePending"},
+	}
 	observer, err := NewNetworkStageObserver(NetworkStageObserverConfig{
 		Plan: plan, ReceiptPrefix: prefix, TargetClusterUID: runtimeUID, Source: source,
 		Profile: networkStageProfile(plan), PollInterval: time.Minute, PollTimeout: 10 * time.Minute,
-		Clock:                        func() time.Time { return current },
-		Wait:                         func(_ context.Context, wait time.Duration) error { current = current.Add(wait); return nil },
-		AllowFunctionalProbeDeferral: true, FunctionalProbeDeferralDelay: 5 * time.Minute,
+		Clock:                  func() time.Time { return current },
+		Wait:                   func(_ context.Context, wait time.Duration) error { current = current.Add(wait); return nil },
+		AllowMVPWarmupDeferral: true, MVPWarmupDeferralDelay: 5 * time.Minute,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -97,9 +100,9 @@ func TestNetworkStageObserverDefersOnlyPersistentFunctionalProbePending(t *testi
 	observer, err = NewNetworkStageObserver(NetworkStageObserverConfig{
 		Plan: plan, ReceiptPrefix: prefix, TargetClusterUID: runtimeUID, Source: source,
 		Profile: networkStageProfile(plan), PollInterval: time.Minute, PollTimeout: 6 * time.Minute,
-		Clock:                        func() time.Time { return current },
-		Wait:                         func(_ context.Context, wait time.Duration) error { current = current.Add(wait); return nil },
-		AllowFunctionalProbeDeferral: true, FunctionalProbeDeferralDelay: 5 * time.Minute,
+		Clock:                  func() time.Time { return current },
+		Wait:                   func(_ context.Context, wait time.Duration) error { current = current.Add(wait); return nil },
+		AllowMVPWarmupDeferral: true, MVPWarmupDeferralDelay: 5 * time.Minute,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -107,6 +110,23 @@ func TestNetworkStageObserverDefersOnlyPersistentFunctionalProbePending(t *testi
 	result, err = observer.Observe(context.Background())
 	if err != nil || result.Outcome != "FAILED" {
 		t.Fatalf("real functional probe failure was deferred: %#v err=%v", result, err)
+	}
+
+	current = time.Date(2026, 8, 16, 21, 0, 0, 0, time.UTC)
+	source = &fakeNetworkStageSource{statuses: []string{"Unknown"}, reasons: []string{"RequiredEvidenceMissing"}}
+	observer, err = NewNetworkStageObserver(NetworkStageObserverConfig{
+		Plan: plan, ReceiptPrefix: prefix, TargetClusterUID: runtimeUID, Source: source,
+		Profile: networkStageProfile(plan), PollInterval: time.Minute, PollTimeout: 6 * time.Minute,
+		Clock:                  func() time.Time { return current },
+		Wait:                   func(_ context.Context, wait time.Duration) error { current = current.Add(wait); return nil },
+		AllowMVPWarmupDeferral: true, MVPWarmupDeferralDelay: 5 * time.Minute,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err = observer.Observe(context.Background())
+	if err != nil || result.Outcome != "STOPPED" {
+		t.Fatalf("unknown non-warmup evidence was deferred: %#v err=%v", result, err)
 	}
 }
 

--- a/internal/runner/observability_evidence_authority_activation.go
+++ b/internal/runner/observability_evidence_authority_activation.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"path/filepath"
 	"sync"
 	"time"
 
@@ -96,9 +97,13 @@ func (execution *ObservabilityEvidenceAuthorityExecution) Run(ctx context.Contex
 	defer cancel()
 	identity, err := WaitForObservabilityIndependentEvidenceIdentity(bounded, ObservabilityIndependentEvidenceIdentityWaitConfig{
 		IdentityPath: execution.activation.IdentityPath, ReceiptPath: execution.activation.IdentityReceiptPath,
+		ExecutorTerminalPath:   filepath.Join(filepath.Dir(execution.activation.IdentityPath), FullRunExecutorTerminalMarkerName),
 		ExpectedManifestDigest: execution.activation.ExpectedManifestDigest,
 		PollInterval:           pollInterval, Timeout: waitTimeout, Wait: execution.wait,
 	})
+	if errors.Is(err, errFullRunExecutorTerminatedBeforeEvidenceIdentity) {
+		return receipt, nil
+	}
 	if err != nil {
 		return receipt, errors.New("load runtime-bound observability evidence identity")
 	}

--- a/internal/runner/observability_evidence_authority_activation_test.go
+++ b/internal/runner/observability_evidence_authority_activation_test.go
@@ -128,3 +128,49 @@ func TestOpenObservabilityEvidenceAuthorityActivationFailsClosed(t *testing.T) {
 		t.Fatal("tampered evidence authority activation was accepted")
 	}
 }
+
+func TestObservabilityEvidenceAuthorityActivationStopsCleanlyWithExecutor(t *testing.T) {
+	config, cleanup := observabilityEvidenceAuthorityPackageFixture(t)
+	defer cleanup()
+	runtimeRoot := t.TempDir()
+	if err := os.Chmod(runtimeRoot, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	authorityRoot, handoffRoot := filepath.Join(runtimeRoot, "authority"), filepath.Join(runtimeRoot, "handoff")
+	for _, directory := range []string{authorityRoot, handoffRoot} {
+		if err := os.Mkdir(directory, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	config.RuntimeAuthorityRoot, config.RuntimeHandoffRoot = authorityRoot, handoffRoot
+	config.IdentityPollInterval, config.IdentityWaitTimeout = time.Millisecond, time.Second
+	packaged, err := BuildObservabilityEvidenceAuthorityPackage(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, _ := packaged.PrivateBytes()
+	var secret postRuntimeActivationSecret
+	if err := json.Unmarshal(raw, &secret); err != nil {
+		t.Fatal(err)
+	}
+	for key, encoded := range secret.Data {
+		content, decodeErr := base64.StdEncoding.DecodeString(encoded)
+		if decodeErr != nil || os.WriteFile(filepath.Join(authorityRoot, key), content, 0o600) != nil {
+			t.Fatal("materialize authority fixture")
+		}
+	}
+	if err := WriteFullRunExecutorTerminalMarker(filepath.Join(handoffRoot, FullRunExecutorTerminalMarkerName)); err != nil {
+		t.Fatal(err)
+	}
+	execution, err := OpenObservabilityEvidenceAuthorityActivation(
+		filepath.Join(authorityRoot, observabilityEvidenceAuthorityActivationKey),
+		ObservabilityEvidenceAuthorityActivationRuntime{Clock: time.Now, Wait: WaitWithTimer},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	receipt, err := execution.Run(context.Background())
+	if err != nil || receipt.State != "STOPPED_ZERO_WRITE" {
+		t.Fatalf("authority did not stop cleanly with executor: receipt=%#v err=%v", receipt, err)
+	}
+}

--- a/internal/runner/observability_evidence_identity.go
+++ b/internal/runner/observability_evidence_identity.go
@@ -19,7 +19,10 @@ const (
 	ObservabilityIndependentEvidenceIdentityFormat        = "ok147-observability-independent-evidence-identity/v1"
 	ObservabilityIndependentEvidenceIdentityReceiptFormat = "ok147-observability-independent-evidence-identity-receipt/v1"
 	maximumObservabilityEvidenceIdentityBytes             = 32 * 1024
+	FullRunExecutorTerminalMarkerName                     = "executor-terminal"
 )
+
+var errFullRunExecutorTerminatedBeforeEvidenceIdentity = errors.New("full-run executor terminated before evidence identity")
 
 // ObservabilityIndependentEvidenceIdentityMaterial is a private handoff. The
 // target UID must never be copied into public receipts or command arguments.
@@ -57,6 +60,7 @@ type ObservabilityIndependentEvidenceIdentityMaterialConfig struct {
 type ObservabilityIndependentEvidenceIdentityWaitConfig struct {
 	IdentityPath           string
 	ReceiptPath            string
+	ExecutorTerminalPath   string
 	ExpectedManifestDigest string
 	PollInterval           time.Duration
 	Timeout                time.Duration
@@ -245,6 +249,11 @@ func WaitForObservabilityIndependentEvidenceIdentity(ctx context.Context, config
 		validateObservabilityIdentityWaitPath(config.IdentityPath) != nil || validateObservabilityIdentityWaitPath(config.ReceiptPath) != nil {
 		return ObservabilityCapabilityObservationIdentity{}, errors.New("observability evidence identity wait binding is invalid")
 	}
+	if config.ExecutorTerminalPath != "" && (filepath.Base(config.ExecutorTerminalPath) != FullRunExecutorTerminalMarkerName ||
+		filepath.Dir(config.ExecutorTerminalPath) != filepath.Dir(config.IdentityPath) ||
+		validateObservabilityIdentityWaitPath(config.ExecutorTerminalPath) != nil) {
+		return ObservabilityCapabilityObservationIdentity{}, errors.New("observability evidence terminal marker binding is invalid")
+	}
 	bounded, cancel := context.WithTimeout(ctx, config.Timeout)
 	defer cancel()
 	for {
@@ -255,10 +264,39 @@ func WaitForObservabilityIndependentEvidenceIdentity(ctx context.Context, config
 		if !errors.Is(err, os.ErrNotExist) {
 			return ObservabilityCapabilityObservationIdentity{}, errors.New("inspect observability evidence identity receipt")
 		}
+		if config.ExecutorTerminalPath != "" {
+			terminal, terminalErr := os.Lstat(config.ExecutorTerminalPath)
+			if terminalErr == nil {
+				if !terminal.Mode().IsRegular() || terminal.Mode()&os.ModeSymlink != 0 || terminal.Mode().Perm() != 0o600 {
+					return ObservabilityCapabilityObservationIdentity{}, errors.New("full-run executor terminal marker is unsafe")
+				}
+				raw, readErr := readBoundedRegular(config.ExecutorTerminalPath, 32)
+				if readErr != nil || !bytes.Equal(raw, []byte("TERMINAL\n")) {
+					return ObservabilityCapabilityObservationIdentity{}, errors.New("full-run executor terminal marker is invalid")
+				}
+				return ObservabilityCapabilityObservationIdentity{}, errFullRunExecutorTerminatedBeforeEvidenceIdentity
+			}
+			if !errors.Is(terminalErr, os.ErrNotExist) {
+				return ObservabilityCapabilityObservationIdentity{}, errors.New("inspect full-run executor terminal marker")
+			}
+		}
 		if err := config.Wait(bounded, config.PollInterval); err != nil {
 			return ObservabilityCapabilityObservationIdentity{}, errors.New("wait for observability evidence identity receipt")
 		}
 	}
+}
+
+// WriteFullRunExecutorTerminalMarker closes the private inter-container wait
+// without granting either container Kubernetes read access. The fixed marker
+// is create-only and contains no execution result or credential.
+func WriteFullRunExecutorTerminalMarker(path string) error {
+	if filepath.Base(path) != FullRunExecutorTerminalMarkerName || validateRuntimeBindingOutputPath(path) != nil {
+		return errors.New("full-run executor terminal marker destination is invalid")
+	}
+	if err := writeExclusivePrivateMaterial(path, []byte("TERMINAL\n")); err != nil {
+		return errors.New("persist full-run executor terminal marker")
+	}
+	return nil
 }
 
 func validateObservabilityIdentityWaitPath(path string) error {

--- a/internal/runner/observability_evidence_identity_test.go
+++ b/internal/runner/observability_evidence_identity_test.go
@@ -2,6 +2,7 @@ package runner
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -150,6 +151,31 @@ func TestWaitForObservabilityIndependentEvidenceIdentityIsBoundedAndFailClosed(t
 		},
 	}); err == nil {
 		t.Fatal("invalid existing receipt was accepted")
+	}
+}
+
+func TestWaitForObservabilityIndependentEvidenceIdentityStopsAtExecutorTerminalMarker(t *testing.T) {
+	root := t.TempDir()
+	if err := os.Chmod(root, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	identityPath := filepath.Join(root, "identity.json")
+	receiptPath := filepath.Join(root, "identity-receipt.json")
+	terminalPath := filepath.Join(root, FullRunExecutorTerminalMarkerName)
+	if err := WriteFullRunExecutorTerminalMarker(terminalPath); err != nil {
+		t.Fatal(err)
+	}
+	waits := 0
+	_, err := WaitForObservabilityIndependentEvidenceIdentity(context.Background(), ObservabilityIndependentEvidenceIdentityWaitConfig{
+		IdentityPath: identityPath, ReceiptPath: receiptPath, ExecutorTerminalPath: terminalPath,
+		ExpectedManifestDigest: evidenceIdentitySHA("1"), PollInterval: time.Millisecond, Timeout: time.Second,
+		Wait: func(context.Context, time.Duration) error { waits++; return nil },
+	})
+	if !errors.Is(err, errFullRunExecutorTerminatedBeforeEvidenceIdentity) || waits != 0 {
+		t.Fatalf("terminal executor did not close identity wait: waits=%d err=%v", waits, err)
+	}
+	if err := WriteFullRunExecutorTerminalMarker(terminalPath); err == nil {
+		t.Fatal("terminal marker was overwritten")
 	}
 }
 


### PR DESCRIPTION
## Summary
- defer only known CAAPH/Cilium Unknown warm-up states after a bounded grace period
- keep False, transport, TLS, authorization, identity, and schema failures fail-closed
- add a private create-only executor terminal marker so the evidence sidecar exits promptly after an early executor stop

## Verification
- targeted runner and CLI regression tests pass
- all remaining Go tests pass
- three client-certificate tests also fail unchanged on main under local Go 1.26.7 and are therefore tracked as baseline toolchain incompatibility