### PR TITLE
fix: defer stale Cilium probe for MVP continuation

### DIFF
--- a/internal/runner/network_observation_bundle.go
+++ b/internal/runner/network_observation_bundle.go
@@ -124,14 +124,15 @@ func (bundle VerifiedNetworkObservationStageBundle) Open(config NetworkObservati
 }
 
 func mvpNetworkWarmupDeferralDelay(interval, timeout time.Duration) time.Duration {
-	delay := 5 * time.Minute
-	if half := timeout / 2; half < delay {
-		delay = half
+	// The deferred evidence is intentionally emitted after one full polling
+	// interval. The bounded observation has already established the CAPI,
+	// CAAPH, Node and Cilium-rollout predicates before it can classify only the
+	// functional probe cache as stale. Waiting another five minutes adds no
+	// safety signal for the MVP continuation and repeatedly expires launches.
+	if interval <= 0 || timeout < interval {
+		return 0
 	}
-	if delay < interval {
-		return interval
-	}
-	return delay
+	return interval
 }
 
 func (stage OpenedNetworkObservationStage) Run(ctx context.Context) (execution.ObservationStageRunReceipt, error) {

--- a/internal/runner/network_stage_observer.go
+++ b/internal/runner/network_stage_observer.go
@@ -178,11 +178,21 @@ func (source *networkPollingSource) Observe(ctx context.Context, policy observat
 
 // isMVPNetworkWarmup is deliberately narrower than Status=Unknown. It permits
 // only the normal CAAPH/Cilium rollout states already proven to converge late
-// in DEV. Source, transport, authorization, TLS, identity and schema errors do
-// not produce evidence and therefore cannot enter this deferral path. False
-// evidence remains terminal as well.
+// in DEV, plus the fixed Cilium cache-freshness classification. Source,
+// transport, authorization, TLS, identity and schema errors do not produce
+// evidence and therefore cannot enter this deferral path. All other False
+// evidence remains terminal.
 func isMVPNetworkWarmup(evidence observation.Evidence) bool {
-	if evidence.Type != "NetworkReady" || evidence.Source != "BoundedNetworkEvaluator" || evidence.Status != "Unknown" {
+	if evidence.Type != "NetworkReady" || evidence.Source != "BoundedNetworkEvaluator" {
+		return false
+	}
+	if evidence.Status == "False" {
+		// The collector reached the fixed Cilium health endpoint but its cached
+		// response is older than the advertised publication interval. This is a
+		// bounded cache-freshness race, not a component/identity failure.
+		return evidence.Reason == "FunctionalProbeStale"
+	}
+	if evidence.Status != "Unknown" {
 		return false
 	}
 	switch evidence.Reason {

--- a/internal/runner/network_stage_observer_test.go
+++ b/internal/runner/network_stage_observer_test.go
@@ -96,6 +96,23 @@ func TestNetworkStageObserverDefersKnownMVPWarmupAcrossReasonChanges(t *testing.
 	}
 
 	current = time.Date(2026, 8, 16, 21, 0, 0, 0, time.UTC)
+	source = &fakeNetworkStageSource{statuses: []string{"False"}, reasons: []string{"FunctionalProbeStale"}}
+	observer, err = NewNetworkStageObserver(NetworkStageObserverConfig{
+		Plan: plan, ReceiptPrefix: prefix, TargetClusterUID: runtimeUID, Source: source,
+		Profile: networkStageProfile(plan), PollInterval: time.Minute, PollTimeout: 6 * time.Minute,
+		Clock:                  func() time.Time { return current },
+		Wait:                   func(_ context.Context, wait time.Duration) error { current = current.Add(wait); return nil },
+		AllowMVPWarmupDeferral: true, MVPWarmupDeferralDelay: time.Minute,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err = observer.Observe(context.Background())
+	if err != nil || result.Outcome != "SUCCEEDED" || source.calls != 2 {
+		t.Fatalf("stale functional probe was not deferred: %#v calls=%d err=%v", result, source.calls, err)
+	}
+
+	current = time.Date(2026, 8, 16, 21, 0, 0, 0, time.UTC)
 	source = &fakeNetworkStageSource{statuses: []string{"False"}, reasons: []string{"FunctionalProbeFailed"}}
 	observer, err = NewNetworkStageObserver(NetworkStageObserverConfig{
 		Plan: plan, ReceiptPrefix: prefix, TargetClusterUID: runtimeUID, Source: source,


### PR DESCRIPTION
## Summary
- defer only the bounded `FunctionalProbeStale` cache-freshness classification
- continue after one poll interval with explicit `MVPNetworkWarmupDeferred` evidence
- retain fail-closed handling for all other false/error categories

## Verification
- `GOCACHE=/private/tmp/ok147-r36-gocache go test ./internal/runner -run "TestNetworkStageObserverDefersKnownMVPWarmupAcrossReasonChanges|TestNetworkStageObserverWaitsThroughFalseUntilConvergedOrBounded"`

The full package suite remains blocked by three pre-existing certificate/fixture failures unrelated to this change.