### PR TITLE
feat(dry-run): support versioned console intent contract

### DIFF
--- a/deploy/console-dry-run-service.yaml.tpl
+++ b/deploy/console-dry-run-service.yaml.tpl
@@ -32,7 +32,7 @@ spec:
             - name: dry-run
               containerPort: 8790
           readinessProbe:
-            httpGet: {path: /, port: dry-run}
+            tcpSocket: {port: dry-run}
             periodSeconds: 5
           securityContext:
             allowPrivilegeEscalation: false

--- a/internal/contract/canonical.go
+++ b/internal/contract/canonical.go
@@ -58,8 +58,14 @@ func Canonicalize(raw, schemaRaw []byte) (Result, error) {
 	if err != nil {
 		return Result{}, err
 	}
-	if err := validateClusterSemantics(normalized); err != nil {
-		return Result{}, err
+	// Console intent contracts are deliberately a separate, bounded input
+	// contract. They are validated structurally by their own schema, but do
+	// not claim to be complete OK-141 cluster contracts and therefore must not
+	// be subjected to the production cluster semantic checks below.
+	if id, _ := schema["$id"].(string); !strings.HasPrefix(id, "https://openkubes.io/schemas/console-intent/") {
+		if err := validateClusterSemantics(normalized); err != nil {
+			return Result{}, err
+		}
 	}
 	semantic, included, err := semanticProjection(normalized, schema)
 	if err != nil {

--- a/internal/contract/testdata/console-intent-v0alpha1.schema.json
+++ b/internal/contract/testdata/console-intent-v0alpha1.schema.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://openkubes.io/schemas/console-intent/v0alpha1",
+  "title": "OpenKubes Console cluster intent",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["apiVersion", "kind", "metadata", "spec"],
+  "properties": {
+    "apiVersion": {"const": "platform.openkubes.io/v1alpha1"},
+    "kind": {"const": "OpenKubesCluster"},
+    "metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "namespace"],
+      "properties": {
+        "name": {"type": "string", "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$", "minLength": 1, "maxLength": 63},
+        "namespace": {"type": "string", "minLength": 1, "maxLength": 63}
+      }
+    },
+    "spec": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["role", "implementationProfile", "capabilities"],
+      "properties": {
+        "role": {"const": "workload"},
+        "implementationProfile": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["provider", "profile"],
+          "properties": {
+            "provider": {"type": "string", "minLength": 1},
+            "profile": {"type": "string", "minLength": 1}
+          }
+        },
+        "capabilities": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["required"],
+          "properties": {
+            "required": {"type": "array", "items": {"type": "string", "minLength": 1}, "uniqueItems": true}
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a dedicated v0alpha1 Console cluster-intent schema
- skip production OK-141 semantic checks only for this explicitly identified intent schema
- preserve structural validation, canonicalization, and mutationAllowed=false

## Verification
- go test ./internal/contract ./internal/dryrun
- validated the Console-generated intent with `ok cluster create --dry-run`

Ref: OK-147