### PR TITLE
fix(OK-147): dispatch dry-run serve command

### DIFF
--- a/cmd/ok/main.go
+++ b/cmd/ok/main.go
@@ -696,7 +696,7 @@ func runContext(ctx context.Context, arguments []string, stdout, stderr io.Write
 	if len(arguments) >= 2 && arguments[0] == "cluster" && arguments[1] == "create" {
 		return runClusterCreate(arguments[2:], stdout, stderr)
 	}
-	if len(arguments) >= 4 && arguments[0] == "cluster" && arguments[1] == "dry-run" && arguments[2] == "serve" {
+	if len(arguments) >= 3 && arguments[0] == "cluster" && arguments[1] == "dry-run" && arguments[2] == "serve" {
 		return runClusterDryRunServe(ctx, arguments[3:], stdout, stderr)
 	}
 	if len(arguments) >= 3 && arguments[0] == "cluster" && arguments[1] == "stage" && arguments[2] == "inspect" {


### PR DESCRIPTION
Fixes the service entrypoint dispatch so `ok cluster dry-run serve` is recognized before its flags are parsed. The deployed image currently exits because the previous `len(arguments) >= 4` guard rejected the three-command token sequence.