### PR TITLE
fix(OK-147): use TCP readiness for dry-run service

### DIFF
--- a/deploy/console-dry-run-service.yaml.tpl
+++ b/deploy/console-dry-run-service.yaml.tpl
@@ -32,7 +32,7 @@ spec:
             - name: dry-run
               containerPort: 8790
           readinessProbe:
-            httpGet: {path: /, port: dry-run}
+            tcpSocket: {port: dry-run}
             periodSeconds: 5
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
The dry-run handler intentionally exposes only POST and therefore cannot satisfy an HTTP GET readiness probe. Use a TCP readiness probe instead. The live ok-shared deployment was patched accordingly and rolled out successfully.