### PR TITLE
fix(runner): bind observer token response identity

### DIFF
--- a/internal/runner/observability_collector_installer_credential.go
+++ b/internal/runner/observability_collector_installer_credential.go
@@ -184,7 +184,7 @@ func (issuer *KubernetesObservabilityCollectorInstallerCredentialIssuer) Issue(c
 func (issuer *KubernetesObservabilityCollectorInstallerCredentialIssuer) verifyResponse(value targetCredentialTokenResponse, now time.Time) (VerifiedObservabilityCollectorInstallerCredential, error) {
 	if value.APIVersion != "authentication.k8s.io/v1" || value.Kind != "TokenRequest" || len(value.Status.Token) < 80 ||
 		strings.TrimSpace(value.Status.Token) != value.Status.Token || strings.ContainsAny(value.Status.Token, "\r\n") ||
-		value.Spec.ExpirationSeconds != int64(observabilityCollectorInstallerLifetime/time.Second) || len(value.Spec.Audiences) == 0 {
+		value.Spec.ExpirationSeconds != int64(observabilityCollectorInstallerLifetime/time.Second) || len(value.Spec.Audiences) == 0 || value.Spec.BoundObjectRef != nil {
 		return VerifiedObservabilityCollectorInstallerCredential{}, errors.New("collector installer TokenRequest response is invalid")
 	}
 	expiresAt, err := time.Parse(time.RFC3339, value.Status.ExpirationTimestamp)

--- a/internal/runner/observability_collector_observer_authority_poll.go
+++ b/internal/runner/observability_collector_observer_authority_poll.go
@@ -41,51 +41,55 @@ var observerAuthorityIdentities = []observerAuthorityIdentity{
 
 // awaitObserverAuthority performs only live GETs. Two identical consecutive
 // snapshots are required before the sole TokenRequest is allowed.
-func (issuer *KubernetesObservabilityCollectorObserverCredentialIssuer) awaitObserverAuthority(ctx context.Context) error {
+func (issuer *KubernetesObservabilityCollectorObserverCredentialIssuer) awaitObserverAuthority(ctx context.Context) (string, error) {
 	deadline := issuer.pollClock().Add(issuer.pollTimeout)
 	previous := map[string]string{}
 	seen := map[string]string{}
 	for attempt := 1; attempt <= issuer.maxAttempts; attempt++ {
 		if ctx.Err() != nil || !issuer.pollClock().Before(deadline) {
-			return observerAuthorityExhausted()
+			return "", observerAuthorityExhausted()
 		}
 		current := map[string]string{}
 		transient := false
 		for _, identity := range observerAuthorityIdentities {
 			uid, retry, err := issuer.readObserverAuthorityObject(ctx, deadline, identity)
 			if err != nil {
-				return err
+				return "", err
 			}
 			if retry {
 				if seen[identity.kind] != "" {
-					return newFixedRedactedStop("POST_PREFIX_OBSERVER_AUTHORITY_INVALID", errors.New("observer authority object disappeared after becoming visible"))
+					return "", newFixedRedactedStop("POST_PREFIX_OBSERVER_AUTHORITY_INVALID", errors.New("observer authority object disappeared after becoming visible"))
 				}
 				transient = true
 				break
 			}
 			if firstUID := seen[identity.kind]; firstUID != "" && firstUID != uid {
-				return newFixedRedactedStop("POST_PREFIX_OBSERVER_AUTHORITY_INVALID", errors.New("observer authority object identity changed"))
+				return "", newFixedRedactedStop("POST_PREFIX_OBSERVER_AUTHORITY_INVALID", errors.New("observer authority object identity changed"))
 			}
 			seen[identity.kind] = uid
 			current[identity.kind] = uid
 		}
 		if !transient && sameObserverAuthoritySnapshot(previous, current) {
-			return nil
+			uid := current["ServiceAccount"]
+			if uid == "" {
+				return "", newFixedRedactedStop("POST_PREFIX_OBSERVER_AUTHORITY_INVALID", errors.New("observer service account identity is absent"))
+			}
+			return uid, nil
 		}
 		if len(previous) != 0 {
-			return newFixedRedactedStop("POST_PREFIX_OBSERVER_AUTHORITY_INVALID", errors.New("observer authority regressed after becoming visible"))
+			return "", newFixedRedactedStop("POST_PREFIX_OBSERVER_AUTHORITY_INVALID", errors.New("observer authority regressed after becoming visible"))
 		}
 		if !transient {
 			previous = current
 		}
 		if attempt == issuer.maxAttempts || !issuer.pollClock().Add(issuer.pollInterval).Before(deadline) {
-			return observerAuthorityExhausted()
+			return "", observerAuthorityExhausted()
 		}
 		if err := issuer.wait(ctx, issuer.pollInterval); err != nil {
-			return observerAuthorityExhausted()
+			return "", observerAuthorityExhausted()
 		}
 	}
-	return observerAuthorityExhausted()
+	return "", observerAuthorityExhausted()
 }
 
 func observerAuthorityExhausted() error {

--- a/internal/runner/observability_collector_observer_credential.go
+++ b/internal/runner/observability_collector_observer_credential.go
@@ -162,7 +162,8 @@ func (issuer *KubernetesObservabilityCollectorObserverCredentialIssuer) Issue(ct
 	issuer.mu.Unlock()
 	boundedContext, cancel := context.WithTimeout(ctx, issuer.pollTimeout)
 	defer cancel()
-	if err := issuer.awaitObserverAuthority(boundedContext); err != nil {
+	observerServiceAccountUID, err := issuer.awaitObserverAuthority(boundedContext)
+	if err != nil {
 		return VerifiedObservabilityCollectorObserverCredential{}, err
 	}
 	requestURL := observerCredentialEndpoint(*issuer.endpoint)
@@ -174,14 +175,20 @@ func (issuer *KubernetesObservabilityCollectorObserverCredentialIssuer) Issue(ct
 	if err != nil {
 		return VerifiedObservabilityCollectorObserverCredential{}, err
 	}
-	return issuer.verifyResponse(value, issuer.clock().UTC().Truncate(time.Second))
+	return issuer.verifyResponse(value, issuer.clock().UTC().Truncate(time.Second), observerServiceAccountUID)
 }
 
-func (issuer *KubernetesObservabilityCollectorObserverCredentialIssuer) verifyResponse(value targetCredentialTokenResponse, now time.Time) (VerifiedObservabilityCollectorObserverCredential, error) {
+func (issuer *KubernetesObservabilityCollectorObserverCredentialIssuer) verifyResponse(value targetCredentialTokenResponse, now time.Time, observerServiceAccountUID string) (VerifiedObservabilityCollectorObserverCredential, error) {
 	if value.APIVersion != "authentication.k8s.io/v1" || value.Kind != "TokenRequest" || len(value.Status.Token) < 80 ||
 		strings.TrimSpace(value.Status.Token) != value.Status.Token || strings.ContainsAny(value.Status.Token, "\r\n") ||
-		value.Spec.ExpirationSeconds != int64(observabilityCollectorObserverLifetime/time.Second) || len(value.Spec.Audiences) == 0 {
+		value.Spec.ExpirationSeconds != int64(observabilityCollectorObserverLifetime/time.Second) || len(value.Spec.Audiences) == 0 ||
+		value.Spec.BoundObjectRef == nil {
 		return VerifiedObservabilityCollectorObserverCredential{}, newFixedRedactedStop("POST_PREFIX_OBSERVER_CREDENTIAL_RESPONSE_INVALID", errors.New("collector observer TokenRequest response is invalid"))
+	}
+	if value.Spec.BoundObjectRef.APIVersion != "v1" || value.Spec.BoundObjectRef.Kind != "ServiceAccount" ||
+		value.Spec.BoundObjectRef.Name != observabilityCollectorObserverSA || observerServiceAccountUID == "" ||
+		value.Spec.BoundObjectRef.UID != observerServiceAccountUID {
+		return VerifiedObservabilityCollectorObserverCredential{}, newFixedRedactedStop("POST_PREFIX_OBSERVER_CREDENTIAL_CLAIMS_MISMATCH", errors.New("collector observer TokenRequest bound object identity differs"))
 	}
 	expiresAt, err := time.Parse(time.RFC3339, value.Status.ExpirationTimestamp)
 	if err != nil {

--- a/internal/runner/observability_collector_observer_credential_test.go
+++ b/internal/runner/observability_collector_observer_credential_test.go
@@ -29,12 +29,13 @@ func TestObservabilityCollectorObserverCredentialIssuesOnceInMemory(t *testing.T
 		requests++
 		body, _ := io.ReadAll(request.Body)
 		if request.Method != http.MethodPost || request.URL.Path != "/api/v1/namespaces/ok-observability/serviceaccounts/ok147-observability-autonomy/token" ||
-			request.Header.Get("Authorization") != "Bearer workload-admin" || !bytes.Contains(body, []byte(`"audiences":["https://kubernetes.default.svc"]`)) {
+			request.Header.Get("Authorization") != "Bearer workload-admin" || !bytes.Contains(body, []byte(`"audiences":["https://kubernetes.default.svc"]`)) ||
+			bytes.Contains(body, []byte(`"boundObjectRef"`)) {
 			t.Fatalf("unexpected collector observer TokenRequest: %s %s %s", request.Method, request.URL.Path, body)
 		}
 		return targetCredentialTestResponse(http.StatusCreated, map[string]any{
 			"apiVersion": "authentication.k8s.io/v1", "kind": "TokenRequest", "metadata": map[string]any{},
-			"spec":   map[string]any{"audiences": []string{"https://kubernetes.default.svc"}, "expirationSeconds": 3600},
+			"spec":   observerCredentialResponseSpec([]string{"https://kubernetes.default.svc"}),
 			"status": map[string]any{"token": token, "expirationTimestamp": now.Add(time.Hour).Format(time.RFC3339)},
 		}), nil
 	})}
@@ -80,7 +81,7 @@ func TestObservabilityCollectorObserverCredentialRejectsDifferentReturnedAudienc
 		}
 		return targetCredentialTestResponse(http.StatusCreated, map[string]any{
 			"apiVersion": "authentication.k8s.io/v1", "kind": "TokenRequest", "metadata": map[string]any{},
-			"spec":   map[string]any{"audiences": []string{foreignAudience}, "expirationSeconds": 3600},
+			"spec":   observerCredentialResponseSpec([]string{foreignAudience}),
 			"status": map[string]any{"token": token, "expirationTimestamp": now.Add(time.Hour).Format(time.RFC3339)},
 		}), nil
 	})}
@@ -93,6 +94,49 @@ func TestObservabilityCollectorObserverCredentialRejectsDifferentReturnedAudienc
 	}
 	if _, err := issuer.Issue(context.Background()); err == nil || redactedStopCategory(err) != "POST_PREFIX_OBSERVER_CREDENTIAL_CLAIMS_MISMATCH" {
 		t.Fatal("observer credential with a different returned audience was accepted")
+	}
+}
+
+func TestObservabilityCollectorObserverCredentialBindsReturnedObjectReference(t *testing.T) {
+	now := time.Date(2026, 9, 9, 12, 0, 0, 0, time.UTC)
+	token := string(stageCredentialJWT(t, "https://kubernetes.default.svc.cluster.local", "system:serviceaccount:ok-observability:"+observabilityCollectorObserverSA,
+		[]string{observabilityCollectorObserverAudience}, now, now.Add(time.Hour), 'o'))
+	for _, test := range []struct {
+		name, field, value, want string
+	}{
+		{name: "missing", field: "missing", want: "POST_PREFIX_OBSERVER_CREDENTIAL_RESPONSE_INVALID"},
+		{name: "api version", field: "apiVersion", value: "v2", want: "POST_PREFIX_OBSERVER_CREDENTIAL_CLAIMS_MISMATCH"},
+		{name: "kind", field: "kind", value: "User", want: "POST_PREFIX_OBSERVER_CREDENTIAL_CLAIMS_MISMATCH"},
+		{name: "name", field: "name", value: "foreign", want: "POST_PREFIX_OBSERVER_CREDENTIAL_CLAIMS_MISMATCH"},
+		{name: "uid", field: "uid", value: "foreign-uid", want: "POST_PREFIX_OBSERVER_CREDENTIAL_CLAIMS_MISMATCH"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			client := &http.Client{Transport: submissionStageLauncherRoundTripFunc(func(request *http.Request) (*http.Response, error) {
+				if request.Method == http.MethodGet {
+					return observerAuthorityTestResponse(request.URL.Path), nil
+				}
+				spec := observerCredentialResponseSpec([]string{observabilityCollectorObserverAudience})
+				if test.field == "missing" {
+					delete(spec, "boundObjectRef")
+				} else {
+					spec["boundObjectRef"].(map[string]any)[test.field] = test.value
+				}
+				return targetCredentialTestResponse(http.StatusCreated, map[string]any{
+					"apiVersion": "authentication.k8s.io/v1", "kind": "TokenRequest", "metadata": map[string]any{}, "spec": spec,
+					"status": map[string]any{"token": token, "expirationTimestamp": now.Add(time.Hour).Format(time.RFC3339)},
+				}), nil
+			})}
+			issuer, err := newKubernetesObservabilityCollectorObserverCredentialIssuer(observabilityCollectorObserverIssuerClientConfig{
+				Endpoint: "https://127.0.0.1:12345", BearerToken: "workload-admin", CABundleDigest: runnerStageSHA("a"),
+				CAFile: "/private/tmp/workload-ca.crt", TargetIdentity: digest.SHA256([]byte("target")), Client: client, Clock: func() time.Time { return now },
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := issuer.Issue(context.Background()); err == nil || redactedStopCategory(err) != test.want {
+				t.Fatalf("bound object mismatch accepted: category=%q", redactedStopCategory(err))
+			}
+		})
 	}
 }
 
@@ -142,7 +186,7 @@ func TestObservabilityCollectorObserverCredentialFailsClosed(t *testing.T) {
 				}
 				return targetCredentialTestResponse(http.StatusCreated, map[string]any{
 					"apiVersion": "authentication.k8s.io/v1", "kind": "TokenRequest", "metadata": map[string]any{},
-					"spec":   map[string]any{"audiences": []string{"https://kubernetes.default.svc"}, "expirationSeconds": 3600},
+					"spec":   observerCredentialResponseSpec([]string{"https://kubernetes.default.svc"}),
 					"status": map[string]any{"token": token, "expirationTimestamp": now.Add(time.Hour).Format(time.RFC3339)},
 				}), nil
 			})}
@@ -180,7 +224,7 @@ func TestObserverAuthorityConvergesBeforeExactlyOneTokenRequest(t *testing.T) {
 		postCalls++
 		return targetCredentialTestResponse(http.StatusCreated, map[string]any{
 			"apiVersion": "authentication.k8s.io/v1", "kind": "TokenRequest", "metadata": map[string]any{},
-			"spec":   map[string]any{"audiences": []string{observabilityCollectorObserverAudience}, "expirationSeconds": 3600},
+			"spec":   observerCredentialResponseSpec([]string{observabilityCollectorObserverAudience}),
 			"status": map[string]any{"token": token, "expirationTimestamp": now.Add(time.Hour).Format(time.RFC3339)},
 		}), nil
 	})}
@@ -351,4 +395,14 @@ func observerAuthorityTestResponse(path string) *http.Response {
 		return targetCredentialTestResponse(http.StatusNotFound, map[string]any{})
 	}
 	return targetCredentialTestResponse(http.StatusOK, object)
+}
+
+func observerCredentialResponseSpec(audiences []string) map[string]any {
+	return map[string]any{
+		"audiences": audiences, "expirationSeconds": 3600,
+		"boundObjectRef": map[string]any{
+			"apiVersion": "v1", "kind": "ServiceAccount", "name": observabilityCollectorObserverSA,
+			"uid": "uid-/api/v1/namespaces/ok-observability/serviceaccounts/ok147-observability-autonomy",
+		},
+	}
 }

