### PR TITLE
fix(runner): bind deferred mode at manifest edges

### DIFF
--- a/internal/runner/full_run_execution_manifest.go
+++ b/internal/runner/full_run_execution_manifest.go
@@ -280,7 +280,8 @@ func (manifest VerifiedFullRunExecutionManifest) ExecutionConfig(runtime FullRun
 	expected := fullRunPlanExpected(document.Plan.Expected)
 	if plan.PlanDigest != manifest.receipt.PlanDigest || plan.IntentRevision != expected.IntentRevision ||
 		plan.EnablementRevision != expected.EnablementRevision || plan.PlatformRevision != expected.PlatformRevision ||
-		plan.ExecutionFixture != expected.ExecutionFixture || plan.ExecutionAttempt != expected.ExecutionAttemptDigest {
+		plan.ExecutionFixture != expected.ExecutionFixture || plan.ExecutionAttempt != expected.ExecutionAttemptDigest ||
+		plan.NetworkObservationMode != expected.NetworkObservationMode {
 		return FullRunExecutionConfig{}, errors.New("verified full-run manifest plan changed after loading")
 	}
 	lifecycleInterval, lifecycleTimeout, err := parsePostRuntimePolling(document.LifecycleObservation.PollInterval, document.LifecycleObservation.PollTimeout)
@@ -491,14 +492,7 @@ func LoadFullRunExecutionManifest(path string) (VerifiedFullRunExecutionManifest
 		return VerifiedFullRunExecutionManifest{}, receipt, err
 	}
 	receipt.ManifestDigest = manifestDigest
-	expected := stageplan.Expected{
-		ContractIdentity: document.Plan.Expected.ContractIdentity,
-		IntentRevision:   document.Plan.Expected.IntentRevision, EnablementRevision: document.Plan.Expected.EnablementRevision,
-		PlatformRevision: document.Plan.Expected.PlatformRevision, ExecutionFixture: document.Plan.Expected.ExecutionFixture,
-		ExecutionAttemptDigest:  document.Plan.Expected.ExecutionAttemptDigest,
-		InfrastructureAuthority: document.Plan.Expected.InfrastructureAuthority,
-		ManagementAuthority:     document.Plan.Expected.ManagementAuthority, GitOpsAuthority: document.Plan.Expected.GitOpsAuthority,
-	}
+	expected := fullRunPlanExpected(document.Plan.Expected)
 	plan, err := stageplan.Load(document.Plan.Path, expected)
 	if err != nil {
 		return VerifiedFullRunExecutionManifest{}, receipt, errors.New("load full-run staged plan")

--- a/internal/runner/full_run_execution_manifest_test.go
+++ b/internal/runner/full_run_execution_manifest_test.go
@@ -65,6 +65,31 @@ func TestLoadFullRunExecutionManifestV4BindsExecutionAttempt(t *testing.T) {
 	}
 }
 
+func TestLoadFullRunExecutionManifestBindsDeferredMVPNetworkObservation(t *testing.T) {
+	manifestPath, cleanup := fullRunExecutionManifestFixtureWithNetworkMode(t, "deferred-mvp/v1")
+	defer cleanup()
+
+	manifest, receipt, err := LoadFullRunExecutionManifest(manifestPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if receipt.State != "VERIFIED" || manifest.plan.NetworkObservationMode != "deferred-mvp/v1" {
+		t.Fatalf("deferred network observation mode was not bound at the full-run manifest edge: %#v", receipt)
+	}
+
+	manifest.plan.NetworkObservationMode = ""
+	_, err = manifest.ExecutionConfig(FullRunExecutionManifestRuntime{
+		PlatformCapability: FullRunPlatformCapabilityFactoryFunc(func(FullRunPlatformCapabilityBinding) (PlatformCapabilityResolver, error) {
+			return nil, nil
+		}),
+		Clock: time.Now,
+		Wait:  WaitWithTimer,
+	})
+	if err == nil || !strings.Contains(err.Error(), "plan changed after loading") {
+		t.Fatalf("in-memory network observation mode mutation was accepted: %v", err)
+	}
+}
+
 func TestFullRunExecutionManifestAttemptFormatFailsClosed(t *testing.T) {
 	tests := map[string]func(*fullRunExecutionManifestDocument, map[string]any){
 		"v3 cannot acquire attempt": func(document *fullRunExecutionManifestDocument, plan map[string]any) {
@@ -382,8 +407,12 @@ func TestFullRunExecutionManifestDigestIsFormattingIndependent(t *testing.T) {
 }
 
 func fullRunExecutionManifestFixture(t *testing.T) (string, func()) {
+	return fullRunExecutionManifestFixtureWithNetworkMode(t, "")
+}
+
+func fullRunExecutionManifestFixtureWithNetworkMode(t *testing.T, networkObservationMode string) (string, func()) {
 	t.Helper()
-	postManifest, _, cleanup := postRuntimeManifestFixture(t)
+	postManifest, _, cleanup := postRuntimeManifestFixtureWithNetworkMode(t, networkObservationMode)
 	post, _, err := loadPostRuntimeExecutionManifest(postManifest)
 	if err != nil {
 		cleanup()

--- a/internal/runner/post_runtime_execution_manifest.go
+++ b/internal/runner/post_runtime_execution_manifest.go
@@ -199,14 +199,7 @@ func openPostRuntimeExecutionManifest(path string, factories postRuntimeExecutio
 		return nil, receipt, err
 	}
 	receipt.ManifestDigest = manifestDigest
-	expected := stageplan.Expected{
-		ContractIdentity: document.Plan.Expected.ContractIdentity,
-		IntentRevision:   document.Plan.Expected.IntentRevision, EnablementRevision: document.Plan.Expected.EnablementRevision,
-		PlatformRevision: document.Plan.Expected.PlatformRevision, ExecutionFixture: document.Plan.Expected.ExecutionFixture,
-		ExecutionAttemptDigest:  document.Plan.Expected.ExecutionAttemptDigest,
-		InfrastructureAuthority: document.Plan.Expected.InfrastructureAuthority, ManagementAuthority: document.Plan.Expected.ManagementAuthority,
-		GitOpsAuthority: document.Plan.Expected.GitOpsAuthority,
-	}
+	expected := fullRunPlanExpected(document.Plan.Expected)
 	receipts, err := LoadStageReceiptPrefix(document.Plan.ReceiptPrefixPath, document.Plan.ReceiptPrefixDigest)
 	if err != nil {
 		return nil, receipt, errors.New("load post-runtime receipt prefix")

--- a/internal/runner/post_runtime_execution_manifest_test.go
+++ b/internal/runner/post_runtime_execution_manifest_test.go
@@ -49,6 +49,19 @@ func TestOpenPostRuntimeExecutionManifestBindsExactPrivateActivation(t *testing.
 	}
 }
 
+func TestOpenPostRuntimeExecutionManifestBindsDeferredMVPNetworkObservation(t *testing.T) {
+	manifest, factories, cleanup := postRuntimeManifestFixtureWithNetworkMode(t, "deferred-mvp/v1")
+	defer cleanup()
+
+	executor, receipt, err := openPostRuntimeExecutionManifest(manifest, factories)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if executor == nil || receipt.State != "VERIFIED" {
+		t.Fatalf("deferred network observation mode was not bound at the post-runtime manifest edge: %#v", receipt)
+	}
+}
+
 func TestPostRuntimeExecutionManifestFailsClosedBeforeActivation(t *testing.T) {
 	manifest, factories, cleanup := postRuntimeManifestFixture(t)
 	defer cleanup()
@@ -234,6 +247,10 @@ func postRuntimeRecoveryManifestFixture(t *testing.T, manifest string, includeRe
 }
 
 func postRuntimeManifestFixture(t *testing.T) (string, postRuntimeExecutionFactories, func()) {
+	return postRuntimeManifestFixtureWithNetworkMode(t, "")
+}
+
+func postRuntimeManifestFixtureWithNetworkMode(t *testing.T, networkObservationMode string) (string, postRuntimeExecutionFactories, func()) {
 	t.Helper()
 	root := t.TempDir()
 	at := time.Date(2026, 8, 18, 8, 0, 0, 0, time.UTC)
@@ -242,6 +259,7 @@ func postRuntimeManifestFixture(t *testing.T) (string, postRuntimeExecutionFacto
 		IntentRevision:   runnerStageSHA("a"), EnablementRevision: runnerStageSHA("b"),
 		PlatformRevision: runnerStageSHA("c"), ExecutionFixture: runnerStageSHA("d"),
 		InfrastructureAuthority: "ok-infra", ManagementAuthority: "ok-mgmt", GitOpsAuthority: "ok-shared",
+		NetworkObservationMode: networkObservationMode,
 	}
 	targetAccess := runnerTargetAccessYAML()
 	policy := targetCredentialPolicyDocument{
@@ -404,6 +422,7 @@ func postRuntimeManifestFixture(t *testing.T) (string, postRuntimeExecutionFacto
 				ContractIdentity: plan.ContractIdentity, IntentRevision: plan.IntentRevision, EnablementRevision: plan.EnablementRevision,
 				PlatformRevision: plan.PlatformRevision, ExecutionFixture: plan.ExecutionFixture,
 				InfrastructureAuthority: plan.Authorities.Infrastructure, ManagementAuthority: plan.Authorities.Management, GitOpsAuthority: plan.Authorities.GitOps,
+				NetworkObservationMode: plan.NetworkObservationMode,
 			},
 			ReceiptPrefixPath: prefixPath, ReceiptPrefixDigest: fileSHA(t, prefixPath),
 		},


### PR DESCRIPTION
## Summary
- bind networkObservationMode through both full-run and post-runtime manifest verification edges
- verify the bound mode again when building the in-memory execution configuration
- add full-run and post-runtime deferred-mode integration regressions

## Validation
- targeted deferred manifest tests pass
- full internal/runner suite: only the four known date/environment-dependent fixture failures reported independently in the PR #363 security review

Addresses the fail-closed M1 finding from the independent PR #363 security review.