### PR TITLE
feat(runner): bind deferred MVP network observation

### DIFF
--- a/internal/observation/evaluator.go
+++ b/internal/observation/evaluator.go
@@ -30,12 +30,13 @@ var supportedConditions = map[string]struct{}{
 
 // Policy is derived from the normalized Contract and therefore bound by R.
 type Policy struct {
-	Format             string   `json:"format"`
-	IntentRevision     string   `json:"intentRevision"`
-	EnablementRevision string   `json:"enablementRevision"`
-	PlatformRevision   string   `json:"platformRevision"`
-	TargetClusterUID   string   `json:"targetClusterUid"`
-	Required           []string `json:"required"`
+	Format                 string   `json:"format"`
+	IntentRevision         string   `json:"intentRevision"`
+	EnablementRevision     string   `json:"enablementRevision"`
+	PlatformRevision       string   `json:"platformRevision"`
+	TargetClusterUID       string   `json:"targetClusterUid"`
+	Required               []string `json:"required"`
+	NetworkObservationMode string   `json:"networkObservationMode,omitempty"`
 }
 
 // Evidence is one normalized statement from an authoritative source-specific
@@ -258,6 +259,12 @@ func validatePolicy(policy Policy, requireTarget bool) error {
 	}
 	if requireTarget && !validUID(policy.TargetClusterUID) {
 		return errors.New("observation policy has no valid target Cluster UID")
+	}
+	if policy.NetworkObservationMode != "" && policy.NetworkObservationMode != "deferred-mvp/v1" {
+		return errors.New("observation policy network mode is unsupported")
+	}
+	if policy.NetworkObservationMode != "" && (len(policy.Required) != 1 || policy.Required[0] != "NetworkReady") {
+		return errors.New("observation policy network mode requires only NetworkReady")
 	}
 	seen := map[string]struct{}{}
 	for _, name := range policy.Required {

--- a/internal/runner/full_run_execution_manifest.go
+++ b/internal/runner/full_run_execution_manifest.go
@@ -585,6 +585,7 @@ func fullRunPlanExpected(document postRuntimePlanExpectedDocument) stageplan.Exp
 		ExecutionFixture: document.ExecutionFixture, ExecutionAttemptDigest: document.ExecutionAttemptDigest,
 		InfrastructureAuthority: document.InfrastructureAuthority,
 		ManagementAuthority:     document.ManagementAuthority, GitOpsAuthority: document.GitOpsAuthority,
+		NetworkObservationMode: document.NetworkObservationMode,
 	}
 }
 

--- a/internal/runner/network_stage_observer.go
+++ b/internal/runner/network_stage_observer.go
@@ -88,6 +88,7 @@ func NewNetworkStageObserver(config NetworkStageObserverConfig) (*NetworkStageOb
 			Format: observation.PolicyFormat, IntentRevision: config.Plan.IntentRevision,
 			EnablementRevision: config.Plan.EnablementRevision, PlatformRevision: config.Plan.PlatformRevision,
 			TargetClusterUID: config.TargetClusterUID, Required: []string{"NetworkReady"},
+			NetworkObservationMode: config.Plan.NetworkObservationMode,
 		},
 		pollInterval: config.PollInterval, pollLimit: config.PollTimeout,
 		clock: config.Clock, wait: config.Wait,
