### PR TITLE
fix(cli): bind deferred mode in authority policy

### DIFF
--- a/cmd/ok/stage_authority.go
+++ b/cmd/ok/stage_authority.go
@@ -123,6 +123,7 @@ func runAuthorityStagePolicy(arguments []string, stdout, stderr io.Writer) error
 	platformRevision := flags.String("platform-revision", "", "expected Platform revision P")
 	executionFixture := flags.String("execution-fixture", "", "expected execution FixtureDigest")
 	executionAttempt := flags.String("execution-attempt-digest", "", "expected execution-attempt digest for plan v2")
+	networkObservationMode := flags.String("network-observation-mode", "", "expected plan-bound network observation mode")
 	infrastructureAuthority := flags.String("infrastructure-authority", "", "expected infrastructure authority")
 	managementAuthority := flags.String("management-authority", "", "expected management authority")
 	gitOpsAuthority := flags.String("gitops-authority", "", "expected GitOps authority")
@@ -147,6 +148,7 @@ func runAuthorityStagePolicy(arguments []string, stdout, stderr io.Writer) error
 		PlatformRevision: *platformRevision, ExecutionFixture: *executionFixture,
 		ExecutionAttemptDigest:  *executionAttempt,
 		InfrastructureAuthority: *infrastructureAuthority, ManagementAuthority: *managementAuthority, GitOpsAuthority: *gitOpsAuthority,
+		NetworkObservationMode: *networkObservationMode,
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary
- add an explicit independently supplied network observation mode to the authority-policy CLI edge
- feed the value into stageplan.Expected so a deferred plan cannot self-authorize
- preserve the empty default for ordinary fail-closed plans

## Validation
- go test ./cmd/ok
- offline R40 policy generation accepts only the explicitly supplied deferred-mvp/v1 binding