### PR TITLE
fix(ok147): bootstrap runtime storage with Talos

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,10 @@ Powered by [Cluster API (CAPI)](https://cluster-api.sigs.k8s.io/), [CAPK (KubeVi
   the private target endpoint, CA and raw runtime UIDs to the five-receipt
   prefix while exposing only digest identities publicly. A bounded source now
   performs only the exact `kube-system` and `local-path` GETs after proving the
-  workload authority, and an exclusive private writer creates and verifies one
+  workload authority. Talos KubeVirt lifecycle artifacts bootstrap the exact
+  `local-path` identity from a vendored, digest-pinned inline manifest, so this
+  prerequisite is part of the staged plan rather than a manual post-create
+  mutation. An exclusive private writer creates and verifies one
   `0600` binding file without overwrite or cleanup. These capabilities are now
   composed with the runner-owned crash-safe stage operation and immutable
   ledger receipt. `ok cluster stage bind runtime --execute` is the first local,

--- a/templates/talos/providers/kubevirt/cluster-base.yaml.tpl
+++ b/templates/talos/providers/kubevirt/cluster-base.yaml.tpl
@@ -112,6 +112,180 @@ spec:
         path: /cluster/proxy
         value:
           disabled: true
+      # Runtime binding and every platform application require this exact
+      # workload storage identity. Keeping the reviewed manifest inline makes
+      # it part of the lifecycle artifact and plan digest; no unbound
+      # post-bootstrap installer is needed.
+      # Source: rancher/local-path-provisioner v0.0.30
+      # deploy/local-path-storage.yaml
+      # Upstream source SHA-256 before image pinning:
+      # fe682186b00400fe7e2b72bae16f63e47a56a6dcc677938c6642139ef670045e
+      - op: add
+        path: /cluster/inlineManifests
+        value:
+        - name: local-path-provisioner-v0.0.30
+          contents: |-
+            apiVersion: v1
+            kind: Namespace
+            metadata:
+              name: local-path-storage
+
+            ---
+            apiVersion: v1
+            kind: ServiceAccount
+            metadata:
+              name: local-path-provisioner-service-account
+              namespace: local-path-storage
+
+            ---
+            apiVersion: rbac.authorization.k8s.io/v1
+            kind: Role
+            metadata:
+              name: local-path-provisioner-role
+              namespace: local-path-storage
+            rules:
+              - apiGroups: [""]
+                resources: ["pods"]
+                verbs: ["get", "list", "watch", "create", "patch", "update", "delete"]
+
+            ---
+            apiVersion: rbac.authorization.k8s.io/v1
+            kind: ClusterRole
+            metadata:
+              name: local-path-provisioner-role
+            rules:
+              - apiGroups: [""]
+                resources: ["nodes", "persistentvolumeclaims", "configmaps", "pods", "pods/log"]
+                verbs: ["get", "list", "watch"]
+              - apiGroups: [""]
+                resources: ["persistentvolumes"]
+                verbs: ["get", "list", "watch", "create", "patch", "update", "delete"]
+              - apiGroups: [""]
+                resources: ["events"]
+                verbs: ["create", "patch"]
+              - apiGroups: ["storage.k8s.io"]
+                resources: ["storageclasses"]
+                verbs: ["get", "list", "watch"]
+
+            ---
+            apiVersion: rbac.authorization.k8s.io/v1
+            kind: RoleBinding
+            metadata:
+              name: local-path-provisioner-bind
+              namespace: local-path-storage
+            roleRef:
+              apiGroup: rbac.authorization.k8s.io
+              kind: Role
+              name: local-path-provisioner-role
+            subjects:
+              - kind: ServiceAccount
+                name: local-path-provisioner-service-account
+                namespace: local-path-storage
+
+            ---
+            apiVersion: rbac.authorization.k8s.io/v1
+            kind: ClusterRoleBinding
+            metadata:
+              name: local-path-provisioner-bind
+            roleRef:
+              apiGroup: rbac.authorization.k8s.io
+              kind: ClusterRole
+              name: local-path-provisioner-role
+            subjects:
+              - kind: ServiceAccount
+                name: local-path-provisioner-service-account
+                namespace: local-path-storage
+
+            ---
+            apiVersion: apps/v1
+            kind: Deployment
+            metadata:
+              name: local-path-provisioner
+              namespace: local-path-storage
+            spec:
+              replicas: 1
+              selector:
+                matchLabels:
+                  app: local-path-provisioner
+              template:
+                metadata:
+                  labels:
+                    app: local-path-provisioner
+                spec:
+                  serviceAccountName: local-path-provisioner-service-account
+                  containers:
+                    - name: local-path-provisioner
+                      image: rancher/local-path-provisioner@sha256:9b914881170048f80ae9302f36e5b99b4a6b18af73a38adc1c66d12f65d360be
+                      imagePullPolicy: IfNotPresent
+                      command:
+                        - local-path-provisioner
+                        - --debug
+                        - start
+                        - --config
+                        - /etc/config/config.json
+                      volumeMounts:
+                        - name: config-volume
+                          mountPath: /etc/config/
+                      env:
+                        - name: POD_NAMESPACE
+                          valueFrom:
+                            fieldRef:
+                              fieldPath: metadata.namespace
+                        - name: CONFIG_MOUNT_PATH
+                          value: /etc/config/
+                  volumes:
+                    - name: config-volume
+                      configMap:
+                        name: local-path-config
+
+            ---
+            apiVersion: storage.k8s.io/v1
+            kind: StorageClass
+            metadata:
+              name: local-path
+            provisioner: rancher.io/local-path
+            volumeBindingMode: WaitForFirstConsumer
+            reclaimPolicy: Delete
+
+            ---
+            kind: ConfigMap
+            apiVersion: v1
+            metadata:
+              name: local-path-config
+              namespace: local-path-storage
+            data:
+              config.json: |-
+                {
+                        "nodePathMap":[
+                        {
+                                "node":"DEFAULT_PATH_FOR_NON_LISTED_NODES",
+                                "paths":["/opt/local-path-provisioner"]
+                        }
+                        ]
+                }
+              setup: |-
+                #!/bin/sh
+                set -eu
+                mkdir -m 0777 -p "$VOL_DIR"
+              teardown: |-
+                #!/bin/sh
+                set -eu
+                rm -rf "$VOL_DIR"
+              helperPod.yaml: |-
+                apiVersion: v1
+                kind: Pod
+                metadata:
+                  name: helper-pod
+                spec:
+                  priorityClassName: system-node-critical
+                  tolerations:
+                    - key: node.kubernetes.io/disk-pressure
+                      operator: Exists
+                      effect: NoSchedule
+                  containers:
+                  - name: helper-pod
+                    image: busybox@sha256:9db7b59979c38555a39def84a31fb98b5296952f9e3afd4f6f11f05b07adfab0
+                    imagePullPolicy: IfNotPresent
       - op: add
         path: /machine/features/hostDNS
         value:

--- a/templates/talos/providers/kubevirt/cluster-base.yaml.tpl
+++ b/templates/talos/providers/kubevirt/cluster-base.yaml.tpl
@@ -129,6 +129,10 @@ spec:
             kind: Namespace
             metadata:
               name: local-path-storage
+              labels:
+                pod-security.kubernetes.io/enforce: privileged
+                pod-security.kubernetes.io/warn: privileged
+                pod-security.kubernetes.io/audit: privileged
 
             ---
             apiVersion: v1

--- a/tests/ok130_talos_golden_test.py
+++ b/tests/ok130_talos_golden_test.py
@@ -223,6 +223,34 @@ def main() -> int:
         rendered = base.read_text(encoding="utf-8")
         rendered_legacy = legacy.read_text(encoding="utf-8")
         resources = docs(base)
+        control_plane = next(
+            item for item in resources if item["kind"] == "TalosControlPlane"
+        )
+        patches = control_plane["spec"]["controlPlaneConfig"]["controlplane"][
+            "configPatches"
+        ]
+        inline_patch = next(
+            item for item in patches
+            if item.get("path") == "/cluster/inlineManifests"
+        )
+        inline_manifests = inline_patch["value"]
+        local_path_manifest = inline_manifests[0]["contents"]
+        check(
+            len(inline_manifests) == 1
+            and inline_manifests[0]["name"]
+            == "local-path-provisioner-v0.0.30"
+            and "name: local-path" in local_path_manifest
+            and "provisioner: rancher.io/local-path" in local_path_manifest
+            and "rancher/local-path-provisioner@sha256:9b914881170048f80ae9302f36e5b99b4a6b18af73a38adc1c66d12f65d360be"
+            in local_path_manifest
+            and "busybox@sha256:9db7b59979c38555a39def84a31fb98b5296952f9e3afd4f6f11f05b07adfab0"
+            in local_path_manifest
+            and 'mkdir -m 0777 -p "$VOL_DIR"' in local_path_manifest
+            and 'rm -rf "$VOL_DIR"' in local_path_manifest
+            and "rancher/local-path-provisioner:v0.0.30"
+            not in local_path_manifest,
+            "Talos bootstrap binds the exact digest-pinned local-path runtime storage",
+        )
         roles = [item for item in resources if item["kind"] == "Role"]
         bindings = [
             item for item in resources if item["kind"] == "RoleBinding"

--- a/tests/ok130_talos_golden_test.py
+++ b/tests/ok130_talos_golden_test.py
@@ -241,6 +241,12 @@ def main() -> int:
             == "local-path-provisioner-v0.0.30"
             and "name: local-path" in local_path_manifest
             and "provisioner: rancher.io/local-path" in local_path_manifest
+            and "pod-security.kubernetes.io/enforce: privileged"
+            in local_path_manifest
+            and "pod-security.kubernetes.io/warn: privileged"
+            in local_path_manifest
+            and "pod-security.kubernetes.io/audit: privileged"
+            in local_path_manifest
             and "rancher/local-path-provisioner@sha256:9b914881170048f80ae9302f36e5b99b4a6b18af73a38adc1c66d12f65d360be"
             in local_path_manifest
             and "busybox@sha256:9db7b59979c38555a39def84a31fb98b5296952f9e3afd4f6f11f05b07adfab0"


### PR DESCRIPTION
## Summary
- bootstrap the required local-path StorageClass through a Talos inline manifest
- pin provisioner and helper images by digest and retain upstream provenance
- cover the rendered storage identity and shell-variable preservation in the Talos golden test

## Context
R41 reached runtime-binding after the deferred network observation, but stopped with RUNTIME_BINDING_SOURCE_STOPPED because StorageClass/local-path was absent. This change makes that prerequisite part of the lifecycle artifact and plan rather than a manual post-create mutation.

## Validation
- python3 tests/ok130_talos_golden_test.py
- python3 tests/ok141_kubevirt_infra_secret_ref_test.py
- git diff --check