@@ -107,6 +108,26 @@ func (observer *NetworkStageObserver) Observe(ctx context.Context) (execution.St
 	if observer == nil {
 		return execution.StageObservationResult{}, errors.New("network stage observer is required")
 	}
+	if observer.policy.NetworkObservationMode == "deferred-mvp/v1" {
+		marker := "ok147-mvp-network-observation-deferred/v1\n" + observer.policy.TargetClusterUID + "\n" + observer.policy.EnablementRevision
+		result, err := observation.Evaluate(observer.policy, observation.Bundle{
+			Format: observation.BundleFormat, IntentRevision: observer.policy.IntentRevision,
+			EvaluatedAt: observer.clock().UTC().Format(time.RFC3339Nano),
+			Evidence: []observation.Evidence{{
+				Type: "NetworkReady", Source: "BoundedNetworkEvaluator",
+				SourceUID:        "ok147-mvp-network-observation-deferral",
+				TargetClusterUID: observer.policy.TargetClusterUID,
+				Status:           "True", Reason: "MVPNetworkObservationDeferred",
+				DesiredRevision:  observer.policy.EnablementRevision,
+				ObservedRevision: observer.policy.EnablementRevision,
+				EvidenceDigest:   digest.SHA256([]byte(marker)),
+			}},
+		})
+		if err != nil {
+			return execution.StageObservationResult{}, errors.New("evaluate deferred MVP network observation")
+		}
+		return networkStageObservationResult(result)
+	}
 	polling, err := NewBoundedPollingObserver(BoundedPollingObserverConfig{
 		Source: &networkPollingSource{
 			source: observer.source, profile: observer.profile, clock: observer.clock,
@@ -124,6 +145,10 @@ func (observer *NetworkStageObserver) Observe(ctx context.Context) (execution.St
 	if err != nil {
 		return execution.StageObservationResult{}, fmt.Errorf("bounded network convergence observation failed: %w", err)
 	}
+	return networkStageObservationResult(result)
+}
+
+func networkStageObservationResult(result observation.VerifiedResult) (execution.StageObservationResult, error) {
 	receipt, err := result.Receipt()
 	if err != nil {
 		return execution.StageObservationResult{}, err

--- a/internal/runner/network_stage_observer_test.go
+++ b/internal/runner/network_stage_observer_test.go
@@ -42,6 +42,26 @@ func TestNetworkStageObserverBindsHistoricalTargetAndConverges(t *testing.T) {
 	}
 }
 
+func TestNetworkStageObserverUsesPlanBoundMVPDeferralWithoutReadingSource(t *testing.T) {
+	fixture := submissionBundleFixtureWithNetworkMode(t, "deferred-mvp/v1")
+	plan, prefix, runtimeUID := networkObserverPrefixForPlan(t, fixture.plan, true)
+	at := time.Date(2026, 9, 5, 0, 0, 0, 0, time.UTC)
+	source := &fakeNetworkStageSource{err: errors.New("source must not be called")}
+	observer, err := NewNetworkStageObserver(NetworkStageObserverConfig{
+		Plan: plan, ReceiptPrefix: prefix,
+		TargetClusterUID: runtimeUID, Source: source, Profile: networkStageProfile(plan),
+		PollInterval: time.Second, PollTimeout: time.Minute, Clock: func() time.Time { return at },
+		Wait: func(context.Context, time.Duration) error { return errors.New("wait must not be called") },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := observer.Observe(context.Background())
+	if err != nil || result.Outcome != "SUCCEEDED" || !platformInputDigestPattern.MatchString(result.EvidenceDigest) || source.calls != 0 {
+		t.Fatalf("unexpected plan-bound MVP deferral: %#v calls=%d err=%v", result, source.calls, err)
+	}
+}
+
 func TestNetworkStageObserverWaitsThroughFalseUntilConvergedOrBounded(t *testing.T) {
 	for name, testCase := range map[string]struct {
 		statuses []string
@@ -235,7 +255,11 @@ func (source *fakeNetworkStageSource) Observe(_ context.Context, policy observat
 
 func networkObserverPrefix(t *testing.T, withTargetDigest bool) (stageplan.Binding, []stagereceipt.Verified, string) {
 	t.Helper()
-	plan := submissionBundleFixture(t, false, "").plan
+	return networkObserverPrefixForPlan(t, submissionBundleFixture(t, false, "").plan, withTargetDigest)
+}
+
+func networkObserverPrefixForPlan(t *testing.T, plan stageplan.Binding, withTargetDigest bool) (stageplan.Binding, []stagereceipt.Verified, string) {
+	t.Helper()
 	at := time.Date(2026, 8, 16, 19, 0, 0, 0, time.UTC)
 	const runtimeUID = "cluster-runtime-uid-147"
 	provider, err := stagereceipt.New(plan, "provider-prerequisites", []stagereceipt.Verified{}, "SUCCEEDED", "ATTEMPTED", bundleSHA("1"), bundleSHA("2"), at)

--- a/internal/runner/post_runtime_execution_manifest.go
+++ b/internal/runner/post_runtime_execution_manifest.go
@@ -34,6 +34,7 @@ type postRuntimePlanExpectedDocument struct {
 	InfrastructureAuthority string            `json:"infrastructureAuthority"`
 	ManagementAuthority     string            `json:"managementAuthority"`
 	GitOpsAuthority         string            `json:"gitOpsAuthority"`
+	NetworkObservationMode  string            `json:"networkObservationMode,omitempty"`
 }
 
 type postRuntimePlanDocument struct {

--- a/internal/runner/staged_submission_bundle_test.go
+++ b/internal/runner/staged_submission_bundle_test.go
@@ -134,14 +134,18 @@ type submissionBundleTestFixture struct {
 }
 
 func submissionBundleFixture(t *testing.T, completedProvider bool, overrideProviderDigest string) submissionBundleTestFixture {
-	return submissionBundleFixtureOptions(t, completedProvider, overrideProviderDigest, false)
+	return submissionBundleFixtureOptions(t, completedProvider, overrideProviderDigest, false, "")
 }
 
 func submissionBundleFixtureWithProviderAccess(t *testing.T) submissionBundleTestFixture {
-	return submissionBundleFixtureOptions(t, true, "", true)
+	return submissionBundleFixtureOptions(t, true, "", true, "")
 }
 
-func submissionBundleFixtureOptions(t *testing.T, completedProvider bool, overrideProviderDigest string, providerAccess bool) submissionBundleTestFixture {
+func submissionBundleFixtureWithNetworkMode(t *testing.T, mode string) submissionBundleTestFixture {
+	return submissionBundleFixtureOptions(t, false, "", false, mode)
+}
+
+func submissionBundleFixtureOptions(t *testing.T, completedProvider bool, overrideProviderDigest string, providerAccess bool, networkMode string) submissionBundleTestFixture {
 	t.Helper()
 	root := t.TempDir()
 	at := time.Date(2026, 8, 16, 14, 0, 0, 0, time.UTC)
@@ -188,6 +192,7 @@ func submissionBundleFixtureOptions(t *testing.T, completedProvider bool, overri
 	expected := stageplan.Expected{
 		ContractIdentity: identity, IntentRevision: revision, EnablementRevision: bundleSHA("b"), PlatformRevision: bundleSHA("c"), ExecutionFixture: bundleSHA("d"),
 		InfrastructureAuthority: "ok-infra", ManagementAuthority: "ok-mgmt", GitOpsAuthority: "ok-shared",
+		NetworkObservationMode: networkMode,
 	}
 	providerAccessPath := ""
 	providerAccessDigest := ""
@@ -273,13 +278,17 @@ func submissionBundlePlanWithProviderAccess(t *testing.T, expected stageplan.Exp
 			stages[index]["grantOperation"] = operations[index]
 		}
 	}
-	return mustJSON(t, map[string]any{
+	document := map[string]any{
 		"format": stageplan.Format, "contractIdentity": expected.ContractIdentity,
 		"intentRevision": expected.IntentRevision, "enablementRevision": expected.EnablementRevision, "platformRevision": expected.PlatformRevision, "executionFixture": expected.ExecutionFixture,
 		"authorizationState": "NO-GO",
 		"authorities":        map[string]any{"infrastructure": expected.InfrastructureAuthority, "management": expected.ManagementAuthority, "gitOps": expected.GitOpsAuthority, "workloadIdentityMode": "capi-cluster-uid/v1", "runnerIdentityMode": "bounded-job/v1"},
 		"stages":             stages,
-	})
+	}
+	if expected.NetworkObservationMode != "" {
+		document["networkObservationMode"] = expected.NetworkObservationMode
+	}
+	return mustJSON(t, document)
 }
 
 func providerAccessBundleKubeconfig() []byte {

--- a/internal/stageplan/plan.go
+++ b/internal/stageplan/plan.go
@@ -44,6 +44,7 @@ type Expected struct {
 	InfrastructureAuthority string
 	ManagementAuthority     string
 	GitOpsAuthority         string
+	NetworkObservationMode  string
 }
 
 type Authorities struct {
@@ -72,37 +73,40 @@ type Stage struct {
 }
 
 type document struct {
-	Format             string            `json:"format"`
-	ContractIdentity   contract.Identity `json:"contractIdentity"`
-	IntentRevision     string            `json:"intentRevision"`
-	EnablementRevision string            `json:"enablementRevision"`
-	PlatformRevision   string            `json:"platformRevision"`
-	ExecutionFixture   string            `json:"executionFixture"`
-	ExecutionAttempt   string            `json:"executionAttemptDigest,omitempty"`
-	AuthorizationState string            `json:"authorizationState"`
-	Authorities        Authorities       `json:"authorities"`
-	Stages             []Stage           `json:"stages"`
+	Format                 string            `json:"format"`
+	ContractIdentity       contract.Identity `json:"contractIdentity"`
+	IntentRevision         string            `json:"intentRevision"`
+	EnablementRevision     string            `json:"enablementRevision"`
+	PlatformRevision       string            `json:"platformRevision"`
+	ExecutionFixture       string            `json:"executionFixture"`
+	ExecutionAttempt       string            `json:"executionAttemptDigest,omitempty"`
+	AuthorizationState     string            `json:"authorizationState"`
+	NetworkObservationMode string            `json:"networkObservationMode,omitempty"`
+	Authorities            Authorities       `json:"authorities"`
+	Stages                 []Stage           `json:"stages"`
 }
 
 // Binding is the immutable, redaction-safe result of successful verification.
 // It carries no source path, raw manifests, credentials or authorization.
 type Binding struct {
-	Format              string            `json:"format"`
-	PlanDigest          string            `json:"planDigest"`
-	ContractIdentity    contract.Identity `json:"contractIdentity"`
-	IntentRevision      string            `json:"intentRevision"`
-	EnablementRevision  string            `json:"enablementRevision"`
-	PlatformRevision    string            `json:"platformRevision"`
-	ExecutionFixture    string            `json:"executionFixture"`
-	ExecutionAttempt    string            `json:"executionAttemptDigest,omitempty"`
-	Authorities         Authorities       `json:"authorities"`
-	Stages              []Stage           `json:"stages"`
-	verified            bool
-	verifiedDigest      string
-	verifiedIdentity    contract.Identity
-	verifiedRevisions   [5]string
-	verifiedAuthorities Authorities
-	stageDigests        map[string]string
+	Format                         string            `json:"format"`
+	PlanDigest                     string            `json:"planDigest"`
+	ContractIdentity               contract.Identity `json:"contractIdentity"`
+	IntentRevision                 string            `json:"intentRevision"`
+	EnablementRevision             string            `json:"enablementRevision"`
+	PlatformRevision               string            `json:"platformRevision"`
+	ExecutionFixture               string            `json:"executionFixture"`
+	ExecutionAttempt               string            `json:"executionAttemptDigest,omitempty"`
+	NetworkObservationMode         string            `json:"networkObservationMode,omitempty"`
+	Authorities                    Authorities       `json:"authorities"`
+	Stages                         []Stage           `json:"stages"`
+	verified                       bool
+	verifiedDigest                 string
+	verifiedIdentity               contract.Identity
+	verifiedRevisions              [5]string
+	verifiedAuthorities            Authorities
+	verifiedNetworkObservationMode string
+	stageDigests                   map[string]string
 }
 
 type stageRule struct {
@@ -175,6 +179,12 @@ func Verify(raw []byte, expected Expected) (Binding, error) {
 	if source.AuthorizationState != "NO-GO" {
 		return Binding{}, errors.New("staged execution plan must remain non-authorizing (authorizationState NO-GO)")
 	}
+	if source.NetworkObservationMode != expected.NetworkObservationMode {
+		return Binding{}, errors.New("staged execution plan network observation mode differs from verified input")
+	}
+	if source.NetworkObservationMode != "" && source.NetworkObservationMode != "deferred-mvp/v1" {
+		return Binding{}, errors.New("staged execution plan network observation mode is unsupported")
+	}
 	if source.IntentRevision != expected.IntentRevision || source.EnablementRevision != expected.EnablementRevision || source.PlatformRevision != expected.PlatformRevision || source.ExecutionFixture != expected.ExecutionFixture {
 		return Binding{}, errors.New("staged execution plan revisions or fixture differ from verified inputs")
 	}
@@ -211,11 +221,13 @@ func Verify(raw []byte, expected Expected) (Binding, error) {
 		ContractIdentity: source.ContractIdentity,
 		IntentRevision:   source.IntentRevision, EnablementRevision: source.EnablementRevision,
 		PlatformRevision: source.PlatformRevision, ExecutionFixture: source.ExecutionFixture,
-		ExecutionAttempt: source.ExecutionAttempt,
-		Authorities:      source.Authorities, Stages: cloneStages(source.Stages),
+		ExecutionAttempt:       source.ExecutionAttempt,
+		NetworkObservationMode: source.NetworkObservationMode,
+		Authorities:            source.Authorities, Stages: cloneStages(source.Stages),
 		verified: true, verifiedDigest: planDigest, verifiedIdentity: source.ContractIdentity,
 		verifiedRevisions:   [5]string{source.IntentRevision, source.EnablementRevision, source.PlatformRevision, source.ExecutionFixture, source.ExecutionAttempt},
 		verifiedAuthorities: source.Authorities, stageDigests: stageDigests,
+		verifiedNetworkObservationMode: source.NetworkObservationMode,
 	}, nil
 }
 
@@ -235,6 +247,9 @@ func ValidateExpected(expected Expected) error {
 	}
 	if expected.ExecutionAttemptDigest != "" && !digestPattern.MatchString(expected.ExecutionAttemptDigest) {
 		return errors.New("expected execution attempt digest is invalid")
+	}
+	if expected.NetworkObservationMode != "" && expected.NetworkObservationMode != "deferred-mvp/v1" {
+		return errors.New("expected network observation mode is unsupported")
 	}
 	for label, value := range map[string]string{
 		"infrastructure authority": expected.InfrastructureAuthority,
@@ -339,7 +354,7 @@ func (binding Binding) Stage(id string) (Stage, string, error) {
 	if !binding.verified || binding.Format != BindingFormat && binding.Format != BindingFormatV2 || binding.PlanDigest != binding.verifiedDigest || !digestPattern.MatchString(binding.PlanDigest) {
 		return Stage{}, "", errors.New("verified staged execution binding is required")
 	}
-	if binding.ContractIdentity != binding.verifiedIdentity || [5]string{binding.IntentRevision, binding.EnablementRevision, binding.PlatformRevision, binding.ExecutionFixture, binding.ExecutionAttempt} != binding.verifiedRevisions || binding.Authorities != binding.verifiedAuthorities {
+	if binding.ContractIdentity != binding.verifiedIdentity || [5]string{binding.IntentRevision, binding.EnablementRevision, binding.PlatformRevision, binding.ExecutionFixture, binding.ExecutionAttempt} != binding.verifiedRevisions || binding.Authorities != binding.verifiedAuthorities || binding.NetworkObservationMode != binding.verifiedNetworkObservationMode {
 		return Stage{}, "", errors.New("staged execution top-level binding changed after verification")
 	}
 	if err := validateStages(binding.Stages); err != nil {

--- a/internal/stageplan/plan_test.go
+++ b/internal/stageplan/plan_test.go
@@ -66,6 +66,30 @@ func TestVerifyV2BindsOneExecutionAttempt(t *testing.T) {
 	}
 }
 
+func TestVerifyBindsExplicitMVPNetworkObservationMode(t *testing.T) {
+	plan := validDocument()
+	plan.Format = FormatV2
+	plan.ExecutionAttempt = sha("5")
+	plan.NetworkObservationMode = "deferred-mvp/v1"
+	want := expected()
+	want.ExecutionAttemptDigest = plan.ExecutionAttempt
+	want.NetworkObservationMode = plan.NetworkObservationMode
+	binding, err := Verify(planJSON(t, plan), want)
+	if err != nil || binding.NetworkObservationMode != plan.NetworkObservationMode {
+		t.Fatalf("explicit network mode was not bound: %#v err=%v", binding, err)
+	}
+	withoutMode := want
+	withoutMode.NetworkObservationMode = ""
+	if _, err := Verify(planJSON(t, plan), withoutMode); err == nil {
+		t.Fatal("plan selected deferred network mode without an independent expected binding")
+	}
+	plan.NetworkObservationMode = "skip-everything/v1"
+	want.NetworkObservationMode = plan.NetworkObservationMode
+	if _, err := Verify(planJSON(t, plan), want); err == nil {
+		t.Fatal("unsupported network mode was accepted")
+	}
+}
+
 func TestRequireInputBindsExactArtifactIdentity(t *testing.T) {
 	binding, err := Verify(planJSON(t, validDocument()), expected())
 	if err != nil {


### PR DESCRIPTION
## Summary

- add an independently expected, plan-digest-bound networkObservationMode
- permit only the exact deferred-mvp/v1 mode
- bind the mode into the NetworkReady observation policy
- emit target- and revision-bound MVPNetworkObservationDeferred evidence without querying the network source
- retain the existing fail-closed path for every plan without the explicit mode

## Safety properties

- the plan cannot self-select deferral because Expected.NetworkObservationMode must match
- unsupported modes fail closed
- in-memory mode tampering invalidates the verified plan binding
- downstream execution still requires the ordinary immutable successful receipt chain
- the bound plan distinguishes deferred MVP evidence from a fully observed network result

## Verification

- go test ./internal/stageplan ./internal/observation
- go test ./internal/runner -run ^TestNetworkStageObserver -count=1
- full go test ./... compiles and runs; three pre-existing Go 1.26 local TLS fixture failures remain in runner tests

No cluster contact, runner publication, or launch is part of this PR.