### PR TITLE
fix(runner): bind observer credential audience explicitly

### DIFF
--- a/internal/runner/observability_collector_activation_package.go
+++ b/internal/runner/observability_collector_activation_package.go
@@ -186,7 +186,7 @@ func BuildObservabilityCollectorActivationPackage(config ObservabilityCollectorA
 	if config.ObserverCredential.AuthorityIdentity != targetAuthority ||
 		config.ObserverCredential.ExpectedSubject != expectedSubject ||
 		len(config.ObserverCredential.ExpectedAudiences) != 1 ||
-		config.ObserverCredential.ExpectedAudiences[0] != "https://kubernetes.default.svc" ||
+		config.ObserverCredential.ExpectedAudiences[0] != observabilityCollectorObserverAudience ||
 		config.ObserverCredential.CABundleDigest != runtimeBinding.material.Target.WorkloadAPICADigest {
 		return VerifiedObservabilityCollectorActivationPackage{}, errors.New("observability collector observer credential identity is invalid")
 	}
@@ -530,7 +530,7 @@ func loadObservabilityCollectorObserverCredential(source SubmissionStageCredenti
 		return observabilityCollectorObserverCredential{}, nil, err
 	}
 	audiences, err := tokenAudiences(claims.Audience)
-	if err != nil || len(audiences) != 1 || audiences[0] != "https://kubernetes.default.svc" {
+	if err != nil || len(audiences) != 1 || audiences[0] != observabilityCollectorObserverAudience {
 		return observabilityCollectorObserverCredential{}, nil, errors.New("observability collector observer audience differs")
 	}
 	return observabilityCollectorObserverCredential{

--- a/internal/runner/observability_collector_observer_credential.go
+++ b/internal/runner/observability_collector_observer_credential.go
@@ -19,6 +19,8 @@ import (
 
 const (
 	ObservabilityCollectorObserverCredentialReceiptFormat = "ok147-observability-collector-observer-credential-receipt/v1"
+	observabilityCollectorObserverAudience                = "https://kubernetes.default.svc"
+	observabilityCollectorObserverAudienceMode            = "explicit/v1"
 	observabilityCollectorObserverLifetime                = time.Hour
 	minimumObservabilityCollectorObserverLifetime         = 55 * time.Minute
 	observabilityCollectorObserverCredentialPollTimeout   = 5 * time.Minute
@@ -121,7 +123,10 @@ func newKubernetesObservabilityCollectorObserverCredentialIssuer(config observab
 	}
 	requestRaw, err := json.Marshal(targetCredentialTokenRequest{
 		APIVersion: "authentication.k8s.io/v1", Kind: "TokenRequest",
-		Spec: targetCredentialTokenRequestSpec{ExpirationSeconds: int64(observabilityCollectorObserverLifetime / time.Second)},
+		Spec: targetCredentialTokenRequestSpec{
+			Audiences:         []string{observabilityCollectorObserverAudience},
+			ExpirationSeconds: int64(observabilityCollectorObserverLifetime / time.Second),
+		},
 	})
 	if err != nil {
 		return nil, errors.New("encode collector observer TokenRequest")
@@ -208,7 +213,8 @@ func (issuer *KubernetesObservabilityCollectorObserverCredentialIssuer) verifyRe
 	audiences, audienceErr := tokenAudiences(claims.Audience)
 	exp, expErr := exactJWTUnix(claims.ExpiresAt)
 	nbf, nbfErr := exactJWTUnix(claims.NotBefore)
-	if audienceErr != nil || len(audiences) != 1 || audiences[0] != "https://kubernetes.default.svc" ||
+	if audienceErr != nil || len(audiences) != 1 || audiences[0] != observabilityCollectorObserverAudience ||
+		len(value.Spec.Audiences) != 1 || value.Spec.Audiences[0] != observabilityCollectorObserverAudience ||
 		expErr != nil || nbfErr != nil || claims.Issuer == "" || claims.Subject != wantSubject || exp != expiresAt.Unix() ||
 		nbf != issuedAtUnix || issuedAt.After(now.Add(5*time.Second)) || issuedAt.Before(now.Add(-5*time.Minute)) ||
 		lifetime < minimumObservabilityCollectorObserverLifetime || lifetime > observabilityCollectorObserverLifetime {
@@ -218,7 +224,7 @@ func (issuer *KubernetesObservabilityCollectorObserverCredentialIssuer) verifyRe
 		Format: ObservabilityCollectorObserverCredentialReceiptFormat, State: "ISSUED",
 		TargetIdentityDigest:         issuer.targetIdentity,
 		ServiceAccountIdentityDigest: digest.SHA256([]byte(wantSubject)), RequestDigest: digest.SHA256(issuer.request),
-		CABundleDigest: issuer.caBundleDigest, AudienceMode: "server-default",
+		CABundleDigest: issuer.caBundleDigest, AudienceMode: observabilityCollectorObserverAudienceMode,
 		IssuedAt: issuedAt.Format(time.RFC3339), ExpiresAt: expiresAt.UTC().Format(time.RFC3339),
 		LifetimeSeconds: int64(lifetime / time.Second), CredentialBytesInReceipt: false, MutationState: "ATTEMPTED",
 	}
@@ -229,7 +235,7 @@ func (issuer *KubernetesObservabilityCollectorObserverCredentialIssuer) verifyRe
 	source := SubmissionStageCredentialSource{
 		AuthorityIdentity: issuer.targetIdentity, TokenDigest: digest.SHA256([]byte(value.Status.Token)),
 		CAFile: issuer.caFile, CABundleDigest: issuer.caBundleDigest, TokenRequestEvidenceDigest: digest.SHA256(receiptRaw),
-		ExpectedIssuer: claims.Issuer, ExpectedSubject: wantSubject, ExpectedAudiences: []string{"https://kubernetes.default.svc"},
+		ExpectedIssuer: claims.Issuer, ExpectedSubject: wantSubject, ExpectedAudiences: []string{observabilityCollectorObserverAudience},
 		IssuedAt: issuedAt, ExpiresAt: expiresAt.UTC(),
 	}
 	if _, err := verifyStageCredentialJWTWithSubject([]byte(value.Status.Token), source, now, func(subject string) bool {

--- a/internal/runner/observability_collector_observer_credential_test.go
+++ b/internal/runner/observability_collector_observer_credential_test.go
@@ -22,7 +22,7 @@ func TestObservabilityCollectorObserverCredentialIssuesOnceInMemory(t *testing.T
 		requests++
 		body, _ := io.ReadAll(request.Body)
 		if request.Method != http.MethodPost || request.URL.Path != "/api/v1/namespaces/ok-observability/serviceaccounts/ok147-observability-autonomy/token" ||
-			request.Header.Get("Authorization") != "Bearer workload-admin" || bytes.Contains(body, []byte("audiences")) {
+			request.Header.Get("Authorization") != "Bearer workload-admin" || !bytes.Contains(body, []byte(`"audiences":["https://kubernetes.default.svc"]`)) {
 			t.Fatalf("unexpected collector observer TokenRequest: %s %s %s", request.Method, request.URL.Path, body)
 		}
 		return targetCredentialTestResponse(http.StatusCreated, map[string]any{
@@ -44,7 +44,7 @@ func TestObservabilityCollectorObserverCredentialIssuesOnceInMemory(t *testing.T
 	}
 	source, privateToken, receipt, err := credential.Material()
 	if err != nil || receipt.Format != ObservabilityCollectorObserverCredentialReceiptFormat || receipt.State != "ISSUED" ||
-		receipt.TargetIdentityDigest != target || receipt.LifetimeSeconds != 3600 || receipt.CredentialBytesInReceipt ||
+		receipt.TargetIdentityDigest != target || receipt.AudienceMode != observabilityCollectorObserverAudienceMode || receipt.LifetimeSeconds != 3600 || receipt.CredentialBytesInReceipt ||
 		source.TokenFile != "" || source.TokenDigest != digest.SHA256([]byte(token)) || string(privateToken) != token || requests != 1 {
 		t.Fatalf("unexpected observer credential: %#v %#v requests=%d err=%v", source, receipt, requests, err)
 	}
@@ -54,6 +54,35 @@ func TestObservabilityCollectorObserverCredentialIssuesOnceInMemory(t *testing.T
 	}
 	if _, err := issuer.Issue(context.Background()); err == nil || requests != 1 {
 		t.Fatal("single-use collector observer credential issuer retried")
+	}
+}
+
+func TestObservabilityCollectorObserverCredentialRejectsDifferentReturnedAudience(t *testing.T) {
+	now := time.Date(2026, 8, 22, 12, 0, 0, 0, time.UTC)
+	target := digest.SHA256([]byte("collector-observer-target"))
+	foreignAudience := "https://kubernetes.default.svc.cluster.local"
+	token := string(stageCredentialJWT(t, foreignAudience, "system:serviceaccount:ok-observability:"+observabilityCollectorObserverSA,
+		[]string{foreignAudience}, now, now.Add(time.Hour), 'o'))
+	client := &http.Client{Transport: submissionStageLauncherRoundTripFunc(func(request *http.Request) (*http.Response, error) {
+		body, _ := io.ReadAll(request.Body)
+		if !bytes.Contains(body, []byte(`"audiences":["https://kubernetes.default.svc"]`)) {
+			t.Fatalf("observer request did not bind the explicit audience: %s", body)
+		}
+		return targetCredentialTestResponse(http.StatusCreated, map[string]any{
+			"apiVersion": "authentication.k8s.io/v1", "kind": "TokenRequest", "metadata": map[string]any{},
+			"spec":   map[string]any{"audiences": []string{foreignAudience}, "expirationSeconds": 3600},
+			"status": map[string]any{"token": token, "expirationTimestamp": now.Add(time.Hour).Format(time.RFC3339)},
+		}), nil
+	})}
+	issuer, err := newKubernetesObservabilityCollectorObserverCredentialIssuer(observabilityCollectorObserverIssuerClientConfig{
+		Endpoint: "https://127.0.0.1:12345", BearerToken: "workload-admin", CABundleDigest: runnerStageSHA("a"),
+		CAFile: "/private/tmp/workload-ca.crt", TargetIdentity: target, Client: client, Clock: func() time.Time { return now },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := issuer.Issue(context.Background()); err == nil {
+		t.Fatal("observer credential with a different returned audience was accepted")
 	}
 }
 

--- a/internal/runner/observability_collector_post_prefix_test.go
+++ b/internal/runner/observability_collector_post_prefix_test.go
@@ -134,7 +134,7 @@ func collectorObserverCredentialFixture(t *testing.T, config ObservabilityCollec
 		Format: ObservabilityCollectorObserverCredentialReceiptFormat, State: "ISSUED",
 		TargetIdentityDigest:         source.AuthorityIdentity,
 		ServiceAccountIdentityDigest: digest.SHA256([]byte(source.ExpectedSubject)),
-		RequestDigest:                runnerStageSHA("c"), CABundleDigest: source.CABundleDigest, AudienceMode: "server-default",
+		RequestDigest:                runnerStageSHA("c"), CABundleDigest: source.CABundleDigest, AudienceMode: observabilityCollectorObserverAudienceMode,
 		IssuedAt: source.IssuedAt.UTC().Format(time.RFC3339), ExpiresAt: source.ExpiresAt.UTC().Format(time.RFC3339),
 		LifetimeSeconds: int64(source.ExpiresAt.Sub(source.IssuedAt) / time.Second), CredentialBytesInReceipt: false, MutationState: "ATTEMPTED",
 	}


### PR DESCRIPTION
## Summary
- request the already-required observer audience explicitly in the TokenRequest
- bind response spec and JWT claims to that exact audience
- record the credential as explicit/v1 and add a negative foreign-audience test

## Verification
- go test ./internal/runner -run 'ObservabilityCollector' -count=1

## Boundaries
No cluster contact, cleanup, launch, retry, failure injection, or runner publication.