### PR TITLE
fix(runner): extend observer credential convergence

### DIFF
--- a/internal/runner/observability_collector_credential_poll_test.go
+++ b/internal/runner/observability_collector_credential_poll_test.go
@@ -43,6 +43,38 @@ func TestObservabilityCollectorCredentialPollingConvergesOnlyOnAllowedStatuses(t
 	}
 }
 
+func TestObservabilityCollectorObserverCredentialDefaultWindowConvergesAfterSlowAuthorityInstallation(t *testing.T) {
+	const transientAttempts = 45
+	requests := 0
+	waits := 0
+	clock := time.Unix(1_700_000_000, 0)
+	client := &http.Client{Transport: collectorCredentialRoundTripFunc(func(*http.Request) (*http.Response, error) {
+		requests++
+		if requests <= transientAttempts {
+			return collectorCredentialResponse(http.StatusNotFound, `{}`), nil
+		}
+		return collectorCredentialResponse(http.StatusCreated, `{"apiVersion":"authentication.k8s.io/v1","kind":"TokenRequest","metadata":{},"spec":{"expirationSeconds":3600},"status":{"token":"token","expirationTimestamp":"2026-09-08T20:00:00Z"}}`), nil
+	})}
+	endpoint, err := url.Parse("https://workload.example.invalid/token")
+	if err != nil {
+		t.Fatal(err)
+	}
+	value, err := issueObservabilityCollectorCredential(context.Background(), observabilityCollectorCredentialPollConfig{
+		client: client, endpoint: *endpoint, authorityToken: "authority", request: []byte(`{}`),
+		pollClock: func() time.Time { return clock }, wait: func(_ context.Context, delay time.Duration) error {
+			waits++
+			clock = clock.Add(delay)
+			return nil
+		},
+		pollInterval: observabilityCollectorCredentialPollInterval,
+		pollTimeout:  observabilityCollectorObserverCredentialPollTimeout,
+		maxAttempts:  observabilityCollectorObserverCredentialMaxAttempts,
+	})
+	if err != nil || value.Kind != "TokenRequest" || requests != transientAttempts+1 || waits != transientAttempts {
+		t.Fatalf("slow authority installation did not converge: value=%+v err=%v requests=%d waits=%d", value, err, requests, waits)
+	}
+}
+
 func TestObservabilityCollectorCredentialPollingRejectsTerminalStatusesWithoutRetry(t *testing.T) {
 	for _, status := range []int{http.StatusBadRequest, http.StatusUnauthorized, http.StatusForbidden, http.StatusNotImplemented} {
 		t.Run(http.StatusText(status), func(t *testing.T) {

--- a/internal/runner/observability_collector_observer_credential.go
+++ b/internal/runner/observability_collector_observer_credential.go
@@ -21,6 +21,8 @@ const (
 	ObservabilityCollectorObserverCredentialReceiptFormat = "ok147-observability-collector-observer-credential-receipt/v1"
 	observabilityCollectorObserverLifetime                = time.Hour
 	minimumObservabilityCollectorObserverLifetime         = 55 * time.Minute
+	observabilityCollectorObserverCredentialPollTimeout   = 5 * time.Minute
+	observabilityCollectorObserverCredentialMaxAttempts   = 300
 )
 
 type ObservabilityCollectorObserverCredentialConfig struct {
@@ -138,8 +140,8 @@ func newKubernetesObservabilityCollectorObserverCredentialIssuer(config observab
 		caBundleDigest: config.CABundleDigest, caFile: config.CAFile, targetIdentity: config.TargetIdentity,
 		client: &client, clock: config.Clock, pollClock: time.Now, wait: WaitWithTimer,
 		pollInterval: observabilityCollectorCredentialPollInterval,
-		pollTimeout:  observabilityCollectorCredentialPollTimeout,
-		maxAttempts:  observabilityCollectorCredentialMaxAttempts, request: requestRaw,
+		pollTimeout:  observabilityCollectorObserverCredentialPollTimeout,
+		maxAttempts:  observabilityCollectorObserverCredentialMaxAttempts, request: requestRaw,
 	}, nil
 }
 


### PR DESCRIPTION
## Summary
- extend only the observability collector observer-credential convergence window to five minutes
- retain a hard 300-attempt cap and the existing one-second interval
- keep the installer credential default unchanged at 30 seconds / 30 attempts
- preserve the existing strict transient-status allowlist and terminal authz/TLS/response validation

## Rationale
R47 stopped as `POST_PREFIX_OBSERVER_CREDENTIAL_STOPPED`; the bounded 30-second observer TokenRequest window expired, while read-only diagnostics later confirmed the workload prerequisites were present. This replaces that insufficient timing bound without introducing a stage retry or widening terminal classifications.

## Verification
- focused observer/installer/polling tests: PASS
- new test proves convergence after 45 transient 404 responses
- full runner package reaches only three known time-dependent certificate-fixture failures in unmodified tests

No cluster contact, cleanup, launch, or private evidence is included.