--- a/internal/runner/target_credential_issuer.go
+++ b/internal/runner/target_credential_issuer.go
@@ -101,8 +101,16 @@ type targetCredentialTokenRequest struct {
 }
 
 type targetCredentialTokenRequestSpec struct {
-	Audiences         []string `json:"audiences,omitempty"`
-	ExpirationSeconds int64    `json:"expirationSeconds"`
+	Audiences         []string                                    `json:"audiences,omitempty"`
+	ExpirationSeconds int64                                       `json:"expirationSeconds"`
+	BoundObjectRef    *targetCredentialTokenRequestBoundObjectRef `json:"boundObjectRef,omitempty"`
+}
+
+type targetCredentialTokenRequestBoundObjectRef struct {
+	Kind       string `json:"kind"`
+	APIVersion string `json:"apiVersion"`
+	Name       string `json:"name"`
+	UID        string `json:"uid"`
 }
 
 type targetCredentialTokenResponse struct {
@@ -246,7 +254,7 @@ func (issuer *KubernetesTargetCredentialIssuer) verifyResponse(value targetCrede
 	if value.APIVersion != "authentication.k8s.io/v1" || value.Kind != "TokenRequest" || len(value.Status.Token) < 80 || strings.TrimSpace(value.Status.Token) != value.Status.Token || strings.ContainsAny(value.Status.Token, "\r\n") {
 		return VerifiedTargetCredentialMaterial{}, errors.New("target-credential response identity or token is invalid")
 	}
-	if value.Spec.ExpirationSeconds != int64(issuer.policy.ExpirationSeconds) || len(value.Spec.Audiences) == 0 {
+	if value.Spec.ExpirationSeconds != int64(issuer.policy.ExpirationSeconds) || len(value.Spec.Audiences) == 0 || value.Spec.BoundObjectRef != nil {
 		return VerifiedTargetCredentialMaterial{}, errors.New("target-credential response did not apply the bounded request")
 	}
 	expiresAt, err := time.Parse(time.RFC3339, value.Status.ExpirationTimestamp)


### PR DESCRIPTION
## Summary
- model Kubernetes TokenRequest response `spec.boundObjectRef` without adding it to outgoing requests
- bind the returned reference to the stable observer ServiceAccount UID established by authority convergence
- preserve strict fail-closed behavior for all other credential issuers

## Verification
- focused observer authority and credential tests pass
- extended target/installer/observer credential tests pass
- full runner suite shows only the three known time-dependent certificate fixture failures

## Safety
No cluster contact, launch, cleanup, publisher dispatch, or private evidence is included.