### PR TITLE
fix(runner): bound runtime binding convergence

### DIFF
--- a/internal/execution/staged_binding.go
+++ b/internal/execution/staged_binding.go
@@ -26,9 +26,10 @@ type StageBinderBinding struct {
 // StageBindingResult is the redaction-safe result of producing one private,
 // digest-bound runtime correlation artifact.
 type StageBindingResult struct {
-	Outcome        string
-	EvidenceDigest string
-	CompletedAt    time.Time
+	Outcome         string
+	EvidenceDigest  string
+	CompletedAt     time.Time
+	FailureCategory string
 }
 
 // StageBinder is preconstructed for exactly one local binding stage. It has no
@@ -53,10 +54,17 @@ type BindingStageRunReceipt struct {
 	StageReceiptDigest string `json:"stageReceiptDigest,omitempty"`
 }
 
-type BindingStageResultError struct{ State string }
+type BindingStageResultError struct {
+	State           string
+	FailureCategory string
+}
 
 func (err *BindingStageResultError) Error() string {
 	return "binding stage completed with " + err.State
+}
+
+func (err *BindingStageResultError) RedactedStopCategory() string {
+	return err.FailureCategory
 }
 
 // Run invokes at most one prebound local binder. An already persisted receipt
@@ -121,7 +129,8 @@ func (operation BindingStageOperation) run(ctx context.Context, plan stageplan.B
 	if bindErr != nil {
 		return receipt, errors.New("bounded runtime binding failed")
 	}
-	if !oneOf(result.Outcome, "SUCCEEDED", "FAILED", "STOPPED") || !stagedDigestPattern.MatchString(result.EvidenceDigest) || result.CompletedAt.IsZero() {
+	if !oneOf(result.Outcome, "SUCCEEDED", "FAILED", "STOPPED") || !stagedDigestPattern.MatchString(result.EvidenceDigest) || result.CompletedAt.IsZero() ||
+		(result.Outcome == "SUCCEEDED" && result.FailureCategory != "") || (result.FailureCategory != "" && !validBindingFailureCategory(result.FailureCategory)) {
 		return receipt, errors.New("stage binder returned an invalid redaction-safe result")
 	}
 	verified, err := stagereceipt.New(plan, decision.StageID, predecessors, result.Outcome, "NOT_APPLICABLE", "", result.EvidenceDigest, result.CompletedAt)
@@ -131,10 +140,23 @@ func (operation BindingStageOperation) run(ctx context.Context, plan stageplan.B
 	if _, err := operation.Ledger.StoreStageReceipt(ctx, plan, verified, predecessors); err != nil {
 		return receipt, err
 	}
-	return finalizeBindingRunReceipt(receipt, verified)
+	return finalizeBindingRunReceiptWithCategory(receipt, verified, result.FailureCategory)
+}
+
+func validBindingFailureCategory(category string) bool {
+	switch category {
+	case "RUNTIME_BINDING_SOURCE_STOPPED", "RUNTIME_BINDING_MATERIALIZATION_STOPPED", "RUNTIME_BINDING_MATERIAL_VERIFICATION_STOPPED", "RUNTIME_BINDING_PERSISTENCE_STOPPED", "RUNTIME_BINDING_WRITER_OPEN_STOPPED":
+		return true
+	default:
+		return false
+	}
 }
 
 func finalizeBindingRunReceipt(receipt BindingStageRunReceipt, verified stagereceipt.Verified) (BindingStageRunReceipt, error) {
+	return finalizeBindingRunReceiptWithCategory(receipt, verified, "")
+}
+
+func finalizeBindingRunReceiptWithCategory(receipt BindingStageRunReceipt, verified stagereceipt.Verified, category string) (BindingStageRunReceipt, error) {
 	stageReceipt, err := verified.Receipt()
 	if err != nil {
 		return receipt, err
@@ -146,7 +168,7 @@ func finalizeBindingRunReceipt(receipt BindingStageRunReceipt, verified stagerec
 	receipt.StageReceiptDigest = digest
 	receipt.State = "COMPLETED_" + stageReceipt.State
 	if stageReceipt.State != "SUCCEEDED" {
-		return receipt, &BindingStageResultError{State: receipt.State}
+		return receipt, &BindingStageResultError{State: receipt.State, FailureCategory: category}
 	}
 	return receipt, nil
 }

--- a/internal/execution/staged_binding_test.go
+++ b/internal/execution/staged_binding_test.go
@@ -37,12 +37,15 @@ func TestBindingStagePersistsTerminalResultWithoutRawError(t *testing.T) {
 	store, _ := ledger.Open(filepath.Join(t.TempDir(), "ledger"))
 	binder := &fakeStageBinder{
 		binding: binderBinding(t, plan, "runtime-binding"),
-		result:  StageBindingResult{Outcome: "STOPPED", EvidenceDigest: stagedSHA("f"), CompletedAt: at},
+		result:  StageBindingResult{Outcome: "STOPPED", EvidenceDigest: stagedSHA("f"), CompletedAt: at, FailureCategory: "RUNTIME_BINDING_SOURCE_STOPPED"},
 	}
 	receipt, err := (BindingStageOperation{Ledger: store, Binder: binder}).Run(context.Background(), plan, cursor)
 	var resultErr *BindingStageResultError
 	if !errors.As(err, &resultErr) || receipt.State != "COMPLETED_STOPPED" || receipt.StageReceiptDigest == "" {
 		t.Fatalf("terminal binding was not retained: %#v %v", receipt, err)
+	}
+	if resultErr.RedactedStopCategory() != "RUNTIME_BINDING_SOURCE_STOPPED" {
+		t.Fatalf("redacted binding failure category was lost: %#v", resultErr)
 	}
 }
 

--- a/internal/runner/pre_runtime_orchestrator.go
+++ b/internal/runner/pre_runtime_orchestrator.go
@@ -121,7 +121,10 @@ func (orchestration PreRuntimeOrchestration) Run(ctx context.Context) (PreRuntim
 
 	runtimeBindingReceipt, runErr := orchestration.RunRuntimeBinding(ctx, networkObservationReceipt)
 	if err := appendPreRuntimeCheckpoint(&receipt, preRuntimeStageOrder[5], execution.BindingStageReceiptFormat, runtimeBindingReceipt.Format, runtimeBindingReceipt.State, runtimeBindingReceipt.PlanDigest, runtimeBindingReceipt.StageID, runtimeBindingReceipt.StageReceiptDigest); err != nil || runErr != nil {
-		return stopPreRuntimeOrchestration(receipt, preRuntimeStageOrder[5])
+		if runErr != nil {
+			return stopPreRuntimeOrchestrationWithCause(receipt, preRuntimeStageOrder[5], runErr)
+		}
+		return stopPreRuntimeOrchestrationWithCause(receipt, preRuntimeStageOrder[5], err)
 	}
 	if err := ctx.Err(); err != nil {
 		return stopPreRuntimeOrchestration(receipt, preRuntimeStageOrder[6])
@@ -177,7 +180,8 @@ func redactedStopCategory(cause error) string {
 	var categorized redactedStopCategorizer
 	if errors.As(cause, &categorized) {
 		switch category := categorized.RedactedStopCategory(); category {
-		case "OBSERVATION_SOURCE_ERROR", "OBSERVATION_RESULT_INVALID", "OBSERVATION_INTERRUPTED":
+		case "OBSERVATION_SOURCE_ERROR", "OBSERVATION_RESULT_INVALID", "OBSERVATION_INTERRUPTED",
+			"RUNTIME_BINDING_SOURCE_STOPPED", "RUNTIME_BINDING_MATERIALIZATION_STOPPED", "RUNTIME_BINDING_MATERIAL_VERIFICATION_STOPPED", "RUNTIME_BINDING_PERSISTENCE_STOPPED", "RUNTIME_BINDING_WRITER_OPEN_STOPPED":
 			return category
 		}
 	}
@@ -192,7 +196,8 @@ func validRedactedStopCategory(category string) bool {
 	switch category {
 	case "ORCHESTRATION_STOPPED", "STAGE_EXECUTION_ERROR", "OBSERVATION_SOURCE_ERROR",
 		"OBSERVATION_RESULT_INVALID", "OBSERVATION_INTERRUPTED", "OBSERVATION_COMPLETED_FAILED",
-		"OBSERVATION_COMPLETED_STOPPED":
+		"OBSERVATION_COMPLETED_STOPPED", "RUNTIME_BINDING_SOURCE_STOPPED", "RUNTIME_BINDING_MATERIALIZATION_STOPPED",
+		"RUNTIME_BINDING_MATERIAL_VERIFICATION_STOPPED", "RUNTIME_BINDING_PERSISTENCE_STOPPED", "RUNTIME_BINDING_WRITER_OPEN_STOPPED":
 		return true
 	default:
 		return false

--- a/internal/runner/pre_runtime_orchestrator_test.go
+++ b/internal/runner/pre_runtime_orchestrator_test.go
@@ -160,6 +160,22 @@ func TestPreRuntimeOrchestrationReportsRedactedNetworkStopCategory(t *testing.T)
 	}
 }
 
+func TestPreRuntimeOrchestrationReportsRedactedRuntimeBindingStopCategory(t *testing.T) {
+	orchestration := successfulPreRuntimeOrchestration(nil)
+	orchestration.RunRuntimeBinding = func(context.Context, execution.ObservationStageRunReceipt) (execution.BindingStageRunReceipt, error) {
+		return execution.BindingStageRunReceipt{Format: execution.BindingStageReceiptFormat, State: "COMPLETED_STOPPED", PlanDigest: runnerStageSHA("a"), StageID: "runtime-binding", StageReceiptDigest: runnerStageSHA("6")},
+			&execution.BindingStageResultError{State: "COMPLETED_STOPPED", FailureCategory: "RUNTIME_BINDING_SOURCE_STOPPED"}
+	}
+	receipt, err := orchestration.Run(context.Background())
+	if err == nil || receipt.State != "STOPPED" || receipt.StoppedAt != "runtime-binding" || receipt.StopCategory != "RUNTIME_BINDING_SOURCE_STOPPED" || len(receipt.Checkpoints) != 5 {
+		t.Fatalf("runtime binding stop category was not preserved: %#v err=%v", receipt, err)
+	}
+	encoded, marshalErr := json.Marshal(receipt)
+	if marshalErr != nil || strings.Contains(string(encoded), "private") {
+		t.Fatalf("runtime binding receipt exposed a private cause: %s err=%v", encoded, marshalErr)
+	}
+}
+
 func TestPreRuntimeOrchestrationRejectsMalformedAndForeignReceipts(t *testing.T) {
 	for name, mutate := range map[string]func(*execution.ObservationStageRunReceipt){
 		"wrong format": func(receipt *execution.ObservationStageRunReceipt) { receipt.Format = execution.StagedReceiptFormat },

--- a/internal/runner/runtime_binding_source.go
+++ b/internal/runner/runtime_binding_source.go
@@ -2,10 +2,12 @@ package runner
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"errors"
-	"fmt"
 	"io"
 	"mime"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -16,16 +18,34 @@ import (
 )
 
 const (
-	runtimeBindingKubeSystemPath = "/api/v1/namespaces/kube-system"
-	runtimeBindingLocalPathPath  = "/apis/storage.k8s.io/v1/storageclasses/local-path"
-	maximumRuntimeBindingSource  = 1024 * 1024
+	runtimeBindingKubeSystemPath  = "/api/v1/namespaces/kube-system"
+	runtimeBindingLocalPathPath   = "/apis/storage.k8s.io/v1/storageclasses/local-path"
+	maximumRuntimeBindingSource   = 1024 * 1024
+	runtimeBindingPollInterval    = 5 * time.Second
+	runtimeBindingPollTimeout     = 30 * time.Minute
+	runtimeBindingMaximumAttempts = 361
 )
+
+type runtimeBindingWaiter func(context.Context, time.Duration) error
+
+type runtimeBindingSourceError struct {
+	transient bool
+	missing   bool
+	resource  string
+}
+
+func (err *runtimeBindingSourceError) Error() string { return "bounded runtime binding source stopped" }
 
 type KubernetesRuntimeBindingSource struct {
 	endpoint          *url.URL
 	token             string
 	clientCertificate bool
 	client            *http.Client
+	clock             func() time.Time
+	wait              runtimeBindingWaiter
+	interval          time.Duration
+	timeout           time.Duration
+	maximumAttempts   int
 }
 
 // OpenKubernetesRuntimeBindingSource opens one short-lived, read-only workload
@@ -88,34 +108,75 @@ func newKubernetesRuntimeBindingSourceWithTransport(endpoint string, transport b
 	parsed.Path, parsed.RawPath = "", ""
 	return &KubernetesRuntimeBindingSource{
 		endpoint: parsed, token: transport.bearerToken, clientCertificate: transport.clientCertificate, client: &bounded,
+		clock: time.Now, wait: WaitWithTimer, interval: runtimeBindingPollInterval, timeout: runtimeBindingPollTimeout,
+		maximumAttempts: runtimeBindingMaximumAttempts,
 	}, nil
 }
 
-// Observe performs exactly the namespace GET followed by the StorageClass GET.
-// It exposes only the immutable fields consumed by runtime materialization.
+// Observe polls only the two fixed read-only identities within hard time and
+// attempt bounds. Permanent identity or response failures remain fail-closed.
 func (source *KubernetesRuntimeBindingSource) Observe(ctx context.Context) (RuntimeBindingObservation, error) {
-	if source == nil || source.endpoint == nil || source.client == nil {
+	if source == nil || source.endpoint == nil || source.client == nil || source.clock == nil || source.wait == nil ||
+		source.interval < time.Second || source.timeout < source.interval || source.maximumAttempts < 1 {
 		return RuntimeBindingObservation{}, errors.New("runtime binding source is required")
 	}
+	deadline := source.clock().Add(source.timeout)
+	namespaceSeen, storageSeen := false, false
+	namespaceUID := ""
+	for attempt := 1; attempt <= source.maximumAttempts; attempt++ {
+		previousNamespaceSeen, previousStorageSeen := namespaceSeen, storageSeen
+		observation, namespaceObserved, storageObserved, err := source.observeOnce(ctx, namespaceUID)
+		if namespaceObserved {
+			namespaceUID = observation.KubeSystemUID
+		}
+		namespaceSeen = namespaceSeen || namespaceObserved
+		storageSeen = storageSeen || storageObserved
+		if err == nil {
+			return observation, nil
+		}
+		var sourceErr *runtimeBindingSourceError
+		categorized := errors.As(err, &sourceErr)
+		regressedMissing := categorized && sourceErr.missing &&
+			(sourceErr.resource == runtimeBindingKubeSystemPath && previousNamespaceSeen || sourceErr.resource == runtimeBindingLocalPathPath && previousStorageSeen)
+		if !categorized || !sourceErr.transient || regressedMissing {
+			return RuntimeBindingObservation{}, errors.New("bounded runtime binding source stopped")
+		}
+		now := source.clock()
+		if attempt == source.maximumAttempts || !now.Before(deadline) {
+			return RuntimeBindingObservation{}, errors.New("bounded runtime binding convergence exhausted")
+		}
+		wait := source.interval
+		if remaining := deadline.Sub(now); remaining < wait {
+			wait = remaining
+		}
+		if err := source.wait(ctx, wait); err != nil {
+			return RuntimeBindingObservation{}, errors.New("bounded runtime binding convergence interrupted")
+		}
+	}
+	return RuntimeBindingObservation{}, errors.New("bounded runtime binding convergence exhausted")
+}
+
+func (source *KubernetesRuntimeBindingSource) observeOnce(ctx context.Context, expectedNamespaceUID string) (RuntimeBindingObservation, bool, bool, error) {
 	namespaceRaw, err := source.get(ctx, runtimeBindingKubeSystemPath)
 	if err != nil {
-		return RuntimeBindingObservation{}, errors.New("read bounded kube-system identity")
+		return RuntimeBindingObservation{}, false, false, err
 	}
 	namespace, err := decodeRuntimeBindingObject(namespaceRaw)
 	if err != nil || namespace.kind != "Namespace" || !runtimeInputUIDPattern.MatchString(namespace.uid) {
-		return RuntimeBindingObservation{}, errors.New("kube-system identity is invalid")
+		return RuntimeBindingObservation{}, true, false, errors.New("kube-system identity is invalid")
+	}
+	if expectedNamespaceUID != "" && namespace.uid != expectedNamespaceUID {
+		return RuntimeBindingObservation{}, true, false, errors.New("kube-system identity changed during convergence")
 	}
 	storageRaw, err := source.get(ctx, runtimeBindingLocalPathPath)
 	if err != nil {
-		return RuntimeBindingObservation{}, errors.New("read bounded local-path identity")
+		return RuntimeBindingObservation{KubeSystemUID: namespace.uid}, true, false, err
 	}
 	storage, err := decodeRuntimeBindingObject(storageRaw)
 	if err != nil || storage.kind != "StorageClass" || !runtimeInputUIDPattern.MatchString(storage.uid) || storage.provisioner != "rancher.io/local-path" {
-		return RuntimeBindingObservation{}, errors.New("local-path identity is invalid")
+		return RuntimeBindingObservation{}, true, true, errors.New("local-path identity is invalid")
 	}
-	return RuntimeBindingObservation{
-		KubeSystemUID: namespace.uid, LocalPathStorageClassUID: storage.uid, LocalPathProvisioner: storage.provisioner,
-	}, nil
+	return RuntimeBindingObservation{KubeSystemUID: namespace.uid, LocalPathStorageClassUID: storage.uid, LocalPathProvisioner: storage.provisioner}, true, true, nil
 }
 
 func (source *KubernetesRuntimeBindingSource) get(ctx context.Context, path string) ([]byte, error) {
@@ -134,7 +195,7 @@ func (source *KubernetesRuntimeBindingSource) get(ctx context.Context, path stri
 	}
 	response, err := source.client.Do(request)
 	if err != nil {
-		return nil, errors.New("bounded runtime binding request failed")
+		return nil, &runtimeBindingSourceError{transient: transientRuntimeBindingTransportError(err), resource: path}
 	}
 	defer response.Body.Close()
 	raw, readErr := io.ReadAll(io.LimitReader(response.Body, maximumRuntimeBindingSource+1))
@@ -142,13 +203,38 @@ func (source *KubernetesRuntimeBindingSource) get(ctx context.Context, path stri
 		return nil, errors.New("bounded runtime binding response exceeds accepted size")
 	}
 	if response.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("bounded runtime binding request returned HTTP %d", response.StatusCode)
+		return nil, &runtimeBindingSourceError{transient: transientRuntimeBindingStatus(response.StatusCode), missing: response.StatusCode == http.StatusNotFound, resource: path}
 	}
 	mediaType, _, err := mime.ParseMediaType(response.Header.Get("Content-Type"))
 	if err != nil || mediaType != "application/json" {
 		return nil, errors.New("bounded runtime binding response is not JSON")
 	}
 	return raw, nil
+}
+
+func transientRuntimeBindingStatus(status int) bool {
+	switch status {
+	case http.StatusNotFound, http.StatusTooManyRequests, http.StatusInternalServerError, http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout:
+		return true
+	default:
+		return false
+	}
+}
+
+func transientRuntimeBindingTransportError(err error) bool {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	var unknownAuthority x509.UnknownAuthorityError
+	var certificateInvalid x509.CertificateInvalidError
+	var hostname x509.HostnameError
+	var recordHeader tls.RecordHeaderError
+	var verification *tls.CertificateVerificationError
+	if errors.As(err, &unknownAuthority) || errors.As(err, &certificateInvalid) || errors.As(err, &hostname) || errors.As(err, &recordHeader) || errors.As(err, &verification) {
+		return false
+	}
+	var networkError net.Error
+	return errors.As(err, &networkError)
 }
 
 type runtimeBindingObject struct {

--- a/internal/runner/runtime_binding_source_test.go
+++ b/internal/runner/runtime_binding_source_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/openkubes/ok-cluster/internal/digest"
 )
@@ -117,5 +118,180 @@ func TestRuntimeBindingSourceFailsClosed(t *testing.T) {
 	}
 	if _, err := (&KubernetesRuntimeBindingSource{}).Observe(context.Background()); err == nil {
 		t.Fatal("unopened runtime binding source could observe")
+	}
+}
+
+func TestRuntimeBindingSourcePollsTransientAbsenceThenSucceeds(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		requests++
+		response.Header().Set("Content-Type", "application/json")
+		if requests == 1 {
+			response.WriteHeader(http.StatusNotFound)
+			return
+		}
+		if request.URL.Path == runtimeBindingKubeSystemPath {
+			fmt.Fprint(response, `{"kind":"Namespace","metadata":{"uid":"kube-system-runtime-uid"}}`)
+			return
+		}
+		fmt.Fprint(response, `{"kind":"StorageClass","metadata":{"uid":"local-path-runtime-uid"},"provisioner":"rancher.io/local-path"}`)
+	}))
+	defer server.Close()
+	source, err := newKubernetesRuntimeBindingSource(server.URL, "runtime-token", server.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	waits := 0
+	source.wait = func(context.Context, time.Duration) error { waits++; return nil }
+	if _, err := source.Observe(context.Background()); err != nil || waits != 1 || requests != 3 {
+		t.Fatalf("transient convergence did not succeed: requests=%d waits=%d err=%v", requests, waits, err)
+	}
+}
+
+func TestRuntimeBindingSourceFailsWhenSeenIdentityDisappears(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		requests++
+		response.Header().Set("Content-Type", "application/json")
+		switch requests {
+		case 1:
+			fmt.Fprint(response, `{"kind":"Namespace","metadata":{"uid":"kube-system-runtime-uid"}}`)
+		case 2:
+			response.WriteHeader(http.StatusServiceUnavailable)
+		default:
+			response.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+	source, err := newKubernetesRuntimeBindingSource(server.URL, "runtime-token", server.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	waits := 0
+	source.wait = func(context.Context, time.Duration) error { waits++; return nil }
+	if _, err := source.Observe(context.Background()); err == nil || waits != 1 || requests != 3 {
+		t.Fatalf("seen-then-missing identity was retried: requests=%d waits=%d err=%v", requests, waits, err)
+	}
+}
+
+func TestRuntimeBindingSourceFailsWhenSeenIdentityChanges(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		requests++
+		response.Header().Set("Content-Type", "application/json")
+		if request.URL.Path == runtimeBindingLocalPathPath {
+			response.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		uid := "kube-system-runtime-uid-a"
+		if requests > 2 {
+			uid = "kube-system-runtime-uid-b"
+		}
+		fmt.Fprintf(response, `{"kind":"Namespace","metadata":{"uid":%q}}`, uid)
+	}))
+	defer server.Close()
+	source, err := newKubernetesRuntimeBindingSource(server.URL, "runtime-token", server.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	waits := 0
+	source.wait = func(context.Context, time.Duration) error { waits++; return nil }
+	if _, err := source.Observe(context.Background()); err == nil || waits != 1 || requests != 3 {
+		t.Fatalf("changed identity was retried: requests=%d waits=%d err=%v", requests, waits, err)
+	}
+}
+
+func TestRuntimeBindingSourceBoundsTransientPollingByAttempts(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, _ *http.Request) {
+		requests++
+		response.Header().Set("Content-Type", "application/json")
+		response.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+	source, err := newKubernetesRuntimeBindingSource(server.URL, "runtime-token", server.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	source.maximumAttempts = 2
+	waits := 0
+	source.wait = func(context.Context, time.Duration) error { waits++; return nil }
+	if _, err := source.Observe(context.Background()); err == nil || waits != 1 || requests != 2 {
+		t.Fatalf("attempt bound was not enforced: requests=%d waits=%d err=%v", requests, waits, err)
+	}
+}
+
+func TestRuntimeBindingSourcePermanentHTTPFailuresAreNotPolled(t *testing.T) {
+	for _, status := range []int{http.StatusUnauthorized, http.StatusForbidden, http.StatusNotImplemented} {
+		t.Run(fmt.Sprint(status), func(t *testing.T) {
+			requests := 0
+			server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, _ *http.Request) {
+				requests++
+				response.Header().Set("Content-Type", "application/json")
+				response.WriteHeader(status)
+			}))
+			defer server.Close()
+			source, err := newKubernetesRuntimeBindingSource(server.URL, "runtime-token", server.Client())
+			if err != nil {
+				t.Fatal(err)
+			}
+			source.wait = func(context.Context, time.Duration) error { t.Fatal("permanent failure reached waiter"); return nil }
+			if _, err := source.Observe(context.Background()); err == nil || requests != 1 {
+				t.Fatalf("permanent HTTP failure was accepted or retried: requests=%d err=%v", requests, err)
+			}
+		})
+	}
+}
+
+func TestRuntimeBindingSourceHTTPTransientAllowlistIsExact(t *testing.T) {
+	transient := map[int]bool{
+		http.StatusNotFound: true, http.StatusTooManyRequests: true, http.StatusInternalServerError: true,
+		http.StatusBadGateway: true, http.StatusServiceUnavailable: true, http.StatusGatewayTimeout: true,
+	}
+	for _, status := range []int{400, 401, 403, 404, 408, 409, 422, 429, 500, 501, 502, 503, 504, 505} {
+		if got := transientRuntimeBindingStatus(status); got != transient[status] {
+			t.Fatalf("HTTP %d transient=%t want=%t", status, got, transient[status])
+		}
+	}
+}
+
+func TestRuntimeBindingSourceBoundsTransientPollingByDeadline(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, _ *http.Request) {
+		requests++
+		response.Header().Set("Content-Type", "application/json")
+		response.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+	source, err := newKubernetesRuntimeBindingSource(server.URL, "runtime-token", server.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2026, 9, 5, 8, 0, 0, 0, time.UTC)
+	source.clock = func() time.Time { return now }
+	source.interval, source.timeout, source.maximumAttempts = time.Second, 2*time.Second, 20
+	waits := 0
+	source.wait = func(_ context.Context, duration time.Duration) error { waits++; now = now.Add(duration); return nil }
+	if _, err := source.Observe(context.Background()); err == nil || waits != 2 || requests != 3 {
+		t.Fatalf("deadline bound was not enforced: requests=%d waits=%d err=%v", requests, waits, err)
+	}
+}
+
+func TestRuntimeBindingSourceContextCancellationIsTerminal(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, _ *http.Request) {
+		requests++
+		response.Header().Set("Content-Type", "application/json")
+		response.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+	source, err := newKubernetesRuntimeBindingSource(server.URL, "runtime-token", server.Client())
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	source.wait = func(context.Context, time.Duration) error { cancel(); return context.Canceled }
+	if _, err := source.Observe(ctx); err == nil || requests != 1 {
+		t.Fatalf("cancelled convergence was accepted or retried: requests=%d err=%v", requests, err)
 	}
 }

--- a/internal/runner/runtime_binding_stage.go
+++ b/internal/runner/runtime_binding_stage.go
@@ -152,6 +152,7 @@ func (bundle VerifiedRuntimeBindingStageBundle) open(ledgerConfig KubernetesLedg
 	if err != nil {
 		return OpenedRuntimeBindingStage{}, errors.New("open bounded runtime binding source")
 	}
+	source.clock = clock
 	if sameSecret(ledgerToken, workloadToken) || persistenceToken != "" && (sameSecret(persistenceToken, ledgerToken) || sameSecret(persistenceToken, workloadToken)) {
 		return OpenedRuntimeBindingStage{}, errors.New("runtime binding stage credentials must be pairwise distinct")
 	}
@@ -289,7 +290,11 @@ func (binder *runtimeBindingStageBinder) finish(evidence RuntimeBindingStageEvid
 	binder.mu.Lock()
 	binder.evidence, binder.hasEvidence = evidence, true
 	binder.mu.Unlock()
-	return execution.StageBindingResult{Outcome: outcome, EvidenceDigest: evidenceDigest, CompletedAt: at}, nil
+	category := ""
+	if evidence.FailureCategory != "" {
+		category = "RUNTIME_BINDING_" + evidence.FailureCategory
+	}
+	return execution.StageBindingResult{Outcome: outcome, EvidenceDigest: evidenceDigest, CompletedAt: at, FailureCategory: category}, nil
 }
 
 func (binder *runtimeBindingStageBinder) evidenceReceipt() (RuntimeBindingStageEvidenceReceipt, error) {


### PR DESCRIPTION
## Summary

- make runtime binding poll its two fixed workload identities within hard time and attempt bounds
- retry only the explicit transient allowlist while keeping identity, TLS, authorization, and response validation failures terminal
- propagate fixed redacted runtime-binding stop categories into the orchestration receipt

## Safety properties

- polling stays inside one `Bind()` and creates no additional stage receipts
- 30-minute deadline and 361-attempt maximum; timeout remains fail-closed
- seen-then-missing or changed namespace identity stops immediately
- no credential, endpoint, UID, raw response, or private error enters the orchestration receipt

## Verification

- focused runtime-binding, orchestration, and execution tests pass
- all packages compile with `go test ./... -run '^$'`\n- focused external review of `d8bb670` found the change ready for Draft PR\n\nThe known full-run test failures are pre-existing date/environment fixtures (expired test certificates and root filesystem semantics), unrelated to this change.