### PR TITLE
fix(runner): report redacted observation stop categories

### DIFF
--- a/internal/execution/staged_observation.go
+++ b/internal/execution/staged_observation.go
@@ -53,6 +53,11 @@ func (err *ObservationStageResultError) Error() string {
 	return "observation stage completed with " + err.State
 }
 
+type stageObservationFailure struct{ cause error }
+
+func (err *stageObservationFailure) Error() string { return "bounded stage observation failed" }
+func (err *stageObservationFailure) Unwrap() error { return err.cause }
+
 // Run invokes at most one prebound read-only observer. An already persisted
 // receipt is returned without observing again, making process termination
 // after receipt persistence safe to resume.
@@ -115,7 +120,7 @@ func (operation ObservationStageOperation) run(ctx context.Context, plan stagepl
 
 	result, observeErr := operation.Observer.Observe(ctx)
 	if observeErr != nil {
-		return receipt, errors.New("bounded stage observation failed")
+		return receipt, &stageObservationFailure{cause: observeErr}
 	}
 	if !oneOf(result.Outcome, "SUCCEEDED", "FAILED", "STOPPED") || !stagedDigestPattern.MatchString(result.EvidenceDigest) || result.CompletedAt.IsZero() {
 		return receipt, errors.New("stage observer returned an invalid redaction-safe result")

--- a/internal/runner/full_run_execution.go
+++ b/internal/runner/full_run_execution.go
@@ -179,7 +179,7 @@ func (continuation *concretePreRuntimeContinuation) Run(ctx context.Context) (Pr
 	}
 	receipt, err := continuation.executor.Run(ctx)
 	converted := PreRuntimeOrchestrationReceipt{
-		Format: receipt.Format, State: receipt.State, PlanDigest: receipt.PlanDigest, StoppedAt: receipt.StoppedAt,
+		Format: receipt.Format, State: receipt.State, PlanDigest: receipt.PlanDigest, StoppedAt: receipt.StoppedAt, StopCategory: receipt.StopCategory,
 		Checkpoints: append([]PreRuntimeStageCheckpoint(nil), receipt.Checkpoints...),
 	}
 	if receipt.Format == PreRuntimeExecutionReceiptFormat {

--- a/internal/runner/full_run_orchestrator.go
+++ b/internal/runner/full_run_orchestrator.go
@@ -26,11 +26,12 @@ type FullRunStageCheckpoint struct {
 // It does not contain authorization material, credentials, endpoints, target
 // identities, raw objects or local paths.
 type FullRunOrchestrationReceipt struct {
-	Format      string                   `json:"format"`
-	State       string                   `json:"state"`
-	PlanDigest  string                   `json:"planDigest,omitempty"`
-	StoppedAt   string                   `json:"stoppedAt,omitempty"`
-	Checkpoints []FullRunStageCheckpoint `json:"checkpoints"`
+	Format       string                   `json:"format"`
+	State        string                   `json:"state"`
+	PlanDigest   string                   `json:"planDigest,omitempty"`
+	StoppedAt    string                   `json:"stoppedAt,omitempty"`
+	StopCategory string                   `json:"stopCategory,omitempty"`
+	Checkpoints  []FullRunStageCheckpoint `json:"checkpoints"`
 }
 
 // PostRuntimeContinuationBinding proves that one already-opened Stage 8-12
@@ -95,13 +96,13 @@ func (orchestration *FullRunOrchestration) Run(ctx context.Context) (FullRunOrch
 	prefix, prefixErr := orchestration.PreRuntime.Run(ctx)
 	if prefixErr != nil && prefix.State == "STOPPED" && prefix.StoppedAt == preRuntimeStageOrder[0] &&
 		prefix.PlanDigest == "" && len(prefix.Checkpoints) == 0 {
-		return stopFullRunOrchestrationWithCause(receipt, prefix.StoppedAt, prefixErr)
+		return stopFullRunOrchestrationWithCategory(receipt, prefix.StoppedAt, prefix.StopCategory, prefixErr)
 	}
 	if err := appendFullRunPrefix(&receipt, prefix); err != nil {
 		return stopFullRunOrchestration(receipt, nextFullRunStage(receipt.Checkpoints))
 	}
 	if prefixErr != nil || prefix.State != "SUCCEEDED" {
-		return stopFullRunOrchestrationWithCause(receipt, prefix.StoppedAt, prefixErr)
+		return stopFullRunOrchestrationWithCategory(receipt, prefix.StoppedAt, prefix.StopCategory, prefixErr)
 	}
 	if err := ctx.Err(); err != nil {
 		return stopFullRunOrchestration(receipt, postRuntimeStageOrder[0])
@@ -142,6 +143,9 @@ func appendFullRunPrefix(receipt *FullRunOrchestrationReceipt, prefix PreRuntime
 	if prefix.State == "STOPPED" {
 		if !validStoppedStage(preRuntimeStageOrder, len(prefix.Checkpoints), prefix.StoppedAt) {
 			return errors.New("stopped full-run prefix is inconsistent")
+		}
+		if prefix.StopCategory != "" && !validRedactedStopCategory(prefix.StopCategory) {
+			return errors.New("stopped full-run prefix category is invalid")
 		}
 	}
 	receipt.PlanDigest = prefix.PlanDigest
@@ -245,14 +249,23 @@ func stopFullRunOrchestration(receipt FullRunOrchestrationReceipt, stageID strin
 		stageID = nextFullRunStage(receipt.Checkpoints)
 	}
 	receipt.State, receipt.StoppedAt = "STOPPED", stageID
+	receipt.StopCategory = "ORCHESTRATION_STOPPED"
 	return receipt, errors.New("full-run orchestration stopped at " + stageID)
 }
 
 func stopFullRunOrchestrationWithCause(receipt FullRunOrchestrationReceipt, stageID string, cause error) (FullRunOrchestrationReceipt, error) {
+	return stopFullRunOrchestrationWithCategory(receipt, stageID, "", cause)
+}
+
+func stopFullRunOrchestrationWithCategory(receipt FullRunOrchestrationReceipt, stageID, category string, cause error) (FullRunOrchestrationReceipt, error) {
 	if stageID == "" {
 		stageID = nextFullRunStage(receipt.Checkpoints)
 	}
 	receipt.State, receipt.StoppedAt = "STOPPED", stageID
+	if category == "" {
+		category = redactedStopCategory(cause)
+	}
+	receipt.StopCategory = category
 	if cause == nil {
 		return receipt, errors.New("full-run orchestration stopped at " + stageID)
 	}

--- a/internal/runner/full_run_orchestrator_test.go
+++ b/internal/runner/full_run_orchestrator_test.go
@@ -19,6 +19,15 @@ type fakePostRuntimeContinuation struct {
 	calls   atomic.Int32
 }
 
+type fakePreRuntimeContinuation struct {
+	receipt PreRuntimeOrchestrationReceipt
+	err     error
+}
+
+func (continuation *fakePreRuntimeContinuation) Run(context.Context) (PreRuntimeOrchestrationReceipt, error) {
+	return continuation.receipt, continuation.err
+}
+
 func (continuation *fakePostRuntimeContinuation) ContinuationBinding() (PostRuntimeContinuationBinding, error) {
 	if continuation == nil {
 		return PostRuntimeContinuationBinding{}, errors.New("missing continuation")
@@ -118,6 +127,48 @@ func TestFullRunOrchestrationStopsBeforeContinuationWhenPrefixStops(t *testing.T
 	}
 	if !strings.Contains(err.Error(), "private failure") {
 		t.Fatalf("prefix failure cause was not preserved: %v", err)
+	}
+}
+
+func TestFullRunOrchestrationPropagatesPrefixStopCategory(t *testing.T) {
+	prefix := successfulPreRuntimeOrchestration(nil)
+	prefix.RunNetworkObservation = func(context.Context, execution.StagedOperationReceipt) (execution.ObservationStageRunReceipt, error) {
+		return execution.ObservationStageRunReceipt{
+			Format: execution.ObservationStageReceiptFormat,
+			State:  "PREOBSERVATION", PlanDigest: runnerStageSHA("a"), StageID: "network-observation",
+		}, newRedactedObservationError("OBSERVATION_SOURCE_ERROR", "redacted source failure")
+	}
+	orchestration := &FullRunOrchestration{
+		PreRuntime: prefix,
+		BindPostRuntime: func(context.Context, PreRuntimeOrchestrationReceipt) (PostRuntimeContinuation, error) {
+			t.Fatal("stopped prefix reached continuation")
+			return nil, nil
+		},
+	}
+	receipt, err := orchestration.Run(context.Background())
+	if err == nil || receipt.StoppedAt != "network-observation" || receipt.StopCategory != "OBSERVATION_SOURCE_ERROR" || len(receipt.Checkpoints) != 4 {
+		t.Fatalf("full-run stop category was not propagated: %#v err=%v", receipt, err)
+	}
+}
+
+func TestFullRunOrchestrationRejectsUnboundedPrefixStopCategory(t *testing.T) {
+	prefix := &fakePreRuntimeContinuation{
+		receipt: PreRuntimeOrchestrationReceipt{
+			Format: PreRuntimeOrchestrationReceiptFormat, State: "STOPPED", PlanDigest: runnerStageSHA("a"),
+			StoppedAt: "provider-prerequisites", StopCategory: "sensitive arbitrary detail",
+			Checkpoints: []PreRuntimeStageCheckpoint{},
+		},
+	}
+	orchestration := &FullRunOrchestration{
+		PreRuntime: prefix,
+		BindPostRuntime: func(context.Context, PreRuntimeOrchestrationReceipt) (PostRuntimeContinuation, error) {
+			t.Fatal("invalid prefix reached continuation")
+			return nil, nil
+		},
+	}
+	receipt, err := orchestration.Run(context.Background())
+	if err == nil || strings.Contains(receipt.StopCategory, "sensitive") {
+		t.Fatalf("unbounded prefix category was accepted: %#v err=%v", receipt, err)
 	}
 }
 

--- a/internal/runner/network_stage_observer.go
+++ b/internal/runner/network_stage_observer.go
@@ -3,6 +3,7 @@ package runner
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/openkubes/ok-cluster/internal/digest"
@@ -121,7 +122,7 @@ func (observer *NetworkStageObserver) Observe(ctx context.Context) (execution.St
 	}
 	result, err := polling.Observe(ctx, observer.policy)
 	if err != nil {
-		return execution.StageObservationResult{}, errors.New("bounded network convergence observation failed")
+		return execution.StageObservationResult{}, fmt.Errorf("bounded network convergence observation failed: %w", err)
 	}
 	receipt, err := result.Receipt()
 	if err != nil {

--- a/internal/runner/polling_observer.go
+++ b/internal/runner/polling_observer.go
@@ -14,6 +14,18 @@ type ObservationSource interface {
 
 type ObservationWaiter func(context.Context, time.Duration) error
 
+type redactedObservationError struct {
+	category string
+	message  string
+}
+
+func (err *redactedObservationError) Error() string                { return err.message }
+func (err *redactedObservationError) RedactedStopCategory() string { return err.category }
+
+func newRedactedObservationError(category, message string) error {
+	return &redactedObservationError{category: category, message: message}
+}
+
 type BoundedPollingObserverConfig struct {
 	Source          ObservationSource
 	Interval        time.Duration
@@ -50,7 +62,7 @@ func (observer *BoundedPollingObserver) Observe(ctx context.Context, policy obse
 		return observation.VerifiedResult{}, errors.New("bounded polling observer is required")
 	}
 	if err := ctx.Err(); err != nil {
-		return observation.VerifiedResult{}, errors.New("bounded observation polling cancelled")
+		return observation.VerifiedResult{}, newRedactedObservationError("OBSERVATION_INTERRUPTED", "bounded observation polling cancelled")
 	}
 	started := observer.config.Clock()
 	deadline := started.Add(observer.config.Timeout)
@@ -61,19 +73,19 @@ func (observer *BoundedPollingObserver) Observe(ctx context.Context, policy obse
 		if err != nil {
 			initialTransient := !haveLast && observer.config.ContinueOnInitialError != nil && observer.config.ContinueOnInitialError(err)
 			if !initialTransient && (!observer.config.ContinueOnErrorAfterObservation || !haveLast) {
-				return observation.VerifiedResult{}, errors.New("bounded aggregate observation failed")
+				return observation.VerifiedResult{}, newRedactedObservationError("OBSERVATION_SOURCE_ERROR", "bounded aggregate observation failed")
 			}
 		} else {
 			receipt, receiptErr := result.Receipt()
 			if receiptErr != nil {
-				return observation.VerifiedResult{}, errors.New("aggregate observer returned an unverified result")
+				return observation.VerifiedResult{}, newRedactedObservationError("OBSERVATION_RESULT_INVALID", "aggregate observer returned an unverified result")
 			}
 			last, haveLast = result, true
 			if receipt.Ready == "True" || (receipt.Ready == "False" && !observer.config.ContinueOnFalse) {
 				return result, nil
 			}
 			if receipt.Ready != "Unknown" && receipt.Ready != "False" {
-				return observation.VerifiedResult{}, errors.New("aggregate observer returned an invalid readiness state")
+				return observation.VerifiedResult{}, newRedactedObservationError("OBSERVATION_RESULT_INVALID", "aggregate observer returned an invalid readiness state")
 			}
 		}
 		now := observer.config.Clock()
@@ -85,7 +97,7 @@ func (observer *BoundedPollingObserver) Observe(ctx context.Context, policy obse
 			wait = remaining
 		}
 		if err := observer.config.Wait(ctx, wait); err != nil {
-			return observation.VerifiedResult{}, errors.New("bounded observation polling interrupted")
+			return observation.VerifiedResult{}, newRedactedObservationError("OBSERVATION_INTERRUPTED", "bounded observation polling interrupted")
 		}
 	}
 }

--- a/internal/runner/pre_runtime_execution.go
+++ b/internal/runner/pre_runtime_execution.go
@@ -78,6 +78,7 @@ type PreRuntimeExecutionReceipt struct {
 	State                  string                              `json:"state"`
 	PlanDigest             string                              `json:"planDigest,omitempty"`
 	StoppedAt              string                              `json:"stoppedAt,omitempty"`
+	StopCategory           string                              `json:"stopCategory,omitempty"`
 	Checkpoints            []PreRuntimeStageCheckpoint         `json:"checkpoints"`
 	ResolvedAuthorizations []ResolvedStageAuthorizationReceipt `json:"resolvedAuthorizations"`
 }
@@ -326,7 +327,7 @@ func (executor *PreRuntimeExecution) Run(ctx context.Context) (PreRuntimeExecuti
 	orchestrationReceipt, runErr := orchestration.Run(ctx)
 	result := PreRuntimeExecutionReceipt{
 		Format: PreRuntimeExecutionReceiptFormat, State: orchestrationReceipt.State,
-		PlanDigest: orchestrationReceipt.PlanDigest, StoppedAt: orchestrationReceipt.StoppedAt,
+		PlanDigest: orchestrationReceipt.PlanDigest, StoppedAt: orchestrationReceipt.StoppedAt, StopCategory: orchestrationReceipt.StopCategory,
 		Checkpoints:            append([]PreRuntimeStageCheckpoint(nil), orchestrationReceipt.Checkpoints...),
 		ResolvedAuthorizations: append([]ResolvedStageAuthorizationReceipt(nil), authorizations...),
 	}

--- a/internal/runner/pre_runtime_orchestrator.go
+++ b/internal/runner/pre_runtime_orchestrator.go
@@ -29,11 +29,12 @@ type PreRuntimeStageCheckpoint struct {
 // PreRuntimeOrchestrationReceipt is a redaction-safe summary. It contains no
 // credential, endpoint, target UID, CA, raw object or local path.
 type PreRuntimeOrchestrationReceipt struct {
-	Format      string                      `json:"format"`
-	State       string                      `json:"state"`
-	PlanDigest  string                      `json:"planDigest,omitempty"`
-	StoppedAt   string                      `json:"stoppedAt,omitempty"`
-	Checkpoints []PreRuntimeStageCheckpoint `json:"checkpoints"`
+	Format       string                      `json:"format"`
+	State        string                      `json:"state"`
+	PlanDigest   string                      `json:"planDigest,omitempty"`
+	StoppedAt    string                      `json:"stoppedAt,omitempty"`
+	StopCategory string                      `json:"stopCategory,omitempty"`
+	Checkpoints  []PreRuntimeStageCheckpoint `json:"checkpoints"`
 }
 
 // PreRuntimeOrchestration composes only the already bounded Stage 1-7
@@ -108,8 +109,11 @@ func (orchestration PreRuntimeOrchestration) Run(ctx context.Context) (PreRuntim
 	}
 
 	networkObservationReceipt, runErr := orchestration.RunNetworkObservation(ctx, enablementReceipt)
-	if err := appendPreRuntimeCheckpoint(&receipt, preRuntimeStageOrder[4], execution.ObservationStageReceiptFormat, networkObservationReceipt.Format, networkObservationReceipt.State, networkObservationReceipt.PlanDigest, networkObservationReceipt.StageID, networkObservationReceipt.StageReceiptDigest); err != nil || runErr != nil {
-		return stopPreRuntimeOrchestration(receipt, preRuntimeStageOrder[4])
+	if appendErr := appendPreRuntimeCheckpoint(&receipt, preRuntimeStageOrder[4], execution.ObservationStageReceiptFormat, networkObservationReceipt.Format, networkObservationReceipt.State, networkObservationReceipt.PlanDigest, networkObservationReceipt.StageID, networkObservationReceipt.StageReceiptDigest); appendErr != nil || runErr != nil {
+		if runErr != nil {
+			return stopPreRuntimeOrchestrationWithCause(receipt, preRuntimeStageOrder[4], runErr)
+		}
+		return stopPreRuntimeOrchestrationWithCause(receipt, preRuntimeStageOrder[4], appendErr)
 	}
 	if err := ctx.Err(); err != nil {
 		return stopPreRuntimeOrchestration(receipt, preRuntimeStageOrder[5])
@@ -149,13 +153,48 @@ func appendPreRuntimeCheckpoint(receipt *PreRuntimeOrchestrationReceipt, expecte
 
 func stopPreRuntimeOrchestration(receipt PreRuntimeOrchestrationReceipt, stageID string) (PreRuntimeOrchestrationReceipt, error) {
 	receipt.State, receipt.StoppedAt = "STOPPED", stageID
+	receipt.StopCategory = "ORCHESTRATION_STOPPED"
 	return receipt, errors.New("pre-runtime orchestration stopped at " + stageID)
 }
 
 func stopPreRuntimeOrchestrationWithCause(receipt PreRuntimeOrchestrationReceipt, stageID string, cause error) (PreRuntimeOrchestrationReceipt, error) {
 	receipt.State, receipt.StoppedAt = "STOPPED", stageID
+	receipt.StopCategory = redactedStopCategory(cause)
 	if cause == nil {
 		return receipt, errors.New("pre-runtime orchestration stopped at " + stageID)
 	}
 	return receipt, fmt.Errorf("pre-runtime orchestration stopped at %s: %w", stageID, cause)
+}
+
+type redactedStopCategorizer interface {
+	RedactedStopCategory() string
+}
+
+func redactedStopCategory(cause error) string {
+	if cause == nil {
+		return "ORCHESTRATION_STOPPED"
+	}
+	var categorized redactedStopCategorizer
+	if errors.As(cause, &categorized) {
+		switch category := categorized.RedactedStopCategory(); category {
+		case "OBSERVATION_SOURCE_ERROR", "OBSERVATION_RESULT_INVALID", "OBSERVATION_INTERRUPTED":
+			return category
+		}
+	}
+	var observationResult *execution.ObservationStageResultError
+	if errors.As(cause, &observationResult) {
+		return "OBSERVATION_" + observationResult.State
+	}
+	return "STAGE_EXECUTION_ERROR"
+}
+
+func validRedactedStopCategory(category string) bool {
+	switch category {
+	case "ORCHESTRATION_STOPPED", "STAGE_EXECUTION_ERROR", "OBSERVATION_SOURCE_ERROR",
+		"OBSERVATION_RESULT_INVALID", "OBSERVATION_INTERRUPTED", "OBSERVATION_COMPLETED_FAILED",
+		"OBSERVATION_COMPLETED_STOPPED":
+		return true
+	default:
+		return false
+	}
 }

--- a/internal/runner/pre_runtime_orchestrator_test.go
+++ b/internal/runner/pre_runtime_orchestrator_test.go
@@ -2,7 +2,9 @@ package runner
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -136,6 +138,25 @@ func TestPreRuntimeOrchestrationPreservesProviderFailureCause(t *testing.T) {
 	if err == nil || receipt.State != "STOPPED" || receipt.StoppedAt != "provider-prerequisites" ||
 		!strings.Contains(err.Error(), "safe provider authorization cause") {
 		t.Fatalf("provider failure cause was not preserved: %#v err=%v", receipt, err)
+	}
+}
+
+func TestPreRuntimeOrchestrationReportsRedactedNetworkStopCategory(t *testing.T) {
+	orchestration := successfulPreRuntimeOrchestration(nil)
+	orchestration.RunNetworkObservation = func(context.Context, execution.StagedOperationReceipt) (execution.ObservationStageRunReceipt, error) {
+		return execution.ObservationStageRunReceipt{
+			Format: execution.ObservationStageReceiptFormat,
+			State:  "PREOBSERVATION", PlanDigest: runnerStageSHA("a"), StageID: "network-observation",
+		}, fmt.Errorf("safe wrapper: %w", newRedactedObservationError("OBSERVATION_SOURCE_ERROR", "redacted source failure"))
+	}
+	receipt, err := orchestration.Run(context.Background())
+	if err == nil || receipt.State != "STOPPED" || receipt.StoppedAt != "network-observation" ||
+		receipt.StopCategory != "OBSERVATION_SOURCE_ERROR" || len(receipt.Checkpoints) != 4 {
+		t.Fatalf("network stop category was not preserved: %#v err=%v", receipt, err)
+	}
+	encoded, marshalErr := json.Marshal(receipt)
+	if marshalErr != nil || strings.Contains(string(encoded), "redacted source failure") {
+		t.Fatalf("receipt exposed the underlying cause: %s err=%v", encoded, marshalErr)
 	}
 }
 


### PR DESCRIPTION
## Summary
- preserve typed, redaction-safe observation failure categories through stage execution
- propagate `stopCategory` through pre-runtime and full-run orchestration receipts
- reject arbitrary externally supplied stop-category text with a fixed allowlist

## Why
R38 stopped at `network-observation` although transient initial-read polling and the 45-minute convergence window were already active. The orchestration layer discarded the concrete safe failure class, leaving only the stage name. This change makes the next run distinguish source, invalid-result, interruption, and terminal observation outcomes without exposing raw errors, endpoints, or credentials.

## Validation
- `go test ./internal/execution`
- focused runner tests for pre-runtime/full-run orchestration, bounded polling, and network observation
- full runner suite compiled and ran; three existing Go 1.26 client-certificate trust tests remain failing outside this change