### PR TITLE
fix(runner): preserve post-prefix stop categories

### DIFF
--- a/internal/runner/full_run_execution_test.go
+++ b/internal/runner/full_run_execution_test.go
@@ -235,9 +235,15 @@ func TestPostPrefixActivationStopCategoryBoundary(t *testing.T) {
 	if got := redactedStopCategory(postPrefixActivationStopOrFallback(trusted)); got != "POST_PREFIX_OBSERVER_CREDENTIAL_STOPPED" {
 		t.Fatalf("trusted post-prefix category was lost: %s", got)
 	}
+	if got := redactedStopCategory(redactedStopOrFallback("POST_RUNTIME_BIND_STOPPED", postPrefixActivationStopOrFallback(trusted))); got != "POST_PREFIX_OBSERVER_CREDENTIAL_STOPPED" {
+		t.Fatalf("trusted post-prefix category was lost at orchestration boundary: %s", got)
+	}
 	untrusted := newFixedRedactedStop("AUTHORIZATION_HTTP_REJECTED", errors.New("private unrelated detail"))
 	if got := redactedStopCategory(postPrefixActivationStopOrFallback(untrusted)); got != "POST_RUNTIME_ACTIVATION_STOPPED" {
 		t.Fatalf("untrusted category crossed post-prefix boundary: %s", got)
+	}
+	if got := redactedStopCategory(redactedStopOrFallback("POST_RUNTIME_BIND_STOPPED", untrusted)); got != "POST_RUNTIME_BIND_STOPPED" {
+		t.Fatalf("untrusted category crossed orchestration boundary: %s", got)
 	}
 }
 

--- a/internal/runner/pre_runtime_orchestrator.go
+++ b/internal/runner/pre_runtime_orchestrator.go
@@ -190,8 +190,11 @@ func newFixedRedactedStop(category string, cause error) error {
 
 func redactedStopOrFallback(fallback string, cause error) error {
 	var categorized redactedStopCategorizer
-	if errors.As(cause, &categorized) && validPostRuntimeBindStopCategory(categorized.RedactedStopCategory()) {
-		return cause
+	if errors.As(cause, &categorized) {
+		category := categorized.RedactedStopCategory()
+		if validPostRuntimeBindStopCategory(category) || validPostPrefixActivationStopCategory(category) {
+			return cause
+		}
 	}
 	return newFixedRedactedStop(fallback, cause)
 }


### PR DESCRIPTION
## Summary
- preserve the fixed POST_PREFIX_* categories across the outer post-runtime bind boundary
- retain the generic POST_RUNTIME_BIND_STOPPED fallback for unrelated categories
- cover both trusted propagation and untrusted-category rejection

## R46 evidence
The run completed stages 1-7 and stopped at target-credential, but the inner post-prefix category was masked by the outer boundary. This patch changes only redacted category plumbing.

## Verification
Focused orchestration, credential-polling, and category-boundary tests pass.

No cluster contact, cleanup, launch, retry, or publication.