### PR TITLE
fix(runner): preserve transient network read classification

### DIFF
--- a/internal/observation/network_collector.go
+++ b/internal/observation/network_collector.go
@@ -229,6 +229,9 @@ func networkRuntimeReadyForProbe(nodes []NetworkNode, components []NetworkCompon
 func getNetworkObject(ctx context.Context, source NetworkRawGetter, path string) (map[string]any, error) {
 	raw, err := source.Get(ctx, path)
 	if err != nil {
+		if IsTransientNetworkSourceError(err) {
+			return nil, fmt.Errorf("bounded network source GET failed: %w", err)
+		}
 		return nil, errors.New("bounded network source GET failed")
 	}
 	if len(raw) == 0 || len(raw) > maximumNetworkSourceBytes {

--- a/internal/observation/network_collector_test.go
+++ b/internal/observation/network_collector_test.go
@@ -258,6 +258,21 @@ func TestNetworkSourceCollectorClassifiesProbeExecutionFailureAsTransient(t *tes
 	}
 }
 
+func TestNetworkSourceCollectorPreservesTransientGETClassification(t *testing.T) {
+	policy, profile, management, workload, probe := collectorFixture(t)
+	management.errors = map[string]error{
+		managementPathHCP: transientNetworkSourceError{cause: errors.New("sensitive transport detail")},
+	}
+	collector := mustNetworkCollector(t, policy, management, workload, probe)
+	_, err := collector.Observe(context.Background(), policy, profile)
+	if err == nil || !IsTransientNetworkSourceError(err) {
+		t.Fatalf("transient GET classification was lost: %v", err)
+	}
+	if strings.Contains(err.Error(), "sensitive") {
+		t.Fatalf("raw GET error leaked: %v", err)
+	}
+}
+
 func TestNetworkSourceCollectorNormalizesProbeWarmupExitAsPending(t *testing.T) {
 	policy, profile, management, workload, probe := collectorFixture(t)
 	probe.err = NewFunctionalProbePendingError(errors.New("sensitive raw failure"))


### PR DESCRIPTION
## Summary
- preserve the typed, redacted transient classification across the network collector GET boundary
- keep untyped source errors fully redacted and fail-closed
- cover the regression with a focused collector test

## Verification
- `go test ./internal/observation`
- targeted network observer/poller tests
- runner suite passes with the three unchanged local Go 1.26 certificate-fixture baseline failures excluded

Relates to OK-147.