### PR TITLE
fix(runner): accept explicit null observer binding

### DIFF
--- a/internal/runner/observability_collector_observer_authority_poll.go
+++ b/internal/runner/observability_collector_observer_authority_poll.go
@@ -41,55 +41,51 @@ var observerAuthorityIdentities = []observerAuthorityIdentity{
 
 // awaitObserverAuthority performs only live GETs. Two identical consecutive
 // snapshots are required before the sole TokenRequest is allowed.
-func (issuer *KubernetesObservabilityCollectorObserverCredentialIssuer) awaitObserverAuthority(ctx context.Context) (string, error) {
+func (issuer *KubernetesObservabilityCollectorObserverCredentialIssuer) awaitObserverAuthority(ctx context.Context) error {
 	deadline := issuer.pollClock().Add(issuer.pollTimeout)
 	previous := map[string]string{}
 	seen := map[string]string{}
 	for attempt := 1; attempt <= issuer.maxAttempts; attempt++ {
 		if ctx.Err() != nil || !issuer.pollClock().Before(deadline) {
-			return "", observerAuthorityExhausted()
+			return observerAuthorityExhausted()
 		}
 		current := map[string]string{}
 		transient := false
 		for _, identity := range observerAuthorityIdentities {
 			uid, retry, err := issuer.readObserverAuthorityObject(ctx, deadline, identity)
 			if err != nil {
-				return "", err
+				return err
 			}
 			if retry {
 				if seen[identity.kind] != "" {
-					return "", newFixedRedactedStop("POST_PREFIX_OBSERVER_AUTHORITY_INVALID", errors.New("observer authority object disappeared after becoming visible"))
+					return newFixedRedactedStop("POST_PREFIX_OBSERVER_AUTHORITY_INVALID", errors.New("observer authority object disappeared after becoming visible"))
 				}
 				transient = true
 				break
 			}
 			if firstUID := seen[identity.kind]; firstUID != "" && firstUID != uid {
-				return "", newFixedRedactedStop("POST_PREFIX_OBSERVER_AUTHORITY_INVALID", errors.New("observer authority object identity changed"))
+				return newFixedRedactedStop("POST_PREFIX_OBSERVER_AUTHORITY_INVALID", errors.New("observer authority object identity changed"))
 			}
 			seen[identity.kind] = uid
 			current[identity.kind] = uid
 		}
 		if !transient && sameObserverAuthoritySnapshot(previous, current) {
-			uid := current["ServiceAccount"]
-			if uid == "" {
-				return "", newFixedRedactedStop("POST_PREFIX_OBSERVER_AUTHORITY_INVALID", errors.New("observer service account identity is absent"))
-			}
-			return uid, nil
+			return nil
 		}
 		if len(previous) != 0 {
-			return "", newFixedRedactedStop("POST_PREFIX_OBSERVER_AUTHORITY_INVALID", errors.New("observer authority regressed after becoming visible"))
+			return newFixedRedactedStop("POST_PREFIX_OBSERVER_AUTHORITY_INVALID", errors.New("observer authority regressed after becoming visible"))
 		}
 		if !transient {
 			previous = current
 		}
 		if attempt == issuer.maxAttempts || !issuer.pollClock().Add(issuer.pollInterval).Before(deadline) {
-			return "", observerAuthorityExhausted()
+			return observerAuthorityExhausted()
 		}
 		if err := issuer.wait(ctx, issuer.pollInterval); err != nil {
-			return "", observerAuthorityExhausted()
+			return observerAuthorityExhausted()
 		}
 	}
-	return "", observerAuthorityExhausted()
+	return observerAuthorityExhausted()
 }
 
 func observerAuthorityExhausted() error {

--- a/internal/runner/observability_collector_observer_credential.go
+++ b/internal/runner/observability_collector_observer_credential.go
@@ -162,8 +162,7 @@ func (issuer *KubernetesObservabilityCollectorObserverCredentialIssuer) Issue(ct
 	issuer.mu.Unlock()
 	boundedContext, cancel := context.WithTimeout(ctx, issuer.pollTimeout)
 	defer cancel()
-	observerServiceAccountUID, err := issuer.awaitObserverAuthority(boundedContext)
-	if err != nil {
+	if err := issuer.awaitObserverAuthority(boundedContext); err != nil {
 		return VerifiedObservabilityCollectorObserverCredential{}, err
 	}
 	requestURL := observerCredentialEndpoint(*issuer.endpoint)
@@ -175,20 +174,15 @@ func (issuer *KubernetesObservabilityCollectorObserverCredentialIssuer) Issue(ct
 	if err != nil {
 		return VerifiedObservabilityCollectorObserverCredential{}, err
 	}
-	return issuer.verifyResponse(value, issuer.clock().UTC().Truncate(time.Second), observerServiceAccountUID)
+	return issuer.verifyResponse(value, issuer.clock().UTC().Truncate(time.Second))
 }
 
-func (issuer *KubernetesObservabilityCollectorObserverCredentialIssuer) verifyResponse(value targetCredentialTokenResponse, now time.Time, observerServiceAccountUID string) (VerifiedObservabilityCollectorObserverCredential, error) {
+func (issuer *KubernetesObservabilityCollectorObserverCredentialIssuer) verifyResponse(value targetCredentialTokenResponse, now time.Time) (VerifiedObservabilityCollectorObserverCredential, error) {
 	if value.APIVersion != "authentication.k8s.io/v1" || value.Kind != "TokenRequest" || len(value.Status.Token) < 80 ||
 		strings.TrimSpace(value.Status.Token) != value.Status.Token || strings.ContainsAny(value.Status.Token, "\r\n") ||
 		value.Spec.ExpirationSeconds != int64(observabilityCollectorObserverLifetime/time.Second) || len(value.Spec.Audiences) == 0 ||
-		value.Spec.BoundObjectRef == nil {
+		!bytes.Equal(bytes.TrimSpace(value.Spec.BoundObjectRef), []byte("null")) {
 		return VerifiedObservabilityCollectorObserverCredential{}, newFixedRedactedStop("POST_PREFIX_OBSERVER_CREDENTIAL_RESPONSE_INVALID", errors.New("collector observer TokenRequest response is invalid"))
-	}
-	if value.Spec.BoundObjectRef.APIVersion != "v1" || value.Spec.BoundObjectRef.Kind != "ServiceAccount" ||
-		value.Spec.BoundObjectRef.Name != observabilityCollectorObserverSA || observerServiceAccountUID == "" ||
-		value.Spec.BoundObjectRef.UID != observerServiceAccountUID {
-		return VerifiedObservabilityCollectorObserverCredential{}, newFixedRedactedStop("POST_PREFIX_OBSERVER_CREDENTIAL_CLAIMS_MISMATCH", errors.New("collector observer TokenRequest bound object identity differs"))
 	}
 	expiresAt, err := time.Parse(time.RFC3339, value.Status.ExpirationTimestamp)
 	if err != nil {

--- a/internal/runner/observability_collector_observer_credential_test.go
+++ b/internal/runner/observability_collector_observer_credential_test.go
@@ -97,18 +97,18 @@ func TestObservabilityCollectorObserverCredentialRejectsDifferentReturnedAudienc
 	}
 }
 
-func TestObservabilityCollectorObserverCredentialBindsReturnedObjectReference(t *testing.T) {
+func TestObservabilityCollectorObserverCredentialRequiresNullReturnedObjectReference(t *testing.T) {
 	now := time.Date(2026, 9, 9, 12, 0, 0, 0, time.UTC)
 	token := string(stageCredentialJWT(t, "https://kubernetes.default.svc.cluster.local", "system:serviceaccount:ok-observability:"+observabilityCollectorObserverSA,
 		[]string{observabilityCollectorObserverAudience}, now, now.Add(time.Hour), 'o'))
 	for _, test := range []struct {
-		name, field, value, want string
+		name  string
+		value any
 	}{
-		{name: "missing", field: "missing", want: "POST_PREFIX_OBSERVER_CREDENTIAL_RESPONSE_INVALID"},
-		{name: "api version", field: "apiVersion", value: "v2", want: "POST_PREFIX_OBSERVER_CREDENTIAL_CLAIMS_MISMATCH"},
-		{name: "kind", field: "kind", value: "User", want: "POST_PREFIX_OBSERVER_CREDENTIAL_CLAIMS_MISMATCH"},
-		{name: "name", field: "name", value: "foreign", want: "POST_PREFIX_OBSERVER_CREDENTIAL_CLAIMS_MISMATCH"},
-		{name: "uid", field: "uid", value: "foreign-uid", want: "POST_PREFIX_OBSERVER_CREDENTIAL_CLAIMS_MISMATCH"},
+		{name: "missing"},
+		{name: "object", value: map[string]any{"apiVersion": "v1", "kind": "ServiceAccount", "name": observabilityCollectorObserverSA, "uid": "uid"}},
+		{name: "string", value: "null"},
+		{name: "array", value: []any{}},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			client := &http.Client{Transport: submissionStageLauncherRoundTripFunc(func(request *http.Request) (*http.Response, error) {
@@ -116,10 +116,10 @@ func TestObservabilityCollectorObserverCredentialBindsReturnedObjectReference(t 
 					return observerAuthorityTestResponse(request.URL.Path), nil
 				}
 				spec := observerCredentialResponseSpec([]string{observabilityCollectorObserverAudience})
-				if test.field == "missing" {
+				if test.name == "missing" {
 					delete(spec, "boundObjectRef")
 				} else {
-					spec["boundObjectRef"].(map[string]any)[test.field] = test.value
+					spec["boundObjectRef"] = test.value
 				}
 				return targetCredentialTestResponse(http.StatusCreated, map[string]any{
 					"apiVersion": "authentication.k8s.io/v1", "kind": "TokenRequest", "metadata": map[string]any{}, "spec": spec,
@@ -133,7 +133,7 @@ func TestObservabilityCollectorObserverCredentialBindsReturnedObjectReference(t 
 			if err != nil {
 				t.Fatal(err)
 			}
-			if _, err := issuer.Issue(context.Background()); err == nil || redactedStopCategory(err) != test.want {
+			if _, err := issuer.Issue(context.Background()); err == nil || redactedStopCategory(err) != "POST_PREFIX_OBSERVER_CREDENTIAL_RESPONSE_INVALID" {
 				t.Fatalf("bound object mismatch accepted: category=%q", redactedStopCategory(err))
 			}
 		})
@@ -400,9 +400,6 @@ func observerAuthorityTestResponse(path string) *http.Response {
 func observerCredentialResponseSpec(audiences []string) map[string]any {
 	return map[string]any{
 		"audiences": audiences, "expirationSeconds": 3600,
-		"boundObjectRef": map[string]any{
-			"apiVersion": "v1", "kind": "ServiceAccount", "name": observabilityCollectorObserverSA,
-			"uid": "uid-/api/v1/namespaces/ok-observability/serviceaccounts/ok147-observability-autonomy",
-		},
+		"boundObjectRef": nil,
 	}
 }

--- a/internal/runner/target_credential_issuer.go
+++ b/internal/runner/target_credential_issuer.go
@@ -101,16 +101,9 @@ type targetCredentialTokenRequest struct {
 }
 
 type targetCredentialTokenRequestSpec struct {
-	Audiences         []string                                    `json:"audiences,omitempty"`
-	ExpirationSeconds int64                                       `json:"expirationSeconds"`
-	BoundObjectRef    *targetCredentialTokenRequestBoundObjectRef `json:"boundObjectRef,omitempty"`
-}
-
-type targetCredentialTokenRequestBoundObjectRef struct {
-	Kind       string `json:"kind"`
-	APIVersion string `json:"apiVersion"`
-	Name       string `json:"name"`
-	UID        string `json:"uid"`
+	Audiences         []string        `json:"audiences,omitempty"`
+	ExpirationSeconds int64           `json:"expirationSeconds"`
+	BoundObjectRef    json.RawMessage `json:"boundObjectRef,omitempty"`
 }
 
 type targetCredentialTokenResponse struct {


### PR DESCRIPTION
## Summary
- model the Kubernetes TokenRequest response `spec.boundObjectRef` as strict raw JSON
- accept only the live-observed explicit JSON `null` for the unbound observer TokenRequest
- reject a missing field and every non-null value fail-closed
- remove the unsupported assumption that the response is UID-bound

## Evidence
R52 returned HTTP 2xx with the exact spec keys `audiences`, `boundObjectRef`, and `expirationSeconds`; `boundObjectRef` was explicitly null. No private response content is included.

## Verification
Focused target/installer/observer credential and authority tests pass. The full runner suite has only the three pre-existing expired-certificate fixture failures.

## Safety
No cluster contact, cleanup, launch, publisher dispatch, or private evidence is included.